### PR TITLE
design(v2): unify page-level error state via PageError primitive

### DIFF
--- a/web/src/components/page-error.tsx
+++ b/web/src/components/page-error.tsx
@@ -1,0 +1,69 @@
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { StatusPanel } from "@/components/status-panel";
+
+interface PageErrorProps {
+  /** What couldn't load (rendered as `Couldn't load {resource}.`). */
+  resource: string;
+  /** Underlying error to surface; `Error.message` is used as the body. */
+  error?: unknown;
+  /** Optional fetcher to invoke when the user presses Retry. */
+  onRetry?: () => unknown | Promise<unknown>;
+  /** Whether the retry call is currently in-flight. */
+  retrying?: boolean;
+}
+
+// PageError renders the canonical page-level "this page couldn't fetch its
+// data" state — destructive-toned StatusPanel with an AlertTriangle icon, a
+// concrete heading, the error message (or a fallback), and an optional
+// inline Retry button.
+//
+// Until iter 82 every page hand-rolled its own `<Alert variant="destructive">
+// + AlertTitle + AlertDescription` for this state. Six pages now route
+// through this primitive: accounts, connections, providers, rules, rule-form,
+// rule-detail. Don't fork — extend this primitive if a seventh consumer
+// needs a new variant.
+//
+// The component reuses the StatusPanel vocabulary (3px tone-tinted left rail
+// + tinted icon tile + heading + body + trailing slot) so destructive page
+// errors speak the same language as warnings, success notices, and env-locked
+// states (see iter 16). The retry button lands in StatusPanel's `trailing`
+// slot so it sits on the right edge, aligned with the icon row.
+export function PageError({
+  resource,
+  error,
+  onRetry,
+  retrying = false,
+}: PageErrorProps) {
+  const message =
+    error instanceof Error && error.message
+      ? error.message
+      : "Try again or refresh the page.";
+
+  return (
+    <StatusPanel
+      tone="destructive"
+      icon={AlertTriangle}
+      heading={`Couldn't load ${resource}`}
+      body={message}
+      trailing={
+        onRetry ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              void onRetry();
+            }}
+            disabled={retrying}
+          >
+            <RefreshCw
+              className={retrying ? "size-3.5 animate-spin" : "size-3.5"}
+            />
+            {retrying ? "Retrying…" : "Retry"}
+          </Button>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/empty-state";
 import { ListCard } from "@/components/list-card";
 import { Button } from "@/components/ui/button";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { PageError } from "@/components/page-error";
 import {
   ToggleGroup,
   ToggleGroupItem,
@@ -186,14 +186,12 @@ export function AccountsPage() {
           )}
         />
       ) : isError ? (
-        <Alert variant="destructive">
-          <AlertTitle>Couldn't load accounts</AlertTitle>
-          <AlertDescription>
-            {accountsQuery.error instanceof Error
-              ? accountsQuery.error.message
-              : "Try refreshing the page."}
-          </AlertDescription>
-        </Alert>
+        <PageError
+          resource="accounts"
+          error={accountsQuery.error}
+          onRetry={() => accountsQuery.refetch()}
+          retrying={accountsQuery.isFetching}
+        />
       ) : accounts.length === 0 ? (
         <EmptyState
           icon={Banknote}

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -8,7 +8,9 @@ import { ListCard } from "@/components/list-card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { PageError } from "@/components/page-error";
+import { StatusPanel } from "@/components/status-panel";
+import { AlertTriangle } from "lucide-react";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useShortcut } from "@/lib/shortcuts";
 import { useConnections, useSyncAll } from "@/api/queries/connections";
