### PR TITLE
design(v2): tooltip presence on icon-only action buttons

### DIFF
--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SectionCard } from "@/components/section-card";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -236,21 +237,26 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
         </div>
       </div>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-7"
-            aria-label="Link actions"
-            disabled={reconcile.isPending || remove.isPending}
-          >
-            {reconcile.isPending || remove.isPending ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <MoreHorizontal className="size-3.5" />
-            )}
-          </Button>
-        </DropdownMenuTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-7"
+                aria-label="Link actions"
+                disabled={reconcile.isPending || remove.isPending}
+              >
+                {reconcile.isPending || remove.isPending ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <MoreHorizontal className="size-3.5" />
+                )}
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Link actions</TooltipContent>
+        </Tooltip>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={onReconcile} disabled={reconcile.isPending}>
             <RotateCw className="size-3.5" /> Reconcile matches

--- a/web/src/features/accounts/account-settings-card.tsx
+++ b/web/src/features/accounts/account-settings-card.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SectionCard } from "@/components/section-card";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useUpdateAccount } from "@/api/queries/accounts";
@@ -84,30 +85,40 @@ export function AccountSettingsCard({ account: a }: AccountSettingsCardProps) {
                 disabled={update.isPending}
                 className="h-9"
               />
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={saveName}
-                disabled={update.isPending}
-                aria-label="Save display name"
-                className="size-9"
-              >
-                {update.isPending ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Check className="size-4" />
-                )}
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={cancelName}
-                disabled={update.isPending}
-                aria-label="Cancel"
-                className="size-9"
-              >
-                <X className="size-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={saveName}
+                    disabled={update.isPending}
+                    aria-label="Save display name"
+                    className="size-9"
+                  >
+                    {update.isPending ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Check className="size-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Save</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={cancelName}
+                    disabled={update.isPending}
+                    aria-label="Cancel"
+                    className="size-9"
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Cancel</TooltipContent>
+              </Tooltip>
             </div>
           ) : (
             <div className="flex items-center justify-between gap-2">

--- a/web/src/features/api-keys/api-keys-table.tsx
+++ b/web/src/features/api-keys/api-keys-table.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DataTable } from "@/components/data-table";
 import { IdPill } from "@/components/id-pill";
 import { formatLongDate, formatRelativeTime } from "@/lib/format";
