### PR TITLE
design(v2): size tokens for CategoryBadge + TagChip; retire rule-display fork

### DIFF
--- a/web/src/components/category-badge.tsx
+++ b/web/src/components/category-badge.tsx
@@ -7,8 +7,21 @@ interface CategoryBadgeProps {
   category: TransactionCategory | null | undefined;
   /** Show a subtle ring when the category was set by a manual override. */
   overridden?: boolean;
+  /**
+   * Visual density.
+   * - `sm` — table rows / dense list cells
+   * - `md` — default; detail page Hero, pickers, sandbox surfaces
+   */
+  size?: "sm" | "md";
   className?: string;
 }
+
+// Per-size token recipe. Kept inline so the size axis is grep-able alongside
+// TagChip's matching recipe — if one shifts the other should too.
+const SIZE: Record<"sm" | "md", string> = {
+  sm: "h-5 px-1.5 text-[11px] gap-0.5 [&>svg]:size-2.5",
+  md: "h-6 px-2 text-xs gap-1 [&>svg]:size-3",
+};
 
 // CategoryBadge is the single rendering of a transaction category across v2 —
 // list rows, the detail page, pickers. Icon + display name, tinted by the
@@ -17,6 +30,7 @@ interface CategoryBadgeProps {
 export function CategoryBadge({
   category,
   overridden,
+  size = "md",
   className,
 }: CategoryBadgeProps) {
   if (!category?.display_name) {
@@ -28,7 +42,8 @@ export function CategoryBadge({
     <Badge
       variant="secondary"
       className={cn(
-        "gap-1 rounded-md",
+        "rounded-md",
+        SIZE[size],
         overridden && "ring-1 ring-primary/40",
         className,
       )}
@@ -36,7 +51,6 @@ export function CategoryBadge({
       {category.icon && (
         <DynamicIcon
           name={category.icon}
-          className="size-3"
           style={category.color ? { color: category.color } : undefined}
         />
       )}

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -53,10 +53,17 @@ export function CategoryPicker({
           )}
         >
           {category?.display_name ? (
-            <CategoryBadge category={category} overridden={overridden} />
+            <CategoryBadge
+              category={category}
+              overridden={overridden}
+              size="sm"
+            />
           ) : (
-            <span className="text-muted-foreground border-border hover:text-foreground inline-flex items-center gap-1 rounded-md border border-dashed px-2 py-0.5 text-xs">
-              <Plus className="size-3" />
+            // Empty-state pill mirrors the sm CategoryBadge geometry (h-5,
+            // text-[11px], rounded-md) so the column doesn't shift when the
+            // user assigns or clears a category from the row.
+            <span className="text-muted-foreground border-border hover:text-foreground inline-flex h-5 items-center gap-0.5 rounded-md border border-dashed px-1.5 text-[11px]">
+              <Plus className="size-2.5" />
               Category
             </span>
           )}

--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -12,27 +12,43 @@ interface TagChipProps {
   tag: TagLike;
   /** When set, renders a remove (×) button that calls this on click. */
   onRemove?: () => void;
+  /**
+   * Visual density.
+   * - `sm` — table rows / dense list cells (parity with `CategoryBadge size="sm"`)
+   * - `md` — default; detail-page hero actions, sandbox, rule-display
+   */
+  size?: "sm" | "md";
   className?: string;
 }
 
+// Per-size token recipe — mirrors CategoryBadge's recipe so the two share a
+// rhythm when rendered side-by-side in a transaction row. Adjust as a pair.
+const SIZE: Record<"sm" | "md", string> = {
+  sm: "h-5 px-1.5 text-[11px] gap-0.5 [&>svg]:size-2.5",
+  md: "h-6 px-2 text-xs gap-1 [&>svg]:size-3",
+};
+
 // TagChip is the single rendering of one tag — icon + display name tinted by
 // the tag's color, with an optional remove button for editable contexts.
-export function TagChip({ tag, onRemove, className }: TagChipProps) {
+export function TagChip({
+  tag,
+  onRemove,
+  size = "md",
+  className,
+}: TagChipProps) {
   const tint = tag.color ? { color: tag.color } : undefined;
   return (
-    <Badge variant="outline" className={cn("gap-1", className)}>
-      {tag.icon && (
-        <DynamicIcon name={tag.icon} className="size-3" style={tint} />
-      )}
+    <Badge variant="outline" className={cn(SIZE[size], className)}>
+      {tag.icon && <DynamicIcon name={tag.icon} style={tint} />}
       <span style={tint}>{tag.display_name}</span>
       {onRemove && (
         <button
           type="button"
           onClick={onRemove}
           aria-label={`Remove ${tag.display_name}`}
-          className="text-muted-foreground hover:text-foreground -mr-0.5 ml-0.5 rounded-full"
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 -mr-0.5 ml-0.5 rounded-full focus-visible:ring-[3px] focus-visible:outline-none"
         >
-          <X className="size-3" />
+          <X className={size === "sm" ? "size-2.5" : "size-3"} />
         </button>
       )}
     </Badge>
@@ -44,13 +60,15 @@ interface TagListProps {
   slugs: string[] | undefined;
   /** Cap the chips shown; the remainder collapse into a "+N" badge. */
   max?: number;
+  /** Forwarded to every `TagChip` and the overflow badge for density parity. */
+  size?: "sm" | "md";
   className?: string;
 }
 
 // TagList resolves a transaction's tag slugs against the cached tag catalog
 // and renders chips. A slug with no matching tag still renders (display name
 // falls back to the slug) so a freshly-created tag never silently vanishes.
-export function TagList({ slugs, max, className }: TagListProps) {
+export function TagList({ slugs, max, size = "md", className }: TagListProps) {
   const { data: tags } = useTags();
   // Memoized above the early return (Rules of Hooks) — TagList renders in
   // every table row, so rebuilding this Map per row per render is wasteful.
@@ -70,10 +88,13 @@ export function TagList({ slugs, max, className }: TagListProps) {
   return (
     <div className={cn("flex flex-wrap items-center gap-1", className)}>
       {shown.map((tag) => (
-        <TagChip key={tag.slug} tag={tag} />
+        <TagChip key={tag.slug} tag={tag} size={size} />
       ))}
       {overflow > 0 && (
-        <Badge variant="outline" className="text-muted-foreground">
+        <Badge
+          variant="outline"
+          className={cn("text-muted-foreground", SIZE[size])}
+        >
           +{overflow}
         </Badge>
       )}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -64,7 +64,7 @@ function TransactionMeta({ transaction: t }: { transaction: Transaction }) {
             {t.tags!.length}
           </span>
           <span className="hidden sm:inline-flex">
-            <TagList slugs={t.tags} max={2} />
+            <TagList slugs={t.tags} max={2} size="sm" />
           </span>
         </>
       )}

--- a/web/src/features/rules/rule-display.tsx
+++ b/web/src/features/rules/rule-display.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
-import { Infinity as InfinityIcon, MessageSquare, Plus, Shapes, Tag as TagIcon, X } from "lucide-react";
+import { Infinity as InfinityIcon, MessageSquare, Plus, Shapes, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { TagChip } from "@/components/tag-chip";
 import { DynamicIcon } from "@/lib/icon";
 import { useCategories } from "@/api/queries/categories";
 import { useTags } from "@/api/queries/tags";
@@ -152,7 +153,7 @@ function ActionCard({
             <Plus className="size-4" />
           </div>
           <p className="text-sm">
-            Add tag <TagChip slug={action.tag_slug} tagBySlug={tagBySlug} />
+            Add tag <RuleTagChip slug={action.tag_slug} tagBySlug={tagBySlug} />
           </p>
         </div>
       );
@@ -163,7 +164,7 @@ function ActionCard({
             <X className="size-4" />
           </div>
           <p className="text-sm">
-            Remove tag <TagChip slug={action.tag_slug} tagBySlug={tagBySlug} />
+            Remove tag <RuleTagChip slug={action.tag_slug} tagBySlug={tagBySlug} />
           </p>
         </div>
       );
@@ -188,7 +189,11 @@ function ActionCard({
   }
 }
 
-function TagChip({
+// RuleTagChip resolves a slug against the cached tag catalog, then renders the
+// shared inline `<TagChip>` so color tinting and density match every other
+// tag rendering in the v2 SPA. The "?" badge fallback is reserved for the rare
+// case where the rule action carries no slug at all (malformed legacy data).
+function RuleTagChip({
   slug,
   tagBySlug,
 }: {
@@ -196,14 +201,13 @@ function TagChip({
   tagBySlug: Map<string, Tag>;
 }) {
   if (!slug) return <Badge variant="outline">?</Badge>;
-  const tag = tagBySlug.get(slug);
-  return (
-    <Badge variant="outline" className="gap-1">
-      {tag?.icon && <DynamicIcon name={tag.icon} className="size-3" />}
-      <span>{tag?.display_name ?? slug}</span>
-      <TagIcon className="text-muted-foreground/60 size-3" />
-    </Badge>
-  );
+  const tag = tagBySlug.get(slug) ?? {
+    slug,
+    display_name: slug,
+    color: null,
+    icon: null,
+  };
+  return <TagChip tag={tag} size="sm" className="align-middle" />;
 }
 
 // indexCategoriesBySlug walks the parent/children tree once into a Map keyed

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -730,33 +730,81 @@ export function ComponentsSection() {
       <Specimen
         label="CategoryBadge"
         code="components/category-badge"
-        description="Single rendering of a category — rounded-rect, color-tinted. The ring marks a manual override; em-dash when uncategorized."
+        description="Single rendering of a category — rounded-rect, color-tinted. The ring marks a manual override; em-dash when uncategorized. Two sizes share one recipe with TagChip — sm (h-5 / 11px) for dense list cells, md (h-6 / 12px) for hero / pickers / sandbox."
+        className="block"
       >
-        <CategoryBadge category={coffeeCategory} />
-        <CategoryBadge category={gasCategory} />
-        <CategoryBadge category={coffeeCategory} overridden />
-        <CategoryBadge category={null} />
+        <div className="space-y-2">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+            md (default)
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <CategoryBadge category={coffeeCategory} />
+            <CategoryBadge category={gasCategory} />
+            <CategoryBadge category={coffeeCategory} overridden />
+            <CategoryBadge category={null} />
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+            sm — dense list / table cells
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <CategoryBadge category={coffeeCategory} size="sm" />
+            <CategoryBadge category={gasCategory} size="sm" />
+            <CategoryBadge category={coffeeCategory} size="sm" overridden />
+            <CategoryBadge category={null} size="sm" />
+          </div>
+        </div>
       </Specimen>
 
       <Specimen
         label="TagChip · TagList"
         code="components/tag-chip"
-        description="Pill-shaped (the shape category badges deliberately avoid). TagList resolves slugs against the tag catalog and caps with a +N overflow."
+        description="Pill-shaped (the shape category badges deliberately avoid). Color-tinted icon + label; optional remove (×) for editable contexts. TagList resolves slugs against the tag catalog and caps with a +N overflow. Same sm / md sizes as CategoryBadge — pass through TagList to keep dense rows aligned."
         className="block"
       >
-        <div className="flex flex-wrap items-center gap-2">
-          <TagChip tag={sampleTags[0]} />
-          <TagChip tag={sampleTags[1]} />
-          <TagChip
-            tag={sampleTags[2]}
-            onRemove={() => toast.message("Removed Subscription")}
-          />
+        <div className="space-y-2">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+            md (default)
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <TagChip tag={sampleTags[0]} />
+            <TagChip tag={sampleTags[1]} />
+            <TagChip
+              tag={sampleTags[2]}
+              onRemove={() => toast.message("Removed Subscription")}
+            />
+          </div>
         </div>
-        <div className="mt-3">
-          <TagList
-            slugs={["needs-review", "business", "subscription", "reimbursable"]}
-            max={2}
-          />
+        <div className="mt-4 space-y-2">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+            sm — dense list / table cells
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <TagChip tag={sampleTags[0]} size="sm" />
+            <TagChip tag={sampleTags[1]} size="sm" />
+            <TagChip
+              tag={sampleTags[2]}
+              size="sm"
+              onRemove={() => toast.message("Removed Subscription")}
+            />
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+            TagList · md + sm
+          </p>
+          <div className="space-y-2">
+            <TagList
+              slugs={["needs-review", "business", "subscription", "reimbursable"]}
+              max={2}
+            />
+            <TagList
+              slugs={["needs-review", "business", "subscription", "reimbursable"]}
+              max={2}
+              size="sm"
+            />
+          </div>
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary
- `CategoryBadge`, `TagChip`, and `TagList` gain a `size` prop (`sm` | `md`) with a shared per-size recipe (sm = h-5 / 11px / size-2.5 icon; md = h-6 / 12px / size-3 icon) so chip + badge align in the same row.
- Transactions table consumers (`CategoryPicker`, `TransactionPrimary` tag rail) switch to `sm` for density parity; the dashed empty-state pill mirrors the sm geometry so the column doesn't shift when a row gets a category.
- Retire the local `TagChip` fork inside `features/rules/rule-display.tsx` — the fork ignored the tag's color and added a redundant trailing tag icon. Rule actions now use the shared, color-tinted chip.
- Sandbox specimens render both sizes side-by-side so dark-mode / density sweeps catch sm automatically.

## Before / After (Transactions list — denser, calmer category column)
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/eev7qnw4i7.jpg) | ![after](https://i.img402.dev/847hy9ye3r.jpg) |

## Sandbox (CategoryBadge + TagChip size matrix)
![sandbox](https://i.img402.dev/t3vwi527rj.jpg)

## Notes
- Closes the cross-cutting backlog item `category-badge.tsx / tag-chip.tsx — colour tokens, sizes`.
- The shared SIZE recipe in `category-badge.tsx` and `tag-chip.tsx` is grep-able; adjust both together if the density vocabulary shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
