### PR TITLE
feat(agents): observability + contributor rules + sandbox specimens

### DIFF
--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -1,0 +1,103 @@
+# Agents subsystem
+
+The Claude Agent SDK integration. Lets a self-hoster schedule recurring AI runs that call breadbox MCP. Replaces the v1 admin "agent prompts" wizard.
+
+User-facing reference: `docs/agents.md`. Sprint history + design decisions: `.claude/sprint-state.md` on the `agents/claude-agent-sdk-sprint` branch.
+
+## The five layers
+
+```
+v2 SPA (web/src/routes/agents*.tsx, features/agents/*)
+   │ REST /api/v1/agents/*
+   ▼
+internal/api/agents.go            ← HTTP handlers, error envelope mapping
+   │
+internal/service/agents.go         ← CRUD, validation, helpers
+internal/service/agent_settings.go ← AES-GCM masked-on-GET token storage
+internal/service/agent_orchestrator.go ← mint → run → persist → revoke
+internal/service/agent_scheduler.go    ← robfig/cron, one entry per enabled def
+   │
+internal/agent/                    ← Runner / Sidecar / Semaphore / Spec types
+   │ exec ./bin/breadbox-agent
+   ▼
+agent/sidecar/index.ts             ← TypeScript Claude Agent SDK runner
+   │ MCP stdio
+   ▼
+breadbox mcp                       ← MCP tool registry (read-only or full-access)
+```
+
+When in doubt about where new code belongs, ask: is it user input/response shaping → `api/`; is it stateful behavior → `service/`; is it the runner protocol / event shapes → `internal/agent/`; is it sidecar logic → `agent/sidecar/`.
+
+## Locked invariants
+
+These are easy to break and painful to re-discover.
+
+### Auth precedence trap
+
+If both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are set in the sidecar's env, the API key silently wins. The sidecar must scrub the unused var before invoking the SDK (`agent/sidecar/index.ts::configureAuth`). Never remove that scrub; never assume the SDK does the right thing here.
+
+### Mint-and-revoke
+
+Every run mints a scoped `actor_type='agent'` API key (name format `agent:<slug>:<runShortID>`) and revokes it in a `defer` with a fresh context. Never leave a key valid past the run that minted it. If you add a new entry point that runs an agent, wrap it in `Orchestrator.RunNow` or `Orchestrator.RunOrSkip` — don't reimplement the mint-revoke dance.
+
+### Concurrency split
+
+- `RunNow` (manual trigger from HTTP): `ErrConcurrencyLocked` returns WITHOUT creating an `agent_runs` row. Caller maps to 503; user can retry without polluting history.
+- `RunOrSkip` (cron trigger): always leaves a row. Status `skipped` when locked, so the run history shows what was missed.
+
+Don't blur these. Cron callers must use `RunOrSkip`; HTTP callers must use `RunNow`.
+
+### Seed-on-empty, never-overwrite
+
+`agent.SeedDefaults` runs ONLY when `agent_definitions` is empty (fresh install). User edits to seeded agents, custom agents, and renamed agents must survive every restart. Never add an "upsert" path here — that would silently undo user customization.
+
+### Fresh-ctx revocation
+
+`Orchestrator.runLocked` defers the API key revoke with `context.WithTimeout(context.Background(), 10*time.Second)` — a NEW root context, not the request ctx. A cancelled parent (user closed the run-now request, scheduler restart, server shutdown) must NOT prevent revocation.
+
+### Hot-reload via `OnDefinitionChanged`
+
+CRUD mutations on agent_definitions call `svc.OnDefinitionChanged()` which the orchestrator wires to `AgentScheduler.Reload(ctx)`. The full sequence: service method updates DB → notifies hook → scheduler removes all per-agent entries → re-registers from DB. Don't add new mutation paths without calling the hook.
+
+## Adding a new starter agent
+
+1. Drop the markdown prompt at `prompts/agents/strategy-<slug>.md`.
+2. Add an entry to `agent.DefaultSeed` in `internal/agent/seed.go`.
+3. Existing installs are unaffected (seed is fresh-install-only). New installs get it on next boot.
+
+That's the whole flow.
+
+## Tests + CI
+
+- Service-layer integration tests: `internal/service/agents_test.go`, `agent_orchestrator_test.go` (one TestMain shared with the rest of `service_test`).
+- Schema + sqlc integration tests: `internal/db/agent_tables_integration_test.go`, `agent_queries_integration_test.go`.
+- Seed tests: `internal/agent/seed_test.go`.
+- Runner unit tests: `internal/agent/sidecar_test.go` (no DB; uses a fake shell-script sidecar).
+- OpenAPI drift: every new HTTP route MUST land in `openapi.yaml` in the same PR, or `TestOpenAPIDrift` will red-fail CI.
+- Iteration PRs on the agents sprint branch get the full CI matrix because the branch is in `.github/workflows/ci.yml::pull_request.branches`.
+
+## Observability
+
+The sidecar inherits the parent process env, so any `OTEL_*` env var set on `breadbox serve` flows through to the Anthropic SDK automatically. To enable distributed tracing:
+
+```sh
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_LOGS_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
+OTEL_LOG_TOOL_DETAILS=1 \
+./breadbox serve
+```
+
+Without OTel, the orchestrator emits structured slog at run boundaries (`orchestrator: run starting / finished`) and the scheduler emits at register/reload/cleanup boundaries. Every run also persists a full NDJSON transcript at `<agent.transcript_dir>/<runID>.ndjson` viewable from the v2 SPA.
+
+## v1 retirement state
+
+Every legacy admin agent URL 302s to `/v2/agents`. Symbols (`AgentsPageHandler`, `PromptBuilderHandler`, `PromptCopyHandler`, the `agent_wizard.templ` template) stay compiled but unwired so a rollback is one router line. The full deletion belongs in the broader v1-admin retirement sweep — don't bundle it with agent-subsystem changes.
+
+## Do not
+
+- Don't call `RunNow` from a cron callback — it skips the skipped-row semantics.
+- Don't add an upsert path to `SeedDefaults`.
+- Don't return the full plaintext of `subscription_token` or `anthropic_api_key` from any endpoint. The mask helper in `agent_settings.go::maskToken` is the only shape that leaves the server.
+- Don't bypass the concurrency semaphore (e.g., a "force run" debug endpoint). One safety net should not be optional.
+- Don't store the per-run minted API key in `agent_runs`. It's deliberately ephemeral — `actor_type='agent'` + the `agent:<slug>:<runID>` name in `api_keys` is the audit trail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Claude Agent SDK integration**: schedule recurring AI workflows from the v2 SPA at `/v2/agents`. Self-hosters configure an Anthropic credential (subscription OAuth token or API key, AES-256-GCM encrypted at rest), pick from 5 seeded starter agents (Initial Setup, Bulk Review, Quick Review, Routine Review, Spending Report), or author their own with a full prompt builder. Runs fire via the bundled `breadbox-agent` sidecar (built with `make agent-sidecar`), call breadbox MCP to enrich/categorize/review data, and surface in a run history page with a transcript viewer showing turns, tool calls, cost, and token usage. Safety: per-agent + global cost/turn caps; server-wide concurrency mutex; mint-and-revoke scoped API keys per run; daily cleanup of old runs. Every legacy v1 admin agent URL (`/agent-prompts`, `/agent-wizard/*`, `/agents`) now 302s to `/v2/agents`. See `docs/agents.md`.
+
 ### Breaking Changes (Pre-1.0)
 
 - **Renamed provider-data fields on transactions table.** Raw data fields from bank providers are now prefixed with `provider_` to clarify they are unmodified provider data, not Breadbox assignments. This affects:

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -134,7 +134,15 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	o.logger.Info("orchestrator: run starting",
 		"agent", def.Slug, "run", runResp.ShortID, "trigger", trigger, "model", def.Model)
 
