### PR TITLE
design(v2): DetailList primitive + SectionCard header band fix

### DIFF
--- a/web/src/components/detail-list.tsx
+++ b/web/src/components/detail-list.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { Eyebrow } from "@/components/eyebrow";
+import { IdPill } from "@/components/id-pill";
+import { cn } from "@/lib/utils";
+
+export interface DetailRowData {
+  label: string;
+  // `null` / `undefined` are dropped by `compactDetailRows`; the rendered
+  // contract is "if you got here, the value is real".
+  value: string | null | undefined;
+  // When true, render the value through `<IdPill>` (short_id / slug / mono
+  // identifier). Default plain text.
+  mono?: boolean;
+  // Optional secondary hint that appears below the value (smaller, muted).
+  // Used today by transaction-detail to explain "Attributed to" rows.
+  hint?: string;
+}
+
+// `compactDetailRows` is the canonical row-list builder for `<DetailList>`.
+// Pass nullable rows so callers can write `cond ? row : null` inline without
+// per-row conditionals; the helper filters anything without a value. Mirrors
+// the previous open-coded `compactRows` helper that lived in every detail
+// route.
+export function compactDetailRows(
+  rows: (DetailRowData | null | undefined | false)[],
+): DetailRowData[] {
+  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
+}
+
+interface DetailListProps {
+  // Uppercase tracked label rendered through `<Eyebrow as="h3">`. Optional —
+  // a single ungrouped list (just rows, no eyebrow) is also valid.
+  label?: string;
+  rows: DetailRowData[];
+  className?: string;
+}
+
+// `<DetailList>` is the canonical "label / value" key-value block that
+// every v2 detail-page Details sidebar (transaction, account, connection,
+// category) used to open-code as a local `DetailGroup`. Visual contract:
+//
+//   `<div className="space-y-2.5">`
+//     optional `<Eyebrow as="h3">` (uppercase tracked label)
+//     `<dl className="space-y-2">`
+//       per row: `<dt>` label muted-xs + `<dd>` value xs, baseline-aligned,
+//       label-left / value-right with `break-words` so long values
+//       (full datetimes, multi-word provider categories) wrap inside the
+//       column instead of getting clipped by `truncate` on 375px viewports.
+//
+// Renders a `<dl>` per call so screen-reader semantics stay correct
+// (label/value pairs are a description list, not a generic grid). Consumers
+// stack two or three `<DetailList>` blocks inside a single `<SectionCard
+// bodyClassName="space-y-5 px-5 py-5 text-sm">` host card — same rhythm as
+// the previous open-coded version.
+export function DetailList({ label, rows, className }: DetailListProps) {
+  if (rows.length === 0) return null;
+  return (
+    <div className={cn("space-y-2.5", className)}>
+      {label && <Eyebrow as="h3">{label}</Eyebrow>}
+      <dl className="space-y-2">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex min-w-0 items-baseline justify-between gap-3"
+          >
+            <dt className="text-muted-foreground shrink-0 text-xs">
+              {row.label}
+            </dt>
+            <dd className="min-w-0 text-right text-xs break-words">
+              {row.mono ? <IdPill value={row.value as string} /> : row.value}
+              {row.hint && (
+                <span className="text-muted-foreground mt-1 block text-[11px] leading-snug whitespace-normal">
+                  {row.hint}
+                </span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -63,7 +63,14 @@ export function SectionCard({
       className={cn("gap-0 py-0", cardClassName, className)}
       {...rest}
     >
-      <CardHeader className={cn("border-b px-5 py-4", headerClassName)}>
+      {/* Override the shadcn Card primitive's `[.border-b]:pb-6` rule: when
+          a SectionCard header carries the divider the primitive injects an
+          extra 24px of bottom padding, which on top of our intentional
+          `py-4` produced an empty band before the body. `!pb-4` keeps the
+          density we designed for and matches the `pt-4` on top. */}
+      <CardHeader
+        className={cn("border-b px-5 py-4 !pb-4", headerClassName)}
+      >
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           {icon}
           {title}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -21,9 +21,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  DetailList,
+  compactDetailRows,
+  type DetailRowData,
+} from "@/components/detail-list";
 import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
-import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
@@ -373,7 +377,7 @@ function QuickActions({ account: a }: { account: AccountDetail }) {
 }
 
 function DetailsCard({ account: a }: { account: AccountDetail }) {
-  const balanceRows: DetailRowData[] = compactRows([
+  const balanceRows: DetailRowData[] = compactDetailRows([
     a.balance_limit != null && isLiability(a.type)
       ? {
           label: "Credit limit",
@@ -389,70 +393,31 @@ function DetailsCard({ account: a }: { account: AccountDetail }) {
     a.iso_currency_code ? { label: "Currency", value: a.iso_currency_code } : null,
     a.last_balance_update
       ? {
+          // Short date keeps the row from wrapping on a 375px viewport; the
+          // exact wall-clock seconds are noise — last-sync precision lives
+          // on the connection page.
           label: "Last update",
-          value: new Date(a.last_balance_update).toLocaleString(),
+          value: new Date(a.last_balance_update).toLocaleDateString(),
         }
       : null,
   ]);
 
-  const providerRows: DetailRowData[] = compactRows([
+  const providerRows: DetailRowData[] = compactDetailRows([
     a.official_name ? { label: "Bank name", value: a.official_name } : null,
     a.mask ? { label: "Mask", value: `····${a.mask}`, mono: false } : null,
     a.subtype ? { label: "Subtype", value: a.subtype } : null,
   ]);
 
-  const referenceRows: DetailRowData[] = compactRows([
+  const referenceRows: DetailRowData[] = compactDetailRows([
     { label: "ID", value: a.short_id, mono: true },
   ]);
 
   return (
     <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
-      {balanceRows.length > 0 && (
-        <DetailGroup label="Balance" rows={balanceRows} />
-      )}
-      {providerRows.length > 0 && (
-        <DetailGroup label="Provider" rows={providerRows} />
-      )}
-      {referenceRows.length > 0 && (
-        <DetailGroup label="Reference" rows={referenceRows} />
-      )}
+      <DetailList label="Balance" rows={balanceRows} />
+      <DetailList label="Provider" rows={providerRows} />
+      <DetailList label="Reference" rows={referenceRows} />
     </SectionCard>
-  );
-}
-
-interface DetailRowData {
-  label: string;
-  value: string | null | undefined;
-  mono?: boolean;
-}
-
-function compactRows(
-  rows: (DetailRowData | null | undefined | false)[],
-): DetailRowData[] {
-  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
-}
-
-function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) {
-  if (rows.length === 0) return null;
-  return (
-    <div className="space-y-2.5">
-      <Eyebrow as="h3">{label}</Eyebrow>
-      <dl className="space-y-2">
-        {rows.map((row) => (
-          <div
-            key={row.label}
-            className="flex items-baseline justify-between gap-3"
-          >
-            <dt className="text-muted-foreground shrink-0 text-xs">
-              {row.label}
-            </dt>
-            <dd className="min-w-0 truncate text-right text-xs">
-              {row.mono ? <IdPill value={row.value as string} /> : row.value}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </div>
   );
 }
 

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -18,9 +18,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { DangerZone } from "@/components/danger-zone";
+import {
+  DetailList,
+  compactDetailRows,
+  type DetailRowData,
+} from "@/components/detail-list";
 import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
-import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryForm } from "@/features/categories/category-form";
@@ -320,18 +324,18 @@ function DetailsCard({
   category: Category;
   parent: Category | undefined;
 }) {
-  const identityRows: DetailRowData[] = compactRows([
+  const identityRows: DetailRowData[] = compactDetailRows([
     { label: "Slug", value: category.slug, mono: true },
     { label: "Sort order", value: String(category.sort_order) },
     parent ? { label: "Parent", value: parent.display_name } : null,
   ]);
 
-  const stateRows: DetailRowData[] = compactRows([
+  const stateRows: DetailRowData[] = compactDetailRows([
     { label: "System", value: category.is_system ? "Yes" : "No" },
     { label: "Hidden", value: category.hidden ? "Yes" : "No" },
   ]);
 
-  const referenceRows: DetailRowData[] = compactRows([
+  const referenceRows: DetailRowData[] = compactDetailRows([
     { label: "ID", value: category.short_id, mono: true },
     category.created_at
       ? {
@@ -343,52 +347,10 @@ function DetailsCard({
 
   return (
     <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
-      {identityRows.length > 0 && (
-        <DetailGroup label="Identity" rows={identityRows} />
-      )}
-      {stateRows.length > 0 && (
-        <DetailGroup label="State" rows={stateRows} />
-      )}
-      {referenceRows.length > 0 && (
-        <DetailGroup label="Reference" rows={referenceRows} />
-      )}
+      <DetailList label="Identity" rows={identityRows} />
+      <DetailList label="State" rows={stateRows} />
+      <DetailList label="Reference" rows={referenceRows} />
     </SectionCard>
-  );
-}
-
-interface DetailRowData {
-  label: string;
-  value: string | null | undefined;
-  mono?: boolean;
-}
-
-function compactRows(
-  rows: (DetailRowData | null | undefined | false)[],
-): DetailRowData[] {
-  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
-}
-
-function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) {
-  if (rows.length === 0) return null;
-  return (
-    <div className="space-y-2.5">
-      <Eyebrow as="h3">{label}</Eyebrow>
-      <dl className="space-y-2">
-        {rows.map((row) => (
-          <div
-            key={row.label}
-            className="flex items-baseline justify-between gap-3"
-          >
-            <dt className="text-muted-foreground shrink-0 text-xs">
-              {row.label}
-            </dt>
-            <dd className="min-w-0 truncate text-right text-xs">
-              {row.mono ? <IdPill value={row.value as string} /> : row.value}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </div>
   );
 }
 

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -43,8 +43,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  DetailList,
+  compactDetailRows,
+  type DetailRowData,
+} from "@/components/detail-list";
 import { Eyebrow } from "@/components/eyebrow";
-import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -834,48 +838,6 @@ function SettingsCard({
   );
 }
 
-interface DetailRowData {
-  label: string;
-  value: string | null | undefined;
-  mono?: boolean;
-}
-
-function compactRows(
-  rows: (DetailRowData | null | undefined | false)[],
-): DetailRowData[] {
-  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
-}
-
-function DetailGroup({
-  label,
-  rows,
-}: {
-  label: string;
-  rows: DetailRowData[];
-}) {
-  if (rows.length === 0) return null;
-  return (
-    <div className="space-y-2.5">
-      <Eyebrow as="h3">{label}</Eyebrow>
-      <dl className="space-y-2">
-        {rows.map((row) => (
-          <div
-            key={row.label}
-            className="flex items-baseline justify-between gap-3"
-          >
-            <dt className="text-muted-foreground shrink-0 text-xs">
-              {row.label}
-            </dt>
-            <dd className="min-w-0 truncate text-right text-xs">
-              {row.mono ? <IdPill value={row.value as string} /> : row.value}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </div>
-  );
-}
-
 function DetailsCard({
   conn,
   successRate,
@@ -889,7 +851,7 @@ function DetailsCard({
   totalSyncs: number;
   syncLogsLoading: boolean;
 }) {
-  const healthRows: DetailRowData[] = compactRows([
+  const healthRows: DetailRowData[] = compactDetailRows([
     {
       label: "Success rate",
       value: successRate
@@ -908,7 +870,7 @@ function DetailsCard({
     },
   ]);
 
-  const providerRows: DetailRowData[] = compactRows([
+  const providerRows: DetailRowData[] = compactDetailRows([
     { label: "Provider", value: providerLabel(conn.provider) },
     conn.user_name ? { label: "User", value: conn.user_name } : null,
     conn.institution_id
@@ -916,7 +878,7 @@ function DetailsCard({
       : null,
   ]);
 
-  const referenceRows: DetailRowData[] = compactRows([
+  const referenceRows: DetailRowData[] = compactDetailRows([
     { label: "ID", value: conn.short_id, mono: true },
     { label: "Created", value: new Date(conn.created_at).toLocaleDateString() },
     {
@@ -927,15 +889,9 @@ function DetailsCard({
 
   return (
     <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
-      {healthRows.length > 0 && (
-        <DetailGroup label="Health" rows={healthRows} />
-      )}
-      {providerRows.length > 0 && (
-        <DetailGroup label="Provider" rows={providerRows} />
-      )}
-      {referenceRows.length > 0 && (
-        <DetailGroup label="Reference" rows={referenceRows} />
-      )}
+      <DetailList label="Health" rows={healthRows} />
+      <DetailList label="Provider" rows={providerRows} />
+      <DetailList label="Reference" rows={referenceRows} />
     </SectionCard>
   );
 }

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -14,8 +14,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  DetailList,
+  compactDetailRows,
+  type DetailRowData,
+} from "@/components/detail-list";
 import { Eyebrow } from "@/components/eyebrow";
-import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryEditor } from "@/features/transactions/category-editor";
@@ -285,8 +289,8 @@ function DetailsCard({ transaction: t }: { transaction: Transaction }) {
   const attributedDiffers =
     !!t.attributed_user_name && t.attributed_user_name !== t.user_name;
 
-  const accountRows: DetailRowData[] = compactRows([
-    { label: "Account", value: t.account_name },
+  const accountRows: DetailRowData[] = compactDetailRows([
+    { label: "Name", value: t.account_name },
     { label: "Member", value: t.user_name },
     attributedDiffers
       ? {
@@ -298,82 +302,36 @@ function DetailsCard({ transaction: t }: { transaction: Transaction }) {
     { label: "Currency", value: t.iso_currency_code },
   ]);
 
-  const providerRows: DetailRowData[] = compactRows([
+  // Drop low-signal provider rows: a `Channel: other` row reads as
+  // "Breadbox didn't get a channel" noise; same for an empty category. We
+  // already render the detailed category in the hero. The Details sidebar
+  // earns its keep when every row carries information the user couldn't get
+  // upstream — pad it out and it reads as a dump.
+  const channelLabel = titleize(t.provider_payment_channel);
+  const providerCategory = titleize(
+    t.provider_category_detailed ?? t.provider_category_primary,
+  );
+  const providerRows: DetailRowData[] = compactDetailRows([
     {
       label: "Authorized",
       value: t.authorized_date ? formatLongDate(t.authorized_date) : null,
     },
-    { label: "Channel", value: titleize(t.provider_payment_channel) },
-    {
-      label: "Provider category",
-      value: titleize(
-        t.provider_category_detailed ?? t.provider_category_primary,
-      ),
-    },
+    channelLabel && channelLabel.toLowerCase() !== "other"
+      ? { label: "Channel", value: channelLabel }
+      : null,
+    providerCategory ? { label: "Category", value: providerCategory } : null,
   ]);
 
-  const referenceRows: DetailRowData[] = compactRows([
+  const referenceRows: DetailRowData[] = compactDetailRows([
     { label: "ID", value: t.short_id, mono: true },
   ]);
 
   return (
     <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
-      <DetailGroup label="Account" rows={accountRows} />
-      {providerRows.length > 0 && (
-        <DetailGroup label="Provider" rows={providerRows} />
-      )}
-      {referenceRows.length > 0 && (
-        <DetailGroup label="Reference" rows={referenceRows} />
-      )}
+      <DetailList label="Account" rows={accountRows} />
+      <DetailList label="Provider" rows={providerRows} />
+      <DetailList label="Reference" rows={referenceRows} />
     </SectionCard>
-  );
-}
-
-interface DetailRowData {
-  label: string;
-  value: string | null | undefined;
-  hint?: string;
-  mono?: boolean;
-}
-
-function compactRows(
-  rows: (DetailRowData | null | undefined)[],
-): DetailRowData[] {
-  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
-}
-
-function DetailGroup({
-  label,
-  rows,
-}: {
-  label: string;
-  rows: DetailRowData[];
-}) {
-  if (rows.length === 0) return null;
-  return (
-    <div className="space-y-2.5">
-      <Eyebrow as="h3">{label}</Eyebrow>
-      <dl className="space-y-2">
-        {rows.map((row) => (
-          <div
-            key={row.label}
-            className="flex items-baseline justify-between gap-3"
-          >
-            <dt className="text-muted-foreground shrink-0 text-xs">
-              {row.label}
-            </dt>
-            <dd className="min-w-0 truncate text-right text-xs">
-              {row.mono ? <IdPill value={row.value} /> : row.value}
-              {row.hint && (
-                <span className="text-muted-foreground mt-1 block text-[11px] leading-snug whitespace-normal">
-                  {row.hint}
-                </span>
-              )}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </div>
   );
 }
 

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -50,6 +50,7 @@ import { ColorPicker } from "@/components/color-picker";
 import { TransactionPrimary } from "@/components/transaction-primary";
 import { TransactionAmount } from "@/components/transaction-amount";
 import { KbdTooltip } from "@/components/kbd-tooltip";
+import { DetailList } from "@/components/detail-list";
 import { ListCard } from "@/components/list-card";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { SectionCard } from "@/components/section-card";
@@ -300,6 +301,40 @@ export function ComponentsSection() {
         <IdPill value="acct_3rR9pq01" />
         <IdPill value="food_and_drink_coffee" />
         <IdPill value="/api/v1/transactions" />
+      </Specimen>
+
+      <Specimen
+        label="DetailList"
+        code="components/detail-list"
+        description="The canonical label / value KV block used by every v2 detail-page Details sidebar (transaction, account, connection, category). Stack two or three inside a `<SectionCard bodyClassName='space-y-5 px-5 py-5 text-sm'>` host — uppercase tracked group label, `<dl>` for screen-reader semantics, label-left / value-right with `break-words` so long values wrap inside the column on 375px viewports. `compactDetailRows` keeps callsites declarative — pass nullable rows inline, the helper filters anything without a value. Mono rows route through `<IdPill>`. Don't fork — extend this primitive."
+        className="block"
+      >
+        <div className="max-w-sm rounded-xl border">
+          <div className="space-y-5 px-5 py-5 text-sm">
+            <DetailList
+              label="Account"
+              rows={[
+                { label: "Name", value: "Plaid Checking" },
+                { label: "Member", value: "Ricardo (hosted-link test)" },
+                { label: "Currency", value: "USD" },
+              ]}
+            />
+            <DetailList
+              label="Provider"
+              rows={[
+                { label: "Authorized", value: "May 9, 2026" },
+                {
+                  label: "Category",
+                  value: "Transfer In Other Transfer In",
+                },
+              ]}
+            />
+            <DetailList
+              label="Reference"
+              rows={[{ label: "ID", value: "JKHqiBWP", mono: true }]}
+            />
+          </div>
+        </div>
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
## Summary
- Extract `<DetailList>` to `web/src/components/detail-list.tsx` — the label/value KV block was open-coded as a local `DetailGroup` on every v2 detail page (transaction, account, connection, category). Four copies of the same `<div><Eyebrow><dl><dt><dd>` markup plus four copies of the `compactRows` nullable filter, now one primitive. Drops `truncate` on `<dd>` for `break-words` + row-level `min-w-0` so long values (full datetimes, multi-word provider categories) wrap inside the column on 375px viewports instead of getting clipped.
- Fix the SectionCard header empty band on every detail page: shadcn's Card primitive injects `[.border-b]:pb-6` on `CardHeader`, which combined with our intentional `py-4` produced a stale empty band below the section title (most visible on the Activity card on mobile). Override with `!pb-4` so the rhythm matches the design.
- Drive-by TX-detail mobile-readability polish: rename "Account → Name" inside the Account group so the eyebrow + first row label don't repeat the word; drop `Channel: other` low-signal rows; tighten "Provider category" → "Category"; account-detail "Last update" drops the wall-clock seconds (`5/15/2026, 10:35:13 PM` → `5/15/2026`) — connection detail is the right host for sync-precision timestamps.

## Before / After — TX detail (375x812)
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/5ghsavgt9o.jpg) | ![after](https://i.img402.dev/bbsy19imyf.jpg) |

## Before / After — Account detail (375x812)
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/f9juvd4w0l.jpg) | ![after](https://i.img402.dev/a6tiwa1hmf.jpg) |

## Notes
- 15th shared primitive (after ListCard, ColorRailCard, IdPill, SectionCard, SoftBackButton, AuthShell, StatusPanel, FormFooter, ConfirmDialog, TimelineRail, Eyebrow, DetailSheetHeader, ListRowSkeleton, EmptyState variants).
- Sandbox specimen added under Components: shows the canonical "stack of three DetailLists inside a SectionCard body" layout with the same fixture vocabulary the TX-detail Details sidebar uses.
- `IdPill` import is now scoped to the primitive — account-detail / connection-detail / category-detail no longer need the import.
- SectionCard `!pb-4` override is annotated in the source so a future reader understands the `[.border-b]:pb-6` rule it's neutralising.
- Audit method for the next time: `grep -rn "function DetailGroup\b" web/src/routes/` returned the four duplicates that triggered extraction — same playbook as the SoftBackButton / FormFooter promotions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
