### PR TITLE
design(v2): connection-detail DetailSkeleton adopts ColorRailCardSkeleton

### DIFF
--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -42,7 +42,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ColorRailCard } from "@/components/color-rail-card";
+import { ColorRailCard, ColorRailCardSkeleton } from "@/components/color-rail-card";
 import {
   DetailList,
   compactDetailRows,
@@ -915,9 +915,15 @@ function formatIntervalLabel(minutes: number): string {
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <Skeleton className="h-32 rounded-xl" />
+      {/* Hero — matches the loaded `<ColorRailCard>` shape: status-tinted
+          rail + `rounded-lg` icon tile + bordered action-strip footer
+          (Sync now / Re-authenticate / overflow). Mirrors the
+          account-detail and transaction-detail loading vocabulary so
+          the three sibling detail pages converge on a single skeleton
+          shape. */}
+      <ColorRailCardSkeleton tileShape="rounded-lg" withFooter />
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <div className="space-y-6">
+        <div className="min-w-0 space-y-6">
           <Skeleton className="h-32 rounded-xl" />
           <Skeleton className="h-48 rounded-xl" />
           <Skeleton className="h-48 rounded-xl" />


### PR DESCRIPTION
## Summary

- Connection-detail's `DetailSkeleton` now uses `<ColorRailCardSkeleton tileShape="rounded-lg" withFooter />` for the hero band so the loading shape matches the loaded `<ColorRailCard>` exactly (status-tinted rail + `rounded-lg` icon tile + bordered action-strip footer for Sync now / Re-authenticate / overflow).
- Aligns with the transaction-detail, account-detail, and category-detail loading vocabulary so the four detail-page skeletons converge on a single hero shape.
- Adds `min-w-0` to the primary column so long sync-history rows can't push the sidebar off-screen at narrow viewports.

## Before / After

```diff
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <Skeleton className="h-32 rounded-xl" />
+      <ColorRailCardSkeleton tileShape="rounded-lg" withFooter />
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <div className="space-y-6">
+        <div className="min-w-0 space-y-6">
           <Skeleton className="h-32 rounded-xl" />
           <Skeleton className="h-48 rounded-xl" />
           <Skeleton className="h-48 rounded-xl" />
         </div>
         <div className="space-y-6">
           <Skeleton className="h-40 rounded-xl" />
           <Skeleton className="h-48 rounded-xl" />
         </div>
       </div>
     </div>
   );
 }
```

The `ColorRailCardSkeleton` primitive is on display in the sandbox showcase (`/v2/sandbox?section=components`) alongside the loaded `ColorRailCard` it mirrors — both `tileShape="rounded-md"` (TX-detail) and `tileShape="rounded-lg" withFooter` (account-detail, now also connection-detail).

(No browser screenshot for this PR — the visible delta is a sub-second loading flash on a route that requires authentication, and the dev DB admin password drifted off the canonical credential. The diff above + the sandbox specimen are the visual evidence.)

## Notes

- Resolves the last detail page that wasn't routed through the `ColorRailCardSkeleton` primitive lifted in iter 67 (#1180). The four `<ColorRailCard>` heroes now share one skeleton vocabulary.
- Drift to watch: the matching loaded action strip on connection-detail still hand-rolls its `MoreHorizontal` icon button in the `ColorRailCard` `footer` slot — same shape as the dropdown trigger in transaction-detail. If a third surface adopts the trigger, promote to a `ColorRailCard` action slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)