### PR TITLE
feat(agents): Test connection button in Settings + POST /api/v1/agents/test

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -265,6 +265,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | POST | `/agents/{slug}/enable` | W | Flip enabled=true |
 | POST | `/agents/{slug}/disable` | W | Flip enabled=false |
 | POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; 503 `CONCURRENCY_LOCKED` when another run is in progress |
+| POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200) |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | GET | `/agents/runs/{shortId}/transcript` | R | Streams the NDJSON transcript; 404 when not yet written |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -355,6 +355,59 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 	}
 }
 
+// agentTestResponse mirrors agent.SmokeResult for the JSON wire format.
+type agentTestResponse struct {
+	AuthMode     string  `json:"auth_mode"`
+	BinaryPath   string  `json:"binary_path,omitempty"`
+	Model        string  `json:"model"`
+	DurationMs   int64   `json:"duration_ms"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	InputTokens  int     `json:"input_tokens"`
+	OutputTokens int     `json:"output_tokens"`
+	Response     string  `json:"response,omitempty"`
+}
+
+// SmokeTestAgentHandler runs the same diagnostic the CLI's
+// `breadbox agent test` does. Surfaces it through the UI so non-CLI
+// self-hosters can validate their setup before scheduling real runs.
+// Cost-bounded (~5¢ ceiling).
+func SmokeTestAgentHandler(orch *service.Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if orch == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "AGENTS_DISABLED",
+				"Agent orchestrator is not configured on this server")
+			return
+		}
+		result, err := orch.SmokeTest(r.Context())
+		if err != nil {
+			switch {
+			case errors.Is(err, agent.ErrAuthNotConfigured):
+				mw.WriteError(w, http.StatusUnprocessableEntity,
+					"AUTH_NOT_CONFIGURED",
+					"Set a subscription token or Anthropic API key in agent settings before running the smoke test.")
+			case errors.Is(err, agent.ErrBinaryNotFound):
+				mw.WriteError(w, http.StatusUnprocessableEntity,
+					"AGENT_BINARY_NOT_FOUND",
+					"breadbox-agent binary not found. Run `make agent-sidecar` or set agent.runtime_path.")
+			default:
+				mw.WriteError(w, http.StatusInternalServerError,
+					"AGENT_TEST_FAILED", err.Error())
+			}
+			return
+		}
+		writeData(w, agentTestResponse{
+			AuthMode:     result.AuthMode,
+			BinaryPath:   result.BinaryPath,
+			Model:        result.Model,
+			DurationMs:   result.DurationMs,
+			TotalCostUSD: result.TotalCostUSD,
+			InputTokens:  result.InputTokens,
+			OutputTokens: result.OutputTokens,
+			Response:     result.AssistantText,
+		})
+	}
+}
+
 // writeAgentError maps a service error to the JSON error envelope.
 func writeAgentError(w http.ResponseWriter, err error, notFoundMsg string) {
 	switch {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -193,6 +193,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/agents/{slug}/enable", EnableAgentHandler(svc))
 			r.Post("/agents/{slug}/disable", DisableAgentHandler(svc))
 			r.Post("/agents/{slug}/run", RunAgentNowHandler(svc, a.AgentOrchestrator))
+			r.Post("/agents/test", SmokeTestAgentHandler(a.AgentOrchestrator))
 			r.Post("/providers/{name}/test", TestProviderHandler(a))
 			r.Delete("/providers/{name}", DisableProviderHandler(a))
 			r.Get("/config", ListConfigHandler(a))

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"breadbox/internal/agent"
+	"breadbox/internal/appconfig"
 	"breadbox/internal/pgconv"
 )
 
@@ -53,6 +54,15 @@ func (o *Orchestrator) NotifyDefinitionChanged() {
 	if o.sched != nil {
 		o.sched.Reload(context.Background())
 	}
+}
+
+// SmokeTest runs the diagnostic round-trip via the orchestrator's existing
+// runner. Bypasses the concurrency semaphore (diagnostic, not a real run)
+// and never touches agent_runs / api_keys. Used by the v2 SPA settings
+// "Test connection" button and the `breadbox agent test` CLI alike.
+func (o *Orchestrator) SmokeTest(ctx context.Context) (*agent.SmokeResult, error) {
+	binaryPath := appconfig.String(ctx, o.svc.Queries, appconfig.KeyAgentRuntimePath, "")
+	return agent.SmokeTest(ctx, o.svc.Queries, o.encKey, o.runner, binaryPath)
 }
 
 // RunNow executes one agent run synchronously, for "run now" requests.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2532,6 +2532,24 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/test:
+    post:
+      tags: [Agents]
+      summary: Run the agent diagnostic smoke test
+      description: |
+        Spawns the breadbox-agent sidecar with a tiny "say OK" prompt and
+        returns the result. Bypasses agent_definitions, mints no API key,
+        writes no agent_runs row. Cost-bounded to ~5¢. **Requires `full_access` scope.**
+      responses:
+        "200":
+          description: Diagnostic result.
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "422":
+          description: Auth or binary not configured.
+        "500":
+          description: Test ran but the sidecar / model returned an error.
   /api/v1/agents/{slug}/run:
     parameters:
       - { name: slug, in: path, required: true, schema: { type: string } }

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -226,6 +226,26 @@ export function useUpdateAgentSettings() {
   });
 }
 
+// --- Smoke test (diagnostic) ---
+
+export interface AgentTestResult {
+  auth_mode: string;
+  binary_path?: string;
+  model: string;
+  duration_ms: number;
+  total_cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  response?: string;
+}
+
+export function useSmokeTestAgent() {
+  return useMutation({
+    mutationFn: () =>
+      api<AgentTestResult>("/api/v1/agents/test", { method: "POST" }),
+  });
+}
+
 // --- Transcript types ---
 
 // Discriminated union of NDJSON event shapes emitted by the breadbox sidecar.

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Bot, KeyRound, Loader2 } from "lucide-react";
+import { Bot, CheckCircle2, KeyRound, Loader2, Stethoscope, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -28,8 +28,11 @@ import { SettingsSectionHeader } from "@/components/settings-section-header";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useAgentSettings,
+  useSmokeTestAgent,
   useUpdateAgentSettings,
+  type AgentTestResult,
 } from "@/api/queries/agents";
+import { ApiError } from "@/api/client";
 
 const settingsSchema = z.object({
   auth_mode: z.enum(["subscription", "api_key"]),
@@ -43,8 +46,11 @@ const settingsSchema = z.object({
 export function AgentsSection() {
   const settingsQuery = useAgentSettings();
   const updateSettings = useUpdateAgentSettings();
+  const smokeTest = useSmokeTestAgent();
   const [tokenDraft, setTokenDraft] = useState("");
   const [apiKeyDraft, setApiKeyDraft] = useState("");
+  const [testResult, setTestResult] = useState<AgentTestResult | null>(null);
+  const [testError, setTestError] = useState<{ code: string; message: string } | null>(null);
 
   const form = useForm({
     resolver: zodResolver(settingsSchema),
@@ -111,6 +117,21 @@ export function AgentsSection() {
         error: "Failed to clear credential",
       },
     );
+  };
+
+  const runSmokeTest = async () => {
+    setTestResult(null);
+    setTestError(null);
+    try {
+      const r = await smokeTest.mutateAsync();
+      setTestResult(r);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setTestError({ code: err.code, message: err.message });
+      } else {
+        setTestError({ code: "UNKNOWN", message: String(err) });
+      }
+    }
   };
 
   const settings = settingsQuery.data;
@@ -249,7 +270,20 @@ export function AgentsSection() {
               )}
             />
 
-            <div className="flex justify-end">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={runSmokeTest}
+                disabled={smokeTest.isPending}
+              >
+                {smokeTest.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Stethoscope className="size-4" />
+                )}
+                Test connection
+              </Button>
               <Button type="submit" disabled={updateSettings.isPending}>
                 {updateSettings.isPending && (
                   <Loader2 className="size-4 animate-spin" />
@@ -257,6 +291,37 @@ export function AgentsSection() {
                 Save settings
               </Button>
             </div>
+
+            {testResult && (
+              <Alert>
+                <CheckCircle2 className="size-4" />
+                <AlertTitle>Test passed</AlertTitle>
+                <AlertDescription className="space-y-1">
+                  <p>
+                    Auth ✓ {testResult.auth_mode} · Model {testResult.model}
+                    {" · "}
+                    {testResult.duration_ms}ms · $
+                    {testResult.total_cost_usd.toFixed(6)} (
+                    {testResult.input_tokens} in / {testResult.output_tokens} out)
+                  </p>
+                  {testResult.response && (
+                    <p className="text-muted-foreground">
+                      Response:{" "}
+                      <code className="bg-muted rounded px-1">
+                        {testResult.response}
+                      </code>
+                    </p>
+                  )}
+                </AlertDescription>
+              </Alert>
+            )}
+            {testError && (
+              <Alert variant="destructive">
+                <XCircle className="size-4" />
+                <AlertTitle>Test failed — {testError.code}</AlertTitle>
+                <AlertDescription>{testError.message}</AlertDescription>
+              </Alert>
+            )}
           </form>
         </Form>
       ) : (


### PR DESCRIPTION
## Iteration 9 of the Claude Agent SDK integration sprint

Surfaces iter-8's smoke test in the v2 SPA. Non-CLI self-hosters can now validate their setup with a click — paste a token, hit "Test connection", get pass/fail + cost in one second.

Targets the sprint branch.

## Evidence

<img src="https://i.img402.dev/3g8ygyvrrc.jpg" width="900" alt="Settings → Agents tab after iter 9 (Test connection button is below the form fold)">

The composite shows the top of the Agents settings tab. The new **Test connection** button lives at the bottom-left of the form (paired with **Save settings** on the right), below the modal fold in this viewport — the visible content above it confirms the page renders cleanly with the iter-9 changes.

## What's in

**Go side**
- `internal/service/agent_orchestrator.go` — `Orchestrator.SmokeTest(ctx)` method. Reads `agent.runtime_path` from `app_config`, calls `agent.SmokeTest` with the existing runner. Bypasses the concurrency semaphore (diagnostic, not a real run); writes no `agent_runs` row; mints no API key.
- `internal/api/agents.go` — `SmokeTestAgentHandler`. Returns the `SmokeResult` as `agentTestResponse` JSON. Errors map to 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` / 500 `AGENT_TEST_FAILED`.
- `internal/api/router.go` — `POST /agents/test` registered in the write group.
- `docs/api-endpoints.md` + `openapi.yaml` — new endpoint documented; drift test green.

**SPA side**
- `web/src/api/queries/agents.ts` — `useSmokeTestAgent` mutation hook + `AgentTestResult` type mirroring the wire format.
- `web/src/features/settings/agents-section.tsx` — `Test connection` button next to `Save settings`. Renders an inline `Alert`:
  - **Pass** — "Auth ✓ subscription · Model claude-haiku-4-5 · 812ms · $0.000123 (15 in / 1 out)" + response text.
  - **Fail** — destructive variant with the error code in the title and the message body.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `-tags=headless` / `-tags=lite` — all clean
- [x] `go test ./...` — all unit tests pass
- [x] `TestOpenAPIDrift` green
- [x] `cd web && bun run lint` clean
- [x] `cd web && bun run build` clean
- [x] Local end-to-end: built iter-9 binary, served on :8200, settings page loads with both buttons visible

## Deferred

- **Sandbox specimen** for the Test connection button — feature-scoped today; promote only when reused outside this settings panel.
- **`breadbox doctor` integration** of the smoke test — small follow-up iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)