### PR TITLE
design(v2): promote ComingSoonPill primitive

### DIFF
--- a/web/src/components/coming-soon-pill.tsx
+++ b/web/src/components/coming-soon-pill.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { Clock, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * ComingSoonPill — the canonical muted "Coming soon" status pill rendered
+ * in the trailing slot of a `<StatusPanel tone="info">` for unbuilt
+ * surfaces.
+ *
+ * Vocabulary: muted background + muted-foreground label, fully-rounded
+ * pill (`rounded-full`), `px-2.5 py-1 text-[11px]`, uppercase + wide
+ * tracking, leading `Clock` icon at `size-3`. Distinct from the iter-37
+ * `<Eyebrow>` (no chip, used as a section/page micro-label) and from
+ * shadcn `<Badge>` (rectangular, semantic-tone variants) — this is a
+ * neutral inline status chip whose only job is to caption "not yet."
+ *
+ * Two consumers share it today: `routes/placeholder.tsx` (the canonical
+ * unbuilt-nav-leaf shell, iter 21) and `components/settings-shell.tsx`
+ * (the in-the-works settings section panel, iter 78). Both previously
+ * hand-rolled a 10-class span — promoted in iter 102 so the pill shape,
+ * padding, and rhythm live in one place. Sibling of `<JumpToPill>` in
+ * the iter-30 "primary-tinted pill triad" drift note: when a new
+ * surface needs the muted variant, reach for this; when it needs the
+ * primary-tinted v2-chip variant, that one is still inlined in
+ * `BrandHeader` / `AuthShell` until the third surface adopts it.
+ *
+ * `icon` defaults to `Clock` (matches both live consumers); pass a
+ * different `LucideIcon` if a new caller wants a different leading
+ * glyph without losing the chip rhythm. `children` is the label —
+ * keep it short ("Coming soon", "In review", "Beta"). If a non-muted
+ * tone is ever needed, add a `tone` prop here rather than forking the
+ * className — keep the vocabulary in one file.
+ */
+export interface ComingSoonPillProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Leading lucide icon; defaults to `Clock`. */
+  icon?: LucideIcon;
+  /** The pill label — defaults to "Coming soon". */
+  children?: React.ReactNode;
+}
+
+export function ComingSoonPill({
+  icon: Icon = Clock,
+  className,
+  children = "Coming soon",
+  ...rest
+}: ComingSoonPillProps) {
+  return (
+    <span
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase",
+        className,
+      )}
+      {...rest}
+    >
+      <Icon className="size-3" />
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { Clock, Hammer } from "lucide-react";
+import { Hammer } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -23,6 +23,7 @@ import { BackupsSection } from "@/features/settings/backups-section";
 import { HouseholdSection } from "@/features/settings/household-section";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
 import { StatusPanel } from "@/components/status-panel";
+import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { Eyebrow } from "@/components/eyebrow";
 
 const SETTINGS_MODAL_KEY = "settings";
@@ -223,12 +224,7 @@ function SectionContent({ section }: { section: SettingsSection }) {
         icon={Hammer}
         heading={`${section.title} settings are in the works`}
         body="We're still building this surface. The configuration that lives here will land in a follow-up PR — for now, the panel is wired but empty."
-        trailing={
-          <span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase">
-            <Clock className="size-3" />
-            Coming soon
-          </span>
-        }
+        trailing={<ComingSoonPill />}
       />
     </div>
   );

--- a/web/src/routes/placeholder.tsx
+++ b/web/src/routes/placeholder.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowRight,
-  Clock,
   FileText,
   Hammer,
   type LucideIcon,
@@ -8,6 +7,7 @@ import {
 } from "lucide-react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
+import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { JumpToPill } from "@/components/jump-to-pill";
 import { PageHeader } from "@/components/page-header";
 import { SectionCard } from "@/components/section-card";
