### PR TITLE
design(v2): SearchInput primitive (4 list-page search inputs unified)

### DIFF
--- a/web/src/components/search-input.tsx
+++ b/web/src/components/search-input.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface SearchInputProps
+  extends Omit<React.ComponentProps<"input">, "type"> {
+  // `containerClassName` controls the outer relative wrapper (width,
+  // responsive sizing). The Tags/Categories list pages use `w-full max-w-sm`;
+  // API-keys uses `w-full max-w-xs`; the Transactions toolbar uses
+  // `w-full min-w-48 sm:w-64`. Default is `w-full max-w-sm` (matches the
+  // most common list-page pattern).
+  containerClassName?: string;
+}
+
+// SearchInput is the canonical text input with a leading magnifier glyph
+// used by every v2 list page (Tags, Categories, API keys, Transactions).
+// Geometry: `Search` is a `size-4 text-muted-foreground` absolutely
+// positioned at `top-1/2 left-2.5 -translate-y-1/2`; the input is the
+// stock `<Input>` primitive with `pl-8` to clear the icon.
+//
+// The icon is `pointer-events-none` so clicking on it focuses the input
+// underneath instead of swallowing the event. Forward all native input
+// props (value, onChange, onKeyDown, placeholder, etc.) plus a ref via
+// React's standard ref forwarding.
+//
+// Don't fork the look — extend this primitive.
+export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  function SearchInput(
+    { containerClassName, className, ...props },
+    ref,
+  ) {
+    return (
+      <div className={cn("relative w-full max-w-sm", containerClassName)}>
+        <Search
+          className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2"
+          aria-hidden
+        />
+        <Input
+          ref={ref}
+          type="search"
+          className={cn("pl-8", className)}
+          {...props}
+        />
+      </div>
+    );
+  },
+);

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -6,7 +6,6 @@ import {
   CheckSquare,
   CircleDot,
   DollarSign,
-  Search,
   Shapes,
   X,
 } from "lucide-react";
