### PR TITLE
design(v2): align settings desktop nav with canonical sidebar rail

### DIFF
--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -91,7 +91,7 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
   if (desktop) {
     return (
       <div className="flex h-full">
-        <nav className="bg-muted/40 w-56 shrink-0 border-r p-3">
+        <nav className="bg-sidebar text-sidebar-foreground w-56 shrink-0 border-r p-3">
           <p className="text-muted-foreground/80 mb-2 px-2 text-[10px] font-semibold tracking-[0.08em] uppercase">
             Settings
           </p>
@@ -106,16 +106,24 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
                     onClick={() => onSelect(s.slug)}
                     data-active={isActive ? "true" : undefined}
                     className={cn(
-                      "group relative flex w-full items-center gap-2 rounded-md py-2 pr-3 pl-3.5 text-left text-sm transition-colors",
-                      "before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-r-full before:bg-transparent before:transition-all before:duration-200 before:ease-out",
+                      "group relative flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                      // 3px primary-tinted rail at the outer panel edge, scaled
+                      // in via transform on activation. Matches the canonical
+                      // nav-main vocabulary (iter 1, timing parity iter 73):
+                      // before:transition-transform before:duration-200 before:ease-out.
+                      "before:bg-primary before:absolute before:top-1.5 before:bottom-1.5 before:-left-3 before:w-[3px] before:scale-y-0 before:rounded-r-full before:transition-transform before:duration-200 before:ease-out",
+                      "data-[active=true]:before:scale-y-100",
                       // Shared focus-visible vocabulary (matches Button +
                       // SidebarMenuButton) so keyboard users can see which
                       // section is focused before pressing Enter.
                       "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
-                      "[&>svg]:size-4 [&>svg]:text-muted-foreground",
+                      // Icon picks up the primary tint on active so the row
+                      // reads at a glance — matches nav-main's NAV_ROW_CLS.
+                      "[&>svg]:text-muted-foreground/80 [&>svg]:size-4 [&>svg]:transition-colors",
+                      "data-[active=true]:[&>svg]:text-primary",
                       isActive
-                        ? "bg-accent text-accent-foreground before:bg-primary before:inset-y-1 [&>svg]:text-primary"
-                        : "hover:bg-accent/60",
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                        : "hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
                     )}
                   >
                     <Icon />


### PR DESCRIPTION
## Summary
- Settings shell's desktop nav now speaks the canonical iter-1 active-state vocabulary: 3px primary-tinted rail at the panel's outer edge, animated in via `scale-y-0` → `scale-y-100` with the iter-73 timing (`transition-transform duration-200 ease-out`).
- Icon on the active row picks up the primary tint via the same `data-[active=true]:[&>svg]:text-primary` selector `nav-main` uses — settings + sidebar now share one set of active-row classes.
- Panel chrome switched from `bg-muted/40` to `bg-sidebar` so the settings modal reads as "sidebar lifted into a dialog" instead of a generic muted panel; row padding tightened to symmetric `px-2.5` matching sidebar menu rhythm.

## Before / After

Account section:

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/gb9w3q692c.jpg) | ![after](https://i.img402.dev/235h4b3ieu.jpg) |

Household section:

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/skq2id4bu5.jpg) | ![after](https://i.img402.dev/kh8lx1dnze.jpg) |

## Notes
- No new primitive — settings nav is a tiny standalone surface so the 8-line class block stays inline rather than extracting a shared `RailButton` (would need to satisfy both Sidebar's `overflow-hidden` constraint and the settings dialog's no-overflow context).
- Mobile pill strip (already using `bg-primary/10` for active) is untouched — different visual contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
