### PR TITLE
design(v2): PageError inline variant + activity-timeline error state

### DIFF
--- a/web/src/components/page-error.tsx
+++ b/web/src/components/page-error.tsx
@@ -1,6 +1,9 @@
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { StatusPanel } from "@/components/status-panel";
+import { cn } from "@/lib/utils";
+
+export type PageErrorVariant = "panel" | "inline";
 
 interface PageErrorProps {
   /** What couldn't load (rendered as `Couldn't load {resource}.`). */
@@ -11,6 +14,17 @@ interface PageErrorProps {
   onRetry?: () => unknown | Promise<unknown>;
   /** Whether the retry call is currently in-flight. */
   retrying?: boolean;
+  /**
+   * Visual shell.
+   * - `panel` (default): bordered StatusPanel with the destructive rail.
+   *   Use for top-level page errors that own the whole route body.
+   * - `inline`: chrome-less variant for nesting inside an existing bordered
+   *   host (a SectionCard body, a ListCard slot). Keeps the destructive icon
+   *   tile + heading + body + retry vocabulary, but drops the panel border +
+   *   rail so two nested borders don't read heavy.
+   */
+  variant?: PageErrorVariant;
+  className?: string;
 }
 
 // PageError renders the canonical page-level "this page couldn't fetch its
@@ -24,21 +38,73 @@ interface PageErrorProps {
 // rule-detail. Don't fork — extend this primitive if a seventh consumer
 // needs a new variant.
 //
-// The component reuses the StatusPanel vocabulary (3px tone-tinted left rail
-// + tinted icon tile + heading + body + trailing slot) so destructive page
-// errors speak the same language as warnings, success notices, and env-locked
-// states (see iter 16). The retry button lands in StatusPanel's `trailing`
-// slot so it sits on the right edge, aligned with the icon row.
+// The `panel` variant reuses the StatusPanel vocabulary (3px tone-tinted left
+// rail + tinted icon tile + heading + body + trailing slot) so destructive
+// page errors speak the same language as warnings, success notices, and
+// env-locked states (see iter 16). The retry button lands in StatusPanel's
+// `trailing` slot so it sits on the right edge, aligned with the icon row.
+//
+// The `inline` variant (iter 88) drops the panel chrome — same icon tile +
+// heading + body + retry, but no border / rail / muted background. Used by
+// the activity-timeline inside a SectionCard, where nesting a second
+// bordered destructive panel inside the section's bordered card read heavy.
+// Two nested borders → one tile + text block aligned with the rest of the
+// section body.
 export function PageError({
   resource,
   error,
   onRetry,
   retrying = false,
+  variant = "panel",
+  className,
 }: PageErrorProps) {
   const message =
     error instanceof Error && error.message
       ? error.message
       : "Try again or refresh the page.";
+
+  const retryButton = onRetry ? (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      onClick={() => {
+        void onRetry();
+      }}
+      disabled={retrying}
+    >
+      <RefreshCw
+        className={retrying ? "size-3.5 animate-spin" : "size-3.5"}
+      />
+      {retrying ? "Retrying…" : "Retry"}
+    </Button>
+  ) : null;
+
+  if (variant === "inline") {
+    return (
+      <div
+        className={cn(
+          "flex items-start gap-3",
+          className,
+        )}
+      >
+        <span className="bg-destructive/10 text-destructive flex size-8 shrink-0 items-center justify-center rounded-md">
+          <AlertTriangle className="size-4" />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="text-foreground text-sm font-medium">
+            {`Couldn't load ${resource}`}
+          </span>
+          <span className="text-muted-foreground text-xs leading-relaxed">
+            {message}
+          </span>
+        </div>
+        {retryButton && (
+          <div className="ml-2 flex shrink-0 items-center">{retryButton}</div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <StatusPanel
@@ -46,24 +112,8 @@ export function PageError({
       icon={AlertTriangle}
       heading={`Couldn't load ${resource}`}
       body={message}
-      trailing={
-        onRetry ? (
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              void onRetry();
-            }}
-            disabled={retrying}
-          >
-            <RefreshCw
-              className={retrying ? "size-3.5 animate-spin" : "size-3.5"}
-            />
-            {retrying ? "Retrying…" : "Retry"}
-          </Button>
-        ) : undefined
-      }
+      trailing={retryButton ?? undefined}
+      className={className}
     />
   );
 }

--- a/web/src/features/transactions/activity-timeline.tsx
+++ b/web/src/features/transactions/activity-timeline.tsx
@@ -9,6 +9,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
+import { PageError } from "@/components/page-error";
 import { TimelineRail } from "@/components/timeline-rail";
 import { useAnnotations } from "@/api/queries/annotations";
 import { formatRelativeTime } from "@/lib/format";
@@ -67,7 +68,8 @@ function groupByDay(annotations: Annotation[]): DayGroup[] {
 // server hands back ready-to-render `summary` lines, so this stays a pure
 // layout component on top of the shared <TimelineRail> primitive (iter 26).
 export function ActivityTimeline({ transactionId }: { transactionId: string }) {
-  const { data, isLoading, isError } = useAnnotations(transactionId);
+  const { data, isLoading, isError, isFetching, error, refetch } =
+    useAnnotations(transactionId);
   const groups = useMemo(() => groupByDay(data ?? []), [data]);
 
   if (isLoading) {
@@ -88,10 +90,19 @@ export function ActivityTimeline({ transactionId }: { transactionId: string }) {
   }
 
   if (isError) {
+    // PageError `inline` variant (iter 88) drops the bordered StatusPanel
+    // chrome so this error sits flush inside the parent <SectionCard
+    // title="Activity"> without doubling up borders. Same destructive icon
+    // tile + heading + body + retry vocabulary as every other v2 error
+    // surface.
     return (
-      <p className="text-muted-foreground text-sm">
-        Couldn't load the activity timeline.
-      </p>
+      <PageError
+        variant="inline"
+        resource="the activity timeline"
+        error={error}
+        onRetry={() => refetch()}
+        retrying={isFetching}
+      />
     );
   }
 

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -940,29 +940,53 @@ export function ComponentsSection() {
       <Specimen
         label="PageError"
         code="components/page-error"
-        description="The canonical page-level 'this page couldn't fetch its data' state. Composition on top of `<StatusPanel tone='destructive'>` — AlertTriangle icon, `Couldn't load {resource}` heading, the error's `message` (or a fallback) as body, and an outline `RefreshCw` Retry button in the trailing slot that swaps to a spinning icon + `Retrying…` label while in-flight. Sibling of `<EmptyState>` (no-data) and `<DetailPageSkeleton>` (loading) — three states, three vocabularies, one visual system. Six pages share it today: accounts, connections, providers, rules, rule-form, rule-detail. Don't fork — extend this primitive."
+        description="The canonical page-level 'this page couldn't fetch its data' state. Two variants. `panel` (default) composes `<StatusPanel tone='destructive'>` — AlertTriangle icon, `Couldn't load {resource}` heading, the error's `message` (or a fallback) as body, and an outline `RefreshCw` Retry button in the trailing slot that swaps to a spinning icon + `Retrying…` label while in-flight. `inline` (iter 88) drops the bordered StatusPanel chrome so the same icon tile + heading + body + retry sits flush inside an already-bordered host (a SectionCard body, a ListCard slot) — used by the transaction-detail activity-timeline. Sibling of `<EmptyState>` (no-data) and `<DetailPageSkeleton>` (loading) — three states, three vocabularies, one visual system. Seven surfaces share it today: accounts, connections, providers, rules, rule-form, rule-detail, activity-timeline (inline). Don't fork — extend this primitive."
         className="block"
       >
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <div className="text-muted-foreground mb-2 px-1 text-[11px] tracking-wide uppercase">
-              with retry handler
+        <div className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <div className="text-muted-foreground mb-2 px-1 text-[11px] tracking-wide uppercase">
+                panel · with retry handler
+              </div>
+              <PageError
+                resource="accounts"
+                error={new Error("Network request failed (ECONNRESET).")}
+                onRetry={() => {
+                  setPageErrorRetrying(true);
+                  window.setTimeout(() => setPageErrorRetrying(false), 1200);
+                }}
+                retrying={pageErrorRetrying}
+              />
             </div>
-            <PageError
-              resource="accounts"
-              error={new Error("Network request failed (ECONNRESET).")}
-              onRetry={() => {
-                setPageErrorRetrying(true);
-                window.setTimeout(() => setPageErrorRetrying(false), 1200);
-              }}
-              retrying={pageErrorRetrying}
-            />
+            <div>
+              <div className="text-muted-foreground mb-2 px-1 text-[11px] tracking-wide uppercase">
+                panel · without retry · fallback message
+              </div>
+              <PageError resource="rules" />
+            </div>
           </div>
           <div>
             <div className="text-muted-foreground mb-2 px-1 text-[11px] tracking-wide uppercase">
-              without retry · fallback message
+              inline · nested inside a bordered host (SectionCard / ListCard)
             </div>
-            <PageError resource="rules" />
+            <div className="bg-card rounded-lg border">
+              <div className="border-b px-5 py-3 text-sm font-medium">
+                Activity
+              </div>
+              <div className="p-5">
+                <PageError
+                  variant="inline"
+                  resource="the activity timeline"
+                  error={new Error("Request failed with status 500.")}
+                  onRetry={() => {
+                    setPageErrorRetrying(true);
+                    window.setTimeout(() => setPageErrorRetrying(false), 1200);
+                  }}
+                  retrying={pageErrorRetrying}
+                />
+              </div>
+            </div>
           </div>
         </div>
       </Specimen>


### PR DESCRIPTION
## Summary

- Add an `inline` variant to `<PageError>` that drops the bordered StatusPanel chrome so the canonical "couldn't load X" vocabulary (destructive icon tile + heading + body + retry) can nest inside an already-bordered host (SectionCard / ListCard) without doubling up borders.
- Wire the transaction-detail activity timeline through it. Was a bare `<p className="text-muted-foreground text-sm">Couldn't load the activity timeline.</p>` with no retry — now matches every other v2 error surface and lets the user retry the request without a full page reload.
- Sandbox specimen demonstrates the `panel`/`inline` split — the inline variant is rendered inside a fake `Activity` SectionCard so the nesting semantics read at a glance.

Closes the iter 87 follow-up observation ("Activity-timeline isError uses bare `<p>`") that explicitly queued the choice between lifting the error up or growing a compact PageError variant. Picked the variant route — the inline shape is reusable for the next nested error state.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/sqwowbjn90.jpg) | ![after](https://i.img402.dev/pthnbhwdbc.jpg) |

## Notes

- Seventh surface for `<PageError>` (the previous six were panel-only top-level page errors). The `panel` variant remains the default and visual contract is byte-identical.
- No new primitive, no new server work, no API change at any existing call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)