### PR TITLE
feat(agents): scheduler, orchestrator, run-now + CI trigger fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   pull_request:
-    branches: [main, "stack/**", "feat/**"]
+    branches: [main, "stack/**", "feat/**", "agents/**"]
   merge_group:
   push:
     branches: [main]

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -264,6 +264,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | DELETE | `/agents/{slug}` | W | Delete the definition; historical runs preserved (FK SET NULL) |
 | POST | `/agents/{slug}/enable` | W | Flip enabled=true |
 | POST | `/agents/{slug}/disable` | W | Flip enabled=false |
+| POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; 503 `CONCURRENCY_LOCKED` when another run is in progress |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200) |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | GET | `/agents/runs/{shortId}/transcript` | R | Streams the NDJSON transcript; 404 when not yet written |

--- a/internal/agent/concurrency.go
+++ b/internal/agent/concurrency.go
@@ -1,0 +1,47 @@
+//go:build !lite
+
+package agent
+
+import "context"
+
+// Semaphore is a bounded concurrency token implemented as a buffered channel.
+// v1 default capacity is 1 — only one agent run at a time across the process.
+type Semaphore struct {
+	ch chan struct{}
+}
+
+// NewSemaphore creates a semaphore with the given capacity.
+// Values < 1 are clamped to 1.
+func NewSemaphore(capacity int) *Semaphore {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &Semaphore{ch: make(chan struct{}, capacity)}
+}
+
+// Acquire tries to grab a slot non-blockingly. Returns ErrConcurrencyLocked
+// immediately when the semaphore is full. ctx is accepted for future
+// blocking-acquire variants but currently unused.
+func (s *Semaphore) Acquire(_ context.Context) error {
+	select {
+	case s.ch <- struct{}{}:
+		return nil
+	default:
+		return ErrConcurrencyLocked
+	}
+}
+
+// Release returns a slot to the semaphore. Always pair with a successful
+// Acquire via defer.
+func (s *Semaphore) Release() {
+	select {
+	case <-s.ch:
+	default:
+		// Already drained — pairing bug; ignore rather than panic.
+	}
+}
+
+// Available returns how many slots are currently free. For tests only.
+func (s *Semaphore) Available() int {
+	return cap(s.ch) - len(s.ch)
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -47,3 +47,12 @@ type EventHandler func(Event) error
 type Runner interface {
 	Run(ctx context.Context, spec JobSpec, handler EventHandler) (RunResult, error)
 }
+
+// RunnerFunc adapts a plain function to the Runner interface, useful for
+// fake runners in tests.
+type RunnerFunc func(ctx context.Context, spec JobSpec, handler EventHandler) (RunResult, error)
+
+// Run implements Runner.
+func (f RunnerFunc) Run(ctx context.Context, spec JobSpec, handler EventHandler) (RunResult, error) {
+	return f(ctx, spec, handler)
+}

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"breadbox/internal/agent"
 	"breadbox/internal/app"
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
@@ -297,6 +298,60 @@ func UpdateAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFu
 			return
 		}
 		writeData(w, out)
+	}
+}
+
+// RunAgentNowHandler triggers an immediate synchronous run of the named agent.
+// 503 CONCURRENCY_LOCKED when another run is in progress (no DB row written).
+// 422 AUTH_NOT_CONFIGURED when no Anthropic credentials are set.
+// 422 AGENT_BINARY_NOT_FOUND when the sidecar binary can't be located.
+// 200 with the agent_runs row otherwise (status may be 'error' if the run
+// itself failed — the row contains error_message).
+func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if orch == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "AGENTS_DISABLED",
+				"Agent orchestrator is not configured on this server")
+			return
+		}
+		slug := chi.URLParam(r, "slug")
+		def, err := svc.GetAgentDefinition(r.Context(), slug)
+		if err != nil {
+			writeAgentError(w, err, "agent not found")
+			return
+		}
+		runResp, runErr := orch.RunNow(r.Context(), def)
+		if errors.Is(runErr, agent.ErrConcurrencyLocked) {
+			mw.WriteError(w, http.StatusServiceUnavailable,
+				"CONCURRENCY_LOCKED",
+				"Another agent run is in progress. Retry when it completes.")
+			return
+		}
+		if errors.Is(runErr, agent.ErrAuthNotConfigured) {
+			mw.WriteError(w, http.StatusUnprocessableEntity,
+				"AUTH_NOT_CONFIGURED",
+				"Agent authentication is not configured. Set subscription_token or anthropic_api_key in settings.")
+			return
+		}
+		if errors.Is(runErr, agent.ErrBinaryNotFound) {
+			mw.WriteError(w, http.StatusUnprocessableEntity,
+				"AGENT_BINARY_NOT_FOUND",
+				"breadbox-agent binary not found. Run `make agent-sidecar` or set agent.runtime_path.")
+			return
+		}
+		// runResp may be non-nil even when runErr is set (mint succeeded but
+		// the sidecar reported failure). Return the row in that case.
+		if runResp != nil {
+			w.WriteHeader(http.StatusCreated)
+			writeData(w, runResp)
+			return
+		}
+		if runErr != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Agent run failed")
+			return
+		}
+		// Unreachable in practice: runResp nil and err nil.
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -192,6 +192,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Delete("/agents/{slug}", DeleteAgentDefinitionHandler(svc))
 			r.Post("/agents/{slug}/enable", EnableAgentHandler(svc))
 			r.Post("/agents/{slug}/disable", DisableAgentHandler(svc))
