### PR TITLE
design(v2): unify list-row hover vocabulary on muted/40

### DIFF
--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -38,7 +38,7 @@ export function AccountRecentTransactions({
         <Link
           to="/transactions/$id"
           params={{ id: t.short_id }}
-          className="hover:bg-accent/40 flex items-center gap-3 px-5 py-2.5 transition-colors"
+          className="hover:bg-muted/40 flex items-center gap-3 px-5 py-2.5 transition-colors"
         >
           <TransactionPrimary transaction={t} className="flex-1" />
           <TransactionAmount transaction={t} />

--- a/web/src/features/home/home-recent-transactions.tsx
+++ b/web/src/features/home/home-recent-transactions.tsx
@@ -66,7 +66,7 @@ export function HomeRecentTransactions({
         <Link
           to="/transactions/$txId"
           params={{ txId: t.short_id }}
-          className="hover:bg-muted/50 focus-visible:bg-muted/50 flex min-w-0 items-center gap-4 px-5 py-3 outline-none transition-colors"
+          className="hover:bg-muted/40 focus-visible:bg-muted/40 flex min-w-0 items-center gap-4 px-5 py-3 outline-none transition-colors"
         >
           <div className="min-w-0 flex-1">
             <TransactionPrimary transaction={t} />

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -355,7 +355,7 @@ export function RuleForm({
               <CollapsibleTrigger asChild>
                 <button
                   type="button"
-                  className="hover:bg-muted/50 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none group -mx-2 flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-xs transition-colors"
+                  className="hover:bg-muted/40 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none group -mx-2 flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-xs transition-colors"
                 >
                   <span className="text-muted-foreground inline-flex items-center gap-2">
                     Pipeline stage

--- a/web/src/sandbox/sections/foundations.tsx
+++ b/web/src/sandbox/sections/foundations.tsx
@@ -174,6 +174,88 @@ export function FoundationsSection() {
           </div>
         ))}
       </Specimen>
+
+      <Specimen
+        label="Hover & transition vocabulary"
+        code="transition-colors · hover:bg-*"
+        description="Three canonical hover patterns — pick the one that matches the host surface, not by visual weight. Drift across these tokens reads as inconsistency; never invent a fourth."
+        className="block"
+      >
+        <div className="grid w-full gap-3 sm:grid-cols-3">
+          <div className="space-y-2">
+            <div className="rounded-lg border bg-card overflow-hidden">
+              <div className="border-b px-3 py-2 text-xs text-muted-foreground">
+                Divide-y list row
+              </div>
+              <ul className="divide-y">
+                {["Coffee", "Groceries", "Fuel"].map((label) => (
+                  <li
+                    key={label}
+                    className="hover:bg-muted/40 flex items-center justify-between gap-3 px-3 py-2.5 text-sm transition-colors"
+                  >
+                    <span>{label}</span>
+                    <span className="text-muted-foreground tabular-nums text-xs">
+                      −$12.34
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              <code className="font-mono">transition-colors hover:bg-muted/40</code>
+              — matches <code className="font-mono">&lt;TableRow&gt;</code>. Use
+              inside <code className="font-mono">&lt;ListCard&gt;</code> rows
+              (Home recent activity, Account recent transactions, Categories,
+              Shortcut sheet).
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <div className="grid gap-2">
+              {["Plaid", "Teller"].map((label) => (
+                <button
+                  key={label}
+                  type="button"
+                  className="hover:bg-accent/40 hover:border-primary/40 flex w-full items-center gap-3 rounded-lg border bg-card px-3 py-3 text-left text-sm transition-colors"
+                >
+                  <span className="bg-muted/50 size-7 rounded-md" />
+                  <span className="flex-1 font-medium">{label}</span>
+                  <span className="text-muted-foreground text-xs">Connect</span>
+                </button>
+              ))}
+            </div>
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              <code className="font-mono">transition-colors hover:bg-accent/40</code>
+              — bordered card grid items that act as selectable picks
+              (provider-picker, connection-accounts-list cards).
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <div className="grid gap-2">
+              {["Jump to Categories", "Open shortcuts"].map((label) => (
+                <a
+                  key={label}
+                  href="#"
+                  onClick={(e) => e.preventDefault()}
+                  className="group bg-muted/20 hover:bg-muted/40 hover:border-ring/40 relative flex items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-sm transition-colors"
+                >
+                  <span>{label}</span>
+                  <span className="text-muted-foreground text-xs">↗</span>
+                </a>
+              ))}
+            </div>
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              <code className="font-mono">
+                bg-muted/20 hover:bg-muted/40 hover:border-ring/40
+              </code>
+              — tinted-idle card grid items (not-found quick jumps). Idle
+              tint signals "this is interactive" before hover; ring border on
+              hover doubles the affordance.
+            </p>
+          </div>
+        </div>
+      </Specimen>
     </SandboxSection>
   );
 }


### PR DESCRIPTION
## Summary
- Three list-row surfaces had drifted to non-canonical hover tints (`/50`, `accent/40`, `/50` again). Unified to `transition-colors hover:bg-muted/40` — matches `<TableRow>` so every row in the v2 vocabulary shares the same hover signal.
- Adds a **"Hover & transition vocabulary"** Foundations specimen documenting the three canonical patterns side-by-side, so future surfaces pick by host shape (not visual weight) and don't reinvent a fourth token.

## Files touched
- `features/home/home-recent-transactions.tsx` (`/50` → `/40` on hover + focus-visible)
- `features/accounts/account-recent-transactions.tsx` (`accent/40` → `muted/40`)
- `features/rules/rule-form.tsx` pipeline-stage trigger (`/50` → `/40`)
- `sandbox/sections/foundations.tsx` — new specimen with three labelled cards demonstrating divide-y row, bordered selectable card, and tinted-idle card grid

## Canonical patterns documented
1. **Divide-y list row** → `transition-colors hover:bg-muted/40` (matches `<TableRow>`). For Home recent activity, Account recent transactions, Categories, Shortcut sheet, Category-detail children.
2. **Bordered card grid pick** → `transition-colors hover:bg-accent/40 hover:border-primary/40`. For provider-picker, connection-accounts-list, anywhere a card is a discrete selectable.
3. **Tinted-idle card grid** → `bg-muted/20 hover:bg-muted/40 hover:border-ring/40`. Idle tint signals "interactive"; ring border on hover doubles the affordance. For not-found quick jumps.

## Screenshots
| Sandbox specimen | Home recent activity (row hovered) |
| --- | --- |
| ![sandbox](https://i.img402.dev/5px4ohdpdn.jpg) | ![home](https://i.img402.dev/ahnlb5fw5m.jpg) |

The Foundations specimen now lives at `/v2/sandbox` and demonstrates all three patterns side-by-side with labelled host containers. The home page hover shows the canonical `hover:bg-muted/40` tint on a `<ListCard>` row (Century Link row in the screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)