### PR TITLE
design(v2): ActionPill primitive for h-7 action buttons

### DIFF
--- a/web/src/components/action-pill.tsx
+++ b/web/src/components/action-pill.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * ActionPill — the canonical small action button used inside
+ * `<ColorRailCard footer>` strips and `<StatusPanel trailing>` slots.
+ *
+ * Vocabulary: 28px-tall pill (`h-7`), `text-xs` label, `gap-1.5`
+ * between leading icon and label, `size-3.5` leading icon. Distinct
+ * from `<JumpToPill>` (same `h-7` height, but `variant="outline"` +
+ * `px-2.5` + `size-3` icon for lateral nav) and from a standalone CTA
+ * (`<Button size="sm">` is 32px tall).
+ *
+ * The button has a real handler (`onClick`, or wraps a `<Link>` via
+ * `asChild`) — it's a dispatched action, not a navigation pill. Tone
+ * is governed by `variant`: `ghost` for action strips inside a card
+ * surface (account-detail / connection-detail `<ColorRailCard footer>`),
+ * `outline` for top-of-page `<StatusPanel trailing>` CTAs where the
+ * pill needs slightly more visual weight.
+ *
+ * Eight surfaces share the recipe today; promoting it to a primitive
+ * keeps the icon-size and padding constants in one place so future
+ * tweaks (height, gap, icon size) propagate everywhere.
+ *
+ * `asChild` forwards to shadcn `Button.asChild` so consumers can wrap
+ * a router `<Link>` without losing keyboard ergonomics.
+ */
+export interface ActionPillProps
+  extends React.ComponentProps<typeof Button> {
+  asChild?: boolean;
+}
+
+export function ActionPill({
+  className,
+  asChild,
+  variant = "ghost",
+  children,
+  ...rest
+}: ActionPillProps) {
+  return (
+    <Button
+      variant={variant}
+      size="sm"
+      asChild={asChild}
+      className={cn("h-7 gap-1.5 text-xs", className)}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ActionPill } from "@/components/action-pill";
 import {
   ColorRailCard,
   ColorRailCardSkeleton,
@@ -210,17 +211,17 @@ function Hero({
       footer={
         <>
           {!a.is_dependent_linked && (
-            <Button variant="ghost" size="sm" onClick={onAddLink} className="h-7 gap-1.5 text-xs">
+            <ActionPill onClick={onAddLink}>
               <Link2 className="size-3.5" />
               Link account
-            </Button>
+            </ActionPill>
           )}
-          <Button variant="ghost" size="sm" asChild className="h-7 gap-1.5 text-xs">
+          <ActionPill asChild>
             <Link to="/transactions" search={{ account: a.short_id }}>
               <Eye className="size-3.5" />
               View transactions
             </Link>
-          </Button>
+          </ActionPill>
         </>
       }
     >
@@ -435,12 +436,12 @@ function connectionStatusAlert(a: AccountDetail) {
   // `<AlertDescription>` flex-wrap row would wrap the CTA below the body
   // text in a half-aligned column.
   const openCta = a.connection_short_id ? (
-    <Button size="sm" variant="outline" asChild className="h-7 gap-1.5 text-xs">
+    <ActionPill variant="outline" asChild>
       <Link to="/connections/$id" params={{ id: a.connection_short_id }}>
         Open connection
         <ArrowRight className="size-3.5" />
       </Link>
-    </Button>
+    </ActionPill>
   ) : undefined;
 
   if (status === "pending_reauth") {

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -43,6 +43,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ActionPill } from "@/components/action-pill";
 import { ColorRailCard, ColorRailCardSkeleton } from "@/components/color-rail-card";
 import {
   DetailList,
@@ -411,15 +412,10 @@ function DetailBody({
             "Reconnect to the bank to resume syncing this connection."
           }
           trailing={
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onReauth}
-              className="h-7 gap-1.5 text-xs"
-            >
+            <ActionPill variant="outline" onClick={onReauth}>
               <RefreshCw className="size-3.5" />
               Re-authenticate
-            </Button>
+            </ActionPill>
           }
         />
       )}
@@ -575,42 +571,26 @@ function Hero({
       footer={
         <>
           {canSync && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onSync}
-              disabled={syncPending}
-              className="h-7 gap-1.5 text-xs"
-            >
+            <ActionPill onClick={onSync} disabled={syncPending}>
               {syncPending ? (
                 <Loader2 className="size-3.5 animate-spin" />
               ) : (
                 <RefreshCw className="size-3.5" />
               )}
               Sync now
-            </Button>
+            </ActionPill>
           )}
           {conn.provider === "csv" && conn.status !== "disconnected" && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onImportCsv}
-              className="h-7 gap-1.5 text-xs"
-            >
+            <ActionPill onClick={onImportCsv}>
               <Upload className="size-3.5" />
               Import more
-            </Button>
+            </ActionPill>
           )}
           {conn.status !== "disconnected" && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onReauth}
-              className="h-7 gap-1.5 text-xs"
-            >
+            <ActionPill onClick={onReauth}>
               <Plug className="size-3.5" />
               Re-authenticate
-            </Button>
+            </ActionPill>
           )}
           <DropdownMenu>
             <Tooltip>
@@ -816,22 +796,20 @@ function SettingsCard({
             {conn.paused ? "Scheduled syncs paused" : "Syncing on schedule"}
           </div>
         </div>
-        <Button
+        <ActionPill
           variant="outline"
-          size="sm"
           onClick={onTogglePause}
           disabled={pausePending || conn.status === "disconnected"}
-          className="h-7 gap-1.5 text-xs"
         >
           {pausePending ? (
-            <Loader2 className="size-3 animate-spin" />
+            <Loader2 className="size-3.5 animate-spin" />
           ) : conn.paused ? (
-            <Play className="size-3" />
+            <Play className="size-3.5" />
           ) : (
-            <Pause className="size-3" />
+            <Pause className="size-3.5" />
           )}
           {conn.paused ? "Resume" : "Pause"}
-        </Button>
+        </ActionPill>
       </div>
     </SectionCard>
   );

--- a/web/src/routes/error.tsx
+++ b/web/src/routes/error.tsx
@@ -7,6 +7,7 @@ import {
   RotateCw,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+import { ActionPill } from "@/components/action-pill";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/page-header";
 import { SectionCard } from "@/components/section-card";
@@ -111,15 +112,10 @@ export function ErrorPage({ error, reset }: ErrorPageProps) {
           heading={message}
           body="If this keeps happening, reload the page or check the browser console for more context."
           trailing={
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => window.location.reload()}
-              className="h-7 gap-1.5 px-2.5 text-xs"
-            >
-              <RotateCw className="size-3" />
+            <ActionPill onClick={() => window.location.reload()}>
+              <RotateCw className="size-3.5" />
               Reload
-            </Button>
+            </ActionPill>
           }
         />
 

--- a/web/src/routes/placeholder.tsx
+++ b/web/src/routes/placeholder.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
+import { JumpToPill } from "@/components/jump-to-pill";
 import { PageHeader } from "@/components/page-header";
 import { SectionCard } from "@/components/section-card";
 import { StatusPanel } from "@/components/status-panel";
@@ -188,18 +189,12 @@ export function Placeholder({ title }: { title: string }) {
                     </span>
                     <div className="flex flex-wrap items-center gap-1.5">
                       {content.related.map((r) => (
-                        <Button
-                          key={r.to}
-                          asChild
-                          variant="outline"
-                          size="sm"
-                          className="h-7 gap-1.5 px-2.5 text-xs"
-                        >
+                        <JumpToPill key={r.to} asChild>
                           <Link to={r.to}>
                             {r.title}
                             <ArrowRight className="size-3" />
                           </Link>
-                        </Button>
+                        </JumpToPill>
                       ))}
                     </div>
                   </div>

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUpRight,
   Check,
   CheckCircle2,
+  Eye,
   EyeOff,
   Inbox,
   Info,
@@ -66,6 +67,7 @@ import {
 import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
+import { ActionPill } from "@/components/action-pill";
 import { JumpToPill, JumpToRow } from "@/components/jump-to-pill";
 import { MetaBadge } from "@/components/meta-badge";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
@@ -440,6 +442,39 @@ export function ComponentsSection() {
               Dining out
             </JumpToPill>
           </JumpToRow>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="ActionPill"
+        code="components/action-pill"
+        description="The canonical small action button used inside `<ColorRailCard footer>` strips (account-detail / connection-detail) and `<StatusPanel trailing>` slots. 28px-tall pill (`h-7`), `text-xs` label, `gap-1.5` between leading icon and label, `size-3.5` leading icon. Same height as `<JumpToPill>` but the action is a dispatched handler (`onClick`, or wraps a `<Link>` via `asChild`) rather than a lateral nav. Tone is governed by `variant`: `ghost` for action strips inside a card surface, `outline` for top-of-page `<StatusPanel trailing>` CTAs where the pill needs more visual weight. Don't fork the className triplet — extend this primitive."
+        className="block"
+      >
+        <div className="flex flex-col gap-3 rounded-lg border p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <ActionPill onClick={() => toast.message("Sync started")}>
+              <RefreshCw className="size-3.5" />
+              Sync now
+            </ActionPill>
+            <ActionPill onClick={() => toast.message("Pause toggled")}>
+              <Pause className="size-3.5" />
+              Pause
+            </ActionPill>
+            <ActionPill onClick={() => toast.message("View transactions")}>
+              <Eye className="size-3.5" />
+              View transactions
+            </ActionPill>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <ActionPill
+              variant="outline"
+              onClick={() => toast.message("Re-authenticate")}
+            >
+              <RefreshCw className="size-3.5" />
+              Re-authenticate
+            </ActionPill>
+          </div>
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary

- Extracts the canonical `h-7 gap-1.5 text-xs` + `size-3.5` icon recipe used inside `<ColorRailCard footer>` strips and `<StatusPanel trailing>` slots into a new `<ActionPill>` primitive (19th shared primitive). Eight open-coded sites converge on it across `account-detail`, `connection-detail`, and `error.tsx`.
- Settles drift along the way: connection-detail Pause/Resume was using `size-3` icons (vs canonical `size-3.5`); error-page Reload was a `ghost` JumpToPill-shape oddity (`px-2.5` + `size-3`). Both promoted to the canonical recipe. placeholder.tsx related-pills migrated to `<JumpToPill>` (5th surface), retiring the last open-coded `h-7 px-2.5` site.
- Sandbox specimen lives next to `<JumpToPill>` so the two pill vocabularies (`ActionPill` = dispatched action inside a card surface; `JumpToPill` = lateral nav from a hero) are side-by-side for future reference.

## Screenshots

| Connection detail (Sync / Re-authenticate / Pause action pills) | Account detail (Link / View transactions footer strip) |
| --- | --- |
| ![connection-detail](https://i.img402.dev/p7y7jwbhkj.jpg) | ![account-detail](https://i.img402.dev/ge9kkcrgvt.jpg) |

Sandbox specimen side-by-side with `<JumpToPill>`:

![sandbox](https://i.img402.dev/iicslczo06.jpg)

## Notes

- 19th shared primitive in the v2 vocabulary. `<ActionPill>` and `<JumpToPill>` share the 28px height (`h-7`) and `text-xs` label but diverge in tone (`ghost`/`outline` vs `outline`), padding (no `px-2.5` vs `px-2.5`), and icon size (`size-3.5` vs `size-3`). Semantic split: action pill carries a handler (sync, pause, reload); jump pill is a labelled lateral link from a hero.
- Drift swept: the last `h-7 gap-1.5 px-2.5 text-xs` open-coded site (placeholder.tsx) is gone. Only the two primitive files own that className triplet now.
- Future drift to watch: section-card action slots use a tighter shape (`h-7 gap-1 px-2 text-xs`) for "Show / Hide" toggles (error-page Technical details, connection-detail Accounts header). Two consumers today, sibling vocabulary; promote to a `<SectionCardAction>` slot if a third surface adopts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
