### PR TITLE
design(v2): Eyebrow nav variant retires 3 sidebar-label drift sites

### DIFF
--- a/web/src/components/eyebrow.tsx
+++ b/web/src/components/eyebrow.tsx
@@ -27,20 +27,28 @@ interface EyebrowProps extends React.HTMLAttributes<HTMLElement> {
    * `text-[11px] tracking-[0.08em]` rhythm used at the *page* scale —
    * `<PageHeader>` eyebrow, the home-stats KPI cell labels, and the
    * provider-card "Provider" caption — where the eyebrow has to hold its
-   * own next to a 2xl–3xl title without disappearing.
+   * own next to a 2xl–3xl title without disappearing. `nav` is the
+   * heavier `font-semibold` cousin used by sidebar / shortcut-sheet
+   * group labels (`text-[10px] tracking-[0.08em]`) where the eyebrow
+   * sits inside chrome rather than next to content and needs the extra
+   * weight to read against a coloured surface.
    */
-  variant?: "default" | "hero" | "page";
+  variant?: "default" | "hero" | "page" | "nav";
   className?: string;
   children: React.ReactNode;
 }
 
 // Eyebrow is the canonical uppercase micro-label used across detail pages,
-// hero cards, and timeline rails: `text-muted-foreground text-[10px]
-// font-medium tracking-[0.1em] uppercase`. The pattern was open-coded
-// across ten files in five subtly different sizes/trackings before iter 37
-// consolidated them. Don't reach for raw `text-[10px] font-medium
+// hero cards, timeline rails, AND sidebar/menu group labels:
+// `text-muted-foreground text-[10px] font-medium tracking-[0.1em]
+// uppercase` is the default; `font-semibold` cousins live behind the
+// `nav` variant. The pattern was open-coded across ten files in five
+// subtly different sizes/trackings before iter 37 consolidated them, and
+// the `nav`-scale `font-semibold` cousins (sidebar group labels +
+// shortcut-sheet group headers) were unified onto the primitive in
+// iter 95. Don't reach for raw `text-[10px] font-medium/semibold
 // tracking-* uppercase` markup again — extend this primitive with a new