-	result, runErr := o.runner.Run(ctx, *spec, nil)
+	// Event handler emits one structured slog line per sidecar NDJSON event.
+	// Useful for tracing without OTel; cheap (Debug level by default — the
+	// transcript file on disk is the canonical replay surface).
+	handler := func(ev agent.Event) error {
+		o.logger.Debug("orchestrator: sidecar event",
+			"agent", def.Slug, "run", runResp.ShortID, "event_type", ev.Type)
+		return nil
+	}
+	result, runErr := o.runner.Run(ctx, *spec, handler)
 
 	completedRow, completeErr := o.svc.CompleteAgentRunDB(ctx, runRow.ID, result)
 	if completeErr != nil {

--- a/web/src/sandbox/fixtures.ts
+++ b/web/src/sandbox/fixtures.ts
@@ -9,6 +9,7 @@ import type {
   Transaction,
   TransactionCategory,
 } from "@/api/types";
+import type { TranscriptEvent } from "@/api/queries/agents";
 
 const NOW = "2026-05-14T12:00:00Z";
 
@@ -297,5 +298,128 @@ export const sampleAccounts: Account[] = [
     balance_limit: 5000,
     iso_currency_code: "USD",
     is_dependent_linked: false,
+  },
+];
+
+// --- Agent SDK transcript fixtures ---
+//
+// Used by the TranscriptViewer specimen in sandbox/sections/components.tsx.
+// Mirrors the NDJSON event shapes the breadbox-agent sidecar emits (see
+// agent/sidecar/index.ts + the TranscriptEvent union in
+// api/queries/agents.ts).
+
+export const sampleTranscriptEvents: TranscriptEvent[] = [
+  {
+    type: "assistant_message",
+    ts: 1747440001000,
+    data: {
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Starting routine review. Let me pull this week's uncategorized transactions and see what needs attention.",
+          },
+        ],
+      },
+    },
+  },
+  {
+    type: "tool_use",
+    ts: 1747440002000,
+    data: {
+      type: "tool_use",
+      id: "toolu_01ABCXYZ",
+      name: "list_transactions",
+      input: { limit: 20, uncategorized_only: true, since: "2026-05-08" },
+    },
+  },
+  {
+    type: "tool_result",
+    ts: 1747440003200,
+    data: {
+      type: "tool_result",
+      tool_use_id: "toolu_01ABCXYZ",
+      content:
+        '[{"short_id":"abc12345","provider_name":"SQ *BLUE BOTTLE COFFEE","amount":6.75},{"short_id":"def67890","provider_name":"WHOLE FOODS MARKET","amount":54.12}]',
+    },
+  },
+  {
+    type: "assistant_message",
+    ts: 1747440004000,
+    data: {
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Found two clear matches. SQ *BLUE BOTTLE is coffee (Food & Drink → Coffee Shops). WHOLE FOODS is groceries. Applying both.",
+          },
+        ],
+      },
+    },
+  },
+  {
+    type: "tool_use",
+    ts: 1747440005000,
+    data: {
+      type: "tool_use",
+      id: "toolu_02ABC",
+      name: "update_transactions",
+      input: {
+        operations: [
+          { transaction_id: "abc12345", category_slug: "food_and_drink_coffee" },
+          { transaction_id: "def67890", category_slug: "food_and_drink_groceries" },
+        ],
+      },
+    },
+  },
+  {
+    type: "tool_result",
+    ts: 1747440006500,
+    data: {
+      type: "tool_result",
+      tool_use_id: "toolu_02ABC",
+      content: '{"updated":2,"skipped":0}',
+      is_error: false,
+    },
+  },
+  {
+    type: "result",
+    ts: 1747440007000,
+    data: {
+      totalCostUsd: 0.0042,
+      inputTokens: 1204,
+      outputTokens: 287,
+      cacheReadTokens: 450,
+      cacheCreationTokens: 0,
+      turnCount: 2,
+      numToolCalls: 2,
+      sessionId: "sess-sandbox-1",
+      stopReason: "end_turn",
+    },
+  },
+];
+
+export const sampleTranscriptEventsError: TranscriptEvent[] = [
+  {
+    type: "assistant_message",
+    ts: 1747440001000,
+    data: {
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Pulling uncategorized transactions…" },
+        ],
+      },
+    },
+  },
+  {
+    type: "error",
+    ts: 1747440002000,
+    data: {
+      code: "MCP_CONNECT_ERROR",
+      message: "MCP connection refused: dial tcp 127.0.0.1:8080",
+    },
   },
 ];

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -101,8 +101,12 @@ import type { Transaction } from "@/api/types";
 import { SandboxSection, Specimen } from "@/sandbox/kit";
 import {
   sampleTags,
+  sampleTranscriptEvents,
+  sampleTranscriptEventsError,
   sampleTransactions,
 } from "@/sandbox/fixtures";
