### PR TITLE
design(v2): MetaBadge primitive — unify tiny status meta chips

### DIFF
--- a/web/src/components/meta-badge.tsx
+++ b/web/src/components/meta-badge.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+/**
+ * Inline meta badge — the canonical "tiny status chip" used in list rows and
+ * detail headers to label a row's secondary state (Hidden, Excluded, Linked,
+ * Re-auth, System, Paused, …). Owns the v2 density vocabulary so the chip is
+ * never hand-rolled:
+ *
+ *   text-[10px]  +  gap-1  +  px-1.5 py-0  +  [&>svg]:size-2.5
+ *
+ * Tone routes through the underlying `<Badge>` variant. The default tone is
+ * `outline` because the chip is a *meta* label, not the row's primary
+ * classification — a louder primary badge belongs on `<Badge>` directly.
+ *
+ * Use `muted` to opt into the `text-muted-foreground font-normal` shading that
+ * the categories list uses for "System" / "Hidden" labels (so they don't
+ * compete with the category name). For a tone-specific chip with custom
+ * colours (e.g. the amber `Re-auth` pill in the accounts list) pass
+ * `className` and use `variant="outline"` — the density tokens still apply,
+ * which is the whole point.
+ */
+type MetaBadgeProps = React.ComponentProps<typeof Badge> & {
+  icon?: LucideIcon;
+  /** Apply the muted-foreground + font-normal shading used for low-emphasis labels. */
+  muted?: boolean;
+};
+
+export function MetaBadge({
+  icon: Icon,
+  muted,
+  className,
+  children,
+  variant = "outline",
+  ...rest
+}: MetaBadgeProps) {
+  return (
+    <Badge
+      variant={variant}
+      data-slot="meta-badge"
+      className={cn(
+        "gap-1 px-1.5 py-0 text-[10px] [&>svg]:size-2.5",
+        muted && "text-muted-foreground font-normal",
+        className,
+      )}
+      {...rest}
+    >
+      {Icon ? <Icon aria-hidden="true" /> : null}
+      {children}
+    </Badge>
+  );
+}

--- a/web/src/features/accounts/account-row.tsx
+++ b/web/src/features/accounts/account-row.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { AlertTriangle, ChevronRight, Link2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { MetaBadge } from "@/components/meta-badge";
 import { formatBalance } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Account } from "@/api/types";