-// variant if a hero needs a different rhythm.
+// variant if a host needs a different rhythm.
 export function Eyebrow({
   as: Tag = "span",
   variant = "default",
@@ -51,10 +59,12 @@ export function Eyebrow({
   return (
     <Tag
       className={cn(
-        "text-muted-foreground font-medium uppercase",
+        "text-muted-foreground uppercase",
+        variant === "nav" ? "font-semibold" : "font-medium",
         variant === "default" && "text-[10px] tracking-[0.1em]",
         variant === "hero" && "text-[10px] tracking-[0.12em]",
         variant === "page" && "text-[11px] tracking-[0.08em]",
+        variant === "nav" && "text-[10px] tracking-[0.08em]",
         className,
       )}
       {...rest}

--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -6,6 +6,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { Eyebrow } from "@/components/eyebrow";
 import { isNavMatch, navKey, type NavGroup, type NavLeaf } from "@/lib/nav";
 import { openModal, useActiveModal } from "@/lib/modals";
 import { cn } from "@/lib/utils";
@@ -17,8 +18,10 @@ export function NavMain({ group }: { group: NavGroup }) {
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel className="text-muted-foreground/80 text-[10px] font-semibold tracking-[0.08em] uppercase">
-        {group.label}
+      <SidebarGroupLabel asChild>
+        <Eyebrow variant="nav" as="div" className="text-muted-foreground/80">
+          {group.label}
+        </Eyebrow>
       </SidebarGroupLabel>
       <SidebarMenu>
         {group.items.map((item) => (

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -23,6 +23,7 @@ import { BackupsSection } from "@/features/settings/backups-section";
 import { HouseholdSection } from "@/features/settings/household-section";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
 import { StatusPanel } from "@/components/status-panel";
+import { Eyebrow } from "@/components/eyebrow";
 
 const SETTINGS_MODAL_KEY = "settings";
 
@@ -94,9 +95,13 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
     return (
       <div className="flex h-full">
         <nav className="bg-sidebar text-sidebar-foreground w-56 shrink-0 border-r p-3">
-          <p className="text-muted-foreground/80 mb-2 px-2 text-[10px] font-semibold tracking-[0.08em] uppercase">
+          <Eyebrow
+            as="p"
+            variant="nav"
+            className="text-muted-foreground/80 mb-2 px-2"
+          >
             Settings
-          </p>
+          </Eyebrow>
           <ul className="space-y-0.5">
             {SETTINGS_SECTIONS.map((s) => {
               const Icon = s.icon;

--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Keyboard } from "lucide-react";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { DetailSheetHeader } from "@/components/detail-sheet-header";
+import { Eyebrow } from "@/components/eyebrow";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { displayKey } from "@/lib/kbd-display";
 import {
@@ -99,9 +100,9 @@ export function ShortcutSheet() {
                   className="bg-card overflow-hidden rounded-md border"
                 >
                   <header className="bg-muted/30 flex items-baseline justify-between gap-2 border-b px-3 py-2">
-                    <h3 className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
+                    <Eyebrow as="h3" variant="nav">
                       {group}
-                    </h3>
+                    </Eyebrow>
                     <span className="text-muted-foreground/70 text-[10px] tabular-nums">
                       {items.length}
                     </span>

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -405,10 +405,10 @@ export function ComponentsSection() {
       <Specimen
         label="Eyebrow"
         code="components/eyebrow"
-        description="The canonical uppercase micro-label used across detail-page hero columns, section headers, 'Jump to' pills, and timeline-rail day headings. Open-coded across ten files in five subtly different sizes before iter 37 consolidated them. Three variants — `default` (`text-[10px] tracking-[0.1em]`) is the everyday eyebrow; `hero` (`tracking-[0.12em]`) gets extra letter air for spots where it sits directly under a large display title; `page` (`text-[11px] tracking-[0.08em]`) is the slightly heavier rhythm reserved for *page*-scale framing — `<PageHeader>` eyebrow, home-stats KPI cell labels, provider-card 'Provider' caption — where the eyebrow has to hold its own next to a 2xl–3xl title without disappearing (iter 94, retiring six hand-rolled call sites). Don't reach for raw `text-[10-11px] font-medium tracking-* uppercase` markup — extend this primitive."
+        description="The canonical uppercase micro-label used across detail-page hero columns, section headers, 'Jump to' pills, timeline-rail day headings, AND sidebar/menu group labels. Open-coded across ten files in five subtly different sizes before iter 37 consolidated them; iter 95 added the `nav` cousin to retire the remaining three `font-semibold` sidebar-group-label drift sites (`nav-main`, `settings-shell` desktop sidebar, `shortcut-sheet` group headers). Four variants — `default` (`text-[10px] tracking-[0.1em]`) is the everyday eyebrow; `hero` (`tracking-[0.12em]`) gets extra letter air for spots where it sits directly under a large display title; `page` (`text-[11px] tracking-[0.08em]`) is the slightly heavier rhythm reserved for *page*-scale framing (PageHeader eyebrow, home-stats KPI labels, provider-card 'Provider' caption); `nav` (`font-semibold text-[10px] tracking-[0.08em]`) is the heavier cousin used inside sidebar / menu chrome where the label sits against a coloured surface and needs the extra weight to read. Don't reach for raw `text-[10-11px] font-medium/semibold tracking-* uppercase` markup — extend this primitive."
         className="block"
       >
-        <div className="grid gap-4 sm:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-lg border p-4">
             <Eyebrow>Default · in a card header</Eyebrow>
             <p className="text-foreground mt-1 text-sm">
@@ -438,6 +438,23 @@ export function ComponentsSection() {
             </h1>
             <p className="text-muted-foreground mt-1 text-xs">
               page · text-[11px] · tracking-[0.08em]
+            </p>
+          </div>
+          <div className="bg-sidebar text-sidebar-foreground rounded-lg border p-4">
+            <Eyebrow
+              variant="nav"
+              as="p"
+              className="text-muted-foreground/80"
+            >
+              Workspace
+            </Eyebrow>
+            <ul className="mt-2 space-y-0.5 text-sm">
+              <li className="rounded-md px-2 py-1">Home</li>
+              <li className="rounded-md px-2 py-1">Transactions</li>
+              <li className="rounded-md px-2 py-1">Categories</li>
+            </ul>
+            <p className="text-muted-foreground mt-2 text-xs">
+              nav · font-semibold · text-[10px] · tracking-[0.08em]
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds a fourth `nav` variant to `<Eyebrow>` (`font-semibold text-[10px] tracking-[0.08em]`) — the heavier cousin used inside sidebar / menu chrome where the label sits against a coloured surface and needs extra weight to read against `bg-sidebar`.
- Migrates three hand-rolled call sites onto it: `nav-main` `SidebarGroupLabel` (Money / Library / System group headers), `settings-shell` desktop sidebar 'Settings' caption, and `shortcut-sheet` group-section headers.
- Sandbox showcase grows a fourth specimen so all four variants (`default` / `hero` / `page` / `nav`) sit side-by-side, the new tile rendered on a `bg-sidebar` host so the nav rhythm is visible against the surface it was designed for.

## After

App sidebar — group labels (Money / Library / System) now route through `<Eyebrow variant="nav">`:

![sidebar](https://i.img402.dev/hin944am1h.jpg)

Settings modal — desktop sidebar 'Settings' caption now routes through the primitive too:

![settings](https://i.img402.dev/wf78do8hy3.jpg)

Sandbox — four-up Eyebrow specimen including the new sidebar-tinted `nav` tile:

![sandbox](https://i.img402.dev/83btybh1hv.jpg)

## Notes

- Shared primitive count stays at 23 — no new component, just a richer prop. Iter 94 retired the page-scale drift; this iteration retires the nav-scale cousin so the iter-37 invariant ("raw `text-[10-11px] font-medium/semibold tracking-* uppercase` markup never appears outside `<Eyebrow>`") now holds across every weight tier (default · hero · page · nav).
- Sweep clean: `grep -rn 'text-\[10px\] font-semibold tracking' web/src --include='*.tsx' | grep -v sandbox | grep -v eyebrow.tsx` returns only intentional non-eyebrow weights (brand-header version chip, nav-user role pill — both coloured chips, not labels).
- `SidebarGroupLabel` is preserved as the host element via `asChild` so the shadcn chrome (flex h-8, ring/focus, collapsible-icon transitions) keeps working — Eyebrow only owns the type rhythm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
