### PR TITLE
design(v2): extract DetailSheetHeader primitive

### DIFF
--- a/web/src/components/detail-sheet-header.tsx
+++ b/web/src/components/detail-sheet-header.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Eyebrow } from "@/components/eyebrow";
+import { cn } from "@/lib/utils";
+
+interface DetailSheetHeaderProps {
+  /**
+   * Lucide icon component rendered inside the leading icon tile. The tile uses
+   * the same `bg-muted text-muted-foreground rounded-lg border` vocabulary as
+   * `StatusPanel`, `EmptyState`, and `SectionCard` so every v2 Sheet reads as
+   * part of the system instead of a stock shadcn surface.
+   */
+  icon: React.ComponentType<{ className?: string }>;
+  /** Optional uppercase eyebrow above the title (e.g. "New connection"). */
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /**
+   * Visual density. `default` is the lighter shortcut-sheet rhythm
+   * (`size-9` tile + `p-5` + base title); `accent` is the heavier
+   * Connect-bank rhythm (`size-10` tile + `bg-muted/20 p-6` + `text-lg`
+   * title) used by the primary flow Sheets. Both share the icon-tile lockup
+   * + title/description stack.
+   */
+  density?: "default" | "accent";
+  /** Optional trailing slot (e.g. status pill, badge). */
+  trailing?: React.ReactNode;
+  className?: string;
+}
+
+// DetailSheetHeader is the canonical icon-tile header for v2 Sheets. The
+// shape — leading icon tile + optional eyebrow + title + description — was
+// established by `ShortcutSheet` (iter 39) and adopted again by
+// `ConnectBankSheet` (iter 40); promoted into a shared primitive in iter 41
+// once two consumers shared it. Don't fork the lockup — pass `density` and
+// `trailing` rather than re-opening `<SheetHeader>` inline.
+//
+// Visual contract:
+//   <SheetHeader class="gap-3 border-b {p-5|bg-muted/20 p-6}">
+//     row: icon-tile (size-9|10 rounded-lg bg-muted border)
+//        + (eyebrow ↳ title ↳ description) column
+//        + optional trailing slot
+export function DetailSheetHeader({
+  icon: Icon,
+  eyebrow,
+  title,
+  description,
+  density = "default",
+  trailing,
+  className,
+}: DetailSheetHeaderProps) {
+  const isAccent = density === "accent";
+  return (
+    <SheetHeader
+      className={cn(
+        "gap-3 border-b",
+        isAccent ? "bg-muted/20 p-6" : "p-5",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden
+          className={cn(
+            "bg-muted text-muted-foreground flex shrink-0 items-center justify-center rounded-lg border",
+            isAccent ? "size-10" : "size-9",
+          )}
+        >
+          <Icon className={isAccent ? "size-5" : "size-4"} />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {eyebrow ? <Eyebrow as="p">{eyebrow}</Eyebrow> : null}
+          <SheetTitle
+            className={cn(
+              "leading-tight",
+              isAccent ? "text-lg font-semibold" : "text-base",
+            )}
+          >
+            {title}
+          </SheetTitle>
+          {description ? (
+            <SheetDescription
+              className={cn(isAccent ? "text-sm" : "mt-0.5 text-xs")}
+            >
+              {description}
+            </SheetDescription>
+          ) : null}
+        </div>
+        {trailing ? (
+          <div className="ms-2 flex shrink-0 items-start">{trailing}</div>
+        ) : null}
+      </div>
+    </SheetHeader>
+  );
+}

--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -1,12 +1,7 @@
 import * as React from "react";
 import { Keyboard } from "lucide-react";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { displayKey } from "@/lib/kbd-display";
 import {
@@ -71,28 +66,19 @@ export function ShortcutSheet() {
         // sticky footer sits flush against the panel edge.
         className="w-full gap-0 p-0 sm:max-w-md"
       >
-        {/* Header — mirrors the icon-tile vocabulary used by StatusPanel /
-            EmptyState / SectionCard so the sheet reads as part of the v2
-            system, not an ad-hoc overlay. */}
-        <SheetHeader className="gap-3 border-b p-5">
-          <div className="flex items-start gap-3">
-            <span
-              className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-lg border"
-              aria-hidden
-            >
-              <Keyboard className="size-4" />
-            </span>
-            <div className="min-w-0 flex-1">
-              <SheetTitle className="text-base leading-tight">
-                Keyboard shortcuts
-              </SheetTitle>
-              <SheetDescription className="mt-0.5 text-xs">
-                Available across the app. Shortcuts pause while you&apos;re
-                typing in an input.
-              </SheetDescription>
-            </div>
-          </div>
-        </SheetHeader>
+        {/* Header — `DetailSheetHeader` mirrors the icon-tile vocabulary used
+            by StatusPanel / EmptyState / SectionCard so the sheet reads as
+            part of the v2 system, not an ad-hoc overlay. */}
+        <DetailSheetHeader
+          icon={Keyboard}
+          title="Keyboard shortcuts"
+          description={
+            <>
+              Available across the app. Shortcuts pause while you&apos;re
+              typing in an input.
+            </>
+          }
+        />
 
         {/* Body — scrollable list of grouped cards. Each group is a bordered
             card with an uppercase eyebrow header + a divide-y body, mirroring

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -1,13 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { Building2, Landmark, Loader2 } from "lucide-react";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -17,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Eyebrow } from "@/components/eyebrow";
+import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { StatusPanel } from "@/components/status-panel";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
@@ -267,30 +262,13 @@ export function ConnectBankSheet({
   return (
     <Sheet open={open} onOpenChange={handleSheetChange}>
       <SheetContent className="flex flex-col gap-0 p-0">
-        <SheetHeader className="bg-muted/20 border-b p-6">
-          <div className="flex items-start gap-3">
-            <span
-              aria-hidden
-              className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg border"
-            >
-              {(() => {
-                const Icon = headerIcon;
-                return <Icon className="size-5" />;
-              })()}
-            </span>
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <Eyebrow as="p">
-                {appendToConnectionId ? "Append rows" : "New connection"}
-              </Eyebrow>
-              <SheetTitle className="text-lg font-semibold leading-tight">
-                {headerTitle}
-              </SheetTitle>
-              <SheetDescription className="text-sm">
-                {headerDescription}
-              </SheetDescription>
-            </div>
-          </div>
-        </SheetHeader>
+        <DetailSheetHeader
+          density="accent"
+          icon={headerIcon}
+          eyebrow={appendToConnectionId ? "Append rows" : "New connection"}
+          title={headerTitle}
+          description={headerDescription}
+        />
 
         <div className="flex flex-1 flex-col overflow-y-auto p-6">
           {stage.kind === "pick" && (

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -8,7 +8,9 @@ import {
   CheckCircle2,
   Inbox,
   Info,
+  Keyboard,
   KeyRound,
+  Landmark,
   MessageSquare,
   Monitor,
   Moon,
@@ -53,6 +55,7 @@ import { ColorRailCard } from "@/components/color-rail-card";
 import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
+import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
@@ -320,6 +323,38 @@ export function ComponentsSection() {
             <p className="text-muted-foreground mt-1 text-xs">
               hero variant — sits under a display title with extra letter air
             </p>
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="DetailSheetHeader"
+        code="components/detail-sheet-header"
+        description="The canonical icon-tile header for v2 Sheets — leading muted-tile icon + optional eyebrow + title + description. Same lockup vocabulary as StatusPanel / EmptyState / SectionCard so every Sheet reads as part of the v2 system, not a stock shadcn surface. Two density tokens: `default` (size-9 tile + p-5, used by ShortcutSheet for ambient overlays) and `accent` (size-10 tile + bg-muted/20 + p-6, used by ConnectBankSheet for primary flows). Don't open `<SheetHeader>` inline for a new Sheet — extend this primitive instead."
+        className="block"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="bg-card overflow-hidden rounded-lg border">
+            <div className="text-muted-foreground border-b px-3 py-2 text-[11px] tracking-wide uppercase">
+              default · ambient overlay
+            </div>
+            <DetailSheetHeader
+              icon={Keyboard}
+              title="Keyboard shortcuts"
+              description="Available across the app. Shortcuts pause while you're typing in an input."
+            />
+          </div>
+          <div className="bg-card overflow-hidden rounded-lg border">
+            <div className="text-muted-foreground border-b px-3 py-2 text-[11px] tracking-wide uppercase">
+              accent · primary flow
+            </div>
+            <DetailSheetHeader
+              density="accent"
+              icon={Landmark}
+              eyebrow="New connection"
+              title="Connect a bank"
+              description="Pick a provider and the family member this connection belongs to."
+            />
           </div>
         </div>
       </Specimen>

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -8,9 +8,7 @@ import {
   CheckCircle2,
   Inbox,
   Info,
-  Keyboard,
   KeyRound,
-  Landmark,
   MessageSquare,
   Monitor,
   Moon,
@@ -55,7 +53,6 @@ import { ColorRailCard } from "@/components/color-rail-card";
 import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
-import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
@@ -323,38 +320,6 @@ export function ComponentsSection() {
             <p className="text-muted-foreground mt-1 text-xs">
               hero variant — sits under a display title with extra letter air
             </p>
-          </div>
-        </div>
-      </Specimen>
-
-      <Specimen
-        label="DetailSheetHeader"
-        code="components/detail-sheet-header"
-        description="The canonical icon-tile header for v2 Sheets — leading muted-tile icon + optional eyebrow + title + description. Same lockup vocabulary as StatusPanel / EmptyState / SectionCard so every Sheet reads as part of the v2 system, not a stock shadcn surface. Two density tokens: `default` (size-9 tile + p-5, used by ShortcutSheet for ambient overlays) and `accent` (size-10 tile + bg-muted/20 + p-6, used by ConnectBankSheet for primary flows). Don't open `<SheetHeader>` inline for a new Sheet — extend this primitive instead."
-        className="block"
-      >
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="bg-card overflow-hidden rounded-lg border">
-            <div className="text-muted-foreground border-b px-3 py-2 text-[11px] tracking-wide uppercase">
-              default · ambient overlay
-            </div>
-            <DetailSheetHeader
-              icon={Keyboard}
-              title="Keyboard shortcuts"
-              description="Available across the app. Shortcuts pause while you're typing in an input."
-            />
-          </div>
-          <div className="bg-card overflow-hidden rounded-lg border">
-            <div className="text-muted-foreground border-b px-3 py-2 text-[11px] tracking-wide uppercase">
-              accent · primary flow
-            </div>
-            <DetailSheetHeader
-              density="accent"
-              icon={Landmark}
-              eyebrow="New connection"
-              title="Connect a bank"
-              description="Pick a provider and the family member this connection belongs to."
-            />
           </div>
         </div>
       </Specimen>


### PR DESCRIPTION
## Summary

- Extracts the icon-tile Sheet header lockup (icon-tile + optional eyebrow + title + description) shared by ShortcutSheet (iter 39) and ConnectBankSheet (iter 40) into a shared primitive at `web/src/components/detail-sheet-header.tsx`.
- Two density tokens — `default` (size-9 tile + p-5, ambient overlays) and `accent` (size-10 tile + bg-muted/20 + p-6, primary flows) — so both rhythms live in one place.
- Both consumers now route through the primitive.

## After

| Connect-bank (`accent`) | Shortcut sheet (`default`) |
| --- | --- |
| ![connect-bank](https://i.img402.dev/ju7b3y6emq.jpg) | ![shortcut-sheet](https://i.img402.dev/xen7jm10z3.jpg) |

## Notes

- 14th shared primitive in the v2 vocabulary. New Sheets should reach for `<DetailSheetHeader>` rather than open `<SheetHeader>` inline.
- `reauth-sheet` and `link-account-sheet` use different header shapes (no icon-tile lockup) and stay open-coded — promote if a third Sheet adopts the lockup with a yet-different rhythm.
- No sandbox specimen: `SheetTitle` / `SheetDescription` are radix-Dialog-context-bound, so the primitive can't render standalone in `/v2/sandbox`. The live consumers carry the visual reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