+			r.Post("/agents/{slug}/run", RunAgentNowHandler(svc, a.AgentOrchestrator))
 			r.Post("/providers/{name}/test", TestProviderHandler(a))
 			r.Delete("/providers/{name}", DisableProviderHandler(a))
 			r.Get("/config", ListConfigHandler(a))

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,8 @@ type App struct {
 	SyncEngine            *sync.Engine
 	Service               *service.Service
 	Scheduler             *sync.Scheduler
+	AgentOrchestrator     *service.Orchestrator
+	AgentScheduler        *service.AgentScheduler
 	BackupService         *service.BackupService
 	VersionChecker        *version.Checker
 	DockerSocketAvailable bool

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -34,6 +34,10 @@ const (
 	// transcripts are written. One file per run, named "<runID>.ndjson".
 	// Default: "<data dir>/agent-transcripts" resolved by the runner.
 	KeyAgentTranscriptDir = "agent.transcript_dir"
+
+	// KeyAgentRunRetentionDays is the number of days to keep completed
+	// agent_runs rows. Default: 30. 0 disables cleanup.
+	KeyAgentRunRetentionDays = "agent.run_retention_days"
 )
 
 // AuthMode values for KeyAgentAuthMode.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"breadbox/internal/agent"
 	"breadbox/internal/api"
 	"breadbox/internal/app"
 	"breadbox/internal/appconfig"
@@ -115,6 +116,29 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	scheduler := sync.NewScheduler(a.SyncEngine, a.Queries, logger, syncTimeout)
 	scheduler.Start(cfg.SyncIntervalMinutes)
 	a.Scheduler = scheduler
+
+	// Agent orchestrator + scheduler — drives Claude Agent SDK runs against
+	// the MCP server. Both subscription-token and Anthropic API-key auth
+	// modes are supported (see app_config agent.auth_mode).
+	if cleanupResult, cerr := a.Queries.CleanupOrphanedAgentRuns(ctx); cerr != nil {
+		logger.Warn("failed to clean up orphaned agent runs", "error", cerr)
+	} else if n := cleanupResult.RowsAffected(); n > 0 {
+		logger.Info("cleaned up orphaned agent runs", "count", n)
+	}
+	agentMaxConcurrent := appconfig.Int(ctx, a.Queries, appconfig.KeyAgentMaxConcurrent, 1)
+	agentRuntimePath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
+	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "")
+	agentSidecar := &agent.Sidecar{
+		BinaryPath:    agentRuntimePath,
+		TranscriptDir: agentTranscriptDir,
+	}
+	agentOrch := service.NewOrchestrator(a.Service, agentSidecar, agentMaxConcurrent, cfg.EncryptionKey, logger)
+	agentSched := service.NewAgentScheduler(agentOrch, a.Service, logger)
+	agentOrch.AttachScheduler(agentSched)
+	agentSched.Start(ctx)
+	a.AgentOrchestrator = agentOrch
+	a.AgentScheduler = agentSched
+	a.Service.OnDefinitionChanged = agentOrch.NotifyDefinitionChanged
 
 	if _, err := exec.LookPath("pg_dump"); err == nil {
 		backupDir := os.Getenv("BACKUP_DIR")

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -1,0 +1,169 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/pgconv"
+)
+
+// Orchestrator drives one agent run end-to-end: acquires concurrency,
+// mints a scoped API key, assembles the JobSpec, runs the sidecar, persists
+// the resulting agent_runs row, and revokes the key.
+type Orchestrator struct {
+	svc    *Service
+	runner agent.Runner
+	sem    *agent.Semaphore
+	encKey []byte
+	logger *slog.Logger
+
+	// sched is the agent scheduler this orchestrator notifies on CRUD changes.
+	// Wired via AttachScheduler after construction (avoids a chicken-and-egg).
+	sched *AgentScheduler
+}
+
+// NewOrchestrator constructs an Orchestrator.
+// maxConcurrent < 1 is clamped to 1.
+func NewOrchestrator(svc *Service, runner agent.Runner, maxConcurrent int, encKey []byte, logger *slog.Logger) *Orchestrator {
+	return &Orchestrator{
+		svc:    svc,
+		runner: runner,
+		sem:    agent.NewSemaphore(maxConcurrent),
+		encKey: encKey,
+		logger: logger,
+	}
+}
+
+// AttachScheduler wires the scheduler so NotifyDefinitionChanged can trigger
+// Reload. Call after both Orchestrator and Scheduler are built.
+func (o *Orchestrator) AttachScheduler(s *AgentScheduler) {
+	o.sched = s
+}
+
+// NotifyDefinitionChanged tells the attached scheduler (if any) to reload
+// its registrations from DB. Safe to call from any goroutine; nop if no
+// scheduler is attached.
+func (o *Orchestrator) NotifyDefinitionChanged() {
+	if o.sched != nil {
+		o.sched.Reload(context.Background())
+	}
+}
+
+// RunNow executes one agent run synchronously, for "run now" requests.
+// Returns ErrConcurrencyLocked WITHOUT creating a run row when the semaphore
+// is full — the caller (HTTP handler) maps to 503 and the user retries.
+// Returns the resulting agent_runs row on any other outcome (success or error).
+func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse) (*AgentRunResponse, error) {
+	if err := o.sem.Acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer o.sem.Release()
+	return o.runLocked(ctx, def, "manual")
+}
+
+// RunOrSkip is the entry point for scheduled (cron) runs. Always leaves
+// a row in agent_runs — either completed/errored, or 'skipped' when the
+// semaphore was full. Returns ErrConcurrencyLocked alongside the skipped
+// row so the scheduler can log appropriately.
+func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionResponse, trigger string) (*AgentRunResponse, error) {
+	if err := o.sem.Acquire(ctx); err != nil {
+		// Leave a 'skipped' row so the run history shows the missed fire.
+		defUUID, perr := pgconv.ParseUUID(def.ID)
+		if perr != nil {
+			return nil, fmt.Errorf("orchestrator: parse def id: %w", perr)
+		}
+		runRow, crerr := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+		if crerr != nil {
+			return nil, fmt.Errorf("orchestrator: create skipped run row: %w (acquire err: %v)", crerr, err)
+		}
+		_ = o.svc.MarkAgentRunSkippedDB(ctx, runRow.ID, "another run was in progress")
+		resp := AgentRunFromRow(runRow)
+		resp.Status = "skipped"
+		return &resp, err
+	}
+	defer o.sem.Release()
+	return o.runLocked(ctx, def, trigger)
+}
+
+// runLocked assumes the caller holds the semaphore.
+func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionResponse, trigger string) (*AgentRunResponse, error) {
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		return nil, fmt.Errorf("orchestrator: parse def id: %w", err)
+	}
+
+	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+	if err != nil {
+		return nil, fmt.Errorf("orchestrator: create run row: %w", err)
+	}
+	runResp := AgentRunFromRow(runRow)
+
+	keyResult, err := o.svc.MintRunAPIKey(ctx, def, runResp.ShortID)
+	if err != nil {
+		o.logger.Warn("orchestrator: mint api key failed",
+			"agent", def.Slug, "run", runResp.ShortID, "error", err)
+		_ = o.svc.MarkAgentRunErrorDB(ctx, runRow.ID, fmt.Sprintf("mint api key: %v", err), "")
+		return &runResp, fmt.Errorf("orchestrator: mint api key: %w", err)
+	}
+	defer func() {
+		// Always revoke. Use a fresh ctx with timeout so a cancelled parent
+		// doesn't prevent cleanup.
+		revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if rerr := o.svc.RevokeAPIKey(revokeCtx, keyResult.ID); rerr != nil {
+			o.logger.Warn("orchestrator: revoke api key failed",
+				"agent", def.Slug, "run", runResp.ShortID,
+				"key_id", keyResult.ID, "error", rerr)
+		}
+	}()
+
+	spec, err := o.svc.AssembleJobSpec(ctx, def, &runResp, keyResult.PlaintextKey, o.encKey)
+	if err != nil {
+		o.logger.Warn("orchestrator: assemble spec failed",
+			"agent", def.Slug, "run", runResp.ShortID, "error", err)
+		_ = o.svc.MarkAgentRunErrorDB(ctx, runRow.ID, fmt.Sprintf("assemble spec: %v", err), "")
+		return &runResp, fmt.Errorf("orchestrator: assemble spec: %w", err)
+	}
+
+	o.logger.Info("orchestrator: run starting",
+		"agent", def.Slug, "run", runResp.ShortID, "trigger", trigger, "model", def.Model)
+
+	result, runErr := o.runner.Run(ctx, *spec, nil)
+
+	completedRow, completeErr := o.svc.CompleteAgentRunDB(ctx, runRow.ID, result)
+	if completeErr != nil {
+		o.logger.Error("orchestrator: persist completed run failed",
+			"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)
+		if runErr != nil {
+			return &runResp, runErr
+		}
+		return &runResp, completeErr
+	}
+
+	finalResp := AgentRunFromRow(completedRow)
+
+	switch {
+	case errors.Is(runErr, agent.ErrAuthNotConfigured),
+		errors.Is(runErr, agent.ErrBinaryNotFound):
+		// Surface the upstream error so the handler can produce a clearer
+		// error code than the generic agent_runs.error_message.
+		return &finalResp, runErr
+	case runErr != nil:
+		o.logger.Warn("orchestrator: run finished with error",
+			"agent", def.Slug, "run", runResp.ShortID,
+			"status", result.Status, "error", runErr)
+		return &finalResp, runErr
+	}
+
+	o.logger.Info("orchestrator: run finished",
+		"agent", def.Slug, "run", runResp.ShortID,
+		"status", result.Status, "cost_usd", result.TotalCostUSD,
+		"duration_ms", result.DurationMs, "turns", result.TurnCount)
+	return &finalResp, nil
+}

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -1,0 +1,241 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/appconfig"
+	"breadbox/internal/service"
+)
+
+// seedSubscriptionAuth writes a fake subscription token so AssembleJobSpec
+// doesn't error on auth-not-configured. Returns the test enc key.
+func seedSubscriptionAuth(t *testing.T, svc *service.Service) []byte {
+	t.Helper()
+	tok := "sk-ant-oat01-FAKE-TEST-TOKEN-FOR-INTEGRATION"
+	if _, err := svc.UpdateAgentSettings(context.Background(), service.UpdateAgentSettingsParams{
+		SubscriptionToken: &tok,
+	}, devEncKey); err != nil {
+		t.Fatalf("seed subscription auth: %v", err)
+	}
+	return devEncKey
+}
+
+func TestOrchestratorRunNow_Success(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-success", true)
+
+	fake := agent.RunnerFunc(func(ctx context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{
+			Status:       agent.StatusSuccess,
+			TotalCostUSD: 0.0123,
+			InputTokens:  100,
+			OutputTokens: 50,
+			TurnCount:    2,
+			NumToolCalls: 1,
+			SessionID:    "sess-test",
+			DurationMs:   42,
+		}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	runResp, err := orch.RunNow(context.Background(), def)
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	if runResp.Status != agent.StatusSuccess {
+		t.Errorf("Status = %q, want success", runResp.Status)
+	}
+	if runResp.TotalCostUSD == nil || *runResp.TotalCostUSD != 0.0123 {
+		t.Errorf("TotalCostUSD = %v, want 0.0123", runResp.TotalCostUSD)
+	}
+	if runResp.SessionID == nil || *runResp.SessionID != "sess-test" {
+		t.Errorf("SessionID = %v, want sess-test", runResp.SessionID)
+	}
+
+	// Verify the row was persisted with the same fields.
+	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if persisted.Status != agent.StatusSuccess {
+		t.Errorf("persisted Status = %q, want success", persisted.Status)
+	}
+}
+
+func TestOrchestratorRunNow_ConcurrencyLocked(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-locked", true)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	slow := agent.RunnerFunc(func(ctx context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		close(started)
+		<-release
+		return agent.RunResult{Status: agent.StatusSuccess}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, slow, 1, encKey, slog.Default())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var firstRun *service.AgentRunResponse
+	var firstErr error
+	go func() {
+		defer wg.Done()
+		firstRun, firstErr = orch.RunNow(context.Background(), def)
+	}()
+
+	<-started // first goroutine holds the slot
+
+	_, secondErr := orch.RunNow(context.Background(), def)
+	if !errors.Is(secondErr, agent.ErrConcurrencyLocked) {
+		t.Errorf("second RunNow err = %v, want ErrConcurrencyLocked", secondErr)
+	}
+
+	close(release)
+	wg.Wait()
+
+	if firstErr != nil {
+		t.Errorf("first RunNow err = %v, want nil", firstErr)
+	}
+	if firstRun == nil || firstRun.Status != agent.StatusSuccess {
+		t.Errorf("first run status = %v, want success", firstRun)
+	}
+}
+
+func TestOrchestratorRunOrSkip_LeavesSkippedRow(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-skip", true)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	slow := agent.RunnerFunc(func(ctx context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		close(started)
+		<-release
+		return agent.RunResult{Status: agent.StatusSuccess}, nil
+	})
+	orch := service.NewOrchestrator(svc, slow, 1, encKey, slog.Default())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = orch.RunNow(context.Background(), def)
+	}()
+	<-started
+
+	skippedRun, err := orch.RunOrSkip(context.Background(), def, "cron")
+	if !errors.Is(err, agent.ErrConcurrencyLocked) {
+		t.Errorf("RunOrSkip err = %v, want ErrConcurrencyLocked", err)
+	}
+	if skippedRun == nil {
+		t.Fatal("expected a skipped run row, got nil")
+	}
+	if skippedRun.Status != "skipped" {
+		t.Errorf("skipped Status = %q, want skipped", skippedRun.Status)
+	}
+	if skippedRun.Trigger != "cron" {
+		t.Errorf("skipped Trigger = %q, want cron", skippedRun.Trigger)
+	}
+
+	close(release)
+	wg.Wait()
+
+	// Verify the skipped row is in the run history.
+	persisted, err := svc.GetAgentRun(context.Background(), skippedRun.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun(skipped): %v", err)
+	}
+	if persisted.Status != "skipped" {
+		t.Errorf("persisted skipped Status = %q, want skipped", persisted.Status)
+	}
+}
+
+func TestOrchestratorRunNow_AuthNotConfigured(t *testing.T) {
+	svc, _, _ := newService(t)
+	// Deliberately do NOT seed auth — orchestrator should surface ErrAuthNotConfigured.
+	def := mustCreateAgentDefinition(t, svc, "orch-noauth", true)
+	fake := agent.RunnerFunc(func(ctx context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		t.Error("runner should not be invoked when auth is missing")
+		return agent.RunResult{}, nil
+	})
+	orch := service.NewOrchestrator(svc, fake, 1, devEncKey, slog.Default())
+	_, err := orch.RunNow(context.Background(), def)
+	if !errors.Is(err, agent.ErrAuthNotConfigured) {
+		t.Errorf("err = %v, want ErrAuthNotConfigured", err)
+	}
+}
+
+func TestOrchestratorRunNow_RunnerErrorPersisted(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-error", true)
+
+	fake := agent.RunnerFunc(func(ctx context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{
+			Status:     agent.StatusError,
+			DurationMs: 5,
+			Err:        errors.New("sidecar said no"),
+		}, errors.New("sidecar said no")
+	})
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+
+	runResp, err := orch.RunNow(context.Background(), def)
+	if err == nil {
+		t.Fatal("expected error from RunNow on runner failure")
+	}
+	if runResp == nil || runResp.Status != agent.StatusError {
+		t.Errorf("expected error-status row, got %v", runResp)
+	}
+}
+
+func TestOrchestratorRunNow_MintRevokeRoundTrip(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-mintrevoke", true)
+
+	var capturedToken string
+	fake := agent.RunnerFunc(func(ctx context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		// Find the BREADBOX_API_KEY env var in the MCP server config.
+		if mcp, ok := spec.MCPServers["breadbox"]; ok {
+			capturedToken = mcp.Env["BREADBOX_API_KEY"]
+		}
+		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
+	})
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+
+	runResp, err := orch.RunNow(context.Background(), def)
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	if capturedToken == "" {
+		t.Error("expected BREADBOX_API_KEY to be set in JobSpec MCP env")
+	}
+
+	// Confirm the minted key was revoked after the run.
+	keys, err := svc.ListAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	wantName := "agent:" + def.Slug + ":" + runResp.ShortID
+	for _, k := range keys {
+		if k.Name == wantName && k.RevokedAt == nil {
+			t.Errorf("minted key %q should be revoked, but RevokedAt is nil", wantName)
+		}
+	}
+	// Touch the unused appconfig reader to keep the import live in case
+	// the test file evolves to read settings directly.
+	_ = appconfig.String(context.Background(), svc.Queries, appconfig.KeyAgentAuthMode, "")
+}