@@ -168,12 +168,7 @@ export function Placeholder({ title }: { title: string }) {
               ? "We're still building this surface. The plan below sketches the shape it'll take — follow the related pages for the data that's live today."
               : "This page is part of the v2 admin shell. The full implementation lands in a follow-up PR."
           }
-          trailing={
-            <span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase">
-              <Clock className="size-3" />
-              Coming soon
-            </span>
-          }
+          trailing={<ComingSoonPill />}
         />
 
         {hasPlan && (

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -28,6 +28,7 @@ import {
   Search,
   Shapes,
   ShieldAlert,
+  Sparkles,
   Sun,
   Tag,
   Trash2,
@@ -71,6 +72,7 @@ import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
 import { ActionPill } from "@/components/action-pill";
+import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { JumpToPill, JumpToRow } from "@/components/jump-to-pill";
 import { RowActionsMenu } from "@/components/row-actions-menu";
 import {
@@ -600,6 +602,25 @@ export function ComponentsSection() {
               Re-authenticate
             </ActionPill>
           </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="ComingSoonPill"
+        code="components/coming-soon-pill"
+        description="The canonical muted 'Coming soon' status pill rendered in the trailing slot of a `<StatusPanel tone='info'>` for unbuilt surfaces. Fully-rounded pill (`rounded-full`) with muted background + muted-foreground label, `px-2.5 py-1 text-[11px]` uppercase + wide tracking, leading `Clock` icon at `size-3`. Two consumers today: `routes/placeholder.tsx` (the unbuilt-nav-leaf shell, iter 21) and `components/settings-shell.tsx` (the in-the-works settings panel, iter 78) — both previously hand-rolled the 10-class span. Distinct from `<Eyebrow>` (no chip; section/page micro-label) and shadcn `<Badge>` (rectangular, semantic-tone variants). Pass a different `icon` to swap the leading glyph without losing the rhythm; pass `children` to override the label. Promoted in iter 102."
+        className="block"
+      >
+        <div className="flex flex-col gap-3 rounded-lg border p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <ComingSoonPill />
+            <ComingSoonPill icon={Sparkles}>Beta</ComingSoonPill>
+            <ComingSoonPill icon={Wand2}>In review</ComingSoonPill>
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Default leading icon is <code>Clock</code>. Override with the
+            <code> icon</code> prop and the label via <code>children</code>.
+          </p>
         </div>
       </Specimen>
 


### PR DESCRIPTION
## Summary

- Retired the byte-identical 10-class "Coming soon" pill span (settings-shell + placeholder) onto a shared `<ComingSoonPill>` primitive at `web/src/components/coming-soon-pill.tsx`.
- Same visual contract — muted fill, fully-rounded, `text-[11px]` uppercase wide tracking, leading `Clock size-3` — but in one place. `icon` and `children` props admit future glyph/label swaps without forking the className.
- Sandbox specimen registered at `/v2/sandbox?section=components` (after `<ActionPill>`) so the muted inline-status vocabulary lives next to the sibling `JumpToPill` / `ActionPill` chips. Three preview chips show the default, an icon override (`Sparkles` + "Beta"), and a label override ("In review").

28th shared primitive in the v2 vocabulary.

## Screenshots (after — visual output is preserved; the win is in code)

**Placeholder `/v2/reports`** — "Coming soon" pill in the StatusPanel trailing slot.

![placeholder](https://i.img402.dev/oicoe0c5dp.jpg)

**Settings → Security pane** — same pill, same trailing slot, now sourced from the same primitive.

![settings](https://i.img402.dev/riiqgm0mz1.jpg)

**Sandbox specimen** — default + override variants.

![sandbox](https://i.img402.dev/af9mh4doeb.jpg)

## Notes

- The iter-30 drift note flagged that the *primary-tinted* pill recipe (V2 chip in `BrandHeader` + `AuthShell`, admin role pill in `NavUser`) should promote to a `<PrimaryPill>` when a fourth surface adopts. That's a separate primitive — this one covers the muted variant. The two pill recipes carry different signal (primary = brand/version/role chrome, muted = "not yet"), so they should stay separate primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)