@@ -247,16 +249,16 @@ export function ConnectionsPage() {
       )}
 
       {attentionCount > 0 && (
-        <Alert variant="default" className="border-amber-500/30 bg-amber-500/5">
-          <AlertTitle className="text-amber-700 dark:text-amber-400">
-            {attentionCount === 1
+        <StatusPanel
+          tone="warning"
+          icon={AlertTriangle}
+          heading={
+            attentionCount === 1
               ? "1 connection needs attention"
-              : `${attentionCount} connections need attention`}
-          </AlertTitle>
-          <AlertDescription>
-            Re-authenticate the rows below to resume syncing.
-          </AlertDescription>
-        </Alert>
+              : `${attentionCount} connections need attention`
+          }
+          body="Re-authenticate the rows below to resume syncing."
+        />
       )}
 
       {(usersQuery.data?.length ?? 0) > 1 && (
@@ -287,14 +289,12 @@ export function ConnectionsPage() {
           )}
         />
       ) : isError ? (
-        <Alert variant="destructive">
-          <AlertTitle>Couldn't load connections</AlertTitle>
-          <AlertDescription>
-            {connectionsQuery.error instanceof Error
-              ? connectionsQuery.error.message
-              : "Try refreshing the page."}
-          </AlertDescription>
-        </Alert>
+        <PageError
+          resource="connections"
+          error={connectionsQuery.error}
+          onRetry={() => connectionsQuery.refetch()}
+          retrying={connectionsQuery.isFetching}
+        />
       ) : connections.length === 0 ? (
         <EmptyState
           icon={Plug}

--- a/web/src/routes/providers.tsx
+++ b/web/src/routes/providers.tsx
@@ -1,6 +1,6 @@
 import { Loader2 } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { PageError } from "@/components/page-error";
 import {
   useProviderConfig,
   useProviderHealth,
@@ -63,14 +63,12 @@ export function ProvidersPage() {
           title="Providers"
           description={PROVIDERS_DESCRIPTION}
         />
-        <Alert variant="destructive">
-          <AlertTitle>Couldn't load provider configuration</AlertTitle>
-          <AlertDescription>
-            {config.error instanceof Error
-              ? config.error.message
-              : "Try refreshing the page."}
-          </AlertDescription>
-        </Alert>
+        <PageError
+          resource="provider configuration"
+          error={config.error}
+          onRetry={() => config.refetch()}
+          retrying={config.isFetching}
+        />
       </>
     );
   }

--- a/web/src/routes/rule-detail.tsx
+++ b/web/src/routes/rule-detail.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { Loader2, Pause, Pencil, Play, PlayCircle, Shield, Trash2 } from "lucide-react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Loader2, Pause, Pencil, Play, PlayCircle, Shield, Trash2, Wand2 } from "lucide-react";
+import { EmptyState } from "@/components/empty-state";
+import { PageError } from "@/components/page-error";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -44,27 +45,28 @@ export function RuleDetailPage() {
   }
   if (ruleQuery.isError) {
     return (
-      <Alert variant="destructive">
-        <AlertTitle>Couldn't load this rule</AlertTitle>
-        <AlertDescription>
-          {ruleQuery.error instanceof Error
-            ? ruleQuery.error.message
-            : "Try refreshing the page."}
-        </AlertDescription>
-      </Alert>
+      <PageError
+        resource="this rule"
+        error={ruleQuery.error}
+        onRetry={() => ruleQuery.refetch()}
+        retrying={ruleQuery.isFetching}
+      />
     );
   }
   const rule = ruleQuery.data;
   if (!rule) {
     return (
-      <Alert>
-        <AlertTitle>Rule not found</AlertTitle>
-        <AlertDescription>
-          <Button asChild variant="link" className="px-0">
+      <EmptyState
+        variant="card"
+        icon={Wand2}
+        title="Rule not found"
+        description="This rule may have been deleted, or the link is out of date. Head back to the rules list to pick another."
+        action={
+          <Button asChild>
             <Link to="/rules">Back to rules</Link>
           </Button>
-        </AlertDescription>
-      </Alert>
+        }
+      />
     );
   }
 

--- a/web/src/routes/rule-form.tsx
+++ b/web/src/routes/rule-form.tsx
@@ -1,9 +1,10 @@
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
+import { Loader2, Wand2 } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
 import { SoftBackButton } from "@/components/soft-back-button";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { EmptyState } from "@/components/empty-state";
+import { PageError } from "@/components/page-error";
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/api/client";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -85,27 +86,28 @@ export function RuleFormPage({ mode }: RuleFormPageProps) {
 
   if (isEdit && ruleQuery.isError) {
     return (
-      <Alert variant="destructive">
-        <AlertTitle>Couldn't load this rule</AlertTitle>
-        <AlertDescription>
-          {ruleQuery.error instanceof Error
-            ? ruleQuery.error.message
-            : "Try refreshing the page."}
-        </AlertDescription>
-      </Alert>
+      <PageError
+        resource="this rule"
+        error={ruleQuery.error}
+        onRetry={() => ruleQuery.refetch()}
+        retrying={ruleQuery.isFetching}
+      />
     );
   }
 
   if (isEdit && !rule) {
     return (
-      <Alert>
-        <AlertTitle>Rule not found</AlertTitle>
-        <AlertDescription>
-          <Button asChild variant="link" className="px-0">
+      <EmptyState
+        variant="card"
+        icon={Wand2}
+        title="Rule not found"
+        description="This rule may have been deleted, or the link is out of date. Head back to the rules list to pick another."
+        action={
+          <Button asChild>
             <Link to="/rules">Back to rules</Link>
           </Button>
-        </AlertDescription>
-      </Alert>
+        }
+      />
     );
   }
 

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { PageError } from "@/components/page-error";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -175,14 +175,12 @@ export function RulesPage() {
       )}
 
       {isError ? (
-        <Alert variant="destructive">
-          <AlertTitle>Couldn't load rules</AlertTitle>
-          <AlertDescription>
-            {rulesQuery.error instanceof Error
-              ? rulesQuery.error.message
-              : "Try refreshing the page."}
-          </AlertDescription>
-        </Alert>
+        <PageError
+          resource="rules"
+          error={rulesQuery.error}
+          onRetry={() => rulesQuery.refetch()}
+          retrying={isFetching}
+        />
       ) : isLoading ? (
         <div className="flex flex-col gap-3">
           {Array.from({ length: 5 }).map((_, i) => (


### PR DESCRIPTION
## Summary

- New `PageError` primitive at `web/src/components/page-error.tsx` wraps `StatusPanel` with the canonical "Couldn't load X" lockup + an inline Retry button that calls the query's `refetch()`.
- Six pages convert from a hand-rolled `<Alert variant="destructive">` to `<PageError>` — accounts, connections, providers, rules, rule-form, rule-detail — so destructive page-level errors finally speak the same 3px tone-tinted left rail vocabulary as warnings, success notices, and env-locked states.
- Drift cleanups in the same sweep:
  - Connections' amber "N connections need attention" alert moves to `<StatusPanel tone="warning">`.
  - Rule-form / rule-detail "Rule not found" branches drop the bare `<Alert>` for `<EmptyState variant="card">`, matching tag-detail / category-detail.

## Before / After

### Accounts (page-level error)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/8w6hesd53q.jpg) | ![after](https://i.img402.dev/554cs58ra4.jpg) |

### Connections (page-level error)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/ndcm5mggyo.jpg) | ![after](https://i.img402.dev/xutrvmjpaf.jpg) |

## Notes

- The retry button lands in `StatusPanel`'s `trailing` slot, picks up the small outline `RefreshCw` icon, and switches to an animated spinner + "Retrying…" label while `isFetching` is true.
- StatusPanel is unchanged — `PageError` is purely a composition. Sibling of `EmptyState` (no-data) and `StatusPanel` (inline notice) — three states, three vocabularies, one visual system.
- Component-level alerts inside features (`backups-section`, `reauth-sheet`, `account-links-section`, `preview-panel`) intentionally stay on the raw `Alert` primitive — they're scoped inline contexts, not full-page error surfaces.
- Errors were forced for the screenshots via a Chrome DevTools `initScript` that intercepts `fetch` on the relevant `/api/v1/*` paths and returns a stubbed 500 with a realistic error envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
