### PR TITLE
feat(agents): seed default agents + retire v1 admin agent-prompts

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,65 @@
+# Agents
+
+Recurring AI-powered workflows that run via the Claude Agent SDK and call breadbox MCP to enrich, categorize, and review your data. Agents replace the v1 admin "agent prompts" wizard with a real scheduling + execution system.
+
+## Quick start
+
+1. **Authenticate**: Settings → Agents → pick auth mode.
+   - **Subscription token (recommended for hobbyists)**: run `claude setup-token` on any machine, paste the resulting `sk-ant-oat01-…` token. Free under your Claude plan's monthly Agent SDK credit (until 2026-06-15; details: https://support.claude.com/en/articles/15036540).
+   - **Anthropic API key**: paste an `sk-ant-…` key from console.anthropic.com. Billed per API call; durable past the 2026-06-15 cutover.
+2. **Build the sidecar binary** (one-time):
+   ```sh
+   make agent-sidecar
+   ```
+   Outputs `bin/breadbox-agent`. Set `agent.runtime_path` in Settings → Agents if you put it elsewhere.
+3. **Pick a starter agent** from the v2 SPA at `/v2/agents`. Five defaults are seeded on fresh installs (disabled):
+   - **Initial Setup** — broad rule + category mapping after first sync.
+   - **Bulk Review** — thorough categorization pass over a large queue.
+   - **Quick Review** — fast batch-categorize, prioritizes speed.
+   - **Routine Review** — daily/weekly pass over fresh transactions.
+   - **Spending Report** — weekly category-grouped summary with anomalies.
+4. **Edit prompt + schedule**, click Save, then flip the Enabled toggle. The agent fires on its cron schedule and shows up in the Runs page.
+5. **Hit Run now** in the list page to trigger immediately. The result lands in the run history with a full transcript (tool calls + cost + token usage).
+
+## Architecture (one-line view per layer)
+
+| Layer | Lives at | What it does |
+|---|---|---|
+| v2 SPA | `web/src/routes/agents*.tsx` | List, edit, run history, transcript viewer |
+| REST API | `internal/api/agents.go` | 13 endpoints under `/api/v1/agents` |
+| Service layer | `internal/service/agents.go` | CRUD, mint scoped API key, assemble JobSpec |
+| Orchestrator | `internal/service/agent_orchestrator.go` | Mint → Run → Persist → Revoke |
+| Scheduler | `internal/service/agent_scheduler.go` | One cron entry per enabled definition |
+| Sidecar | `agent/sidecar/index.ts` | TypeScript Agent SDK runner; spawned per run |
+| Storage | `agent_definitions`, `agent_runs` | Plus transcript NDJSON files on disk |
+
+## Safety controls
+
+- **Per-agent caps**: `max_turns` and `max_budget_usd` on every definition.
+- **Global ceiling**: `agent.global_max_budget_usd` in Settings → Agents.
+- **Concurrency**: `agent.max_concurrent` (default 1). Excess cron fires log as `skipped` rows; manual runs return 503 `CONCURRENCY_LOCKED`.
+- **Scope**: per-agent `tool_scope` is `read_only` or `read_write`. Read-only agents mint a read-only API key that the MCP server rejects writes on.
+- **Mint-and-revoke**: every run gets a fresh, scoped API key named `agent:<slug>:<runShortID>`. It's revoked the instant the run completes (or errors).
+- **Encrypted at rest**: subscription tokens and API keys are AES-256-GCM encrypted in `app_config`. The full value never leaves the server after you save it — `GET /api/v1/agents/settings` returns a masked display string.
+
+## Operational notes
+
+- **Cleanup**: completed runs older than `agent.run_retention_days` (default 30) are pruned daily at 3:15 AM local time.
+- **Orphan recovery**: in-progress runs from a previous boot are marked `error` at startup so the run history doesn't lie.
+- **Auth precedence trap**: if both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are in the sidecar's env, the API key wins. The sidecar scrubs the unused var before invoking the SDK so this can't bite you accidentally.
+
+## What replaced what
+
+The v1 admin "agent prompts" library at `/admin/agent-prompts` is retired. Every legacy path 302s to `/v2/agents`:
+- `/agent-prompts` (and `/agent-prompts/builder/*`)
+- `/agents`
+- `/agent-wizard/*`
+
+The five seeded starter agents are direct ports of the v1 wizard's prompts. Edit them in place; they're now real schedulable agents rather than copy-to-clipboard text.
+
+## See also
+
+- `docs/api-endpoints.md` — REST catalog for `/api/v1/agents/*`
+- `internal/agent/seed.go` — list of starter agents and their prompt mappings
+- `prompts/agents/` — the markdown source for every seeded prompt
+- `.claude/sprint-state.md` — sprint history and design decisions

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -161,25 +161,27 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// session data is hosted on the Logs page's Sessions tab;
 		// it's registered here under the editor+ scope to preserve the
 		// previous /agents/sessions/{id} permission level.
