### PR TITLE
design(v2): treat timeline day-headings as temporal dividers

### DIFF
--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -58,7 +58,28 @@ function TimelineRailGroup({
   return (
     <div className={cn("space-y-3", className)} {...rest}>
       {label !== undefined && label !== null && (
-        <Eyebrow as="h3">{label}</Eyebrow>
+        // Day-heading separator: a small dot anchored on the rail's x-axis
+        // (matches the disc centre below), followed by the eyebrow label,
+        // and a hairline rule that fills the remaining width. The dot +
+        // hairline make the heading read as a *temporal divider inside the
+        // timeline* instead of a generic section header — distinguishing it
+        // from the SectionCard/CardHeader "Activity" title that sits above
+        // the whole feed. Iter 62.
+        //
+        // Geometry: `pl-3.5` mirrors the rows below so the eyebrow's
+        // baseline aligns vertically with row content. The 6px dot
+        // (`size-1.5`) needs `-ml-[17px]` (= -14px row-padding − 3px
+        // half-dot-width) so its centre sits exactly on the rail's x-axis
+        // at x=0, matching the disc centres of the rows.
+        <div className="flex items-center gap-2 pl-3.5">
+          <span
+            aria-hidden
+            className="bg-border/80 size-1.5 shrink-0 rounded-full"
+            style={{ marginLeft: "-17px" }}
+          />
+          <Eyebrow as="h3">{label}</Eyebrow>
+          <span aria-hidden className="bg-border/60 h-px flex-1" />
+        </div>
       )}
       {/* Rail is drawn per-row via `::before` on each <li>, not as a
           continuous border on the <ol>. This lets us clip the line to the

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -683,7 +683,7 @@ export function ComponentsSection() {
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
-        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels sit outside the rail as anchors. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
+        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
         className="block"
       >
         <div className="max-w-md">


### PR DESCRIPTION
## Summary
- Re-rendered `TimelineRail.Group`'s `label` as a temporal divider — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so day-headings read as separators *inside* the timeline rather than generic section headers.
- Distinguishes the day-heading from the surrounding `<SectionCard>` "Activity" title that sits above the whole feed.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/ux59ip9435.jpg) | ![after](https://i.img402.dev/u0jsfbd2eu.jpg) |

## Notes
- No consumer API change — every `TimelineRail.Group` site inherits the new look. Live consumer today: activity-timeline on TX-detail. Sandbox specimen description updated.
- Geometry: 6px dot uses `marginLeft: "-17px"` (= -14px row-padding − 3px half-dot-width) so its centre sits exactly on the rail's x-axis at x=0, matching the disc centres of the rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)