### PR TITLE
design(v2): consolidate currency formatters in lib/format

### DIFF
--- a/web/src/features/accounts/account-row.tsx
+++ b/web/src/features/accounts/account-row.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { AlertTriangle, ChevronRight, Link2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { formatBalance } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Account } from "@/api/types";
 import {
@@ -8,7 +9,6 @@ import {
   accountTypeIcon,
   accountTypeLabel,
   creditUtilization,
-  formatCurrency,
   isLiability,
   utilizationBarClass,
 } from "./account-utils";
@@ -65,7 +65,7 @@ export function AccountRow({ account: a }: AccountRowProps) {
               <span>{Math.round(util)}% used</span>
               {a.balance_limit != null && (
                 <span>
-                  {formatCurrency(a.balance_limit, a.iso_currency_code)} limit
+                  {formatBalance(a.balance_limit, a.iso_currency_code)} limit
                 </span>
               )}
             </div>
@@ -89,7 +89,7 @@ export function AccountRow({ account: a }: AccountRowProps) {
             )}
           >
             {a.balance_current != null
-              ? formatCurrency(
+              ? formatBalance(
                   liability ? -a.balance_current : a.balance_current,
                   a.iso_currency_code,
                 )

--- a/web/src/features/accounts/account-utils.ts
+++ b/web/src/features/accounts/account-utils.ts
@@ -75,21 +75,6 @@ export function utilizationBarClass(pct: number): string {
   return "bg-emerald-500";
 }
 
-// formatCurrency renders an amount in the supplied ISO code via Intl.
-// Currency keys are scarce enough that we don't bother caching formatters
-// (cf. lib/format.ts) — most accounts use one of two currencies and
-// list pages re-render rarely.
-export function formatCurrency(amount: number, currency: string | null): string {
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: currency ?? "USD",
-      maximumFractionDigits: 2,
-    }).format(amount);
-  } catch {
-    return `${amount.toFixed(2)} ${currency ?? ""}`.trim();
-  }
-}
 
 export interface CurrencyTotal {
   currency: string;

--- a/web/src/features/accounts/accounts-summary.tsx
+++ b/web/src/features/accounts/accounts-summary.tsx
@@ -1,8 +1,9 @@
 import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatBalance } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Account } from "@/api/types";
-import { formatCurrency, isLiability, totalsByCurrency } from "./account-utils";
+import { isLiability, totalsByCurrency } from "./account-utils";
 
 interface AccountsSummaryProps {
   accounts: Account[];
@@ -42,7 +43,7 @@ export function AccountsSummary({ accounts }: AccountsSummaryProps) {
       <SummaryStat
         icon={Wallet}
         label="Net worth"
-        value={formatCurrency(primary.total, primary.currency)}
+        value={formatBalance(primary.total, primary.currency)}
         sublabel={
           others.length > 0
             ? `+ ${others.length} other currenc${others.length === 1 ? "y" : "ies"}`
@@ -54,13 +55,13 @@ export function AccountsSummary({ accounts }: AccountsSummaryProps) {
       <SummaryStat
         icon={ArrowUpRight}
         label="Assets"
-        value={formatCurrency(assets, primary.currency)}
+        value={formatBalance(assets, primary.currency)}
         tone="success"
       />
       <SummaryStat
         icon={ArrowDownRight}
         label="Liabilities"
-        value={formatCurrency(liabilities, primary.currency)}
+        value={formatBalance(liabilities, primary.currency)}
         tone="muted"
       />
     </div>

--- a/web/src/features/connections/connection-accounts-list.tsx
+++ b/web/src/features/connections/connection-accounts-list.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { Banknote, CreditCard, Landmark, PiggyBank, Wallet } from "lucide-react";
 import type { Account } from "@/api/types";
 import { EmptyState } from "@/components/empty-state";
-import { formatCurrency } from "./connection-utils";
+import { formatBalance } from "@/lib/format";
 
 const TYPE_ICON: Record<string, typeof Banknote> = {
   depository: PiggyBank,
@@ -57,7 +57,7 @@ function AccountCard({ account: a }: { account: Account }) {
       </div>
       <div className="text-right text-sm font-semibold tabular-nums whitespace-nowrap">
         {a.balance_current != null && a.iso_currency_code
-          ? formatCurrency(a.balance_current, a.iso_currency_code)
+          ? formatBalance(a.balance_current, a.iso_currency_code)
           : "—"}
       </div>
     </Link>

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { formatBalance } from "@/lib/format";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { cn } from "@/lib/utils";
 import {
@@ -28,7 +29,6 @@ import {
 import type { Connection } from "@/api/types";
 import { ConnectionStatusBadge } from "./connection-status-badge";
 import {
-  formatCurrency,
   primaryBalance,
   providerLabel,
   relativeTime,
@@ -165,7 +165,7 @@ export function ConnectionRow({
           <div className="text-right">
             {balance ? (
               <div className="text-sm font-semibold tabular-nums">
-                {formatCurrency(balance.amount, balance.currency)}
+                {formatBalance(balance.amount, balance.currency)}
               </div>
             ) : null}
             <div className="text-muted-foreground text-xs">

--- a/web/src/features/connections/connection-utils.ts
+++ b/web/src/features/connections/connection-utils.ts
@@ -127,16 +127,3 @@ export function primaryBalance(
   };
 }
 
-// Currency formatter — defers to Intl. Returns the original number formatted
-// to the supplied currency, no leading sign manipulation.
-export function formatCurrency(amount: number, currency: string): string {
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency,
-      maximumFractionDigits: 2,
-    }).format(amount);
-  } catch {
-    return `${amount.toFixed(2)} ${currency}`;
-  }
-}

--- a/web/src/features/home/home-stats.tsx
+++ b/web/src/features/home/home-stats.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { formatCompactAmount } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Account, Connection } from "@/api/types";
 
@@ -42,14 +43,6 @@ function primary(b: CurrencyTotals): { amount: number; currency: string } {
     }
   }
   return { amount: b.totals.get(bestC) ?? 0, currency: bestC };
-}
-
-function formatCompact(amount: number, currency: string): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 0,
-  }).format(amount);
 }
 
 // HomeStats is the hero balance summary on the home page. A single
@@ -109,7 +102,7 @@ export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) 
               Net cash
             </>
           }