-		r.Get("/agent-prompts", AgentsPageHandler(svc, sm, tr))
-		r.Get("/agent-prompts/builder/{type}", PromptBuilderHandler(sm, tr))
-		r.Get("/agent-prompts/builder/{type}/copy", PromptCopyHandler())
+		// v1 admin agent surfaces are retired in favor of the v2 SPA
+		// /v2/agents page. Every legacy path 302s there so bookmarks,
+		// CLI completions, and external references continue to work.
+		// AgentsPageHandler / PromptBuilderHandler / PromptCopyHandler
+		// remain compiled (unwired) until the broader v1 admin retirement
+		// so a rollback is a one-line change.
+		r.Get("/agent-prompts", redirectGET("/v2/agents"))
+		r.Get("/agent-prompts/builder/{type}", redirectGET("/v2/agents"))
+		r.Get("/agent-prompts/builder/{type}/copy", redirectGET("/v2/agents"))
 		r.Get("/logs/sessions/{id}", SessionDetailHandler(svc, sm, tr))
 
-		// Legacy /agents, /agent-wizard, and /activity/sessions redirects.
-		r.Get("/agents", redirectGET("/agent-prompts"))
+		// Legacy /agents and /activity/sessions redirects.
+		r.Get("/agents", redirectGET("/v2/agents"))
 		r.Get("/agents/sessions/{id}", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/logs/sessions/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
 		})
 		r.Get("/activity/sessions/{id}", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/logs/sessions/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
 		})
-		r.Get("/agent-wizard/{type}", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/agent-prompts/builder/"+chi.URLParam(r, "type"), http.StatusMovedPermanently)
-		})
-		r.Get("/agent-wizard/{type}/copy", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/agent-prompts/builder/"+chi.URLParam(r, "type")+"/copy", http.StatusMovedPermanently)
-		})
+		r.Get("/agent-wizard/{type}", redirectGET("/v2/agents"))
+		r.Get("/agent-wizard/{type}/copy", redirectGET("/v2/agents"))
 	})
 
 	// Admin-only authenticated routes (HTML pages).

