### PR TITLE
design(v2): extract ProviderCardHeader primitive

### DIFF
--- a/web/src/components/provider-card-header.tsx
+++ b/web/src/components/provider-card-header.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Eyebrow } from "@/components/eyebrow";
+
+interface ProviderCardHeaderProps {
+  /**
+   * Icon node, typically a `lucide-react` icon at `size-5`. Rendered inside
+   * the rounded tone tile on the left edge of the header.
+   */
+  icon: React.ReactNode;
+  /**
+   * Tailwind classes for the icon tile background/text color. Examples:
+   * `"bg-blue-500/10 text-blue-600 dark:text-blue-400"` (Plaid),
+   * `"bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"` (Teller),
+   * `"bg-amber-500/10 text-amber-600 dark:text-amber-400"` (CSV).
+   */
+  iconClassName: string;
+  /** Provider display name, e.g. "Plaid", "Teller", "CSV import". */
+  title: string;
+  /** One-line marketing description. Capped at `max-w-md`. */
+  description: string;
+  /**
+   * Optional inline badge rendered to the right of the title — typically a
+   * `<ProviderStatusBadge>`. CSV omits this because there are no credentials
+   * to gate.
+   */
+  badge?: React.ReactNode;
+  /**
+   * Right-aligned slot, typically a `<ProviderScoreboard>`. Docks below
+   * the identity column on mobile and to the right on ≥640px.
+   */
+  trailing?: React.ReactNode;
+}
+
+// ProviderCardHeader is the canonical header body inside a provider settings
+// card — the layer that sits one level inside `<ColorRailCard>` on the Plaid,
+// Teller, and CSV provider pages. Promoted in iter 98 from three near-byte-
+// identical header blocks (each ~25 LOC). 26th shared primitive in the v2
+// vocabulary.
+//
+// Visual contract:
+//   Wrapper: `flex flex-col gap-5 px-6 py-5
+//             sm:flex-row sm:items-center sm:justify-between sm:px-7`
+//   Identity column: icon tile (size-11 rounded-lg) + eyebrow "Provider" +
+//     title row (h2 + optional badge) + description.
+//   Trailing column: scoreboard slot, right-docked on ≥640px.
+//
+// The breakpoints encode the same density story for every provider card:
+// mobile stacks the scoreboard under the identity column; ≥640px aligns
+// them on a single baseline. Always render inside `<ColorRailCard>` —
+// ProviderCardHeader is the body layer, not the chrome.
+export function ProviderCardHeader({
+  icon,
+  iconClassName,
+  title,
+  description,
+  badge,
+  trailing,
+}: ProviderCardHeaderProps) {
+  return (
+    <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
+      <div className="flex min-w-0 items-start gap-3">
+        <div
+          className={cn(
+            "flex size-11 shrink-0 items-center justify-center rounded-lg",
+            iconClassName,
+          )}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0 space-y-1">
+          <Eyebrow as="p" variant="page">
+            Provider
+          </Eyebrow>
+          {badge ? (
+            <div className="flex items-center gap-2">
+              <h2 className="text-foreground text-lg font-semibold tracking-tight">
+                {title}
+              </h2>
+              {badge}
+            </div>
+          ) : (
+            <h2 className="text-foreground text-lg font-semibold tracking-tight">
+              {title}
+            </h2>
+          )}
+          <p className="text-muted-foreground max-w-md text-sm">{description}</p>
+        </div>
+      </div>
+      {trailing}
+    </div>
+  );
+}

