### PR TITLE
design(v2): unify rule pages to rounded-xl surface radius

### DIFF
--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -289,7 +289,7 @@ export function RuleForm({
       <Form {...form}>
         <form
           onSubmit={submitHandler}
-          className="bg-card overflow-hidden rounded-2xl border"
+          className="bg-card overflow-hidden rounded-xl border"
         >
           <div className="space-y-4 p-5 sm:p-6">
             <div className="flex items-center gap-3">

--- a/web/src/routes/rule-detail.tsx
+++ b/web/src/routes/rule-detail.tsx
@@ -113,7 +113,7 @@ export function RuleDetailPage() {
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
         <div className="space-y-4">
-          <section className="bg-card rounded-2xl border p-5">
+          <section className="bg-card rounded-xl border p-5">
             <h2 className="text-sm font-medium">What this rule does</h2>
             <div className="mt-4 space-y-4">
               <div>
@@ -156,7 +156,7 @@ export function RuleDetailPage() {
         </div>
 
         <aside className="space-y-3">
-          <section className="bg-card space-y-3 rounded-2xl border p-4">
+          <section className="bg-card space-y-3 rounded-xl border p-4">
             <div>
               <h3 className="text-sm font-medium">Apply retroactively</h3>
               <p className="text-muted-foreground mt-1 text-xs">
@@ -181,7 +181,7 @@ export function RuleDetailPage() {
           </section>
 
           {!isSystem && (
-            <section className="bg-card space-y-3 rounded-2xl border p-4">
+            <section className="bg-card space-y-3 rounded-xl border p-4">
               <div>
                 <h3 className="text-sm font-medium">Delete rule</h3>
                 <p className="text-muted-foreground mt-1 text-xs">


### PR DESCRIPTION
## Summary

- Sweep 4 stray `rounded-2xl` surfaces in `rule-form.tsx` (form shell) and `rule-detail.tsx` (What this rule does + Apply retroactively + Delete rule) down to `rounded-xl`, the canonical v2 surface radius.
- Every other surface card in v2 — shadcn `Card`, `SectionCard`, `ListCard`, `ColorRailCard`, `rule-row`, `preview-panel` — already uses `rounded-xl` (54 instances). These four were the only `rounded-2xl` sites anywhere in `web/src`.
- Border-radii vocabulary is now coherent across all rule surfaces and matches the rest of the v2 page family.

## Before / After

No live screenshot pair this iteration — same dev DB / admin password wall noted by iter 65. The visual diff is a 2px corner-radius reduction (`16px → 12px`) on three sections of the rule-detail page + the rule-form shell, bringing those surfaces into alignment with the surrounding `rule-row` and `preview-panel` cards which already use `rounded-xl`. Code diff is mechanical (4 edits, `rounded-2xl` → `rounded-xl`).

## Notes

- Foundational radii sweep — no behavioural change.
- Confirms the iter-65 backlog hypothesis: the rest of the codebase is already on `rounded-xl` for surface cards / `rounded-lg` for nested controls / `rounded-md` for buttons + inputs / `rounded-full` for badges + status dots. No further radius drift detected after this sweep.
- Radius vocabulary census (post-sweep): `rounded-md` 130, `rounded-lg` 60, `rounded-xl` 58 (+4 from this PR), `rounded-full` 40, `rounded-sm` 16, `rounded-none` 5 (all inside shadcn calendar / tabs / toggle-group internals), `rounded-xs` 2 (Dialog/Sheet close buttons, shadcn defaults), `rounded-2xl` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)