--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -1,0 +1,150 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/appconfig"
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/robfig/cron/v3"
+)
+
+// AgentScheduler registers one cron entry per enabled agent_definition that
+// has a non-null schedule_cron. Reload re-syncs from DB.
+type AgentScheduler struct {
+	cron   *cron.Cron
+	orch   *Orchestrator
+	svc    *Service
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	entryIDs map[string]cron.EntryID // slug → entry id
+}
+
+// NewAgentScheduler constructs the scheduler. Call Start to begin firing.
+func NewAgentScheduler(orch *Orchestrator, svc *Service, logger *slog.Logger) *AgentScheduler {
+	return &AgentScheduler{
+		cron:     cron.New(),
+		orch:     orch,
+		svc:      svc,
+		logger:   logger,
+		entryIDs: make(map[string]cron.EntryID),
+	}
+}
+
+// Start registers all enabled definitions and the daily cleanup job, then
+// kicks off the cron loop.
+func (s *AgentScheduler) Start(ctx context.Context) {
+	s.registerAll(ctx)
+	_, err := s.cron.AddFunc("15 3 * * *", func() {
+		s.cleanupAgentRuns(context.Background())
+	})
+	if err != nil {
+		s.logger.Error("agent scheduler: add cleanup job failed", "error", err)
+	}
+	s.cron.Start()
+	s.logger.Info("agent scheduler started", "enabled_count", len(s.entryIDs))
+}
+
+// Stop gracefully halts the scheduler, waiting for any in-flight jobs.
+func (s *AgentScheduler) Stop() {
+	stopCtx := s.cron.Stop()
+	<-stopCtx.Done()
+	s.logger.Info("agent scheduler stopped")
+}
+
+// Reload removes all per-definition cron entries and re-registers from DB.
+// Called after any agent_definition CRUD mutation.
+func (s *AgentScheduler) Reload(ctx context.Context) {
+	s.mu.Lock()
+	for slug, id := range s.entryIDs {
+		s.cron.Remove(id)
+		delete(s.entryIDs, slug)
+	}
+	s.mu.Unlock()
+	s.registerAll(ctx)
+	s.logger.Info("agent scheduler reloaded", "registered", len(s.entryIDs))
+}
+
+// registerAll reads enabled definitions and registers one cron entry per
+// definition with a non-empty schedule_cron.
+func (s *AgentScheduler) registerAll(ctx context.Context) {
+	defs, err := s.svc.Queries.ListEnabledAgentDefinitions(ctx)
+	if err != nil {
+		s.logger.Error("agent scheduler: list enabled defs failed", "error", err)
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, def := range defs {
+		if !def.ScheduleCron.Valid || def.ScheduleCron.String == "" {
+			continue
+		}
+		slug := def.Slug
+		schedCron := def.ScheduleCron.String
+		defID := def.ID
+		id, err := s.cron.AddFunc(schedCron, func() {
+			s.fireCronJob(defID, slug)
+		})
+		if err != nil {
+			s.logger.Error("agent scheduler: invalid cron expression",
+				"agent", slug, "cron", schedCron, "error", err)
+			continue
+		}
+		s.entryIDs[slug] = id
+		s.logger.Info("agent scheduler: registered", "agent", slug, "cron", schedCron)
+	}
+}
+
+// fireCronJob is the cron callback for one definition. It resolves the
+// definition fresh, then calls RunOrSkip on the orchestrator.
+func (s *AgentScheduler) fireCronJob(defID pgtype.UUID, slug string) {
+	ctx := context.Background()
+	def, err := s.svc.GetAgentDefinition(ctx, pgconv.FormatUUID(defID))
+	if err != nil {
+		s.logger.Error("agent scheduler: resolve definition failed",
+			"agent", slug, "error", err)
+		return
+	}
+	if !def.Enabled {
+		return
+	}
+	_, runErr := s.orch.RunOrSkip(ctx, def, "cron")
+	if errors.Is(runErr, agent.ErrConcurrencyLocked) {
+		s.logger.Warn("agent scheduler: run skipped (concurrency locked)", "agent", slug)
+		return
+	}
+	if runErr != nil {
+		s.logger.Error("agent scheduler: run failed", "agent", slug, "error", runErr)
+	}
+}
+
+// cleanupAgentRuns prunes completed agent_runs older than the retention
+// period (default 30 days; 0 disables). Transcript file GC is deferred
+// to a later iteration.
+func (s *AgentScheduler) cleanupAgentRuns(ctx context.Context) {
+	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
+	if retentionDays <= 0 {
+		s.logger.Debug("agent run cleanup disabled", "retention_days", retentionDays)
+		return
+	}
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	result, err := s.svc.Queries.DeleteAgentRunsOlderThan(ctx,
+		pgtype.Timestamptz{Time: cutoff, Valid: true})
+	if err != nil {
+		s.logger.Error("agent run cleanup failed", "error", err)
+		return
+	}
+	if n := result.RowsAffected(); n > 0 {
+		s.logger.Info("agent run cleanup completed",
+			"deleted", n, "retention_days", retentionDays)
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -208,6 +208,7 @@ func (s *Service) CreateAgentDefinition(ctx context.Context, p CreateAgentDefini
 	if err != nil {
 		return nil, fmt.Errorf("create agent definition: %w", err)
 	}
+	s.notifyDefinitionChanged()
 	resp := agentDefinitionFromRow(row, nil)
 	return &resp, nil
 }
@@ -285,6 +286,7 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 	if err != nil {
 		return nil, fmt.Errorf("update agent definition: %w", err)
 	}
+	s.notifyDefinitionChanged()
 	resp := agentDefinitionFromRow(row, nil)
 	return &resp, nil
 }
@@ -303,6 +305,7 @@ func (s *Service) DeleteAgentDefinition(ctx context.Context, slugOrID string) er
 	if n == 0 {
 		return ErrNotFound
 	}
+	s.notifyDefinitionChanged()
 	return nil
 }
 
@@ -319,6 +322,7 @@ func (s *Service) SetAgentDefinitionEnabled(ctx context.Context, slugOrID string
 	if err != nil {
 		return nil, fmt.Errorf("set agent definition enabled: %w", err)
 	}
+	s.notifyDefinitionChanged()
 	resp := agentDefinitionFromRow(row, nil)
 	return &resp, nil
 }
@@ -367,6 +371,68 @@ func (s *Service) GetAgentRun(ctx context.Context, shortIDOrUUID string) (*Agent
 	}
 	resp := agentRunFromRow(row)
 	return &resp, nil
+}
+
+// notifyDefinitionChanged invokes the (optional) registered callback so the
+// agent scheduler can re-register cron entries after a CRUD mutation.
+func (s *Service) notifyDefinitionChanged() {
+	if s.OnDefinitionChanged != nil {
+		s.OnDefinitionChanged()
+	}
+}
+
+// --- Orchestrator-facing helpers (called by internal/service/agent_orchestrator.go) ---
+
+// CreateAgentRunDB inserts an in_progress run row.
+func (s *Service) CreateAgentRunDB(ctx context.Context, defID pgtype.UUID, trigger string) (db.AgentRun, error) {
+	return s.Queries.CreateAgentRun(ctx, db.CreateAgentRunParams{
+		AgentDefinitionID: defID,
+		Trigger:           trigger,
+	})
+}
+
+// MarkAgentRunErrorDB transitions a run row to status='error'.
+func (s *Service) MarkAgentRunErrorDB(ctx context.Context, runID pgtype.UUID, errMsg, transcriptPath string) error {
+	return s.Queries.MarkAgentRunError(ctx, db.MarkAgentRunErrorParams{
+		ID:             runID,
+		ErrorMessage:   pgtype.Text{String: errMsg, Valid: errMsg != ""},
+		TranscriptPath: pgtype.Text{String: transcriptPath, Valid: transcriptPath != ""},
+	})
+}
+
+// MarkAgentRunSkippedDB transitions a run row to status='skipped'.
+func (s *Service) MarkAgentRunSkippedDB(ctx context.Context, runID pgtype.UUID, reason string) error {
+	return s.Queries.MarkAgentRunSkipped(ctx, db.MarkAgentRunSkippedParams{
+		ID:           runID,
+		ErrorMessage: pgtype.Text{String: reason, Valid: reason != ""},
+	})
+}
+
+// CompleteAgentRunDB persists a terminal RunResult onto the run row.
+// Used by the orchestrator after Runner.Run returns.
+func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult) (db.AgentRun, error) {
+	costPtr := result.TotalCostUSD
+	return s.Queries.CompleteAgentRun(ctx, db.CompleteAgentRunParams{
+		ID:                  runID,
+		Status:              result.Status,
+		DurationMs:          pgtype.Int4{Int32: int32(result.DurationMs), Valid: true},
+		TotalCostUsd:        agentNumericFromFloat(&costPtr),
+		InputTokens:         pgtype.Int4{Int32: int32(result.InputTokens), Valid: true},
+		OutputTokens:        pgtype.Int4{Int32: int32(result.OutputTokens), Valid: true},
+		CacheReadTokens:     pgtype.Int4{Int32: int32(result.CacheReadTokens), Valid: true},
+		CacheCreationTokens: pgtype.Int4{Int32: int32(result.CacheCreationTokens), Valid: true},
+		TurnCount:           pgtype.Int4{Int32: int32(result.TurnCount), Valid: true},
+		MaxTurnsUsed:        pgtype.Int4{Int32: int32(result.TurnCount), Valid: true},
+		NumToolCalls:        pgtype.Int4{Int32: int32(result.NumToolCalls), Valid: true},
+		TranscriptPath:      pgtype.Text{String: result.TranscriptPath, Valid: result.TranscriptPath != ""},
+		SessionID:           pgtype.Text{String: result.SessionID, Valid: result.SessionID != ""},
+	})
+}
+
+// AgentRunFromRow is exported so the orchestrator (same package) can build
+// API responses from raw db rows.
+func AgentRunFromRow(row db.AgentRun) AgentRunResponse {
+	return agentRunFromRow(row)
 }
 
 // MintRunAPIKey mints a scoped API key for one agent run.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -16,6 +16,11 @@ type Service struct {
 	Pool       *pgxpool.Pool
 	SyncEngine *sync.Engine
 	Logger     *slog.Logger
