### PR TITLE
design(v2): wire link-account + reauth sheets onto DetailSheetHeader

### DIFF
--- a/web/src/features/accounts/link-account-sheet.tsx
+++ b/web/src/features/accounts/link-account-sheet.tsx
@@ -1,15 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link2, Loader2 } from "lucide-react";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -19,6 +11,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { DetailSheetHeader } from "@/components/detail-sheet-header";
+import { Eyebrow } from "@/components/eyebrow";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useAccountLinks,
@@ -106,33 +100,27 @@ export function LinkAccountSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="flex w-full flex-col sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle className="flex items-center gap-2">
-            <Link2 className="size-4" />
-            Link an account
-          </SheetTitle>
-          <SheetDescription>
-            Attribute matched transactions on a dependent account to its
-            primary cardholder. The dependent account is excluded from totals
-            so charges aren&apos;t double-counted.
-          </SheetDescription>
-        </SheetHeader>
+      <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-md">
+        <DetailSheetHeader
+          density="accent"
+          icon={Link2}
+          eyebrow="Account link"
+          title="Link an account"
+          description="Attribute matched transactions on a dependent account to its primary cardholder. The dependent account is excluded from totals so charges aren't double-counted."
+        />
 
-        <div className="flex-1 space-y-5 overflow-y-auto px-4">
-          <div className="space-y-1.5">
-            <Label className="text-muted-foreground text-xs">
-              Primary (this account)
-            </Label>
+        <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-6">
+          <div className="flex flex-col gap-2">
+            <Eyebrow as="p">Primary (this account)</Eyebrow>
             <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm">
               {primaryLabel}
             </div>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="dependent" className="text-muted-foreground text-xs">
+          <div className="flex flex-col gap-2">
+            <Eyebrow as="label" htmlFor="dependent">
               Dependent account
