### PR TITLE
design(v2): DetailPageSkeleton primitive (22nd, 4 detail pages unified)

### DIFF
--- a/web/src/components/color-rail-card.tsx
+++ b/web/src/components/color-rail-card.tsx
@@ -82,7 +82,7 @@ export function ColorRailCard({
   );
 }
 
-interface ColorRailCardSkeletonProps {
+export interface ColorRailCardSkeletonProps {
   /**
    * Shape of the hero icon tile to mirror — match what the loaded hero
    * renders. `rounded-md` for transaction-detail (matches

--- a/web/src/components/detail-page-skeleton.tsx
+++ b/web/src/components/detail-page-skeleton.tsx
@@ -1,0 +1,106 @@
+import {
+  ColorRailCardSkeleton,
+  type ColorRailCardSkeletonProps,
+} from "@/components/color-rail-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface DetailPageSkeletonProps {
+  /**
+   * Hero options forwarded to `<ColorRailCardSkeleton>`. The hero is
+   * always rendered — every v2 detail page leads with a hero card, so
+   * the contract is "you must mirror the loaded hero shape".
+   */
+  hero?: Pick<ColorRailCardSkeletonProps, "tileShape" | "withFooter" | "body">;
+  /**
+   * Number of `<JumpToPill>`-shaped pills to render below the hero
+   * (matches the iter-75 `<JumpToRow>` vocabulary — `h-7` pills).
+   * Omit (or pass `0`) when the detail page doesn't carry a lateral-nav
+   * pill strip (e.g. Connection detail puts its actions in the hero
+   * footer instead).
+   */
+  jumpPills?: number;
+  /**
+   * Heights for the main column's stacked block placeholders, in
+   * Tailwind class form (e.g. `["h-72"]`, `["h-32", "h-48", "h-48"]`).
+   * Each entry renders as a `rounded-xl` skeleton block — matches the
+   * `<SectionCard>` / `<ListCard>` chrome the loaded page renders.
+   */
+  main?: ReadonlyArray<string>;
+  /**
+   * Heights for the sidebar column's stacked block placeholders, in
+   * Tailwind class form (e.g. `["h-56"]`, `["h-40", "h-48"]`). When
+   * the loaded page has no sidebar (rare), pass an empty array — the
+   * grid collapses to a single column.
+   */
+  sidebar?: ReadonlyArray<string>;
+  className?: string;
+}
+
+// DetailPageSkeleton is the canonical loading shell for every v2 detail
+// page (transaction, account, category, connection). It composes the
+// existing iter-10 `<ColorRailCardSkeleton>` hero with the iter-75
+// `<JumpToRow>`-shaped pill strip and a two-column grid of `rounded-xl`
+// block placeholders matching `<SectionCard>` / `<ListCard>` chrome.
+//
+// Sibling of `<PageError>` (iter 82 #1196) — three states, three
+// vocabularies, one visual system: error → `<PageError>`, loading →
+// `<DetailPageSkeleton>`, empty → `<EmptyState>`. Every v2 detail page
+// already routes its error state through `<PageError>`; this primitive
+// gives the loading state the same one-place-to-edit treatment.
+//
+// Before this primitive landed, every detail route hand-rolled its own
+// `function DetailSkeleton()` with copy-pasted layout markup that drifted
+// in subtle ways (gap spacing, sidebar widths, pill widths). Four
+// surfaces now route through it: transaction-detail, account-detail,
+// category-detail, connection-detail. Don't fork — extend this
+// primitive if a fifth consumer needs a new layout knob.
+export function DetailPageSkeleton({
+  hero,
+  jumpPills = 0,
+  main = [],
+  sidebar = [],
+  className,
+}: DetailPageSkeletonProps) {
+  const hasSidebar = sidebar.length > 0;
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      <ColorRailCardSkeleton
+        tileShape={hero?.tileShape}
+        withFooter={hero?.withFooter}
+        body={hero?.body}
+      />
+      {jumpPills > 0 && (
+        <div className="flex gap-2">
+          {Array.from({ length: jumpPills }).map((_, i) => (
+            <Skeleton key={i} className="h-7 w-32 rounded-md" />
+          ))}
+        </div>
+      )}
+      {(main.length > 0 || hasSidebar) && (
+        <div
+          className={cn(
+            "grid gap-6",
+            hasSidebar && "lg:grid-cols-[minmax(0,1fr)_18rem]",
+          )}
+        >
+          {main.length > 0 && (
+            <div className="min-w-0 space-y-6">
+              {main.map((h, i) => (
+                <Skeleton key={i} className={cn(h, "rounded-xl")} />
+              ))}
+            </div>
+          )}
+          {hasSidebar && (
+            <div className="space-y-6">
+              {sidebar.map((h, i) => (
+                <Skeleton key={i} className={cn(h, "rounded-xl")} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -18,12 +18,9 @@ import {
   Wallet,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { ActionPill } from "@/components/action-pill";
-import {
-  ColorRailCard,
-  ColorRailCardSkeleton,
-} from "@/components/color-rail-card";
+import { ColorRailCard } from "@/components/color-rail-card";
+import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import {
   DetailList,
   compactDetailRows,
@@ -482,19 +479,11 @@ function connectionStatusAlert(a: AccountDetail) {
 
 function DetailSkeleton() {
   return (
-    <div className="space-y-6">
-      <ColorRailCardSkeleton tileShape="rounded-lg" withFooter />
-      <div className="flex gap-2">
-        <Skeleton className="h-7 w-32 rounded-md" />
-        <Skeleton className="h-7 w-32 rounded-md" />
-      </div>
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <Skeleton className="h-96 rounded-xl" />
-        <div className="space-y-6">
-          <Skeleton className="h-56 rounded-xl" />
-          <Skeleton className="h-72 rounded-xl" />
-        </div>
-      </div>
-    </div>
+    <DetailPageSkeleton
+      hero={{ tileShape: "rounded-lg", withFooter: true }}
+      jumpPills={2}
+      main={["h-96"]}
+      sidebar={["h-56", "h-72"]}
+    />
   );
 }

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -16,11 +16,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CategoryIconTile } from "@/components/category-icon-tile";
-import {
-  ColorRailCard,
-  ColorRailCardSkeleton,
-} from "@/components/color-rail-card";
+import { ColorRailCard } from "@/components/color-rail-card";
 import { DangerZone } from "@/components/danger-zone";
+import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import {
   DetailList,
   compactDetailRows,
@@ -390,19 +388,11 @@ function DeleteCategory({ category }: { category: Category }) {
 
 function DetailSkeleton() {
   return (
-    <div className="space-y-6">
-      <ColorRailCardSkeleton tileShape="rounded-lg" />
-      <div className="flex gap-2">
-        <Skeleton className="h-7 w-48 rounded-md" />
-        <Skeleton className="h-7 w-32 rounded-md" />
-      </div>
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <Skeleton className="h-96 rounded-xl" />
-        <div className="space-y-6">
-          <Skeleton className="h-48 rounded-xl" />
-          <Skeleton className="h-64 rounded-xl" />
-        </div>
-      </div>
-    </div>
+    <DetailPageSkeleton
+      hero={{ tileShape: "rounded-lg" }}
+      jumpPills={2}
+      main={["h-96"]}
+      sidebar={["h-48", "h-64"]}
+    />
   );
 }

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -44,7 +44,8 @@ import {
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ActionPill } from "@/components/action-pill";
-import { ColorRailCard, ColorRailCardSkeleton } from "@/components/color-rail-card";
+import { ColorRailCard } from "@/components/color-rail-card";
+import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import {
   DetailList,
   compactDetailRows,
@@ -885,26 +886,17 @@ function formatIntervalLabel(minutes: number): string {
 }
 
 function DetailSkeleton() {
+  // Hero matches the loaded `<ColorRailCard>` shape: status-tinted rail +
+  // `rounded-lg` icon tile + bordered action-strip footer (Sync now /
+  // Re-authenticate / overflow). The `DetailPageSkeleton` primitive
+  // converges every v2 detail page on a single skeleton shape — no
+  // jump-pill strip here because connection-detail puts its actions in
+  // the hero footer instead.
   return (
-    <div className="space-y-6">
-      {/* Hero — matches the loaded `<ColorRailCard>` shape: status-tinted
-          rail + `rounded-lg` icon tile + bordered action-strip footer
-          (Sync now / Re-authenticate / overflow). Mirrors the
-          account-detail and transaction-detail loading vocabulary so
-          the three sibling detail pages converge on a single skeleton
-          shape. */}
-      <ColorRailCardSkeleton tileShape="rounded-lg" withFooter />
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <div className="min-w-0 space-y-6">
-          <Skeleton className="h-32 rounded-xl" />
-          <Skeleton className="h-48 rounded-xl" />
-          <Skeleton className="h-48 rounded-xl" />
-        </div>
-        <div className="space-y-6">
-          <Skeleton className="h-40 rounded-xl" />
-          <Skeleton className="h-48 rounded-xl" />
-        </div>
-      </div>
-    </div>
+    <DetailPageSkeleton
+      hero={{ tileShape: "rounded-lg", withFooter: true }}
+      main={["h-32", "h-48", "h-48"]}
+      sidebar={["h-40", "h-48"]}
+    />
   );
 }

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -11,12 +11,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { CategoryIconTile } from "@/components/category-icon-tile";
-import {
-  ColorRailCard,
-  ColorRailCardSkeleton,
-} from "@/components/color-rail-card";
+import { ColorRailCard } from "@/components/color-rail-card";
 import {
   DetailList,
   compactDetailRows,
@@ -353,10 +351,10 @@ function titleize(value: string | null | undefined): string | null {
 
 function DetailSkeleton() {
   return (
-    <div className="space-y-6">
-      <ColorRailCardSkeleton
-        tileShape="rounded-md"
-        body={
+    <DetailPageSkeleton
+      hero={{
+        tileShape: "rounded-md",
+        body: (
           <div className="space-y-5">
             <Separator />
             <div className="grid gap-4 sm:grid-cols-2">
@@ -370,16 +368,11 @@ function DetailSkeleton() {
               </div>
             </div>
           </div>
-        }
-      />
-      <div className="flex gap-2">
-        <Skeleton className="h-7 w-32 rounded-md" />
-        <Skeleton className="h-7 w-32 rounded-md" />
-      </div>
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <Skeleton className="h-72 rounded-xl" />
-        <Skeleton className="h-56 rounded-xl" />
-      </div>
-    </div>
+        ),
+      }}
+      jumpPills={2}
+      main={["h-72"]}
+      sidebar={["h-56"]}
+    />
   );
 }


### PR DESCRIPTION
## Summary

- Extract `DetailPageSkeleton` primitive (`web/src/components/detail-page-skeleton.tsx`) — composes the iter-10 `ColorRailCardSkeleton` hero + a `JumpToRow`-shaped pill strip + a 2-column grid of `rounded-xl` block placeholders matching `SectionCard` / `ListCard` chrome.
- Migrate all four v2 detail pages onto it (transaction, account, category, connection). Each route's hand-rolled `function DetailSkeleton()` collapses from ~15 lines of copy-pasted JSX to a single props call.
- Sibling of iter-82's `PageError` primitive — three states, three vocabularies, one visual system: error -> PageError, loading -> DetailPageSkeleton, empty -> EmptyState. Every v2 detail page already routes its error state through PageError; this gives the loading state the same one-place-to-edit treatment.

## After

| Transaction detail (jumpPills + hero body) | Connection detail (no pills, 3+2 grid) |
| --- | --- |
| ![tx-skeleton](https://i.img402.dev/krucsli8mj.jpg) | ![connection-skeleton](https://i.img402.dev/bpbdm79a7v.jpg) |

Skeletons captured by stubbing `fetch` to delay the `/api/v1/{transactions,connections}/...` response for 30s. The change is intentionally byte-equivalent to the prior hand-rolled skeletons — the win is one-place-to-edit, not pixel drift.

## Notes

- API: `hero` (forwards to `ColorRailCardSkeleton`), `jumpPills` (count of pill placeholders), `main` / `sidebar` (arrays of Tailwind height classes for stacked block placeholders).
- Width-variance on jump pills (Category had `w-48` + `w-32`) collapsed to uniform `w-32` — decorative-only difference, not worth a knob.
- Exports the `ColorRailCardSkeletonProps` interface so the primitive can forward props with full type safety.
- 22nd shared primitive in the v2 vocabulary (after iter-82's `PageError`).

Generated with Claude Code