-          value={formatCompact(netP.amount, netP.currency)}
+          value={formatCompactAmount(netP.amount, netP.currency)}
           valueTone={positive ? "positive" : "negative"}
           hint={
             <>
@@ -131,7 +124,7 @@ export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) 
               Cash
             </>
           }
-          value={formatCompact(cashP.amount, cashP.currency)}
+          value={formatCompactAmount(cashP.amount, cashP.currency)}
           hint={`${cash.count} ${cash.count === 1 ? "depository" : "depository accounts"}`}
           className="px-6 py-5 sm:border-l sm:py-7"
         />
@@ -142,7 +135,7 @@ export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) 
               Credit &amp; loans
             </>
           }
-          value={formatCompact(creditP.amount, creditP.currency)}
+          value={formatCompactAmount(creditP.amount, creditP.currency)}
           valueTone={creditP.amount > 0 ? "warning" : "neutral"}
           hint={`${credit.count} ${credit.count === 1 ? "balance" : "balances"}`}
           className="px-6 py-5 sm:border-l sm:py-7 sm:pr-7"

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -20,6 +20,46 @@ export function formatAmount(amount: number, currency: string | null): string {
   return amount < 0 ? `+${formatted}` : formatted;
 }
 
+// formatBalance renders an account balance / non-transaction amount with the
+// sign preserved (no leading + for negatives). Use this for balances,
+// totals, and any surface that isn't following the transaction sign
+// convention. Cached `Intl.NumberFormat` per currency, same as
+// `formatAmount`.
+export function formatBalance(amount: number, currency: string | null): string {
+  try {
+    return currencyFormatter(currency ?? "USD").format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency ?? ""}`.trim();
+  }
+}
+
+const compactCurrencyFormatters = new Map<string, Intl.NumberFormat>();
+
+function compactCurrencyFormatter(currency: string): Intl.NumberFormat {
+  let f = compactCurrencyFormatters.get(currency);
+  if (!f) {
+    f = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    });
+    compactCurrencyFormatters.set(currency, f);
+  }
+  return f;
+}
+
+// formatCompactAmount renders a currency amount without minor units —
+// `$1,234` rather than `$1,234.56`. Used for hero KPIs where two decimals
+// add noise but the headline number is what the user is scanning. Cached
+// `Intl.NumberFormat` per currency.
+export function formatCompactAmount(amount: number, currency: string | null): string {
+  try {
+    return compactCurrencyFormatter(currency ?? "USD").format(amount);
+  } catch {
+    return `${Math.round(amount)} ${currency ?? ""}`.trim();
+  }
+}
+
 // parseIsoDate parses a YYYY-MM-DD string as a local-midnight Date so day-of
 // boundaries don't drift by a day when the user's timezone is west of UTC.
 // (`new Date("2026-01-02")` parses as UTC midnight, then renders as the prior

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -38,10 +38,10 @@ import {
   accountTypeIcon,
   accountTypeLabel,
   creditUtilization,
-  formatCurrency,
   isLiability,
   utilizationBarClass,
 } from "@/features/accounts/account-utils";
+import { formatBalance } from "@/lib/format";
 import { AccountSettingsCard } from "@/features/accounts/account-settings-card";
 import { AccountRecentTransactions } from "@/features/accounts/account-recent-transactions";
 import { AccountLinksSection } from "@/features/accounts/account-links-section";
@@ -305,7 +305,7 @@ function Hero({
             )}
           >
             {current != null
-              ? formatCurrency(current, a.iso_currency_code)
+              ? formatBalance(current, a.iso_currency_code)
               : "—"}
           </div>
 
@@ -315,7 +315,7 @@ function Hero({
                 <span>{Math.round(util)}% used</span>
                 {a.balance_limit != null && (
                   <span>
-                    of {formatCurrency(a.balance_limit, a.iso_currency_code)}
+                    of {formatBalance(a.balance_limit, a.iso_currency_code)}
                   </span>
                 )}
               </div>
@@ -331,7 +331,7 @@ function Hero({
             </div>
           ) : a.balance_available != null ? (
             <p className="text-muted-foreground pt-1 text-[11px] tabular-nums">
-              {formatCurrency(a.balance_available, a.iso_currency_code)} available
+              {formatBalance(a.balance_available, a.iso_currency_code)} available
             </p>
           ) : a.iso_currency_code ? (
             <p className="text-muted-foreground pt-1 text-[11px]">
@@ -381,13 +381,13 @@ function DetailsCard({ account: a }: { account: AccountDetail }) {
     a.balance_limit != null && isLiability(a.type)
       ? {
           label: "Credit limit",
-          value: formatCurrency(a.balance_limit, a.iso_currency_code),
+          value: formatBalance(a.balance_limit, a.iso_currency_code),
         }
       : null,
     a.balance_available != null && !isLiability(a.type)
       ? {
           label: "Available",
-          value: formatCurrency(a.balance_available, a.iso_currency_code),
+          value: formatBalance(a.balance_available, a.iso_currency_code),
         }
       : null,
     a.iso_currency_code ? { label: "Currency", value: a.iso_currency_code } : null,

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -18,11 +18,11 @@ import { FamilyTabs } from "@/features/connections/family-tabs";
 import { AccountRow } from "@/features/accounts/account-row";
 import { AccountsSummary } from "@/features/accounts/accounts-summary";
 import {
-  formatCurrency,
   groupAccounts,
   groupNetTotal,
   type AccountGroupBy,
 } from "@/features/accounts/account-utils";
+import { formatBalance } from "@/lib/format";
 
 // Search-param schema.
 //   user → "all" or a user short_id  (family-member filter)
@@ -228,7 +228,7 @@ export function AccountsPage() {
                   <div className="flex items-center gap-3">
                     {totals.currency != null && (
                       <span className="text-sm font-medium tabular-nums whitespace-nowrap">
-                        {formatCurrency(totals.total, totals.currency)}
+                        {formatBalance(totals.total, totals.currency)}
                       </span>
                     )}
                     <span className="bg-muted text-muted-foreground inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums">

--- a/web/src/sandbox/sections/amounts.tsx
+++ b/web/src/sandbox/sections/amounts.tsx
@@ -1,4 +1,4 @@
-import { formatAmount } from "@/lib/format";
+import { formatAmount, formatBalance, formatCompactAmount } from "@/lib/format";
 import { TransactionAmount } from "@/components/transaction-amount";
 import { SandboxSection, Specimen } from "@/sandbox/kit";
 import { sampleTransactions } from "@/sandbox/fixtures";
@@ -106,6 +106,69 @@ export function AmountsSection() {
               </div>
               <span className="shrink-0 text-sm font-medium tabular-nums">
                 {a.output}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="formatBalance"
+        code="lib/format"
+        description="Account balances, totals, scoreboard cells — anything that isn't following the transaction sign convention. Same cached Intl.NumberFormat as formatAmount; no leading + for negatives, sign rendered literally."
+        className="block"
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          {[
+            { code: "formatBalance(8240.55, 'USD')", out: formatBalance(8240.55, "USD"), note: "asset balance" },
+            { code: "formatBalance(-1240, 'USD')", out: formatBalance(-1240, "USD"), note: "overdraft — sign preserved" },
+            { code: "formatBalance(42, 'EUR')", out: formatBalance(42, "EUR") },
+            { code: "formatBalance(0, null)", out: formatBalance(0, null), note: "null currency → USD fallback" },
+          ].map((a) => (
+            <div
+              key={a.code}
+              className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+            >
+              <div className="min-w-0">
+                <code className="text-muted-foreground block truncate font-mono text-xs">
+                  {a.code}
+                </code>
+                {a.note && (
+                  <span className="text-muted-foreground text-[10px]">
+                    {a.note}
+                  </span>
+                )}
+              </div>
+              <span className="shrink-0 text-sm font-medium tabular-nums">
+                {a.out}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="formatCompactAmount"
+        code="lib/format"
+        description="Hero KPIs — strips minor units so the headline number reads at a glance. Used by the home stats card. Cached Intl.NumberFormat per currency."
+        className="block"
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          {[
+            { code: "formatCompactAmount(12450.55, 'USD')", out: formatCompactAmount(12450.55, "USD") },
+            { code: "formatCompactAmount(-3200, 'USD')", out: formatCompactAmount(-3200, "USD") },
+            { code: "formatCompactAmount(8240, 'EUR')", out: formatCompactAmount(8240, "EUR") },
+            { code: "formatCompactAmount(420000, 'JPY')", out: formatCompactAmount(420000, "JPY") },
+          ].map((a) => (
+            <div
+              key={a.code}
+              className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+            >
+              <code className="text-muted-foreground block truncate font-mono text-xs">
+                {a.code}
+              </code>
+              <span className="shrink-0 text-sm font-medium tabular-nums">
+                {a.out}
               </span>
             </div>
           ))}


### PR DESCRIPTION
## Summary

Three currency formatters had forked across the SPA — `home-stats`'s
`formatCompact`, `connection-utils`'s `formatCurrency`,
`account-utils`'s `formatCurrency`. Each rebuilt `Intl.NumberFormat`
on every call, side-stepping the cached pattern in `lib/format.ts`
that `formatAmount` uses. This PR promotes two siblings —
`formatBalance` and `formatCompactAmount` — to `lib/format.ts`, sweeps
all five consumers onto them, and drops the forks. One module, one
locale, one cache per currency for every money surface.

- **`formatBalance(amount, currency)`** — same cached `Intl.NumberFormat`
  per currency as `formatAmount`, but renders the sign literally (no
  leading `+`). For account balances, totals, scoreboard cells.
- **`formatCompactAmount(amount, currency)`** — strips minor units
  (`$1,234` not `$1,234.56`). Used by the home KPI hero. Same cache
  pattern.

## Sandbox specimen

Visual output for live currency surfaces (home stats, accounts list, account
detail, connection rows) is byte-for-byte identical — this is a refactor.
The sandbox `AmountsSection` is the audit surface for the consolidated
vocabulary; it now documents all three formatters with cases that cover
sign, locale, fallback, and the compact (no-minor-units) variant.

![Sandbox amounts after](https://i.img402.dev/wgro0chaiw.jpg)

## Notes

- Drift retired: `Intl.NumberFormat` no longer constructed outside
  `lib/format.ts`. `grep -rn "new Intl.NumberFormat" web/src` now
  returns one hit (the helper itself).
- `account-utils.ts` and `connection-utils.ts` lose their inline
  helpers — both files shrink to their actual domain logic
  (account/balance grouping, primary-balance picking).
- Audit method (record for next iteration): `grep -rn "new Intl.NumberFormat\|formatCurrency\|formatCompact" web/src --include='*.tsx' --include='*.ts'` enumerates every money-formatter callsite in one pass; a single fork is the trigger to consolidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)