@@ -27,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SearchInput } from "@/components/search-input";
 import { KbdTooltip } from "@/components/kbd-tooltip";
 import { CategoryCommandList } from "@/components/category-command";
 import {
@@ -200,22 +200,19 @@ export function TransactionsToolbar({
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
-        <div className="relative w-full min-w-48 sm:w-64">
-          <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-          <Input
-            ref={searchRef}
-            value={query}
-            onChange={(e) => onQueryChange(e.target.value)}
-            // Esc inside the search box blurs back to the page so the global
-            // shortcuts (j/k/c/Esc-to-clear-selection) regain control without
-            // a manual click-away.
-            onKeyDown={(e) => {
-              if (e.key === "Escape") e.currentTarget.blur();
-            }}
-            placeholder="Search merchant or description…"
-            className="pl-8"
-          />
-        </div>
+        <SearchInput
+          ref={searchRef}
+          containerClassName="w-full min-w-48 sm:w-64"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          // Esc inside the search box blurs back to the page so the global
+          // shortcuts (j/k/c/Esc-to-clear-selection) regain control without
+          // a manual click-away.
+          onKeyDown={(e) => {
+            if (e.key === "Escape") e.currentTarget.blur();
+          }}
+          placeholder="Search merchant or description…"
+        />
 
         {/* Filter pills — grouped so they wrap as a unit, independent of
             the sort/select controls. */}

--- a/web/src/routes/api-keys.tsx
+++ b/web/src/routes/api-keys.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
-import { Key, Plus, Search } from "lucide-react";
+import { Key, Plus } from "lucide-react";
 import { z } from "zod";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAPIKeys } from "@/api/queries/api-keys";
 import { APIKeysTable } from "@/features/api-keys/api-keys-table";
@@ -132,15 +132,12 @@ export function APIKeysPage() {
             </TabsList>
           </Tabs>
 
-          <div className="relative w-full max-w-xs">
-            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-            <Input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by name, prefix, actor…"
-              className="pl-8"
-            />
-          </div>
+          <SearchInput
+            containerClassName="w-full max-w-xs"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name, prefix, actor…"
+          />
         </div>
 
         <APIKeysTable

--- a/web/src/routes/categories.tsx
+++ b/web/src/routes/categories.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Plus, Search, Shapes } from "lucide-react";
+import { Plus, Shapes } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { ListCard } from "@/components/list-card";
 import { PageError } from "@/components/page-error";
@@ -77,15 +77,11 @@ export function CategoriesPage() {
 
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="relative w-full max-w-sm">
-            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-            <Input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by name or slug…"
-              className="pl-8"
-            />
-          </div>
+          <SearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name or slug…"
+          />
         </div>
 
         {isLoading ? (

--- a/web/src/routes/tags.tsx
+++ b/web/src/routes/tags.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Plus, Search, Tags as TagsIcon } from "lucide-react";
+import { Plus, Tags as TagsIcon } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { SearchInput } from "@/components/search-input";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { TagsTable } from "@/features/tags/tags-table";
 import { useTags } from "@/api/queries/tags";
 
@@ -59,15 +59,11 @@ export function TagsPage() {
 
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="relative w-full max-w-sm">
-            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-            <Input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by name, slug, or description…"
-              className="pl-8"
-            />
-          </div>
+          <SearchInput
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name, slug, or description…"
+          />
         </div>
 
         <TagsTable

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -91,6 +91,7 @@ import { ConfirmDialog } from "@/components/confirm-dialog";
 import { DangerZone } from "@/components/danger-zone";
 import { PaginationBar } from "@/components/pagination-bar";
 import { ViewAllPill } from "@/components/view-all-pill";
+import { SearchInput } from "@/components/search-input";
 import { ProviderPicker } from "@/features/connections/provider-picker";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
@@ -593,6 +594,45 @@ export function ComponentsSection() {
           <ViewAllPill to="/">View all</ViewAllPill>
           <ViewAllPill to="/">Manage</ViewAllPill>
           <ViewAllPill to="/">See all transactions</ViewAllPill>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="SearchInput"
+        code="components/search-input"
+        description="The canonical text input with a leading magnifier glyph used by every v2 list page (Tags, Categories, API keys, Transactions). Wraps the stock `<Input>` primitive with a `pointer-events-none` `Search` glyph absolutely positioned at `left-2.5` and `pl-8` on the field to clear it. Forwards every native input prop (value, onChange, onKeyDown, placeholder, …) and a `ref` for callers that need to focus from a keyboard shortcut. `containerClassName` is the escape hatch for the outer wrapper width (default `w-full max-w-sm`; API keys uses `w-full max-w-xs`; Transactions toolbar uses `w-full min-w-48 sm:w-64`). Don't open-code the icon + Input pair — extend this primitive."
+        className="block"
+      >
+        <div className="space-y-4 rounded-lg border p-4">
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Default · `w-full max-w-sm`
+            </div>
+            <SearchInput
+              defaultValue=""
+              placeholder="Search by name, slug, or description…"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Narrow · `containerClassName='w-full max-w-xs'`
+            </div>
+            <SearchInput
+              containerClassName="w-full max-w-xs"
+              defaultValue=""
+              placeholder="Search by name, prefix, actor…"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Toolbar · `containerClassName='w-full min-w-48 sm:w-64'`
+            </div>
+            <SearchInput
+              containerClassName="w-full min-w-48 sm:w-64"
+              defaultValue="coffee"
+              placeholder="Search merchant or description…"
+            />
+          </div>
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary
- New `<SearchInput>` primitive at `web/src/components/search-input.tsx` wraps the icon+input lockup used by every v2 list-page search field (Tags, Categories, API keys, Transactions).
- Forwards all native input props plus a `ref` so the Transactions toolbar keeps its `Esc`-to-blur keyboard handler intact. `containerClassName` is the escape hatch for the outer wrapper width.
- Retires four open-coded sites of the `relative` wrapper + `pointer-events-none absolute` Search glyph + `pl-8` Input triplet.
- Adds a sandbox specimen at `/v2/sandbox#components` showing the three width presets (default `w-full max-w-sm`, narrow `w-full max-w-xs`, toolbar `w-full min-w-48 sm:w-64`).

24th shared primitive in the v2 vocabulary.

## Sandbox specimen
![SearchInput specimen at /v2/sandbox#components](https://i.img402.dev/bzdie6f1gv.jpg)

## Live consumer (Tags list)
![Tags page using SearchInput](https://i.img402.dev/uuytoddhrn.jpg)

## Notes
- Pairs with the iter-86 RowActionsMenu sweep (another open-coded icon-button lockup that became a primitive).
- Iter 4 (#1117) called out the `ListToolbar` primitive opportunity for "search input + filter controls in a flex row" — this PR ships the search-input half. The filter half is still per-page (and will stay that way until a third page picks up the Transactions toolbar's `FilterPill` vocabulary).
- Next plausible targets: same audit found two more 3-site duplications worth promoting — the `flex flex-col gap-5 px-6 py-5 sm:flex-row...` provider-card header bar (plaid/teller/csv) and the `grid gap-5 px-5 py-5 sm:gap-6 sm:px-7...` detail-page hero body grid (account/category/connection-detail). Queued.
- Visual change is by design negligible: every consumer renders byte-equivalent geometry (same icon position, same `pl-8`, same wrapper width). The win is one place to evolve the search-field vocabulary instead of four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
