### PR TITLE
design(v2): SettingsSectionHeader baseline polish ripple from iter 106

### DIFF
--- a/web/src/components/settings-section-header.tsx
+++ b/web/src/components/settings-section-header.tsx
@@ -32,10 +32,17 @@ interface SettingsSectionHeaderProps {
  * line-height, action alignment — stays in one place.
  *
  * Vocabulary tokens:
- *   - `section` → `<h2>` `text-lg font-medium`, baseline-aligned action,
- *     `space-y-1` description.
- *   - `sub`     → `<h3>` `text-sm font-medium`, baseline-aligned action,
- *     `space-y-1` description.
+ *   - `section` → `<h2>` `text-lg font-semibold`, action centered to title
+ *     row, `space-y-1` description.
+ *   - `sub`     → `<h3>` `text-sm font-semibold`, action centered to title
+ *     row, `space-y-1` description.
+ *
+ * Iter 107 ripple from iter 106's `SectionCard` / `ListCard` baseline polish:
+ * bumped both heading tokens from `font-medium` to `font-semibold` so the
+ * title carries enough anchor next to a real action button (`Button size="sm"`,
+ * `Add member` etc.) instead of reading as a caption. The vocabulary now
+ * matches `PageHeader` (`text-2xl font-semibold`) and the canonical card
+ * header recipe (`text-sm font-semibold`).
  *
  * Don't fork the look — extend the primitive. If a fourth weight is needed
  * (e.g. a "field group" rhythm tighter than `sub`), add it as a new token
@@ -51,13 +58,20 @@ export function SettingsSectionHeader({
   const Heading = level === "section" ? "h2" : "h3";
   const headingClass =
     level === "section"
-      ? "text-lg font-medium tracking-tight"
-      : "text-sm font-medium";
+      ? "text-lg font-semibold tracking-tight"
+      : "text-sm font-semibold";
 
   return (
     <div
       className={cn(
-        "flex flex-col items-start gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-4",
+        // Iter 107: when an action is present and the title row is the
+        // visual anchor, `sm:items-center` keeps the button vertically
+        // centered relative to the title+description block instead of
+        // bottom-docked under the description (which protruded the button
+        // below the title baseline by 8-12px — the same mismatch iter 106
+        // fixed on `SectionCard` / `ListCard`). When there's no action the
+        // alignment is moot — `flex-col` collapses to a single column.
+        "flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4",
         className,
       )}
     >

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -980,7 +980,7 @@ export function ComponentsSection() {
       <Specimen
         label="SettingsSectionHeader"
         code="components/settings-section-header"
-        description="The canonical title + description block used by every section inside the Settings shell. Top-of-pane titles (Account / Household / Backups) and inline sub-sections (Change password / Actions / Stored backups / Automatic schedule) both route through here, so the typographic rhythm — heading size + weight, description colour + line-height, action alignment — stays in one place. Tokens: `section` (h2, text-lg, baseline-aligned action) and `sub` (h3, text-sm). The optional `action` slot is sm:right-aligned and baseline-aligned to the heading so an Add-member CTA sits flush with the title."
+        description="The canonical title + description block used by every section inside the Settings shell. Top-of-pane titles (Account / Household / Backups) and inline sub-sections (Change password / Actions / Stored backups / Automatic schedule) both route through here, so the typographic rhythm — heading size + weight, description colour + line-height, action alignment — stays in one place. Tokens: `section` (h2, text-lg, font-semibold) and `sub` (h3, text-sm, font-semibold). Iter 107 ripple from the iter 106 card-header polish: both heads now share `font-semibold` weight + `items-center` action alignment with `SectionCard` / `ListCard` / `PageHeader`, so an Add-member CTA sits flush with the title midline instead of bottom-docking under the description."
         className="block"
       >
         <div className="grid gap-4 lg:grid-cols-2">


### PR DESCRIPTION
## Summary

Iter 107 — ripple from iter 106's `SectionCard` / `ListCard` header polish. Applies the same header-anchor vocabulary to `SettingsSectionHeader` so every section title in the Settings shell (Account, Household, Backups) reads with the same weight + alignment as the rest of the v2 shell.

- **section** heading `text-lg font-medium` → `text-lg font-semibold`
- **sub** heading `text-sm font-medium` → `text-sm font-semibold`
- Action alignment `sm:items-end` → `sm:items-center` so a `Button size=sm` (Add member, etc.) sits centered against the title row instead of bottom-docking under the description (the same 8–12px baseline mismatch iter 106 fixed on the card-header recipe).

Now matches `PageHeader` (`text-2xl font-semibold`), `SectionCard` + `ListCard` (`text-sm font-semibold` + `items-center`), so every page-level / section-level title-and-action lockup in the v2 shell speaks one vocabulary.

## Before / After

Household settings (the most action-bearing section header) — title weight bump + action button now sits centered to the title row instead of bottom-docking under the description:

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/7ji73sf4wn.jpg) | ![after](https://i.img402.dev/dl3yxjw48e.jpg) |

## Notes

- Zero new primitives, contained to `settings-section-header.tsx` + the matching sandbox specimen description.
- Four consumers benefit today: `AccountSection` (Account / Change password), `HouseholdSection` (Household + Add-member CTA — visible in screenshot), `BackupsSection` (Backups / Actions / Stored backups / Automatic schedule), and the settings-shell placeholder fallback.
- Drift status: page-level / section-level / card-header title weights are now all `font-semibold`. If a future surface needs a lighter caption-weight title, add it as a new `SettingsSectionHeader` token (e.g. `field`) rather than forking the rhythm again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)