### PR TITLE
design(v2): TimelineRail.RowSkeleton primitive

### DIFF
--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { type LucideIcon } from "lucide-react";
 import { Eyebrow } from "@/components/eyebrow";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 // TimelineRail is the v2 vocabulary for a vertical activity feed: a thin
@@ -173,15 +174,66 @@ function TimelineRailRow({
   );
 }
 
+interface TimelineRailRowSkeletonProps
+  extends Omit<React.HTMLAttributes<HTMLLIElement>, "children"> {
+  // Whether the row carries a body block under the headline (e.g. a comment
+  // bubble). Defaults to false so the skeleton matches the dominant row shape
+  // (single-line summary + timestamp).
+  body?: boolean;
+  className?: string;
+}
+
+// RowSkeleton mirrors the real <TimelineRail.Row> geometry — same disc + rail
+// + content column — so loading-to-loaded transitions don't jump. Reach for
+// this inside a <TimelineRail.Group> with the same `label` you'll render for
+// the real rows (or no label for a flat feed). Added in iter 65; previously
+// the activity timeline hand-rolled a `gap-3` skeleton with a `size-7
+// rounded-full` chip that didn't carry the rail line, so the loading state
+// shifted layout when annotations arrived.
+function TimelineRailRowSkeleton({
+  body = false,
+  className,
+  ...rest
+}: TimelineRailRowSkeletonProps) {
+  return (
+    <li
+      className={cn(
+        // Geometry mirrors TimelineRailRow exactly so the disc lands on the
+        // rail x-axis and the rail pseudo-element clips identically — see the
+        // long-form comment on TimelineRailRow for the math.
+        "relative flex gap-3 pl-3.5",
+        "before:content-[''] before:absolute before:left-0 before:w-px before:bg-border/60",
+        "before:-top-3 before:-bottom-3",
+        "[&:first-of-type]:before:top-[14px]",
+        "[&:last-of-type]:before:bottom-[calc(100%-14px)]",
+        className,
+      )}
+      {...rest}
+    >
+      <Skeleton
+        aria-hidden
+        className="bg-card border-border/60 relative z-10 -ml-3.5 size-7 shrink-0 rounded-full border"
+      />
+      <div className="min-w-0 flex-1 space-y-1.5 py-1">
+        <Skeleton className="h-3 w-3/4" />
+        {body && <Skeleton className="h-8 w-full rounded-md" />}
+        <Skeleton className="h-3 w-1/4" />
+      </div>
+    </li>
+  );
+}
+
 // Compound export — `TimelineRail.Group` / `TimelineRail.Row` matches the
 // shadcn-style composition used by Card, Table, Sidebar, etc.
 export const TimelineRail = Object.assign(TimelineRailRoot, {
   Group: TimelineRailGroup,
   Row: TimelineRailRow,
+  RowSkeleton: TimelineRailRowSkeleton,
 });
 
 export type {
   TimelineRailProps,
   TimelineRailGroupProps,
   TimelineRailRowProps,
+  TimelineRailRowSkeletonProps,
 };

--- a/web/src/features/transactions/activity-timeline.tsx
+++ b/web/src/features/transactions/activity-timeline.tsx
@@ -8,7 +8,6 @@ import {
   Wand2,
   type LucideIcon,
 } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { TimelineRail } from "@/components/timeline-rail";
 import { useAnnotations } from "@/api/queries/annotations";
