### PR TITLE
design(v2): pending vocabulary for TransactionAmount + TransactionPrimary

### DIFF
--- a/web/src/components/transaction-amount.tsx
+++ b/web/src/components/transaction-amount.tsx
@@ -8,20 +8,31 @@ interface TransactionAmountProps {
 }
 
 // TransactionAmount is the reusable right-aligned amount block — the signed
-// amount with the transaction date beneath it. Inflows (negative amounts)
-// render in the success color.
+// amount with the transaction date beneath it.
+//
+// Sign vocabulary: inflows (negative amounts) render in the success color.
+//
+// Pending vocabulary (iter 103): when the transaction has not posted yet
+// (`t.pending`), the amount renders italic + at 70% opacity so a scanning eye
+// reads the row as tentative. Pairs with the `Pending` `<MetaBadge>` in
+// `<TransactionPrimary>` — once a row is settled the visual settles down too.
+// Title attribute carries the contract for keyboard/sighted hover; the badge
+// alongside the description carries the screen-reader text.
 export function TransactionAmount({
   transaction: t,
   className,
 }: TransactionAmountProps) {
   const isInflow = t.amount < 0;
+  const isPending = t.pending;
   return (
     <div className={cn("text-right whitespace-nowrap", className)}>
       <div
         className={cn(
           "font-medium tabular-nums",
           isInflow && "text-success",
+          isPending && "italic opacity-70",
         )}
+        title={isPending ? "Pending — amount may change once posted" : undefined}
       >
         {formatAmount(t.amount, t.iso_currency_code)}
       </div>

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -1,5 +1,6 @@
-import { Tag as TagIcon } from "lucide-react";
+import { Clock, Tag as TagIcon } from "lucide-react";
 import { CategoryIconTile } from "@/components/category-icon-tile";
+import { MetaBadge } from "@/components/meta-badge";
 import { TagList } from "@/components/tag-chip";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
@@ -13,6 +14,13 @@ interface TransactionPrimaryProps {
 // category icon tile, the bank description as the title with an inline
 // "Pending" marker, and a secondary line of metadata (account · member · tags).
 // Shared by the transactions table and any future transaction list.
+//
+// Pending vocabulary (iter 103): the inline "Pending" marker now rides
+// `<MetaBadge muted icon={Clock}>` so it reads as part of the v2
+// secondary-state chip family (System / Hidden / Excluded / Linked / Re-auth)
+// instead of an orphan muted span. Pairs with the italic + opacity
+// treatment in `<TransactionAmount>` so both columns communicate
+// "not yet settled" at a glance.
 export function TransactionPrimary({
   transaction: t,
   className,
@@ -28,9 +36,9 @@ export function TransactionPrimary({
         <div className="flex items-center gap-1.5">
           <span className="truncate font-medium">{t.provider_name}</span>
           {t.pending && (
-            <span className="text-muted-foreground shrink-0 text-xs">
+            <MetaBadge muted icon={Clock} className="shrink-0">
               Pending
-            </span>
+            </MetaBadge>
           )}
         </div>
         <TransactionMeta transaction={t} />

--- a/web/src/sandbox/sections/amounts.tsx
+++ b/web/src/sandbox/sections/amounts.tsx
@@ -178,7 +178,7 @@ export function AmountsSection() {
       <Specimen
         label="TransactionAmount"
         code="components/transaction-amount"
-        description="The reusable amount block — signed amount over its date, right-aligned, tabular figures. Inflows pick up the success color automatically."
+        description="The reusable amount block — signed amount over its date, right-aligned, tabular figures. Inflows pick up the success color automatically. Pending transactions render italic at 70% opacity so the column reads as tentative until the row settles (pairs with the `Pending` `MetaBadge` chip in `TransactionPrimary`)."
         className="block divide-y"
       >
         {AMOUNT_ROWS.map((t) => (


### PR DESCRIPTION
## Summary

Pairs the two reusable transaction-row blocks so a row visually reads as tentative until it settles.

- `TransactionAmount` renders **italic + opacity-70** when `t.pending`, with `title="Pending — amount may change once posted"` for hover/keyboard. Inflow success color still wins on tone.
- `TransactionPrimary` upgrades the bare `Pending` muted span to `<MetaBadge muted icon={Clock}>Pending</MetaBadge>` so the chip reads as part of the v2 secondary-state vocabulary (System / Hidden / Excluded / Linked / Re-auth) instead of an orphan text fragment.
- Sandbox `Amounts` specimen description updated to document the pending treatment; existing fixture already includes a pending row so the live demo picks up the new vocabulary for free.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/s6tt10vbyn.jpg) | ![after](https://i.img402.dev/ye8qspdo47.jpg) |

The top three rows (Domino's Pizza, Century Link, Zelle Payment) are all pending — both the amount column (italic + dimmed) and the chip in the description column now communicate "not yet settled". Settled rows render exactly as before.

## Notes

- No new primitive — both blocks already existed and `<MetaBadge>` is the canonical chip for low-emphasis secondary state. Pure consumer migration.
- Visual rhythm now consistent across both columns: the amount column communicates settlement status without forcing the eye back to the description column.
- Future surfaces that render a transaction list pick up the treatment for free (every row already routes through the two shared blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)