+import { CronField } from "@/features/agents/cron-field";
+import { TranscriptViewer } from "@/features/agents/transcript-viewer";
 
 const coffeeCategory = sampleTransactions[0].category;
 const gasCategory = sampleTransactions[2].category;
@@ -1552,6 +1556,47 @@ export function ComponentsSection() {
           </p>
         </div>
       </Specimen>
+
+      <Specimen
+        label="CronField"
+        code="features/agents/cron-field"
+        description="Cron input + live human-readable preview + popover preset picker. Used in the agent edit form (web/src/routes/agents.$slug.edit.tsx). The preview shows 'Mondays at 9 AM' style labels for known patterns, falls back to 'Custom: <expr>' otherwise."
+        className="block"
+      >
+        <CronFieldDemo />
+      </Specimen>
+
+      <Specimen
+        label="TranscriptViewer — successful run"
+        code="features/agents/transcript-viewer"
+        description="Parses NDJSON sidecar events into turn-grouped assistant blocks with collapsible tool calls + a result footer (cost, tokens, turn count, stop reason). Used inside the run-history Sheet at /v2/agents/$slug/runs."
+        className="block"
+      >
+        <div className="bg-background h-[480px] overflow-y-auto rounded-md border p-3">
+          <TranscriptViewer
+            events={sampleTranscriptEvents}
+            rawLength={sampleTranscriptEvents.length}
+            truncated={false}
+            shortId="abc12345"
+          />
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="TranscriptViewer — errored run"
+        code="features/agents/transcript-viewer"
+        description="The error banner variant — surfaces an SDK/sidecar error at the top with a destructive-tone Alert."
+        className="block"
+      >
+        <div className="bg-background overflow-y-auto rounded-md border p-3">
+          <TranscriptViewer
+            events={sampleTranscriptEventsError}
+            rawLength={sampleTranscriptEventsError.length}
+            truncated={false}
+            shortId="err00000"
+          />
+        </div>
+      </Specimen>
     </SandboxSection>
   );
 }
