### PR TITLE
design(v2): home dashboard rebuild — hero balance + attention panel

### DIFF
--- a/web/src/features/home/home-attention-panel.tsx
+++ b/web/src/features/home/home-attention-panel.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { StatusPanel } from "@/components/status-panel";
+import type { Connection } from "@/api/types";
+
+interface HomeAttentionPanelProps {
+  connections: Connection[] | undefined;
+}
+
+// Inline warning shown above the hero scoreboard when one or more
+// connections need user action (reauth, error). Renders nothing when
+// the household is healthy — the home page reads cleanly with no
+// orphaned "All good!" empty-state.
+//
+// Uses the canonical StatusPanel primitive so the tone-rail vocabulary
+// matches the rest of the v2 surfaces (setup-account, providers).
+export function HomeAttentionPanel({ connections }: HomeAttentionPanelProps) {
+  if (!connections) return null;
+  const attention = connections.filter(
+    (c) => c.status === "pending_reauth" || c.status === "error",
+  );
+  if (attention.length === 0) return null;
+
+  const reauthCount = attention.filter((c) => c.status === "pending_reauth").length;
+  const errorCount = attention.filter((c) => c.status === "error").length;
+
+  const heading =
+    attention.length === 1
+      ? `${attention[0].institution_name || "A connection"} needs your attention`
+      : `${attention.length} connections need your attention`;
+
+  const parts: string[] = [];
+  if (reauthCount > 0) {
+    parts.push(`${reauthCount} ${reauthCount === 1 ? "needs" : "need"} re-authentication`);
+  }
+  if (errorCount > 0) {
+    parts.push(`${errorCount} ${errorCount === 1 ? "has" : "have"} a sync error`);
+  }
+  const body =
+    parts.length > 0
+      ? `${parts.join(", ")}. Resolve them to keep balances and transactions current.`
+      : "Resolve them to keep balances and transactions current.";
+
+  return (
+    <StatusPanel
+      tone="warning"
+      icon={AlertTriangle}
+      heading={heading}
+      body={body}
+      trailing={
+        <Button asChild size="sm" variant="outline">
+          <Link to="/connections">Review</Link>
+        </Button>
+      }
+    />
+  );
+}

