### PR TITLE
design(v2): tighten primitive header + footer padding

### DIFF
--- a/web/src/components/color-rail-card.tsx
+++ b/web/src/components/color-rail-card.tsx
@@ -70,7 +70,7 @@ export function ColorRailCard({
       {footer && (
         <div
           className={cn(
-            "border-t bg-muted/20 flex flex-wrap items-center justify-end gap-2 px-6 py-2.5 sm:px-7",
+            "border-t bg-muted/20 flex flex-wrap items-center justify-end gap-2 px-6 py-3 sm:px-7",
             footerClassName,
           )}
         >

--- a/web/src/components/form-footer.tsx
+++ b/web/src/components/form-footer.tsx
@@ -18,14 +18,17 @@ interface FormFooterProps {
 // adopts it. Iter 15 brings tag-form and category-form onto the pattern, so
 // it lives here.
 //
-// Visual contract (matches the api-key-new pattern):
-//   `<div className="bg-muted/20 -mx-5 -mb-5 mt-2 flex items-center justify-end
+// Visual contract:
+//   `<div className="bg-muted/20 -mx-5 -mb-5 flex items-center justify-end
 //                    gap-2 border-t px-5 py-3">`
 //
 // The negative margins (`-mx-5 -mb-5`) push the strip out to the SectionCard
 // body's edges so the top border lines up with the card's outer border and
 // the action strip reads as a footer of the card, not as floating content.
-// Drop it inside a SectionCard with the default `bodyClassName="px-5 py-5"`.
+// Drop it inside a SectionCard with the default `bodyClassName="px-5 py-5"` —
+// the body's `py-5` (20px) supplies the breathing room above the strip; no
+// extra `mt-*` is needed (and adding one re-introduces a sliver of plain
+// card background above the muted footer, breaking the flush look).
 //
 // Don't fork the look — change this primitive instead.
 export function FormFooter({
@@ -37,7 +40,7 @@ export function FormFooter({
   return (
     <div
       className={cn(
-        "bg-muted/20 -mx-5 -mb-5 mt-2 flex flex-wrap items-center justify-end gap-2 border-t px-5 py-3",
+        "bg-muted/20 -mx-5 -mb-5 flex flex-wrap items-center justify-end gap-2 border-t px-5 py-3",
         hint && "sm:justify-between",
         className,
       )}

--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -51,10 +51,15 @@ interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "c
 // Visual contract — identical to SectionCard but the body is always a
 // `<ul className="divide-y">`:
 //   `<Card className="gap-0 py-0">`
-//     optional `<CardHeader className="border-b px-5 py-3.5">` title + action
+//     optional `<CardHeader className="border-b px-5 py-4">` title + action
 //     optional `<div className="border-b px-5 py-2">` toolbar slot
 //     `<ul className="divide-y">` rows (each `renderRow` result wrapped in `<li>`)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
+//
+// Header uses `py-4` (16px) to match `SectionCard`'s header — the two
+// primitives must share vertical rhythm or pages that stack them feel
+// off. Row padding is consumer-supplied (typically `px-5 py-3` or
+// `px-5 py-3.5`), one stride below the header.
 //
 // When `rows.length === 0`, the `empty` slot replaces the `<ul>`. Pass
 // `<EmptyState>` for first-class look + CTA, or a short muted string for a
@@ -89,7 +94,7 @@ export function ListCard<T>({
       {...rest}
     >
       {showHeader && (
-        <CardHeader className={cn("border-b px-5 py-3.5", headerClassName)}>
+        <CardHeader className={cn("border-b px-5 py-4", headerClassName)}>
           {title !== undefined && (
             <CardTitle className="flex items-center gap-2 text-sm font-medium">
               {icon}

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -36,11 +36,14 @@ interface SectionCardProps extends React.HTMLAttributes<HTMLDivElement> {
 //
 // Visual contract:
 //   `<Card className="gap-0 py-0">`
-//     `<CardHeader className="border-b px-5 py-3.5">` title (text-sm font-medium)
+//     `<CardHeader className="border-b px-5 py-4">` title (text-sm font-medium)
 //     `<CardContent className="px-5 py-5">` content (or px-0 py-0 when flushBody)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
 //
-// Don't fork the look — change this primitive.
+// Vertical rhythm: header `py-4` (16px) + body `py-5` (20px) reads as a
+// slight density step from chrome to content. Matched by `ListCard` so the
+// two cards visually align when they sit on the same page. Don't fork the
+// look — change this primitive.
 export function SectionCard({
   title,
   action,
@@ -60,7 +63,7 @@ export function SectionCard({
       className={cn("gap-0 py-0", cardClassName, className)}
       {...rest}
     >
-      <CardHeader className={cn("border-b px-5 py-3.5", headerClassName)}>
+      <CardHeader className={cn("border-b px-5 py-4", headerClassName)}>
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           {icon}
           {title}

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -245,7 +245,7 @@ export function APIKeyForm() {
           )}
         />
 
-        <div className="bg-muted/20 -mx-5 -mb-5 mt-2 flex items-center justify-end gap-2 border-t px-5 py-3">
+        <div className="bg-muted/20 -mx-5 -mb-5 flex items-center justify-end gap-2 border-t px-5 py-3">
           <Button
             type="button"
             variant="ghost"

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -543,7 +543,7 @@ function DetailSkeleton() {
             <Skeleton className="h-3 w-28" />
           </div>
         </div>
-        <div className="border-t flex justify-end gap-2 px-6 py-2.5">
+        <div className="border-t flex justify-end gap-2 px-6 py-3">
           <Skeleton className="h-7 w-24 rounded-md" />
           <Skeleton className="h-7 w-32 rounded-md" />
         </div>


### PR DESCRIPTION
## Summary

Detail-pass tightening of the four shared card-style primitives so headers / footers / form action strips share a consistent vertical rhythm. No new APIs; only padding values changed.

- **`SectionCard` + `ListCard` headers**: `py-3.5` (14px) → `py-4` (16px). The previous value left the header noticeably tighter than the body's `py-5` (20px); +2px brings it close enough that the chrome → content step reads as a deliberate density shift rather than a mismatch. Both primitives changed in lockstep so pages that stack them stay aligned.
- **`FormFooter`**: drop the `mt-2` (8px) above the strip. With the existing `-mb-5` cancelling the body's bottom padding, the `mt-2` was producing a thin sliver of plain card background between the form fields and the muted action strip — visible as a "gap that shouldn't be there". The body's own `py-5` (20px) already provides the breathing room above the strip, so the strip can sit flush against the form content with no extra margin. Same change applied to the still-hand-rolled api-key-form footer.
- **`ColorRailCard` footer**: `py-2.5` (10px) → `py-3` (12px) so the hero footer matches `SectionCard` / `ListCard` plain footers. Inline action strips inside `py-2.5` (with sm-height buttons ~32px) felt cramped against the `px-6` horizontal inset. Matching skeleton strip on `account-detail.tsx` adjusted in the same pass.

## Primitives left alone (with rationale)

- **`ColorRailCard` body padding** (`px-6 py-5 sm:px-7`) is still consumer-rolled in 7+ places. Baking it in is the right move, but it would cascade through every consumer (the structural change is non-trivial). Queued for a follow-up — see sprint state.
- **`IdPill`, `SoftBackButton`, `AuthShell`, `StatusPanel`, `ConfirmDialog`, `EmptyState`, `TimelineRail`**: spacing already coherent and consistent with the v2 vocabulary. No drift to fix.

## Before / After

Screenshots incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
