### PR TITLE
design(v2): boost dark-mode visibility for Input/Textarea/Select/RadioGroup

### DIFF
--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -8,7 +8,12 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        // Dark-mode border bump: stock `border-input` is `oklch(1 0 0 / 15%)`
+        // which over `bg-card` reads as a barely-there hairline. Bumping to
+        // `dark:border-white/20` (and `/30` on hover) makes the field
+        // outline legible without competing with focus. The fill stays
+        // at `dark:bg-input/30` so unfocused fields read soft, not loud.
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30 dark:border-white/20 dark:hover:border-white/30",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className

--- a/web/src/components/ui/radio-group.tsx
+++ b/web/src/components/ui/radio-group.tsx
@@ -25,7 +25,14 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        // Dark-mode parity with the checkbox fix from iter 45:
+        // stock `border-input` + `dark:bg-input/30` is ~4.5% white
+        // over `bg-card`, so unchecked radios read as hairline dots.
+        // Bump the border to white/25 and the dish fill to
+        // white/[0.04] (hover white/[0.07]) so unchecked items are
+        // legible. Checked state keeps the stock `text-primary` +
+        // filled dot.
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:border-white/25 dark:bg-white/[0.04] dark:hover:bg-white/[0.07] dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -35,7 +35,13 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        // Dark-mode border bump matches Input + Textarea: stock
+        // `border-input` (`oklch(1 0 0 / 15%)`) is a hairline over
+        // `bg-card`. `dark:border-white/20` (hover `/30`) makes the
+        // closed-state trigger outline legible. Fill keeps the stock
+        // `dark:bg-input/30 dark:hover:bg-input/50` rhythm so the
+        // hover feedback is unchanged.
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:border-white/20 dark:hover:border-white/30 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -7,7 +7,11 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        // Dark-mode border bump matches the Input primitive: stock
+        // `border-input` (`oklch(1 0 0 / 15%)`) is a hairline over
+        // `bg-card`. `dark:border-white/20` + `dark:hover:border-white/30`
+        // makes the textarea outline legible. Fill stays soft.
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:border-white/20 dark:hover:border-white/30 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -7,6 +7,13 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Card,
   CardContent,
   CardDescription,
@@ -189,6 +196,38 @@ export function PrimitivesSection() {
             <RadioGroupItem value="disabled" disabled /> Disabled
           </Label>
         </RadioGroup>
+      </Specimen>
+
+      <Specimen label="Select" className="block">
+        <div className="flex flex-wrap items-center gap-3">
+          <Select defaultValue="full">
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Pick a scope" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="full">Full access</SelectItem>
+              <SelectItem value="read">Read only</SelectItem>
+              <SelectItem value="none">None</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select>
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Placeholder" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="a">Option A</SelectItem>
+              <SelectItem value="b">Option B</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select disabled>
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Disabled" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="x">Unused</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </Specimen>
 
       <Specimen label="Card" className="block">


### PR DESCRIPTION
## Summary

Extends iter 45's checkbox fix to the rest of the form primitives. Stock shadcn's `border-input` is `oklch(1 0 0 / 15%)` — at ~4.5% white over `bg-card` (oklch 0.205) the border reads as a hairline, and for the tiny RadioGroup dish the unchecked state is essentially invisible.

- **Input / Textarea / Select**: keep the soft `dark:bg-input/30` fill, bump border to `dark:border-white/20` with hover `/30`.
- **RadioGroup**: matches the iter-45 checkbox recipe — `dark:border-white/25` + `dark:bg-white/[0.04]` (hover `/[0.07]`). The unchecked dish now reads as a clear circle instead of a faint dot.
- **Sandbox**: add a Select specimen (placeholder / chosen / disabled variants) so the primitives section covers the full form-control surface and future dark-mode regressions are caught at a glance.

Light mode untouched. Checked / focus / aria-invalid vocabulary unchanged.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/oxf8977sfg.jpg) | ![after](https://i.img402.dev/03wjh7k1s4.jpg) |

Notice the after frame: Email + Disabled inputs now have a crisp outline, the Note textarea reads as a real field, all three Select triggers (Full access / Placeholder / Disabled) are visible at rest, and the unchecked RadioGroup items (Read only, Disabled) are recognizable circles rather than ghosts.

## Notes

- Drift swept: this closes the iter-45 follow-up ("first iteration of the dark-mode spot-check on shared primitives"). All form-primitive borders now read in dark mode without leaning on focus to spot the field.
- Live consumers benefiting today: every form in the SPA (api-key-form's scope/mode radios; tag-form / category-form / connect-bank-sheet / link-account-sheet / rule-form inputs + selects).
- Select specimen now lives in the sandbox primitives section so the next dark-mode regression check picks it up automatically — previously it was a blind spot.

Generated with [Claude Code](https://claude.com/claude-code)