### PR TITLE
fix(main): repair type errors from rollup #1192 — restore Docker build

### DIFF
--- a/web/src/components/detail-list.tsx
+++ b/web/src/components/detail-list.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Eyebrow } from "@/components/eyebrow";
 import { IdPill } from "@/components/id-pill";
 import { cn } from "@/lib/utils";

--- a/web/src/components/eyebrow.tsx
+++ b/web/src/components/eyebrow.tsx
@@ -5,11 +5,17 @@ interface EyebrowProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Element to render. Defaults to `span` so the primitive composes inside
    * inline contexts; pass `"p"`, `"h3"`, etc. when the eyebrow is a block
-   * label (section headers, hero eyebrows). Avoid heading levels that
-   * conflict with the document outline — pick `"div"` or `"span"` for
-   * non-semantic decoration.
+   * label (section headers, hero eyebrows). Pass `"label"` (paired with
+   * `htmlFor`) when the eyebrow doubles as a form-control label. Avoid
+   * heading levels that conflict with the document outline — pick `"div"`
+   * or `"span"` for non-semantic decoration.
    */
-  as?: "span" | "p" | "div" | "h3" | "h4";
+  as?: "span" | "p" | "div" | "h3" | "h4" | "label";
+  /**
+   * Forwarded to the underlying element when `as="label"`. Ignored
+   * otherwise (React will warn if you pass it to a non-label element).
+   */
+  htmlFor?: string;
   /**
    * Visual emphasis. `default` is the standard `text-[10px]
    * tracking-[0.1em]` muted eyebrow used on detail-page section headers,

--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "children" | "title"> {
   // Optional bordered header — matches the SectionCard vocabulary. Omit for
   // a header-less list (just a card holding rows).
   title?: React.ReactNode;

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface SectionCardProps extends React.HTMLAttributes<HTMLDivElement> {
+interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   title: React.ReactNode;
   // Slot rendered on the right of the bordered header (button, badge, etc).
   action?: React.ReactNode;

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -5,7 +5,6 @@ import { z } from "zod";
 import {
   AlertTriangle,
   Calendar,
-  CheckCircle2,
   Download,
   HardDrive,
   Loader2,

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -18,7 +18,6 @@ import { FamilyTabs } from "@/features/connections/family-tabs";
 import { AccountRow } from "@/features/accounts/account-row";
 import { AccountsSummary } from "@/features/accounts/accounts-summary";
 import {
-  formatCurrency,
   groupAccounts,
   groupNetTotal,
   type AccountGroupBy,

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -725,7 +725,7 @@ function Hero({
 // Account detail — labelled lateral navigation that surfaces concrete
 // targets (the connection's accounts, the global sync-logs feed) rather
 // than just verbs.
-function QuickActions({ conn }: { conn: ConnectionDetail }) {
+function QuickActions(_props: { conn: ConnectionDetail }) {
   return (
     <JumpToRow>
       <JumpToPill asChild>

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -329,10 +329,6 @@ function DetailsCard({ transaction: t }: { transaction: Transaction }) {
     { label: "ID", value: t.short_id, mono: true },
   ]);
 
-  const referenceRows: DetailRowData[] = compactRows([
-    { label: "ID", value: t.short_id, mono: true },
-  ]);
-
   return (
     <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
       <DetailList label="Account" rows={accountRows} />


### PR DESCRIPTION
## Summary

Rollup #1192 landed several TypeScript type errors that pass PR-level checks (which skip the production SPA build) but break the post-merge Docker \`Build & Push\` step that runs \`tsc -b && vite build\` for real. Main's Docker build (and therefore the auto-deploy to \`breadbox.exe.xyz\`) has been red since the rollup merged — see [run 25978803278](https://github.com/canalesb93/breadbox/actions/runs/25978803278).

These are the **same bugs** that iters #80 and #81 already fixed on \`design/v2-shadcn\` (PRs #1194 and #1195). The rollup landed first, so the fixes never made it to \`main\`. This PR cherry-picks the minimum surface needed.

## Fixes

- \`eyebrow.tsx\`: extend \`as\` to accept \`"label"\` and add optional \`htmlFor\` so form-control eyebrows compile (callers in \`connect-bank-sheet.tsx\` and \`csv-import-form.tsx\` already pass \`as="label"\`).
- \`detail-list.tsx\`: drop unused \`React\` import.
- \`list-card.tsx\`, \`section-card.tsx\`: \`Omit<..., "title">\` from the DOM attrs so the \`ReactNode\` \`title\` prop doesn't conflict with the DOM \`title?: string\`.
- \`backups-section.tsx\`: drop unused \`CheckCircle2\` import.
- \`accounts.tsx\`: drop unused \`formatCurrency\` import.
- \`connection-detail.tsx\`: rename \`{ conn }\` to \`_props\` in \`QuickActions\` (the parameter is currently unused).
- \`transaction-detail.tsx\`: delete the duplicate \`referenceRows\` declaration that referenced the non-existent \`compactRows\`.

No behavior change — purely the minimum diff needed to make \`tsc -b && vite build\` exit 0 so main can ship the Docker image again.

## Test plan

- [x] \`cd web && bun run build\` exits 0 locally
- [x] \`go build ./...\` exits 0 locally
- [ ] CI green (will be the proof point — that's the exact step that was failing)
- [ ] Post-merge Docker build succeeds and \`breadbox.exe.xyz\` redeploys

Auto-merge enabled — this will land as soon as CI is green so the deploy resumes.