### PR TITLE
design(v2): Loader2 spinner consistency across pending mutations

### DIFF
--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -3,6 +3,7 @@ import {
   ChevronsUpDown,
   ExternalLink,
   Keyboard,
+  Loader2,
   LogOut,
   type LucideIcon,
   MessageSquareText,
@@ -287,7 +288,11 @@ export function NavUser({ me }: { me: Me | null }) {
               }}
               className="text-destructive focus:text-destructive focus:bg-destructive/10 gap-2"
             >
-              <LogOut />
+              {logout.isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : (
+                <LogOut />
+              )}
               {logout.isPending ? "Signing out…" : "Sign out"}
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useFieldArray, useForm, type UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { AlertCircle, AlertTriangle, ChevronDown, Code2, Infinity as InfinityIcon, ListFilter, Plus, Save, Wand2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, ChevronDown, Code2, Infinity as InfinityIcon, ListFilter, Loader2, Plus, Save, Wand2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -656,7 +656,11 @@ export function RuleForm({
               Cancel
             </Button>
             <Button type="submit" disabled={submitting}>
-              <Save className="size-4" />
+              {submitting ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Save className="size-4" />
+              )}
               {submitting ? "Saving…" : submitLabel}
             </Button>
           </div>

--- a/web/src/features/settings/account-section.tsx
+++ b/web/src/features/settings/account-section.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -108,6 +109,7 @@ export function AccountSection() {
               )}
             />
             <Button type="submit" disabled={changePassword.isPending}>
+              {changePassword.isPending && <Loader2 className="size-4 animate-spin" />}
               {changePassword.isPending ? "Updating…" : "Update password"}
             </Button>
           </form>

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -418,6 +418,7 @@ function ScheduleForm({
         </div>
 
         <Button type="submit" disabled={save.isPending}>
+          {save.isPending && <Loader2 className="size-4 animate-spin" />}
           {save.isPending ? "Saving…" : "Save schedule"}
         </Button>
       </form>

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   Copy,
   Link2,
+  Loader2,
   MoreVertical,
   RefreshCw,
   Trash2,
@@ -497,6 +498,7 @@ function AddMemberDialog({ onDone }: { onDone: () => void }) {
               Cancel
             </Button>
             <Button type="submit" disabled={submitting}>
+              {submitting && <Loader2 className="size-4 animate-spin" />}
               {submitting ? "Adding…" : "Add member"}
             </Button>
           </DialogFooter>
@@ -606,6 +608,7 @@ function CreateLoginDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={createLogin.isPending}>
+              {createLogin.isPending && <Loader2 className="size-4 animate-spin" />}
               {createLogin.isPending ? "Creating…" : "Create login"}
             </Button>
           </DialogFooter>

--- a/web/src/features/transactions/comment-composer.tsx
+++ b/web/src/features/transactions/comment-composer.tsx
@@ -1,4 +1,5 @@
 import { useState, type KeyboardEvent } from "react";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useUpdateTransactions } from "@/api/queries/transactions";
@@ -55,6 +56,7 @@ export function CommentComposer({ transactionId }: CommentComposerProps) {
           disabled={!canSubmit}
           className="ml-auto"
         >
+          {update.isPending && <Loader2 className="size-4 animate-spin" />}
           {update.isPending ? "Posting…" : "Post note"}
         </Button>
       </div>


### PR DESCRIPTION
## Summary

- Six straggler buttons gain a `Loader2` spinner alongside their pending label, matching the established v2 convention from `FormFooter` / plaid-card / teller-card / backups Actions / reauth-sheet / connections toolbar.
- `nav-user` sign-out swaps the `LogOut` glyph for `Loader2` during pending so the dropdown row's leading icon also reflects the spin.
- `rule-form` swaps the `Save` glyph for `Loader2` during pending (icon-for-icon swap, since rule-form keeps a leading icon on the submit button at rest).

## Before / After

The comment composer's "Post note" button — pre-PR shows only a text swap to "Posting…" with no motion, post-PR shows the canonical spinner + label vocabulary the rest of the app uses. Captured via `fetch`-delay in DevTools.

| Before (text-only) | After (spinner + label) |
| --- | --- |
| ![before](https://i.img402.dev/zxvn5r43tj.jpg) | ![after](https://i.img402.dev/lbsd8g4pfb.jpg) |

## Affected callsites

| File | Before | After |
| --- | --- | --- |
| `transactions/comment-composer.tsx` | "Posting…" only | `<Loader2 />` + "Posting…" |
| `components/nav-user.tsx` | `<LogOut />` + "Signing out…" | `<Loader2 />` + "Signing out…" |
| `settings/backups-section.tsx` (Save schedule) | "Saving…" only | `<Loader2 />` + "Saving…" |
| `settings/household-section.tsx` (Add member) | "Adding…" only | `<Loader2 />` + "Adding…" |
| `settings/household-section.tsx` (Create login) | "Creating…" only | `<Loader2 />` + "Creating…" |
| `settings/account-section.tsx` (Update password) | "Updating…" only | `<Loader2 />` + "Updating…" |
| `rules/rule-form.tsx` | `<Save />` + "Saving…" | `<Loader2 />` + "Saving…" |

## Notes

- Convention canonicalised: every pending mutation button reads as the same spin-+-label vocabulary across the app. No new primitive — the pattern is small enough that the abstraction would weigh more than the duplication. Worth promoting to a `<PendingButton>` helper only if a fourth axis lands (e.g. variant-aware leading icon swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)