+
+	// OnDefinitionChanged is invoked after any agent_definition CRUD mutation.
+	// Set at startup (in serve.go) to the agent scheduler's Reload trigger so
+	// new/edited/deleted definitions are picked up immediately. Nil = no-op.
+	OnDefinitionChanged func()
 }
 
 func New(queries *db.Queries, pool *pgxpool.Pool, syncEngine *sync.Engine, logger *slog.Logger) *Service {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2532,6 +2532,25 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/{slug}/run:
+    parameters:
+      - { name: slug, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Agents]
+      summary: Trigger an immediate agent run
+      description: |
+        Synchronously runs the named agent. Returns the resulting `agent_runs`
+        row. Status may be `success`, `error`, or `timeout`. **Requires `full_access` scope.**
+      responses:
+        "201":
+          description: Run completed (may be in error state — see `status` and `error_message`).
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "422":
+          description: Auth or binary not configured.
+        "503":
+          description: Another run is in progress (CONCURRENCY_LOCKED).
 
 components:
   securitySchemes:


### PR DESCRIPTION
## Iteration 3 of the Claude Agent SDK integration sprint

Closes the loop on the agent system: cron fires → orchestrator runs the sidecar → run row persisted → API key revoked. After this PR, the only thing missing for a live end-to-end test is a valid Anthropic credential.

**Targets the sprint branch** (`agents/claude-agent-sdk-sprint`). Iter 1 is on main; iter 2 + iter 3 accumulate on the sprint branch until the final sprint→main PR.

## What's in

**Concurrency**
- `internal/agent/concurrency.go` — `Semaphore` with cap from `app_config.agent.max_concurrent` (default 1). Non-blocking `Acquire` returns `ErrConcurrencyLocked` immediately when full.

**Orchestrator** (`internal/service/agent_orchestrator.go`)
- `RunNow(ctx, def)` — manual trigger. `ErrConcurrencyLocked` without creating a DB row → 503 from the handler.
- `RunOrSkip(ctx, def, trigger)` — cron trigger. Always leaves a row; status='skipped' when locked so users see the missed fire in run history.
- Mint scoped API key → insert in_progress row → assemble JobSpec → `Runner.Run` → persist completed row → revoke key (deferred with fresh ctx so a cancelled parent doesn't strand the key).
- Surfaces `ErrAuthNotConfigured` and `ErrBinaryNotFound` cleanly to the handler for distinct 422 codes.

**Scheduler** (`internal/service/agent_scheduler.go`)
- `AgentScheduler` wraps `robfig/cron/v3`. One entry per enabled definition with a non-null `schedule_cron`.
- `Start` / `Stop` / `Reload` — `Reload` is invoked automatically after any CRUD mutation (via the new `Service.OnDefinitionChanged` hook wired in `serve.go`).
- Daily 3:15am cleanup job prunes `agent_runs` older than `app_config.agent.run_retention_days` (default 30, 0 disables). Disk-level transcript GC deferred to iter 7.

**HTTP**
- `POST /api/v1/agents/{slug}/run` — synchronous "run now" endpoint. 503 `CONCURRENCY_LOCKED` / 422 `AUTH_NOT_CONFIGURED` / 422 `AGENT_BINARY_NOT_FOUND` for clear UX.
- Settings hook in `internal/cli/serve.go` cleans up orphaned `in_progress` rows from prior restarts.

**CI**
- `.github/workflows/ci.yml` — `agents/**` added to `pull_request.branches`. This PR itself will be the first iteration PR to actually exercise CI.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go build -tags=headless ./...\` clean
- [x] \`go build -tags=lite ./...\` clean
- [x] \`go test ./...\` — all unit tests pass
- [x] \`TestOpenAPIDrift\` green
- [x] 6 new orchestrator integration tests: happy path, concurrency lock under contention (goroutine + channel sync), skipped-row semantics for cron, auth-not-configured, runner-error persistence, mint→spec-env→revoke round-trip
- [x] Build + tests run locally; CI matrix should run this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)