--- a/web/src/features/home/home-connections-panel.tsx
+++ b/web/src/features/home/home-connections-panel.tsx
@@ -22,13 +22,20 @@ const PROVIDER_ICON: Record<string, typeof Building2> = {
 
 // Side-rail summary of household connections. Sorts attention-needed ones to
 // the top so the user sees what to fix first. Caps at 5 rows; the card
-// header's "Manage" link goes to the full Connections page.
+// header's "Manage" link goes to the full Connections page. The bordered
+// header carries the household-level health summary (active/needs-action
+// count) so the page header doesn't need a fourth scoreboard tile for the
+// same number.
 export function HomeConnectionsPanel({
   connections,
   isLoading,
 }: HomeConnectionsPanelProps) {
   const visible = connections ? rankForDashboard(connections).slice(0, 5) : [];
   const remaining = connections ? Math.max(0, connections.length - visible.length) : 0;
+  const attention = (connections ?? []).filter(
+    (c) => c.status === "pending_reauth" || c.status === "error",
+  ).length;
+  const active = (connections ?? []).filter((c) => c.status === "active").length;
 
   const manage = (
     <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
@@ -42,10 +49,34 @@ export function HomeConnectionsPanel({
     </Button>
   );
 
+  // Health line appears in the header subtitle when we have any connections.
+  // It replaces the standalone "Connections" stat card in the hero strip —
+  // the same number, but inline next to where the user is about to read it.
+  const title =
+    !isLoading && connections && connections.length > 0 ? (
+      <span className="flex flex-col gap-0.5">
+        <span>Connections</span>
+        <span className="text-muted-foreground text-xs font-normal">
+          {attention > 0 ? (
+            <>
+              <span className="text-amber-600 dark:text-amber-400">
+                {attention} need{attention === 1 ? "s" : ""} action
+              </span>
+              <span> · {active} healthy</span>
+            </>
+          ) : (
+            <>{active} healthy</>
+          )}
+        </span>
+      </span>
+    ) : (
+      "Connections"
+    );
+
   if (isLoading) {
     return (
       <ListCard
-        title="Connections"
+        title={title}
         action={manage}
         rows={[0, 1, 2, 3]}
         getRowKey={(i) => i}
@@ -66,7 +97,7 @@ export function HomeConnectionsPanel({
   if (!connections || connections.length === 0) {
     return (
       <ListCard
-        title="Connections"
+        title={title}
         action={manage}
         rows={[]}
         renderRow={() => null}
@@ -90,7 +121,7 @@ export function HomeConnectionsPanel({
 
   return (
     <ListCard
-      title="Connections"
+      title={title}
       action={manage}
       rows={visible}
       getRowKey={(c) => c.id}

--- a/web/src/features/home/home-stats.tsx
+++ b/web/src/features/home/home-stats.tsx
@@ -1,11 +1,6 @@
-import {
-  Banknote,
-  CreditCard,
-  Plug,
-  TrendingUp,
-  type LucideIcon,
-} from "lucide-react";
+import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ColorRailCard } from "@/components/color-rail-card";
 import { cn } from "@/lib/utils";
 import type { Account, Connection } from "@/api/types";
 
@@ -15,11 +10,11 @@ interface HomeStatsProps {
   isLoading: boolean;
 }
 
-// Aggregates the same /api/v1/accounts payload that the Accounts page reads,
-// bucketed into the four card metrics. Currency is kept per-bucket so the
-// header rendering never sums across currencies — we just show the largest
-// bucket and a "+N more" hint if other currencies exist (rare on a household
-// dataset; keeps the card honest without inventing a single number).
+// Aggregates the /api/v1/accounts payload into the household-level balance
+// summary that anchors the home page. Currency is kept per-bucket so totals
+// are never summed across currencies — we show the dominant bucket and a
+// "+N currencies" hint when more than one exists. Same convention used by
+// the v1 dashboard so the numbers match across surfaces.
 interface CurrencyTotals {
   totals: Map<string, number>;
   count: number;
@@ -57,15 +52,21 @@ function formatCompact(amount: number, currency: string): string {
   }).format(amount);
 }
 
+// HomeStats is the hero balance summary on the home page. A single
+// ColorRailCard reads as the page's "first read" — the rail encodes
+// solvency (success when net is positive, destructive when underwater)
+// and the value uses a much larger tabular-num display so the headline
+// number is unambiguous. Two secondary metrics (Cash / Credit & loans)
+// sit inside the same card as labelled cells, separated by the card
+// border so they read as supporting context rather than four equal
+// scoreboard tiles.
+//
+// Connection health moved into the side connections panel header — the
+// number was duplicated here for no reason and the side panel already
+// has the right context for it.
 export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) {
   if (isLoading || !accounts || !connections) {
-    return (
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {[0, 1, 2, 3].map((i) => (
-          <StatCardSkeleton key={i} />
-        ))}
-      </div>
-    );
+    return <HomeStatsSkeleton />;
   }
 
   const cash = bucket();
@@ -73,8 +74,10 @@ export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) 
   // Net = depository minus credit/loan (loans counted as debt, positive
   // balance_current). Same logic as the v1 dashboard summary.
   const netByCurrency = new Map<string, number>();
+  let activeAccounts = 0;
   for (const a of accounts) {
     if (a.is_dependent_linked) continue;
+    activeAccounts += 1;
     const c = a.iso_currency_code ?? "USD";
     const bal = a.balance_current ?? 0;
     if (a.type === "depository") {
@@ -85,101 +88,156 @@ export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) 
       netByCurrency.set(c, (netByCurrency.get(c) ?? 0) - bal);
     }
   }
-  const net: CurrencyTotals = { totals: netByCurrency, count: accounts.length };
-
-  const healthy = connections.filter((c) => c.status === "active").length;
-  const attention = connections.filter(
-    (c) => c.status === "pending_reauth" || c.status === "error",
-  ).length;
+  const net: CurrencyTotals = { totals: netByCurrency, count: activeAccounts };
 
   const cashP = primary(cash);
   const creditP = primary(credit);
   const netP = primary(net);
+  const positive = netP.amount >= 0;
+  const currencyCount = net.totals.size;
 
   return (
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-      <StatCard
-        icon={TrendingUp}
-        label="Net cash"
-        value={formatCompact(netP.amount, netP.currency)}
-        accent={netP.amount >= 0 ? "positive" : "negative"}
-        hint={`${accounts.length} ${accounts.length === 1 ? "account" : "accounts"}${net.totals.size > 1 ? ` · ${net.totals.size} currencies` : ""}`}
-      />
-      <StatCard
-        icon={Banknote}
-        label="Cash"
-        value={formatCompact(cashP.amount, cashP.currency)}
-        hint={`${cash.count} depository`}
-      />
-      <StatCard
-        icon={CreditCard}
-        label="Credit & loans"
-        value={formatCompact(creditP.amount, creditP.currency)}
-        accent={creditP.amount > 0 ? "negative" : "neutral"}
-        hint={`${credit.count} balance${credit.count === 1 ? "" : "s"}`}
-      />
-      <StatCard
-        icon={Plug}
-        label="Connections"
-        value={String(connections.length)}
-        hint={
-          attention > 0
-            ? `${healthy} healthy · ${attention} need action`
-            : `${healthy} healthy`
-        }
-        accent={attention > 0 ? "warning" : "neutral"}
-      />
-    </div>
+    <ColorRailCard
+      accent={positive ? "var(--success)" : "var(--destructive)"}
+      cardClassName="shadow-sm"
+    >
+      <div className="grid gap-0 sm:grid-cols-[1.4fr_1fr_1fr]">
+        <HeroCell
+          eyebrow={
+            <>
+              <Wallet className="size-3.5" />
+              Net cash
+            </>
+          }
+          value={formatCompact(netP.amount, netP.currency)}
+          valueTone={positive ? "positive" : "negative"}
+          hint={
+            <>
+              {activeAccounts} {activeAccounts === 1 ? "account" : "accounts"}
+              {currencyCount > 1 && (
+                <span className="text-muted-foreground/70">
+                  {" "}
+                  · {currencyCount} currencies
+                </span>
+              )}
+            </>
+          }
+          className="px-6 py-6 sm:py-7 sm:pl-7"
+        />
+        <SecondaryCell
+          eyebrow={
+            <>
+              <ArrowUpRight className="size-3.5" />
+              Cash
+            </>
+          }
+          value={formatCompact(cashP.amount, cashP.currency)}
+          hint={`${cash.count} ${cash.count === 1 ? "depository" : "depository accounts"}`}
+          className="px-6 py-5 sm:border-l sm:py-7"
+        />
+        <SecondaryCell
+          eyebrow={
+            <>
+              <ArrowDownRight className="size-3.5" />
+              Credit &amp; loans
+            </>
+          }
+          value={formatCompact(creditP.amount, creditP.currency)}
+          valueTone={creditP.amount > 0 ? "warning" : "neutral"}
+          hint={`${credit.count} ${credit.count === 1 ? "balance" : "balances"}`}
+          className="px-6 py-5 sm:border-l sm:py-7 sm:pr-7"
+        />
+      </div>
+    </ColorRailCard>
   );
 }
 
-interface StatCardProps {
-  icon: LucideIcon;
-  label: string;
+interface CellProps {
+  eyebrow: React.ReactNode;
   value: string;
-  hint?: string;
-  accent?: "positive" | "negative" | "warning" | "neutral";
+  hint?: React.ReactNode;
+  valueTone?: "positive" | "negative" | "warning" | "neutral";
+  className?: string;
 }
 
-// One stat tile: tiny uppercase label, big tabular-num value, a footnote line.
-// Border-only card — flatter than the default shadcn Card so a row of four
-// reads as a scoreboard, not a deck of feature cards.
-function StatCard({ icon: Icon, label, value, hint, accent = "neutral" }: StatCardProps) {
-  const valueColor =
-    accent === "positive"
-      ? "text-success"
-      : accent === "negative"
-        ? "text-destructive"
-        : accent === "warning"
-          ? "text-amber-600 dark:text-amber-400"
-          : undefined;
+const TONE_CLASS: Record<NonNullable<CellProps["valueTone"]>, string> = {
+  positive: "text-success",
+  negative: "text-destructive",
+  warning: "text-amber-600 dark:text-amber-400",
+  neutral: "",
+};
+
+// HeroCell is the dominant value. Eyebrow + 3xl value + hint.
+function HeroCell({ eyebrow, value, hint, valueTone = "neutral", className }: CellProps) {
   return (
-    <div className="bg-card rounded-xl border p-5 shadow-sm">
-      <div className="text-muted-foreground flex items-center gap-2 text-[11px] font-medium tracking-[0.08em] uppercase">
-        <Icon className="size-3.5" />
-        {label}
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="text-muted-foreground inline-flex items-center gap-1.5 text-[11px] font-medium tracking-[0.08em] uppercase">
+        {eyebrow}
       </div>
       <div
         className={cn(
-          "mt-3 text-2xl font-semibold tracking-tight tabular-nums",
-          valueColor,
+          "text-3xl font-semibold tracking-tight tabular-nums sm:text-[2rem] sm:leading-tight",
+          TONE_CLASS[valueTone],
         )}
       >
         {value}
       </div>
       {hint && (
-        <div className="text-muted-foreground mt-1 text-xs">{hint}</div>
+        <div className="text-muted-foreground text-xs">{hint}</div>
       )}
     </div>
   );
 }
 
-function StatCardSkeleton() {
+// SecondaryCell shares the cell shape but smaller value, used for the
+// supporting metrics inside the hero.
+function SecondaryCell({
+  eyebrow,
+  value,
+  hint,
+  valueTone = "neutral",
+  className,
+}: CellProps) {
   return (
-    <div className="bg-card rounded-xl border p-5 shadow-sm">
-      <Skeleton className="h-3 w-20" />
-      <Skeleton className="mt-3 h-7 w-32" />
-      <Skeleton className="mt-2 h-3 w-24" />
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="text-muted-foreground inline-flex items-center gap-1.5 text-[11px] font-medium tracking-[0.08em] uppercase">
+        {eyebrow}
+      </div>
+      <div
+        className={cn(
+          "text-xl font-semibold tracking-tight tabular-nums",
+          TONE_CLASS[valueTone],
+        )}
+      >
+        {value}
+      </div>
+      {hint && (
+        <div className="text-muted-foreground text-xs">{hint}</div>
+      )}
     </div>
+  );
+}
+
+function HomeStatsSkeleton() {
+  return (
+    <ColorRailCard accent="var(--muted)" cardClassName="shadow-sm">
+      <div className="grid gap-0 sm:grid-cols-[1.4fr_1fr_1fr]">
+        <div className="flex flex-col gap-2 px-6 py-6 sm:py-7 sm:pl-7">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-8 w-40 sm:h-9" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <div className="flex flex-col gap-2 px-6 py-5 sm:border-l sm:py-7">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+        <div className="flex flex-col gap-2 px-6 py-5 sm:border-l sm:py-7 sm:pr-7">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-6 w-28" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      </div>
+    </ColorRailCard>
   );
 }

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -11,6 +11,7 @@ import { relativeTime } from "@/features/connections/connection-utils";
 import { HomeStats } from "@/features/home/home-stats";
 import { HomeRecentTransactions } from "@/features/home/home-recent-transactions";
 import { HomeConnectionsPanel } from "@/features/home/home-connections-panel";
+import { HomeAttentionPanel } from "@/features/home/home-attention-panel";
 
 // Greeting strips the email domain so "admin@example.com" reads as "admin".
 // Username can already be a display name on real installs, in which case it
@@ -77,6 +78,8 @@ export function HomePage() {
           </>
         }
       />
+
+      <HomeAttentionPanel connections={connectionsQuery.data} />
 
       <HomeStats
         accounts={accountsQuery.data}


### PR DESCRIPTION
## Summary

- Replace the 4-up scoreboard with a single `ColorRailCard` hero (Net cash on the left, Cash + Credit & loans as supporting metrics). The rail tint encodes solvency (success when positive, destructive when underwater) and the value reads at 3xl tabular-nums vs the old text-2xl, giving the page a clear "first read."
- Move connection-health summary into the Connections panel header so the same number isn't duplicated as a fourth stat tile.
- New `HomeAttentionPanel`: a tone-rail `StatusPanel` rendered above the hero only when one or more connections need re-auth or have a sync error. Reuses the same warning vocabulary as setup-account + providers — silent on a healthy household.

Home was iter 2, shipped before most of the v2 primitives (`ColorRailCard`, `StatusPanel`, `ListCard`) existed. This pass aligns the dashboard with the current vocabulary so it reads as polished as the detail pages.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/hnjhfe9ooa.jpg) | ![after](https://i.img402.dev/r5zgd34n5h.jpg) |

## Notes

- The hero uses an `sm:grid-cols-[1.4fr_1fr_1fr]` ratio so the dominant value gets ~40% of the row width on tablet+; below `sm` the three cells stack vertically.
- Credit value picks up the amber/warning tone when the balance is positive (debt outstanding), neutral when zero — matches the v1 dashboard semantics.
- Attention panel only mounts when there's something to act on; no orphaned "all good!" empty-state to mute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)