### PR TITLE
design(v2): pin sticky table header below app shell header

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -71,9 +71,10 @@ export interface DataTableProps<TData, TValue> {
    */
   focusedRowId?: string;
   /**
-   * Render the column header as a sticky band that pins to the top of the
-   * scroll container. Pairs well with long lists. Uses a subtle muted
+   * Render the column header as a sticky band that pins flush under the
+   * app shell's sticky header (h-14) on long lists. Uses a subtle muted
    * backdrop so it visually separates from the body without a hard line.
+   * Pairs well with `transactions.tsx`, `tags-table.tsx`, `api-keys-table.tsx`.
    */
   stickyHeader?: boolean;
   /**
@@ -141,7 +142,11 @@ export function DataTable<TData, TValue>({
         <TableHeader
           className={cn(
             stickyHeader &&
-              "bg-muted/40 supports-[backdrop-filter]:bg-muted/30 sticky top-0 z-10 backdrop-blur-sm",
+              // top-14 sits the band flush under the app shell's sticky
+              // header (`h-14` in `__root.tsx`) so the column labels stay
+              // visible without being obscured. z-10 keeps the band above
+              // the table body but well below the app header (z-30).
+              "bg-muted/40 supports-[backdrop-filter]:bg-muted/30 sticky top-14 z-10 backdrop-blur-sm",
           )}
         >
           {table.getHeaderGroups().map((headerGroup) => (

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -329,10 +329,6 @@ function DetailsCard({ transaction: t }: { transaction: Transaction }) {
     { label: "ID", value: t.short_id, mono: true },
   ]);
 
-  const referenceRows: DetailRowData[] = compactRows([
-    { label: "ID", value: t.short_id, mono: true },
-  ]);
-
   return (
     <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
       <DetailList label="Account" rows={accountRows} />

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -196,9 +196,9 @@ export function ComponentsSection() {
             }
           >
             <p className="text-muted-foreground text-sm leading-relaxed">
-              Reach for `SectionCard` for any non-list section. The footer slot
-              renders a flush bordered strip — typically a `<ViewAllPill>`
-              link to a fuller index.
+              Reach for <code>SectionCard</code> for any non-list section. The
+              footer slot renders a flush bordered strip — typically a{" "}
+              <code>&lt;ViewAllPill&gt;</code> link to a fuller index.
             </p>
           </SectionCard>
         </div>


### PR DESCRIPTION
## Summary
- DataTable's `stickyHeader` opt-in pinned the column band to `top-0`, hiding it behind the v2 SPA's own sticky app header (`h-14` in `__root.tsx`). Bump the offset to `top-14` so the column labels stay flush under the chrome instead of disappearing under it.
- Also unblocks the design-branch dev build: a stray duplicate `referenceRows` declaration in `transaction-detail.tsx` plus a literal `<ViewAllPill>` token sitting inside JSX prose in the sandbox were both crashing `vite` / `tsc -b` (root `tsconfig` has `files: []` so `bun run lint` happily ignored them).

## Affected surfaces
`stickyHeader` is on in `transactions.tsx`, `tags-table.tsx`, `api-keys-table.tsx`.

## Before / After
Captured at /v2/transactions, viewport 1440×900, scrolled past the page header so the sticky column band engages.

| Before — pinned to top-0, hidden by app header | After — pinned to top-14, flush under app header |
| --- | --- |
| ![before](https://i.img402.dev/3y874p6dah.jpg) | ![after](https://i.img402.dev/xehv29tmsb.jpg) |

## Notes
- Updated the JSDoc on `stickyHeader` to call out the shell coupling so future surfaces don't reintroduce the regression.
- Build-unblock fixes are scoped to the two parse errors — no semantic changes to the sandbox copy or transaction-detail rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)