### PR TITLE
design(v2): structured loading skeletons for Rules / Tags / API keys list pages

### DIFF
--- a/web/src/features/api-keys/api-key-row-skeleton.tsx
+++ b/web/src/features/api-keys/api-key-row-skeleton.tsx
@@ -1,0 +1,52 @@
+import { TableCell } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface APIKeyRowSkeletonProps {
+  /**
+   * Mirrors the loaded table — the revoked tab drops the actions column and
+   * shows the revoked-at timestamp in place of last-used, but the skeleton
+   * geometry is the same shape (a date-style text placeholder), so the only
+   * thing that changes is whether the trailing action cell renders.
+   */
+  revoked?: boolean;
+}
+
+/**
+ * API-key row skeleton — mirrors the six columns of the loaded row so the
+ * table doesn't shift when data arrives:
+ *  - Name + faint mono prefix pill (32% Name column)
+ *  - Scope badge
+ *  - Actor badge (md+)
+ *  - Last-used / revoked-at relative time (lg+)
+ *  - Created date (xl+)
+ *  - Action button (w-px, omitted on the revoked tab)
+ */
+export function APIKeyRowSkeleton({ revoked = false }: APIKeyRowSkeletonProps) {
+  return (
+    <>
+      <TableCell className="w-[32%]">
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3.5 w-36" />
+          <Skeleton className="h-4 w-20 rounded" />
+        </div>
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-20 rounded-md" />
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        <Skeleton className="h-5 w-24 rounded-md" />
+      </TableCell>
+      <TableCell className="hidden lg:table-cell">
+        <Skeleton className="h-3 w-20" />
+      </TableCell>
+      <TableCell className="hidden xl:table-cell">
+        <Skeleton className="h-3 w-24" />
+      </TableCell>
+      {!revoked && (
+        <TableCell className="w-px">
+          <Skeleton className="ml-auto size-8 rounded-md" />
+        </TableCell>
+      )}
+    </>
+  );
+}

--- a/web/src/features/api-keys/api-keys-table.tsx
+++ b/web/src/features/api-keys/api-keys-table.tsx
@@ -27,6 +27,7 @@ import {
   ActorBadge,
   ScopeBadge,
 } from "@/features/api-keys/api-key-badges";
