### PR TITLE
design(v2): fix lint script to type-check + clean surfaced errors

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "tsc --noEmit",
+    "lint": "tsc -b --noEmit",
     "validate": "bun run scripts/validate.ts"
   },
   "dependencies": {

--- a/web/src/components/detail-list.tsx
+++ b/web/src/components/detail-list.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { cn } from "@/lib/utils";

--- a/web/src/components/eyebrow.tsx
+++ b/web/src/components/eyebrow.tsx
@@ -5,11 +5,17 @@ interface EyebrowProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Element to render. Defaults to `span` so the primitive composes inside
    * inline contexts; pass `"p"`, `"h3"`, etc. when the eyebrow is a block
-   * label (section headers, hero eyebrows). Avoid heading levels that
-   * conflict with the document outline — pick `"div"` or `"span"` for
-   * non-semantic decoration.
+   * label (section headers, hero eyebrows). Pass `"label"` (paired with
+   * `htmlFor`) when the eyebrow doubles as a form-control label. Avoid
+   * heading levels that conflict with the document outline — pick `"div"`
+   * or `"span"` for non-semantic decoration.
    */
-  as?: "span" | "p" | "div" | "h3" | "h4";
+  as?: "span" | "p" | "div" | "h3" | "h4" | "label";
+  /**
+   * Forwarded to the underlying element when `as="label"`. Ignored
+   * otherwise (React will warn if you pass it to a non-label element).
+   */
+  htmlFor?: string;
   /**
    * Visual emphasis. `default` is the standard `text-[10px]
    * tracking-[0.1em]` muted eyebrow used on detail-page section headers,

--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "children" | "title"> {
   // Optional bordered header — matches the SectionCard vocabulary. Omit for
   // a header-less list (just a card holding rows).
   title?: React.ReactNode;

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface SectionCardProps extends React.HTMLAttributes<HTMLDivElement> {
+interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   title: React.ReactNode;
   // Slot rendered on the right of the bordered header (button, badge, etc).
   action?: React.ReactNode;

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -5,7 +5,6 @@ import { z } from "zod";
 import {
   AlertTriangle,
   Calendar,
-  CheckCircle2,
   Download,
   HardDrive,
   Loader2,

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -18,7 +18,6 @@ import { FamilyTabs } from "@/features/connections/family-tabs";
 import { AccountRow } from "@/features/accounts/account-row";
 import { AccountsSummary } from "@/features/accounts/accounts-summary";
 import {
-  formatCurrency,
   groupAccounts,
   groupNetTotal,
   type AccountGroupBy,

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -723,7 +723,7 @@ function Hero({
 // Account detail — labelled lateral navigation that surfaces concrete
 // targets (the connection's accounts, the global sync-logs feed) rather
 // than just verbs.
-function QuickActions({ conn }: { conn: ConnectionDetail }) {
+function QuickActions(_props: { conn: ConnectionDetail }) {
   return (
     <JumpToRow>
       <JumpToPill asChild>


### PR DESCRIPTION
## Summary

- **Root cause:** `web/`'s lint script ran `tsc --noEmit` with no `-p` flag. `tsconfig.json` is a project-references root with `files: []`, so the no-arg invocation compiled zero files. Iter #79's PR #1193 landed a duplicate declaration + unescaped JSX text that real type-checking would have caught — that bug existed because lint was a silent no-op.
- **Fix:** change the script to `tsc -b --noEmit` (build mode honors project references), then fix the 8 pre-existing type errors that surfaced so the script can merge green.

## Errors fixed
- `list-card` / `section-card`: `Omit<HTMLAttributes, "title">` so the `ReactNode` title prop doesn't collide with the DOM string `title` attr
- `detail-list`: drop unused `import * as React from "react"`
- `eyebrow`: add `"label"` to the `as` union (and `htmlFor`) — the pattern was already in use on `connect-bank-sheet.tsx` and `csv-import-form.tsx`
- `backups-section`: drop unused `CheckCircle2` import
- `accounts.tsx`: drop unused `formatCurrency` import (no such export — would have been a real bug if anything tried to call it)
- `connection-detail` QuickActions: unused `conn` prop renamed to `_props`

## Verification
- `bun run lint` exits 0 on this branch
- Inserting `const x: string = 123` in `main.tsx` now exits 2 with the expected `TS2322` error (and the `noUnusedLocals` rule fires too) — confirmed that lint will actually catch errors now
- `go build ./...` clean

## Notes
- No design/visual changes; this is plumbing so future design iterations can't regress type safety silently.
- Future iterations should rely on `bun run lint` to catch the same class of bug that landed in #1193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)