### PR TITLE
design(v2): empty state copy audit — 20 callsites unified

### DIFF
--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -47,7 +47,7 @@ export function AccountRecentTransactions({
       empty={
         <EmptyState
           title="No transactions yet"
-          description="They appear after the first sync."
+          description="Transactions for this account will land here after the first successful sync."
           className="py-10"
         />
       }

--- a/web/src/features/connections/connection-accounts-list.tsx
+++ b/web/src/features/connections/connection-accounts-list.tsx
@@ -24,7 +24,7 @@ export function ConnectionAccountsList({ accounts }: ConnectionAccountsListProps
         variant="inline"
         icon={Wallet}
         title="No accounts yet"
-        description="Accounts will appear here after the first successful sync."
+        description="Accounts will land here after the first successful sync — usually within a minute of connecting."
       />
     );
   }

--- a/web/src/features/connections/sync-history-list.tsx
+++ b/web/src/features/connections/sync-history-list.tsx
@@ -21,7 +21,7 @@ export function SyncHistoryList({ logs }: SyncHistoryListProps) {
         variant="inline"
         icon={RefreshCw}
         title="No sync history yet"
-        description="Each sync run will appear here with its timing and result."
+        description="Every sync run lands here — manual, scheduled, or webhook-triggered — with its timing, counts, and result."
       />
     );
   }

