### PR TITLE
design(v2): tint TimelineRail discs by event kind

### DIFF
--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -91,10 +91,45 @@ function TimelineRailGroup({
   );
 }
 
+// Semantic tone for the icon disc. Encodes the *kind* of event so a
+// scanning eye can pick out rule applications vs sync events vs comments
+// without parsing the summary line. Default `neutral` matches the legacy
+// look — switch to a tinted variant when the event carries a clear
+// semantic role (sync, rule fire, classification change, etc.). Tones
+// adapt to light/dark themes via the standard shadcn vocabulary
+// (primary / emerald / amber / sky) used elsewhere in v2 (StatusPanel,
+// ColorRailCard, MetaBadge). Iter 93.
+type TimelineRailTone =
+  | "neutral"
+  | "primary"
+  | "success"
+  | "warning"
+  | "info"
+  | "muted";
+
+// TONE_CLASSES tints both the disc *border* and the inner icon so the
+// accent reads on both — a bare-coloured icon on a neutral border looks
+// like a colour smudge, and a coloured border with a neutral icon looks
+// like the disc itself is wrong. Backgrounds stay `bg-card` (set on the
+// disc base in TimelineRailRow) so the disc still punches through the
+// rail line.
+const TONE_CLASSES: Record<TimelineRailTone, string> = {
+  neutral: "border-border/60 text-muted-foreground",
+  primary: "border-primary/40 text-primary",
+  success: "border-emerald-500/40 text-emerald-600 dark:text-emerald-400",
+  warning: "border-amber-500/40 text-amber-600 dark:text-amber-400",
+  info: "border-sky-500/40 text-sky-600 dark:text-sky-400",
+  muted: "border-border/60 text-muted-foreground/70",
+};
+
 interface TimelineRailRowProps extends React.HTMLAttributes<HTMLLIElement> {
   // Icon disc on the rail. Required — the primitive's identity is the
   // punched-through disc.
   icon: LucideIcon;
+  // Semantic tone for the icon disc — see `TimelineRailTone`. Defaults
+  // to `neutral` (the legacy look). Combines with `muted` — a
+  // `tone="primary" muted` row keeps the primary tint at reduced opacity.
+  tone?: TimelineRailTone;
   // Optional muted/strikethrough rendering — for soft-deleted or otherwise
   // de-emphasised rows. Two intensities so consumers don't have to fork a
   // class string.
@@ -108,6 +143,7 @@ interface TimelineRailRowProps extends React.HTMLAttributes<HTMLLIElement> {
 
 function TimelineRailRow({
   icon: Icon,
+  tone = "neutral",
   muted = false,
   className,
   iconClassName,
@@ -157,8 +193,10 @@ function TimelineRailRow({
           // Disc centred on the rail (x=0). `-ml-3.5` (-14px) pulls the
           // 28px-wide disc back so its centre sits on the row's left edge.
           // `relative z-10` + `bg-card` punches the disc through the rail
-          // pseudo behind it.
-          "bg-card border-border/60 text-muted-foreground relative z-10 -ml-3.5 flex size-7 shrink-0 items-center justify-center rounded-full border",
+          // pseudo behind it. Tone classes layered after the base set the
+          // border + icon tint per event kind.
+          "bg-card relative z-10 -ml-3.5 flex size-7 shrink-0 items-center justify-center rounded-full border",
+          TONE_CLASSES[tone],
           iconMuted && "opacity-50",
           iconClassName,
         )}
@@ -240,4 +278,5 @@ export type {
   TimelineRailGroupProps,
   TimelineRailRowProps,
   TimelineRailRowSkeletonProps,
+  TimelineRailTone,
 };

--- a/web/src/features/transactions/activity-timeline.tsx
+++ b/web/src/features/transactions/activity-timeline.tsx
@@ -10,7 +10,10 @@ import {
 } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { PageError } from "@/components/page-error";
-import { TimelineRail } from "@/components/timeline-rail";
+import {
+  TimelineRail,
+  type TimelineRailTone,
+} from "@/components/timeline-rail";
 import { useAnnotations } from "@/api/queries/annotations";
 import { formatRelativeTime } from "@/lib/format";
 import type { Annotation } from "@/api/types";
@@ -23,6 +26,28 @@ const KIND_ICON: Record<string, LucideIcon> = {
   category_set: Shapes,
   sync_started: RefreshCw,
   sync_updated: RefreshCw,
+};
+
+// KIND_TONE tints each event's disc semantically so a scanning eye can
+// pick out rule fires, sync events, and classification changes without
+// reading the summary line. Iter 93. Mapping rationale:
+//   - rule_applied / category_set → primary (system-driven /
+//     classification edits are the dominant signal on a transaction)
+//   - sync_started / sync_updated → info (sky; data arrived from the
+//     outside, matches the sync vocabulary on Connections)
+//   - tag_added → success (additive change)
+//   - tag_removed → warning (amber; something was taken away)
+//   - comment → neutral (the body bubble carries its own colour cue)
+//   - unmapped kinds → neutral via the default `tone="neutral"` on
+//     <TimelineRail.Row>.
+const KIND_TONE: Record<string, TimelineRailTone> = {
+  comment: "neutral",
+  rule_applied: "primary",
+  category_set: "primary",
+  tag_added: "success",
+  tag_removed: "warning",
+  sync_started: "info",
+  sync_updated: "info",
 };
 
 const dayHeadingFormatter = new Intl.DateTimeFormat("en-US", {
@@ -134,9 +159,13 @@ function TimelineRow({ annotation }: { annotation: Annotation }) {
   const deleted = annotation.is_deleted;
   // Comments carry a body; everything else is fully described by `summary`.
   const showBody = annotation.kind === "comment" && !deleted && annotation.content;
+  // Deleted rows drop the tint entirely (the strikethrough vocabulary
+  // owns the signal); live rows pick from KIND_TONE, falling back to
+  // neutral for unmapped kinds.
+  const tone: TimelineRailTone = deleted ? "neutral" : (KIND_TONE[annotation.kind] ?? "neutral");
 
   return (
-    <TimelineRail.Row icon={Icon} muted={deleted ? true : false}>
+    <TimelineRail.Row icon={Icon} tone={tone} muted={deleted ? true : false}>
       <p className="text-sm leading-snug">
         {deleted
           ? `${annotation.actor_name} deleted a comment`

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -1029,7 +1029,7 @@ export function ComponentsSection() {
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
-        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
+        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Each row accepts a semantic `tone` (`neutral` · `primary` · `success` · `warning` · `info` · `muted`, iter 93) that tints the disc border + icon so the eye can pick out rule fires, classification changes, and sync events without parsing the summary line. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
         className="block"
       >
         <div className="grid gap-6 max-w-3xl sm:grid-cols-2">
@@ -1039,7 +1039,7 @@ export function ComponentsSection() {
             </div>
             <TimelineRail>
             <TimelineRail.Group label="Today">
-              <TimelineRail.Row icon={MessageSquare}>
+              <TimelineRail.Row icon={MessageSquare} tone="neutral">
                 <p className="text-sm leading-snug">
                   You left a comment
                 </p>
@@ -1050,7 +1050,7 @@ export function ComponentsSection() {
                   2 minutes ago
                 </p>
               </TimelineRail.Row>
-              <TimelineRail.Row icon={Wand2}>
+              <TimelineRail.Row icon={Wand2} tone="primary">
                 <p className="text-sm leading-snug">
                   Rule "Coffee shops" applied — category set to Dining out
                 </p>
@@ -1058,9 +1058,17 @@ export function ComponentsSection() {
                   18 minutes ago
                 </p>
               </TimelineRail.Row>
+              <TimelineRail.Row icon={RefreshCw} tone="info">
+                <p className="text-sm leading-snug">
+                  Sync from Chase updated this transaction
+                </p>
+                <p className="text-muted-foreground mt-1 text-[11px]">
+                  42 minutes ago
+                </p>
+              </TimelineRail.Row>
             </TimelineRail.Group>
             <TimelineRail.Group label="Yesterday">
-              <TimelineRail.Row icon={Shapes}>
+              <TimelineRail.Row icon={Shapes} tone="primary">
                 <p className="text-sm leading-snug">
                   Ricardo changed category to Groceries
                 </p>
@@ -1068,12 +1076,20 @@ export function ComponentsSection() {
                   Yesterday at 4:12 PM
                 </p>
               </TimelineRail.Row>
-              <TimelineRail.Row icon={Tag}>
+              <TimelineRail.Row icon={Tag} tone="success">
                 <p className="text-sm leading-snug">
                   Ricardo added tag "reimbursable"
                 </p>
                 <p className="text-muted-foreground mt-1 text-[11px]">
                   Yesterday at 4:11 PM
+                </p>
+              </TimelineRail.Row>
+              <TimelineRail.Row icon={Tag} tone="warning">
+                <p className="text-sm leading-snug">
+                  Ricardo removed tag "needs-review"
+                </p>
+                <p className="text-muted-foreground mt-1 text-[11px]">
+                  Yesterday at 4:00 PM
                 </p>
               </TimelineRail.Row>
               <TimelineRail.Row icon={MessageSquare} muted>


### PR DESCRIPTION
## Summary
- Adds a `tone` prop to `<TimelineRail.Row>` (`neutral|primary|success|warning|info|muted`) that tints the disc border + icon so the eye can pick out rule applications, classification changes, sync events, and tag adds/removes at a glance.
- Wires it into the transaction-detail activity timeline via a per-kind `KIND_TONE` map: `rule_applied` + `category_set` → primary, `sync_*` → info (sky), `tag_added` → success, `tag_removed` → warning, comments + unmapped → neutral.
- Expanded the sandbox specimen to demo five tones in a single timeline so the visual contract is browseable.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/ufmkq898k9.jpg) | ![after](https://i.img402.dev/bfouwpnjkc.jpg) |

## Notes
- Tones are additive — every existing call site keeps the legacy look (default `tone="neutral"`).
- Deleted comments drop the tint regardless of kind (the strikethrough vocabulary owns the signal).
- TimelineRail is the only primitive with kind-based colour encoding in v2; sandbox description now spells out the vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)