### PR TITLE
design(v2): polish shortcut sheet to match v2 vocabulary

### DIFF
--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Keyboard } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -58,38 +59,104 @@ export function ShortcutSheet() {
     });
   }, [list]);
 
+  const totalCount = list.length;
+
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetContent side="right" className="w-full sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle>Keyboard shortcuts</SheetTitle>
-          <SheetDescription>
-            Available across the app. Inputs are ignored while typing.
-          </SheetDescription>
-        </SheetHeader>
-        <div className="space-y-6 px-4 pb-6">
-          {grouped.map(([group, items]) => (
-            <div key={group} className="space-y-2">
-              <h3 className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-                {group}
-              </h3>
-              <ul className="divide-border divide-y">
-                {items.map((s) => (
-                  <li
-                    key={s.id}
-                    className="flex items-center justify-between gap-4 py-2"
-                  >
-                    <span className="text-sm">{s.label}</span>
-                    <KbdGroup>
-                      {s.keys.map((k) => (
-                        <Kbd key={k}>{displayKey(k)}</Kbd>
-                      ))}
-                    </KbdGroup>
-                  </li>
-                ))}
-              </ul>
+      <SheetContent
+        side="right"
+        // Override the default sheet width — shortcut rows + multi-key chord
+        // pills need a touch more room than the stock max-w-sm. `p-0` so the
+        // header/body/footer strips can control their own padding and the
+        // sticky footer sits flush against the panel edge.
+        className="w-full gap-0 p-0 sm:max-w-md"
+      >
+        {/* Header — mirrors the icon-tile vocabulary used by StatusPanel /
+            EmptyState / SectionCard so the sheet reads as part of the v2
+            system, not an ad-hoc overlay. */}
+        <SheetHeader className="gap-3 border-b p-5">
+          <div className="flex items-start gap-3">
+            <span
+              className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-lg border"
+              aria-hidden
+            >
+              <Keyboard className="size-4" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <SheetTitle className="text-base leading-tight">
+                Keyboard shortcuts
+              </SheetTitle>
+              <SheetDescription className="mt-0.5 text-xs">
+                Available across the app. Shortcuts pause while you&apos;re
+                typing in an input.
+              </SheetDescription>
             </div>
-          ))}
+          </div>
+        </SheetHeader>
+
+        {/* Body — scrollable list of grouped cards. Each group is a bordered
+            card with an uppercase eyebrow header + a divide-y body, mirroring
+            the ListCard vocabulary used across the v2 surfaces. */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {totalCount === 0 ? (
+            <div className="text-muted-foreground flex flex-col items-center gap-1 rounded-md border border-dashed py-10 text-sm">
+              <span className="font-medium">No shortcuts registered</span>
+              <span className="text-xs">
+                Pages register shortcuts as they mount.
+              </span>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {grouped.map(([group, items]) => (
+                <section
+                  key={group}
+                  className="bg-card overflow-hidden rounded-md border"
+                >
+                  <header className="bg-muted/30 flex items-baseline justify-between gap-2 border-b px-3 py-2">
+                    <h3 className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
+                      {group}
+                    </h3>
+                    <span className="text-muted-foreground/70 text-[10px] tabular-nums">
+                      {items.length}
+                    </span>
+                  </header>
+                  <ul className="divide-border/70 divide-y">
+                    {items.map((s) => (
+                      <li
+                        key={s.id}
+                        className="hover:bg-muted/40 flex items-center justify-between gap-4 px-3 py-2 transition-colors"
+                      >
+                        <span className="text-foreground text-sm">
+                          {s.label}
+                        </span>
+                        <KbdGroup>
+                          {s.keys.map((k) => (
+                            <Kbd key={k}>{displayKey(k)}</Kbd>
+                          ))}
+                        </KbdGroup>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer — thin action strip matching the cmdk footer vocabulary so
+            the two overlays feel like siblings. */}
+        <div className="bg-muted/30 text-muted-foreground flex items-center justify-between gap-3 border-t px-5 py-2.5 text-[11px]">
+          <span className="inline-flex items-center gap-1.5">
+            <KbdGroup>
+              <Kbd className="bg-background/80">⇧</Kbd>
+              <Kbd className="bg-background/80">?</Kbd>
+            </KbdGroup>
+            Toggle this sheet
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Kbd className="bg-background/80">esc</Kbd>
+            Close
+          </span>
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary
- Header gets the icon-tile lockup used by StatusPanel / EmptyState / SectionCard, so the sheet reads as a first-class v2 surface instead of a stock shadcn Sheet.
- Group rows move into bordered cards with an uppercase eyebrow header + count + divide-y rows + subtle hover — mirroring the ListCard vocabulary used across the rest of v2.
- Footer adds a thin Esc / shift-? action strip that matches the cmdk footer, so the shortcut sheet and command palette read as siblings.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/0w1lj8qgvk.jpg) | ![after](https://i.img402.dev/dguxhn5koy.jpg) |

## Notes
- Empty-state added for the no-shortcuts-registered case (paranoia — in practice Global always registers at least cmd+K and shift+?).
- No drift unified; no new shared primitive — the inline cards are tiny and tightly coupled to the sheet's chrome. If we ever want a second sheet to adopt the icon-tile-header pattern, promote the inner shell into a `<DetailSheetHeader>`.

Generated with Claude Code