### PR TITLE
design(v2): HeroGrid primitive (4 detail-page hero bodies unified)

### DIFF
--- a/web/src/components/hero-grid.tsx
+++ b/web/src/components/hero-grid.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface HeroGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Override the row-gap on lg+. Defaults to `lg:gap-10` (the shared
+   * `gap-10` axis used by account / category / connection detail heroes).
+   * Transaction-detail uses `lg:gap-x-10 lg:gap-y-5` because the left
+   * column stacks an identity row on top of a classify row and the
+   * vertical rhythm needs to be tighter — pass `"lg:gap-x-10 lg:gap-y-5"`
+   * to opt in.
+   */
+  lgGapClassName?: string;
+  children: React.ReactNode;
+}
+
+// HeroGrid is the canonical body grid inside a detail-page hero card —
+// the layer that sits one level inside `<ColorRailCard>` and arranges
+// the identity column on the left and the metric column on the right.
+// Promoted in iter 97 from three byte-identical sites (account-detail,
+// category-detail, connection-detail) plus a near-identical transaction-
+// detail variant. 25th shared primitive in the v2 vocabulary.
+//
+// Visual contract:
+//   `grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6
+//    lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10`
+//
+// The grid breakpoints encode the same density story across every
+// detail page: mobile stacks rows top-to-bottom (identity → metric →
+// optional extras); ≥640px loosens spacing without changing layout;
+// ≥1024px docks the metric column to the right edge so the identity
+// column gets the priority left slot. Always render inside
+// `<ColorRailCard>` — HeroGrid is the body layer, not the chrome.
+export function HeroGrid({
+  className,
+  lgGapClassName = "lg:gap-10",
+  children,
+  ...rest
+}: HeroGridProps) {
+  return (
+    <div
+      className={cn(
+        "grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start",
+        lgGapClassName,
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ActionPill } from "@/components/action-pill";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { HeroGrid } from "@/components/hero-grid";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import {
   DetailList,
@@ -235,7 +236,7 @@ function Hero({
         </>
       }
     >
-      <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
+      <HeroGrid>
         {/* Identity column */}
         <div className="min-w-0 space-y-3">
           <div className="flex items-start gap-4">
@@ -352,7 +353,7 @@ function Hero({
             </p>
           ) : null}
         </div>
-      </div>
+      </HeroGrid>
 
     </ColorRailCard>
   );

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { HeroGrid } from "@/components/hero-grid";
 import { DangerZone } from "@/components/danger-zone";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import {
@@ -158,7 +159,7 @@ function Hero({
 
   return (
     <ColorRailCard accent={accent}>
-      <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
+      <HeroGrid>
         {/* Identity column */}
         <div className="min-w-0 space-y-3">
           <div className="flex items-start gap-4">
@@ -243,7 +244,7 @@ function Hero({
                 : "Tagged with this category"}
           </p>
         </div>
-      </div>
+      </HeroGrid>
     </ColorRailCard>
   );
 }

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -41,6 +41,7 @@ import {
 import { ActionPill } from "@/components/action-pill";
 import { RowActionsMenu } from "@/components/row-actions-menu";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { HeroGrid } from "@/components/hero-grid";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import { PageError } from "@/components/page-error";
 import {
@@ -629,7 +630,7 @@ function Hero({
         </>
       }
     >
-      <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
+      <HeroGrid>
         {/* Identity column */}
         <div className="min-w-0 space-y-3">
           <div className="flex items-start gap-4">
@@ -711,7 +712,7 @@ function Hero({
             </p>
           ) : null}
         </div>
-      </div>
+      </HeroGrid>
     </ColorRailCard>
   );
 }

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -16,6 +16,7 @@ import { EmptyState } from "@/components/empty-state";
 import { PageError } from "@/components/page-error";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
+import { HeroGrid } from "@/components/hero-grid";
 import {
   DetailList,
   compactDetailRows,
@@ -129,7 +130,7 @@ function Hero({ transaction: t }: { transaction: Transaction }) {
           the identity + classify stack on the left and the amount column
           docks to the right (identity stays anchored at the top via
           `lg:row-span-2`). */}
-      <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-x-10 lg:gap-y-5">
+      <HeroGrid lgGapClassName="lg:gap-x-10 lg:gap-y-5">
         {/* Identity row (full width on mobile, left column on lg) */}
         <div className="flex min-w-0 items-start gap-3 sm:gap-4 lg:row-start-1">
           <CategoryIconTile
@@ -232,7 +233,7 @@ function Hero({ transaction: t }: { transaction: Transaction }) {
             </ClassifyField>
           </div>
         </div>
-      </div>
+      </HeroGrid>
     </ColorRailCard>
   );
 }

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -92,6 +92,7 @@ import { DangerZone } from "@/components/danger-zone";
 import { PaginationBar } from "@/components/pagination-bar";
 import { ViewAllPill } from "@/components/view-all-pill";
 import { SearchInput } from "@/components/search-input";
+import { HeroGrid } from "@/components/hero-grid";
 import { ProviderPicker } from "@/features/connections/provider-picker";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
@@ -282,6 +283,42 @@ export function ComponentsSection() {
                 Posted May 14, 2026 · Chase ····2890
               </p>
             </div>
+          </ColorRailCard>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="HeroGrid"
+        code="components/hero-grid"
+        description="Body grid that sits one level inside `<ColorRailCard>` — arranges the identity column on the left and the metric column on the right. Promoted from three byte-identical sites (account, category, connection detail) plus a near-identical TX-detail variant. Stacks rows on mobile, docks the metric column to the right on lg. The transaction-detail variant tightens the lg row-gap via `lgGapClassName='lg:gap-x-10 lg:gap-y-5'` because the left column stacks identity on top of classify rows."
+        className="block"
+      >
+        <div className="max-w-xl">
+          <ColorRailCard accent="#0ea5e9">
+            <HeroGrid>
+              <div className="min-w-0 space-y-1">
+                <span className="text-muted-foreground text-[11px] font-medium tracking-wider uppercase">
+                  Asset
+                </span>
+                <h3 className="text-foreground text-xl font-semibold tracking-tight">
+                  Chase Sapphire
+                </h3>
+                <p className="text-muted-foreground text-xs">
+                  Credit card · ····2890
+                </p>
+              </div>
+              <div className="flex flex-col items-start gap-1.5 lg:items-end lg:text-right">
+                <span className="bg-success/10 text-success inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
+                  Balance
+                </span>
+                <div className="text-3xl font-semibold tabular-nums sm:text-4xl">
+                  $4,210.55
+                </div>
+                <p className="text-muted-foreground text-[11px] tabular-nums">
+                  $1,789.45 available
+                </p>
+              </div>
+            </HeroGrid>
           </ColorRailCard>
         </div>
       </Specimen>


### PR DESCRIPTION
## Summary

- Promote the detail-page hero body grid to a shared primitive — **25th in the v2 vocabulary**.
- Replaces 4 sites of open-coded `grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10`: `account-detail`, `category-detail`, `connection-detail` (byte-identical), and `transaction-detail` (uses the `lgGapClassName` escape hatch for tighter `lg:gap-x-10 lg:gap-y-5` row rhythm).
- Sandbox specimen added between `ColorRailCard` and `ColorRailCardSkeleton` showing the asset hero shape.

## After

| Account detail (live) | Sandbox specimen |
| --- | --- |
| ![account](https://i.img402.dev/itgvw5vqs1.jpg) | ![sandbox](https://i.img402.dev/o0ay49ojpt.jpg) |

Visual change is by design negligible — every consumer renders byte-equivalent geometry (same grid breakpoints, same padding, same lg row-gap). The win is **one place to evolve the hero body density** instead of four.

## Notes

- Queued from iter 96's long-className audit. The sibling candidate (`<ProviderCardHeader>` — 3 provider cards) remains in the backlog.
- `lgGapClassName` is a thin escape hatch — keeps the dominant `lg:gap-10` rhythm in the default while admitting TX-detail's tighter `lg:gap-x-10 lg:gap-y-5` because its left column stacks identity + classify rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
