### PR TITLE
design(v2): add 404 + error boundary pages

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,8 @@ import { HomePage } from "@/routes/home";
 import { LoginPage } from "@/routes/login";
 import { SetupAccountPage } from "@/routes/setup-account";
 import { Placeholder } from "@/routes/placeholder";
+import { NotFoundPage } from "@/routes/not-found";
+import { ErrorPage } from "@/routes/error";
 import { TransactionsPage, transactionsSearchSchema } from "@/routes/transactions";
 import { TransactionDetailPage } from "@/routes/transaction-detail";
 import { CategoriesPage } from "@/routes/categories";
@@ -251,6 +253,14 @@ const router = createRouter({
   routeTree,
   basepath: "/v2",
   defaultPreload: "intent",
+  // Default not-found + error components render in place of <Outlet/> inside
+  // the authenticated shell, so the sidebar/topbar/command palette stay live
+  // and the user has a way out without a hard reload. See the route files
+  // for the visual contract.
+  defaultNotFoundComponent: NotFoundPage,
+  defaultErrorComponent: ({ error, reset }) => (
+    <ErrorPage error={error} reset={reset} />
+  ),
 });
 
 declare module "@tanstack/react-router" {

--- a/web/src/routes/error.tsx
+++ b/web/src/routes/error.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  ChevronDown,
+  ChevronRight,
+  RotateCw,
+} from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/page-header";
+import { SectionCard } from "@/components/section-card";
+import { StatusPanel } from "@/components/status-panel";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { cn } from "@/lib/utils";
+
+interface ErrorPageProps {
+  /** The error thrown during render — typed loosely to match TanStack
+   *  Router's `ErrorComponent` props (`error: unknown`). */
+  error?: unknown;
+  /** Reset handler from the router. When invoked, the router re-renders the
+   *  failing route as if it were a fresh mount. Optional so the same
+   *  component can be used standalone (where reload is the recovery). */
+  reset?: () => void;
+}
+
+function openCommandPalette() {
+  window.dispatchEvent(new CustomEvent("breadbox:command-palette:open"));
+}
+
+// Extract a human-readable message + an optional stack from any thrown
+// value. Strings are common (`throw "boom"`), Error instances even more so,
+// but ApiError and similar carry useful extra context.
+function readError(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { message: err.message, stack: err.stack };
+  }
+  if (typeof err === "string") return { message: err };
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return { message };
+  }
+  return { message: "An unexpected error occurred." };
+}
+
+// ErrorPage is the canonical error-boundary surface for the v2 SPA. Wired
+// into `createRouter({ defaultErrorComponent })` so it renders in place of
+// `<Outlet/>` whenever a route throws during render — the sidebar, topbar,
+// and command palette stay live, so the user has a way out without a hard
+// reload.
+//
+// Visual contract (matches NotFoundPage / Placeholder):
+//   <PageHeader eyebrow="500 · ERROR" title="Something went wrong" />
+//   <StatusPanel tone="destructive" />  ← human-readable message
+//   <SectionCard title="Technical details">
+//     collapsible details payload with the raw stack trace (dev affordance)
+//   </SectionCard>
+//
+// Reset wiring: the router passes a `reset` callback that re-renders the
+// failing route. We expose it as "Try again" alongside a "Reload" fallback
+// (full-page) and a Home link.
+export function ErrorPage({ error, reset }: ErrorPageProps) {
+  const [showDetails, setShowDetails] = useState(false);
+  const { message, stack } = readError(error);
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="500 · ERROR"
+        title="Something went wrong"
+        description="The page hit an unexpected error while rendering. The shell is still healthy — try again, or jump to another page."
+        actions={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={openCommandPalette}
+              className="gap-2"
+            >
+              <span>Jump to…</span>
+              <KbdGroup>
+                <Kbd>⌘</Kbd>
+                <Kbd>K</Kbd>
+              </KbdGroup>
+            </Button>
+            {reset ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={reset}
+                className="gap-1.5"
+              >
+                <RotateCw className="size-3.5" />
+                Try again
+              </Button>
+            ) : null}
+            <Button asChild size="sm">
+              <Link to="/">
+                Back to Home
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+          </>
+        }
+      />
+
+      <div className="flex flex-col gap-4">
+        <StatusPanel
+          tone="destructive"
+          icon={AlertTriangle}
+          heading={message}
+          body="If this keeps happening, reload the page or check the browser console for more context."
+          trailing={
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => window.location.reload()}
+              className="h-7 gap-1.5 px-2.5 text-xs"
+            >
+              <RotateCw className="size-3" />
+              Reload
+            </Button>
+          }
+        />
+
+        {stack ? (
+          <SectionCard
+            title="Technical details"
+            icon={
+              <AlertTriangle className="text-muted-foreground size-4" />
+            }
+            action={
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowDetails((v) => !v)}
+                className="h-7 gap-1 px-2 text-xs"
+              >
+                {showDetails ? (
+                  <ChevronDown className="size-3.5" />
+                ) : (
+                  <ChevronRight className="size-3.5" />
+                )}
+                {showDetails ? "Hide" : "Show"}
+              </Button>
+            }
+          >
+            <div
+              className={cn(
+                "overflow-hidden transition-all",
+                showDetails ? "max-h-[480px]" : "max-h-0",
+              )}
+            >
+              <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed">
+                {stack}
+              </pre>
+            </div>
+          </SectionCard>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/web/src/routes/not-found.tsx
+++ b/web/src/routes/not-found.tsx
@@ -1,0 +1,130 @@
+import { ArrowRight, Compass, FileQuestion } from "lucide-react";
+import { Link, useRouterState } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/page-header";
+import { SectionCard } from "@/components/section-card";
+import { StatusPanel } from "@/components/status-panel";
+import { IdPill } from "@/components/id-pill";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+
+// Suggested jumps for a not-found page. Pulled out as a flat list so the
+// hero stays scannable — these are the top entry points any wandering link
+// likely meant to land on.
+const QUICK_JUMPS: Array<{ title: string; description: string; to: string }> = [
+  {
+    title: "Home",
+    description: "Dashboard, recent activity, and attention items.",
+    to: "/",
+  },
+  {
+    title: "Transactions",
+    description: "All transactions across every account.",
+    to: "/transactions",
+  },
+  {
+    title: "Accounts",
+    description: "Banks, cards, and balances by household member.",
+    to: "/accounts",
+  },
+  {
+    title: "Categories",
+    description: "Category tree, rules, and category settings.",
+    to: "/categories",
+  },
+];
+
+function openCommandPalette() {
+  window.dispatchEvent(new CustomEvent("breadbox:command-palette:open"));
+}
+
+// NotFoundPage is the canonical 404 surface for the v2 SPA. Wired into
+// `createRouter({ defaultNotFoundComponent })` so it renders in place of
+// `<Outlet/>` inside the authenticated shell — the sidebar, topbar, and
+// command palette stay live, so the user has a way out without a hard
+// reload.
+//
+// Visual contract (matches the rest of v2):
+//   <PageHeader eyebrow="404 · NOT FOUND" title="Page not found" description />
+//   <StatusPanel tone="info" />  ← shows the attempted path as an IdPill
+//   <SectionCard title="Jump to a page">
+//     2x2 grid of quick-jump tiles with arrow affordance
+//   </SectionCard>
+//
+// Reuses the same StatusPanel + SectionCard + IdPill vocabulary as the
+// Placeholder page so the two "you've landed somewhere unexpected" surfaces
+// feel like siblings.
+export function NotFoundPage() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="404 · NOT FOUND"
+        title="Page not found"
+        description="The path you followed doesn't match any page in the v2 admin. It may have moved, been renamed, or never existed."
+        actions={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={openCommandPalette}
+              className="gap-2"
+            >
+              <span>Jump to…</span>
+              <KbdGroup>
+                <Kbd>⌘</Kbd>
+                <Kbd>K</Kbd>
+              </KbdGroup>
+            </Button>
+            <Button asChild size="sm">
+              <Link to="/">
+                Back to Home
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+          </>
+        }
+      />
+
+      <div className="flex flex-col gap-4">
+        <StatusPanel
+          tone="info"
+          icon={FileQuestion}
+          heading="No route matched this URL"
+          body={
+            <span className="flex flex-wrap items-center gap-2">
+              <span>Attempted path:</span>
+              <IdPill value={pathname} />
+            </span>
+          }
+        />
+
+        <SectionCard
+          title="Jump to a page"
+          icon={<Compass className="text-muted-foreground size-4" />}
+        >
+          <ol className="grid gap-3 sm:grid-cols-2">
+            {QUICK_JUMPS.map((jump) => (
+              <li key={jump.to}>
+                <Link
+                  to={jump.to}
+                  className="group bg-muted/20 hover:bg-muted/40 hover:border-ring/40 relative flex h-full items-center justify-between gap-3 rounded-md border p-4 transition-colors"
+                >
+                  <div className="space-y-1">
+                    <h3 className="text-foreground text-sm font-medium">
+                      {jump.title}
+                    </h3>
+                    <p className="text-muted-foreground text-xs leading-relaxed">
+                      {jump.description}
+                    </p>
+                  </div>
+                  <ArrowRight className="text-muted-foreground/50 group-hover:text-muted-foreground size-4 shrink-0 transition-colors" />
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </SectionCard>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Wires `defaultNotFoundComponent` (`NotFoundPage`) + `defaultErrorComponent` (`ErrorPage`) on the TanStack router so the v2 SPA has proper unknown-route / render-error surfaces instead of TanStack's bare default text.
- Both render in place of `<Outlet/>` inside the authenticated shell — sidebar, topbar, and command palette stay live, so the user has a way out without a hard reload.
- Pure composition of existing primitives (PageHeader / StatusPanel / SectionCard / IdPill / Kbd) — no new design vocabulary.

## Before / After (404)
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/0j0618riiw.jpg) | ![after](https://i.img402.dev/8v1j1sklw5.jpg) |

## NotFoundPage (`/v2/anything-unknown`)
- PageHeader eyebrow `404 · NOT FOUND` + title + description matching the rest of v2 vocabulary.
- `StatusPanel tone="info"` with the attempted path rendered as an `IdPill`.
- `SectionCard` "Jump to a page" with a 2x2 grid of quick-jump tiles to Home / Transactions / Accounts / Categories.
- Header actions: `⌘K Jump to…` button + Back to Home.

## ErrorPage (any route that throws during render)
- PageHeader eyebrow `500 · ERROR` + title + description.
- `StatusPanel tone="destructive"` with the human-readable error message + trailing Reload button.
- Collapsible `SectionCard` "Technical details" with the raw stack trace (showDetails toggle) — dev affordance, not loud by default.
- Header actions: `⌘K Jump to…` + Try again (router `reset()`) + Back to Home.
- Not screenshotted here because triggering it requires a code-side throw in a real route; the visual contract mirrors NotFoundPage exactly (same shell + PageHeader + StatusPanel + SectionCard), just with `destructive` tone and the stack-trace panel.

## Notes
- Sixth + seventh production surfaces for `StatusPanel` (info + destructive tones).
- Eighth surface for `IdPill` — first time it carries a URL path instead of a short_id/slug, which fits its "machine identifier" framing.
- The error reset wiring uses TanStack Router's per-route `reset()` callback for "Try again"; `window.location.reload()` is the fallback Reload affordance inside the StatusPanel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