@@ -126,16 +127,21 @@ export function APIKeysTable({
         meta: { className: "w-px" },
         cell: ({ row }) => (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label={`Actions for ${row.original.name}`}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Actions for ${row.original.name}`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>API key actions</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent
               align="end"
               onClick={(e) => e.stopPropagation()}

--- a/web/src/features/categories/category-list.tsx
+++ b/web/src/features/categories/category-list.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { ChevronRight, EyeOff, Lock, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ListCard } from "@/components/list-card";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { IdPill } from "@/components/id-pill";
@@ -137,20 +138,25 @@ function CategoryRow({
           </div>
         </Link>
 
-        <Button
-          variant="ghost"
-          size="icon"
-          asChild
-          className="text-muted-foreground hover:text-foreground size-8 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-        >
-          <Link
-            to="/categories/$id"
-            params={{ id: category.short_id }}
-            aria-label={`Edit ${category.display_name}`}
-          >
-            <Pencil className="size-3.5" />
-          </Link>
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              asChild
+              className="text-muted-foreground hover:text-foreground size-8 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            >
+              <Link
+                to="/categories/$id"
+                params={{ id: category.short_id }}
+                aria-label={`Edit ${category.display_name}`}
+              >
+                <Pencil className="size-3.5" />
+              </Link>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Edit category</TooltipContent>
+        </Tooltip>
       </div>
 
       {isOpen && hasChildren && (

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatBalance } from "@/lib/format";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { cn } from "@/lib/utils";
@@ -174,16 +175,21 @@ export function ConnectionRow({
           </div>
 
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-muted-foreground hover:text-foreground size-8"
-                aria-label="Connection actions"
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-foreground size-8"
+                    aria-label="Connection actions"
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Connection actions</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent align="end">
               {showReauthBanner && (
                 <DropdownMenuItem onClick={() => onReauth(connection)}>

--- a/web/src/features/rules/action-row.tsx
+++ b/web/src/features/rules/action-row.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCategories } from "@/api/queries/categories";
 import {
   ACTION_TYPES,
@@ -75,21 +76,30 @@ export function ActionRowFields({
         </SelectContent>
       </Select>
 
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7 shrink-0 sm:order-last"
-        onClick={onRemove}
-        disabled={totalRows === 1}
-        title={
-          totalRows === 1
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0 sm:order-last"
+            onClick={onRemove}
+            disabled={totalRows === 1}
+            aria-label={
+              totalRows === 1
+                ? "A rule needs at least one action"
+                : "Remove this action"
+            }
+          >
+            <X className="text-muted-foreground/60 size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {totalRows === 1
             ? "A rule needs at least one action"
-            : "Remove this action"
-        }
-      >
-        <X className="text-muted-foreground/60 size-3.5" />
-      </Button>
+            : "Remove action"}
+        </TooltipContent>
+      </Tooltip>
 
       {/* Mobile row break — same trick as the condition row. */}
       <div className="order-3 h-0 w-full basis-full sm:hidden" aria-hidden />

--- a/web/src/features/rules/condition-row.tsx
+++ b/web/src/features/rules/condition-row.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { flattenCategories, useCategories } from "@/api/queries/categories";
 import {
   RULE_FIELDS,
@@ -106,20 +107,29 @@ export function ConditionRowFields({
         onChange={(v) => onChange({ ...value, value: v })}
       />
 
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7 shrink-0"
-        onClick={onRemove}
-        title={
-          totalRows === 1
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0"
+            onClick={onRemove}
+            aria-label={
+              totalRows === 1
+                ? "Remove (rule will match all transactions)"
+                : "Remove condition"
+            }
+          >
+            <X className="text-muted-foreground/60 size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {totalRows === 1
             ? "Remove (rule will match all transactions)"
-            : "Remove condition"
-        }
-      >
-        <X className="text-muted-foreground/60 size-3.5" />
-      </Button>
+            : "Remove condition"}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/web/src/features/rules/rule-row.tsx
+++ b/web/src/features/rules/rule-row.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format";
 import type { TransactionRule } from "@/api/types";
@@ -117,28 +118,38 @@ export function RuleRow({ rule, onToggle, onDelete }: RuleRowProps) {
       {/* Sibling action cluster — absolutely positioned over the Link so
           clicks land on the buttons before bubbling into the navigation. */}
       <div className="absolute top-1/2 right-3 flex -translate-y-1/2 items-center gap-0.5">
-        <Button
-          asChild
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          aria-label={`Edit rule ${rule.name}`}
-        >
-          <Link to="/rules/$id/edit" params={{ id: rule.short_id }}>
-            <Pencil className="size-3.5" />
-          </Link>
-        </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
             <Button
+              asChild
               variant="ghost"
               size="icon"
               className="size-7"
-              aria-label={`Rule ${rule.name} actions`}
+              aria-label={`Edit rule ${rule.name}`}
             >
-              <MoreVertical className="size-4" />
+              <Link to="/rules/$id/edit" params={{ id: rule.short_id }}>
+                <Pencil className="size-3.5" />
+              </Link>
             </Button>
-          </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Edit rule</TooltipContent>
+        </Tooltip>
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  aria-label={`Rule ${rule.name} actions`}
+                >
+                  <MoreVertical className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Rule actions</TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end" className="w-44">
             <DropdownMenuItem onSelect={() => onToggle(rule)}>
               {rule.enabled ? (

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -39,7 +39,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
@@ -513,67 +512,65 @@ function BackupRowItem({
         </div>
       </div>
 
-      <TooltipProvider delayDuration={200}>
-        <div className="flex items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                asChild
-                aria-label="Download backup"
-              >
-                <a href={backupDownloadHref(row.filename)}>
-                  <Download className="size-4" />
-                </a>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Download</TooltipContent>
-          </Tooltip>
+      <div className="flex items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              asChild
+              aria-label="Download backup"
+            >
+              <a href={backupDownloadHref(row.filename)}>
+                <Download className="size-4" />
+              </a>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Download</TooltipContent>
+        </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={() => setConfirm("restore")}
-                disabled={busy || restoreDisabled}
-                aria-label="Restore from this backup"
-              >
-                {restore.isPending ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <RotateCcw className="size-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Restore</TooltipContent>
-          </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setConfirm("restore")}
+              disabled={busy || restoreDisabled}
+              aria-label="Restore from this backup"
+            >
+              {restore.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RotateCcw className="size-4" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Restore</TooltipContent>
+        </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={() => setConfirm("delete")}
-                disabled={busy}
-                aria-label="Delete backup"
-                className="text-destructive hover:text-destructive"
-              >
-                {del.isPending ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Trash2 className="size-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
-          </Tooltip>
-        </div>
-      </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setConfirm("delete")}
+              disabled={busy}
+              aria-label="Delete backup"
+              className="text-destructive hover:text-destructive"
+            >
+              {del.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Trash2 className="size-4" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Delete</TooltipContent>
+        </Tooltip>
+      </div>
 
       <ConfirmDialog
         open={confirm === "restore"}

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import {
   setupAccountURL,
@@ -229,16 +230,21 @@ function MemberMenu({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground hover:text-foreground size-8"
-        >
-          <MoreVertical className="size-4" />
-          <span className="sr-only">Member actions</span>
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-foreground size-8"
+            >
+              <MoreVertical className="size-4" />
+              <span className="sr-only">Member actions</span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Member actions</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end" className="w-52">
         {login ? (
           <>

--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DataTable } from "@/components/data-table";
 import { IdPill } from "@/components/id-pill";
 import { TagChip } from "@/components/tag-chip";
@@ -100,16 +101,21 @@ export function TagsTable({
         meta: { className: "w-px" },
         cell: ({ row }) => (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label={`Actions for ${row.original.display_name}`}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Actions for ${row.original.display_name}`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Tag actions</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent
               align="end"
               onClick={(e) => e.stopPropagation()}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -279,7 +279,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <TooltipProvider>
+        <TooltipProvider delayDuration={200}>
           <RouterProvider router={router} />
         </TooltipProvider>
       </ThemeProvider>

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -42,6 +42,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ColorRailCard, ColorRailCardSkeleton } from "@/components/color-rail-card";
 import {
   DetailList,
@@ -611,16 +612,21 @@ function Hero({
             </Button>
           )}
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-7 rounded-full"
-                aria-label="Connection actions"
-              >
-                <MoreHorizontal className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 rounded-full"
+                    aria-label="Connection actions"
+                  >
+                    <MoreHorizontal className="size-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Connection actions</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent align="end">
               {conn.status !== "disconnected" && (
                 <DropdownMenuItem


### PR DESCRIPTION
## Summary

- Wraps every icon-only `<Button>` in the SPA (that previously had only an `aria-label` / `sr-only`) with a `Tooltip`, so mouse users get the same affordance discoverability screen readers had.
- Bumps the global `TooltipProvider` `delayDuration` from `0` to `200ms` so hovers feel deliberate without flickering during transient cursor passes.
- Removes a redundant local `TooltipProvider` in `backups-section.tsx` that no longer needs its own (it inherits the new global delay).

## Sites covered

- `account-settings-card` — inline rename Save / Cancel
- `account-links-section` — Link actions dropdown trigger
- `connection-row` + `connection-detail` — Connection actions dropdown trigger
- `tags-table` + `api-keys-table` — row Actions dropdown trigger
- `rule-row` — Edit link + Rule actions trigger
- `category-list` — Edit
- `rules/condition-row` + `rules/action-row` — Remove (upgraded from native `title=` to a real Tooltip)
- `settings/household-section` — Member actions trigger

## Pattern

Dropdown-menu triggers wrap `DropdownMenuTrigger` *inside* `TooltipTrigger` so hover reveals the label and click still opens the menu — the canonical shadcn composition pattern:

```tsx
<DropdownMenu>
  <Tooltip>
    <TooltipTrigger asChild>
      <DropdownMenuTrigger asChild>
        <Button size="icon" variant="ghost" aria-label="Connection actions">
          <MoreHorizontal />
        </Button>
      </DropdownMenuTrigger>
    </TooltipTrigger>
    <TooltipContent>Connection actions</TooltipContent>
  </Tooltip>
  <DropdownMenuContent>…</DropdownMenuContent>
</DropdownMenu>
```

## Before / After

Rules list — row icon-only actions (`Edit` link + `Rule actions` trigger):

| Before (hover row, no tooltip) | After (hover Edit, tooltip surfaces label) |
| --- | --- |
| ![before](https://i.img402.dev/c1nfmbo1fa.jpg) | ![after](https://i.img402.dev/859xdxib7t.jpg) |

Connections list — Connection actions trigger on hover:

![connections](https://i.img402.dev/ybw3qf40ta.jpg)

## Notes

- 200ms global delay is the same value `backups-section` was already using locally — promoting it makes the v2 SPA feel uniform on hover discovery.
- The `condition-row` and `action-row` upgrades replace the browser-native `title=` (delayed, OS-styled) with the shadcn `Tooltip` (instant on hover after delay, themed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
