### PR TITLE
feat(agents): prompt builder + run history + transcript viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /breadbox-server
 breadbox.exe
 /bin/
+# Local iteration test binaries built during the agents sprint
+/breadbox-iter*
 
 # Tailwind CSS standalone binary and generated CSS
 tailwindcss-extra

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -39,3 +39,26 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
   if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
+
+// apiText is the text/plain sibling of api<T>. Used for endpoints that stream
+// a non-JSON body (the agent transcript NDJSON viewer). Same credentials +
+// error-envelope behavior as api<T>.
+export async function apiText(
+  path: string,
+  init: RequestInit = {},
+): Promise<string> {
+  const res = await fetch(path, { credentials: "include", ...init });
+  if (!res.ok) {
+    let code = "HTTP_ERROR";
+    let message = res.statusText;
+    try {
+      const body = await res.json();
+      code = body?.error?.code ?? code;
+      message = body?.error?.message ?? message;
+    } catch {
+      // ignore parse errors
+    }
+    throw new ApiError(res.status, code, message);
+  }
+  return res.text();
+}

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/api/client";
+import { api, apiText } from "@/api/client";
 
 // Types mirror the Go-side response shapes in internal/service/agents.go
 // and internal/service/agent_settings.go. Endpoints documented in
@@ -223,5 +223,128 @@ export function useUpdateAgentSettings() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents", "settings"] });
     },