+import { APIKeyRowSkeleton } from "@/features/api-keys/api-key-row-skeleton";
 
 export interface APIKeysTableProps {
   keys: APIKey[];
@@ -187,6 +188,7 @@ export function APIKeysTable({
         emptyState={emptyState}
         stickyHeader
         refinedHeader
+        renderSkeletonRow={() => <APIKeyRowSkeleton revoked={revoked} />}
       />
 
       <Dialog

--- a/web/src/features/rules/rule-row-skeleton.tsx
+++ b/web/src/features/rules/rule-row-skeleton.tsx
@@ -1,0 +1,68 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface RuleRowSkeletonProps {
+  /**
+   * Per-row width override for the title placeholder. The defaults rotate
+   * across `Array.from(...).map(i, …)` calls so the loading stack reads as
+   * a stack of varied-length rules instead of a metronome.
+   */
+  titleClassName?: string;
+  /** Whether to render the lg-only stats columns (stage + last active). */
+  showStats?: boolean;
+  className?: string;
+}
+
+/**
+ * RuleRowSkeleton mirrors the layout of `<RuleRow>` while the rules list
+ * loads — same `rounded-xl border` card, same `size-9 rounded-xl` avatar
+ * tile, same title + meta-line stack, and the lg-only stage / last-active
+ * columns + the absolute action cluster on the right. Lifts the rules
+ * list out of the generic `Skeleton h-[72px] rounded-xl` block strip and
+ * onto a real row-shape skeleton, matching the polish the rest of the v2
+ * list pages (Connections / Accounts / Categories / Transactions) ship.
+ */
+export function RuleRowSkeleton({
+  titleClassName = "w-48",
+  showStats = true,
+  className,
+}: RuleRowSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "bg-card relative rounded-xl border",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3 px-4 py-4 pr-20 sm:gap-4 sm:px-5 sm:py-5 sm:pr-24">
+        <Skeleton className="size-9 shrink-0 rounded-xl" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className={cn("h-3.5", titleClassName)} />
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-3 w-14" />
+            <span className="text-muted-foreground/40 text-xs">·</span>
+            <Skeleton className="h-3 w-16" />
+            <span className="text-muted-foreground/40 text-xs">·</span>
+            <Skeleton className="h-3 w-12" />
+          </div>
+        </div>
+        {showStats && (
+          <div className="hidden shrink-0 items-center gap-4 lg:flex">
+            <div className="flex w-16 flex-col items-center gap-1">
+              <Skeleton className="h-3.5 w-10" />
+              <Skeleton className="h-2.5 w-8" />
+            </div>
+            <div className="flex w-20 flex-col items-center gap-1">
+              <Skeleton className="h-3 w-12" />
+              <Skeleton className="h-2.5 w-14" />
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="absolute top-1/2 right-3 flex -translate-y-1/2 items-center gap-0.5">
+        <Skeleton className="size-7 rounded-md" />
+        <Skeleton className="size-7 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/tags/tag-row-skeleton.tsx
+++ b/web/src/features/tags/tag-row-skeleton.tsx
@@ -1,0 +1,32 @@
+import { TableCell } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Tag-table row skeleton — mirrors the four columns of the loaded row so the
+ * table doesn't shift when data arrives:
+ *  - Tag chip (dot + name) inside the 28% Tag column
+ *  - Mono slug pill inside the 22% Slug column (md+)
+ *  - One-line description placeholder in the Description column
+ *  - Action button in the w-px Actions column
+ */
+export function TagRowSkeleton() {
+  return (
+    <>
+      <TableCell className="w-[28%]">
+        <div className="flex items-center gap-2">
+          <Skeleton className="size-5 rounded-md" />
+          <Skeleton className="h-3.5 w-20" />
+        </div>
+      </TableCell>
+      <TableCell className="hidden w-[22%] md:table-cell">
+        <Skeleton className="h-4 w-24 rounded" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-3 w-3/5" />
+      </TableCell>
+      <TableCell className="w-px">
+        <Skeleton className="ml-auto size-8 rounded-md" />
+      </TableCell>
+    </>
+  );
+}

--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -25,6 +25,7 @@ import { TagChip } from "@/components/tag-chip";
 import { useDeleteTag } from "@/api/queries/tags";
 import { withMutationToast } from "@/lib/mutation-toast";
 import type { Tag } from "@/api/types";
+import { TagRowSkeleton } from "./tag-row-skeleton";
 
 interface TagsTableProps {
   tags: Tag[];
@@ -171,6 +172,7 @@ export function TagsTable({
         // band + uppercase vocabulary as the Transactions list.
         stickyHeader
         refinedHeader
+        renderSkeletonRow={() => <TagRowSkeleton />}
       />
 
       <Dialog

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/select";
 import { PageError } from "@/components/page-error";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { Skeleton } from "@/components/ui/skeleton";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import {
@@ -28,6 +27,7 @@ import {
 import type { RulesFilters } from "@/api/queries/rules";
 import type { TransactionRule } from "@/api/types";
 import { RuleRow } from "@/features/rules/rule-row";
+import { RuleRowSkeleton } from "@/features/rules/rule-row-skeleton";
 
 export const rulesSearchSchema = z.object({
   q: z.string().optional(),
@@ -39,6 +39,11 @@ export const rulesSearchSchema = z.object({
 });
 
 export type RulesSearch = z.infer<typeof rulesSearchSchema>;
+
+// Title-bar widths rotate per-row so the skeleton stack reads as a stack of
+// varied-length rules instead of a metronome. Five rows matches the page-size
+// preview the loaded list shows below the toolbar.
+const SKELETON_TITLE_WIDTHS = ["w-52", "w-40", "w-64", "w-44", "w-48"];
 
 function searchToFilters(s: RulesSearch): RulesFilters {
   return {
@@ -183,8 +188,8 @@ export function RulesPage() {
         />
       ) : isLoading ? (
         <div className="flex flex-col gap-3">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-[72px] rounded-xl" />
+          {SKELETON_TITLE_WIDTHS.map((w, i) => (
+            <RuleRowSkeleton key={i} titleClassName={w} />
           ))}
         </div>
       ) : rows.length === 0 ? (


### PR DESCRIPTION
## Summary

Parallel to iter 83's `DetailPageSkeleton` sweep — every v2 detail page now loads through a real-shape skeleton, but three list pages (Rules, Tags, API keys) still fell back to generic `Skeleton` blocks while the rest of the list pages (Connections, Accounts, Categories, Transactions) ship a row-shape skeleton. This iteration closes the drift.

- **`RuleRowSkeleton`** — mirrors the `rounded-xl border` card, `size-9 rounded-xl` avatar tile, title + meta-line stack, lg-only stage / last-active stat columns, and the absolute action cluster. Title widths rotate per-row so the loading stack reads varied instead of metronomic.
- **`TagRowSkeleton`** — mirrors the four columns of the Tags table (chip + name, mono slug pill, description, action button). Wired through `DataTable.renderSkeletonRow`.
- **`APIKeyRowSkeleton`** — mirrors the six columns of the API-keys table (name + prefix pill stack, scope badge, actor badge, last-used / revoked-at text, created date, action button). Respects the revoked tab's no-actions-column shape via a `revoked` prop.

## Before / After

### Tags

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/t0o1jcybm0.jpg) | ![after](https://i.img402.dev/o5s81gwd9a.jpg) |

### API keys

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/eat018ohuh.jpg) | ![after](https://i.img402.dev/4z02pvei6z.jpg) |

### Rules

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/z6f1iwb0df.jpg) | ![after](https://i.img402.dev/a47t4i48cb.jpg) |

## Notes

- No new shared primitive — these skeletons live alongside their consumers (matching the `TransactionRowSkeleton` pattern from iter 4). If a fourth or fifth DataTable list grows that wants the same per-cell skeleton structure, the per-cell shapes (`badge`, `value-stack`, `text`, `chip`, `pill`) are good candidates to lift into a `<TableRowSkeleton>` primitive sibling of `<ListRowSkeleton>`.
- `RuleRowSkeleton` is fully self-contained — it doesn't fork the `<RuleRow>` markup, it only mirrors the geometry tokens (paddings, sizes, gaps) that matter for layout stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
