### PR TITLE
design(v2): Eyebrow primitive consolidates uppercase micro-label drift

### DIFF
--- a/web/src/components/eyebrow.tsx
+++ b/web/src/components/eyebrow.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface EyebrowProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Element to render. Defaults to `span` so the primitive composes inside
+   * inline contexts; pass `"p"`, `"h3"`, etc. when the eyebrow is a block
+   * label (section headers, hero eyebrows). Avoid heading levels that
+   * conflict with the document outline — pick `"div"` or `"span"` for
+   * non-semantic decoration.
+   */
+  as?: "span" | "p" | "div" | "h3" | "h4";
+  /**
+   * Visual emphasis. `default` is the standard `text-[10px]
+   * tracking-[0.1em]` muted eyebrow used on detail-page section headers,
+   * "Jump to" pills, and the timeline-rail day-heading. `hero` is the
+   * slightly tighter-cap `tracking-[0.12em]` variant used in
+   * detail-page hero columns ("Liability" / "Income" / "Category") where
+   * the eyebrow sits directly under a large display title and benefits
+   * from the extra letter air.
+   */
+  variant?: "default" | "hero";
+  className?: string;
+  children: React.ReactNode;
+}
+
+// Eyebrow is the canonical uppercase micro-label used across detail pages,
+// hero cards, and timeline rails: `text-muted-foreground text-[10px]
+// font-medium tracking-[0.1em] uppercase`. The pattern was open-coded
+// across ten files in five subtly different sizes/trackings before iter 37
+// consolidated them. Don't reach for raw `text-[10px] font-medium
+// tracking-* uppercase` markup again — extend this primitive with a new
+// variant if a hero needs a different rhythm.
+export function Eyebrow({
+  as: Tag = "span",
+  variant = "default",
+  className,
+  children,
+  ...rest
+}: EyebrowProps) {
+  return (
+    <Tag
+      className={cn(
+        "text-muted-foreground font-medium uppercase",
+        variant === "default" && "text-[10px] tracking-[0.1em]",
+        variant === "hero" && "text-[10px] tracking-[0.12em]",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { type LucideIcon } from "lucide-react";
+import { Eyebrow } from "@/components/eyebrow";
 import { cn } from "@/lib/utils";
 
 // TimelineRail is the v2 vocabulary for a vertical activity feed: a thin
@@ -52,9 +53,7 @@ function TimelineRailGroup({
   return (
     <div className={cn("space-y-3", className)} {...rest}>
       {label !== undefined && label !== null && (
-        <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-          {label}
-        </h3>
+        <Eyebrow as="h3">{label}</Eyebrow>
       )}
       {/* Subtle vertical rail behind the icons gives the feed a sense of
           continuity without leaning on dividers between rows. Icons sit on

--- a/web/src/features/providers/provider-status.tsx
+++ b/web/src/features/providers/provider-status.tsx
@@ -1,5 +1,6 @@
 import { Activity, AlertTriangle, CheckCircle2, CircleDashed, Loader2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Eyebrow } from "@/components/eyebrow";
 import { cn } from "@/lib/utils";
 import type { ProviderHealthResponse } from "@/api/types";
 
@@ -192,9 +193,7 @@ export function ProviderScoreboard({ health, tone, alwaysAvailable }: ProviderSc
 function ScoreCell({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <div className="text-muted-foreground text-[10px] font-medium tracking-[0.08em] uppercase">
-        {label}
-      </div>
+      <Eyebrow as="div">{label}</Eyebrow>
       <div className="text-foreground text-lg font-semibold tabular-nums">{value}</div>
     </div>
   );

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { EmptyState } from "@/components/empty-state";
+import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
@@ -227,9 +228,9 @@ function Hero({
               <Icon className="text-muted-foreground size-5" />
             </div>
             <div className="min-w-0 space-y-1">
-              <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
+              <Eyebrow as="p" variant="hero">
                 {liability ? "Liability" : "Asset"}
-              </p>
+              </Eyebrow>
               <div className="flex flex-wrap items-center gap-2">
                 <h1 className="truncate text-xl font-semibold tracking-tight">
                   {accountLabel(a)}
@@ -348,9 +349,7 @@ function QuickActions({ account: a }: { account: AccountDetail }) {
   if (!hasAny) return null;
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <span className="text-muted-foreground mr-1 text-[10px] font-medium tracking-[0.1em] uppercase">
-        Jump to
-      </span>
+      <Eyebrow className="mr-1">Jump to</Eyebrow>
       <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
         <Link to="/transactions" search={{ account: a.short_id }}>
           <Wallet className="size-3" />
@@ -436,9 +435,7 @@ function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) 
   if (rows.length === 0) return null;
   return (
     <div className="space-y-2.5">
-      <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-        {label}
-      </h3>
+      <Eyebrow as="h3">{label}</Eyebrow>
       <dl className="space-y-2">
         {rows.map((row) => (
           <div

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -19,6 +19,7 @@ import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { DangerZone } from "@/components/danger-zone";
 import { EmptyState } from "@/components/empty-state";
+import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
@@ -149,9 +150,9 @@ function Hero({
               size="lg"
             />
             <div className="min-w-0 space-y-1">
-              <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
+              <Eyebrow as="p" variant="hero">
                 {eyebrow}
-              </p>
+              </Eyebrow>
               <div className="flex flex-wrap items-center gap-2">
                 <h1 className="truncate text-xl font-semibold tracking-tight">
                   {category.display_name}
@@ -244,9 +245,7 @@ function QuickActions({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <span className="text-muted-foreground mr-1 text-[10px] font-medium tracking-[0.1em] uppercase">
-        Jump to
-      </span>
+      <Eyebrow className="mr-1">Jump to</Eyebrow>
       <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
         <Link to="/transactions" search={{ category: category.slug }}>
           <Receipt className="size-3" />
@@ -373,9 +372,7 @@ function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) 
   if (rows.length === 0) return null;
   return (
     <div className="space-y-2.5">
-      <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-        {label}
-      </h3>
+      <Eyebrow as="h3">{label}</Eyebrow>
       <dl className="space-y-2">
         {rows.map((row) => (
           <div

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -42,6 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
@@ -441,11 +442,7 @@ function DetailBody({
           <SectionCard
             title="Sync activity"
             icon={<Activity className="text-muted-foreground size-4" />}
-            action={
-              <span className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-                Last 7 days
-              </span>
-            }
+            action={<Eyebrow>Last 7 days</Eyebrow>}
           >
             {syncLogsLoading ? (
               <Skeleton className="h-[72px] w-full" />
@@ -489,11 +486,7 @@ function DetailBody({
           <SectionCard
             title="Sync history"
             icon={<RefreshCw className="text-muted-foreground size-4" />}
-            action={
-              <span className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-                Last 10
-              </span>
-            }
+            action={<Eyebrow>Last 10</Eyebrow>}
             footer={
               syncLogs.length > 0 ? (
                 <Link
@@ -665,9 +658,9 @@ function Hero({
               <Icon className="text-muted-foreground size-5" />
             </div>
             <div className="min-w-0 space-y-1">
-              <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
+              <Eyebrow as="p" variant="hero">
                 Connection
-              </p>
+              </Eyebrow>
               <div className="flex flex-wrap items-center gap-2">
                 <h1 className="truncate text-xl font-semibold tracking-tight">
                   {conn.institution_name ?? "Untitled connection"}
@@ -746,9 +739,7 @@ function Hero({
 function QuickActions({ conn }: { conn: ConnectionDetail }) {
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <span className="text-muted-foreground mr-1 text-[10px] font-medium tracking-[0.1em] uppercase">
-        Jump to
-      </span>
+      <Eyebrow className="mr-1">Jump to</Eyebrow>
       <Button
         variant="outline"
         size="sm"
@@ -870,9 +861,7 @@ function DetailGroup({
   if (rows.length === 0) return null;
   return (
     <div className="space-y-2.5">
-      <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-        {label}
-      </h3>
+      <Eyebrow as="h3">{label}</Eyebrow>
       <dl className="space-y-2">
         {rows.map((row) => (
           <div

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
@@ -111,9 +112,9 @@ function Hero({ transaction: t }: { transaction: Transaction }) {
               size="lg"
             />
             <div className="min-w-0 space-y-1">
-              <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
+              <Eyebrow as="p" variant="hero">
                 Transaction
-              </p>
+              </Eyebrow>
               <div className="flex flex-wrap items-center gap-2">
                 <h1 className="truncate text-xl font-semibold tracking-tight">
                   {t.provider_name}
@@ -215,9 +216,7 @@ function ClassifyField({
 }) {
   return (
     <div className="space-y-1.5">
-      <p className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-        {label}
-      </p>
+      <Eyebrow as="p">{label}</Eyebrow>
       {children}
     </div>
   );
@@ -235,9 +234,7 @@ function QuickActions({
   // straight into the transactions list `?account=` filter.
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <span className="text-muted-foreground mr-1 text-[10px] font-medium tracking-[0.1em] uppercase">
-        Jump to
-      </span>
+      <Eyebrow className="mr-1">Jump to</Eyebrow>
       <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
         <Link
           to="/transactions"
@@ -347,9 +344,7 @@ function DetailGroup({
   if (rows.length === 0) return null;
   return (
     <div className="space-y-2.5">
-      <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
-        {label}
-      </h3>
+      <Eyebrow as="h3">{label}</Eyebrow>
       <dl className="space-y-2">
         {rows.map((row) => (
           <div


### PR DESCRIPTION
## Summary

Six subtle variations of the uppercase muted-foreground micro-label were open-coded across ten files (audited in iter 24). This iteration extracts `<Eyebrow>` as the canonical primitive and migrates the dominant consumers (detail-page section headers, hero eyebrows, "Jump to" pills, sync-activity action labels, provider scoreboard cells, timeline-rail day-headings).

The visual diff is microscopic — most call sites already used the dominant `text-[10px] tracking-[0.1em]` shape. The win is the consistency guard: future surfaces reach for `<Eyebrow>` instead of hand-rolling new tracking/size combinations.

- New primitive: `web/src/components/eyebrow.tsx`. Two variants — `default` (`tracking-[0.1em]`) and `hero` (`tracking-[0.12em]`). Both keep the canonical `text-muted-foreground text-[10px] font-medium uppercase` base.
- Migrated 6 files (10+ open-coded eyebrow sites). Provider scoreboard cell's stale `tracking-[0.08em]` collapses to the standard `tracking-[0.1em]`.
- Brand-header / auth-shell / shortcut-sheet group label kept as-is — they're surface-specific framing (login chrome, command-palette grouping) not part of the detail-page eyebrow vocabulary.
- `<label htmlFor="sync-interval">` in connection-detail intentionally stays as a raw `<label>` element (accessibility), even though the visual matches.

## Before / After

The eyebrow tracking shift is subtle; the win is consistency across pages. Captured on `/v2/transactions/<id>` at 1440x900.

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/b6x30n7ph1.jpg) | ![after](https://i.img402.dev/2ouyxtyx6z.jpg) |

## Notes

- 13th primitive in the v2 design vocabulary.
- Sprint state will add the "uppercase eyebrow drift" entry retiring it, with a guardrail: new surfaces use `<Eyebrow>`; don't hand-roll `text-[10px] tracking-* uppercase` markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)