--- a/internal/agent/seed.go
+++ b/internal/agent/seed.go
@@ -1,0 +1,141 @@
+//go:build !lite
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"breadbox/internal/db"
+	"breadbox/prompts"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// DefaultSeed is the canonical set of starter agents — direct ports of the
+// v1 admin "agent prompts" wizard library. Each entry references a markdown
+// file embedded under `prompts/agents/`. All seeds ship disabled so the
+// self-hoster opts in by enabling them in the v2 SPA.
+//
+// Adding a new entry here AND a matching `prompts/agents/strategy-<slug>.md`
+// is the entire workflow — the seed runs at startup on fresh installs only.
+var DefaultSeed = []SeedDefinition{
+	{
+		Slug:         "initial-setup",
+		Name:         "Initial Setup",
+		Description:  "Establish rules and categories after connecting your first accounts.",
+		PromptFile:   "strategy-initial-setup",
+		MaxTurns:     30,
+		MaxBudgetUSD: 1.50,
+	},
+	{
+		Slug:         "bulk-review",
+		Name:         "Bulk Review",
+		Description:  "Thorough pass over a large pending-review queue with rule creation.",
+		PromptFile:   "strategy-bulk-review",
+		MaxTurns:     30,
+		MaxBudgetUSD: 1.50,
+	},
+	{
+		Slug:         "quick-review",
+		Name:         "Quick Review",
+		Description:  "Fast batch-categorize over a backlog. Prioritizes speed over precision.",
+		PromptFile:   "strategy-quick-review",
+		MaxTurns:     15,
+		MaxBudgetUSD: 0.50,
+	},
+	{
+		Slug:         "routine-review",
+		Name:         "Routine Review",
+		Description:  "Daily or weekly pass over fresh transactions. Best paired with a cron schedule.",
+		PromptFile:   "strategy-routine-review",
+		MaxTurns:     15,
+		MaxBudgetUSD: 0.50,
+	},
+	{
+		Slug:         "spending-report",
+		Name:         "Spending Report",
+		Description:  "Weekly or monthly category-grouped summary with anomaly callouts.",
+		PromptFile:   "strategy-spending-report",
+		MaxTurns:     10,
+		MaxBudgetUSD: 0.30,
+	},
+}
+
+// SeedDefinition is one entry in DefaultSeed.
+type SeedDefinition struct {
+	Slug         string
+	Name         string
+	Description  string  // short blurb for surfacing in seed logs / UI hints
+	PromptFile   string  // filename in prompts/agents/ without .md
+	MaxTurns     int32
+	MaxBudgetUSD float64 // dollars
+}
+
+// SeederQueries is the minimal sqlc surface needed by SeedDefaults.
+type SeederQueries interface {
+	ListAgentDefinitions(ctx context.Context) ([]db.AgentDefinition, error)
+	CreateAgentDefinition(ctx context.Context, arg db.CreateAgentDefinitionParams) (db.AgentDefinition, error)
+}
+
+// SeedDefaults inserts DefaultSeed entries into agent_definitions ONLY on a
+// fresh install — when the table is empty. On any subsequent startup it is
+// a no-op (so user edits to seeded agents are preserved across restarts).
+//
+// All seeded definitions are inserted with enabled=false; the user opts in
+// via the v2 SPA. Schedule is NULL (manual-only) so nothing fires until the
+// user picks a cron expression. Tool scope is read_write — these agents'
+// job is to apply rules and enrich, not just suggest.
+func SeedDefaults(ctx context.Context, q SeederQueries, logger *slog.Logger) error {
+	existing, err := q.ListAgentDefinitions(ctx)
+	if err != nil {
+		return fmt.Errorf("agent seed: list existing: %w", err)
+	}
+	if len(existing) > 0 {
+		logger.Debug("agent seed: skipping — agent_definitions already populated",
+			"existing_count", len(existing))
+		return nil
+	}
+
+	inserted := 0
+	for _, s := range DefaultSeed {
+		prompt, err := prompts.Agent(s.PromptFile)
+		if err != nil {
+			// A missing prompt is a programming error (we ship the .md
+			// files in the binary), but we keep going — better to seed
+			// the agents we have than abort the whole startup.
+			logger.Warn("agent seed: prompt file missing", "slug", s.Slug, "file", s.PromptFile, "error", err)
+			continue
+		}
+		var bud pgtype.Numeric
+		_ = bud.Scan(fmt.Sprintf("%.4f", s.MaxBudgetUSD))
+
+		_, err = q.CreateAgentDefinition(ctx, db.CreateAgentDefinitionParams{
+			Name:         s.Name,
+			Slug:         s.Slug,
+			Prompt:       strings.TrimSpace(string(prompt)),
+			SystemPrompt: pgtype.Text{},
+			ScheduleCron: pgtype.Text{},
+			ToolScope:    "read_write",
+			AllowedTools: []byte("[]"),
+			Model:        "claude-opus-4-7",
+			MaxTurns:     s.MaxTurns,
+			MaxBudgetUsd: bud,
+			Enabled:      false,
+		})
+		if err != nil {
+			// Soft-fail: log and continue so a single bad row doesn't
+			// block the whole seed (or block startup).
+			logger.Warn("agent seed: insert failed", "slug", s.Slug, "error", err)
+			continue
+		}
+		inserted++
+	}
+	if inserted > 0 {
+		logger.Info("agent seed: inserted default agents",
+			"count", inserted, "total_planned", len(DefaultSeed))
+	}
+	return nil
+}

