### PR TITLE
design(v2): PageHeader description copy consistency sweep

### DIFF
--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -1,11 +1,25 @@
 import { cn } from "@/lib/utils";
 
 export interface PageHeaderProps {
-  /** Optional small label rendered above the title. Use sparingly — only
-      when the page needs a section label that isn't already visible in
-      the topbar breadcrumb (e.g. "Settings ›" on a deep detail page). */
+  /** Optional small label rendered above the title. Sentence case in the
+      source ("New tag", "Edit rule", "Settings", "Key created") — the
+      uppercase comes from CSS. On detail pages it doubles as the entity
+      type ("Tag", "Category"); on form pages it frames the verb ("New
+      tag" / "Edit tag"); on dynamic pages it can carry live status
+      ("3 healthy · 3 of 3 configured"). Use it whenever the title alone
+      is ambiguous about which family the page belongs to. */
   eyebrow?: string;
+  /** The page H1. Sentence case ("Connections", "Mint an API key",
+      "Welcome back, Ricardo"). No trailing punctuation. */
   title: string;
+  /** One short paragraph that frames the page for someone landing cold.
+      Full sentence(s) ending with a period — same voice across pages so
+      the system reads coherently. Prefer a noun-led framing ("Bank data
+      providers that sync accounts and transactions into Breadbox.")
+      over an imperative fragment ("Configure bank providers."). When the
+      same page renders multiple states (loading, error, loaded), hoist
+      the copy to a module-level constant so the description doesn't
+      momentarily shift on transition. */
   description?: string;
   /** Optional right-aligned actions — usually a <Button> or a cluster. */
   actions?: React.ReactNode;

--- a/web/src/routes/providers.tsx
+++ b/web/src/routes/providers.tsx
@@ -8,6 +8,12 @@ import {
 import { CsvCard, PlaidCard, TellerCard } from "@/features/providers";
 import type { ProviderConfigResponse, ProviderHealthResponse } from "@/api/types";
 
+// Canonical description — hoisted so every render state (loading, error,
+// loaded) reads with the same voice and the page never momentarily swaps
+// to a shorter sentence on transition.
+const PROVIDERS_DESCRIPTION =
+  "Bank data providers that sync accounts and transactions into Breadbox. Each provider stores its own encrypted credentials.";
+
 // Build the small "N healthy · M of 3 configured" eyebrow that lands in
 // PageHeader so the page reads as a status overview before the cards.
 function buildEyebrow(
@@ -40,7 +46,7 @@ export function ProvidersPage() {
         <PageHeader
           eyebrow="Settings"
           title="Providers"
-          description="Configure bank data providers that sync accounts and transactions."
+          description={PROVIDERS_DESCRIPTION}
         />
         <div className="text-muted-foreground flex items-center justify-center gap-2 py-16 text-sm">
           <Loader2 className="size-4 animate-spin" /> Loading provider configuration…
@@ -55,7 +61,7 @@ export function ProvidersPage() {
         <PageHeader
           eyebrow="Settings"
           title="Providers"
-          description="Configure bank data providers that sync accounts and transactions."
+          description={PROVIDERS_DESCRIPTION}
         />
         <Alert variant="destructive">
           <AlertTitle>Couldn't load provider configuration</AlertTitle>
@@ -78,7 +84,7 @@ export function ProvidersPage() {
       <PageHeader
         eyebrow={eyebrow}
         title="Providers"
-        description="Bank data providers that sync accounts and transactions into Breadbox. Each provider stores its own encrypted credentials."
+        description={PROVIDERS_DESCRIPTION}
       />
       <div className="grid gap-5">
         <PlaidCard config={plaid} health={healthMap["plaid"]} />

--- a/web/src/routes/rule-form.tsx
+++ b/web/src/routes/rule-form.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/api/client";
@@ -108,23 +109,25 @@ export function RuleFormPage({ mode }: RuleFormPageProps) {
     );
   }
 
-  const title = isEdit ? `Edit rule` : "New rule";
+  // Match the canonical form-page shell — SoftBackButton + eyebrow +
+  // PageHeader description voice. Descriptions are full sentences with a
+  // trailing period, framing the page's intent the same way tag-new /
+  // category-new / api-key-new do.
+  const eyebrow = isEdit ? "Edit rule" : "New rule";
+  const title = isEdit && rule ? rule.name : "Create a rule";
   const description = isEdit
-    ? "Changes apply on the next sync. Use 'Apply retroactively' on the detail page to re-run against existing transactions."
-    : "When transactions match the conditions, the actions are applied automatically.";
+    ? "Changes apply on the next sync. Use Apply retroactively on the detail page to re-run against existing transactions."
+    : "Rules watch every incoming transaction during sync. When the conditions match, the actions fire automatically — categorize, tag, comment, or skip review.";
   const submitting = isEdit ? updateRule.isPending : createRule.isPending;
+  // SoftBackButton prefers history.back() on plain click, so /rules is a
+  // safe fallback for both create and edit (the latter usually navigated
+  // through /rules/$id, which has its own SoftBackButton to /rules).
+  const backLabel = isEdit ? "Back to rule" : "Back to rules";
 
   return (
     <>
-      <PageHeader
-        title={title}
-        description={description}
-        actions={
-          <Button asChild variant="ghost" size="sm">
-            <Link to="/rules">Back</Link>
-          </Button>
-        }
-      />
+      <SoftBackButton to="/rules">{backLabel}</SoftBackButton>
+      <PageHeader eyebrow={eyebrow} title={title} description={description} />
       <RuleForm
         initialRule={rule}
         submitting={submitting}

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -131,11 +131,23 @@ export function RulesPage() {
 
   const showCount = !isLoading && !isError && rows.length > 0;
 
+  // Match the canonical list-page eyebrow vocabulary (Connections, Tags,
+  // Accounts, Categories): one short state string. The count line below
+  // the header carries the precise number when the body is populated.
+  const eyebrow = isLoading
+    ? "Loading"
+    : isError
+      ? "Error"
+      : total === 1
+        ? "1 rule"
+        : `${total} rules`;
+
   return (
     <>
       <PageHeader
+        eyebrow={eyebrow}
         title="Rules"
-        description="Automatically categorize, tag, or comment on transactions during sync."
+        description="Conditions that fire during every sync. Match transactions on merchant, amount, account, or category, then categorize, tag, comment, or skip review automatically."
         actions={
           <Button asChild size="sm">
             <Link to="/rules/new">


### PR DESCRIPTION
## Summary

- Documents the canonical **PageHeader copy vocabulary** in the prop docstrings (eyebrow casing, title no trailing punctuation, description as a noun-led sentence ending in a period, multi-state pages hoist copy to a module-level constant).
- **providers**: hoists the description to one `PROVIDERS_DESCRIPTION` constant — the loading / error / loaded states no longer momentarily shrink the description on data arrival.
- **rule-form**: brings onto the canonical form-page shell already shared by `tag-new`, `category-new`, `api-key-new` — `SoftBackButton` + `PageHeader` with eyebrow ("New rule" / "Edit rule"). Title becomes the rule name in edit mode (matches `tag-detail`).
- **rules**: gains a dynamic eyebrow ("N rules" / "Loading" / "Error") matching Connections / Tags / Accounts / Categories. Description rewritten in the same noun-led voice as the rest of the list pages.

## Before / After

### Rules list page

The list page now carries the same eyebrow vocabulary as every other list page (Connections, Tags, Accounts, Categories) — a single dynamic count — and the description shifts from an imperative fragment ("Automatically categorize, tag, or comment on transactions during sync.") to a noun-led sentence that frames what a rule actually *is* before what it does ("Conditions that fire during every sync. Match transactions on merchant, amount, account, or category, then categorize, tag, comment, or skip review automatically.").

| Before | After |
| --- | --- |
| ![before rules](https://i.img402.dev/narlja25jb.jpg) | ![after rules](https://i.img402.dev/qraiwszno3.jpg) |

### New rule form

The rule form was the last form/edit page hand-rolling its own back-link affordance and skipping the canonical eyebrow + `SoftBackButton` shell. It now matches `tag-new`, `category-new`, and `api-key-new`: a soft back link above the header, a sentence-case "NEW RULE" eyebrow, "Create a rule" as the title (matching "Create a tag" / "Create a category"), and a richer description framing what the rule pipeline does. The bespoke "Back" ghost button in the actions slot is gone.

| Before | After |
| --- | --- |
| ![before rule-new](https://i.img402.dev/hpkswrafkx.jpg) | ![after rule-new](https://i.img402.dev/a4b4ydsfzc.jpg) |

## Notes

- No primitive count change (still 17 shared primitives). This is pure copy + voice consistency on existing `<PageHeader>` calls.
- Drift retired: rule-form was the last form/edit page hand-rolling its own back-link and skipping the canonical `eyebrow` + `SoftBackButton` shell. rules was the last list page without an eyebrow.
- Providers screenshot omitted from the table — the loaded state already used the canonical sentence pre-PR; the win is hoisting it so loading/error stop momentarily shrinking the description on data arrival. Invisible from a single frame, visible during transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)