+  });
+}
+
+// --- Transcript types ---
+
+// Discriminated union of NDJSON event shapes emitted by the breadbox sidecar.
+// Payloads pass through from the SDK message objects for assistant_message /
+// tool_use / tool_result; the result event has the structured shape the
+// Go-side internal/service expects.
+
+export interface AssistantContentText {
+  type: "text";
+  text: string;
+}
+
+export interface AssistantContentToolUse {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+export type AssistantContent = AssistantContentText | AssistantContentToolUse;
+
+export interface AssistantMessageData {
+  message: {
+    role: "assistant";
+    content: AssistantContent[];
+  };
+}
+
+export interface ToolUseData {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResultData {
+  type: "tool_result";
+  tool_use_id: string;
+  content: unknown; // string | ContentBlock[]
+  is_error?: boolean;
+}
+
+export interface ResultData {
+  totalCostUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  turnCount: number;
+  numToolCalls: number;
+  sessionId: string;
+  stopReason: string; // "end_turn" | "max_turns" | "budget_exceeded" | ""
+}
+
+export interface TranscriptErrorData {
+  message: string;
+  stack?: string;
+  code?: string;
+}
+
+export interface CostCapHitData {
+  code: string;
+  message: string;
+}
+
+export interface SystemEventData {
+  [key: string]: unknown;
+}
+
+interface EventBase {
+  ts: number;
+}
+
+export type TranscriptEvent =
+  | (EventBase & { type: "assistant_message"; data: AssistantMessageData })
+  | (EventBase & { type: "tool_use"; data: ToolUseData })
+  | (EventBase & { type: "tool_result"; data: ToolResultData })
+  | (EventBase & { type: "result"; data: ResultData })
+  | (EventBase & { type: "error"; data: TranscriptErrorData })
+  | (EventBase & { type: "cost_cap_hit"; data: CostCapHitData })
+  | (EventBase & { type: "system"; data: SystemEventData });
+
+export interface TranscriptResult {
+  events: TranscriptEvent[];
+  rawLength: number;
+  truncated: boolean;
+}
+
+// Hard cap on parsed events so a multi-MB transcript doesn't crash the
+// browser. Above this the viewer renders a banner linking to the raw file.
+const TRANSCRIPT_MAX_EVENTS = 500;
+
+export function useTranscript(shortId: string | undefined) {
+  return useQuery({
+    queryKey: ["agents", "runs", shortId, "transcript"],
+    queryFn: async (): Promise<TranscriptResult> => {
+      const text = await apiText(
+        `/api/v1/agents/runs/${shortId}/transcript`,
+      );
+      const lines = text.split("\n").filter((l) => l.trim().length > 0);
+      const rawLength = lines.length;
+      const slice = lines.slice(0, TRANSCRIPT_MAX_EVENTS);
+      const events: TranscriptEvent[] = [];
+      for (const line of slice) {
+        try {
+          events.push(JSON.parse(line) as TranscriptEvent);
+        } catch {
+          // skip malformed lines
+        }
+      }
+      return {
+        events,
+        rawLength,
+        truncated: rawLength > TRANSCRIPT_MAX_EVENTS,
+      };
+    },
+    enabled: Boolean(shortId),
+    // Transcripts are immutable once a run completes — keep them cached
+    // across Sheet open/close.
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/web/src/features/agents/agent-constants.ts
+++ b/web/src/features/agents/agent-constants.ts
@@ -1,0 +1,14 @@
+// Model picker options surfaced in the edit form. Keep aligned with the
+// Go-side DefaultAgentModel constant (internal/service/agents.go) — when
+// Anthropic ships a new model family, update this list AND the migration
+// default + service constant.
+export const AGENT_MODELS = [
+  { value: "claude-opus-4-7", label: "Claude Opus 4.7 (most capable)" },
+  { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6 (balanced)" },
+  { value: "claude-haiku-4-5", label: "Claude Haiku 4.5 (fastest)" },
+] as const;
+
+export const TOOL_SCOPES = [
+  { value: "read_write" as const, label: "Read & write (default)" },
+  { value: "read_only" as const, label: "Read only" },
+];

--- a/web/src/features/agents/cron-field.tsx
+++ b/web/src/features/agents/cron-field.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  CRON_PRESETS,
+  cronToProseLabel,
+  isValidCronExpr,
+} from "@/lib/cron-prose";
+
+interface CronFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  onBlur?: () => void;
+  name?: string;
+  placeholder?: string;
+}
+
+// CronField is the cron-input + live-preview + preset-picker combo used by
+// the agent edit form. Empty value reads as "Manual trigger only";
+// non-empty values are validated client-side via isValidCronExpr (a
+// permissive structural check — robfig is the canonical validator at
+// server registration time).
+export function CronField({
+  value,
+  onChange,
+  onBlur,
+  name,
+  placeholder = "0 9 * * 1",
+}: CronFieldProps) {
+  const [open, setOpen] = useState(false);
+  const trimmed = value.trim();
+  const valid = trimmed === "" || isValidCronExpr(trimmed);
+  const previewLabel = cronToProseLabel(trimmed);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="relative">
+        <Input
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onBlur}
+          className="pr-10 font-mono text-sm"
+          aria-invalid={!valid}
+        />
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 top-1/2 size-7 -translate-y-1/2"
+              aria-label="Cron presets"
+            >
+              <ChevronDown className="size-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-0" align="end">
+            <Command>
+              <CommandInput placeholder="Search presets…" />
+              <CommandList>
+                <CommandEmpty>No matching preset.</CommandEmpty>
+                <CommandGroup heading="Common schedules">
+                  {CRON_PRESETS.map((p) => (
+                    <CommandItem
+                      key={p.value}
+                      value={`${p.value} ${p.label}`}
+                      onSelect={() => {
+                        onChange(p.value);
+                        setOpen(false);
+                      }}
+                    >
+                      <span className="flex-1">{p.label}</span>
+                      <span className="text-muted-foreground font-mono text-[10px]">
+                        {p.value}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
+      <p
+        className={cn(
+          "text-xs",
+          valid ? "text-muted-foreground" : "text-destructive",
+        )}
+      >
+        {valid
+          ? `Runs: ${previewLabel}`
+          : "Doesn't look like a valid 5-field cron expression"}
+      </p>
+    </div>
+  );
+}

--- a/web/src/features/agents/run-status-pill.tsx
+++ b/web/src/features/agents/run-status-pill.tsx
@@ -1,0 +1,81 @@
+import { AlertCircle, CheckCircle2, Clock, Loader2, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface RunStatusPillProps {
+  status: string;
+  className?: string;
+}
+
+// Compact status indicator for one agent run row. Icon + label, color
+// derives from semantic meaning of the status enum (not raw status
+// strings). Unknown statuses fall through to a neutral gray.
+export function RunStatusPill({ status, className }: RunStatusPillProps) {
+  const palette = paletteFor(status);
+  const Icon = palette.icon;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium",
+        palette.bg,
+        palette.text,
+        className,
+      )}
+    >
+      <Icon className={cn("size-3.5", palette.spin && "animate-spin")} />
+      {palette.label}
+    </span>
+  );
+}
+
+function paletteFor(status: string) {
+  switch (status) {
+    case "success":
+      return {
+        icon: CheckCircle2,
+        bg: "bg-emerald-100 dark:bg-emerald-950/40",
+        text: "text-emerald-700 dark:text-emerald-300",
+        label: "Success",
+        spin: false,
+      };
+    case "error":
+      return {
+        icon: XCircle,
+        bg: "bg-red-100 dark:bg-red-950/40",
+        text: "text-red-700 dark:text-red-300",
+        label: "Error",
+        spin: false,
+      };
+    case "timeout":
+      return {
+        icon: AlertCircle,
+        bg: "bg-amber-100 dark:bg-amber-950/40",
+        text: "text-amber-700 dark:text-amber-300",
+        label: "Timeout",
+        spin: false,
+      };
+    case "in_progress":
+      return {
+        icon: Loader2,
+        bg: "bg-blue-100 dark:bg-blue-950/40",
+        text: "text-blue-700 dark:text-blue-300",
+        label: "Running",
+        spin: true,
+      };
+    case "skipped":
+      return {
+        icon: AlertCircle,
+        bg: "bg-zinc-100 dark:bg-zinc-800",
+        text: "text-zinc-700 dark:text-zinc-300",
+        label: "Skipped",
+        spin: false,
+      };
+    default:
+      return {
+        icon: Clock,
+        bg: "bg-zinc-100 dark:bg-zinc-800",
+        text: "text-zinc-700 dark:text-zinc-300",
+        label: status,
+        spin: false,
+      };
+  }
+}

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -1,0 +1,353 @@
+import { useMemo, useState } from "react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Coins,
+  Cpu,
+  Download,
+  Wrench,
+} from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { formatDuration } from "@/lib/format";
+import type {
+  AssistantContent,
+  AssistantMessageData,
+  ResultData,
+  ToolResultData,
+  ToolUseData,
+  TranscriptEvent,
+} from "@/api/queries/agents";
+
+interface TranscriptViewerProps {
+  events: TranscriptEvent[];
+  rawLength: number;
+  truncated: boolean;
+  shortId: string;
+}
+
+// Grouped representation of one assistant turn: the assistant's message
+// plus any tool_use blocks and matching tool_result blocks before the next
+// assistant_message.
+interface TurnGroup {
+  assistant: (AssistantMessageData & { ts: number }) | null;
+  toolUses: Array<ToolUseData & { ts: number }>;
+  toolResults: Array<ToolResultData & { ts: number }>;
+}
+
+function groupIntoTurns(events: TranscriptEvent[]): TurnGroup[] {
+  const turns: TurnGroup[] = [];
+  let current: TurnGroup = { assistant: null, toolUses: [], toolResults: [] };
+  for (const ev of events) {
+    if (ev.type === "assistant_message") {
+      if (current.assistant !== null || current.toolUses.length > 0) {
+        turns.push(current);
+        current = { assistant: null, toolUses: [], toolResults: [] };
+      }
+      current.assistant = { ...ev.data, ts: ev.ts };
+    } else if (ev.type === "tool_use") {
+      current.toolUses.push({ ...ev.data, ts: ev.ts });
+    } else if (ev.type === "tool_result") {
+      current.toolResults.push({ ...ev.data, ts: ev.ts });
+    }
+  }
+  if (current.assistant !== null || current.toolUses.length > 0) {
+    turns.push(current);
+  }
+  return turns;
+}
+
+export function TranscriptViewer({
+  events,
+  rawLength,
+  truncated,
+  shortId,
+}: TranscriptViewerProps) {
+  const turns = useMemo(() => groupIntoTurns(events), [events]);
+  const resultEvent = useMemo(
+    () => events.find((e) => e.type === "result"),
+    [events],
+  );
+  const errorEvent = useMemo(
+    () => events.find((e) => e.type === "error"),
+    [events],
+  );
+  const costCapEvent = useMemo(
+    () => events.find((e) => e.type === "cost_cap_hit"),
+    [events],
+  );
+
+  return (
+    <div className="flex flex-col gap-4 px-1 pb-4">
+      {truncated && (
+        <Alert>
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Transcript truncated</AlertTitle>
+          <AlertDescription className="flex items-center gap-2">
+            <span>
+              Showing first {events.length} of {rawLength} events.
+            </span>
+            <Button asChild variant="link" size="sm" className="h-auto p-0">
+              <a
+                href={`/api/v1/agents/runs/${shortId}/transcript`}
+                download={`transcript-${shortId}.ndjson`}
+              >
+                <Download className="size-3" /> Download full
+              </a>
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {errorEvent?.type === "error" && (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" />
+          <AlertTitle>Run errored</AlertTitle>
+          <AlertDescription>{errorEvent.data.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {costCapEvent?.type === "cost_cap_hit" && (
+        <Alert>
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Budget cap reached</AlertTitle>
+          <AlertDescription>{costCapEvent.data.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {turns.length === 0 && !errorEvent && (
+        <p className="text-muted-foreground text-sm">
+          No assistant messages yet — the run may have failed before the
+          model produced output.
+        </p>
+      )}
+
+      {turns.map((turn, i) => (
+        <TurnBlock key={i} turn={turn} index={i} />
+      ))}
+
+      {resultEvent?.type === "result" && (
+        <ResultFooter data={resultEvent.data} />
+      )}
+    </div>
+  );
+}
+
+function TurnBlock({ turn, index }: { turn: TurnGroup; index: number }) {
+  return (
+    <div className="border-border space-y-2 rounded-lg border p-3">
+      <div className="text-muted-foreground text-[10px] uppercase tracking-wider">
+        Turn {index + 1}
+      </div>
+      {turn.assistant && <MessageBubble data={turn.assistant} />}
+      {turn.toolUses.map((tu) => {
+        const result = turn.toolResults.find(
+          (tr) => tr.tool_use_id === tu.id,
+        );
+        return (
+          <ToolCallPair key={tu.id} toolUse={tu} toolResult={result} />
+        );
+      })}
+    </div>
+  );
+}
+
+function MessageBubble({ data }: { data: AssistantMessageData }) {
+  const text = useMemo(() => extractText(data.message.content), [data]);
+  if (!text) return null;
+  return (
+    <div className="bg-muted/40 rounded-md p-3">
+      <pre className="text-foreground whitespace-pre-wrap break-words font-sans text-sm">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+function extractText(content: AssistantContent[]): string {
+  return content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text)
+    .join("\n\n");
+}
+
+interface ToolCallPairProps {
+  toolUse: ToolUseData & { ts: number };
+  toolResult?: ToolResultData & { ts: number };
+}
+
+function ToolCallPair({ toolUse, toolResult }: ToolCallPairProps) {
+  const [open, setOpen] = useState(false);
+  const errored = toolResult?.is_error === true;
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="hover:bg-accent flex w-full items-center gap-2 rounded-md border bg-background px-2 py-1.5 text-left text-xs"
+        >
+          {open ? (
+            <ChevronDown className="size-3.5 shrink-0" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0" />
+          )}
+          <Wrench className="text-muted-foreground size-3.5 shrink-0" />
+          <span className="font-mono text-xs">{toolUse.name}</span>
+          {toolResult && (
+            <Badge
+              variant={errored ? "destructive" : "outline"}
+              className="ml-auto text-[10px]"
+            >
+              {errored ? "error" : "ok"}
+            </Badge>
+          )}
+          {!toolResult && (
+            <Badge variant="secondary" className="ml-auto text-[10px]">
+              pending
+            </Badge>
+          )}
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-2 px-2 pt-2">
+        <CollapsibleSection label="Input">
+          <CodeJson value={toolUse.input} />
+        </CollapsibleSection>
+        {toolResult && (
+          <CollapsibleSection
+            label={errored ? "Error output" : "Output"}
+            tone={errored ? "error" : "default"}
+          >
+            <CodeJson value={toolResult.content} />
+          </CollapsibleSection>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function CollapsibleSection({
+  label,
+  tone = "default",
+  children,
+}: {
+  label: string;
+  tone?: "default" | "error";
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <div
+        className={cn(
+          "text-[10px] font-medium uppercase tracking-wider",
+          tone === "error" ? "text-destructive" : "text-muted-foreground",
+        )}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CodeJson({ value }: { value: unknown }) {
+  const text = useMemo(() => {
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }, [value]);
+  return (
+    <pre className="bg-muted max-h-48 overflow-auto rounded p-2 text-[11px] leading-tight">
+      {text}
+    </pre>
+  );
+}
+
+function ResultFooter({ data }: { data: ResultData }) {
+  const stopPalette =
+    data.stopReason === "budget_exceeded"
+      ? "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300"
+      : data.stopReason === "max_turns"
+        ? "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+        : "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300";
+  return (
+    <div className="bg-muted/40 mt-2 rounded-lg p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-muted-foreground text-xs uppercase tracking-wider">
+          Result
+        </span>
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium",
+            stopPalette,
+          )}
+        >
+          {data.stopReason || "completed"}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+        <FooterStat
+          icon={Coins}
+          label="Cost"
+          value={`$${data.totalCostUsd.toFixed(4)}`}
+        />
+        <FooterStat icon={Cpu} label="Turns" value={String(data.turnCount)} />
+        <FooterStat
+          icon={Wrench}
+          label="Tool calls"
+          value={String(data.numToolCalls)}
+        />
+        <FooterStat
+          icon={Cpu}
+          label="Tokens"
+          value={`${data.inputTokens.toLocaleString()} in / ${data.outputTokens.toLocaleString()} out`}
+          sub={
+            data.cacheReadTokens + data.cacheCreationTokens > 0
+              ? `cache: ${(data.cacheReadTokens + data.cacheCreationTokens).toLocaleString()}`
+              : undefined
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+function FooterStat({
+  icon: Icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-muted-foreground flex items-center gap-1 text-[10px] uppercase tracking-wider">
+        <Icon className="size-3" />
+        {label}
+      </div>
+      <div className="text-foreground text-sm font-medium">{value}</div>
+      {sub && (
+        <div className="text-muted-foreground text-[10px]">{sub}</div>
+      )}
+    </div>
+  );
+}
+
+// Re-export formatDuration for sites that pair the viewer with run metadata.
+// (Importing from "@/lib/format" works too — this is a convenience alias.)
+export { formatDuration };

--- a/web/src/lib/cron-prose.ts
+++ b/web/src/lib/cron-prose.ts
@@ -1,0 +1,74 @@
+// Hand-rolled cron→prose for the ~12 schedules a self-hoster will realistically
+// pick. Anything else falls back to "Custom: <expression>". No external
+// dependency — robfig/cron is the server-side schedule engine and supports
+// 5-field standard cron plus @-shorthands; we cover both.
+
+export function cronToProseLabel(expr: string | null | undefined): string {
+  if (!expr) return "Manual trigger only";
+  const e = expr.trim();
+  switch (e) {
+    case "@daily":
+    case "0 0 * * *":
+      return "Daily at midnight";
+    case "0 6 * * *":
+      return "Daily at 6 AM";
+    case "0 9 * * *":
+      return "Daily at 9 AM";
+    case "0 18 * * *":
+      return "Daily at 6 PM";
+    case "0 9 * * 1":
+      return "Mondays at 9 AM";
+    case "0 9 * * 5":
+      return "Fridays at 9 AM";
+    case "0 9 1 * *":
+      return "1st of month at 9 AM";
+    case "0 0 1 * *":
+      return "1st of month at midnight";
+    case "*/30 * * * *":
+      return "Every 30 minutes";
+    case "0 */6 * * *":
+      return "Every 6 hours";
+    case "@weekly":
+    case "0 0 * * 0":
+      return "Sundays at midnight";
+    case "@hourly":
+    case "0 * * * *":
+      return "Every hour";
+  }
+  return `Custom: ${e}`;
+}
+
+// isValidCronExpr does a permissive structural check — 5 fields, each one of
+// the standard sub-grammars. Robfig will reject anything truly malformed at
+// registration time; this helper just gates UI inline errors.
+export function isValidCronExpr(expr: string): boolean {
+  const e = expr.trim();
+  if (e.startsWith("@")) {
+    return ["@daily", "@hourly", "@weekly", "@monthly", "@yearly", "@annually"].includes(e);
+  }
+  const fieldRe = /^(\*|(\d+)(-\d+)?(,\d+(-\d+)?)*|(\*\/\d+))$/;
+  const parts = e.split(/\s+/);
+  if (parts.length !== 5) return false;
+  return parts.every((p) => fieldRe.test(p));
+}
+
+export interface CronPreset {
+  value: string;
+  label: string;
+}
+
+// The preset list shown in the CronField popover. Keep ordered by frequency
+// (high → low) so users see the most likely choices first.
+export const CRON_PRESETS: CronPreset[] = [
+  { value: "*/30 * * * *", label: "Every 30 minutes" },
+  { value: "0 * * * *", label: "Every hour (top of hour)" },
+  { value: "0 */6 * * *", label: "Every 6 hours" },
+  { value: "0 6 * * *", label: "Daily at 6 AM" },
+  { value: "0 9 * * *", label: "Daily at 9 AM" },
+  { value: "0 18 * * *", label: "Daily at 6 PM" },
+  { value: "0 9 * * 1", label: "Mondays at 9 AM" },
+  { value: "0 9 * * 5", label: "Fridays at 9 AM" },
+  { value: "0 9 1 * *", label: "1st of month at 9 AM" },
+  { value: "@daily", label: "Daily (midnight)" },
+  { value: "@hourly", label: "Hourly (top of hour)" },
+];

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -133,6 +133,19 @@ export function formatRelativeTime(iso: string): string {
   return relativeTimeFormatter.format(Math.round(diffSec), "second");
 }
 
+// formatDuration renders a millisecond count as a compact "5m 12s" / "823ms"
+// label. Returns "—" for null/undefined/zero — agent runs and sync logs both
+// surface NULL when a row hasn't completed yet.
+export function formatDuration(ms: number | null | undefined): string {
+  if (!ms) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const min = Math.floor(s / 60);
+  const rest = s % 60;
+  return rest > 0 ? `${min}m ${rest}s` : `${min}m`;
+}
+
 // formatRelativeShort renders an RFC3339 timestamp as a compact "12m ago" /
 // "3h ago" / "5d ago" — the dense form for connection rows, sync history,
 // and other surfaces where the long form ("12 minutes ago") would crowd

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -46,6 +46,8 @@ import {
 } from "@/routes/account-detail";
 import { RulesPage, rulesSearchSchema } from "@/routes/rules";
 import { AgentsPage } from "@/routes/agents";
+import { AgentEditPage } from "@/routes/agents.$slug.edit";
+import { AgentRunsPage, agentRunsSearchSchema } from "@/routes/agents.$slug.runs";
 import { RuleDetailPage } from "@/routes/rule-detail";
 import { RuleFormPage } from "@/routes/rule-form";
 import { NAV_LEAVES } from "@/lib/nav";
@@ -218,6 +220,21 @@ const ruleDetailRoute = createRoute({
   component: RuleDetailPage,
 });
 
+// /agents/$slug/edit and /agents/$slug/runs — declared before the more
+// general /agents nav-leaf route so chi-style longest-match prevails.
+const agentEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/agents/$slug/edit",
+  component: AgentEditPage,
+});
+
+const agentRunsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/agents/$slug/runs",
+  component: AgentRunsPage,
+  validateSearch: agentRunsSearchSchema,
+});
+
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
   const override = PAGE_OVERRIDES[leaf.to];
@@ -250,6 +267,8 @@ const routeTree = rootRoute.addChildren([
   ruleNewRoute,
   ruleEditRoute,
   ruleDetailRoute,
+  agentEditRoute,
+  agentRunsRoute,
   ...pageRoutes,
 ]);
 

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -1,0 +1,379 @@
+import { useEffect } from "react";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageHeader } from "@/components/page-header";
+import { PageError } from "@/components/page-error";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useAgent, useUpdateAgent } from "@/api/queries/agents";
+import {
+  AGENT_MODELS,
+  TOOL_SCOPES,
+} from "@/features/agents/agent-constants";
+import { CronField } from "@/features/agents/cron-field";
+
+// Use z.preprocess (not z.coerce) for numerics to dodge the iter-4 resolver
+// bug where coerce.number leaves the input type as `unknown`. Preprocess
+// converts string → number explicitly at submit time; defaults stay typed.
+const agentEditSchema = z.object({
+  name: z.string().min(1, "Name is required").max(120),
+  prompt: z.string().min(1, "Prompt is required"),
+  system_prompt: z.string().optional().or(z.literal("")),
+  schedule_cron: z.string().optional().or(z.literal("")),
+  tool_scope: z.enum(["read_only", "read_write"]),
+  allowed_tools_raw: z.string().optional(), // comma-separated; split at submit
+  model: z.string().min(1),
+  max_turns: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? undefined : Number(v)),
+    z.number().int().min(1).max(200),
+  ),
+  max_budget_usd: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
+    z.number().positive().nullable(),
+  ),
+});
+type AgentEditForm = z.input<typeof agentEditSchema>;
+
+export function AgentEditPage() {
+  const { slug } = useParams({ strict: false }) as { slug: string };
+  const navigate = useNavigate();
+  const agentQuery = useAgent(slug);
+  const updateAgent = useUpdateAgent(slug);
+
+  const form = useForm<AgentEditForm>({
+    resolver: zodResolver(agentEditSchema),
+    defaultValues: {
+      name: "",
+      prompt: "",
+      system_prompt: "",
+      schedule_cron: "",
+      tool_scope: "read_write",
+      allowed_tools_raw: "",
+      model: "claude-opus-4-7",
+      max_turns: 10,
+      max_budget_usd: null,
+    },
+  });
+
+  // Hydrate the form once the agent loads. Depend on short_id (immutable)
+  // not the whole object, so a cache refetch doesn't wipe in-flight edits.
+  useEffect(() => {
+    const agent = agentQuery.data;
+    if (!agent) return;
+    form.reset({
+      name: agent.name,
+      prompt: agent.prompt,
+      system_prompt: agent.system_prompt ?? "",
+      schedule_cron: agent.schedule_cron ?? "",
+      tool_scope: agent.tool_scope,
+      allowed_tools_raw: (agent.allowed_tools ?? []).join(", "),
+      model: agent.model,
+      max_turns: agent.max_turns,
+      max_budget_usd: agent.max_budget_usd ?? null,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentQuery.data?.short_id]);
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const tools = (values.allowed_tools_raw ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const ok = await withMutationToast(
+      () =>
+        updateAgent.mutateAsync({
+          name: values.name,
+          prompt: values.prompt,
+          system_prompt: values.system_prompt ? values.system_prompt : null,
+          schedule_cron: values.schedule_cron ? values.schedule_cron : null,
+          tool_scope: values.tool_scope,
+          allowed_tools: tools,
+          model: values.model,
+          max_turns: values.max_turns as unknown as number,
+          max_budget_usd: values.max_budget_usd as unknown as number | null,
+        }),
+      {
+        success: "Agent saved",
+        error: "Save failed",
+      },
+    );
+    if (ok) navigate({ to: "/agents" });
+  });
+
+  if (agentQuery.isError) {
+    return (
+      <PageError
+        resource="agent"
+        error={agentQuery.error}
+        onRetry={() => agentQuery.refetch()}
+        retrying={agentQuery.isFetching}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+        <Link to="/agents">
+          <ArrowLeft className="size-4" /> Back to agents
+        </Link>
+      </Button>
+      <PageHeader
+        eyebrow="Agent"
+        title={agentQuery.data?.name ?? "Edit agent"}
+        description="Update prompt, schedule, model, and safety caps. Changes take effect on the next scheduled fire or manual run."
+      />
+
+      {agentQuery.isLoading ? (
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-1/2" />
+        </div>
+      ) : (
+        <Form {...form}>
+          <form onSubmit={onSubmit} className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <div className="space-y-4 md:col-span-2">
+              <Card className="space-y-4 p-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="prompt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Prompt</FormLabel>
+                      <FormControl>
+                        <Textarea rows={10} {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Sent to Claude on every run. Be specific about the
+                        outcome (what to categorize, what to report, what
+                        not to touch).
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="system_prompt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>System prompt (optional)</FormLabel>
+                      <FormControl>
+                        <Textarea rows={4} {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Optional override sent as the SDK system prompt
+                        instead of the default. Leave blank for default behavior.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Card>
+            </div>
+
+            <div className="space-y-4">
+              <Card className="space-y-4 p-4">
+                <FormField
+                  control={form.control}
+                  name="model"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Model</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {AGENT_MODELS.map((m) => (
+                            <SelectItem key={m.value} value={m.value}>
+                              {m.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="schedule_cron"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Schedule</FormLabel>
+                      <FormControl>
+                        <CronField
+                          value={field.value ?? ""}
+                          onChange={field.onChange}
+                          onBlur={field.onBlur}
+                          name={field.name}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="tool_scope"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tool scope</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {TOOL_SCOPES.map((s) => (
+                            <SelectItem key={s.value} value={s.value}>
+                              {s.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Controls which MCP write tools the run can call.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="allowed_tools_raw"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Allowed tools (optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={3}
+                          placeholder="mcp__breadbox__*"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Comma-separated MCP tool names. Leave blank to allow
+                        every tool in scope.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="max_turns"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Max turns</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={200}
+                            value={
+                              field.value === undefined || field.value === null
+                                ? ""
+                                : String(field.value)
+                            }
+                            onChange={(e) => field.onChange(e.target.value)}
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            ref={field.ref}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="max_budget_usd"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Max cost (USD)</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            step="0.01"
+                            min={0}
+                            placeholder="0.50"
+                            value={
+                              field.value === undefined || field.value === null
+                                ? ""
+                                : String(field.value)
+                            }
+                            onChange={(e) => field.onChange(e.target.value)}
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            ref={field.ref}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </Card>
+
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" asChild>
+                  <Link to="/agents">Cancel</Link>
+                </Button>
+                <Button type="submit" disabled={updateAgent.isPending}>
+                  {updateAgent.isPending && (
+                    <Loader2 className="size-4 animate-spin" />
+                  )}
+                  Save changes
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+      )}
+    </>
+  );
+}

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -1,0 +1,207 @@
+import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+import { ArrowLeft, Clock, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { PageHeader } from "@/components/page-header";
+import { PageError } from "@/components/page-error";
+import { EmptyState } from "@/components/empty-state";
+import {
+  useAgent,
+  useAgentRuns,
+  useTranscript,
+  type AgentRun,
+} from "@/api/queries/agents";
+import { formatDuration, formatRelativeTime } from "@/lib/format";
+import { RunStatusPill } from "@/features/agents/run-status-pill";
+import { TranscriptViewer } from "@/features/agents/transcript-viewer";
+
+export const agentRunsSearchSchema = z.object({
+  run: z.string().optional(),
+  page: z.number().int().positive().optional(),
+});
+type AgentRunsSearch = z.infer<typeof agentRunsSearchSchema>;
+
+const PAGE_SIZE = 25;
+
+export function AgentRunsPage() {
+  const { slug } = useParams({ strict: false }) as { slug: string };
+  const search = useSearch({ strict: false }) as AgentRunsSearch;
+  const navigate = useNavigate();
+  const page = search.page ?? 1;
+
+  const agentQuery = useAgent(slug);
+  const runsQuery = useAgentRuns(slug, PAGE_SIZE, (page - 1) * PAGE_SIZE);
+
+  const openRunShortId = search.run ?? null;
+
+  const openRun = (shortId: string) => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, run: shortId }),
+    });
+  };
+  const closeRun = () => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, run: undefined }),
+    });
+  };
+  const loadMore = () => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, page: page + 1 }),
+    });
+  };
+
+  const runs = runsQuery.data?.runs ?? [];
+  const hasMore = runsQuery.data?.has_more ?? false;
+
+  return (
+    <>
+      <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+        <Link to="/agents">
+          <ArrowLeft className="size-4" /> Back to agents
+        </Link>
+      </Button>
+      <PageHeader
+        eyebrow="Agent runs"
+        title={agentQuery.data ? `${agentQuery.data.name} — runs` : "Run history"}
+        description="Every fire of this agent (cron or manual). Click any row to view its transcript."
+      />
+
+      {runsQuery.isError ? (
+        <PageError
+          resource="runs"
+          error={runsQuery.error}
+          onRetry={() => runsQuery.refetch()}
+          retrying={runsQuery.isFetching}
+        />
+      ) : runsQuery.isLoading ? (
+        <div className="flex flex-col gap-2">
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      ) : runs.length === 0 ? (
+        <EmptyState
+          icon={Clock}
+          title="No runs yet"
+          description="Trigger a run from the agents list, or wait for the next scheduled fire."
+        />
+      ) : (
+        <Card className="overflow-hidden p-0">
+          <div className="divide-border divide-y">
+            {runs.map((run) => (
+              <RunRow key={run.id} run={run} onClick={() => openRun(run.short_id)} />
+            ))}
+          </div>
+          {hasMore && (
+            <div className="flex justify-center border-t p-3">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={runsQuery.isFetching}
+                onClick={loadMore}
+              >
+                {runsQuery.isFetching && (
+                  <Loader2 className="size-4 animate-spin" />
+                )}
+                Load more
+              </Button>
+            </div>
+          )}
+        </Card>
+      )}
+
+      <TranscriptSheet shortId={openRunShortId} onClose={closeRun} />
+    </>
+  );
+}
+
+function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="hover:bg-accent/40 flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left text-sm"
+    >
+      <RunStatusPill status={run.status} />
+      <span className="text-muted-foreground text-xs uppercase tracking-wide">
+        {run.trigger}
+      </span>
+      <span className="flex-1 text-xs">
+        {formatRelativeTime(run.started_at)}
+      </span>
+      <span className="text-muted-foreground text-xs">
+        {formatDuration(run.duration_ms)}
+      </span>
+      <span className="text-muted-foreground text-xs font-mono">
+        {run.total_cost_usd != null ? `$${run.total_cost_usd.toFixed(4)}` : "—"}
+      </span>
+      <span className="text-muted-foreground text-xs">
+        {run.num_tool_calls != null ? `${run.num_tool_calls} tools` : "—"}
+      </span>
+    </button>
+  );
+}
+
+interface TranscriptSheetProps {
+  shortId: string | null;
+  onClose: () => void;
+}
+
+function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
+  const open = Boolean(shortId);
+  const runQuery = useAgentRuns; // unused — kept here as a reminder that the
+  // single-run detail comes via useTranscript; the run summary is in the
+  // parent's runs list.
+  void runQuery;
+  const transcript = useTranscript(shortId ?? undefined);
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-2xl">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle>Transcript</SheetTitle>
+          <SheetDescription>
+            {shortId ? (
+              <span className="font-mono text-xs">Run {shortId}</span>
+            ) : null}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {transcript.isLoading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-32 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+          ) : transcript.isError ? (
+            <PageError
+              resource="transcript"
+              error={transcript.error}
+              onRetry={() => transcript.refetch()}
+              retrying={transcript.isFetching}
+            />
+          ) : transcript.data && shortId ? (
+            <TranscriptViewer
+              events={transcript.data.events}
+              rawLength={transcript.data.rawLength}
+              truncated={transcript.data.truncated}
+              shortId={shortId}
+            />
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -7,6 +8,8 @@ import {
   Bot,
   CheckCircle2,
   Clock,
+  History,
+  Pencil,
   Play,
   Plus,
   Trash2,
@@ -358,6 +361,16 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
           >
             <Play className="size-3.5" />
             Run now
+          </Button>
+          <Button asChild variant="ghost" size="icon" aria-label="Run history">
+            <Link to="/agents/$slug/runs" params={{ slug: agent.slug }}>
+              <History className="size-4" />
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" size="icon" aria-label="Edit agent">
+            <Link to="/agents/$slug/edit" params={{ slug: agent.slug }}>
+              <Pencil className="size-4" />
+            </Link>
           </Button>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Iteration 5 of the Claude Agent SDK integration sprint

Full agent management UI. After this PR self-hosters can:
- **Edit** any agent (prompt, system prompt, schedule with cron preset picker + live preview, model, tool scope, allowed tools, max turns + max cost)
- **Review every run** with a transcript drawer that renders the SDK's NDJSON event stream as a chat-style transcript: assistant turns, collapsible tool calls + results, cost/usage footer

Targets the sprint branch (`agents/claude-agent-sdk-sprint`).

## Evidence

**`/v2/agents` — list page with the new Edit (pencil) and History (clock) icon buttons:**

<img src="https://i.img402.dev/3pklpddyja.jpg" width="900" alt="Agents list with Edit + History buttons">

**`/v2/agents/$slug/edit` — full edit form. Schedule field has a live cron preview (\"Mondays at 9 AM\") and a preset picker popover:**

<img src="https://i.img402.dev/91t5it1k6r.jpg" width="900" alt="Agent edit page — desktop+tablet+mobile">

**`/v2/agents/$slug/runs` — run history with color-coded status pills, click any row to open the transcript drawer:**

<img src="https://i.img402.dev/wd2y29mg7s.jpg" width="900" alt="Agent runs page — desktop+tablet+mobile">

## What's in

**Edit page** (`web/src/routes/agents.$slug.edit.tsx`)
- 2-col layout on md+; single column on mobile. RHF + zod with `z.preprocess` (not `z.coerce` — that hit the resolver typing bug in iter 4).
- Hydrates from `useAgent` once on mount; reset key is `short_id` so cache refetches don't wipe in-flight edits.
- All 9 fields wired to `useUpdateAgent`. `allowed_tools` is a comma-separated Textarea today; a TagInput chip control is a follow-up.

**Runs page** (`web/src/routes/agents.$slug.runs.tsx`)
- Status pills (Success/Error/Timeout/Running/Skipped), trigger, relative time, duration, cost, tool-call count.
- "Load more" pagination — the runs API is offset + `has_more`, not totaled.
- Row click → opens transcript Sheet via `?run=<shortId>` (shareable URL, doesn't unmount the list).

**Transcript viewer** (`web/src/features/agents/transcript-viewer.tsx`)
- Parses NDJSON, groups events into assistant-turn blocks (assistant message → tool_use[] → tool_result[]).
- Tool-call pairs are collapsible: header shows the tool name + status pill, body shows JSON input + output.
- Result footer: stop-reason pill (color-coded), cost (4-decimal), turn count, tool count, tokens with cache sub-line.
- Banners: error (destructive), cost-cap (amber), truncated-transcript with a "Download full transcript" link (capped at 500 events for browser perf).

**Cron field** (`web/src/features/agents/cron-field.tsx`) — input + live human-readable preview + Popover preset picker (12 curated schedules).

**Plumbing**
- `apiText()` added to `web/src/api/client.ts` for non-JSON endpoints.
- `TranscriptEvent` discriminated union + `useTranscript` hook (5-minute staleTime — transcripts are immutable once a run completes) added to `web/src/api/queries/agents.ts`.
- `formatDuration` added to `web/src/lib/format.ts`.
- `.gitignore` excludes `/breadbox-iter*` so local test binaries can't sneak into commits (lesson from iter 4 that the iteration log captured).

## Deferred (intentional scope cuts)

- **Sandbox specimens** for TranscriptViewer + CronField. These will be promoted to `components/` when reuse outside the agents area appears; until then they're feature-scoped per the design-system rule.
- **TagInput chip control** for `allowed_tools` — current Textarea works, will polish in a later iter.
- **MCP tool registry endpoint** to source the allowed-tools picker from live data instead of free text. Worth doing once the runtime tool list is non-trivial.

## Test plan

- [x] `cd web && bun run lint` — green
- [x] `cd web && bun run build` — green (Vite production bundle)
- [x] Local end-to-end: built iter-5 binary, seeded one agent + 3 runs covering success/error/skipped, captured screenshots above at desktop+tablet+mobile composite
- [x] No Go-side changes — Go tests + drift test still green from iter 3
- [x] Demo data cleaned up after capture; no leftover seed rows in dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)