### PR TITLE
design(v2): route settings 'Coming soon' fallback through StatusPanel

### DIFF
--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
+import { Clock, Hammer } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +22,7 @@ import { AccountSection } from "@/features/settings/account-section";
 import { BackupsSection } from "@/features/settings/backups-section";
 import { HouseholdSection } from "@/features/settings/household-section";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
+import { StatusPanel } from "@/components/status-panel";
 
 const SETTINGS_MODAL_KEY = "settings";
 
@@ -199,13 +201,30 @@ function SectionContent({ section }: { section: SettingsSection }) {
     return <BackupsSection />;
   }
 
+  // Fallback for sections defined in `lib/settings-sections.ts` that don't
+  // yet have a real implementation (today: Security). Mirrors the canonical
+  // "Coming soon" vocabulary from `routes/placeholder.tsx` — a
+  // `<StatusPanel tone="info">` with a pill in the trailing slot — so the
+  // settings modal speaks the same language as the rest of the SPA's
+  // unbuilt-nav-leaf surfaces instead of a naked muted paragraph.
   return (
     <div className="space-y-4">
       <SettingsSectionHeader
         title={section.title}
         description={section.description}
       />
-      <p className="text-muted-foreground text-sm">Coming soon.</p>
+      <StatusPanel
+        tone="info"
+        icon={Hammer}
+        heading={`${section.title} settings are in the works`}
+        body="We're still building this surface. The configuration that lives here will land in a follow-up PR — for now, the panel is wired but empty."
+        trailing={
+          <span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase">
+            <Clock className="size-3" />
+            Coming soon
+          </span>
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The settings modal's unbuilt-section fallback (today: Security) was the last "naked text" empty-state surface in the v2 SPA — a bare `<p className="text-muted-foreground text-sm">Coming soon.</p>` paragraph that lived under the `<SettingsSectionHeader>` with no icon, no rail, no structure. Routes it through `<StatusPanel tone="info">` so it speaks the same vocabulary as `routes/placeholder.tsx`:

- Hammer icon tile + tone-tinted 3px left rail + heading + body (matches every other v2 "in the works" notice).
- Uppercase `Coming soon` pill with `Clock` glyph in the trailing slot.
- Heading interpolates the section title so the same fallback reads as `Security settings are in the works` today and works for any future section added to `lib/settings-sections.ts`.

No new primitive. Same `<StatusPanel>` that already powers placeholder routes, env-locked notices, setup-account states.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/9myjybsgb4.jpg) | ![after](https://i.img402.dev/bdef99bteh.jpg) |

## Notes

- Closes the iter-92 follow-up "Settings shell desktop secondary states" — the Security tab is the only stub section today; if a new section is added to `SETTINGS_SECTIONS` without an implementation, it inherits the canonical "Coming soon" lockup for free.
- Lockup matches `routes/placeholder.tsx`'s `<StatusPanel>` precisely (same `Hammer` icon, same `Clock` pill geometry) so a user clicking around v2 reads "this surface isn't built yet" as one consistent affordance, whether they got there via a sidebar leaf (Reports / Agents) or via the settings modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
