### PR TITLE
fix(v2): expose Teller app id on reauth response so reconnect Sheet works

### DIFF
--- a/internal/api/connections_reauth.go
+++ b/internal/api/connections_reauth.go
@@ -19,9 +19,14 @@ import (
 // POST /api/v1/connections/{id}/reauth. Mirrors the admin
 // linkTokenResponse field-for-field so SDK clients see one contract for
 // link-token issuance regardless of which surface called it.
+//
+// ApplicationID is Teller-specific: Teller Connect needs both the app id
+// and the existing enrollment id (carried in LinkToken) to launch in
+// reconnection mode. Plaid leaves it empty.
 type reauthLinkTokenResponse struct {
-	LinkToken  string `json:"link_token"`
-	Expiration string `json:"expiration"`
+	LinkToken     string `json:"link_token"`
+	Expiration    string `json:"expiration"`
+	ApplicationID string `json:"application_id,omitempty"`
 }
 
 // ConnectionReauthHandler serves POST /api/v1/connections/{id}/reauth.
@@ -71,8 +76,9 @@ func ConnectionReauthHandler(a *app.App) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, reauthLinkTokenResponse{
-			LinkToken:  session.Token,
-			Expiration: session.Expiry.Format("2006-01-02T15:04:05Z"),
+			LinkToken:     session.Token,
+			Expiration:    session.Expiry.Format("2006-01-02T15:04:05Z"),
+			ApplicationID: session.ApplicationID,
 		})
 	}
 }

