### PR TITLE
design(v2): retire 2 destructive dialogs onto ConfirmDialog

### DIFF
--- a/web/src/features/api-keys/api-keys-table.tsx
+++ b/web/src/features/api-keys/api-keys-table.tsx
@@ -1,16 +1,8 @@
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Ban, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Ban } from "lucide-react";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { DataTable } from "@/components/data-table";
 import { IdPill } from "@/components/id-pill";
 import { RowActionsMenu } from "@/components/row-actions-menu";
@@ -170,40 +162,17 @@ export function APIKeysTable({
         renderSkeletonRow={() => <APIKeyRowSkeleton revoked={revoked} />}
       />
 
-      <Dialog
+      <ConfirmDialog
         open={confirmRevoke !== null}
-        onOpenChange={(o) =>
-          !o && !revokeInFlight && setConfirmRevoke(null)
-        }
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Revoke "{confirmRevoke?.name}"?</DialogTitle>
-            <DialogDescription>
-              The next request using this key will be rejected. Existing
-              activity history is preserved, but the key can't be restored —
-              you'll need to mint a new one.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="ghost"
-              onClick={() => setConfirmRevoke(null)}
-              disabled={revokeInFlight}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={onConfirmRevoke}
-              disabled={revokeInFlight}
-            >
-              {revokeInFlight && <Loader2 className="size-4 animate-spin" />}
-              Revoke key
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={(o) => !o && setConfirmRevoke(null)}
+        icon={Ban}
+        title={`Revoke "${confirmRevoke?.name ?? ""}"?`}
+        description="The next request using this key will be rejected. Existing activity history is preserved, but the key can't be restored — you'll need to mint a new one."
+        confirmLabel="Revoke key"
+        pendingLabel="Revoking…"
+        pending={revokeInFlight}
+        onConfirm={onConfirmRevoke}
+      />
     </>
   );
 }

--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -1,20 +1,12 @@
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Loader2, Pencil, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Pencil, Trash2 } from "lucide-react";
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { DataTable } from "@/components/data-table";
 import { IdPill } from "@/components/id-pill";
 import { RowActionsMenu } from "@/components/row-actions-menu";
@@ -156,39 +148,17 @@ export function TagsTable({
         renderSkeletonRow={() => <TagRowSkeleton />}
       />
 
-      <Dialog
+      <ConfirmDialog
         open={confirmDelete !== null}
-        onOpenChange={(o) => !o && !del.isPending && setConfirmDelete(null)}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              Delete tag "{confirmDelete?.display_name}"?
-            </DialogTitle>
-            <DialogDescription>
-              The tag will be removed from every transaction it's attached to.
-              Activity history is preserved. This can't be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="ghost"
-              onClick={() => setConfirmDelete(null)}
-              disabled={del.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={onConfirmDelete}
-              disabled={del.isPending}
-            >
-              {del.isPending && <Loader2 className="size-4 animate-spin" />}
-              Delete tag
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={(o) => !o && setConfirmDelete(null)}
+        icon={Trash2}
+        title={`Delete tag "${confirmDelete?.display_name ?? ""}"?`}
+        description="The tag will be removed from every transaction it's attached to. Activity history is preserved. This can't be undone."
+        confirmLabel="Delete tag"
+        pendingLabel="Deleting…"
+        pending={del.isPending}
+        onConfirm={onConfirmDelete}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- `tags-table` (Delete tag) and `api-keys-table` (Revoke key) both hand-rolled a `Dialog` + `DialogHeader/Footer` + destructive `Button` with a `Loader2` spinner, when `ConfirmDialog` (iter 18) already exists and 8 other surfaces already speak its vocabulary (backups x3, household delete-member, plaid/teller cards, etc).
- Both surfaces now route through `<ConfirmDialog>`. They inherit the canonical tone-tinted icon tile (`Trash2` / `Ban`) + Cancel/primary footer + pending-state spinner + block-close-during-mutation behaviour for free, and lose ~40 LOC of duplicate Dialog markup.

## Before / After

Tags — delete confirmation:

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/gt8kvzxois.jpg) | ![after](https://i.img402.dev/x93o6op7hg.jpg) |

API keys — revoke confirmation:

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/rnch6ahaqw.jpg) | ![after](https://i.img402.dev/hr5bxtonsh.jpg) |

## Notes
- 10th and 11th `ConfirmDialog` consumers. Two open-coded destructive `Dialog`s remaining in `web/src/` are both centered-modal *form* surfaces (`household-section` Add/CreateLogin/ShareLink), not confirmations — they don't belong here.
- No primitive changes; pure consumer migration.
- Wins: the tone-tinted destructive icon tile reads the dialog's intent at a glance (no longer relying on the red "Revoke key" / "Delete tag" button text alone); destructive vs default tone now encoded by an icon tile, parallel to every other v2 destructive confirmation.

Generated with [Claude Code](https://claude.com/claude-code)