--- a/web/src/features/providers/csv-card.tsx
+++ b/web/src/features/providers/csv-card.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { FileSpreadsheet, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ColorRailCard } from "@/components/color-rail-card";
-import { Eyebrow } from "@/components/eyebrow";
+import { ProviderCardHeader } from "@/components/provider-card-header";
 import { SectionCard } from "@/components/section-card";
 import type { ProviderHealthResponse } from "@/api/types";
 import {
@@ -24,25 +24,15 @@ export function CsvCard({ health }: CsvCardProps) {
   return (
     <div className="space-y-4">
       <ColorRailCard accent={providerToneAccent(tone)}>
-        <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
-          <div className="flex min-w-0 items-start gap-3">
-            <div className="bg-amber-500/10 text-amber-600 dark:text-amber-400 flex size-11 shrink-0 items-center justify-center rounded-lg">
-              <FileSpreadsheet className="size-5" />
-            </div>
-            <div className="min-w-0 space-y-1">
-              <Eyebrow as="p" variant="page">
-                Provider
-              </Eyebrow>
-              <h2 className="text-foreground text-lg font-semibold tracking-tight">
-                CSV import
-              </h2>
-              <p className="text-muted-foreground max-w-md text-sm">
-                Drop in transactions exported from any bank — no API credentials required.
-              </p>
-            </div>
-          </div>
-          <ProviderScoreboard health={health} tone={tone} alwaysAvailable />
-        </div>
+        <ProviderCardHeader
+          icon={<FileSpreadsheet className="size-5" />}
+          iconClassName="bg-amber-500/10 text-amber-600 dark:text-amber-400"
+          title="CSV import"
+          description="Drop in transactions exported from any bank — no API credentials required."
+          trailing={
+            <ProviderScoreboard health={health} tone={tone} alwaysAvailable />
+          }
+        />
       </ColorRailCard>
 
       <SectionCard

--- a/web/src/features/providers/plaid-card.tsx
+++ b/web/src/features/providers/plaid-card.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ColorRailCard } from "@/components/color-rail-card";
-import { Eyebrow } from "@/components/eyebrow";
+import { ProviderCardHeader } from "@/components/provider-card-header";
 import { SectionCard } from "@/components/section-card";
 import { FormFooter } from "@/components/form-footer";
 import { IdPill } from "@/components/id-pill";
@@ -116,28 +116,16 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
   return (
     <div className="space-y-4">
       <ColorRailCard accent={providerToneAccent(tone)}>
-        <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
-          <div className="flex min-w-0 items-start gap-3">
-            <div className="bg-blue-500/10 text-blue-600 dark:text-blue-400 flex size-11 shrink-0 items-center justify-center rounded-lg">
-              <Building2 className="size-5" />
-            </div>
-            <div className="min-w-0 space-y-1">
-              <Eyebrow as="p" variant="page">
-                Provider
-              </Eyebrow>
-              <div className="flex items-center gap-2">
-                <h2 className="text-foreground text-lg font-semibold tracking-tight">
-                  Plaid
-                </h2>
-                <ProviderStatusBadge health={health} configured={config.configured} />
-              </div>
-              <p className="text-muted-foreground max-w-md text-sm">
-                Thousands of financial institutions across the US, Canada, and Europe.
-              </p>
-            </div>
-          </div>
-          <ProviderScoreboard health={health} tone={tone} />
-        </div>
+        <ProviderCardHeader
+          icon={<Building2 className="size-5" />}
+          iconClassName="bg-blue-500/10 text-blue-600 dark:text-blue-400"
+          title="Plaid"
+          description="Thousands of financial institutions across the US, Canada, and Europe."
+          badge={
+            <ProviderStatusBadge health={health} configured={config.configured} />
+          }
+          trailing={<ProviderScoreboard health={health} tone={tone} />}
+        />
       </ColorRailCard>
 
       <SectionCard

--- a/web/src/features/providers/teller-card.tsx
+++ b/web/src/features/providers/teller-card.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ColorRailCard } from "@/components/color-rail-card";
-import { Eyebrow } from "@/components/eyebrow";
+import { ProviderCardHeader } from "@/components/provider-card-header";
 import { SectionCard } from "@/components/section-card";
 import { FormFooter } from "@/components/form-footer";
 import { IdPill } from "@/components/id-pill";
@@ -140,28 +140,16 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
   return (
     <div className="space-y-4">
       <ColorRailCard accent={providerToneAccent(tone)}>
-        <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
-          <div className="flex min-w-0 items-start gap-3">
-            <div className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex size-11 shrink-0 items-center justify-center rounded-lg">
-              <Landmark className="size-5" />
-            </div>
-            <div className="min-w-0 space-y-1">
-              <Eyebrow as="p" variant="page">
-                Provider
-              </Eyebrow>
-              <div className="flex items-center gap-2">
-                <h2 className="text-foreground text-lg font-semibold tracking-tight">
-                  Teller
-                </h2>
-                <ProviderStatusBadge health={health} configured={config.configured} />
-              </div>
-              <p className="text-muted-foreground max-w-md text-sm">
-                US bank coverage via mutual-TLS authentication.
-              </p>
-            </div>
-          </div>
-          <ProviderScoreboard health={health} tone={tone} />
-        </div>
+        <ProviderCardHeader
+          icon={<Landmark className="size-5" />}
+          iconClassName="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+          title="Teller"
+          description="US bank coverage via mutual-TLS authentication."
+          badge={
+            <ProviderStatusBadge health={health} configured={config.configured} />
+          }
+          trailing={<ProviderScoreboard health={health} tone={tone} />}
+        />
       </ColorRailCard>
 
       <SectionCard


### PR DESCRIPTION
## Summary
- 26th shared v2 primitive: `<ProviderCardHeader>` extracts the icon-tile + eyebrow + title (+ optional badge) + description + trailing scoreboard slot that appears identically inside `<ColorRailCard>` on the Plaid, Teller, and CSV provider pages.
- Three near-byte-identical header blocks (~25 LOC each) collapse to a single prop-driven primitive (~95 LOC total → 3 × 9-LOC call sites).
- Pairs cleanly with iter 97's `<HeroGrid>` — both are body layers that sit inside `<ColorRailCard>` chrome.

## Screenshot

Visual output is byte-identical (pure refactor). Providers page renders all three cards with the new primitive:

![providers page with ProviderCardHeader](https://i.img402.dev/kef4erditx.jpg)

## Notes
- Visual contract preserved exactly: same flex wrapper (`flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7`), same icon tile (`size-11 rounded-lg`), same typography stack (Eyebrow `page` variant + `h2 text-lg font-semibold tracking-tight` + `text-muted-foreground max-w-md text-sm`).
- `badge` is an optional slot — CSV omits it because there are no credentials to gate.
- `iconClassName` carries the tone color so Plaid (blue), Teller (emerald), and CSV (amber) each keep their identity.
- Follow-up candidate: add a `<ProviderCardHeader>` specimen to `/v2/sandbox?section=components` alongside the existing HeroGrid + SearchInput + RowActionsMenu specimens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)