### PR TITLE
design(v2): merge CsvFooterStrip into FormFooter (inset="sheet")

### DIFF
--- a/web/src/components/form-footer.tsx
+++ b/web/src/components/form-footer.tsx
@@ -1,56 +1,73 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+type FormFooterInset = "card" | "sheet";
+
 interface FormFooterProps {
-  /** Primary action — submit button (right). */
-  primary: React.ReactNode;
+  /**
+   * Primary action — submit button (right). Optional so the footer can host
+   * a single Cancel-only state (e.g. the CSV drop stage, where the user
+   * hasn't picked a file yet).
+   */
+  primary?: React.ReactNode;
   /** Secondary action — typically Cancel (left of primary). */
   secondary?: React.ReactNode;
   /** Optional helper text rendered left-aligned (e.g. validation hint). */
   hint?: React.ReactNode;
+  /**
+   * Which container is the strip flushing to?
+   * - `"card"` (default) — inside a `<SectionCard>` body (`px-5 py-5`);
+   *   the strip negates to `-mx-5 -mb-5` so the muted footer lines up with
+   *   the card border.
+   * - `"sheet"` — inside a `<Sheet>` body (`p-6`); the strip negates to
+   *   `-mx-6 -mb-6` and uses `mt-auto` so it sticks to the Sheet bottom
+   *   when the form body is short.
+   */
+  inset?: FormFooterInset;
   className?: string;
 }
 
 // FormFooter renders the canonical flush bordered action strip at the bottom
-// of a `<SectionCard>` that wraps a form. Established in iter 13 on
-// api-key-new (`features/api-keys/api-key-form.tsx`); the iter-13 drift
-// note explicitly queued promotion to a primitive once a second/third form
-// adopts it. Iter 15 brings tag-form and category-form onto the pattern, so
-// it lives here.
+// of a form container. Established in iter 13 on api-key-new
+// (`features/api-keys/api-key-form.tsx`); promoted in iter 15 once
+// tag-form + category-form adopted it.
 //
 // Visual contract:
-//   `<div className="bg-muted/20 -mx-5 -mb-5 flex items-center justify-end
-//                    gap-2 border-t px-5 py-3">`
+//   `<div className="bg-muted/20 flex items-center justify-end gap-2
+//                    border-t px-{INSET} py-3 -mx-{INSET} -mb-{INSET}">`
 //
-// The negative margins (`-mx-5 -mb-5`) push the strip out to the SectionCard
-// body's edges so the top border lines up with the card's outer border and
-// the action strip reads as a footer of the card, not as floating content.
-// Drop it inside a SectionCard with the default `bodyClassName="px-5 py-5"` —
-// the body's `py-5` (20px) supplies the breathing room above the strip; no
-// extra `mt-*` is needed (and adding one re-introduces a sliver of plain
-// card background above the muted footer, breaking the flush look).
+// The negative margins push the strip out to the parent container's edges
+// so the top border lines up with the outer border and the action strip
+// reads as a footer of the container, not as floating content. Iter 49
+// folded the iter-48 `CsvFooterStrip` into here as the `inset="sheet"`
+// variant — same visual vocabulary, different padding scale.
 //
