### PR TITLE
design(v2): extract ColorRailCardSkeleton primitive

### DIFF
--- a/web/src/components/color-rail-card.tsx
+++ b/web/src/components/color-rail-card.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 interface ColorRailCardProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -75,6 +76,82 @@ export function ColorRailCard({
           )}
         >
           {footer}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ColorRailCardSkeletonProps {
+  /**
+   * Shape of the hero icon tile to mirror — match what the loaded hero
+   * renders. `rounded-md` for transaction-detail (matches
+   * `<CategoryIconTile>`), `rounded-lg` for account-detail and
+   * category-detail (slightly chunkier accounting/folder tile).
+   */
+  tileShape?: "rounded-md" | "rounded-lg";
+  /**
+   * Whether to render the bordered footer strip (action bar) under the
+   * hero. Matches `<ColorRailCard footer={…}>` consumers.
+   */
+  withFooter?: boolean;
+  /**
+   * Optional content slot rendered between the hero body and the footer
+   * strip — used by transaction-detail for the secondary details grid
+   * that sits below the identity row.
+   */
+  body?: React.ReactNode;
+  className?: string;
+}
+
+// ColorRailCardSkeleton mirrors the `<ColorRailCard>` wrapper for loading
+// states — the same `bg-card rounded-xl border` shell + 4px muted left
+// rail. The identity column on the left is a stable shape across every
+// detail-page hero (size-12 tile, eyebrow line, title line, meta line) so
+// it lives inside the primitive; the trailing column carries the
+// per-entity metric (amount / balance / count) and is a smaller shared
+// shape. Don't fork the look — consumers can hang an additional `body`
+// row off the bottom (e.g. TX-detail's secondary details grid) or opt in
+// to a `withFooter` strip when the loaded hero has a footer action bar.
+export function ColorRailCardSkeleton({
+  tileShape = "rounded-md",
+  withFooter = false,
+  body,
+  className,
+}: ColorRailCardSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "bg-card relative overflow-hidden rounded-xl border",
+        className,
+      )}
+    >
+      <div
+        aria-hidden
+        className="bg-muted absolute inset-y-0 left-0 w-1"
+      />
+      <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
+        {/* Identity column */}
+        <div className="flex items-start gap-3 sm:gap-4">
+          <Skeleton className={cn("size-12", tileShape)} />
+          <div className="space-y-2 py-1">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+        {/* Metric column */}
+        <div className="space-y-2 lg:items-end">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-3 w-28" />
+        </div>
+        {body && <div className="lg:col-span-2">{body}</div>}
+      </div>
+      {withFooter && (
+        <div className="border-t flex justify-end gap-2 px-5 py-3 sm:px-7">
+          <Skeleton className="h-7 w-24 rounded-md" />
+          <Skeleton className="h-7 w-32 rounded-md" />
         </div>
       )}
     </div>

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -20,7 +20,10 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  ColorRailCard,
+  ColorRailCardSkeleton,
+} from "@/components/color-rail-card";
 import {
   DetailList,
   compactDetailRows,
@@ -481,28 +484,7 @@ function connectionStatusAlert(a: AccountDetail) {
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="bg-card relative overflow-hidden rounded-xl border">
-        <div className="bg-muted absolute inset-y-0 left-0 w-1" />
-        <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
-          <div className="flex items-start gap-3 sm:gap-4">
-            <Skeleton className="size-12 rounded-lg" />
-            <div className="space-y-2 py-1">
-              <Skeleton className="h-3 w-20" />
-              <Skeleton className="h-5 w-40" />
-              <Skeleton className="h-3 w-48" />
-            </div>
-          </div>
-          <div className="space-y-2 lg:items-end">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-9 w-32" />
-            <Skeleton className="h-3 w-28" />
-          </div>
-        </div>
-        <div className="border-t flex justify-end gap-2 px-6 py-3">
-          <Skeleton className="h-7 w-24 rounded-md" />
-          <Skeleton className="h-7 w-32 rounded-md" />
-        </div>
-      </div>
+      <ColorRailCardSkeleton tileShape="rounded-lg" withFooter />
       <div className="flex gap-2">
         <Skeleton className="h-7 w-32 rounded-md" />
         <Skeleton className="h-7 w-32 rounded-md" />

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -16,7 +16,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CategoryIconTile } from "@/components/category-icon-tile";
-import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  ColorRailCard,
+  ColorRailCardSkeleton,
+} from "@/components/color-rail-card";
 import { DangerZone } from "@/components/danger-zone";
 import {
   DetailList,
@@ -393,24 +396,7 @@ function DeleteCategory({ category }: { category: Category }) {
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="bg-card relative overflow-hidden rounded-xl border">
-        <div className="bg-muted absolute inset-y-0 left-0 w-1" />
-        <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
-          <div className="flex items-start gap-3 sm:gap-4">
-            <Skeleton className="size-12 rounded-lg" />
-            <div className="space-y-2 py-1">
-              <Skeleton className="h-3 w-20" />
-              <Skeleton className="h-5 w-40" />
-              <Skeleton className="h-3 w-48" />
-            </div>
-          </div>
-          <div className="space-y-2 lg:items-end">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-9 w-32" />
-            <Skeleton className="h-3 w-28" />
-          </div>
-        </div>
-      </div>
+      <ColorRailCardSkeleton tileShape="rounded-lg" />
       <div className="flex gap-2">
         <Skeleton className="h-7 w-48 rounded-md" />
         <Skeleton className="h-7 w-32 rounded-md" />

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -13,7 +13,10 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { CategoryIconTile } from "@/components/category-icon-tile";
-import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  ColorRailCard,
+  ColorRailCardSkeleton,
+} from "@/components/color-rail-card";
 import {
   DetailList,
   compactDetailRows,
@@ -351,22 +354,10 @@ function titleize(value: string | null | undefined): string | null {
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="bg-card relative overflow-hidden rounded-xl border">
-        <div className="bg-muted absolute inset-y-0 left-0 w-1" />
-        <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:gap-x-10 lg:gap-y-5">
-          <div className="flex items-start gap-3 sm:gap-4 lg:row-start-1">
-            <Skeleton className="size-12 rounded-md" />
-            <div className="space-y-2 py-1">
-              <Skeleton className="h-3 w-20" />
-              <Skeleton className="h-5 w-40" />
-              <Skeleton className="h-3 w-32" />
-            </div>
-          </div>
-          <div className="space-y-2 lg:row-start-1 lg:row-span-2 lg:items-end">
-            <Skeleton className="h-5 w-20" />
-            <Skeleton className="h-9 w-32" />
-          </div>
-          <div className="space-y-5 lg:row-start-2">
+      <ColorRailCardSkeleton
+        tileShape="rounded-md"
+        body={
+          <div className="space-y-5">
             <Separator />
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-1.5">
@@ -379,8 +370,8 @@ function DetailSkeleton() {
               </div>
             </div>
           </div>
-        </div>
-      </div>
+        }
+      />
       <div className="flex gap-2">
         <Skeleton className="h-7 w-32 rounded-md" />
         <Skeleton className="h-7 w-32 rounded-md" />

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -52,7 +52,10 @@ import { TransactionAmount } from "@/components/transaction-amount";
 import { KbdTooltip } from "@/components/kbd-tooltip";
 import { DetailList } from "@/components/detail-list";
 import { ListCard } from "@/components/list-card";
-import { ColorRailCard } from "@/components/color-rail-card";
+import {
+  ColorRailCard,
+  ColorRailCardSkeleton,
+} from "@/components/color-rail-card";
 import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
@@ -256,6 +259,18 @@ export function ComponentsSection() {
               </p>
             </div>
           </ColorRailCard>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="ColorRailCardSkeleton"
+        code="components/color-rail-card"
+        description="Loading mirror of `<ColorRailCard>` — same shell + rail, with the stable identity column (tile + eyebrow + title + meta) and trailing metric column already baked in. `tileShape` picks `rounded-md` (transactions) vs `rounded-lg` (accounts, categories) to match the loaded tile. `withFooter` toggles the bordered action strip; `body` slots in any extra hero row (e.g. TX-detail's secondary details grid)."
+        className="block"
+      >
+        <div className="max-w-xl space-y-4">
+          <ColorRailCardSkeleton tileShape="rounded-md" />
+          <ColorRailCardSkeleton tileShape="rounded-lg" withFooter />
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary
- Lifted shared detail-page loading hero into `<ColorRailCardSkeleton>` next to `<ColorRailCard>`. Three pages (transaction, account, category detail) previously hand-rolled the same `bg-card rounded-xl border` + 4px rail wrapper + size-12 tile + eyebrow/title/meta column.
- `tileShape` selects `rounded-md` (transactions, matches `CategoryIconTile`) vs `rounded-lg` (accounts/categories). `withFooter` toggles the bordered action strip used by account-detail. `body` slot covers TX-detail's secondary details row (Separator + 2-col field grid).
- Sandbox showcase updated alongside so the loading mirror lives next to the live primitive.

## After — `<ColorRailCard>` + `<ColorRailCardSkeleton>` side by side in the sandbox

The skeleton mirrors the card's shell + rail exactly; switching `tileShape` between `rounded-md` (TX-detail / matches `CategoryIconTile`) and `rounded-lg` (account- and category-detail) keeps the loading icon tile flush with the loaded one. `withFooter` adds the bordered action strip used by account-detail.

![sandbox overview](https://i.img402.dev/0546za5dcx.jpg)

![skeleton variants](https://i.img402.dev/hp3acha9jv.jpg)

## Notes
- Loading state now stays in lockstep with `<ColorRailCard>` automatically — a future tweak to the wrapper (radius, rail width, padding) lands in both places.
- Three detail pages remain on bespoke skeletons (tag, rule, connection) because they don't host a `<ColorRailCard>` hero. Worth a follow-up: a leaner shared shell for the "no hero" detail pages, but they're shaped differently enough today that forcing them onto one primitive would distort the loaded view.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>