@@ -44,9 +45,9 @@ export function AccountRow({ account: a }: AccountRowProps) {
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium">{accountLabel(a)}</span>
           {a.is_dependent_linked && (
-            <Badge variant="secondary" className="gap-1 px-1.5 py-0 text-[10px]">
-              <Link2 className="size-2.5" /> Linked
-            </Badge>
+            <MetaBadge icon={Link2} variant="secondary">
+              Linked
+            </MetaBadge>
           )}
           {statusPill}
         </div>
@@ -111,12 +112,12 @@ function statusBadge(status: string | null) {
   if (!status || status === "active") return null;
   if (status === "pending_reauth") {
     return (
-      <Badge
-        variant="outline"
-        className="gap-1 border-amber-500/40 bg-amber-500/5 px-1.5 py-0 text-[10px] text-amber-700 dark:text-amber-400"
+      <MetaBadge
+        icon={AlertTriangle}
+        className="border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400"
       >
-        <AlertTriangle className="size-2.5" /> Re-auth
-      </Badge>
+        Re-auth
+      </MetaBadge>
     );
   }
   if (status === "error") {

--- a/web/src/features/categories/category-list.tsx
+++ b/web/src/features/categories/category-list.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { ChevronRight, EyeOff, Lock, Pencil } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ListCard } from "@/components/list-card";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { IdPill } from "@/components/id-pill";
+import { MetaBadge } from "@/components/meta-badge";
 import { cn } from "@/lib/utils";
 import type { Category } from "@/api/types";
 
@@ -116,20 +116,14 @@ function CategoryRow({
               {category.display_name}
             </span>
             {category.is_system && (
-              <Badge
-                variant="outline"
-                className="text-muted-foreground gap-1 px-1.5 py-0 text-[10px] font-normal"
-              >
-                <Lock className="size-2.5" /> System
-              </Badge>
+              <MetaBadge icon={Lock} muted>
+                System
+              </MetaBadge>
             )}
             {category.hidden && (
-              <Badge
-                variant="outline"
-                className="text-muted-foreground gap-1 px-1.5 py-0 text-[10px] font-normal"
-              >
-                <EyeOff className="size-2.5" /> Hidden
-              </Badge>
+              <MetaBadge icon={EyeOff} muted>
+                Hidden
+              </MetaBadge>
             )}
           </div>
           <div className="text-muted-foreground mt-0.5 flex items-center gap-2 text-xs">
@@ -187,12 +181,9 @@ function CategoryRow({
                       {child.display_name}
                     </span>
                     {child.hidden && (
-                      <Badge
-                        variant="outline"
-                        className="text-muted-foreground gap-1 px-1.5 py-0 text-[10px] font-normal"
-                      >
-                        <EyeOff className="size-2.5" /> Hidden
-                      </Badge>
+                      <MetaBadge icon={EyeOff} muted>
+                        Hidden
+                      </MetaBadge>
                     )}
                   </div>
                   <div className="mt-0.5">

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -17,7 +17,6 @@ import {
   PowerOff,
   Wallet,
 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -31,6 +30,7 @@ import {
 } from "@/components/detail-list";
 import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
+import { MetaBadge } from "@/components/meta-badge";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
@@ -244,14 +244,12 @@ function Hero({
                   {accountLabel(a)}
                 </h1>
                 {a.excluded && (
-                  <Badge variant="outline" className="gap-1 text-[10px]">
-                    <EyeOff className="size-2.5" /> Excluded
-                  </Badge>
+                  <MetaBadge icon={EyeOff}>Excluded</MetaBadge>
                 )}
                 {a.is_dependent_linked && (
-                  <Badge variant="secondary" className="gap-1 text-[10px]">
-                    <Link2 className="size-2.5" /> Linked dependent
-                  </Badge>
+                  <MetaBadge icon={Link2} variant="secondary">
+                    Linked dependent
+                  </MetaBadge>
                 )}
               </div>
               <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/detail-list";
 import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
+import { MetaBadge } from "@/components/meta-badge";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryForm } from "@/features/categories/category-form";
@@ -165,15 +166,9 @@ function Hero({
                 <h1 className="truncate text-xl font-semibold tracking-tight">
                   {category.display_name}
                 </h1>
-                {category.is_system && (
-                  <Badge variant="outline" className="text-[10px]">
-                    System
-                  </Badge>
-                )}
+                {category.is_system && <MetaBadge>System</MetaBadge>}
                 {category.hidden && (
-                  <Badge variant="outline" className="gap-1 text-[10px]">
-                    <EyeOff className="size-2.5" /> Hidden
-                  </Badge>
+                  <MetaBadge icon={EyeOff}>Hidden</MetaBadge>
                 )}
               </div>
               <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -49,6 +49,7 @@ import {
   type DetailRowData,
 } from "@/components/detail-list";
 import { Eyebrow } from "@/components/eyebrow";
+import { MetaBadge } from "@/components/meta-badge";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { formatLongDate } from "@/lib/format";
@@ -668,9 +669,9 @@ function Hero({
                 </h1>
                 <ConnectionStatusBadge status={conn.status} />
                 {conn.paused && (
-                  <span className="bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium">
-                    <Pause className="size-2.5" /> Paused
-                  </span>
+                  <MetaBadge icon={Pause} variant="secondary">
+                    Paused
+                  </MetaBadge>
                 )}
               </div>
               <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -6,14 +6,18 @@ import {
   ArrowUpRight,
   Check,
   CheckCircle2,
+  EyeOff,
   Inbox,
   Info,
   Keyboard,
   KeyRound,
   Landmark,
+  Link2,
+  Lock,
   MessageSquare,
   Monitor,
   Moon,
+  Pause,
   Plus,
   RefreshCw,
   RotateCcw,
@@ -59,6 +63,7 @@ import {
 import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
+import { MetaBadge } from "@/components/meta-badge";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { Sheet } from "@/components/ui/sheet";
@@ -317,6 +322,32 @@ export function ComponentsSection() {
         <IdPill value="acct_3rR9pq01" />
         <IdPill value="food_and_drink_coffee" />
         <IdPill value="/api/v1/transactions" />
+      </Specimen>
+
+      <Specimen
+        label="MetaBadge"
+        code="components/meta-badge"
+        description="Tiny meta chip used in list rows and detail-page hero columns to label a row's secondary state — Hidden, Excluded, Linked, Re-auth, System, Paused, … Owns the v2 density vocabulary (`text-[10px]` + `gap-1` + `px-1.5 py-0` + `[&>svg]:size-2.5`) so the same chip never gets re-derived. Tone routes through the underlying `<Badge>` variant — `outline` by default because a meta label is intentionally calmer than the row's primary classification. `muted` opts into the `text-muted-foreground font-normal` shading the categories list uses so 'System' / 'Hidden' don't compete with the category name. For tone-specific chips (the amber Re-auth pill) pass `className` — the density tokens still apply, which is the whole point. Six surfaces share it: accounts list, accounts detail, categories list (parent + child rows), category detail, connection detail."
+      >
+        <MetaBadge icon={Lock} muted>
+          System
+        </MetaBadge>
+        <MetaBadge icon={EyeOff} muted>
+          Hidden
+        </MetaBadge>
+        <MetaBadge icon={EyeOff}>Excluded</MetaBadge>
+        <MetaBadge icon={Link2} variant="secondary">
+          Linked
+        </MetaBadge>
+        <MetaBadge icon={Pause} variant="secondary">
+          Paused
+        </MetaBadge>
+        <MetaBadge
+          icon={AlertTriangle}
+          className="border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400"
+        >
+          Re-auth
+        </MetaBadge>
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
## Summary

- Promotes the "tiny status chip" pattern (Hidden / Excluded / Linked / Re-auth / System / Paused) into a shared `<MetaBadge>` primitive — owns the v2 density vocabulary (`text-[10px]` + `gap-1` + `px-1.5 py-0` + `[&>svg]:size-2.5`) so the chip is never re-derived.
- Sweeps six surfaces onto it: accounts list (`Linked`, `Re-auth`), categories list (parent `System` + `Hidden`, child `Hidden`), account-detail (`Excluded`, `Linked dependent`), category-detail (`System`, `Hidden`), connection-detail (`Paused` — was a free-floating `<span>`, now a real Badge variant).
- 17th shared primitive in the v2 vocabulary. Sandbox specimen added between `IdPill` and `DetailList`.

## Before / After

| Before (hand-rolled `<Badge>` per chip) | After (`<MetaBadge>`) |
| --- | --- |
| ![before](https://i.img402.dev/qcazgn3m53.jpg) | ![after](https://i.img402.dev/jefkaidybi.jpg) |

The `System` chips render byte-identically — the whole point of the primitive. Visual diff in the surrounding chrome (sidebar role pill, jump-to-search pill, breadcrumb separator) is bleed-through from previous design-branch iterations, not part of this PR.

## Notes

- Tone routes through the underlying `<Badge>` variant — `outline` is the default because a meta chip is intentionally calmer than the row's primary classification.
- `muted` opts into the `text-muted-foreground font-normal` shading the categories list uses so "System" / "Hidden" don't compete with the category name.
- Tone-specific chips with custom colours (the amber `Re-auth` pill in accounts) pass `className` — the density tokens still apply, which is the whole point.
- Connection-detail's `Paused` pill was the odd one out — a free-floating `<span>` with its own `bg-muted` + `rounded-full` + `gap-1` + `text-[10px]` mix. Now it's a `<MetaBadge variant="secondary">` and the rest of the vocabulary applies for free.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
