### PR TITLE
design(v2): clip TimelineRail rail to disc centres

### DIFF
--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -4,21 +4,26 @@ import { Eyebrow } from "@/components/eyebrow";
 import { cn } from "@/lib/utils";
 
 // TimelineRail is the v2 vocabulary for a vertical activity feed: a thin
-// `border-l` rail anchors a stack of rows; each row's icon disc is rendered
-// on the card background so it "punches through" the line. Headings (day
-// labels, week labels, run-status labels) sit outside the rail so they read
-// as anchors instead of belonging to a row.
+// vertical rail anchors a stack of rows; each row's icon disc is rendered on
+// the card background so it "punches through" the line. Headings (day
+// labels, week labels, run-status labels) sit outside the rail as anchors.
 //
 // Promoted in iter 26 from `features/transactions/activity-timeline.tsx`
-// (open-coded since iter 5). The iter-5 drift note explicitly queued this
-// primitive once a second timeline surface needed it; we ship it now even
-// with a single consumer so future surfaces (rule run history, per-connection
-// sync log, agent activity) inherit one vocabulary instead of forking.
+// (open-coded since iter 5). Reworked in iter 56 to fix the rail-tail bug
+// flagged by iter 55's audit: the per-group rail used `<ol border-l>`,
+// which made the line visibly extend past the last row's icon disc — the
+// disc was inset with negative margin so the `<ol>`'s left border kept
+// going past the centred icon. We now draw the rail per-row via an
+// `::before` pseudo-element on each `<li>` and clip it to the disc centre
+// on the first and last row of each group via `:first-of-type` /
+// `:last-of-type`. Middle rows draw a full-height segment so the line
+// reads as continuous within each group.
 //
-// Composition: <TimelineRail> renders the wrapper spacing; nest
-// <TimelineRail.Group> children with optional `label` (day heading); inside
-// the group render any number of <TimelineRail.Row> children. Each row takes
-// an `icon` (Lucide component) and arbitrary children for the content.
+// Composition (unchanged consumer API): <TimelineRail> renders the wrapper
+// spacing; nest <TimelineRail.Group> children with optional `label` (day
+// heading); inside the group render any number of <TimelineRail.Row>
+// children. Each row takes an `icon` (Lucide component) and arbitrary
+// children for the content.
 
 interface TimelineRailProps extends React.HTMLAttributes<HTMLDivElement> {
   // Vertical rhythm between groups. Defaults to `space-y-5` — matches the
@@ -55,17 +60,11 @@ function TimelineRailGroup({
       {label !== undefined && label !== null && (
         <Eyebrow as="h3">{label}</Eyebrow>
       )}
-      {/* Subtle vertical rail behind the icons gives the feed a sense of
-          continuity without leaning on dividers between rows. Icons sit on
-          a card background to "punch through" the line. */}
-      <ol
-        className={cn(
-          "border-border/60 relative space-y-3 border-l pl-0",
-          listClassName,
-        )}
-      >
-        {children}
-      </ol>
+      {/* Rail is drawn per-row via `::before` on each <li>, not as a
+          continuous border on the <ol>. This lets us clip the line to the
+          first and last disc centres so the rail starts and ends exactly
+          where the content does — no stray tail under the last row. */}
+      <ol className={cn("relative space-y-3", listClassName)}>{children}</ol>
     </div>
   );
 }
@@ -97,13 +96,43 @@ function TimelineRailRow({
   const iconMuted = muted === true || muted === "icon-only";
   const contentMuted = muted === true;
   return (
-    <li className={cn("relative flex gap-3 pl-3", className)} {...rest}>
+    <li
+      className={cn(
+        // `relative` so the rail `::before` positions against the row;
+        // `pl-3.5` (14px) plus the disc's `-ml-3.5` lines the disc centre
+        // up with the rail x-position at the row's left edge (x=0).
+        "relative flex gap-3 pl-3.5",
+        // Rail line drawn via `::before`. 1px wide at the disc x-centre
+        // (left:0 of the row's padding-box, since the disc's negative
+        // margin pulls it back so its centre sits on x=0). The pseudo
+        // gets the same `border-border/60` token as the previous border.
+        "before:content-[''] before:absolute before:left-0 before:w-px before:bg-border/60",
+        // Middle rows: full height; the row's `space-y-3` (12px) gap with
+        // the next sibling is bridged by `bottom: -12px` so the rail
+        // appears unbroken between rows. `-top: 12px` mirrors that on the
+        // top edge for parity (the first-of-type override below cancels it
+        // on the first row).
+        "before:-top-3 before:-bottom-3",
+        // Clip the rail on the first row so it begins at the disc centre
+        // (half of size-7 = 14px) rather than extending above into the
+        // group's day heading.
+        "[&:first-of-type]:before:top-[14px]",
+        // Clip the rail on the last row so it ends at the disc centre
+        // rather than extending below the group. `bottom: calc(100% -
+        // 14px)` measured from the row's padding-box bottom edge lands
+        // the line exactly on the disc centre.
+        "[&:last-of-type]:before:bottom-[calc(100%-14px)]",
+        className,
+      )}
+      {...rest}
+    >
       <div
         className={cn(
-          // -ml + the rail-aligned icon disc. The negative margin equals the
-          // pl-3 (0.75rem) + half the disc (0.875rem = size-7/2) + the 1px
-          // rail, so the disc centres exactly on the rail.
-          "bg-card border-border/60 text-muted-foreground -ml-[calc(0.875rem+1px)] flex size-7 shrink-0 items-center justify-center rounded-full border",
+          // Disc centred on the rail (x=0). `-ml-3.5` (-14px) pulls the
+          // 28px-wide disc back so its centre sits on the row's left edge.
+          // `relative z-10` + `bg-card` punches the disc through the rail
+          // pseudo behind it.
+          "bg-card border-border/60 text-muted-foreground relative z-10 -ml-3.5 flex size-7 shrink-0 items-center justify-center rounded-full border",
           iconMuted && "opacity-50",
           iconClassName,
         )}


### PR DESCRIPTION
## Summary
- Replace the `<ol border-l>` rail with a per-row `::before` line clipped to the first and last disc centres via `:first-of-type` / `:last-of-type`.
- Fixes the stray rail-tail that the iter 55 audit flagged: the old rail kept going past the last row's icon disc because the disc was inset with a negative margin while the `<ol>` border ran to the bottom edge.
- Consumer API unchanged (`<TimelineRail><Group><Row /></Group></TimelineRail>`); only the rendering primitive changed.

## Before / After
| Before (rail tails below each group's last disc) | After (rail clipped to disc centres) |
| --- | --- |
| ![before](https://i.img402.dev/q0onu3iaei.jpg) | ![after](https://i.img402.dev/6qmm3pm7g0.jpg) |

Sandbox specimen at `/v2/sandbox` (Components tab → TimelineRail). Look at each group's bottom disc: in Before, the rail continues past it; in After, it stops at the disc centre.

## Notes
- Cross-group continuity (one rail across day groups, not per-group) is still queued as a follow-up. Doing it cleanly requires merging groups into a single `<ol>`, which is a bigger refactor with consumer-API impact — added as an open observation in the sprint state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)