### PR TITLE
feat(agents): v2 SPA /agents list + settings tab

### DIFF
--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -1,0 +1,227 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+// Types mirror the Go-side response shapes in internal/service/agents.go
+// and internal/service/agent_settings.go. Endpoints documented in
+// docs/api-endpoints.md.
+
+export interface AgentRunSummary {
+  short_id: string;
+  status: string;
+  trigger: string;
+  started_at: string;
+  completed_at?: string | null;
+  duration_ms?: number | null;
+  total_cost_usd?: number | null;
+}
+
+export interface AgentDefinition {
+  id: string;
+  short_id: string;
+  name: string;
+  slug: string;
+  prompt: string;
+  system_prompt?: string | null;
+  schedule_cron?: string | null;
+  tool_scope: "read_only" | "read_write";
+  allowed_tools: string[];
+  model: string;
+  max_turns: number;
+  max_budget_usd?: number | null;
+  enabled: boolean;
+  last_run?: AgentRunSummary | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentRun {
+  id: string;
+  short_id: string;
+  agent_definition_id?: string | null;
+  trigger: string;
+  status: string;
+  started_at: string;
+  completed_at?: string | null;
+  duration_ms?: number | null;
+  total_cost_usd?: number | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_read_tokens?: number | null;
+  cache_creation_tokens?: number | null;
+  turn_count?: number | null;
+  max_turns_used?: number | null;
+  num_tool_calls?: number | null;
+  error_message?: string | null;
+  transcript_path?: string | null;
+  session_id?: string | null;
+}
+
+export interface AgentRunListResult {
+  runs: AgentRun[];
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+export interface AgentSettings {
+  auth_mode: "subscription" | "api_key";
+  subscription_token?: string | null; // masked
+  anthropic_api_key?: string | null; // masked
+  max_concurrent: number;
+  global_max_budget_usd?: number | null;
+  runtime_path: string;
+  transcript_dir: string;
+}
+
+export interface CreateAgentInput {
+  name: string;
+  slug: string;
+  prompt: string;
+  system_prompt?: string | null;
+  schedule_cron?: string | null;
+  tool_scope?: "read_only" | "read_write";
+  allowed_tools?: string[];
+  model?: string;
+  max_turns?: number;
+  max_budget_usd?: number | null;
+  enabled?: boolean;
+}
+
+export type UpdateAgentInput = Partial<CreateAgentInput>;
+
+export interface UpdateAgentSettingsInput {
+  auth_mode?: "subscription" | "api_key";
+  subscription_token?: string | null;
+  anthropic_api_key?: string | null;
+  max_concurrent?: number;
+  global_max_budget_usd?: number | null;
+  runtime_path?: string;
+  transcript_dir?: string;
+}
+
+// --- Definition queries ---
+
+export function useAgents() {
+  return useQuery({
+    queryKey: ["agents"],
+    queryFn: () => api<AgentDefinition[]>("/api/v1/agents"),
+  });
+}
+
+export function useAgent(slug: string | undefined) {
+  return useQuery({
+    queryKey: ["agents", slug],
+    queryFn: () => api<AgentDefinition>(`/api/v1/agents/${slug}`),
+    enabled: Boolean(slug),
+  });
+}
+
+// --- Definition mutations ---
+
+export function useCreateAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateAgentInput) =>
+      api<AgentDefinition>("/api/v1/agents", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useUpdateAgent(slug: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpdateAgentInput) =>
+      api<AgentDefinition>(`/api/v1/agents/${slug}`, {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useDeleteAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (slug: string) =>
+      api<void>(`/api/v1/agents/${slug}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useToggleAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ slug, enable }: { slug: string; enable: boolean }) =>
+      api<AgentDefinition>(
+        `/api/v1/agents/${slug}/${enable ? "enable" : "disable"}`,
+        { method: "POST" },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+export function useRunAgentNow() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (slug: string) =>
+      api<AgentRun>(`/api/v1/agents/${slug}/run`, { method: "POST" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
+// --- Run queries ---
+
+export function useAgentRuns(slug: string | undefined, limit = 50, offset = 0) {
+  return useQuery({
+    queryKey: ["agents", slug, "runs", { limit, offset }],
+    queryFn: () =>
+      api<AgentRunListResult>(
+        `/api/v1/agents/${slug}/runs?limit=${limit}&offset=${offset}`,
+      ),
+    enabled: Boolean(slug),
+  });
+}
+
+export function useAgentRun(shortId: string | undefined) {
+  return useQuery({
+    queryKey: ["agents", "runs", shortId],
+    queryFn: () => api<AgentRun>(`/api/v1/agents/runs/${shortId}`),
+    enabled: Boolean(shortId),
+  });
+}
+
+// --- Settings ---
+
+export function useAgentSettings() {
+  return useQuery({
+    queryKey: ["agents", "settings"],
+    queryFn: () => api<AgentSettings>("/api/v1/agents/settings"),
+  });
+}
+
+export function useUpdateAgentSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpdateAgentSettingsInput) =>
+      api<AgentSettings>("/api/v1/agents/settings", {
+        method: "PUT",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents", "settings"] });
+    },
+  });
+}

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -19,6 +19,7 @@ import { SETTINGS_SECTIONS, type SettingsSection } from "@/lib/settings-sections
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { closeModal, openModal, useActiveModal } from "@/lib/modals";
 import { AccountSection } from "@/features/settings/account-section";
+import { AgentsSection } from "@/features/settings/agents-section";
 import { BackupsSection } from "@/features/settings/backups-section";
 import { HouseholdSection } from "@/features/settings/household-section";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
@@ -204,6 +205,10 @@ function SectionContent({ section }: { section: SettingsSection }) {
 
   if (section.slug === "backups") {
     return <BackupsSection />;
+  }
+
+  if (section.slug === "agents") {
+    return <AgentsSection />;
   }
 
   // Fallback for sections defined in `lib/settings-sections.ts` that don't

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Bot, KeyRound, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { SettingsSectionHeader } from "@/components/settings-section-header";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useAgentSettings,
+  useUpdateAgentSettings,
+} from "@/api/queries/agents";
+
+const settingsSchema = z.object({
+  auth_mode: z.enum(["subscription", "api_key"]),
+  subscription_token: z.string().optional(),
+  anthropic_api_key: z.string().optional(),
+  max_concurrent: z.number().int().min(1).max(50),
+  global_max_budget_usd: z.string().optional(),
+  runtime_path: z.string().optional(),
+});
+
+export function AgentsSection() {
+  const settingsQuery = useAgentSettings();
+  const updateSettings = useUpdateAgentSettings();
+  const [tokenDraft, setTokenDraft] = useState("");
+  const [apiKeyDraft, setApiKeyDraft] = useState("");
+
+  const form = useForm({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      auth_mode: "subscription" as const,
+      max_concurrent: 1,
+      subscription_token: "",
+      anthropic_api_key: "",
+      global_max_budget_usd: "",
+      runtime_path: "",
+    },
+  });
+
+  // Hydrate form once settings load.
+  useEffect(() => {
+    if (!settingsQuery.data) return;
+    const s = settingsQuery.data;
+    form.reset({
+      auth_mode: s.auth_mode,
+      max_concurrent: s.max_concurrent,
+      global_max_budget_usd:
+        s.global_max_budget_usd != null
+          ? String(s.global_max_budget_usd)
+          : "",
+      runtime_path: s.runtime_path ?? "",
+    });
+  }, [settingsQuery.data, form]);
+
+  const authMode = form.watch("auth_mode");
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const payload: Parameters<typeof updateSettings.mutateAsync>[0] = {
+      auth_mode: values.auth_mode,
+      max_concurrent: values.max_concurrent,
+      runtime_path: values.runtime_path ?? "",
+    };
+    if (values.global_max_budget_usd && values.global_max_budget_usd !== "") {
+      const n = Number(values.global_max_budget_usd);
+      if (!Number.isNaN(n)) payload.global_max_budget_usd = n;
+    } else {
+      payload.global_max_budget_usd = null;
+    }
+    if (tokenDraft) payload.subscription_token = tokenDraft;
+    if (apiKeyDraft) payload.anthropic_api_key = apiKeyDraft;
+
+    const ok = await withMutationToast(
+      () => updateSettings.mutateAsync(payload),
+      {
+        success: "Agent settings saved",
+        error: "Failed to save agent settings",
+      },
+    );
+    if (ok) {
+      setTokenDraft("");
+      setApiKeyDraft("");
+    }
+  });
+
+  const clearToken = (kind: "subscription_token" | "anthropic_api_key") => {
+    void withMutationToast(
+      () => updateSettings.mutateAsync({ [kind]: "" }),
+      {
+        success: "Credential cleared",
+        error: "Failed to clear credential",
+      },
+    );
+  };
+
+  const settings = settingsQuery.data;
+
+  return (
+    <div className="space-y-6">
+      <SettingsSectionHeader
+        title="Agents"
+        description="Authentication and global caps for the Claude Agent SDK runner. Tokens are encrypted at rest; the full value never leaves the server after you save it."
+      />
+
+      {settingsQuery.isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-1/2" />
+        </div>
+      ) : settings ? (
+        <Form {...form}>
+          <form onSubmit={onSubmit} className="space-y-6">
+            <FormField
+              control={form.control}
+              name="auth_mode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Authentication mode</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Pick auth mode" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="subscription">
+                        Claude subscription token
+                      </SelectItem>
+                      <SelectItem value="api_key">
+                        Anthropic API key
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Subscription tokens come from <code>claude setup-token</code>{" "}
+                    and apply Claude plan credits (free under monthly limits).
+                    API keys bill per usage; durable past 2026-06-15.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {authMode === "subscription" ? (
+              <CredentialField
+                kind="subscription_token"
+                label="Subscription token"
+                placeholder="sk-ant-oat01-…"
+                helper="Run `claude setup-token` on any machine, paste the resulting one-year token here."
+                stored={settings.subscription_token}
+                draft={tokenDraft}
+                onDraftChange={setTokenDraft}
+                onClear={() => clearToken("subscription_token")}
+              />
+            ) : (
+              <CredentialField
+                kind="anthropic_api_key"
+                label="Anthropic API key"
+                placeholder="sk-ant-…"
+                helper="From console.anthropic.com. Billed per API call."
+                stored={settings.anthropic_api_key}
+                draft={apiKeyDraft}
+                onDraftChange={setApiKeyDraft}
+                onClear={() => clearToken("anthropic_api_key")}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="max_concurrent"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Max concurrent runs</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} max={50} {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Server-wide cap on agent runs in flight at once. v1 default
+                    is 1 — additional triggers either skip (cron) or 503 (manual).
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="global_max_budget_usd"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Global max cost per run (USD)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      placeholder="No global cap"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Hard ceiling across all agents, regardless of per-agent
+                    settings. Leave blank for none.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="runtime_path"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>breadbox-agent binary path</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="auto-detected (./bin/breadbox-agent or PATH)"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Absolute path to the sidecar binary. Leave blank to use{" "}
+                    <code>$BREADBOX_AGENT_BIN</code>, <code>./bin/breadbox-agent</code>,
+                    or PATH discovery.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={updateSettings.isPending}>
+                {updateSettings.isPending && (
+                  <Loader2 className="size-4 animate-spin" />
+                )}
+                Save settings
+              </Button>
+            </div>
+          </form>
+        </Form>
+      ) : (
+        <Alert>
+          <Bot className="size-4" />
+          <AlertTitle>Settings unavailable</AlertTitle>
+          <AlertDescription>
+            Could not load agent settings — the server may not be reachable.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}
+
+interface CredentialFieldProps {
+  kind: string;
+  label: string;
+  placeholder: string;
+  helper: string;
+  stored?: string | null;
+  draft: string;
+  onDraftChange: (v: string) => void;
+  onClear: () => void;
+}
+
+function CredentialField({
+  label,
+  placeholder,
+  helper,
+  stored,
+  draft,
+  onDraftChange,
+  onClear,
+}: CredentialFieldProps) {
+  return (
+    <FormItem>
+      <FormLabel>{label}</FormLabel>
+      {stored ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" className="font-mono">
+            <KeyRound className="mr-1 size-3" /> {stored}
+          </Badge>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClear}
+          >
+            Clear stored credential
+          </Button>
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-xs">No credential stored.</p>
+      )}
+      <FormControl>
+        <Input
+          type="password"
+          placeholder={
+            stored ? "Paste a new value to replace…" : placeholder
+          }
+          value={draft}
+          onChange={(e) => onDraftChange(e.target.value)}
+          autoComplete="off"
+        />
+      </FormControl>
+      <FormDescription>{helper}</FormDescription>
+    </FormItem>
+  );
+}

--- a/web/src/lib/settings-sections.ts
+++ b/web/src/lib/settings-sections.ts
@@ -1,4 +1,5 @@
 import {
+  Bot,
   DatabaseBackup,
   Lock,
   User,
@@ -37,5 +38,11 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     title: "Backups",
     description: "Snapshot the database, restore, and schedule automatic backups.",
     icon: DatabaseBackup,
+  },
+  {
+    slug: "agents",
+    title: "Agents",
+    description: "Claude credentials and global caps for the Agent SDK runner.",
+    icon: Bot,
   },
 ];

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -45,6 +45,7 @@ import {
   accountDetailSearchSchema,
 } from "@/routes/account-detail";
 import { RulesPage, rulesSearchSchema } from "@/routes/rules";
+import { AgentsPage } from "@/routes/agents";
 import { RuleDetailPage } from "@/routes/rule-detail";
 import { RuleFormPage } from "@/routes/rule-form";
 import { NAV_LEAVES } from "@/lib/nav";
@@ -120,6 +121,9 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
   "/rules": {
     component: RulesPage,
     validateSearch: rulesSearchSchema,
+  },
+  "/agents": {
+    component: AgentsPage,
   },
 };
 

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -1,0 +1,398 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  Clock,
+  Play,
+  Plus,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import { PageHeader } from "@/components/page-header";
+import { EmptyState } from "@/components/empty-state";
+import { PageError } from "@/components/page-error";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { formatRelativeTime } from "@/lib/format";
+import {
+  useAgents,
+  useCreateAgent,
+  useDeleteAgent,
+  useRunAgentNow,
+  useToggleAgent,
+  type AgentDefinition,
+} from "@/api/queries/agents";
+
+const createAgentSchema = z.object({
+  name: z.string().min(1, "Name is required").max(120),
+  slug: z
+    .string()
+    .min(2, "Slug must be at least 2 characters")
+    .max(64)
+    .regex(
+      /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/,
+      "Use lowercase letters, digits, dashes (kebab-case)",
+    ),
+  prompt: z.string().min(1, "Prompt is required"),
+  schedule_cron: z.string().optional().or(z.literal("")),
+});
+type CreateAgentForm = z.infer<typeof createAgentSchema>;
+
+export function AgentsPage() {
+  const agentsQuery = useAgents();
+  const createAgent = useCreateAgent();
+  const deleteAgent = useDeleteAgent();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<AgentDefinition | null>(
+    null,
+  );
+
+  const agents = agentsQuery.data ?? [];
+
+  const form = useForm<CreateAgentForm>({
+    resolver: zodResolver(createAgentSchema),
+    defaultValues: { name: "", slug: "", prompt: "", schedule_cron: "" },
+  });
+
+  const onCreate = form.handleSubmit(async (values) => {
+    const ok = await withMutationToast(
+      () =>
+        createAgent.mutateAsync({
+          name: values.name,
+          slug: values.slug,
+          prompt: values.prompt,
+          schedule_cron: values.schedule_cron || null,
+        }),
+      {
+        success: `Created agent ${values.name}`,
+        error: "Failed to create agent",
+      },
+    );
+    if (ok) {
+      setCreateOpen(false);
+      form.reset();
+    }
+  });
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="System"
+        title="Agents"
+        description="Recurring Claude Agent SDK runs that call breadbox MCP to enrich, categorize, and review your data."
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            New agent
+          </Button>
+        }
+      />
+
+      {agentsQuery.isError ? (
+        <PageError
+          resource="agents"
+          error={agentsQuery.error}
+          onRetry={() => agentsQuery.refetch()}
+          retrying={agentsQuery.isFetching}
+        />
+      ) : agentsQuery.isLoading ? (
+        <div className="flex flex-col gap-3">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : agents.length === 0 ? (
+        <EmptyState
+          icon={Bot}
+          title="No agents yet"
+          description="Create your first agent to schedule recurring Claude runs against your data. Each agent runs locally via the Claude Agent SDK and the breadbox MCP server."
+          action={
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="size-4" />
+              Create your first agent
+            </Button>
+          }
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {agents.map((agent) => (
+            <AgentRow
+              key={agent.id}
+              agent={agent}
+              onDelete={() => setPendingDelete(agent)}
+            />
+          ))}
+        </div>
+      )}
+
+      <Sheet open={createOpen} onOpenChange={setCreateOpen}>
+        <SheetContent className="sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>New agent</SheetTitle>
+            <SheetDescription>
+              Quick-create with prompt + schedule. The full prompt builder
+              ships in the next iteration; for now you can edit advanced
+              fields via the REST API.
+            </SheetDescription>
+          </SheetHeader>
+          <Form {...form}>
+            <form
+              onSubmit={onCreate}
+              className="mt-4 flex flex-1 flex-col gap-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Weekly transaction review"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="slug"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Slug</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="weekly-transaction-review"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Kebab-case identifier used in URLs and API calls.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="prompt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Prompt</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        rows={6}
+                        placeholder="Review last week's uncategorized transactions and apply the closest matching category…"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="schedule_cron"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Schedule (optional)</FormLabel>
+                    <FormControl>
+                      <Input placeholder="0 9 * * 1 — Mondays at 9 AM" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Standard 5-field cron expression. Leave blank for manual
+                      triggers only.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <SheetFooter className="mt-auto flex-row justify-end gap-2 pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCreateOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={createAgent.isPending}>
+                  {createAgent.isPending ? "Creating…" : "Create agent"}
+                </Button>
+              </SheetFooter>
+            </form>
+          </Form>
+        </SheetContent>
+      </Sheet>
+
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        tone="destructive"
+        title={`Delete agent ${pendingDelete?.name}?`}
+        description="This removes the agent definition. Historical runs are preserved for audit."
+        confirmLabel="Delete agent"
+        pending={deleteAgent.isPending}
+        onConfirm={() => {
+          if (!pendingDelete) return;
+          const slug = pendingDelete.slug;
+          const name = pendingDelete.name;
+          void withMutationToast(() => deleteAgent.mutateAsync(slug), {
+            success: `Deleted ${name}`,
+            error: "Delete failed",
+          }).then((ok) => {
+            if (ok) setPendingDelete(null);
+          });
+        }}
+      />
+    </>
+  );
+}
+
+interface AgentRowProps {
+  agent: AgentDefinition;
+  onDelete: () => void;
+}
+
+function AgentRow({ agent, onDelete }: AgentRowProps) {
+  const toggle = useToggleAgent();
+  const runNow = useRunAgentNow();
+
+  const handleToggle = (enable: boolean) => {
+    void withMutationToast(
+      () => toggle.mutateAsync({ slug: agent.slug, enable }),
+      {
+        success: enable ? "Enabled" : "Disabled",
+        error: "Toggle failed",
+      },
+    );
+  };
+
+  const handleRunNow = () => {
+    void withMutationToast(() => runNow.mutateAsync(agent.slug), {
+      success: `Run started for ${agent.name}`,
+      error:
+        "Run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
+    });
+  };
+
+  return (
+    <Card className="p-4">
+      <div className="flex flex-wrap items-start gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold leading-tight truncate">
+              {agent.name}
+            </h3>
+            <Badge variant="outline" className="font-mono text-[10px]">
+              {agent.slug}
+            </Badge>
+            <Badge
+              variant={agent.tool_scope === "read_write" ? "default" : "secondary"}
+              className="text-[10px] uppercase tracking-wide"
+            >
+              {agent.tool_scope.replace("_", " ")}
+            </Badge>
+          </div>
+          <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">
+            {agent.prompt}
+          </p>
+          <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+            <span className="inline-flex items-center gap-1">
+              <Clock className="size-3" />
+              {agent.schedule_cron
+                ? `Cron: ${agent.schedule_cron}`
+                : "Manual only"}
+            </span>
+            <span>Model: {agent.model}</span>
+            <span>Max turns: {agent.max_turns}</span>
+            <LastRunPill run={agent.last_run} />
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5">
+            <Switch
+              checked={agent.enabled}
+              disabled={toggle.isPending}
+              onCheckedChange={handleToggle}
+            />
+            <span className="text-xs font-medium">
+              {agent.enabled ? "Enabled" : "Disabled"}
+            </span>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={runNow.isPending}
+            onClick={handleRunNow}
+          >
+            <Play className="size-3.5" />
+            Run now
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Delete agent"
+            onClick={onDelete}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function LastRunPill({
+  run,
+}: {
+  run: AgentDefinition["last_run"];
+}) {
+  if (!run) {
+    return <span className="opacity-70">No runs yet</span>;
+  }
+  const Icon =
+    run.status === "success"
+      ? CheckCircle2
+      : run.status === "error"
+        ? XCircle
+        : run.status === "skipped"
+          ? AlertCircle
+          : Clock;
+  return (
+    <span className="inline-flex items-center gap-1">
+      <Icon className="size-3" />
+      {run.status} · {formatRelativeTime(run.started_at)}
+    </span>
+  );
+}


### PR DESCRIPTION
## Iteration 4 of the Claude Agent SDK integration sprint

First UI work — after this PR a self-hoster can manage agents from the v2 SPA: list, toggle, run-now, delete, create. Auth tokens + global caps go in **Settings → Agents**.

Targets the sprint branch (`agents/claude-agent-sdk-sprint`).

## Evidence

**`/v2/agents` — list page (two seeded demo agents shown):**

<img src="https://i.img402.dev/idz912nksw.jpg" width="900" alt="Agents list page — desktop+tablet+mobile">

**`/v2/?m=settings&ms=agents` — settings → agents tab (empty/initial state):**

<img src="https://i.img402.dev/z2y9wmfos5.jpg" width="900" alt="Settings Agents tab — desktop+tablet+mobile">

## What's in

- **`web/src/api/queries/agents.ts`** — TanStack Query hooks for the entire `/api/v1/agents` surface (list / get / create / update / delete / enable / disable / run-now / list-runs / get-run / settings get+update). Typed envelopes mirror `internal/service/agents.go`.
- **`web/src/routes/agents.tsx`** — list page. PageHeader + agent rows (name, slug pill, tool-scope badge, prompt preview, schedule/model/turns/last-run line, enable Switch, Run-now button, delete). Empty/loading/error states. Quick-create Sheet with name/slug/prompt/schedule_cron — the full prompt builder ships in iter 5.
- **`web/src/features/settings/agents-section.tsx`** — Settings → Agents tab. Auth-mode select (subscription vs API key), matching credential field that renders the stored value as a masked Badge with a Clear button, max-concurrent + global max-cost + binary path.
- **`web/src/lib/settings-sections.ts` + `settings-shell.tsx`** — register & wire the tab.
- **`web/src/main.tsx`** — `PAGE_OVERRIDES["/agents"]` swaps the Placeholder for `AgentsPage`. Nav entry was already in System group (added by an earlier iter).
- **`web/src/components/ui/switch.tsx`** — shadcn Switch primitive (`bunx shadcn@latest add switch`).

## Deferred to iter 5 (prompt builder + run history)

- Edit page with full prompt builder, allowed-tools multi-select sourced from the MCP tool registry, schedule preset picker.
- Run history drawer + transcript viewer.
- Sandbox specimens — the agent row is feature-scoped (`routes/agents.tsx`) today; if it gets promoted to `components/` in iter 5 it earns a sandbox slot per the design-system rule.

## Test plan

- [x] `cd web && bun run lint` — green (tsc --noEmit clean)
- [x] `cd web && bun run build` — green (vite production build)
- [x] Local end-to-end: built the iter-4 binary, seeded two demo agents (`routine-review-demo`, `spending-report-demo`), captured the screenshots above at desktop / tablet / mobile.
- [x] Go side untouched in this PR (no Go changes; tests + drift still green from iter 3)
- [x] No changes to `web/src/components/ui/*` styling (per v2-frontend rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)