### PR TITLE
design(v2): split load-error vs not-found on detail pages

### DIFF
--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -35,6 +35,7 @@ import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
 import { useAccount, useAccounts } from "@/api/queries/accounts";
+import { ApiError } from "@/api/client";
 import type { AccountDetail } from "@/api/types";
 import {
   accountLabel,
@@ -95,7 +96,10 @@ export function AccountDetailPage() {
 
       {acctQuery.isLoading ? (
         <DetailSkeleton />
-      ) : acctQuery.isError ? (
+      ) : acctQuery.isError &&
+        !(
+          acctQuery.error instanceof ApiError && acctQuery.error.status === 404
+        ) ? (
         <PageError
           resource="this account"
           error={acctQuery.error}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/detail-list";
 import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
+import { PageError } from "@/components/page-error";
 import { JumpToPill, JumpToRow } from "@/components/jump-to-pill";
 import { MetaBadge } from "@/components/meta-badge";
 import { SectionCard } from "@/components/section-card";
@@ -94,8 +95,16 @@ export function AccountDetailPage() {
 
       {acctQuery.isLoading ? (
         <DetailSkeleton />
-      ) : acctQuery.isError || !acctQuery.data ? (
+      ) : acctQuery.isError ? (
+        <PageError
+          resource="this account"
+          error={acctQuery.error}
+          onRetry={() => acctQuery.refetch()}
+          retrying={acctQuery.isFetching}
+        />
+      ) : !acctQuery.data ? (
         <EmptyState
+          variant="card"
           icon={Banknote}
           title="Account not found"
           description="This account may have been disconnected, or the link is out of date. Head back to the accounts list to pick another."

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -28,6 +28,7 @@ import { EmptyState } from "@/components/empty-state";
 import { Eyebrow } from "@/components/eyebrow";
 import { JumpToPill, JumpToRow } from "@/components/jump-to-pill";
 import { MetaBadge } from "@/components/meta-badge";
+import { PageError } from "@/components/page-error";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryForm } from "@/features/categories/category-form";
@@ -44,7 +45,8 @@ import type { Category } from "@/api/types";
 
 export function CategoryDetailPage() {
   const { id } = useParams({ strict: false }) as { id?: string };
-  const { data: tree, isLoading, isError } = useCategories();
+  const categoriesQuery = useCategories();
+  const { data: tree, isLoading, isError } = categoriesQuery;
   const category = useMemo(
     () =>
       id
@@ -59,8 +61,16 @@ export function CategoryDetailPage() {
 
       {isLoading ? (
         <DetailSkeleton />
-      ) : isError || !category ? (
+      ) : isError ? (
+        <PageError
+          resource="this category"
+          error={categoriesQuery.error}
+          onRetry={() => categoriesQuery.refetch()}
+          retrying={categoriesQuery.isFetching}
+        />
+      ) : !category ? (
         <EmptyState
+          variant="card"
           icon={Shapes}
           title="Category not found"
           description="This category may have been deleted, or the link is out of date. Head back to the categories list to pick another."

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -42,6 +42,7 @@ import { ActionPill } from "@/components/action-pill";
 import { RowActionsMenu } from "@/components/row-actions-menu";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
+import { PageError } from "@/components/page-error";
 import {
   DetailList,
   compactDetailRows,
@@ -209,8 +210,16 @@ export function ConnectionDetailPage() {
 
       {connQuery.isLoading ? (
         <DetailSkeleton />
-      ) : connQuery.isError || !connQuery.data ? (
+      ) : connQuery.isError ? (
+        <PageError
+          resource="this connection"
+          error={connQuery.error}
+          onRetry={() => connQuery.refetch()}
+          retrying={connQuery.isFetching}
+        />
+      ) : !connQuery.data ? (
         <EmptyState
+          variant="card"
           icon={Plug}
           title="Connection not found"
           description="This connection may have been removed, or the link is out of date. Head back to the connections list to pick another."

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/api/queries/connections";
 import { useAccounts } from "@/api/queries/accounts";
 import { useSyncLogs } from "@/api/queries/sync-logs";
+import { ApiError } from "@/api/client";
 import type { Account, ConnectionDetail } from "@/api/types";
 import type { SyncLog } from "@/api/queries/sync-logs";
 import { ConnectionStatusBadge } from "@/features/connections/connection-status-badge";
@@ -210,7 +211,10 @@ export function ConnectionDetailPage() {
 
       {connQuery.isLoading ? (
         <DetailSkeleton />
-      ) : connQuery.isError ? (
+      ) : connQuery.isError &&
+        !(
+          connQuery.error instanceof ApiError && connQuery.error.status === 404
+        ) ? (
         <PageError
           resource="this connection"
           error={connQuery.error}

--- a/web/src/routes/tag-detail.tsx
+++ b/web/src/routes/tag-detail.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { PageError } from "@/components/page-error";
 import { DangerZone } from "@/components/danger-zone";
 import { SectionCard } from "@/components/section-card";
 import { SoftBackButton } from "@/components/soft-back-button";
@@ -16,7 +17,8 @@ import type { Tag } from "@/api/types";
 
 export function TagDetailPage() {
   const { slug } = useParams({ strict: false }) as { slug?: string };
-  const { data: tags, isLoading, isError } = useTags();
+  const tagsQuery = useTags();
+  const { data: tags, isLoading, isError } = tagsQuery;
   const tag = useMemo(
     () => tags?.find((t) => t.slug === slug),
     [tags, slug],
@@ -28,8 +30,16 @@ export function TagDetailPage() {
 
       {isLoading ? (
         <DetailSkeleton />
-      ) : isError || !tag ? (
+      ) : isError ? (
+        <PageError
+          resource="this tag"
+          error={tagsQuery.error}
+          onRetry={() => tagsQuery.refetch()}
+          retrying={tagsQuery.isFetching}
+        />
+      ) : !tag ? (
         <EmptyState
+          variant="card"
           icon={TagsIcon}
           title="Tag not found"
           description="This tag may have been deleted, or the link is out of date. Head back to the tags list to pick another."

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -30,6 +30,7 @@ import { TagManager } from "@/features/transactions/tag-manager";
 import { ActivityTimeline } from "@/features/transactions/activity-timeline";
 import { CommentComposer } from "@/features/transactions/comment-composer";
 import { useTransaction } from "@/api/queries/transactions";
+import { ApiError } from "@/api/client";
 import { formatAmount, formatLongDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
@@ -37,7 +38,12 @@ import type { Transaction } from "@/api/types";
 export function TransactionDetailPage() {
   const { id } = useParams({ strict: false }) as { id?: string };
   const query = useTransaction(id);
-  const { data, isLoading, isError } = query;
+  const { data, isLoading, isError, error } = query;
+  // 404 means the URL is stale (deleted or never existed) — show the
+  // "not found" empty state, which has a concrete back-to-list CTA.
+  // Every other failure (network drop, 500, dropped session) is a real
+  // load error — show PageError with Retry. Three states, three vocabularies.
+  const notFound = isError && error instanceof ApiError && error.status === 404;
 
   return (
     <div className="mx-auto max-w-5xl">
@@ -45,10 +51,10 @@ export function TransactionDetailPage() {
 
       {isLoading ? (
         <DetailSkeleton />
-      ) : isError ? (
+      ) : isError && !notFound ? (
         <PageError
           resource="this transaction"
-          error={query.error}
+          error={error}
           onRetry={() => query.refetch()}
           retrying={query.isFetching}
         />

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -13,6 +13,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import { EmptyState } from "@/components/empty-state";
+import { PageError } from "@/components/page-error";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
 import {
@@ -35,7 +36,8 @@ import type { Transaction } from "@/api/types";
 
 export function TransactionDetailPage() {
   const { id } = useParams({ strict: false }) as { id?: string };
-  const { data, isLoading, isError } = useTransaction(id);
+  const query = useTransaction(id);
+  const { data, isLoading, isError } = query;
 
   return (
     <div className="mx-auto max-w-5xl">
@@ -43,8 +45,16 @@ export function TransactionDetailPage() {
 
       {isLoading ? (
         <DetailSkeleton />
-      ) : isError || !data ? (
+      ) : isError ? (
+        <PageError
+          resource="this transaction"
+          error={query.error}
+          onRetry={() => query.refetch()}
+          retrying={query.isFetching}
+        />
+      ) : !data ? (
         <EmptyState
+          variant="card"
           icon={Receipt}
           title="Transaction not found"
           description="This transaction may have been deleted, or the link is out of date. Head back to the transactions list to pick another."


### PR DESCRIPTION
## Summary

- Five detail pages (transaction, account, category, connection, tag) used to render the same "X not found" `EmptyState` for both `isError` and `!data`. A real failure (network drop, 500, dropped session) looked identical to a stale URL and offered no way to retry.
- Each page now triages three states: `isError` (non-404) -> `<PageError>` with Retry (iter 82 primitive); `404` / `!data` -> `<EmptyState variant="card">` with the prior "X not found" copy; `data` -> the page. Matches the rule-detail vocabulary from iter 75: three states, three vocabularies, one visual system.
- The `api<>` helper throws `ApiError` on every non-2xx, so single-resource endpoints (transaction, account, connection) needed an explicit `error instanceof ApiError && error.status === 404` discriminator to keep 404s out of the destructive PageError lane. Category-detail and tag-detail filter a list client-side so they hit `!result` naturally — no 404 path possible.

## Before / After

**Before — load failure and stale URL render identically.** The screenshot below is a real `Failed to fetch` (init script blocked `/api/v1/transactions/:id`) AND the same page on a non-existent short_id. Both show "Transaction not found" with no Retry affordance and no signal that the network actually failed.

![before](https://i.img402.dev/e66yitkxlh.jpg)

**After — 404 keeps the friendly "not found" empty state.** Bordered card chrome via `variant="card"` parallels the PageError panel so the page doesn't collapse to a flat centered blob.

![after-notfound](https://i.img402.dev/pq9xbo698r.jpg)

**After — a real load failure now lands on `<PageError>` with Retry.** Destructive-toned StatusPanel surfaces the underlying error message and offers a one-click recovery, matching every other v2 page that already routes failures through PageError (accounts, connections, providers, rules, rule-form, rule-detail).

![after-error](https://i.img402.dev/85vgqct0kv.jpg)

## Notes

- Activity-timeline (inside a SectionCard) still uses a bare `<p>` for its isError fallback. A nested PageError inside another card felt visually heavy; queued as a separate observation.
- No new primitive, no new sandbox specimen — both PageError and EmptyState already have showcases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
