### PR TITLE
design(v2): list-page empty/error state polish

### DIFF
--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -208,6 +208,7 @@ export function AccountsPage() {
         />
       ) : visible.length === 0 ? (
         <EmptyState
+          icon={Banknote}
           title="No accounts for this filter"
           description="Switch family member, or clear the filter to see every account in the household."
         />

--- a/web/src/routes/categories.tsx
+++ b/web/src/routes/categories.tsx
@@ -7,12 +7,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { ListCard } from "@/components/list-card";
+import { PageError } from "@/components/page-error";
 import { CategoryList } from "@/features/categories/category-list";
 import { useCategories } from "@/api/queries/categories";
 
 export function CategoriesPage() {
   const [query, setQuery] = useState("");
-  const { data: tree, isLoading, isError } = useCategories();
+  const categoriesQuery = useCategories();
+  const { data: tree, isLoading, isError, isFetching } = categoriesQuery;
 
   // Mirror the iter-3/4 list-page eyebrow vocabulary
   // ("Loading" / "Error" / "N categories" / "Showing N of M" / "No matches" /
@@ -102,10 +104,11 @@ export function CategoriesPage() {
             )}
           />
         ) : isError ? (
-          <EmptyState
-            icon={Shapes}
-            title="Couldn't load categories"
-            description="Something went wrong fetching the category tree. Refresh the page or check back in a moment."
+          <PageError
+            resource="categories"
+            error={categoriesQuery.error}
+            onRetry={() => categoriesQuery.refetch()}
+            retrying={isFetching}
           />
         ) : !tree || tree.length === 0 ? (
           <EmptyState

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -354,6 +354,7 @@ export function ConnectionsPage() {
           }
           empty={
             <EmptyState
+              icon={Plug}
               title="No connections for this filter"
               description="Switch family member, or clear the filter to see every connection in the household."
               className="py-10"

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -202,11 +202,13 @@ export function RulesPage() {
               : "Create a rule to automatically categorize, tag, or comment on transactions as they sync in."
           }
           action={
-            <Button asChild>
-              <Link to="/rules/new">
-                <Plus className="size-4" /> Create rule
-              </Link>
-            </Button>
+            hasActiveFilters ? undefined : (
+              <Button asChild>
+                <Link to="/rules/new">
+                  <Plus className="size-4" /> Create rule
+                </Link>
+              </Button>
+            )
           }
         />
       ) : (


### PR DESCRIPTION
## Summary

Iter 89. Sweep four list pages to align with the iter-87 three-states-three-vocabularies contract and the filter-vs-zero-data empty-state pattern that API keys + Transactions already follow:

- **Categories**: `isError` now renders `<PageError>` (with Retry) instead of a flat `EmptyState` — every other list page (Accounts, Connections, Rules, Transactions) already routes load failures through `PageError`, so this was the lone holdout.
- **Connections**: filter-empty gets the `Plug` icon for visual parity with the zero-data empty (which already had one).
- **Accounts**: filter-empty gets the `Banknote` icon for the same reason.
- **Rules**: filter-empty drops the "Create rule" CTA — the action belongs to the no-rules-yet state, not "your filter excluded the existing rules" (mirrors the pattern Transactions already follows).

No new primitive, no visual contract change — just consistency across the list-page family.

## After

| Categories — load failure (now `<PageError>` with Retry) | Accounts — filter empty (now has the `Banknote` icon) |
| --- | --- |
| ![categories error](https://i.img402.dev/hurab07px9.jpg) | ![accounts filter empty](https://i.img402.dev/ydzb66b7hs.jpg) |

Connections + Rules changes are textual (icon swap / CTA gating) and follow the same vocabulary already shipped on Transactions; not re-screenshotted.

## Notes

- After this, every v2 list page funnels load failures through `<PageError>` and renders filter-empty and zero-data-empty as visually parallel `<EmptyState>` blocks (icon + title + description; CTA only on zero-data).
- Closes the "list-page empty states — verify filter empty vs zero-data empty distinction across all lists" backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
