### PR TITLE
design(v2): a11y focus rings on bare custom buttons

### DIFF
--- a/web/src/components/color-picker.tsx
+++ b/web/src/components/color-picker.tsx
@@ -82,6 +82,11 @@ export function ColorPicker({
                 aria-label={`Pick ${color}`}
                 className={cn(
                   "relative size-7 rounded-md border transition hover:scale-110 hover:shadow-sm",
+                  // Shared focus vocabulary: matches the shadcn Button ring
+                  // recipe (ring-ring/50 + ring-[3px]) so keyboard users can
+                  // see which swatch is focused. Offset keeps the ring from
+                  // hugging the swatch fill.
+                  "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:ring-offset-2 focus-visible:outline-none",
                   selected && "ring-ring ring-2 ring-offset-2",
                 )}
                 style={{ backgroundColor: color }}

--- a/web/src/components/date-range-filter.tsx
+++ b/web/src/components/date-range-filter.tsx
@@ -176,6 +176,9 @@ export function DateRangeFilter({
                 onClick={() => applyPreset(preset)}
                 className={cn(
                   "w-full rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground",
+                  // Shared focus-visible recipe so keyboard users can see
+                  // which preset is focused before pressing Enter.
+                  "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
                   activePreset?.key === preset.key &&
                     "bg-accent font-medium text-accent-foreground",
                 )}

--- a/web/src/components/icon-picker.tsx
+++ b/web/src/components/icon-picker.tsx
@@ -166,7 +166,7 @@ export function IconPicker({
               onChange(null);
               setOpen(false);
             }}
-            className="text-muted-foreground hover:bg-accent flex w-full items-center justify-center gap-1.5 border-t px-2 py-2 text-xs"
+            className="text-muted-foreground hover:bg-accent focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none flex w-full items-center justify-center gap-1.5 border-t px-2 py-2 text-xs"
           >
             <X className="size-3.5" /> Clear icon
           </button>
@@ -194,6 +194,9 @@ function IconTile({
       title={name}
       className={cn(
         "hover:bg-accent flex size-8 items-center justify-center rounded-md transition",
+        // Shared focus-visible recipe (matches Button primitive) so keyboard
+        // users can see which tile is focused as they tab/arrow through.
+        "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
         selected && "bg-accent ring-ring ring-2",
       )}
     >

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -107,6 +107,10 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
                     className={cn(
                       "group relative flex w-full items-center gap-2 rounded-md py-2 pr-3 pl-3.5 text-left text-sm transition-colors",
                       "before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-r-full before:bg-transparent before:transition-all",
+                      // Shared focus-visible vocabulary (matches Button +
+                      // SidebarMenuButton) so keyboard users can see which
+                      // section is focused before pressing Enter.
+                      "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
                       "[&>svg]:size-4 [&>svg]:text-muted-foreground",
                       isActive
                         ? "bg-accent text-accent-foreground before:bg-primary before:inset-y-1 [&>svg]:text-primary"
@@ -148,6 +152,10 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
                   data-active={isActive ? "true" : undefined}
                   className={cn(
                     "group flex h-8 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors",
+                    // Shared focus-visible vocabulary so keyboard users
+                    // tabbing through the mobile pill strip can see which
+                    // section is selected.
+                    "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
                     "[&>svg]:size-3.5",
                     isActive
                       ? "border-primary/30 bg-primary/10 text-primary [&>svg]:text-primary"

--- a/web/src/features/categories/category-list.tsx
+++ b/web/src/features/categories/category-list.tsx
@@ -87,6 +87,10 @@ function CategoryRow({
           disabled={!hasChildren}
           className={cn(
             "text-muted-foreground -ml-1 flex size-6 shrink-0 items-center justify-center rounded-md transition-all",
+            // Shared focus-visible recipe so keyboard users tabbing through
+            // the category list can see which expand/collapse toggle is
+            // focused. Disabled (no-children) state stays invisible.
+            "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
             hasChildren
               ? "hover:bg-muted hover:text-foreground cursor-pointer"
               : "cursor-default opacity-0",

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -28,6 +28,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { useTags } from "@/api/queries/tags";
+import { cn } from "@/lib/utils";
 import type { Condition, TransactionRule } from "@/api/types";
 import { ConditionRowFields } from "./condition-row";
 import { ActionRowFields } from "./action-row";
@@ -353,7 +354,7 @@ export function RuleForm({
               <CollapsibleTrigger asChild>
                 <button
                   type="button"
-                  className="hover:bg-muted/50 group -mx-2 flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-xs transition-colors"
+                  className="hover:bg-muted/50 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none group -mx-2 flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-xs transition-colors"
                 >
                   <span className="text-muted-foreground inline-flex items-center gap-2">
                     Pipeline stage
@@ -380,11 +381,12 @@ export function RuleForm({
                               type="button"
                               onClick={() => field.onChange(preset.value)}
                               title={preset.hint}
-                              className={
+                              className={cn(
+                                "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none flex-1 rounded-lg px-2 py-1 text-xs font-medium",
                                 field.value === preset.value
-                                  ? "bg-background text-foreground flex-1 rounded-lg px-2 py-1 text-xs font-medium shadow-sm"
-                                  : "text-muted-foreground hover:text-foreground flex-1 rounded-lg px-2 py-1 text-xs font-medium transition-colors"
-                              }
+                                  ? "bg-background text-foreground shadow-sm"
+                                  : "text-muted-foreground hover:text-foreground transition-colors",
+                              )}
                             >
                               {preset.label}
                             </button>
@@ -437,22 +439,24 @@ export function RuleForm({
                     <button
                       type="button"
                       onClick={() => form.setValue("logic", "and")}
-                      className={
+                      className={cn(
+                        "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none rounded-md px-2.5 py-0.5 text-xs font-medium",
                         watchedLogic === "and"
-                          ? "bg-background text-foreground rounded-md px-2.5 py-0.5 text-xs font-medium shadow-sm"
-                          : "text-muted-foreground hover:text-foreground rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors"
-                      }
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground transition-colors",
+                      )}
                     >
                       AND
                     </button>
                     <button
                       type="button"
                       onClick={() => form.setValue("logic", "or")}
-                      className={
+                      className={cn(
+                        "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none rounded-md px-2.5 py-0.5 text-xs font-medium",
                         watchedLogic === "or"
-                          ? "bg-background text-foreground rounded-md px-2.5 py-0.5 text-xs font-medium shadow-sm"
-                          : "text-muted-foreground hover:text-foreground rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors"
-                      }
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground transition-colors",
+                      )}
                     >
                       OR
                     </button>
@@ -545,7 +549,7 @@ export function RuleForm({
                       }
                       field.onChange(!field.value);
                     }}
-                    className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+                    className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none flex items-center gap-1 rounded-sm text-xs"
                   >
                     <Code2 className="size-3" />
                     {field.value ? "Hide JSON" : "Edit as JSON"}

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -408,7 +408,7 @@ export function TransactionsToolbar({
                 type="button"
                 onClick={() => clearChip(chip.key)}
                 aria-label={`Clear ${chip.label}`}
-                className="text-muted-foreground hover:text-foreground -mr-0.5"
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none -mr-0.5 rounded-sm"
               >
                 <X className="size-3" />
               </button>


### PR DESCRIPTION
## Summary

- Sweeps the v2 SPA for hand-rolled `<button>` elements that bypass the shadcn `Button` primitive — these had no `focus-visible` ring at all, so keyboard users had no way to see which target was selected before pressing Enter (continuing the iter-50 TagChip remove-button thread).
- 9 sites updated across 7 files: color swatches (`color-picker`), icon tiles + clear icon (`icon-picker`), settings shell sections (desktop + mobile), date-range presets, transactions-toolbar chip-clear `×`, categories expand chevron, rule-form pipeline-stage trigger + STAGE_PRESETS pill row + AND/OR pill row + JSON-mode toggle.
- Shared recipe: `focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none` — matches the shadcn `Button` / `Sidebar*` / `Badge` / `Input` ring vocabulary already in use. Color-swatch grid uses `ring-offset-2` so the ring doesn't hug the fill.

## After — focus ring on the settings nav (keyboard-focused `Household`)

![after](https://i.img402.dev/hu7qv1tmem.png)

The subtle 3px `ring-ring/50` halo around `Household` is the new affordance. Previously the button was a bare `<button>` with no focus-visible styles — only the browser-default outline was available, which the design system suppresses elsewhere via the shadcn primitives. The same recipe now applies to the 8 other bare-button surfaces listed above.

## Notes
- Continues iter 50: TagChip's remove `×` gained the same ring there; this PR sweeps the remaining bare-button surfaces.
- No new primitive — the recipe is too small to extract (3 utility classes). If a fourth surface needs the offset variant, consider a `focusRing` tokenset in `lib/utils.ts`.
- `rule-form.tsx` gained a `cn()` import to centralize the pill-toggle merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)