--- a/internal/api/connections_reauth_integration_test.go
+++ b/internal/api/connections_reauth_integration_test.go
@@ -164,6 +164,9 @@ func TestConnectionReauth_Success(t *testing.T) {
 	if body.Expiration != "2030-01-02T03:04:05Z" {
 		t.Errorf("want expiration %q, got %q", "2030-01-02T03:04:05Z", body.Expiration)
 	}
+	if body.ApplicationID != "" {
+		t.Errorf("want empty application_id for plaid, got %q", body.ApplicationID)
+	}
 	if env.Provider.reauthCalls != 1 {
 		t.Errorf("want 1 provider call, got %d", env.Provider.reauthCalls)
 	}
@@ -263,6 +266,42 @@ func TestConnectionReauthComplete_NotFound(t *testing.T) {
 	env := setupReauthEnv(t, "full_access")
 	resp := env.doPost(t, "/api/v1/connections/00000000-0000-0000-0000-000000000000/reauth-complete")
 	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestConnectionReauth_TellerReturnsApplicationID guards the v2 SPA's
+// re-auth path: Teller Connect can't bootstrap reconnection mode without
+// both the existing enrollment id (LinkToken) and the configured
+// application id. The reauth handler must surface ApplicationID untouched
+// so the SPA can launch the SDK without falling back to a window global.
+func TestConnectionReauth_TellerReturnsApplicationID(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	tellerFake := &fakeProvider{
+		name: "teller",
+		reauthSession: provider.LinkSession{
+			Token:         "enrollment-from-conn-external-id",
+			ApplicationID: "app_test_teller_123",
+			Expiry:        time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+		},
+	}
+	env.App.Providers["teller"] = tellerFake
+
+	user := testutil.MustCreateUser(t, env.Queries, "Tess")
+	conn := testutil.MustCreateTellerConnection(t, env.Queries, user.ID, "ext_teller_reauth")
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body reauthLinkTokenResponse
+	parseJSON(t, resp, &body)
+	if body.LinkToken != "enrollment-from-conn-external-id" {
+		t.Errorf("want link_token %q, got %q", "enrollment-from-conn-external-id", body.LinkToken)
+	}
+	if body.ApplicationID != "app_test_teller_123" {
+		t.Errorf("want application_id %q, got %q", "app_test_teller_123", body.ApplicationID)
+	}
+	if tellerFake.reauthCalls != 1 {
+		t.Errorf("want 1 teller provider call, got %d", tellerFake.reauthCalls)
+	}
 }
 
 func TestConnectionReauth_RequiresWriteScope(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,6 +37,10 @@ type Provider interface {
 type LinkSession struct {
 	Token  string
 	Expiry time.Time
+	// ApplicationID is populated by Teller's reauth flow so the SPA can boot
+	// Teller Connect with both the configured app id and the existing
+	// enrollment id (carried in Token). Other providers leave it empty.
+	ApplicationID string
 }
 
 type Connection struct {

--- a/internal/provider/teller/reauth.go
+++ b/internal/provider/teller/reauth.go
@@ -8,10 +8,12 @@ import (
 	"breadbox/internal/provider"
 )
 
-// CreateReauthSession returns the enrollment ID as the link token for
-// Teller Connect reconnection mode. No API call is needed.
+// CreateReauthSession returns the enrollment ID as the link token plus the
+// configured application id, both needed to boot Teller Connect in
+// reconnection mode. No API call is needed.
 func (p *TellerProvider) CreateReauthSession(ctx context.Context, conn provider.Connection) (provider.LinkSession, error) {
 	return provider.LinkSession{
-		Token: conn.ExternalID,
+		Token:         conn.ExternalID,
+		ApplicationID: p.appID,
 	}, nil
 }

--- a/web/src/api/queries/connections.ts
+++ b/web/src/api/queries/connections.ts
@@ -249,9 +249,9 @@ export function useCsvImport() {
 //   - Plaid replies with {link_token, expiration} — pass link_token straight
 //     to PlaidLinkButton, which runs Plaid Link in update mode when given an
 //     update-mode token.
-//   - Teller replies with {link_token: <enrollment_id>} — the v1 reauth flow
-//     reuses the enrollment_id as the "token". TellerConnectButton accepts it
-//     as `enrollmentId` to launch Connect in reconnection mode.
+//   - Teller replies with {link_token: <enrollment_id>, application_id} —
+//     enrollment_id pins Teller Connect to the existing connection (reconnect
+//     mode); application_id boots the SDK. Both are needed.
 //   - CSV has no concept of re-auth — the dispatcher returns an error there.
 export function useReauthStart() {
   return useMutation({

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -219,11 +219,15 @@ export interface ProviderInfo {
 
 // --- Connect: link-session response (POST /providers/{name}/link-session) ---
 // Returned by providers that need a server-issued init token (Plaid today).
-// Providers without one (Teller, CSV) get a 204 — surfaced here as a null
-// result.
+// Providers without one (CSV) get a 204 — surfaced here as a null result.
+// Teller's connect-flow response carries the configured app id as
+// `link_token`; the Teller-reauth response (POST /connections/{id}/reauth)
+// carries the enrollment id as `link_token` and the app id as the optional
+// `application_id` so Teller Connect can boot in reconnection mode.
 export interface LinkSession {
   link_token: string;
   expiration: string;
+  application_id?: string;
 }
 
 // --- Connect: connection-create envelope (POST /connections) ---

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -28,11 +28,13 @@ interface ReauthSheetProps {
 // launch, Teller reconnection-mode launch, and the post-success completion
 // call. CSV connections never reach here in practice (the Connect/Detail
 // pages don't surface a re-auth affordance for them) but we render an N/A
-// stage for hand-crafted URLs rather than crash.
+// stage for hand-crafted URLs rather than crash. Teller needs both the
+// enrollment id (carries the existing connection) and the application id
+// (boots Teller Connect); both ride on the reauth response.
 type Stage =
   | { kind: "confirm" }
   | { kind: "plaid"; linkToken: string }
-  | { kind: "teller"; enrollmentId: string }
+  | { kind: "teller"; enrollmentId: string; applicationId: string }
   | { kind: "completing" }
   | { kind: "unsupported"; reason: string };
 
@@ -103,7 +105,18 @@ export function ReauthSheet({
       if (conn.provider === "plaid") {
         setStage({ kind: "plaid", linkToken: session.link_token });
       } else if (conn.provider === "teller") {
-        setStage({ kind: "teller", enrollmentId: session.link_token });
+        const applicationId = session.application_id ?? "";
+        if (!applicationId) {
+          toast.error(
+            "Teller application id is not configured on this server.",
+          );
+          return;
+        }
+        setStage({
+          kind: "teller",
+          enrollmentId: session.link_token,
+          applicationId,
+        });
       } else {
         setStage({
           kind: "unsupported",
@@ -147,14 +160,6 @@ export function ReauthSheet({
     }
     setStage({ kind: "confirm" });
   }
-
-  // The Teller application id comes from a window global injected by the
-  // Vite shell, mirroring the Connect-bank Sheet. Without it Teller Connect
-  // can't bootstrap.
-  const tellerAppId =
-    (typeof window !== "undefined" &&
-      (window as Window & { __TELLER_APP_ID__?: string }).__TELLER_APP_ID__) ||
-    "";
 
   return (
     <Sheet open={open} onOpenChange={handleSheetChange}>
@@ -222,7 +227,7 @@ export function ReauthSheet({
               "enroll". */}
           {stage.kind === "teller" && (
             <TellerConnectButton
-              applicationId={tellerAppId}
+              applicationId={stage.applicationId}
               enrollmentId={stage.enrollmentId}
               onSuccess={() => completeReauth()}
               onExit={() => onProviderExit(null)}


### PR DESCRIPTION
## Summary

PR #1114 already shipped half of this fix — Teller **connect** in v2. The other half (Teller **reauth** in v2) was left as a TODO in #1114's PR body. This is that follow-up.

Symptom: clicking *Reconnect* on a Teller connection that's `pending_reauth` does nothing — the Teller Connect popup never opens. `reauth-sheet.tsx` was reading `window.__TELLER_APP_ID__`, a global nobody sets, exactly the same dead-global bug PR #1114 fixed for the connect path.

Why the reauth path can't just reuse #1114's fix: for connect, `link_token` IS the Teller app id (Teller has no server-issued session token). For reauth, `link_token` is the existing enrollment id (it pins Teller Connect to the broken connection so the user re-enters credentials for *that* enrollment). Teller Connect's `setup({applicationId, enrollmentId})` needs **both**, so the reauth response has to carry the app id as a second field.

Changes:
- `internal/provider/provider.go`: add optional `ApplicationID` to `LinkSession`.
- `internal/provider/teller/reauth.go`: populate `ApplicationID: p.appID` (Plaid leaves it empty).
- `internal/api/connections_reauth.go`: add `application_id` (omitempty) to the response.
- `web/src/api/types.ts`: add `application_id?: string` to `LinkSession`.
- `web/src/features/connections/reauth-sheet.tsx`: drop the `__TELLER_APP_ID__` global; read `session.application_id` and surface an error toast if the server isn't configured.
- Integration test asserting Teller reauth returns `application_id` (and a regression-pin asserting Plaid still doesn't).

#1112 is superseded — its connect-flow half is already in main via #1114, and its CI was failing on an older base. Closing it.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean.
- [x] `DATABASE_URL=... go test -tags=integration -count=1 -p 1 -run='TestConnectionReauth' ./internal/api/` — all reauth tests pass, including the new `TestConnectionReauth_TellerReturnsApplicationID`.
- [x] `DATABASE_URL=... go test -tags=integration -count=1 -p 1 ./internal/provider/... ./internal/api/` clean.
- [x] `bun run lint` (tsc) + `bun run build` clean.
- [ ] Manual: with a Teller connection in `pending_reauth`, open the v2 connections page → ⋯ → Reconnect → confirm Teller Connect opens in reconnection mode and re-auth completes. (Could not reproduce locally without a Teller `pending_reauth` connection on hand — flagging for Ricardo to verify against his stuck Teller flow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
