### PR TITLE
design(v2): unify overlay + rail animation durations

### DIFF
--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -107,7 +107,7 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
                     data-active={isActive ? "true" : undefined}
                     className={cn(
                       "group relative flex w-full items-center gap-2 rounded-md py-2 pr-3 pl-3.5 text-left text-sm transition-colors",
-                      "before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-r-full before:bg-transparent before:transition-all",
+                      "before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-r-full before:bg-transparent before:transition-all before:duration-200 before:ease-out",
                       // Shared focus-visible vocabulary (matches Button +
                       // SidebarMenuButton) so keyboard users can see which
                       // section is focused before pressing Enter.

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -60,7 +60,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg duration-200 transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in",
           side === "right" &&
             "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&

--- a/web/src/routes/error.tsx
+++ b/web/src/routes/error.tsx
@@ -147,7 +147,7 @@ export function ErrorPage({ error, reset }: ErrorPageProps) {
           >
             <div
               className={cn(
-                "overflow-hidden transition-all",
+                "overflow-hidden transition-all duration-200 ease-out",
                 showDetails ? "max-h-[480px]" : "max-h-0",
               )}
             >


### PR DESCRIPTION
## Summary

- **Sheet**: open/close now both **200ms** (was open=500 / close=300), matching the Dialog + AlertDialog vocabulary. Sheets read sluggish next to dialogs today; the asymmetric close-faster-than-open also made the dismissal feel rushed relative to entrance.
- **settings-shell active rail**: `before:duration-200 ease-out`, matching the existing `nav-main` rail. Both surfaces share the same primary-tinted left-rail vocabulary (per the iter-1 drift note) — transitions are now in lockstep.
- **error.tsx details disclosure**: 200ms ease-out on the max-h slide (was implicit 150ms). A 480px panel snapping open in 150ms felt too abrupt.

## Notes

- No new shared primitive — three tiny edits surgically tightening already-shared vocabulary.
- Audit: only 9 explicit `duration-*` utilities across the whole SPA pre-change. Sheet was the lone overlay outlier at 300/500. Tooltip / Popover / Dropdown / Select all use the tw-animate default (~150ms), which is fine for tiny floating UI.
- Screenshots not attached: this is a behavioral/timing change, not a layout shift — there's no static frame that captures "the sheet closes 100ms faster than before." Diff is 3 lines + the build is green.

## Files changed
- `web/src/components/ui/sheet.tsx`
- `web/src/components/settings-shell.tsx`
- `web/src/routes/error.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)