### PR TITLE
design(v2): SyncHistoryList onto TimelineRail (+ destructive tone)

### DIFF
--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -97,13 +97,18 @@ function TimelineRailGroup({
 // look — switch to a tinted variant when the event carries a clear
 // semantic role (sync, rule fire, classification change, etc.). Tones
 // adapt to light/dark themes via the standard shadcn vocabulary
-// (primary / emerald / amber / sky) used elsewhere in v2 (StatusPanel,
-// ColorRailCard, MetaBadge). Iter 93.
+// (primary / emerald / amber / sky / destructive) used elsewhere in v2
+// (StatusPanel, ColorRailCard, MetaBadge). Iter 93; `destructive` added
+// in iter 105 to give sync-history rows a "this run failed" disc accent
+// that matches StatusPanel's destructive vocabulary — `warning` (amber)
+// is the wrong colour for an *errored* sync run; it belongs to "tag
+// removed" / "soft warning" semantics.
 type TimelineRailTone =
   | "neutral"
   | "primary"
   | "success"
   | "warning"
+  | "destructive"
   | "info"
   | "muted";
 
@@ -118,6 +123,10 @@ const TONE_CLASSES: Record<TimelineRailTone, string> = {
   primary: "border-primary/40 text-primary",
   success: "border-emerald-500/40 text-emerald-600 dark:text-emerald-400",
   warning: "border-amber-500/40 text-amber-600 dark:text-amber-400",
+  // `destructive` matches StatusPanel / ColorRailCard's destructive tone
+  // (failed-state vocabulary). Use for hard failure rows (errored sync
+  // runs, failed rule runs) — distinct from `warning` (soft / removed).
+  destructive: "border-destructive/40 text-destructive",
   info: "border-sky-500/40 text-sky-600 dark:text-sky-400",
   muted: "border-border/60 text-muted-foreground/70",
 };

--- a/web/src/features/connections/sync-history-list.tsx
+++ b/web/src/features/connections/sync-history-list.tsx
@@ -1,6 +1,16 @@
-import { Check, Loader2, RefreshCw, X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { useMemo } from "react";
+import {
+  AlertCircle,
+  Check,
+  Loader2,
+  RefreshCw,
+  type LucideIcon,
+} from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
+import {
+  TimelineRail,
+  type TimelineRailTone,
+} from "@/components/timeline-rail";
 import { relativeTime } from "./connection-utils";
 import type { SyncLog } from "@/api/queries/sync-logs";
 
@@ -8,13 +18,73 @@ interface SyncHistoryListProps {
   logs: SyncLog[];
 }
 
-const STATUS_TILE: Record<string, string> = {
-  success: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-  error: "bg-destructive/10 text-destructive",
-  in_progress: "bg-primary/10 text-primary",
+// Sync-history rows speak the same TimelineRail vocabulary as the
+// transaction-detail activity feed (iter 26 + iter 93). Status maps to
+// tone so the disc accent reads at a glance — no need to parse the
+// status text to find the failed runs.
+//   - success     → success    (emerald — run landed cleanly)
+//   - error       → destructive(red    — hard failure, demands action)
+//   - in_progress → primary    (run is mid-flight; spinner reinforces)
+// Iter 105 added the `destructive` tone to TimelineRail specifically so
+// errored sync runs don't have to fall back to the softer amber/warning
+// tint used for "tag removed" / soft-warning vocabulary.
+const STATUS_TONE: Record<string, TimelineRailTone> = {
+  success: "success",
+  error: "destructive",
+  in_progress: "primary",
 };
 
+const STATUS_ICON: Record<string, LucideIcon> = {
+  success: Check,
+  error: AlertCircle,
+  in_progress: Loader2,
+};
+
+const dayHeadingFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+
+function dayLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (d.toDateString() === today.toDateString()) return "Today";
+  if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return dayHeadingFormatter.format(d);
+}
+
+interface DayGroup {
+  label: string;
+  rows: SyncLog[];
+}
+
+// Buckets newest-first sync logs into calendar days, preserving order
+// within each day. Logs without any timestamp fall under an "Unknown
+// time" group so they don't silently drop. Mirrors the
+// activity-timeline `groupByDay` shape so the two feeds read as one
+// system.
+function groupByDay(logs: SyncLog[]): DayGroup[] {
+  const groups: DayGroup[] = [];
+  for (const log of logs) {
+    const ts = log.completed_at ?? log.started_at ?? null;
+    const label = ts ? dayLabel(ts) : "Unknown time";
+    const tail = groups[groups.length - 1];
+    if (tail && tail.label === label) {
+      tail.rows.push(log);
+    } else {
+      groups.push({ label, rows: [log] });
+    }
+  }
+  return groups;
+}
+
 export function SyncHistoryList({ logs }: SyncHistoryListProps) {
+  const groups = useMemo(() => groupByDay(logs), [logs]);
+
   if (logs.length === 0) {
     return (
       <EmptyState
@@ -27,17 +97,23 @@ export function SyncHistoryList({ logs }: SyncHistoryListProps) {
   }
 
   return (
-    <div className="divide-border/40 divide-y">
-      {logs.map((log) => (
-        <SyncHistoryRow key={log.id} log={log} />
+    <TimelineRail>
+      {groups.map((group) => (
+        <TimelineRail.Group key={group.label} label={group.label}>
+          {group.rows.map((log) => (
+            <SyncHistoryRow key={log.id} log={log} />
+          ))}
+        </TimelineRail.Group>
       ))}
-    </div>
+    </TimelineRail>
   );
 }
 
 function SyncHistoryRow({ log }: { log: SyncLog }) {
   const ts = log.completed_at ?? log.started_at ?? null;
-  const tile = STATUS_TILE[log.status] ?? STATUS_TILE.in_progress;
+  const tone = STATUS_TONE[log.status] ?? "neutral";
+  const Icon = STATUS_ICON[log.status] ?? RefreshCw;
+  const spin = log.status === "in_progress";
   const counts = formatCounts(log);
   const errorMessage =
     log.status === "error"
@@ -45,42 +121,42 @@ function SyncHistoryRow({ log }: { log: SyncLog }) {
       : null;
 
   return (
-    <div className="flex gap-3 py-3">
-      <div className={cn("flex size-6 shrink-0 items-center justify-center rounded-full", tile)}>
-        {log.status === "success" ? (
-          <Check className="size-3" />
-        ) : log.status === "error" ? (
-          <X className="size-3" />
-        ) : (
-          <Loader2 className="size-3 animate-spin" />
-        )}
-      </div>
-      <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
-        <div className="min-w-0">
+    <TimelineRail.Row
+      icon={Icon}
+      tone={tone}
+      iconClassName={spin ? "[&>svg]:animate-spin" : undefined}
+    >
+      <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
+        <div className="min-w-0 space-y-0.5">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-medium capitalize">{log.trigger}</span>
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {ts ? relativeTime(ts) : ""}
+            <span className="text-sm font-medium capitalize">
+              {log.trigger}
             </span>
             {log.duration && (
-              <span className="text-muted-foreground bg-muted/60 rounded-full px-1.5 py-0.5 text-[0.6rem] tabular-nums">
+              <span className="text-muted-foreground bg-muted/60 rounded-full px-1.5 py-0.5 text-[10px] tabular-nums">
                 {log.duration}
               </span>
             )}
           </div>
+          <p className="text-muted-foreground text-xs tabular-nums">
+            {ts ? relativeTime(ts) : "Unknown time"}
+          </p>
           {errorMessage && (
-            <p className="text-destructive/80 mt-0.5 truncate text-xs" title={log.error_message ?? errorMessage}>
+            <p
+              className="text-destructive/80 mt-1 text-xs"
+              title={log.error_message ?? errorMessage}
+            >
               {errorMessage}
             </p>
           )}
         </div>
         {counts && (
-          <div className="text-muted-foreground shrink-0 text-xs tabular-nums">
+          <div className="text-muted-foreground shrink-0 pt-0.5 text-xs tabular-nums">
             {counts}
           </div>
         )}
       </div>
-    </div>
+    </TimelineRail.Row>
   );
 }
 

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -24,6 +24,7 @@ import {
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TimelineRail } from "@/components/timeline-rail";
 import { EmptyState } from "@/components/empty-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { StatusPanel } from "@/components/status-panel";
@@ -508,11 +509,18 @@ function DetailBody({
             }
           >
             {syncLogsLoading ? (
-              <div className="space-y-2">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <Skeleton key={i} className="h-12 w-full" />
-                ))}
-              </div>
+              // Skeleton mirrors the TimelineRail geometry the loaded
+              // state renders into — disc punched through the rail line,
+              // headline + timestamp lines to the right — so the layout
+              // doesn't shift when sync logs land. Iter 105.
+              <TimelineRail>
+                <TimelineRail.Group>
+                  <TimelineRail.RowSkeleton />
+                  <TimelineRail.RowSkeleton />
+                  <TimelineRail.RowSkeleton />
+                  <TimelineRail.RowSkeleton />
+                </TimelineRail.Group>
+              </TimelineRail>
             ) : (
               <SyncHistoryList logs={syncLogs} />
             )}

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
 import {
+  AlertCircle,
   AlertTriangle,
   ArrowUpRight,
   Check,
@@ -1247,7 +1248,7 @@ export function ComponentsSection() {
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
-        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Each row accepts a semantic `tone` (`neutral` · `primary` · `success` · `warning` · `info` · `muted`, iter 93) that tints the disc border + icon so the eye can pick out rule fires, classification changes, and sync events without parsing the summary line. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
+        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Each row accepts a semantic `tone` (`neutral` · `primary` · `success` · `warning` · `destructive` · `info` · `muted`, iter 93; `destructive` added iter 105 for sync-history errored runs) that tints the disc border + icon so the eye can pick out rule fires, classification changes, and sync events without parsing the summary line. Used by the transaction-detail activity feed and the per-connection sync-history feed."
         className="block"
       >
         <div className="grid gap-6 max-w-3xl sm:grid-cols-2">
@@ -1308,6 +1309,14 @@ export function ComponentsSection() {
                 </p>
                 <p className="text-muted-foreground mt-1 text-[11px]">
                   Yesterday at 4:00 PM
+                </p>
+              </TimelineRail.Row>
+              <TimelineRail.Row icon={AlertCircle} tone="destructive">
+                <p className="text-sm leading-snug">
+                  Sync from Chase failed — credentials expired
+                </p>
+                <p className="text-muted-foreground mt-1 text-[11px]">
+                  Yesterday at 3:58 PM
                 </p>
               </TimelineRail.Row>
               <TimelineRail.Row icon={MessageSquare} muted>


### PR DESCRIPTION
## Summary
- Migrates per-connection Sync history feed onto `<TimelineRail>` with day-group headings — second timeline-shaped surface in v2 now speaks the iter-26 TimelineRail vocabulary instead of forking its own row geometry.
- Adds a `destructive` tone to `TimelineRailTone` (parity with StatusPanel / ColorRailCard) so errored sync runs read in destructive-red rather than the softer amber `warning` already taken by `tag_removed`.
- Loading state in connection-detail swaps four generic Skeleton blocks for `<TimelineRail.RowSkeleton>`s so the loaded data lands without a layout jump.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/ut8u28bwxf.jpg) | ![after](https://i.img402.dev/crp4jtyuqq.jpg) |

## Notes
- Iter-93 `KIND_TONE` pattern carries over: per-status tones live in a small `STATUS_TONE` record so future status values get a one-line addition rather than a deep edit.
- `error` rows now route through the new `destructive` tone (red disc + icon) — distinct from the amber `warning` tone reserved for "soft / removed" semantics (`tag_removed`). The previous flat list could only signal status via the small left-aligned icon tile, and an errored sync's destructive-red tile got lost in the divider-only row chrome. The TimelineRail rail + disc + day-group heading makes the failure clusters visible at a glance.
- `in_progress` rows route to the `primary` tone and the spinner reinforces motion (passing `[&>svg]:animate-spin` via `iconClassName` so the disc target the Lucide svg child without forking the primitive).
- Loading skeleton now uses `<TimelineRail.RowSkeleton>` so the disc + rail are visible during load — same vocabulary as the transaction-detail Activity feed.
- Day-group bucketing matches `groupByDay` in `activity-timeline.tsx` exactly so the two feeds read as one system. "Today" / "Yesterday" / weekday-month-day labels live in a tiny duplicate `dayLabel` until a third surface promotes the helper.
- Sandbox specimen extended with a destructive-tone row alongside success/primary/info/warning so the full tone vocabulary is browseable; description updated to enumerate the seven tones.
- The 28-primitive count is unchanged — this is a pure consumer migration on an existing primitive plus a small richer tone prop, not a new component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
