### PR TITLE
design(v2): form validation icon + StatusPanel sweep for rule/csv banners

### DIFF
--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import type { Label as LabelPrimitive } from "radix-ui"
 import { Slot } from "radix-ui"
+import { AlertCircle } from "lucide-react"
 import {
   Controller,
   FormProvider,
@@ -143,14 +144,27 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     return null
   }
 
+  // Errored messages get a leading AlertCircle so validation reads
+  // as a status signal, not as ordinary copy. Plain messages (passed
+  // as children without an underlying field error) stay clean.
   return (
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-sm text-destructive", className)}
+      className={cn(
+        "flex items-start gap-1.5 text-sm",
+        error ? "text-destructive" : "text-muted-foreground",
+        className
+      )}
       {...props}
     >
-      {body}
+      {error ? (
+        <AlertCircle
+          aria-hidden="true"
+          className="mt-0.5 size-3.5 shrink-0"
+        />
+      ) : null}
+      <span className="min-w-0">{body}</span>
     </p>
   )
 }

--- a/web/src/features/connections/csv-import-form.tsx
+++ b/web/src/features/connections/csv-import-form.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  AlertCircle,
   ArrowLeft,
   FileSpreadsheet,
   Loader2,
@@ -18,7 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { StatusPanel } from "@/components/status-panel";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -576,9 +577,12 @@ function CsvMapStage({
       </section>
 
       {validation && (
-        <Alert variant="destructive">
-          <AlertDescription>{validation}</AlertDescription>
-        </Alert>
+        <StatusPanel
+          tone="destructive"
+          icon={AlertCircle}
+          heading="Fix the column mapping"
+          body={validation}
+        />
       )}
 
       <FormFooter

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useFieldArray, useForm, type UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ChevronDown, Code2, Infinity as InfinityIcon, ListFilter, Plus, Save, Wand2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, ChevronDown, Code2, Infinity as InfinityIcon, ListFilter, Plus, Save, Wand2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { StatusPanel } from "@/components/status-panel";
 import {
   Collapsible,
   CollapsibleContent,
@@ -633,18 +634,20 @@ export function RuleForm({
             )}
 
             {comboWarnings.length > 0 && (
-              <Alert className="border-amber-500/30 bg-amber-500/5">
-                <AlertTitle className="text-amber-700 dark:text-amber-400 text-sm">
-                  Heads up
-                </AlertTitle>
-                <AlertDescription className="space-y-1">
-                  {comboWarnings.map((w, i) => (
-                    <p key={i} className="text-xs">
-                      {w}
-                    </p>
-                  ))}
-                </AlertDescription>
-              </Alert>
+              <StatusPanel
+                tone="warning"
+                icon={AlertTriangle}
+                heading="Heads up"
+                body={
+                  <span className="space-y-1">
+                    {comboWarnings.map((w, i) => (
+                      <span key={i} className="block">
+                        {w}
+                      </span>
+                    ))}
+                  </span>
+                }
+              />
             )}
           </div>
 
@@ -780,6 +783,9 @@ function getRowErrors(
 function RowError({ errors }: { errors: string[] }) {
   if (errors.length === 0) return null;
   return (
-    <p className="text-destructive ml-12 text-xs">{errors.join(" · ")}</p>
+    <p className="text-destructive ml-12 flex items-start gap-1.5 text-xs">
+      <AlertCircle aria-hidden="true" className="mt-0.5 size-3 shrink-0" />
+      <span className="min-w-0">{errors.join(" · ")}</span>
+    </p>
   );
 }


### PR DESCRIPTION
## Summary

- `<FormMessage>` now renders a leading `AlertCircle` so validation errors read as a status signal instead of ordinary copy. Five form families (tag, category, api-key, csv-import, rule) pick up the new look automatically.
- `rule-form.tsx`'s in-row `<RowError>` gains matching AlertCircle vocabulary so per-row condition/action errors align with the field-level ones above.
- `rule-form.tsx`'s open-coded amber `comboWarnings` `<Alert>` swept onto `<StatusPanel tone="warning">` — same vocabulary as the providers / account-detail / connection-detail warning banners.
- `csv-import-form.tsx`'s `<Alert variant="destructive">` validation banner swept onto `<StatusPanel tone="destructive">` (heading: "Fix the column mapping"); drops the unused `Alert` import.

## Before / After (tags/new with an invalid slug)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/mnwygcjuyj.jpg) | ![after](https://i.img402.dev/e1t47rzryb.jpg) |

## Notes

- Plain `<FormMessage>` (no underlying field error, just passed-as-children copy) stays muted-foreground without an icon — the icon is reserved for actual validation errors.
- Only two open-coded validation banners remain in v2 form pages: the rule-form's right-rail "Heads up" `<Alert>` (informational, not a validation banner) and the backups-section `<Alert>` (different shape — not a form). Both stay for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)