--- a/internal/agent/seed_test.go
+++ b/internal/agent/seed_test.go
@@ -1,0 +1,114 @@
+//go:build integration && !lite
+
+package agent_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/db"
+	"breadbox/internal/testutil"
+)
+
+func makeMinimalParams(slug string) db.CreateAgentDefinitionParams {
+	var bud pgtype.Numeric
+	_ = bud.Scan("1.0000")
+	return db.CreateAgentDefinitionParams{
+		Name:         "User Agent",
+		Slug:         slug,
+		Prompt:       "p",
+		SystemPrompt: pgtype.Text{},
+		ScheduleCron: pgtype.Text{},
+		ToolScope:    "read_write",
+		AllowedTools: []byte("[]"),
+		Model:        "claude-opus-4-7",
+		MaxTurns:     10,
+		MaxBudgetUsd: bud,
+		Enabled:      false,
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutil.RunWithDB(m)
+}
+
+func TestSeedDefaults_PopulatesEmptyTable(t *testing.T) {
+	_, q := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	// Truncate is implicit between tests via testutil; agent_definitions
+	// starts empty.
+	if err := agent.SeedDefaults(ctx, q, slog.Default()); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	defs, err := q.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("ListAgentDefinitions: %v", err)
+	}
+	if len(defs) != len(agent.DefaultSeed) {
+		t.Errorf("seeded %d, want %d", len(defs), len(agent.DefaultSeed))
+	}
+
+	// Every seeded definition should be disabled by default.
+	for _, d := range defs {
+		if d.Enabled {
+			t.Errorf("seeded definition %q should be disabled, got enabled=true", d.Slug)
+		}
+		if d.ToolScope != "read_write" {
+			t.Errorf("seeded definition %q ToolScope = %q, want read_write", d.Slug, d.ToolScope)
+		}
+		if len(d.Prompt) < 50 {
+			t.Errorf("seeded definition %q has suspiciously short prompt (%d chars)", d.Slug, len(d.Prompt))
+		}
+	}
+}
+
+func TestSeedDefaults_IdempotentOnSecondRun(t *testing.T) {
+	_, q := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	if err := agent.SeedDefaults(ctx, q, slog.Default()); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	defsFirst, _ := q.ListAgentDefinitions(ctx)
+
+	// Second invocation should be a no-op — the table is no longer empty.
+	if err := agent.SeedDefaults(ctx, q, slog.Default()); err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+	defsSecond, _ := q.ListAgentDefinitions(ctx)
+
+	if len(defsFirst) != len(defsSecond) {
+		t.Errorf("second seed mutated the table: first=%d second=%d",
+			len(defsFirst), len(defsSecond))
+	}
+}
+
+func TestSeedDefaults_SkipsWhenAnyDefinitionExists(t *testing.T) {
+	_, q := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	// Insert one unrelated definition so the seed sees a non-empty table.
+	// Use the existing mustCreate pattern — borrow CreateAgentDefinition
+	// directly with minimum required fields.
+	if _, err := q.CreateAgentDefinition(ctx, makeMinimalParams("user-made")); err != nil {
+		t.Fatalf("seed test: insert user row: %v", err)
+	}
+
+	if err := agent.SeedDefaults(ctx, q, slog.Default()); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	defs, err := q.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("ListAgentDefinitions: %v", err)
+	}
+	if len(defs) != 1 {
+		t.Errorf("seed should have skipped (user row already present); got %d defs", len(defs))
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -135,6 +135,9 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	agentOrch := service.NewOrchestrator(a.Service, agentSidecar, agentMaxConcurrent, cfg.EncryptionKey, logger)
 	agentSched := service.NewAgentScheduler(agentOrch, a.Service, logger)
 	agentOrch.AttachScheduler(agentSched)
+	if err := agent.SeedDefaults(ctx, a.Queries, logger); err != nil {
+		logger.Warn("agent seed failed", "error", err)
+	}
 	agentSched.Start(ctx)
 	a.AgentOrchestrator = agentOrch
 	a.AgentScheduler = agentSched


### PR DESCRIPTION
## Iteration 6 of the Claude Agent SDK integration sprint

Fresh installs now bootstrap with 5 starter agents (disabled), and every legacy v1 admin agent path 302s to `/v2/agents`. Closes the loop on the v1→v2 migration story for this subsystem.

Targets the sprint branch.

## What's in

**Seed**
- `internal/agent/seed.go` — `DefaultSeed` lists the 5 starter agents (initial-setup, bulk-review, quick-review, routine-review, spending-report) and maps each to its `prompts/agents/strategy-*.md` markdown file (those already exist; the seed just imports them as `agent_definitions` rows).
- `SeedDefaults(ctx, queries, logger)` runs **only when `agent_definitions` is empty** — user edits + custom agents survive every restart. All seeded rows ship `enabled=false`, `tool_scope=read_write`, no schedule (manual-only until the user picks a cron).
- Wired into `internal/cli/serve.go` immediately after the agent scheduler is constructed. Soft-fails on error so a seeding hiccup can't block startup.

**Retirement**
- `internal/admin/router.go` — every v1 agent path 302s to `/v2/agents`:
  - `/agent-prompts` and `/agent-prompts/builder/{type}` and `/agent-prompts/builder/{type}/copy`
  - `/agents` (was already 302→/agent-prompts; now points directly at v2)
  - `/agent-wizard/{type}` and `/agent-wizard/{type}/copy`
- `AgentsPageHandler`, `PromptBuilderHandler`, `PromptCopyHandler` symbols are kept compiled (unwired) so a rollback is a one-line change — the broader v1-admin retirement will delete them in a follow-up sweep.

**Docs**
- `docs/agents.md` — new canonical doc. Quick-start, layer-by-layer architecture map, safety controls, operational notes (cleanup, orphan recovery, auth precedence trap), and a what-replaced-what table for the v1 surfaces.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go build -tags=headless ./...`, `go build -tags=lite ./...` — all clean
- [x] `go test ./...` — all unit tests pass
- [x] 3 new seed integration tests pass: populates empty table / idempotent on second run / skips when any definition already exists
- [x] Existing 30+ agent integration tests still pass

## Deferred (intentional scope cuts)

- **Full deletion of v1 admin templ files** (`agent_wizard.templ`, `agents_page.go`, `prompt_builder.go`). Dead code now but removing them belongs in the broader v1-admin retirement sweep, not here.
- **Removing the v1 sidebar "Agent Prompts" nav entry** — leaving it as a discoverable bridge that redirects to v2 during the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)