### PR TITLE
design(v2): polish NavUser footer with theme switcher

### DIFF
--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -1,28 +1,142 @@
-import { ChevronsUpDown, ExternalLink, LogOut, Palette } from "lucide-react";
+import {
+  Check,
+  ChevronsUpDown,
+  ExternalLink,
+  Keyboard,
+  LogOut,
+  type LucideIcon,
+  MessageSquareText,
+  Monitor,
+  Moon,
+  Palette,
+  Shield,
+  Sun,
+  User as UserIcon,
+} from "lucide-react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
+import { useTheme } from "next-themes";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSkeleton,
   useSidebar,
 } from "@/components/ui/sidebar";
 import type { Me } from "@/api/types";
 import { useLogout } from "@/api/queries/auth";
+import { cn } from "@/lib/utils";
 
+// Lifts the email local-part (before "@") into an avatar pair. Falls back to
+// "?" so an empty username never produces a blank tile.
 function initials(name: string) {
   const local = name.split("@")[0];
   const parts = local.split(/[._-]/).filter(Boolean);
   return (parts[0]?.[0] ?? "?").concat(parts[1]?.[0] ?? "").toUpperCase();
+}
+
+// Splits an email-shaped username into local + domain. Real installs may
+// already use a display name (no `@`) in which case we render it whole.
+function splitUsername(username: string) {
+  const at = username.indexOf("@");
+  if (at < 0) return { primary: username, secondary: null as string | null };
+  return {
+    primary: username.slice(0, at),
+    secondary: username.slice(at),
+  };
+}
+
+// Role tone keys the same vocabulary as the rest of the v2 SPA: admin is the
+// elevated "primary" tinted pill (matches BrandHeader's v2 chip), editor reads
+// as a normal authenticated user (muted), viewer is a lighter-weight read-only
+// signal (muted with reduced opacity).
+const ROLE_TONE: Record<string, string> = {
+  admin: "bg-primary/15 text-primary",
+  editor: "bg-muted text-foreground/80",
+  viewer: "bg-muted text-muted-foreground",
+};
+
+function RoleBadge({ role }: { role: string }) {
+  const tone = ROLE_TONE[role] ?? "bg-muted text-muted-foreground";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-sm px-1.5 py-px text-[10px] font-semibold tracking-wider uppercase",
+        tone,
+      )}
+    >
+      {role === "admin" ? <Shield className="size-2.5" /> : null}
+      {role}
+    </span>
+  );
+}
+
+// THEMES is the source of truth for the theme submenu — keeping it as a
+// const tuple lets us drive the active-state radio rendering off `next-themes`
+// without duplicating the label/icon mapping across components. Order matches
+// the canonical shadcn theme-toggle examples.
+const THEMES = [
+  { value: "system", label: "System", icon: Monitor },
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+] as const satisfies ReadonlyArray<{
+  value: string;
+  label: string;
+  icon: LucideIcon;
+}>;
+
+function ThemeSubmenu() {
+  // `useTheme` reads from the `ThemeProvider` mounted in `main.tsx`. `theme`
+  // is the *requested* setting (system / light / dark); `resolvedTheme` is
+  // the realised mode. We key the active row off `theme` so "System" stays
+  // selected even when system resolves to dark — the menu reads "what did
+  // you pick", not "what's currently rendered".
+  const { theme, setTheme } = useTheme();
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger className="gap-2">
+        <Palette className="text-muted-foreground" />
+        <span>Theme</span>
+        <span className="text-muted-foreground ml-auto text-[11px] capitalize">
+          {theme ?? "system"}
+        </span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="min-w-40">
+        {THEMES.map(({ value, label, icon: Icon }) => {
+          const active = (theme ?? "system") === value;
+          return (
+            <DropdownMenuItem
+              key={value}
+              onSelect={(e) => {
+                e.preventDefault();
+                setTheme(value);
+              }}
+              className="gap-2"
+            >
+              <Icon className="text-muted-foreground" />
+              <span>{label}</span>
+              {active ? (
+                <Check className="text-primary ml-auto size-3.5" />
+              ) : null}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
 }
 
 export function NavUser({ me }: { me: Me | null }) {
@@ -41,20 +155,24 @@ export function NavUser({ me }: { me: Me | null }) {
     navigate({ to: "/login" });
   };
 
+  // Loading state: show a sidebar-matching skeleton instead of the placeholder
+  // text the previous version rendered. Reads as "loading", not "broken".
   if (!me) {
     return (
       <SidebarMenu>
         <SidebarMenuItem>
-          <SidebarMenuButton size="lg" disabled>
-            <Avatar className="h-8 w-8 rounded-lg">
-              <AvatarFallback className="rounded-lg">…</AvatarFallback>
-            </Avatar>
-            <span className="text-muted-foreground text-sm">Loading…</span>
-          </SidebarMenuButton>
+          <SidebarMenuSkeleton showIcon />
         </SidebarMenuItem>
       </SidebarMenu>
     );
   }
+
+  const { primary, secondary } = splitUsername(me.username);
+
+  // Open keyboard-shortcuts overlay via the shared event bus (iter 17).
+  const openShortcuts = () => {
+    window.dispatchEvent(new CustomEvent("breadbox:shortcut-sheet:open"));
+  };
 
   return (
     <SidebarMenu>
@@ -63,40 +181,103 @@ export function NavUser({ me }: { me: Me | null }) {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+              tooltip={`${primary} · ${me.role}`}
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group/nav-user h-12 gap-2.5"
             >
-              <Avatar className="h-8 w-8 rounded-lg">
-                <AvatarFallback className="rounded-lg">{initials(me.username)}</AvatarFallback>
+              <Avatar className="ring-border/60 size-8 rounded-md ring-1">
+                <AvatarFallback className="bg-primary/10 text-primary rounded-md text-[11px] font-semibold tracking-tight">
+                  {initials(me.username)}
+                </AvatarFallback>
               </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">{me.username}</span>
-                <span className="truncate text-xs text-muted-foreground">{me.role}</span>
+              <div className="grid flex-1 text-left leading-tight">
+                <span className="truncate text-sm font-medium">{primary}</span>
+                <span className="text-muted-foreground inline-flex items-center gap-1.5 truncate text-[11px]">
+                  <RoleBadge role={me.role} />
+                  {secondary ? (
+                    <span className="truncate">{secondary}</span>
+                  ) : (
+                    <span>Signed in</span>
+                  )}
+                </span>
               </div>
-              <ChevronsUpDown className="ml-auto size-4" />
+              <ChevronsUpDown className="text-muted-foreground/70 group-hover/nav-user:text-foreground ml-auto size-3.5 transition-colors" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-60 rounded-lg"
             side={isMobile ? "bottom" : "right"}
             align="end"
-            sideOffset={4}
+            sideOffset={8}
           >
-            <DropdownMenuLabel className="text-muted-foreground text-xs font-normal">
-              {me.username}
+            <DropdownMenuLabel className="p-0">
+              <div className="flex items-center gap-3 px-2 py-2">
+                <Avatar className="ring-border/60 size-9 rounded-md ring-1">
+                  <AvatarFallback className="bg-primary/10 text-primary rounded-md text-[12px] font-semibold">
+                    {initials(me.username)}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="grid flex-1 leading-tight">
+                  <span className="truncate text-sm font-medium">
+                    {primary}
+                    {secondary ? (
+                      <span className="text-muted-foreground font-normal">
+                        {secondary}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="text-muted-foreground inline-flex items-center gap-1.5 truncate text-[11px]">
+                    <RoleBadge role={me.role} />
+                    <span>Household</span>
+                  </span>
+                </div>
+              </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <a href="/">
-                <ExternalLink />
-                Back to classic UI
-              </a>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link to="/sandbox">
-                <Palette />
-                Design system
-              </Link>
-            </DropdownMenuItem>
+            <DropdownMenuGroup>
+              <ThemeSubmenu />
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  openShortcuts();
+                }}
+                className="gap-2"
+              >
+                <Keyboard className="text-muted-foreground" />
+                <span>Keyboard shortcuts</span>
+                <span className="text-muted-foreground ml-auto inline-flex items-center gap-0.5">
+                  <kbd className="border-border/60 bg-muted/60 rounded border px-1 font-mono text-[10px] leading-none">
+                    ?
+                  </kbd>
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem asChild className="gap-2">
+                <Link to="/sandbox">
+                  <Palette className="text-muted-foreground" />
+                  Design system
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild className="gap-2">
+                <a
+                  href="https://github.com/canalesb93/breadbox/issues/new/choose"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <MessageSquareText className="text-muted-foreground" />
+                  <span>Send feedback</span>
+                  <ExternalLink className="text-muted-foreground/60 ml-auto size-3" />
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild className="gap-2">
+                <a href="/">
+                  <UserIcon className="text-muted-foreground" />
+                  <span>Classic admin UI</span>
+                  <ExternalLink className="text-muted-foreground/60 ml-auto size-3" />
+                </a>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               disabled={logout.isPending}
@@ -104,6 +285,7 @@ export function NavUser({ me }: { me: Me | null }) {
                 e.preventDefault();
                 void onLogout();
               }}
+              className="text-destructive focus:text-destructive focus:bg-destructive/10 gap-2"
             >
               <LogOut />
               {logout.isPending ? "Signing out…" : "Sign out"}

--- a/web/src/components/theme-provider.tsx
+++ b/web/src/components/theme-provider.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+// Wraps `next-themes` so the SPA can flip between light / dark / system.
+// Mounted at the React root (in `main.tsx`) so every consumer — including
+// `ui/sonner.tsx`, which already reads `useTheme()` — gets the right
+// foreground/background tokens. The provider toggles a `.dark` class on
+// `<html>`, which globals.css's `:is(.dark *)` custom-variant already
+// keys off of, so no extra CSS work is needed.
+//
+// `attribute="class"` matches Tailwind v4's recommended setup with
+// `@custom-variant dark (&:is(.dark *))` in globals.css.
+//
+// `disableTransitionOnChange` avoids the brief flicker of tokens
+// transitioning when the user toggles theme — a calmer switch reads
+// as intentional rather than a CSS regression.
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+      storageKey="breadbox:theme"
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,7 @@ import {
   lazyRouteComponent,
 } from "@tanstack/react-router";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ThemeProvider } from "@/components/theme-provider";
 import type { AnyRoute } from "@tanstack/react-router";
 import { RootLayout } from "@/routes/__root";
 import { HomePage } from "@/routes/home";
@@ -267,9 +268,11 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <RouterProvider router={router} />
-      </TooltipProvider>
+      <ThemeProvider>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -4,17 +4,21 @@ import { toast } from "sonner";
 import {
   AlertTriangle,
   ArrowUpRight,
+  Check,
   CheckCircle2,
   Inbox,
   Info,
   KeyRound,
   MessageSquare,
+  Monitor,
+  Moon,
   Plus,
   RefreshCw,
   RotateCcw,
   Save,
   Shapes,
   ShieldAlert,
+  Sun,
   Tag,
   Trash2,
   Users,
@@ -53,6 +57,8 @@ import { StatusPanel } from "@/components/status-panel";
 import { FormFooter } from "@/components/form-footer";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ProviderPicker } from "@/features/connections/provider-picker";
+import { useTheme } from "next-themes";
+import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
 import { SandboxSection, Specimen } from "@/sandbox/kit";
 import {
@@ -380,6 +386,25 @@ export function ComponentsSection() {
       </Specimen>
 
       <Specimen
+        label="ThemeToggle"
+        code="next-themes · ThemeProvider"
+        description="The theme switcher mounted at the React root via `<ThemeProvider>` in main.tsx. The picker keys off the user's stored choice (`system`/`light`/`dark`), not the realised mode, so 'System' stays selected when the OS resolves to dark. The same hook drives the Sonner Toaster's theme prop and the NavUser dropdown's Theme submenu — change it in one place, every surface follows."
+        className="block"
+      >
+        <ThemeSpecimen />
+      </Specimen>
+
+      <Specimen
+        label="NavUser footer"
+        code="components/nav-user"
+        description="The bottom-of-sidebar account row + dropdown that hosts the theme switcher, keyboard-shortcut overlay, classic-UI link, and sign-out. Lives inside the SidebarProvider — view it live in any app route. The role pill picks the same primary tint as the BrandHeader's V2 chip for admins, muted neutral for editor/viewer."
+      >
+        <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-sm">
+          <UserChipDemo />
+        </div>
+      </Specimen>
+
+      <Specimen
         label="EmptyState"
         code="components/empty-state"
         description="Three variants share one primitive — pick the weight that fits the surface. Same icon-tile vocabulary as the rest of v2 (square rounded-xl, not circle)."
@@ -693,5 +718,80 @@ export function ComponentsSection() {
         />
       </Specimen>
     </SandboxSection>
+  );
+}
+
+// Live theme picker — three pill buttons backed by next-themes. Renders the
+// same `<Check>` affordance the NavUser submenu uses for the selected row, so
+// the two surfaces share their visual vocabulary.
+function ThemeSpecimen() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const choices = [
+    { value: "system", label: "System", icon: Monitor },
+    { value: "light", label: "Light", icon: Sun },
+    { value: "dark", label: "Dark", icon: Moon },
+  ] as const;
+  const current = theme ?? "system";
+  return (
+    <div className="space-y-3">
+      <div className="bg-muted/30 inline-flex items-center gap-1 rounded-md border p-1">
+        {choices.map(({ value, label, icon: Icon }) => {
+          const active = current === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setTheme(value)}
+              className={cn(
+                "inline-flex h-8 items-center gap-1.5 rounded-sm px-2.5 text-xs font-medium transition-colors",
+                active
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Icon className="size-3.5" />
+              {label}
+              {active ? (
+                <Check className="text-primary -mr-0.5 ml-1 size-3" />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-muted-foreground text-xs">
+        Stored: <span className="text-foreground font-mono">{current}</span> ·
+        Resolved:{" "}
+        <span className="text-foreground font-mono">
+          {resolvedTheme ?? "—"}
+        </span>{" "}
+        · Storage key{" "}
+        <span className="text-foreground font-mono">breadbox:theme</span>
+      </p>
+    </div>
+  );
+}
+
+// Inline visual demo of the NavUser trigger — the dropdown itself depends on
+// `SidebarProvider`, so we render just the trigger shape (avatar + name + role
+// pill + chevron) here and point readers at the live sidebar for the menu.
+function UserChipDemo() {
+  return (
+    <div className="bg-sidebar/40 ring-sidebar-border flex w-full max-w-sm items-center gap-2.5 rounded-md p-2 ring-1">
+      <span className="bg-primary/10 text-primary ring-border/60 inline-flex size-8 items-center justify-center rounded-md text-[11px] font-semibold ring-1">
+        AD
+      </span>
+      <div className="grid flex-1 leading-tight">
+        <span className="text-sm font-medium">admin</span>
+        <span className="text-muted-foreground inline-flex items-center gap-1.5 text-[11px]">
+          <span className="bg-primary/15 text-primary inline-flex items-center gap-1 rounded-sm px-1.5 py-px text-[10px] font-semibold tracking-wider uppercase">
+            admin
+          </span>
+          @example.com
+        </span>
+      </div>
+      <span className="text-muted-foreground/70 text-[10px]">
+        click in sidebar →
+      </span>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Wires `next-themes` at the React root via a new `<ThemeProvider>` so the SPA gains a real light/dark/system switch (globals.css already had the `.dark` variant; `ui/sonner.tsx` already read `useTheme()` — both now wire up).
- Rebuilds `NavUser` (bottom-of-sidebar account row + dropdown) around the v2 vocabulary: primary-tinted avatar ring, role pill matching BrandHeader's V2 chip, two-line identity (display name + muted domain), destructive sign-out at the bottom.
- New dropdown items: **Theme** submenu (system / light / dark with check affordance), **Keyboard shortcuts** with `?` kbd hint (opens existing ShortcutSheet via the iter-17 event bus), **Send feedback** → GitHub issues. Promoted "Classic admin UI" to its own row with an `ExternalLink` trail icon.

## Before / After

| Before | After (dropdown open) |
| --- | --- |
| ![before](https://i.img402.dev/aveeeogfju.jpg) | ![after](https://i.img402.dev/vdpow1eb6u.jpg) |

### Theme submenu

![theme submenu](https://i.img402.dev/597adanhcp.jpg)

## Notes

- `ThemeProvider` lives in `web/src/components/theme-provider.tsx` and mounts at the React root in `main.tsx`. `storageKey="breadbox:theme"`, `disableTransitionOnChange` to avoid the flicker of OKLCH tokens transitioning on toggle.
- Loading state for `NavUser` now uses `SidebarMenuSkeleton` (the shadcn sidebar primitive) instead of the "Loading…" placeholder text.
- Sandbox specimens added: live ThemeToggle (segmented pill group backed by the same `useTheme` hook) + NavUser footer visual demo with a note pointing readers at the live sidebar for the actual dropdown.
- Drift to watch: the `BrandHeader` "V2 PREVIEW" chip, the new admin role pill, and the existing settings active-state token all use `bg-primary/15 text-primary`. Three surfaces share that token combo now — if a fourth surface lands, consider promoting to a `<PrimaryPill>` primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
