### PR TITLE
design(v2): sweep detail-page status banners onto StatusPanel

### DIFF
--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -14,18 +14,19 @@ import {
   EyeOff,
   Landmark,
   Link2,
+  PowerOff,
   Wallet,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
+import { StatusPanel } from "@/components/status-panel";
 import { useAccount, useAccounts } from "@/api/queries/accounts";
 import type { AccountDetail } from "@/api/types";
 import {
@@ -458,61 +459,55 @@ function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) 
 function connectionStatusAlert(a: AccountDetail) {
   const status = a.connection_status;
   if (!status || status === "active") return null;
+
+  // Tone-tinted `<StatusPanel>` so account-detail speaks the same banner
+  // vocabulary as Setup, Providers, Home attention-panel, and the iter-35
+  // 404/Error pages. Optional trailing slot carries the "Open connection"
+  // CTA — same shape as the iter-35 error-page Reload button. On narrow
+  // viewports StatusPanel's `flex items-start gap-3` row keeps the icon
+  // tile + heading + trailing CTA aligned where the previous
+  // `<AlertDescription>` flex-wrap row would wrap the CTA below the body
+  // text in a half-aligned column.
+  const openCta = a.connection_short_id ? (
+    <Button size="sm" variant="outline" asChild className="h-7 gap-1.5 text-xs">
+      <Link to="/connections/$id" params={{ id: a.connection_short_id }}>
+        Open connection
+        <ArrowRight className="size-3.5" />
+      </Link>
+    </Button>
+  ) : undefined;
+
   if (status === "pending_reauth") {
     return (
-      <Alert className="border-amber-500/30 bg-amber-500/5">
-        <AlertTriangle className="size-4 text-amber-700 dark:text-amber-400" />
-        <AlertTitle className="text-amber-700 dark:text-amber-400">
-          Connection needs re-authentication
-        </AlertTitle>
-        <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
-          <span>Recent syncs may be stale until you reconnect.</span>
-          {a.connection_short_id && (
-            <Button size="sm" variant="outline" asChild>
-              <Link
-                to="/connections/$id"
-                params={{ id: a.connection_short_id }}
-              >
-                Open connection
-                <ArrowRight className="size-3.5" />
-              </Link>
-            </Button>
-          )}
-        </AlertDescription>
-      </Alert>
+      <StatusPanel
+        tone="warning"
+        icon={AlertTriangle}
+        heading="Connection needs re-authentication"
+        body="Recent syncs may be stale until you reconnect."
+        trailing={openCta}
+      />
     );
   }
   if (status === "error") {
     return (
-      <Alert variant="destructive">
-        <AlertTriangle className="size-4" />
-        <AlertTitle>Connection error</AlertTitle>
-        <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
-          <span>Sync is currently failing. Check the connection for details.</span>
-          {a.connection_short_id && (
-            <Button size="sm" variant="outline" asChild>
-              <Link
-                to="/connections/$id"
-                params={{ id: a.connection_short_id }}
-              >
-                Open connection
-                <ArrowRight className="size-3.5" />
-              </Link>
-            </Button>
-          )}
-        </AlertDescription>
-      </Alert>
+      <StatusPanel
+        tone="destructive"
+        icon={AlertTriangle}
+        heading="Connection error"
+        body="Sync is currently failing. Check the connection for details."
+        trailing={openCta}
+      />
     );
   }
   if (status === "disconnected") {
     return (
-      <Alert>
-        <AlertTitle>Connection disconnected</AlertTitle>
-        <AlertDescription>
-          This account is read-only — its parent connection no longer syncs.
-          Historical transactions remain.
-        </AlertDescription>
-      </Alert>
+      <StatusPanel
+        tone="info"
+        icon={PowerOff}
+        heading="Connection disconnected"
+        body="This account is read-only — its parent connection no longer syncs. Historical transactions remain."
+        trailing={openCta}
+      />
     );
   }
   return null;

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { StatusPanel } from "@/components/status-panel";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -378,55 +379,49 @@ function DetailBody({
         </Alert>
       )}
 
-      {/* Banners */}
+      {/* Banners — promoted onto `<StatusPanel>` so they speak the same
+          tone-tinted vocabulary as Setup, Providers, Home attention-panel,
+          and account-detail's connection-status banners. The previous
+          open-coded `<Alert>` row used absolute-positioned icons +
+          inline amber utilities, which forced a different rhythm from the
+          rest of the v2 surfaces and wrapped the Re-authenticate CTA below
+          the body text in a half-aligned column on narrow viewports. The
+          StatusPanel's `flex items-start gap-3 + trailing` slot keeps the
+          icon tile + heading + CTA aligned on mobile, tablet, and desktop. */}
       {isReauthBanner && (
-        <Alert
-          className={
-            conn.status === "error"
-              ? "border-destructive/30 bg-destructive/5"
-              : "border-amber-500/30 bg-amber-500/5"
-          }
-        >
-          <AlertTriangle
-            className={
-              conn.status === "error"
-                ? "text-destructive size-4"
-                : "size-4 text-amber-700 dark:text-amber-400"
-            }
-          />
-          <AlertTitle
-            className={
-              conn.status === "error"
-                ? "text-destructive"
-                : "text-amber-700 dark:text-amber-400"
-            }
-          >
-            {conn.status === "pending_reauth"
+        <StatusPanel
+          tone={conn.status === "error" ? "destructive" : "warning"}
+          icon={AlertTriangle}
+          heading={
+            conn.status === "pending_reauth"
               ? "Login expired"
-              : "This connection had an error"}
-          </AlertTitle>
-          <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
-            <span>
-              {conn.error_message ??
-                "Reconnect to the bank to resume syncing this connection."}
-            </span>
-            <Button size="sm" variant="outline" onClick={onReauth}>
+              : "This connection had an error"
+          }
+          body={
+            conn.error_message ??
+            "Reconnect to the bank to resume syncing this connection."
+          }
+          trailing={
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onReauth}
+              className="h-7 gap-1.5 text-xs"
+            >
+              <RefreshCw className="size-3.5" />
               Re-authenticate
             </Button>
-          </AlertDescription>
-        </Alert>
+          }
+        />
       )}
 
       {showFailureBanner && (
-        <Alert className="border-amber-500/30 bg-amber-500/5">
-          <AlertTriangle className="size-4 text-amber-700 dark:text-amber-400" />
-          <AlertTitle className="text-amber-700 dark:text-amber-400">
-            {conn.consecutive_failures} syncs failed in a row
-          </AlertTitle>
-          <AlertDescription>
-            Recent syncs have been failing. Check the history below for details.
-          </AlertDescription>
-        </Alert>
+        <StatusPanel
+          tone="warning"
+          icon={AlertTriangle}
+          heading={`${conn.consecutive_failures} syncs failed in a row`}
+          body="Recent syncs have been failing. Check the history below for details."
+        />
       )}
 
       <QuickActions conn={conn} />


### PR DESCRIPTION
## Summary

- Promotes 5 hand-rolled `<Alert>` banner variants on account-detail (`connectionStatusAlert`) and connection-detail (reauth + consecutive-failures) onto the canonical `<StatusPanel>` primitive (iter 16/35 vocabulary).
- Each banner now reads with the right tone token: `warning` for pending_reauth, `destructive` for error, `info` for disconnected.
- StatusPanel's `flex items-start gap-3 + trailing` slot keeps the icon tile + heading + CTA aligned on mobile, tablet, and desktop — the old `<AlertDescription>` flex-wrap row dropped the CTA into a half-aligned column on narrow viewports.

## Before / After

Captured at 375×812 with the `pending_reauth` connection state forced so both detail pages render the banner stack.

### Connection detail (mobile)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/0z6kspqx80.jpg) | ![after](https://i.img402.dev/u7eovizwsw.jpg) |

### Account detail (mobile)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/mljwguwmn6.jpg) | ![after](https://i.img402.dev/yz6zu343ba.jpg) |

## Notes

- Disconnect-confirm `<Alert>` on connection-detail intentionally stays — it's an inline confirm-dialog with two interactive buttons, a different shape from the inline tone-banner vocabulary.
- Account-detail "disconnected" gained a `PowerOff` icon so the state reads at a glance.
- Connection-detail reauth CTA gained a leading `RefreshCw` + tightened to `size="sm" h-7` to match the other detail-page action affordances (hero footer Sync / Re-authenticate / Import more strip).
- StatusPanel itself is unchanged — this is a consumer sweep, not a primitive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
