### PR TITLE
design(v2): centre TimelineRail line on icon disc centres

### DIFF
--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -121,14 +121,18 @@ function TimelineRailRow({
     <li
       className={cn(
         // `relative` so the rail `::before` positions against the row;
-        // `pl-3.5` (14px) plus the disc's `-ml-3.5` lines the disc centre
-        // up with the rail x-position at the row's left edge (x=0).
+        // `pl-3.5` (14px) plus the disc's `-ml-3.5` (-14px) sits the
+        // disc's left edge at x=0 and its centre at x=14px (half of the
+        // 28px-wide disc) measured from the row's outer-left edge.
         "relative flex gap-3 pl-3.5",
-        // Rail line drawn via `::before`. 1px wide at the disc x-centre
-        // (left:0 of the row's padding-box, since the disc's negative
-        // margin pulls it back so its centre sits on x=0). The pseudo
-        // gets the same `border-border/60` token as the previous border.
-        "before:content-[''] before:absolute before:left-0 before:w-px before:bg-border/60",
+        // Rail line drawn via `::before`. 1px wide, centred on the disc
+        // centre at x=14px → left = 14px - 0.5px = calc(0.875rem - 0.5px).
+        // Iter 56 introduced this pseudo-element rail (replacing
+        // `<ol border-l>`) but anchored it at `left-0`, which sat the rail
+        // 13.5px to the left of the disc centre — a regression caught in
+        // iter 77 and fixed here. The pseudo gets the same
+        // `border-border/60` token as the previous border.
+        "before:content-[''] before:absolute before:left-[calc(0.875rem-0.5px)] before:w-px before:bg-border/60",
         // Middle rows: full height; the row's `space-y-3` (12px) gap with
         // the next sibling is bridged by `bottom: -12px` so the rail
         // appears unbroken between rows. `-top: 12px` mirrors that on the
@@ -202,7 +206,7 @@ function TimelineRailRowSkeleton({
         // rail x-axis and the rail pseudo-element clips identically — see the
         // long-form comment on TimelineRailRow for the math.
         "relative flex gap-3 pl-3.5",
-        "before:content-[''] before:absolute before:left-0 before:w-px before:bg-border/60",
+        "before:content-[''] before:absolute before:left-[calc(0.875rem-0.5px)] before:w-px before:bg-border/60",
         "before:-top-3 before:-bottom-3",
         "[&:first-of-type]:before:top-[14px]",
         "[&:last-of-type]:before:bottom-[calc(100%-14px)]",


### PR DESCRIPTION
## Summary

- PR #1169 (iter 56) replaced `<ol border-l>` with per-row `::before` rails to fix the tail-extending bug, but anchored the new pseudo at `before:left-0` — which sat ~13.5px left of every disc centre (the disc centre sits at x=14px from the row's outer-left thanks to `pl-3.5` + `-ml-3.5`).
- Fix: `before:left-0` -> `before:left-[calc(0.875rem-0.5px)]` on both `TimelineRailRow` and `TimelineRailRowSkeleton`. The 1px line now centres exactly on the 28px disc centre.
- Closes the HIGH PRIORITY open observation Ricardo flagged on the sprint state.

## Before / After

| Before (rail at x=0, ~13.5px off the disc centres — outside the crop on the left) | After (rail centred on the disc centres) |
| --- | --- |
| ![before](https://i.img402.dev/4rf6xvmvlh.jpg) | ![after](https://i.img402.dev/cywqqqqzbh.jpg) |

In the BEFORE crop the rail is entirely absent because it was sitting 13.5px to the left of the icon column — outside the framed area. In the AFTER crop the hairline rail visibly passes through the centre of every icon disc, and the day-heading dots above each group still anchor cleanly onto the same axis (they were never affected since they use a separate `marginLeft: -17px` offset, not the row `::before`).

## Notes

- No primitive surface area change. No consumer migration needed.
- Only `timeline-rail.tsx` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)