### PR TITLE
design(v2): boost dark-mode checkbox visibility

### DIFF
--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -12,7 +12,14 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        // Dark mode bumps: stock shadcn's `border-input` + `dark:bg-input/30`
+        // is barely visible against `bg-card` (oklch 0.205) because
+        // `--input` is `oklch(1 0 0 / 15%)` and 30% of that is ~4.5% white.
+        // We override both the border (white / 30%) and the unchecked fill
+        // (white / 8%) so unchecked rows in dark mode read as "this is a
+        // checkbox, not a hairline". Checked state keeps the stock
+        // `bg-primary` accent.
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:border-white/25 dark:bg-white/[0.04] dark:hover:bg-white/[0.07] dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:border-primary dark:data-[state=checked]:bg-primary",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Stock shadcn's `border-input` + `dark:bg-input/30` makes unchecked checkboxes nearly invisible in v2's dark palette: `--input` is `oklch(1 0 0 / 15%)`, so 30% of that fill renders at ~4.5% white — indistinguishable from `bg-card` at oklch 0.205. The border at 15% is similarly weak.

Override `dark:` unchecked-state with `border-white/25` + `bg-white/[0.04]` (hover `bg-white/[0.07]`) so list-select rows (connections / accounts / TX) and form checkboxes (`Exclude from sync` on account-detail) read as actual checkboxes rather than hairlines.

Light mode untouched. Checked state keeps the stock `bg-primary` accent — selection vocabulary unchanged.

## Before / After (dark mode, Connections list — unchecked rows)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/me0vulfei8.jpg) | ![after](https://i.img402.dev/l7van29eye.jpg) |

After + checked-state (confirming selection vocabulary unchanged):

![checked](https://i.img402.dev/9n4l0qfund.jpg)

## Notes

- First iteration of a dark-mode spot-check on shared primitives. Other primitives audited in dark this pass and verified clean: Eyebrow, ListRowSkeleton, ColorRailCard (when carrying a meaningful color), SectionCard, ListCard, StatusPanel, FormFooter, DetailSheetHeader, Home ColorRailCard hero, sandbox.
- The visual lift here is real but subtle at desktop crop — the border-only diff between 15% and 25% white is most noticeable when comparing the empty row checkboxes side-by-side. The win is contrast: the new unchecked square now reads as a control at a glance instead of vanishing into the row.
- Open follow-up for the backlog: `ColorRailCard` collapses to `var(--muted)` when no accent is provided (TX-detail uncategorised hero). At dark `--muted = oklch(0.269)` the rail is technically visible but barely. If a fourth surface ships an uncategorised hero, consider bumping the muted-rail rendering — single consumer for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
