### PR TITLE
design(v2): align SectionCard + ListCard header baseline

### DIFF
--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -51,7 +51,7 @@ interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "c
 // Visual contract — identical to SectionCard but the body is always a
 // `<ul className="divide-y">`:
 //   `<Card className="gap-0 py-0">`
-//     optional `<CardHeader className="border-b px-5 py-4">` title + action
+//     optional `<CardHeader className="border-b px-5 py-4 items-center">` title + action
 //     optional `<div className="border-b px-5 py-2">` toolbar slot
 //     `<ul className="divide-y">` rows (each `renderRow` result wrapped in `<li>`)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
@@ -60,6 +60,17 @@ interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "c
 // primitives must share vertical rhythm or pages that stack them feel
 // off. Row padding is consumer-supplied (typically `px-5 py-3` or
 // `px-5 py-3.5`), one stride below the header.
+//
+// Header alignment (iter 105): same fix as `SectionCard`. The shadcn
+// `CardHeader` grid defaults to `items-start` plus a `[.border-b]:pb-6`
+// rule that injects 24px of bottom padding when the header has a divider.
+// On `ListCard`'s "Recent activity" / "Connections" headers — title on
+// the left, `ViewAllPill` / "Manage" pill on the right — the result was
+// a crooked baseline (title pinned to top, action protruding 8px below)
+// AND a too-tall header band (24px below the title instead of 16px,
+// breaking symmetry with the 20px row stride below). `!pb-4` matches
+// `SectionCard`'s long-standing override; `items-center` plus title
+// `font-semibold` cures the baseline.
 //
 // When `rows.length === 0`, the `empty` slot replaces the `<ul>`. Pass
 // `<EmptyState>` for first-class look + CTA, or a short muted string for a
