### PR TITLE
fix(v2): unsticky table headers — table overflow was trapping sticky positioning

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -134,11 +134,22 @@ export function DataTable<TData, TValue>({
   const colCount = columns.length;
 
   return (
-    // The shadcn Table primitive already wraps the <table> in its own
-    // overflow-x-auto container, so narrow viewports scroll horizontally
-    // without a second scroll container here.
-    <div className="bg-card overflow-hidden rounded-lg border">
-      <Table>
+    // The shadcn Table primitive normally wraps the <table> in an
+    // `overflow-x-auto` container for narrow-viewport horizontal scrolling.
+    // That wrapper (plus our own `overflow-hidden` container) creates a
+    // scrolling containing block that traps `position: sticky` inside the
+    // table — `top-14` is then measured from the inner box, not the
+    // viewport, and the header floats inside the table card instead of
+    // pinning under the app shell header. When `stickyHeader` is on we
+    // suppress both overflow layers so the page itself becomes the sticky
+    // ancestor and `top-14` lands flush under the `h-14` app header.
+    <div
+      className={cn(
+        "bg-card rounded-lg border",
+        !stickyHeader && "overflow-hidden",
+      )}
+    >
+      <Table containerClassName={stickyHeader ? "overflow-visible" : undefined}>
         <TableHeader
           className={cn(
             stickyHeader &&

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -2,11 +2,15 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<"table"> & { containerClassName?: string }) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className={cn("relative w-full overflow-x-auto", containerClassName)}
     >
       <table
         data-slot="table"


### PR DESCRIPTION
## Summary
Ricardo flagged that column headers on the Transactions and Tags list pages were visually broken — not in the right spot when scrolled.

**Cause**: the shadcn `<Table>` primitive wraps the `<table>` in an `overflow-x-auto` container for narrow-viewport horizontal scrolling, and `<DataTable>` adds an outer `overflow-hidden` container. Both create a scrolling containing block that traps `position: sticky` inside the table card — so when `stickyHeader` is on, the header's `top-14` was measured from the inner table box instead of the viewport, floating within the card on scroll instead of pinning under the app shell's `h-14` sticky header.

**Fix**: when `stickyHeader` is on, drop the outer `overflow-hidden` on `<DataTable>` and pass `containerClassName="overflow-visible"` into the `<Table>` so the page itself becomes the sticky ancestor. The shadcn `<Table>` primitive gains a `containerClassName` prop for that purpose (cleanest extension point since the wrapper div is generated inside the component).

Visible on Transactions and Tags list pages. Iter-80's `top-14` math was correct all along; the bug was that the sticky ancestor was wrong.

## Notes
- Iter "fix-table-sticky": the bug-fix subagent diagnosed this correctly but stopped before committing. Main session shipped its work.
- Build clean: `bun run lint` (tsc -b --noEmit) + `go build ./...` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)