### PR TITLE
design(v2): calmer disabled treatment for filled buttons

### DIFF
--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -5,13 +5,20 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
+  // Disabled treatment: filled variants (default/destructive) override
+  // `disabled:opacity-50` with a `bg-muted text-muted-foreground` swap below
+  // so dark-mode primary doesn't read as a bright gray block (the dark
+  // `--primary: oklch(0.922)` × `opacity-50` produced a glaring tile).
+  // Outline/ghost/secondary/link keep the inherited opacity treatment —
+  // they have no strong fill, so 50% reads fine.
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100 disabled:shadow-none",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100 disabled:shadow-none",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -104,9 +104,31 @@ export function PrimitivesSection() {
         <Button size="icon" aria-label="Add">
           <Plus />
         </Button>
-        <Button disabled>Disabled</Button>
         <Button>
           <Bell /> With icon
+        </Button>
+      </Specimen>
+
+      <Specimen
+        label="Button — disabled across variants"
+        code="disabled"
+        description="Filled variants (default + destructive) swap to bg-muted text-muted-foreground instead of opacity-50 so dark mode doesn't render the near-white primary token as a bright tile. Outline/ghost/secondary/link keep the inherited opacity dim."
+      >
+        <Button disabled>Default</Button>
+        <Button variant="destructive" disabled>
+          Destructive
+        </Button>
+        <Button variant="secondary" disabled>
+          Secondary
+        </Button>
+        <Button variant="outline" disabled>
+          Outline
+        </Button>
+        <Button variant="ghost" disabled>
+          Ghost
+        </Button>
+        <Button variant="link" disabled>
+          Link
         </Button>
       </Specimen>
 


### PR DESCRIPTION
## Summary
- `default` + `destructive` button variants now use `bg-muted text-muted-foreground` (`opacity-100`) when disabled, instead of inheriting the base `disabled:opacity-50`. In dark mode `--primary` resolves to `oklch(0.922 0 0)` (near-white) — paired with `opacity-50` the disabled "Post note" / "Save" buttons read as a bright gray *tile* rather than a dimmed control.
- Other variants (`outline` / `ghost` / `secondary` / `link`) keep the inherited opacity-50; they have no strong fill so 50% reads fine.
- Sandbox gains a `Button — disabled across variants` specimen so the new treatment is inspectable side-by-side.

Closes the iter-31 dark-mode observation.

## Before / After — TX detail Post note (dark mode)

| Before (bright primary tile) | After (calm muted) |
| --- | --- |
| ![before](https://i.img402.dev/21swezujbz.jpg) | ![after](https://i.img402.dev/g2ohxb122c.jpg) |

## Before / After — Sandbox specimen across variants (dark mode)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/ecxwlq95sq.jpg) | ![after](https://i.img402.dev/59klhrnl5h.jpg) |

## Notes
- No new primitive; tone change is centralized inside `buttonVariants` in `web/src/components/ui/button.tsx`. Every disabled `<Button>` in the SPA picks it up for free.
- The `disabled:shadow-none` rider sands the residual shadow-xs on the destructive variant so the disabled tile reads as a flat muted block instead of a slightly-elevated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