@@ -72,18 +71,19 @@ export function ActivityTimeline({ transactionId }: { transactionId: string }) {
   const groups = useMemo(() => groupByDay(data ?? []), [data]);
 
   if (isLoading) {
+    // Skeleton mirrors the real TimelineRail geometry — disc punched through
+    // the rail line, content lines to the right — so the layout doesn't shift
+    // when annotations land. Second row carries a `body` block to suggest the
+    // comment bubble that often anchors a recent feed.
     return (
-      <div className="space-y-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex gap-3">
-            <Skeleton className="size-7 shrink-0 rounded-full" />
-            <div className="flex-1 space-y-1.5 py-1">
-              <Skeleton className="h-3 w-3/4" />
-              <Skeleton className="h-3 w-1/4" />
-            </div>
-          </div>
-        ))}
-      </div>
+      <TimelineRail>
+        <TimelineRail.Group>
+          <TimelineRail.RowSkeleton />
+          <TimelineRail.RowSkeleton body />
+          <TimelineRail.RowSkeleton />
+          <TimelineRail.RowSkeleton />
+        </TimelineRail.Group>
+      </TimelineRail>
     );
   }
 

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -718,11 +718,15 @@ export function ComponentsSection() {
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
-        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
+        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
         className="block"
       >
-        <div className="max-w-md">
-          <TimelineRail>
+        <div className="grid gap-6 max-w-3xl sm:grid-cols-2">
+          <div>
+            <div className="text-muted-foreground mb-3 text-[11px] uppercase tracking-[0.08em]">
+              Loaded
+            </div>
+            <TimelineRail>
             <TimelineRail.Group label="Today">
               <TimelineRail.Row icon={MessageSquare}>
                 <p className="text-sm leading-snug">
@@ -771,6 +775,20 @@ export function ComponentsSection() {
               </TimelineRail.Row>
             </TimelineRail.Group>
           </TimelineRail>
+          </div>
+          <div>
+            <div className="text-muted-foreground mb-3 text-[11px] uppercase tracking-[0.08em]">
+              Loading
+            </div>
+            <TimelineRail>
+              <TimelineRail.Group>
+                <TimelineRail.RowSkeleton />
+                <TimelineRail.RowSkeleton body />
+                <TimelineRail.RowSkeleton />
+                <TimelineRail.RowSkeleton />
+              </TimelineRail.Group>
+            </TimelineRail>
+          </div>
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary

- Adds `<TimelineRail.RowSkeleton>` to the timeline primitive — geometry mirrors `<TimelineRail.Row>` exactly (same `::before` rail, same disc punched through `bg-card`, same `:first-of-type`/`:last-of-type` clipping). No more layout shift when annotations land.
- Migrates `ActivityTimeline` off its hand-rolled `gap-3` + `size-7 rounded-full` chip loading state. Same pattern as iter 36's `<ListRowSkeleton>` for list surfaces — extend the primitive, don't re-derive the loading shape.
- Sandbox specimen at `/v2/sandbox` gains a side-by-side Loaded / Loading panel so the contract is inspectable.

## Visual contract

`TimelineRail.RowSkeleton` renders inside a `<TimelineRail.Group>`:

- 28px disc (`size-7 rounded-full border bg-card`) on the rail x-axis — identical to the real row's icon disc, so the loading-to-loaded swap doesn't move pixels.
- Same `::before` rail line clipping: first row clips top to the disc centre (14px), last row clips bottom to the disc centre. Middle rows draw a full segment so the rail reads as continuous.
- Right column carries `Skeleton h-3 w-3/4` (headline) + optional `Skeleton h-8` (body, opt-in via the `body` prop) + `Skeleton h-3 w-1/4` (timestamp). Activity timeline's loading state uses four rows with one `body` to suggest the dominant comment + system-event mix.

## Notes

- No call-site behaviour changes — TimelineRail's compound API gains a third member alongside `Group` and `Row`. Drift note in iter 26 ("primitive owns the loading shape") implicitly resolved.
- Skeletons hidden from a11y via `aria-hidden` on the disc (matches the iconography role of the real disc, which is decorative — the row text carries the semantics).
- Skipped screenshots: shared dev DB password didn't match `admin@example.com / password` in this worktree and resetting the shared DB password isn't authorized. The change is a structural skeleton swap — pixel diff for the static specimen is visible at `/v2/sandbox` (Components → TimelineRail) on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)