### PR TITLE
design(v2) iter 43: sweep api-key-form onto FormFooter primitive

### DIFF
--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { FormFooter } from "@/components/form-footer";
 import { cn } from "@/lib/utils";
 import { useCreateAPIKey } from "@/api/queries/api-keys";
 import { storePendingPlaintextKey } from "@/features/api-keys/plaintext-store";
@@ -245,21 +246,25 @@ export function APIKeyForm() {
           )}
         />
 
-        <div className="bg-muted/20 -mx-5 -mb-5 flex items-center justify-end gap-2 border-t px-5 py-3">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate({ to: "/api-keys" })}
-            disabled={create.isPending}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" size="sm" disabled={create.isPending}>
-            {create.isPending && <Loader2 className="size-4 animate-spin" />}
-            {create.isPending ? "Creating…" : "Create key"}
-          </Button>
-        </div>
+        <FormFooter
+          secondary={
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate({ to: "/api-keys" })}
+              disabled={create.isPending}
+            >
+              Cancel
+            </Button>
+          }
+          primary={
+            <Button type="submit" size="sm" disabled={create.isPending}>
+              {create.isPending && <Loader2 className="size-4 animate-spin" />}
+              {create.isPending ? "Creating…" : "Create key"}
+            </Button>
+          }
+        />
       </form>
     </Form>
   );


### PR DESCRIPTION
## Summary
- Retires the last hand-rolled flush bordered action strip in v2: the api-key-form footer now uses the canonical `<FormFooter>` primitive established in iter 15 (#1128).
- Closes the explicit drift TODO in the sprint state ("api-key-form still hand-rolls the same strip — sweep onto `<FormFooter>` next time we touch api-key-form").
- All four canonical form pages — tag-new, category-new, api-key-new, plus the edit variants — now share the same Cancel-left + primary-right rhythm with leading `<Loader2>` spinner.

## Visual diff
Pure markup unification — no pixel diff. The bespoke `<div className="bg-muted/20 -mx-5 -mb-5 ...">` was the literal vocabulary `<FormFooter>` codifies (same classes, same children, same SectionCard host).

```diff
- <div className="bg-muted/20 -mx-5 -mb-5 flex items-center justify-end gap-2 border-t px-5 py-3">
-   <Button type="button" variant="ghost" size="sm" ...>Cancel</Button>
-   <Button type="submit" size="sm" disabled={...}>
-     {pending && <Loader2 className="size-4 animate-spin" />}
-     {pending ? "Creating…" : "Create key"}
-   </Button>
- </div>
+ <FormFooter
+   secondary={<Button type="button" variant="ghost" size="sm" ...>Cancel</Button>}
+   primary={
+     <Button type="submit" size="sm" disabled={...}>
+       {pending && <Loader2 className="size-4 animate-spin" />}
+       {pending ? "Creating…" : "Create key"}
+     </Button>
+   }
+ />
```

The `flex-wrap` class FormFooter adds (vs. the bespoke `flex`) only kicks in if the strip overflows its host — at 1440 desktop both render identically.

## Notes
- Local CI: `bun run lint` + `go build ./...` both green.
- Sprint state's iter-13 / iter-15 drift entries can now drop their "api-key-form still hand-rolls" sweep TODO — resolved this iter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
