### PR TITLE
design(v2): unify list-row trailing chevron vocabulary

### DIFF
--- a/web/src/features/accounts/account-row.tsx
+++ b/web/src/features/accounts/account-row.tsx
@@ -102,7 +102,7 @@ export function AccountRow({ account: a }: AccountRowProps) {
             </div>
           )}
         </div>
-        <ChevronRight className="text-muted-foreground/40 group-hover:text-muted-foreground size-4 transition-colors" />
+        <ChevronRight className="text-muted-foreground/60 group-hover:text-muted-foreground size-3.5 transition-colors" />
       </div>
     </Link>
   );

--- a/web/src/features/categories/category-list.tsx
+++ b/web/src/features/categories/category-list.tsx
@@ -166,7 +166,7 @@ function CategoryRow({
                 to="/categories/$id"
                 params={{ id: child.short_id }}
                 className={cn(
-                  "hover:bg-muted/40 flex items-center gap-3 py-2 pr-4 pl-12 transition-colors",
+                  "hover:bg-muted/40 group flex items-center gap-3 py-2 pr-4 pl-12 transition-colors",
                   child.hidden && "text-muted-foreground",
                 )}
               >
@@ -190,7 +190,7 @@ function CategoryRow({
                     <IdPill value={child.slug} />
                   </div>
                 </div>
-                <ChevronRight className="text-muted-foreground/60 size-3.5" />
+                <ChevronRight className="text-muted-foreground/60 group-hover:text-muted-foreground size-3.5 transition-colors" />
               </Link>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- Account-row trailing chevron drops from `size-4` + opacity/40 → `size-3.5` + opacity/60 to match the categories-list and command-palette canon for a list-row "click to navigate" affordance.
- Categories-list child-row chevron picks up the matching `group-hover:text-muted-foreground transition-colors` recipe so the chevron feels live when the row is hovered (previously static).

## Before / After
Accounts list (most visible diff — chevron at the right of every row gets calmer + smaller):

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/kpl0e2atx1.jpg) | ![before](https://i.img402.dev/8uhlyuk124.jpg) |

Categories list (sub-row chevrons add hover transition — visible only on hover; static screenshots look identical, which is intentional):

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/nio0bfzbwh.jpg) | ![after](https://i.img402.dev/u20tem54jo.jpg) |

## Notes
- Drift discovered: of all list-row trailing chevrons in the v2 SPA, account-row was the lone outlier at `size-4` + opacity/40 + hover-transition. Categories-list, command-palette, and error.tsx had already landed on `size-3.5`. This PR closes the gap.
- New canonical recipe for a list-row trailing chevron: `text-muted-foreground/60 group-hover:text-muted-foreground size-3.5 transition-colors`. Containing row needs the `group` token.
- Will note in the sprint state's drift section so future list rows reach for the same recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