-            </Label>
+            </Eyebrow>
             {eligibleCount === 0 ? (
               <Alert>
                 <AlertTitle>No eligible accounts</AlertTitle>
@@ -159,15 +147,15 @@ export function LinkAccountSheet({
               </Select>
             )}
             <p className="text-muted-foreground text-xs">
-              Matched transactions on the dependent account will be
-              attributed to the same person as this account.
+              Matched transactions on the dependent account will be attributed
+              to the same person as this account.
             </p>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="tolerance" className="text-muted-foreground text-xs">
+          <div className="flex flex-col gap-2">
+            <Eyebrow as="label" htmlFor="tolerance">
               Match tolerance (days)
-            </Label>
+            </Eyebrow>
             <Input
               id="tolerance"
               type="number"
@@ -184,19 +172,26 @@ export function LinkAccountSheet({
           </div>
         </div>
 
-        <SheetFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+        <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={create.isPending}
+          >
             Cancel
           </Button>
           <Button
+            size="sm"
             onClick={onSubmit}
             disabled={!dependentId || create.isPending || eligibleCount === 0}
           >
             {create.isPending && <Loader2 className="size-4 animate-spin" />}
             Link accounts
           </Button>
-        </SheetFooter>
+        </div>
       </SheetContent>
     </Sheet>
   );
 }
+

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -1,15 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { Loader2, ShieldAlert } from "lucide-react";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { toast } from "sonner";
 import { ApiError } from "@/api/client";
 import {
@@ -164,99 +158,114 @@ export function ReauthSheet({
 
   return (
     <Sheet open={open} onOpenChange={handleSheetChange}>
-      <SheetContent className="flex flex-col gap-6 p-6">
-        <SheetHeader className="p-0">
-          <SheetTitle>Re-authenticate</SheetTitle>
-          <SheetDescription>
-            Reconnect to the bank to resume syncing this connection.
-          </SheetDescription>
-        </SheetHeader>
+      <SheetContent className="flex flex-col gap-0 p-0">
+        <DetailSheetHeader
+          density="accent"
+          icon={ShieldAlert}
+          eyebrow="Re-authenticate"
+          title={conn ? institutionName : "Re-authenticate"}
+          description="Reconnect to the bank to resume syncing this connection."
+        />
 
-        {connQuery.isLoading ? (
-          <div className="text-muted-foreground flex flex-1 items-center justify-center gap-2 text-sm">
-            <Loader2 className="size-4 animate-spin" /> Loading connection…
-          </div>
-        ) : !conn ? (
-          <Alert variant="destructive">
-            <AlertTitle>Connection not found</AlertTitle>
-            <AlertDescription>
-              The connection may have been disconnected. Close this and refresh
-              the connections list.
-            </AlertDescription>
-          </Alert>
-        ) : stage.kind === "confirm" ? (
-          <ConfirmBody
-            institutionName={institutionName}
-            errorMessage={conn.error_message}
-            uiError={errorMessage}
-          />
-        ) : stage.kind === "plaid" || stage.kind === "teller" ? (
-          <LaunchingBody providerName={stage.kind} />
-        ) : stage.kind === "completing" ? (
-          <LaunchingBody providerName="completing" />
-        ) : (
-          <Alert>
-            <AlertTitle>Not available here</AlertTitle>
-            <AlertDescription>{stage.reason}</AlertDescription>
-          </Alert>
-        )}
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6">
+          {connQuery.isLoading ? (
+            <div className="text-muted-foreground flex flex-1 items-center justify-center gap-2 text-sm">
+              <Loader2 className="size-4 animate-spin" /> Loading connection…
+            </div>
+          ) : !conn ? (
+            <Alert variant="destructive">
+              <AlertTitle>Connection not found</AlertTitle>
+              <AlertDescription>
+                The connection may have been disconnected. Close this and
+                refresh the connections list.
+              </AlertDescription>
+            </Alert>
+          ) : stage.kind === "confirm" ? (
+            <ConfirmBody
+              institutionName={institutionName}
+              errorMessage={conn.error_message}
+              uiError={errorMessage}
+            />
+          ) : stage.kind === "plaid" || stage.kind === "teller" ? (
+            <LaunchingBody providerName={stage.kind} />
+          ) : stage.kind === "completing" ? (
+            <LaunchingBody providerName="completing" />
+          ) : (
+            <Alert>
+              <AlertTitle>Not available here</AlertTitle>
+              <AlertDescription>{stage.reason}</AlertDescription>
+            </Alert>
+          )}
 
-        {/* Plaid update-mode SDK — autoOpen drives the popup the moment the
-            launcher mounts. */}
-        {stage.kind === "plaid" && (
-          <PlaidLinkButton
-            linkToken={stage.linkToken}
-            onSuccess={() => completeReauth()}
-            onExit={(err) =>
-              onProviderExit(
-                err
-                  ? err.display_message ||
-                      err.error_message ||
-                      "Plaid Link exited with an error."
-                  : null,
-              )
-            }
-          />
-        )}
+          {/* Plaid update-mode SDK — autoOpen drives the popup the moment
+              the launcher mounts. Invisible button; lives inside the body
+              so portal placement stays consistent with the rest of the
+              Sheet. */}
+          {stage.kind === "plaid" && (
+            <PlaidLinkButton
+              linkToken={stage.linkToken}
+              onSuccess={() => completeReauth()}
+              onExit={(err) =>
+                onProviderExit(
+                  err
+                    ? err.display_message ||
+                        err.error_message ||
+                        "Plaid Link exited with an error."
+                    : null,
+                )
+              }
+            />
+          )}
 
-        {/* Teller reconnection-mode SDK — passing the existing enrollmentId
-            switches Connect into "reconnect" rather than "enroll". */}
-        {stage.kind === "teller" && (
-          <TellerConnectButton
-            applicationId={tellerAppId}
-            enrollmentId={stage.enrollmentId}
-            onSuccess={() => completeReauth()}
-            onExit={() => onProviderExit(null)}
-            onFailure={(f) =>
-              onProviderExit(f.message || "Teller Connect failed.")
-            }
-          />
-        )}
+          {/* Teller reconnection-mode SDK — passing the existing
+              enrollmentId switches Connect into "reconnect" rather than
+              "enroll". */}
+          {stage.kind === "teller" && (
+            <TellerConnectButton
+              applicationId={tellerAppId}
+              enrollmentId={stage.enrollmentId}
+              onSuccess={() => completeReauth()}
+              onExit={() => onProviderExit(null)}
+              onFailure={(f) =>
+                onProviderExit(f.message || "Teller Connect failed.")
+              }
+            />
+          )}
+        </div>
 
         {conn && stage.kind === "confirm" && (
-          <SheetFooter className="px-0">
+          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
             <Button
               variant="outline"
+              size="sm"
               onClick={() => handleSheetChange(false)}
               disabled={reauthStart.isPending}
             >
               Cancel
             </Button>
-            <Button onClick={onReconnect} disabled={reauthStart.isPending}>
+            <Button
+              size="sm"
+              onClick={onReconnect}
+              disabled={reauthStart.isPending}
+            >
               {reauthStart.isPending ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : null}
               Reconnect
             </Button>
-          </SheetFooter>
+          </div>
         )}
 
         {conn && stage.kind === "unsupported" && (
-          <SheetFooter className="px-0">
-            <Button variant="outline" onClick={() => handleSheetChange(false)}>
+          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleSheetChange(false)}
+            >
               Close
             </Button>
-          </SheetFooter>
+          </div>
         )}
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary
- `link-account-sheet` adopts `DetailSheetHeader` (density="accent") with the Link2 icon tile + "Account link" eyebrow + canonical title/description lockup; body flows on `flex/gap-5` with `Eyebrow` labels matching the Connect-bank rhythm; SheetFooter is replaced with the canonical `bg-muted/20 border-t` footer strip.
- `reauth-sheet` adopts the same DetailSheetHeader (ShieldAlert icon, "Re-authenticate" eyebrow, title = institution_name once loaded) plus the same inline footer strip for both Confirm and Unsupported stages.
- Resolves the iter-41 drift note: with link-account + reauth migrating, the icon-tile lockup is now canonical across all four v2 Sheet consumers (shortcut, connect-bank, link-account, reauth).

## Before / After — Link account sheet
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/zd7puk5705.jpg) | ![after](https://i.img402.dev/yg8nzjjpb4.jpg) |

## Before / After — Re-authenticate sheet
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/zvkungfnm8.jpg) | ![after](https://i.img402.dev/8fo24xiy0r.jpg) |

## Notes
- `Label` import dropped from link-account-sheet — `<Eyebrow as="label">` replaces every group label so the Sheet speaks the same canonical micro-label vocabulary (iter 37) as the rest of the v2 SPA.
- Reauth-sheet's Plaid + Teller launcher buttons now sit inside the body's scroll container instead of as siblings of `SheetFooter` — they're invisible (auto-open SDKs), but co-locating with the body keeps the footer slot clean.
- Reauth-sheet's title hosts the institution name (e.g. "Chase") once the connection loads so the user knows at a glance which connection they're about to reauth — falls back to "Re-authenticate" while loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
