### PR TITLE
design(v2): wire next-themes — Light/Dark/System switcher in NavUser

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -45,16 +45,34 @@
     <meta name="twitter:image" content="./og-image.svg" />
 
     <script>
-      // Light/dark theme follows the OS — same contract as `BrandHeader`
-      // and the rest of the v2 SPA. Inline + synchronous so the first
-      // paint never flashes the wrong theme.
+      // No-flash theme bootstrap. Inline + synchronous so the first
+      // paint never flashes the wrong theme. Reads the same storage
+      // key (`breadbox-theme`) that `ThemeProvider` writes from
+      // `next-themes` so a user's saved choice survives reloads.
+      // Falls back to the OS preference when nothing is saved or
+      // when the saved value is "system".
       (function () {
-        var mql = window.matchMedia("(prefers-color-scheme: dark)");
-        function apply(e) {
-          document.documentElement.classList.toggle("dark", e.matches);
+        try {
+          var stored = window.localStorage.getItem("breadbox-theme");
+          var mql = window.matchMedia("(prefers-color-scheme: dark)");
+          function resolve() {
+            if (stored === "dark") return true;
+            if (stored === "light") return false;
+            return mql.matches;
+          }
+          function apply() {
+            document.documentElement.classList.toggle("dark", resolve());
+          }
+          apply();
+          // Keep tracking OS changes only while the user is on
+          // "system" (or has not chosen) — `next-themes` handles the
+          // explicit case once the React tree mounts.
+          mql.addEventListener("change", function () {
+            if (!stored || stored === "system") apply();
+          });
+        } catch (_) {
+          /* localStorage blocked — fall through, default light */
         }
-        apply(mql);
-        mql.addEventListener("change", apply);
       })();
     </script>
   </head>

--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -1,5 +1,16 @@
-import { ChevronsUpDown, ExternalLink, LogOut, Palette } from "lucide-react";
+import {
+  Check,
+  ChevronsUpDown,
+  ExternalLink,
+  LogOut,
+  Monitor,
+  Moon,
+  Palette,
+  Sun,
+  SunMoon,
+} from "lucide-react";
 import { Link, useNavigate } from "@tanstack/react-router";
+import { useTheme } from "next-themes";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -7,7 +18,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -25,10 +40,17 @@ function initials(name: string) {
   return (parts[0]?.[0] ?? "?").concat(parts[1]?.[0] ?? "").toUpperCase();
 }
 
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+] as const;
+
 export function NavUser({ me }: { me: Me | null }) {
   const { isMobile } = useSidebar();
   const navigate = useNavigate();
   const logout = useLogout();
+  const { theme, setTheme } = useTheme();
 
   const onLogout = async () => {
     try {
@@ -97,6 +119,37 @@ export function NavUser({ me }: { me: Me | null }) {
                 Design system
               </Link>
             </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="gap-2">
+                <SunMoon className="size-4" />
+                <span>Theme</span>
+                <span className="text-muted-foreground ml-auto text-xs capitalize">
+                  {theme ?? "system"}
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent className="min-w-36">
+                  {THEME_OPTIONS.map(({ value, label, icon: Icon }) => {
+                    const active = (theme ?? "system") === value;
+                    return (
+                      <DropdownMenuItem
+                        key={value}
+                        onSelect={(e) => {
+                          e.preventDefault();
+                          setTheme(value);
+                        }}
+                      >
+                        <Icon className="size-4" />
+                        <span>{label}</span>
+                        {active && (
+                          <Check className="text-muted-foreground ml-auto size-3.5" />
+                        )}
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               disabled={logout.isPending}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,6 +9,7 @@ import {
   createRoute,
   lazyRouteComponent,
 } from "@tanstack/react-router";
+import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AnyRoute } from "@tanstack/react-router";
 import { RootLayout } from "@/routes/__root";
@@ -266,10 +267,18 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <RouterProvider router={router} />
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+      storageKey="breadbox-theme"
+    >
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- Wire `<ThemeProvider>` from `next-themes` in `main.tsx` (class attribute, system default, `breadbox-theme` storage key) so `useTheme()` finally has a provider — Sonner's `useTheme()` call was already in the codebase but reading from no provider, silently falling through to "system".
- Replace the inline OS-follow script in `index.html` with a no-flash bootstrap that respects `localStorage.breadbox-theme` first, then OS preference. OS changes only auto-apply while the saved choice is `system`.
- Add a Theme submenu to `<NavUser>` (Light / Dark / System) using the existing dropdown submenu primitives. Trigger shows the current choice as a muted eyebrow; active option gets a `<Check>`.

Dark-mode tokens were already shipped in `globals.css`; this is the plumbing that lets a user actually pick one. Unlocks dark-mode auditing of the rest of the v2 pages in follow-up iterations.

## Theme switcher (NavUser dropdown → Theme submenu)

![switcher-open](https://i.img402.dev/tm89xrrgps.jpg)

## Home page — Light vs Dark

| Light | Dark |
| --- | --- |
| ![light](https://i.img402.dev/tlbqsq5g68.jpg) | ![dark](https://i.img402.dev/ng1tzyt15m.jpg) |

## Notes

- Storage key is namespaced (`breadbox-theme`) to avoid clobbering whatever the classic UI may write to the unprefixed `theme` key.
- Sonner's `useTheme()` was already in the tree but had no provider — toasts will now follow the user's choice instead of always defaulting to system.
- Submenu uses `DropdownMenuPortal` so it floats above the sidebar even when the sidebar collapses.
- Dark-mode home renders cleanly — no obviously-broken tokens — but a full audit across detail / form pages is queued for a follow-up iteration.

Generated with [Claude Code](https://claude.com/claude-code)