@@ -1604,6 +1649,13 @@ function ThemeSpecimen() {
       </p>
     </div>
   );
+}
+
+// CronField needs local state to render usefully — the demo wraps it in a
+// stateful container so users can click presets and watch the preview update.
+function CronFieldDemo() {
+  const [value, setValue] = useState("0 9 * * 1");
+  return <CronField value={value} onChange={setValue} />;
 }
 
 // Inline visual demo of the NavUser trigger — the dropdown itself depends on


### PR DESCRIPTION
## Iteration 7 of the Claude Agent SDK integration sprint

Polish pass. After this PR future contributors have a rules doc with the locked invariants, a CHANGELOG entry, sandbox specimens to riff on, and structured event logs for runtime tracing. No new user-facing surface — code under the hood + contributor surface.

Targets the sprint branch.

## What's in

**Contributor surface**
- `.claude/rules/agents.md` — the load-bearing locked invariants in one place: auth precedence trap, mint-and-revoke lifecycle, concurrency split (`RunNow` vs `RunOrSkip`), seed-on-empty semantics, fresh-ctx revoke, `OnDefinitionChanged` hot reload, plus the five-layer architecture map, how to add a starter agent, where tests live, and a Do-Not list.
- `CHANGELOG.md` — Unreleased → Added entry for the next release notes.

**Observability**
- `internal/service/agent_orchestrator.go` — the orchestrator now passes an event handler to `Runner.Run` that emits one `slog.Debug` per sidecar NDJSON event (`event_type=tool_use`, etc.). Cheap per-event trace without OTel; the on-disk NDJSON transcript remains the canonical replay surface.
- **OTel passthrough**: the sidecar inherits parent env via `exec.CommandContext`'s default, so any `OTEL_*` env var set on `breadbox serve` flows into the Anthropic SDK with no extra wiring. Documented in both `.claude/rules/agents.md` and `docs/agents.md`.

**Sandbox specimens** (carried over from iter 5's deferred list)
- `web/src/sandbox/fixtures.ts` — `sampleTranscriptEvents` (happy path with two tool calls + a `result` event) and `sampleTranscriptEventsError` (sidecar emits an `error` event).
- `web/src/sandbox/sections/components.tsx` — three new specimens:
  - **CronField** — interactive demo with local state so you can click presets and watch the preview update.
  - **TranscriptViewer — successful run** — full chat-style render with the result footer.
  - **TranscriptViewer — errored run** — destructive-banner variant.

Promotes both `features/agents/*` components to the discoverable design-system catalog per the v2-frontend rule (the rule technically scopes the "must add a specimen" requirement to `components/`, but these are central enough to the agents surface that they earn a specimen anyway).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go build -tags=headless ./...`, `go build -tags=lite ./...` — all clean
- [x] `go test ./...` — all unit tests pass; one orchestrator test spot-checked under -tags=integration with the new event handler in place (still green)
- [x] `cd web && bun run lint` — green
- [x] `cd web && bun run build` — green

## Deferred to a future iteration

- **TagInput chip control** for `allowed_tools` (currently a comma-separated Textarea — works, will polish later).
- **MCP tool registry endpoint** to source the allowed-tools picker from live data instead of free text.
- **Full deletion of the dead v1 templ + handler files** — belongs in the broader v1-admin retirement sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)