### PR TITLE
design(v2): SettingsSectionHeader primitive consolidates settings headings

### DIFF
--- a/web/src/components/settings-section-header.tsx
+++ b/web/src/components/settings-section-header.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface SettingsSectionHeaderProps {
+  /**
+   * Visual weight. `section` is the top-of-pane title (one per settings tab —
+   * Account / Household / Backups). `sub` is a grouping rule used inside a
+   * pane to delimit a logical block (Change password / Actions / Stored
+   * backups / Automatic schedule).
+   *
+   * Defaults to `section` because the most common use is the lead-in
+   * paragraph for a tab body.
+   */
+  level?: "section" | "sub";
+  title: string;
+  description?: React.ReactNode;
+  /**
+   * Right-aligned actions — usually a single `<Button size="sm">` (Add
+   * member, New key, etc.) or a cluster.
+   */
+  action?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * `<SettingsSectionHeader>` is the canonical title + description block used
+ * by every section inside the Settings shell (`AccountSection`,
+ * `HouseholdSection`, `BackupsSection`). Both top-of-pane titles ("Account",
+ * "Household", "Backups") and inline sub-sections ("Change password",
+ * "Actions", "Stored backups", "Automatic schedule") route through here, so
+ * the typographic rhythm — heading size + weight, description colour +
+ * line-height, action alignment — stays in one place.
+ *
+ * Vocabulary tokens:
+ *   - `section` → `<h2>` `text-lg font-medium`, baseline-aligned action,
+ *     `space-y-1` description.
+ *   - `sub`     → `<h3>` `text-sm font-medium`, baseline-aligned action,
+ *     `space-y-1` description.
+ *
+ * Don't fork the look — extend the primitive. If a fourth weight is needed
+ * (e.g. a "field group" rhythm tighter than `sub`), add it as a new token
+ * here rather than open-coding another `<h4>` block in a feature file.
+ */
+export function SettingsSectionHeader({
+  level = "section",
+  title,
+  description,
+  action,
+  className,
+}: SettingsSectionHeaderProps) {
+  const Heading = level === "section" ? "h2" : "h3";
+  const headingClass =
+    level === "section"
+      ? "text-lg font-medium tracking-tight"
+      : "text-sm font-medium";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-start gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-4",
+        className,
+      )}
+    >
+      <div className="min-w-0 space-y-1">
+        <Heading className={headingClass}>{title}</Heading>
+        {description && (
+          <p className="text-muted-foreground max-w-prose text-sm">
+            {description}
+          </p>
+        )}
+      </div>
+      {action && (
+        <div className="flex shrink-0 items-center gap-2">{action}</div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -20,6 +20,7 @@ import { closeModal, openModal, useActiveModal } from "@/lib/modals";
 import { AccountSection } from "@/features/settings/account-section";
 import { BackupsSection } from "@/features/settings/backups-section";
 import { HouseholdSection } from "@/features/settings/household-section";
+import { SettingsSectionHeader } from "@/components/settings-section-header";
 
 const SETTINGS_MODAL_KEY = "settings";
 
@@ -191,10 +192,12 @@ function SectionContent({ section }: { section: SettingsSection }) {
   }
 
   return (
-    <div className="space-y-1">
-      <h2 className="text-lg font-medium">{section.title}</h2>
-      <p className="text-muted-foreground text-sm">{section.description}</p>
-      <p className="text-muted-foreground mt-4 text-sm">Coming soon.</p>
+    <div className="space-y-4">
+      <SettingsSectionHeader
+        title={section.title}
+        description={section.description}
+      />
+      <p className="text-muted-foreground text-sm">Coming soon.</p>
     </div>
   );
 }

--- a/web/src/features/settings/account-section.tsx
+++ b/web/src/features/settings/account-section.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { useMe } from "@/api/queries/me";
 import { useChangePassword } from "@/api/queries/account";
 import { withMutationToast } from "@/lib/mutation-toast";
+import { SettingsSectionHeader } from "@/components/settings-section-header";
 
 const schema = z
   .object({
@@ -48,12 +49,10 @@ export function AccountSection() {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-1">
-        <h2 className="text-lg font-medium">Account</h2>
-        <p className="text-muted-foreground text-sm">
-          Your sign-in identity. The admin role is managed by the household owner.
-        </p>
-      </div>
+      <SettingsSectionHeader
+        title="Account"
+        description="Your sign-in identity. The admin role is managed by the household owner."
+      />
 
       <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <Field label="Email" value={me?.username ?? "—"} />
@@ -61,12 +60,11 @@ export function AccountSection() {
       </dl>
 
       <div className="border-border space-y-4 border-t pt-6">
-        <div className="space-y-1">
-          <h3 className="font-medium">Change password</h3>
-          <p className="text-muted-foreground text-sm">
-            At least 8 characters. You'll stay signed in.
-          </p>
-        </div>
+        <SettingsSectionHeader
+          level="sub"
+          title="Change password"
+          description="At least 8 characters. You'll stay signed in."
+        />
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -56,6 +56,7 @@ import {
 import { formatDateTime, formatRelativeTime } from "@/lib/format";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { EmptyState } from "@/components/empty-state";
+import { SettingsSectionHeader } from "@/components/settings-section-header";
 
 const SCHEDULE_OPTIONS = [
   { value: "off", label: "Disabled — manual only" },
@@ -74,13 +75,16 @@ export function BackupsSection() {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-1">
-        <h2 className="text-lg font-medium">Backups</h2>
-        <p className="text-muted-foreground text-sm">
-          Compressed PostgreSQL dumps (<code className="font-mono text-xs">.sql.gz</code>) of the
-          household database. Restore replaces every row — handle with care.
-        </p>
-      </div>
+      <SettingsSectionHeader
+        title="Backups"
+        description={
+          <>
+            Compressed PostgreSQL dumps (
+            <code className="font-mono text-xs">.sql.gz</code>) of the
+            household database. Restore replaces every row — handle with care.
+          </>
+        }
+      />
 
       {query.isLoading ? (
         <BackupsSkeleton />
@@ -243,12 +247,11 @@ function BackupActions({ disabled }: { disabled: boolean }) {
 
   return (
     <div className="space-y-3">
-      <div className="space-y-1">
-        <h3 className="font-medium">Actions</h3>
-        <p className="text-muted-foreground text-sm">
-          Create an on-demand backup, or restore from a file you have on disk.
-        </p>
-      </div>
+      <SettingsSectionHeader
+        level="sub"
+        title="Actions"
+        description="Create an on-demand backup, or restore from a file you have on disk."
+      />
       <div className="flex flex-wrap items-center gap-2">
         <Button
           type="button"
@@ -358,12 +361,11 @@ function ScheduleForm({
         className="space-y-4"
         noValidate
       >
-        <div className="space-y-1">
-          <h3 className="font-medium">Automatic schedule</h3>
-          <p className="text-muted-foreground text-sm">
-            Backups older than the retention window are pruned at the end of each scheduled run.
-          </p>
-        </div>
+        <SettingsSectionHeader
+          level="sub"
+          title="Automatic schedule"
+          description="Backups older than the retention window are pruned at the end of each scheduled run."
+        />
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-[2fr_1fr]">
           <FormField
@@ -437,12 +439,11 @@ function BackupsTable({
 }) {
   return (
     <div className="space-y-3">
-      <div className="space-y-1">
-        <h3 className="font-medium">Stored backups</h3>
-        <p className="text-muted-foreground text-sm">
-          Newest first. Filenames carry the trigger (manual or scheduled) and a UTC timestamp.
-        </p>
-      </div>
+      <SettingsSectionHeader
+        level="sub"
+        title="Stored backups"
+        description="Newest first. Filenames carry the trigger (manual or scheduled) and a UTC timestamp."
+      />
 
       {backups.length === 0 ? (
         <EmptyState

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -68,6 +68,7 @@ import { withMutationToast } from "@/lib/mutation-toast";
 import type { LoginAccount, User } from "@/api/types";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/empty-state";
+import { SettingsSectionHeader } from "@/components/settings-section-header";
 
 export function HouseholdSection() {
   const { data: users, isLoading } = useUsers();
@@ -77,24 +78,21 @@ export function HouseholdSection() {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-3">
-        <div className="space-y-1">
-          <h2 className="text-lg font-medium">Household</h2>
-          <p className="text-muted-foreground text-sm">
-            Add family members to track everyone's accounts in one place. Each
-            member can be invited to sign in with their own login.
-          </p>
-        </div>
-        <Dialog open={addOpen} onOpenChange={setAddOpen}>
-          <DialogTrigger asChild>
-            <Button size="sm" variant={hasMembers ? "outline" : "default"}>
-              <UserPlus className="size-4" />
-              {hasMembers ? "Add member" : "Add your first member"}
-            </Button>
-          </DialogTrigger>
-          <AddMemberDialog onDone={() => setAddOpen(false)} />
-        </Dialog>
-      </div>
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <SettingsSectionHeader
+          title="Household"
+          description="Add family members to track everyone's accounts in one place. Each member can be invited to sign in with their own login."
+          action={
+            <DialogTrigger asChild>
+              <Button size="sm" variant={hasMembers ? "outline" : "default"}>
+                <UserPlus className="size-4" />
+                {hasMembers ? "Add member" : "Add your first member"}
+              </Button>
+            </DialogTrigger>
+          }
+        />
+        <AddMemberDialog onDone={() => setAddOpen(false)} />
+      </Dialog>
 
       {isLoading ? (
         <p className="text-muted-foreground text-sm">Loading members…</p>

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -63,6 +63,7 @@ import { Badge } from "@/components/ui/badge";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
 import { FormFooter } from "@/components/form-footer";
+import { SettingsSectionHeader } from "@/components/settings-section-header";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ProviderPicker } from "@/features/connections/provider-picker";
 import { useTheme } from "next-themes";
@@ -553,6 +554,40 @@ export function ComponentsSection() {
                 primary={<Button size="sm">Import 241 rows</Button>}
               />
             </div>
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="SettingsSectionHeader"
+        code="components/settings-section-header"
+        description="The canonical title + description block used by every section inside the Settings shell. Top-of-pane titles (Account / Household / Backups) and inline sub-sections (Change password / Actions / Stored backups / Automatic schedule) both route through here, so the typographic rhythm — heading size + weight, description colour + line-height, action alignment — stays in one place. Tokens: `section` (h2, text-lg, baseline-aligned action) and `sub` (h3, text-sm). The optional `action` slot is sm:right-aligned and baseline-aligned to the heading so an Add-member CTA sits flush with the title."
+        className="block"
+      >
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border p-5">
+            <div className="text-muted-foreground mb-3 text-[11px] tracking-wide uppercase">
+              section · h2 · with action
+            </div>
+            <SettingsSectionHeader
+              title="Household"
+              description="Add family members to track everyone's accounts in one place. Each member can be invited to sign in with their own login."
+              action={
+                <Button size="sm">
+                  <Plus /> Add member
+                </Button>
+              }
+            />
+          </div>
+          <div className="rounded-lg border p-5">
+            <div className="text-muted-foreground mb-3 text-[11px] tracking-wide uppercase">
+              sub · h3 · description only
+            </div>
+            <SettingsSectionHeader
+              level="sub"
+              title="Automatic schedule"
+              description="Backups older than the retention window are pruned at the end of each scheduled run."
+            />
           </div>
         </div>
       </Specimen>


### PR DESCRIPTION
## Summary

- Promotes a `<SettingsSectionHeader>` primitive (`web/src/components/settings-section-header.tsx`) so every section + sub-section heading inside the Settings shell renders with the same rhythm.
- Three panes (Account, Household, Backups) and the placeholder Coming-soon fallback retire their hand-rolled `<h2>`/`<h3>` + muted-paragraph blocks onto the primitive.
- Household's Add-member CTA now baseline-aligns with the title via the new `action` slot (sm:right-aligned) instead of stacking below the description.

## Before / After

**Account pane**

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/hsa77al7fn.jpg) | ![after](https://i.img402.dev/es1sft5r01.jpg) |

**Household pane**

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/4st2yqgiq2.jpg) | ![after](https://i.img402.dev/m9ny82qp3r.jpg) |

## Notes

- 16th shared primitive in the v2 vocabulary. Sandbox specimen added under Components (both `section` and `sub` weights).
- Drift retired: every `<h2 className="text-lg font-medium">` / `<h3 className="font-medium">` + adjacent muted-paragraph block inside the settings shell is gone.
- Backups pane (Actions / Automatic schedule / Stored backups sub-sections) also migrated, but the live dev DB returns 404 for `/api/v1/backups` so the AFTER for that pane only shows the heading band — same shape as Account's "Change password" sub-section, verified visually in the sandbox specimen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
