### PR TITLE
design(v2): toast success copy audit — split two-thought titles

### DIFF
--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
 import {
   ArrowRight,
   Link2,
@@ -171,15 +173,22 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
   const otherUser = isPrimary ? link.dependent_user_name : link.primary_user_name;
 
   async function onReconcile() {
-    await withMutationToast(
-      async () => {
-        const r = await reconcile.mutateAsync(link.id);
-        return r;
-      },
-      {
-        success: `Reconciled — ${reconcile.data?.new_matches ?? 0} new matches.`,
-      },
-    );
+    try {
+      const r = await reconcile.mutateAsync(link.id);
+      const count = r?.new_matches ?? 0;
+      toast.success("Reconciled.", {
+        description:
+          count === 0
+            ? "No new matches this pass."
+            : `${count} new match${count === 1 ? "" : "es"} found.`,
+      });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't reconcile this link. Try again.";
+      toast.error(msg);
+    }
   }
 
   async function onDelete() {

--- a/web/src/features/accounts/account-settings-card.tsx
+++ b/web/src/features/accounts/account-settings-card.tsx
@@ -52,9 +52,10 @@ export function AccountSettingsCard({ account: a }: AccountSettingsCardProps) {
     await withMutationToast(
       () => update.mutateAsync({ id: a.short_id, input: { is_excluded: next } }),
       {
-        success: next
-          ? "Account excluded — future syncs will skip it."
-          : "Account included in sync.",
+        success: next ? "Account excluded." : "Account included.",
+        successDescription: next
+          ? "Future syncs will skip it."
+          : "Future syncs will include it again.",
       },
     );
   }

--- a/web/src/features/accounts/link-account-sheet.tsx
+++ b/web/src/features/accounts/link-account-sheet.tsx
@@ -91,7 +91,10 @@ export function LinkAccountSheet({
           dependent_account_id: dependentId,
           match_tolerance_days: Number.isFinite(tol) && tol >= 0 ? tol : undefined,
         }),
-      { success: "Accounts linked. Matches will reconcile on the next sync." },
+      {
+        success: "Accounts linked.",
+        successDescription: "Matches will reconcile on the next sync.",
+      },
     );
     if (ok) {
       setDependentId("");

--- a/web/src/features/connections/selection-action-bar.tsx
+++ b/web/src/features/connections/selection-action-bar.tsx
@@ -72,7 +72,10 @@ export function SelectionActionBar({
     if (syncable.length === 0) return;
     const ok = await withMutationToast(
       () => runChunked(syncable, (c) => sync.mutateAsync(c.id)),
-      { success: `Sync queued for ${syncable.length} connection${syncable.length === 1 ? "" : "s"}.` },
+      {
+        success: `Sync queued for ${syncable.length} connection${syncable.length === 1 ? "" : "s"}.`,
+        successDescription: "New transactions land within a minute.",
+      },
     );
     if (ok) onClear();
   }

--- a/web/src/features/providers/plaid-card.tsx
+++ b/web/src/features/providers/plaid-card.tsx
@@ -104,7 +104,8 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
 
   async function onDisable() {
     const ok = await withMutationToast(() => disable.mutateAsync("plaid"), {
-      success: "Plaid disabled. Stored credentials were cleared.",
+      success: "Plaid disabled.",
+      successDescription: "Stored credentials were cleared.",
     });
     if (ok) setConfirmingDisable(false);
   }

--- a/web/src/features/providers/teller-card.tsx
+++ b/web/src/features/providers/teller-card.tsx
@@ -128,7 +128,8 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
 
   async function onDisable() {
     const ok = await withMutationToast(() => disable.mutateAsync("teller"), {
-      success: "Teller disabled. Stored credentials were cleared.",
+      success: "Teller disabled.",
+      successDescription: "Stored credentials were cleared.",
     });
     if (ok) setConfirmingDisable(false);
   }

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -232,7 +232,8 @@ function BackupActions({ disabled }: { disabled: boolean }) {
     if (!pendingUpload) return;
     const file = pendingUpload;
     const ok = await withMutationToast(() => upload.mutateAsync(file), {
-      success: "Restored from uploaded backup. Restart the server to be safe.",
+      success: "Restored from uploaded backup.",
+      successDescription: "Restart the server to be safe.",
     });
     if (ok) {
       setPendingUpload(null);
@@ -480,7 +481,8 @@ function BackupRowItem({
 
   const runRestore = async () => {
     const ok = await withMutationToast(() => restore.mutateAsync(row.filename), {
-      success: `Restored from ${row.filename}. Restart the server to be safe.`,
+      success: `Restored from ${row.filename}.`,
+      successDescription: "Restart the server to be safe.",
     });
     if (ok) setConfirm(null);
   };

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -303,6 +303,7 @@ function DetailBody({
   async function onSync() {
     await withMutationToast(() => sync.mutateAsync(conn.id), {
       success: `Sync queued for ${conn.institution_name ?? "connection"}.`,
+      successDescription: "New transactions land within a minute.",
     });
   }
 

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -190,6 +190,7 @@ export function ConnectionsPage() {
   async function onSyncAll() {
     await withMutationToast(() => syncAll.mutateAsync(), {
       success: "Sync queued for every active connection.",
+      successDescription: "New transactions land within a minute.",
     });
   }
 

--- a/web/src/routes/rule-detail.tsx
+++ b/web/src/routes/rule-detail.tsx
@@ -86,7 +86,8 @@ export function RuleDetailPage() {
     const ok = await withMutationToast(
       () => applyRule.mutateAsync(rule.short_id),
       {
-        success: "Rule applied retroactively. Transactions are being updated.",
+        success: "Rule applied retroactively.",
+        successDescription: "Transactions are being updated.",
       },
     );
     if (ok) {

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -92,7 +92,7 @@ export function PatternsSection() {
       <Specimen
         label="Toasts"
         code="sonner · withMutationToast"
-        description="One toast surface for the whole app. Each tone gets a coloured left rail + tinted icon tile — same vocabulary as <StatusPanel>. withMutationToast wraps a mutation: success toast on resolve, the ApiError message on reject."
+        description="One toast surface for the whole app. Each tone gets a coloured left rail + tinted icon tile — same vocabulary as <StatusPanel>. withMutationToast wraps a mutation: success toast on resolve, the ApiError message on reject. Use the successDescription slot for any two-thought outcome (what happened + what to expect / do next) instead of cramming both into the title."
         className="block"
       >
         <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- Promoted `successDescription` from "documented but unused" to a real adoption: every two-thought success copy (backups restore, provider disable, account exclude/include, accounts linked, rule applied retroactively, accounts reconciled) now splits "what happened" / "what's next" between the title and the muted description line.
- Enriched the three sync-queued surfaces (connection detail, all-active button, multi-select action bar) with a "New transactions land within a minute" description so the user knows the time horizon — same vocabulary the iter-58 empty-state sweep established for sync history.
- Sandbox patterns specimen description spells out the canonical split so future call sites pick the right shape.

## Pattern (after)

![after — withMutationToast with successDescription](https://i.img402.dev/rvy34njv7h.jpg)

The bottom-right toast shows the canonical two-line shape — title carries "what happened" (`Rule applied.`), the muted description carries "what to expect" (`12 transactions matched and were re-categorised.`). Same Toaster surface (3px tinted left rail + tinted icon tile from iter 20) — every consumer just learned how to use the slot.

## Diff sample (before / after)

```diff
- success: "Restored from uploaded backup. Restart the server to be safe.",
+ success: "Restored from uploaded backup.",
+ successDescription: "Restart the server to be safe.",

- success: "Plaid disabled. Stored credentials were cleared.",
+ success: "Plaid disabled.",
+ successDescription: "Stored credentials were cleared.",

- success: next
-   ? "Account excluded — future syncs will skip it."
-   : "Account included in sync.",
+ success: next ? "Account excluded." : "Account included.",
+ successDescription: next
+   ? "Future syncs will skip it."
+   : "Future syncs will include it again.",

- success: `Reconciled — ${reconcile.data?.new_matches ?? 0} new matches.`,
+ // folded into try/catch so the count comes from the awaited result
+ toast.success("Reconciled.", { description: `${count} new match${count === 1 ? "" : "es"} found.` });
```

## Notes
- `account-links-section.onReconcile()` folded out of `withMutationToast` into a `try/catch` so the new-matches count (only available on the awaited result) can be rendered in the description — the helper's success-string was captured *before* the mutation resolved, so the count was always reading 0 from the previous run. Single-callsite fix; not a primitive change.
- Helper unchanged — `successDescription` shipped in iter 20 (#1133) and had been waiting for its first real consumer. Now 7 surfaces use it.
- Em-dash hacks retired: two callsites ("Account excluded — …", "Reconciled — N new matches.") had been using `—` as an inline title/description separator. The description slot is the right home for that copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)