-// Don't fork the look — change this primitive instead.
+// Don't fork the look — extend this primitive (add an inset variant) when a
+// new form container shape needs a flush footer.
 export function FormFooter({
   primary,
   secondary,
   hint,
+  inset = "card",
   className,
 }: FormFooterProps) {
   return (
     <div
       className={cn(
-        "bg-muted/20 -mx-5 -mb-5 flex flex-wrap items-center justify-end gap-2 border-t px-5 py-3",
+        "bg-muted/20 flex flex-wrap items-center justify-end gap-2 border-t",
+        inset === "card"
+          ? "-mx-5 -mb-5 px-5 py-3"
+          : "-mx-6 -mb-6 mt-auto px-6 py-3",
         hint && "sm:justify-between",
         className,
       )}
     >
       {hint && (
-        <div className="text-muted-foreground order-last text-xs sm:order-first">
+        <div className="text-muted-foreground order-last min-w-0 text-xs sm:order-first">
           {hint}
         </div>
       )}
-      <div className="flex items-center gap-2">
+      <div className="ml-auto flex items-center gap-2">
         {secondary}
         {primary}
       </div>

--- a/web/src/features/connections/csv-import-form.tsx
+++ b/web/src/features/connections/csv-import-form.tsx
@@ -29,6 +29,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Eyebrow } from "@/components/eyebrow";
+import { FormFooter } from "@/components/form-footer";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import {
@@ -231,16 +232,19 @@ function CsvDropStage({
         </span>
       </div>
 
-      <CsvFooterStrip>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onCancel}
-          disabled={loading}
-        >
-          Cancel
-        </Button>
-      </CsvFooterStrip>
+      <FormFooter
+        inset="sheet"
+        secondary={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onCancel}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+        }
+      />
     </div>
   );
 }
@@ -577,7 +581,8 @@ function CsvMapStage({
         </Alert>
       )}
 
