### PR TITLE
design(v2): RowActionsMenu primitive for row kebabs

### DIFF
--- a/web/src/components/row-actions-menu.tsx
+++ b/web/src/components/row-actions-menu.tsx
@@ -1,0 +1,155 @@
+import { Loader2, MoreHorizontal } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type Size = "sm" | "xs";
+
+const TRIGGER_BY_SIZE: Record<Size, string> = {
+  // size-8 ghost square — the dominant row-actions trigger across
+  // connection-row, household-section, tags-table, api-keys-table.
+  sm: "text-muted-foreground hover:text-foreground size-8",
+  // size-7 ghost square — the tighter cluster variant used inside
+  // hero footers + nested list rows (account-links, rule-row,
+  // connection-detail hero).
+  xs: "text-muted-foreground hover:text-foreground size-7",
+};
+
+const ICON_BY_SIZE: Record<Size, string> = {
+  sm: "size-4",
+  xs: "size-3.5",
+};
+
+export interface RowActionsMenuProps {
+  /**
+   * Accessible label for the trigger button — used as both the
+   * `aria-label` and the Tooltip content. Should describe what the
+   * menu controls (e.g. "Connection actions", "Actions for {name}").
+   */
+  label: string;
+  /**
+   * Menu items. Use the shadcn `<DropdownMenuItem>` /
+   * `<DropdownMenuSeparator>` / `<DropdownMenuLabel>` primitives.
+   */
+  children: React.ReactNode;
+  /**
+   * Trigger size token.
+   * - `sm` (default): size-8 square + size-4 icon. The dominant
+   *   row-actions trigger across list tables.
+   * - `xs`: size-7 square + size-3.5 icon. For tighter clusters
+   *   (hero footers, nested list rows).
+   */
+  size?: Size;
+  /**
+   * Content alignment relative to the trigger. Defaults to `end` so
+   * menus open from a right-aligned trigger without colliding with
+   * row content on the left.
+   */
+  align?: "start" | "center" | "end";
+  /**
+   * Optional fixed width on the content. Pass when a menu has long
+   * labels that would otherwise collapse the auto-width content
+   * (e.g. household-section's `w-52`, rule-row's `w-44`).
+   */
+  contentClassName?: string;
+  /**
+   * Trigger disabled flag. While disabled, the button reads
+   * non-interactive and the tooltip stays mounted so the row still
+   * announces what the menu *would* do.
+   */
+  disabled?: boolean;
+  /**
+   * When true, swap the trigger icon for a spinning Loader2 — useful
+   * while a row's underlying mutation (reconcile, pause, etc.) is in
+   * flight. Implies `disabled`.
+   */
+  loading?: boolean;
+  /**
+   * Extra className for the trigger button. Use sparingly — the
+   * built-in `size` token covers the canonical shapes. Today only
+   * connection-detail's hero footer reaches for this to add
+   * `rounded-full` so the kebab pairs visually with the surrounding
+   * pill cluster.
+   */
+  triggerClassName?: string;
+  /**
+   * Click handler on the trigger. The dominant use case is
+   * `e.stopPropagation()` for menus rendered inside clickable list
+   * rows (api-keys-table, tags-table) so opening the menu doesn't
+   * also navigate to the row's detail page.
+   */
+  onTriggerClick?: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Click handler on the content surface. Same `stopPropagation`
+   * pattern as `onTriggerClick`, but on the floating content — useful
+   * when consumers want the menu items themselves to also stop the
+   * row-click handler from firing.
+   */
+  onContentClick?: React.MouseEventHandler<HTMLDivElement>;
+}
+
+/**
+ * Canonical row-actions kebab menu — Tooltip + DropdownMenuTrigger +
+ * Button lockup that every list row, hero footer, and inline action
+ * cluster shares so the trigger geometry, icon glyph, and aria
+ * vocabulary stay consistent across the SPA.
+ *
+ * Sibling of `<ActionPill>` (iter 76) — same `text-muted-foreground →
+ * hover:text-foreground` icon-button vocabulary, but ActionPill is a
+ * labelled inline action, RowActionsMenu is a kebab that opens a
+ * menu.
+ */
+export function RowActionsMenu({
+  label,
+  children,
+  size = "sm",
+  align = "end",
+  contentClassName,
+  disabled,
+  loading,
+  triggerClassName,
+  onTriggerClick,
+  onContentClick,
+}: RowActionsMenuProps) {
+  const Icon = loading ? Loader2 : MoreHorizontal;
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={label}
+              disabled={disabled || loading}
+              onClick={onTriggerClick}
+              className={cn(TRIGGER_BY_SIZE[size], triggerClassName)}
+            >
+              <Icon
+                className={cn(
+                  ICON_BY_SIZE[size],
+                  loading && "animate-spin",
+                )}
+              />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align={align}
+        className={contentClassName}
+        onClick={onContentClick}
+      >
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -6,7 +6,6 @@ import {
   ArrowRight,
   Link2,
   Loader2,
-  MoreHorizontal,
   Plus,
   RotateCw,
   Unlink,
@@ -14,14 +13,11 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import { SectionCard } from "@/components/section-card";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -236,41 +232,23 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
           {!link.enabled && <Badge variant="outline" className="text-[10px]">Disabled</Badge>}
         </div>
       </div>
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-7"
-                aria-label="Link actions"
-                disabled={reconcile.isPending || remove.isPending}
-              >
-                {reconcile.isPending || remove.isPending ? (
-                  <Loader2 className="size-3.5 animate-spin" />
-                ) : (
-                  <MoreHorizontal className="size-3.5" />
-                )}
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>Link actions</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={onReconcile} disabled={reconcile.isPending}>
-            <RotateCw className="size-3.5" /> Reconcile matches
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            variant="destructive"
-            onClick={() => setConfirmUnlink(true)}
-            disabled={remove.isPending}
-          >
-            <Unlink className="size-3.5" /> Unlink
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <RowActionsMenu
+        label="Link actions"
+        size="xs"
+        loading={reconcile.isPending || remove.isPending}
+      >
+        <DropdownMenuItem onClick={onReconcile} disabled={reconcile.isPending}>
+          <RotateCw className="size-3.5" /> Reconcile matches
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          onClick={() => setConfirmUnlink(true)}
+          disabled={remove.isPending}
+        >
+          <Unlink className="size-3.5" /> Unlink
+        </DropdownMenuItem>
+      </RowActionsMenu>
 
       <ConfirmDialog
         open={confirmUnlink}

--- a/web/src/features/api-keys/api-keys-table.tsx
+++ b/web/src/features/api-keys/api-keys-table.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Ban, Loader2, MoreHorizontal } from "lucide-react";
+import { Ban, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,15 +10,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { DataTable } from "@/components/data-table";
 import { IdPill } from "@/components/id-pill";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import { formatLongDate, formatRelativeTime } from "@/lib/format";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useRevokeAPIKey } from "@/api/queries/api-keys";
@@ -127,35 +122,19 @@ export function APIKeysTable({
         header: () => <span className="sr-only">Actions</span>,
         meta: { className: "w-px" },
         cell: ({ row }) => (
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Actions for ${row.original.name}`}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>API key actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent
-              align="end"
-              onClick={(e) => e.stopPropagation()}
+          <RowActionsMenu
+            label={`Actions for ${row.original.name}`}
+            onTriggerClick={(e) => e.stopPropagation()}
+            onContentClick={(e) => e.stopPropagation()}
+          >
+            <DropdownMenuItem
+              variant="destructive"
+              onSelect={() => setConfirmRevoke(row.original)}
             >
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => setConfirmRevoke(row.original)}
-              >
-                <Ban className="size-4" />
-                Revoke
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              <Ban className="size-4" />
+              Revoke
+            </DropdownMenuItem>
+          </RowActionsMenu>
         ),
       },
     ];

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -5,7 +5,6 @@ import {
   FileSpreadsheet,
   Landmark,
   Loader2,
-  MoreHorizontal,
   Pause,
   Plug,
   Unplug,
@@ -13,13 +12,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import { formatBalance } from "@/lib/format";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { cn } from "@/lib/utils";
@@ -174,45 +170,28 @@ export function ConnectionRow({
             </div>
           </div>
 
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="text-muted-foreground hover:text-foreground size-8"
-                    aria-label="Connection actions"
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>Connection actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent align="end">
-              {showReauthBanner && (
-                <DropdownMenuItem onClick={() => onReauth(connection)}>
-                  <Plug className="size-4" /> Re-authenticate
-                </DropdownMenuItem>
-              )}
-              {connection.status === "active" && (
-                <DropdownMenuItem
-                  onClick={onTogglePause}
-                  disabled={pause.isPending}
-                >
-                  <Pause className="size-4" /> Pause syncing
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                variant="destructive"
-                onClick={() => setConfirmingDisconnect(true)}
-              >
-                <Unplug className="size-4" /> Disconnect…
+          <RowActionsMenu label="Connection actions">
+            {showReauthBanner && (
+              <DropdownMenuItem onClick={() => onReauth(connection)}>
+                <Plug className="size-4" /> Re-authenticate
               </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+            )}
+            {connection.status === "active" && (
+              <DropdownMenuItem
+                onClick={onTogglePause}
+                disabled={pause.isPending}
+              >
+                <Pause className="size-4" /> Pause syncing
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={() => setConfirmingDisconnect(true)}
+            >
+              <Unplug className="size-4" /> Disconnect…
+            </DropdownMenuItem>
+          </RowActionsMenu>
         </div>
       </div>
 

--- a/web/src/features/rules/rule-row.tsx
+++ b/web/src/features/rules/rule-row.tsx
@@ -1,14 +1,10 @@
 import { Link } from "@tanstack/react-router";
-import { Infinity as InfinityIcon, ListFilter, MoreVertical, Pause, Pencil, Play, Shield, Trash2, Zap } from "lucide-react";
+import { Infinity as InfinityIcon, ListFilter, Pause, Pencil, Play, Shield, Trash2, Zap } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/format";
 import type { TransactionRule } from "@/api/types";
@@ -134,44 +130,31 @@ export function RuleRow({ rule, onToggle, onDelete }: RuleRowProps) {
           </TooltipTrigger>
           <TooltipContent>Edit rule</TooltipContent>
         </Tooltip>
-        <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-7"
-                  aria-label={`Rule ${rule.name} actions`}
-                >
-                  <MoreVertical className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Rule actions</TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="end" className="w-44">
-            <DropdownMenuItem onSelect={() => onToggle(rule)}>
-              {rule.enabled ? (
-                <>
-                  <Pause className="size-3.5" /> Disable
-                </>
-              ) : (
-                <>
-                  <Play className="size-3.5" /> Enable
-                </>
-              )}
-            </DropdownMenuItem>
-            {!isSystem && (
-              <DropdownMenuItem
-                onSelect={() => onDelete(rule)}
-                className="text-destructive focus:text-destructive"
-              >
-                <Trash2 className="size-3.5" /> Delete
-              </DropdownMenuItem>
+        <RowActionsMenu
+          label={`Rule ${rule.name} actions`}
+          size="xs"
+          contentClassName="w-44"
+        >
+          <DropdownMenuItem onSelect={() => onToggle(rule)}>
+            {rule.enabled ? (
+              <>
+                <Pause className="size-3.5" /> Disable
+              </>
+            ) : (
+              <>
+                <Play className="size-3.5" /> Enable
+              </>
             )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+          </DropdownMenuItem>
+          {!isSystem && (
+            <DropdownMenuItem
+              variant="destructive"
+              onSelect={() => onDelete(rule)}
+            >
+              <Trash2 className="size-3.5" /> Delete
+            </DropdownMenuItem>
+          )}
+        </RowActionsMenu>
       </div>
     </div>
   );

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -7,7 +7,6 @@ import {
   Copy,
   Link2,
   Loader2,
-  MoreVertical,
   RefreshCw,
   Trash2,
   UserPlus,
@@ -27,12 +26,10 @@ import {
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import {
   Form,
   FormControl,
@@ -52,7 +49,6 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import {
   setupAccountURL,
@@ -229,82 +225,65 @@ function MemberMenu({
   };
 
   return (
-    <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-muted-foreground hover:text-foreground size-8"
-            >
-              <MoreVertical className="size-4" />
-              <span className="sr-only">Member actions</span>
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Member actions</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent align="end" className="w-52">
-        {login ? (
-          <>
-            {!login.has_password && (
-              <DropdownMenuItem
-                onSelect={(e) => {
-                  e.preventDefault();
-                  onRegenerateClick();
-                }}
-              >
-                <Link2 className="size-4" />
-                Get setup link
-              </DropdownMenuItem>
-            )}
+    <RowActionsMenu label="Member actions" contentClassName="w-52">
+      {login ? (
+        <>
+          {!login.has_password && (
             <DropdownMenuItem
               onSelect={(e) => {
                 e.preventDefault();
                 onRegenerateClick();
               }}
             >
-              <RefreshCw className="size-4" />
-              Reset password
+              <Link2 className="size-4" />
+              Get setup link
             </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={(e) => {
-                e.preventDefault();
-                onUnlinkLogin();
-              }}
-            >
-              <Trash2 className="size-4" />
-              Remove login
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
-        ) : (
-          <>
-            <DropdownMenuItem
-              onSelect={(e) => {
-                e.preventDefault();
-                onCreateLogin();
-              }}
-            >
-              <UserPlus className="size-4" />
-              Invite to sign in
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
-        )}
-        <DropdownMenuItem
-          variant="destructive"
-          onSelect={(e) => {
-            e.preventDefault();
-            onDelete();
-          }}
-        >
-          <Trash2 className="size-4" />
-          Delete member
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          )}
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              onRegenerateClick();
+            }}
+          >
+            <RefreshCw className="size-4" />
+            Reset password
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              onUnlinkLogin();
+            }}
+          >
+            <Trash2 className="size-4" />
+            Remove login
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+        </>
+      ) : (
+        <>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              onCreateLogin();
+            }}
+          >
+            <UserPlus className="size-4" />
+            Invite to sign in
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+        </>
+      )}
+      <DropdownMenuItem
+        variant="destructive"
+        onSelect={(e) => {
+          e.preventDefault();
+          onDelete();
+        }}
+      >
+        <Trash2 className="size-4" />
+        Delete member
+      </DropdownMenuItem>
+    </RowActionsMenu>
   );
 }
 

--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Loader2, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,15 +12,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DataTable } from "@/components/data-table";
 import { IdPill } from "@/components/id-pill";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import { TagChip } from "@/components/tag-chip";
 import { useDeleteTag } from "@/api/queries/tags";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -101,45 +98,29 @@ export function TagsTable({
         header: () => <span className="sr-only">Actions</span>,
         meta: { className: "w-px" },
         cell: ({ row }) => (
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Actions for ${row.original.display_name}`}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>Tag actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent
-              align="end"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <DropdownMenuItem asChild>
-                <Link
-                  to="/tags/$slug"
-                  params={{ slug: row.original.slug }}
-                >
-                  <Pencil className="size-4" />
-                  Edit
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => setConfirmDelete(row.original)}
+          <RowActionsMenu
+            label={`Actions for ${row.original.display_name}`}
+            onTriggerClick={(e) => e.stopPropagation()}
+            onContentClick={(e) => e.stopPropagation()}
+          >
+            <DropdownMenuItem asChild>
+              <Link
+                to="/tags/$slug"
+                params={{ slug: row.original.slug }}
               >
-                <Trash2 className="size-4" />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <Pencil className="size-4" />
+                Edit
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              variant="destructive"
+              onSelect={() => setConfirmDelete(row.original)}
+            >
+              <Trash2 className="size-4" />
+              Delete
+            </DropdownMenuItem>
+          </RowActionsMenu>
         ),
       },
     ],

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -13,7 +13,6 @@ import {
   FileSpreadsheet,
   Landmark,
   Loader2,
-  MoreHorizontal,
   Pause,
   Play,
   Plug,
@@ -29,11 +28,8 @@ import { EmptyState } from "@/components/empty-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { StatusPanel } from "@/components/status-panel";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
   Select,
@@ -42,8 +38,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ActionPill } from "@/components/action-pill";
+import { RowActionsMenu } from "@/components/row-actions-menu";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import {
@@ -591,45 +587,32 @@ function Hero({
               Re-authenticate
             </ActionPill>
           )}
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-7 rounded-full"
-                    aria-label="Connection actions"
-                  >
-                    <MoreHorizontal className="size-3.5" />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>Connection actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent align="end">
-              {conn.status !== "disconnected" && (
-                <DropdownMenuItem
-                  onClick={onTogglePause}
-                  disabled={pausePending}
-                >
-                  {conn.paused ? (
-                    <>
-                      <Play className="size-4" /> Resume syncing
-                    </>
-                  ) : (
-                    <>
-                      <Pause className="size-4" /> Pause syncing
-                    </>
-                  )}
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem variant="destructive" onClick={onDisconnect}>
-                <Unplug className="size-4" /> Disconnect…
+          <RowActionsMenu
+            label="Connection actions"
+            size="xs"
+            triggerClassName="rounded-full"
+          >
+            {conn.status !== "disconnected" && (
+              <DropdownMenuItem
+                onClick={onTogglePause}
+                disabled={pausePending}
+              >
+                {conn.paused ? (
+                  <>
+                    <Play className="size-4" /> Resume syncing
+                  </>
+                ) : (
+                  <>
+                    <Pause className="size-4" /> Pause syncing
+                  </>
+                )}
               </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive" onClick={onDisconnect}>
+              <Unplug className="size-4" /> Disconnect…
+            </DropdownMenuItem>
+          </RowActionsMenu>
         </>
       }
     >

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -19,6 +19,7 @@ import {
   Monitor,
   Moon,
   Pause,
+  Pencil,
   Plus,
   Receipt,
   RefreshCw,
@@ -30,6 +31,7 @@ import {
   Sun,
   Tag,
   Trash2,
+  Unplug,
   Users,
   Wallet,
   Wand2,
@@ -69,6 +71,11 @@ import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
 import { ActionPill } from "@/components/action-pill";
 import { JumpToPill, JumpToRow } from "@/components/jump-to-pill";
+import { RowActionsMenu } from "@/components/row-actions-menu";
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { MetaBadge } from "@/components/meta-badge";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { PageError } from "@/components/page-error";
@@ -475,6 +482,72 @@ export function ComponentsSection() {
               <RefreshCw className="size-3.5" />
               Re-authenticate
             </ActionPill>
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="RowActionsMenu"
+        code="components/row-actions-menu"
+        description="The canonical row-actions kebab — `Tooltip` + `DropdownMenuTrigger` + `Button` lockup that every list row, hero footer, and inline action cluster shares so trigger geometry, icon glyph (`MoreHorizontal size-4`), and aria vocabulary stay consistent across the SPA. `size='sm'` (default) is the dominant size-8 ghost square (connection-row, household-section, tags-table, api-keys-table). `size='xs'` is the tighter size-7 variant for hero footers and nested list rows (account-links, rule-row, connection-detail hero). `loading` swaps the icon for a spinning Loader2 and disables the trigger. `triggerClassName` is the escape hatch (only connection-detail's hero footer uses it today for `rounded-full` to pair with surrounding pills). Sibling of `<ActionPill>` (labelled inline action) — same `text-muted-foreground → hover:text-foreground` icon-button vocabulary, but RowActionsMenu opens a menu rather than dispatching."
+        className="block"
+      >
+        <div className="flex flex-col gap-4 rounded-lg border p-4">
+          <div className="flex items-center justify-between rounded-md border bg-card px-3 py-2">
+            <div className="text-sm">
+              <div className="font-medium">Tag actions (size sm)</div>
+              <div className="text-muted-foreground text-xs">
+                Dominant row-actions trigger — size-8 ghost square
+              </div>
+            </div>
+            <RowActionsMenu label="Tag actions">
+              <DropdownMenuItem onSelect={() => toast.message("Edit tag")}>
+                <Pencil className="size-4" /> Edit
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => toast.error("Delete tag")}
+              >
+                <Trash2 className="size-4" /> Delete
+              </DropdownMenuItem>
+            </RowActionsMenu>
+          </div>
+          <div className="flex items-center justify-between rounded-md border bg-card px-3 py-2">
+            <div className="text-sm">
+              <div className="font-medium">Rule actions (size xs)</div>
+              <div className="text-muted-foreground text-xs">
+                Tighter variant for hero footers + nested rows — size-7 ghost square
+              </div>
+            </div>
+            <RowActionsMenu
+              label="Rule actions"
+              size="xs"
+              contentClassName="w-44"
+            >
+              <DropdownMenuItem onSelect={() => toast.message("Disable rule")}>
+                <Pause className="size-3.5" /> Disable
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => toast.error("Delete rule")}
+              >
+                <Trash2 className="size-3.5" /> Delete
+              </DropdownMenuItem>
+            </RowActionsMenu>
+          </div>
+          <div className="flex items-center justify-between rounded-md border bg-card px-3 py-2">
+            <div className="text-sm">
+              <div className="font-medium">Link actions (loading)</div>
+              <div className="text-muted-foreground text-xs">
+                `loading` swaps the kebab icon for a spinning Loader2
+              </div>
+            </div>
+            <RowActionsMenu label="Link actions" size="xs" loading>
+              <DropdownMenuItem>
+                <Unplug className="size-3.5" /> Unlink
+              </DropdownMenuItem>
+            </RowActionsMenu>
           </div>
         </div>
       </Specimen>


### PR DESCRIPTION
## Summary

- **New `<RowActionsMenu>` primitive** (`web/src/components/row-actions-menu.tsx`, 23rd shared v2 primitive) bundles Tooltip + DropdownMenuTrigger + Button into one lockup so every list row, hero footer, and inline action cluster shares the same trigger geometry, icon glyph, and aria vocabulary. Sibling of `<ActionPill>` (iter 76) — same muted-foreground → foreground icon-button voice, but RowActionsMenu opens a menu rather than dispatching.
- **Seven open-coded sites consolidated**: connection-row (size sm), api-keys-table (sm), tags-table (sm), household-section (sm), rule-row (xs), account-links-section (xs + loading), connection-detail hero (xs + rounded-full). Across them the drift was four-dimensional:
  - **Icon glyph**: 5 sites used `MoreHorizontal`, 2 used `MoreVertical` — now canonical `MoreHorizontal size-4`.
  - **Trigger size**: size-7 / size-8 / unbranded `size="icon"` (size-9 default) — now `size="sm"` (size-8) and `size="xs"` (size-7) as the two semantic tokens.
  - **Loading affordance**: account-links open-coded the `reconcile.isPending || remove.isPending ? Loader2 : MoreHorizontal` swap — now a `loading` prop with built-in spin.
  - **Destructive item style**: rule-row used `className="text-destructive focus:text-destructive"` while every other consumer used the canonical `variant="destructive"` — swept onto the variant.
- **Sandbox specimen** lives next to `<ActionPill>` in `sections/components.tsx`, showing the two sizes side-by-side plus the loading state.

## Sandbox specimen (closed + open)

| Specimen (closed) | Specimen (sm size, open) |
| --- | --- |
| ![sandbox closed](https://i.img402.dev/5rh8givelb.jpg) | ![sandbox open](https://i.img402.dev/vl6ijz1ewx.jpg) |

## Real consumer — connections list with menu open

![connections list with menu open](https://i.img402.dev/ct414g3u60.jpg)

## Notes

- One escape hatch retained: `triggerClassName` on `RowActionsMenu`. Only one consumer uses it today (connection-detail's hero footer adds `rounded-full` so the kebab pairs visually with the surrounding `<ActionPill>` cluster). Documented in the JSDoc.
- Tooltip imports dropped from 4 files where they were only feeding the kebab trigger (household-section, account-links-section, connection-detail, connection-row). The other 3 consumers kept Tooltip for unrelated buttons.
- 23rd shared primitive (after the iter 83 `DetailPageSkeleton`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