@@ -94,14 +105,21 @@ export function ListCard<T>({
       {...rest}
     >
       {showHeader && (
-        <CardHeader className={cn("border-b px-5 py-4", headerClassName)}>
+        <CardHeader
+          className={cn(
+            "items-center border-b px-5 py-4 !pb-4",
+            headerClassName,
+          )}
+        >
           {title !== undefined && (
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <CardTitle className="flex items-center gap-2 text-sm font-semibold">
               {icon}
               {title}
             </CardTitle>
           )}
-          {action !== undefined && <CardAction>{action}</CardAction>}
+          {action !== undefined && (
+            <CardAction className="self-center">{action}</CardAction>
+          )}
         </CardHeader>
       )}
       {toolbar && (

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -36,7 +36,7 @@ interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "t
 //
 // Visual contract:
 //   `<Card className="gap-0 py-0">`
-//     `<CardHeader className="border-b px-5 py-4">` title (text-sm font-medium)
+//     `<CardHeader className="border-b px-5 py-4 items-center">` title (text-sm font-semibold)
 //     `<CardContent className="px-5 py-5">` content (or px-0 py-0 when flushBody)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
 //
@@ -44,6 +44,16 @@ interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "t
 // slight density step from chrome to content. Matched by `ListCard` so the
 // two cards visually align when they sit on the same page. Don't fork the
 // look — change this primitive.
+//
+// Header alignment (iter 105): the shadcn `CardHeader` grid defaults to
+// `items-start`, which pinned the 20px title to the top of the row while a
+// 28-32px action (ViewAllPill / Button size="sm") protruded downward by
+// 8-12px. That asymmetry — title's baseline higher than the action's
+// vertical center — was the "header looks crooked" complaint. We override
+// to `items-center` so the title and action sit on the same vertical
+// midline regardless of action height. The title weight bump from
+// `font-medium` → `font-semibold` gives it enough anchor that it doesn't
+// read as a caption next to the action button.
 export function SectionCard({
   title,
   action,
@@ -67,15 +77,18 @@ export function SectionCard({
           a SectionCard header carries the divider the primitive injects an
           extra 24px of bottom padding, which on top of our intentional
           `py-4` produced an empty band before the body. `!pb-4` keeps the
-          density we designed for and matches the `pt-4` on top. */}
+          density we designed for and matches the `pt-4` on top.
+          `items-center` overrides the grid's default `items-start` so the
+          title sits on the same midline as a taller action button
+          (ViewAllPill / Button size="sm") — see header note above. */}
       <CardHeader
-        className={cn("border-b px-5 py-4 !pb-4", headerClassName)}
+        className={cn("items-center border-b px-5 py-4 !pb-4", headerClassName)}
       >
-        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+        <CardTitle className="flex items-center gap-2 text-sm font-semibold">
           {icon}
           {title}
         </CardTitle>
-        {action && <CardAction>{action}</CardAction>}
+        {action && <CardAction className="self-center">{action}</CardAction>}
       </CardHeader>
       <CardContent
         className={cn(


### PR DESCRIPTION
Detail-attention iteration on the canonical `SectionCard` + `ListCard` header pattern. Ricardo flagged that the cards still felt "wrong-ish" — too much padding where unexpected, title too small while the action button on the right was bigger, leaving a visible baseline mismatch and asymmetric whitespace between header and content.

## What changed

Two narrowly targeted fixes to the canonical card-header recipe:

1. **`ListCard` was missing the `\!pb-4` override** that `SectionCard` has carried since iter 33. Without it, shadcn's `[.border-b]:pb-6` rule injected 24px of bottom padding when the header had a divider, vs the intentional 16px top padding. Result: the gap between header and first row was visibly larger than the gap above the title — exactly the asymmetric feel Ricardo described. Now matches the SectionCard override.
2. **Title/action baseline mismatch.** Both primitives' headers used the shadcn grid default `items-start` + `CardAction self-start`. The 20px title got pinned to the top of the row while a 28px `ViewAllPill` or 32px `Button size="sm"` protruded 8–12px below it — title baseline visibly higher than the action's vertical center. Switched to `items-center` + `self-center` so they share a midline regardless of action height.
3. **Title weight** `text-sm font-medium` → `text-sm font-semibold`. The font-medium title read as a caption next to the heavier action button; semibold gives it enough anchor to feel like an actual header.

## What I left alone (with rationale)

- **Card body padding** (`px-5 py-5`) and **footer rhythm** (`px-5 py-3`) — iter 33's tightening is right; this was about the header row, not the body/footer.
- **`ColorRailCard`** — its footer already uses `flex items-center justify-end`, so action items line up correctly. Its body is consumer-driven.
- **`StatusPanel`** — doesn't host a title+action header row; trailing slot is a separate flex `items-center` row.
- **`FormFooter`** — already `flex items-center` with consistent vertical center.
- **`EmptyState`, `PageHeader`, `DetailDialogHeader`, `DetailSheetHeader`, `BrandHeader`, `SettingsSectionHeader`, `ProviderCardHeader`** — none of these surface the same `CardAction grid self-start` mismatch.
- **`ui/card.tsx`** (shadcn primitive) — left untouched so the change doesn't propagate to non-header callers we haven't audited.

## Before / after

### Home page (real consumer)

ListCard "Recent activity" + ViewAllPill on the left; SectionCard-style ListCard "Connections" + "Manage" pill on the right. Look at the gap between header bottom and first row, and the vertical alignment of title vs the pill text.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ru3avcbkv7.jpg" width="400" alt="home before"></td>
    <td><img src="https://i.img402.dev/96l810apte.jpg" width="400" alt="home after"></td>
  </tr>
</table>

### Sandbox specimens

`SectionCard` (Details / Notes) and `ListCard` (Recent transactions). Note how "Recent transactions" + "View all →" tightens up and the title carries more weight.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/dni83iandv.jpg" width="400" alt="sandbox before"></td>
    <td><img src="https://i.img402.dev/h0evy15z4q.jpg" width="400" alt="sandbox after"></td>
  </tr>
</table>

### Account-detail (after, full page)

ListCard "Recent transactions" + SectionCards "Settings" / "Account links" / "Details" all picking up the same tightening.

<img src="https://i.img402.dev/9u0sjbfahb.jpg" width="800" alt="account detail after">

## Measurements

| Element | Before | After |
| --- | --- | --- |
| Header bottom padding (ListCard) | 24px | 16px |
| Title font weight | 500 | 600 |
| `align-items` on header grid | `start` (default) | `center` |
| Title vertical offset vs 28px action | top-pinned (-8px from center) | centered |

## Test plan

- [x] `bun run lint` clean
- [x] Verified visually at 1440x900 on sandbox + Home + Account-detail
- [x] No regressions to SectionCards without an action slot (Notes specimen, Details on account-detail)
- [x] Title still wraps gracefully when long (Connections card eyebrow "3 healthy" wraps under title — still aligned)