-      <CsvFooterStrip
+      <FormFooter
+        inset="sheet"
         hint={
           validation ? null : (
             <span className="text-muted-foreground text-xs">
@@ -589,52 +594,28 @@ function CsvMapStage({
             </span>
           )
         }
-      >
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onBack}
-          disabled={importing}
-        >
-          <ArrowLeft className="size-3.5" />
-          Different file
-        </Button>
-        <Button
-          size="sm"
-          onClick={() => onImport(buildImportInput())}
-          disabled={!!validation || importing}
-        >
-          {importing ? <Loader2 className="size-3.5 animate-spin" /> : null}
-          Import {preview.total_rows} rows
-        </Button>
-      </CsvFooterStrip>
-    </div>
-  );
-}
-
-// CsvFooterStrip is the bottom action strip for the CSV form. The form
-// lives inside the Connect-bank Sheet body (`p-6`) rather than a
-// SectionCard, so we can't reuse `<FormFooter>` directly — its negative
-// margins assume the SectionCard `px-5 py-5` contract. Instead we mirror
-// the same visual vocabulary (`bg-muted/20` strip, top border, flush to
-// the parent container edges via `-mx-6 -mb-6 px-6 py-3`) so the action
-// row reads as a footer of the Sheet, not floating content.
-function CsvFooterStrip({
-  children,
-  hint,
-}: {
-  children: React.ReactNode;
-  hint?: React.ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "bg-muted/20 -mx-6 -mb-6 mt-auto flex flex-wrap items-center gap-2 border-t px-6 py-3",
-        hint ? "justify-between" : "justify-end",
-      )}
-    >
-      {hint && <div className="min-w-0">{hint}</div>}
-      <div className="ml-auto flex items-center gap-2">{children}</div>
+        secondary={
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onBack}
+            disabled={importing}
+          >
+            <ArrowLeft className="size-3.5" />
+            Different file
+          </Button>
+        }
+        primary={
+          <Button
+            size="sm"
+            onClick={() => onImport(buildImportInput())}
+            disabled={!!validation || importing}
+          >
+            {importing ? <Loader2 className="size-3.5 animate-spin" /> : null}
+            Import {preview.total_rows} rows
+          </Button>
+        }
+      />
     </div>
   );
 }

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -458,29 +458,67 @@ export function ComponentsSection() {
       <Specimen
         label="FormFooter"
         code="components/form-footer"
-        description="The flush bordered action strip at the bottom of a `<SectionCard>` that wraps a form. Sticks Cancel left, primary right; optional `hint` slot for an inline validation note. Drop inside a `SectionCard` with default body padding — negative margins line the strip up with the card's outer border."
+        description="The flush bordered action strip at the bottom of a form container. Cancel sits left, primary right; optional `hint` slot for an inline validation note. Two insets — `card` (default) flushes to a `<SectionCard>` body (px-5 py-5), `sheet` flushes to a `<Sheet>` body (p-6) and uses `mt-auto` so it sticks to the Sheet bottom. Iter 49 folded the CSV form's bespoke footer onto the `sheet` variant."
         className="block"
       >
-        <div className="max-w-md">
-          <SectionCard title="Edit tag">
-            <div className="grid gap-1.5">
-              <Label htmlFor="sb-form-name">Display name</Label>
-              <Input id="sb-form-name" defaultValue="Reimbursable" />
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div>
+            <div className="text-muted-foreground mb-2 text-[11px] tracking-wide uppercase">
+              inset · card (inside SectionCard)
             </div>
-            <FormFooter
-              hint="Slug is generated automatically from the name."
-              secondary={
-                <Button variant="outline" size="sm">
-                  Cancel
-                </Button>
-              }
-              primary={
-                <Button size="sm">
-                  <Save /> Save changes
-                </Button>
-              }
-            />
-          </SectionCard>
+            <SectionCard title="Edit tag">
+              <div className="grid gap-1.5">
+                <Label htmlFor="sb-form-name">Display name</Label>
+                <Input id="sb-form-name" defaultValue="Reimbursable" />
+              </div>
+              <FormFooter
+                hint="Slug is generated automatically from the name."
+                secondary={
+                  <Button variant="outline" size="sm">
+                    Cancel
+                  </Button>
+                }
+                primary={
+                  <Button size="sm">
+                    <Save /> Save changes
+                  </Button>
+                }
+              />
+            </SectionCard>
+          </div>
+          <div>
+            <div className="text-muted-foreground mb-2 text-[11px] tracking-wide uppercase">
+              inset · sheet (inside a Sheet body)
+            </div>
+            <div className="bg-card flex min-h-[200px] flex-col rounded-lg border p-6">
+              <p className="text-muted-foreground text-sm">
+                Mock Sheet body — the footer below flushes to the surrounding{" "}
+                <code className="bg-muted/60 rounded px-1 font-mono text-[11px]">
+                  p-6
+                </code>{" "}
+                edges and uses <code className="bg-muted/60 rounded px-1 font-mono text-[11px]">mt-auto</code>{" "}
+                so it sticks to the bottom of the Sheet.
+              </p>
+              <FormFooter
+                inset="sheet"
+                hint={
+                  <span className="text-muted-foreground text-xs">
+                    Ready to import{" "}
+                    <span className="text-foreground tabular-nums font-medium">
+                      241
+                    </span>{" "}
+                    rows.
+                  </span>
+                }
+                secondary={
+                  <Button variant="ghost" size="sm">
+                    Different file
+                  </Button>
+                }
+                primary={<Button size="sm">Import 241 rows</Button>}
+              />
+            </div>
+          </div>
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary

Iter 48 left a near-duplicate `CsvFooterStrip` helper inside the CSV import form because `FormFooter`'s `-mx-5 -mb-5` contract assumed a SectionCard host while the Connect-bank Sheet uses `p-6`. Iter 49 folds them back into one primitive.

- `FormFooter` now takes an `inset` prop: `"card"` (default, SectionCard body) and `"sheet"` (Sheet body — `-mx-6 -mb-6` + `mt-auto`).
- `primary` is now optional so the CSV drop stage can ship Cancel-only.
- Both CsvFooterStrip call-sites migrate; the local helper is deleted.
- Sandbox specimen shows both insets side-by-side so future dark-mode / density sweeps catch them automatically.

Net: -97 / +133 LOC, one less drift candidate, single source of truth for the muted bordered action-strip vocabulary.

## Before / After

Sandbox FormFooter specimen — before only the card-inset variant existed; after, both insets render side-by-side so the next sweep catches both.

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/biplxb6ig2.jpg) | ![after](https://i.img402.dev/l0txlsagw7.jpg) |

## Notes

- Five surfaces / form families share `FormFooter` after the sweep (tag-form, category-form, api-key-form, both stages of csv-import-form).
- The iter-48 drift TODO ("Don't promote yet; promote when a second non-SectionCard form needs the same flush strip") was conservative — collapsing it now keeps the design-system surface area smaller and prevents any future Sheet-hosted form from forking the same bespoke strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)