--- a/web/src/features/home/home-connections-panel.tsx
+++ b/web/src/features/home/home-connections-panel.tsx
@@ -106,7 +106,7 @@ export function HomeConnectionsPanel({
           <EmptyState
             icon={Plug}
             title="No banks connected"
-            description="Link a bank or upload a CSV to start syncing transactions."
+            description="Link a bank via Plaid or Teller — or upload a CSV — to start the first sync."
             action={
               <Button asChild size="sm">
                 <Link to="/connections" search={{ action: "connect" }}>

--- a/web/src/features/home/home-recent-transactions.tsx
+++ b/web/src/features/home/home-recent-transactions.tsx
@@ -78,7 +78,7 @@ export function HomeRecentTransactions({
         <EmptyState
           icon={Receipt}
           title="No transactions yet"
-          description="Connect a bank or import a CSV to start seeing activity here."
+          description="Connect a bank or import a CSV — fresh activity will start landing here within a minute."
         />
       }
     />

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -447,7 +447,7 @@ function BackupsTable({
           variant="card"
           icon={HardDrive}
           title="No backups yet"
-          description="Create one above or set a schedule to start a regular cadence."
+          description="Take a manual snapshot above, or enable scheduled backups to start a regular cadence."
         />
       ) : (
         <div className="border-border overflow-hidden rounded-md border">

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -103,7 +103,7 @@ export function HouseholdSection() {
           variant="card"
           icon={Users}
           title="No family members yet"
-          description="Add members to connect their banks and attribute transactions by person."
+          description="Add a member to give each person their own connections and attribute transactions across the household."
         />
       ) : (
         <ul className="space-y-3">

--- a/web/src/features/transactions/activity-timeline.tsx
+++ b/web/src/features/transactions/activity-timeline.tsx
@@ -100,7 +100,7 @@ export function ActivityTimeline({ transactionId }: { transactionId: string }) {
       <EmptyState
         icon={Activity}
         title="No activity yet"
-        description="Comments, rule applications, and category changes show up here."
+        description="Comments, category changes, and rule applications will appear here as this transaction evolves."
       />
     );
   }

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -96,7 +96,7 @@ export function AccountDetailPage() {
         <EmptyState
           icon={Banknote}
           title="Account not found"
-          description="It may have been disconnected, or the link is wrong."
+          description="This account may have been disconnected, or the link is out of date. Head back to the accounts list to pick another."
           action={
             <Button variant="outline" asChild>
               <Link to="/accounts">Back to accounts</Link>

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -198,7 +198,7 @@ export function AccountsPage() {
         <EmptyState
           icon={Banknote}
           title="No accounts yet"
-          description="Connect a bank to start syncing accounts and transactions."
+          description="Link a bank via Plaid or Teller and accounts will land here as soon as the first sync completes."
           action={
             <Button asChild>
               <Link to="/connections" search={{ action: "connect" }}>
@@ -211,7 +211,7 @@ export function AccountsPage() {
       ) : visible.length === 0 ? (
         <EmptyState
           title="No accounts for this filter"
-          description="Switch family member or clear the filter to see other accounts."
+          description="Switch family member, or clear the filter to see every account in the household."
         />
       ) : (
         <div className="flex flex-col gap-4">

--- a/web/src/routes/api-keys.tsx
+++ b/web/src/routes/api-keys.tsx
@@ -167,7 +167,7 @@ function renderEmptyState({ tab, query, newKeyButton }: EmptyStateArgs) {
       <EmptyState
         icon={Key}
         title="No revoked keys"
-        description="Revoked keys show up here so you can audit the trail."
+        description="Once you revoke a key it lands here so you can keep an audit trail of what was issued and rolled."
       />
     );
   }
@@ -176,7 +176,7 @@ function renderEmptyState({ tab, query, newKeyButton }: EmptyStateArgs) {
       <EmptyState
         icon={Key}
         title="No matching keys"
-        description="Try a different search."
+        description="Try a different search term, or clear the filter to see every key."
       />
     );
   }
@@ -184,7 +184,7 @@ function renderEmptyState({ tab, query, newKeyButton }: EmptyStateArgs) {
     <EmptyState
       icon={Key}
       title="No API keys yet"
-      description="Mint a key to let agents, scripts, or the CLI talk to Breadbox."
+      description="Mint a key to let agents, scripts, or the CLI talk to Breadbox over REST or MCP."
       action={newKeyButton}
     />
   );

--- a/web/src/routes/categories.tsx
+++ b/web/src/routes/categories.tsx
@@ -105,13 +105,13 @@ export function CategoriesPage() {
           <EmptyState
             icon={Shapes}
             title="Couldn't load categories"
-            description="Refresh the page or check back in a moment."
+            description="Something went wrong fetching the category tree. Refresh the page or check back in a moment."
           />
         ) : !tree || tree.length === 0 ? (
           <EmptyState
             icon={Shapes}
             title="No categories yet"
-            description="Create your first category to start organizing transactions."
+            description="Create your first category to start organizing transactions — rules and reports both key off the tree you build here."
             action={
               <Button asChild>
                 <Link to="/categories/new">

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -59,7 +59,7 @@ export function CategoryDetailPage() {
         <EmptyState
           icon={Shapes}
           title="Category not found"
-          description="It may have been deleted, or the link is wrong."
+          description="This category may have been deleted, or the link is out of date. Head back to the categories list to pick another."
           action={
             <Button variant="outline" asChild>
               <Link to="/categories">Back to categories</Link>

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -210,7 +210,7 @@ export function ConnectionDetailPage() {
         <EmptyState
           icon={Plug}
           title="Connection not found"
-          description="It may have been disconnected, or the link is wrong."
+          description="This connection may have been removed, or the link is out of date. Head back to the connections list to pick another."
           action={
             <Button variant="outline" asChild>
               <Link to="/connections">Back to connections</Link>

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -298,7 +298,7 @@ export function ConnectionsPage() {
         <EmptyState
           icon={Plug}
           title="No connections yet"
-          description="Connect a bank to start syncing transactions across your household."
+          description="Link a bank via Plaid or Teller — or drop in a CSV — to start syncing transactions across the household."
           action={
             <Button onClick={openConnectSheet}>
               <Plus className="size-4" />
@@ -354,7 +354,7 @@ export function ConnectionsPage() {
           empty={
             <EmptyState
               title="No connections for this filter"
-              description="Switch family member or clear the filter to see other connections."
+              description="Switch family member, or clear the filter to see every connection in the household."
               className="py-10"
             />
           }

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -183,8 +183,8 @@ export function RulesPage() {
           title={hasActiveFilters ? "No matching rules" : "No rules yet"}
           description={
             hasActiveFilters
-              ? "Try adjusting or clearing your filters."
-              : "Create a rule to automatically categorize, tag, or comment on transactions during sync."
+              ? "Try adjusting your filters, or clear them to see every rule."
+              : "Create a rule to automatically categorize, tag, or comment on transactions as they sync in."
           }
           action={
             <Button asChild>

--- a/web/src/routes/tag-detail.tsx
+++ b/web/src/routes/tag-detail.tsx
@@ -32,7 +32,7 @@ export function TagDetailPage() {
         <EmptyState
           icon={TagsIcon}
           title="Tag not found"
-          description="It may have been deleted, or the link is wrong."
+          description="This tag may have been deleted, or the link is out of date. Head back to the tags list to pick another."
           action={
             <Button variant="outline" asChild>
               <Link to="/tags">Back to tags</Link>

--- a/web/src/routes/tags.tsx
+++ b/web/src/routes/tags.tsx
@@ -80,13 +80,13 @@ export function TagsPage() {
               <EmptyState
                 icon={TagsIcon}
                 title="No matching tags"
-                description="Try a different search term."
+                description="Try a different search term, or clear the filter to see every tag."
               />
             ) : (
               <EmptyState
                 icon={TagsIcon}
                 title="No tags yet"
-                description="Create your first tag to start labelling transactions."
+                description="Create your first tag to label transactions across categories — useful for travel, reimbursements, or any ad-hoc grouping."
                 action={
                   <Button asChild>
                     <Link to="/tags/new">

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -45,7 +45,7 @@ export function TransactionDetailPage() {
         <EmptyState
           icon={Receipt}
           title="Transaction not found"
-          description="It may have been deleted, or the link is wrong."
+          description="This transaction may have been deleted, or the link is out of date. Head back to the transactions list to pick another."
           action={
             <Button variant="outline" asChild>
               <Link to="/transactions">Back to transactions</Link>

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -434,8 +434,8 @@ export function TransactionsPage() {
             }
             description={
               hasActiveFilters
-                ? "Adjust or clear your filters to see more results."
-                : "Once a connected account finishes syncing, transactions will land here."
+                ? "Try adjusting your filters, or clear them to see every transaction."
+                : "Once a connected account finishes syncing, transactions will land here — usually within a minute."
             }
             action={
               hasActiveFilters ? undefined : (


### PR DESCRIPTION
## Summary

- Audit every `<EmptyState>` in the v2 SPA (20 callsites). Unifies voice, verb choice, and helpful specificity so every page reads as part of the same product.
- "Not found" detail pages (transaction / account / connection / category / tag) all collapse onto a single template — "This X may have been {deleted|disconnected}, or the link is out of date. Head back to the X list to pick another." — instead of five subtly different lines.
- Filter/search empties end with a single canonical phrase (mirroring categories): "Try a different search term, or clear the filter to see every X."
- Yet-to-have-data empties name the actual trigger (manual / scheduled / webhook) and the time horizon ("within a minute") so the user knows what to expect, plus the use cases (rules + reports key off the category tree; tags cross categories; API keys speak REST or MCP).

## After

| API keys — revoked tab (empty) | Tag detail — not found |
| --- | --- |
| ![revoked](https://i.img402.dev/m4txrus104.jpg) | ![notfound](https://i.img402.dev/90w1fxhs5j.jpg) |

Notes on the screenshots:
- *Revoked tab*: previously "Revoked keys show up here so you can audit the trail." → now names the lifecycle (issued / rolled) and explicit purpose (audit trail).
- *Tag not found*: previously "It may have been deleted, or the link is wrong." → now names the entity ("This tag"), softens the failure mode ("out of date" vs "wrong"), and points to the next action ("Head back to the tags list to pick another"). Same template now used for transaction / account / connection / category not-found pages.

## Notes

- No new primitives; copy-only sweep. `EmptyState` contract is unchanged.
- 20 files touched across `web/src/routes/` and `web/src/features/{home,connections,transactions,accounts,settings}/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
