### PR TITLE
feat(agents): `breadbox agent run <slug>` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **`breadbox agent test` CLI** for diagnosing the agent subsystem end-to-end: verifies auth is configured, sidecar binary is discoverable, and a tiny "say OK" prompt round-trips through the SDK. Exit code 3 = no auth, 5 = no binary.
+- **`breadbox agent run <slug>` CLI** for triggering a named agent from cron/shell — same code path as the v2 SPA "Run now" button. Mints a scoped API key, spawns the sidecar, persists the `agent_runs` row, revokes the key. `--json` emits the full result for scripting.
 - **Claude Agent SDK integration**: schedule recurring AI workflows from the v2 SPA at `/v2/agents`. Self-hosters configure an Anthropic credential (subscription OAuth token or API key, AES-256-GCM encrypted at rest), pick from 5 seeded starter agents (Initial Setup, Bulk Review, Quick Review, Routine Review, Spending Report), or author their own with a full prompt builder. Runs fire via the bundled `breadbox-agent` sidecar (built with `make agent-sidecar`), call breadbox MCP to enrich/categorize/review data, and surface in a run history page with a transcript viewer showing turns, tool calls, cost, and token usage. Safety: per-agent + global cost/turn caps; server-wide concurrency mutex; mint-and-revoke scoped API keys per run; daily cleanup of old runs. Every legacy v1 admin agent URL (`/agent-prompts`, `/agent-wizard/*`, `/agents`) now 302s to `/v2/agents`. See `docs/agents.md`.
 
 ### Breaking Changes (Pre-1.0)

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -44,6 +44,7 @@ These commands operate on the local box (filesystem, DB, embedded migrations) �
 | `breadbox migrate [--down] [--to N]` | L | Run goose migrations against `DATABASE_URL` (local-only — there is no remote migration endpoint by design) |
 | `breadbox doctor [--skip-external]` | R/L | Remote mode (when a host is configured) consumes `GET /api/v1/headless/bootstrap`; local mode (no host) keeps the env/DB/provider preflight checks |
 | `breadbox agent test` | L | End-to-end smoke test of the Claude Agent SDK subsystem — verifies credential is configured, sidecar binary is discoverable, and a tiny "say OK" prompt round-trips through the SDK. Cost-bounded to ~5¢. Exit 3 = no auth; exit 5 = no binary |
+| `breadbox agent run <slug> [--json]` | L | Trigger an immediate run of the named agent — same path as the v2 SPA "Run now" button. Mints a scoped API key, spawns the sidecar, persists the agent_runs row, revokes the key. Output is a human-readable summary; `--json` switches to the full AgentRunResponse JSON |
 | `breadbox version` | — | Print build version, commit, and upgrade check |
 | `breadbox completion [bash\|zsh\|fish]` | — | Print a shell-completion script (e.g. `breadbox completion zsh > _breadbox`) for tab-completion of nouns/verbs/flags — same pattern as `gh`, `kubectl` |
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/appconfig"
 	"breadbox/internal/config"
+	"breadbox/internal/service"
 
 	"github.com/spf13/cobra"
 )
@@ -62,7 +64,129 @@ Exit codes:
 		},
 	}
 	parent.AddCommand(test)
+
+	run := &cobra.Command{
+		Use:   "run <slug>",
+		Short: "Trigger an immediate run of a named agent",
+		Long: `Run one agent end-to-end against the live system: mints a scoped API
+key, spawns the sidecar with the definition's prompt + schedule, calls
+the MCP server, persists the resulting agent_runs row, revokes the key.
+
+Equivalent to clicking "Run now" in the v2 SPA — useful for cron/shell
+automation or local debugging.
+
+Exit codes:
+  0  run completed (status may be success or error — see status field)
+  3  no Anthropic credential configured
+  5  agent slug not found / agent binary not found
+  1  runner crashed or model returned an unexpected error
+`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			return runAgentRun(cmd.Context(), args[0], jsonOut)
+		},
+	}
+	run.Flags().Bool("json", false, "emit the run result as JSON instead of human-readable")
+	parent.AddCommand(run)
+
 	root.AddCommand(parent)
+}
+
+func runAgentRun(parent context.Context, slug string, jsonOut bool) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	a, err := app.New(ctx, cfg, logger)
+	if err != nil {
+		return fmt.Errorf("init app: %w", err)
+	}
+	defer a.DB.Close()
+
+	def, err := a.Service.GetAgentDefinition(ctx, slug)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			fmt.Fprintf(os.Stderr, "agent %q not found\n", slug)
+			return silentlyFail(agent.ErrBinaryNotFound) // map to ExitValidation (5)
+		}
+		return fmt.Errorf("resolve agent: %w", err)
+	}
+
+	// Build a one-shot orchestrator with concurrency=1 (CLI is a single
+	// process; the in-memory semaphore is just belt-and-suspenders).
+	sidecar := &agent.Sidecar{
+		BinaryPath:    appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, ""),
+		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, ""),
+	}
+	orch := service.NewOrchestrator(a.Service, sidecar, 1, cfg.EncryptionKey, logger)
+
+	if !jsonOut {
+		fmt.Fprintf(os.Stdout, "▶  Running %s (%s)…\n", def.Name, def.Slug)
+	}
+	runResp, runErr := orch.RunNow(ctx, def)
+	if runErr != nil {
+		switch {
+		case errors.Is(runErr, agent.ErrAuthNotConfigured):
+			fmt.Fprintln(os.Stderr, "auth not configured — paste a token in Settings → Agents or run `breadbox agent test` for diagnostic detail")
+			return silentlyFail(runErr)
+		case errors.Is(runErr, agent.ErrBinaryNotFound):
+			fmt.Fprintln(os.Stderr, "breadbox-agent binary not found — run `make agent-sidecar` or set agent.runtime_path")
+			return silentlyFail(runErr)
+		case errors.Is(runErr, agent.ErrConcurrencyLocked):
+			// Shouldn't happen with a fresh per-CLI orchestrator, but
+			// surface clearly if it does.
+			fmt.Fprintln(os.Stderr, "another agent run is in progress on this server — retry shortly")
+			return silentlyFail(runErr)
+		}
+		// Runner errored but the row was still written; print the result
+		// then bubble the error for non-zero exit.
+		if runResp != nil {
+			printAgentRunResult(runResp, jsonOut)
+		}
+		fmt.Fprintf(os.Stderr, "\nrun failed: %v\n", runErr)
+		return silentlyFail(runErr)
+	}
+	printAgentRunResult(runResp, jsonOut)
+	return nil
+}
+
+func printAgentRunResult(r *service.AgentRunResponse, jsonOut bool) {
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(r)
+		return
+	}
+	fmt.Fprintln(os.Stdout, "")
+	fmt.Fprintf(os.Stdout, "  status     %s\n", r.Status)
+	fmt.Fprintf(os.Stdout, "  trigger    %s\n", r.Trigger)
+	fmt.Fprintf(os.Stdout, "  short_id   %s\n", r.ShortID)
+	if r.DurationMs != nil {
+		fmt.Fprintf(os.Stdout, "  duration   %dms\n", *r.DurationMs)
+	}
+	if r.TotalCostUSD != nil {
+		fmt.Fprintf(os.Stdout, "  cost       $%.6f\n", *r.TotalCostUSD)
+	}
+	if r.TurnCount != nil {
+		fmt.Fprintf(os.Stdout, "  turns      %d\n", *r.TurnCount)
+	}
+	if r.NumToolCalls != nil {
+		fmt.Fprintf(os.Stdout, "  tool calls %d\n", *r.NumToolCalls)
+	}
+	if r.ErrorMessage != nil {
+		fmt.Fprintf(os.Stdout, "  error      %s\n", *r.ErrorMessage)
+	}
+	if r.TranscriptPath != nil {
+		fmt.Fprintf(os.Stdout, "  transcript %s\n", *r.TranscriptPath)
+	}
 }
 
 func runAgentTest(parent context.Context) error {


### PR DESCRIPTION
## Iteration 10 of the Claude Agent SDK integration sprint

Parallels iter 8's `breadbox agent test` for sysadmins who'd rather trigger agents from cron/shell than the v2 SPA. Same code path as the "Run now" button (`Orchestrator.RunNow`), so behavior matches the UI exactly.

Targets the sprint branch.

## What's in

- **`internal/cli/agent.go`** — new `run` subcommand. Resolves the agent by slug, builds a one-shot `Orchestrator` (concurrency=1) using the same `Sidecar` + `app_config` plumbing `serve.go` uses, calls `RunNow`, prints a human-readable summary OR the full `AgentRunResponse` JSON with `--json` for scripting.
- Exit codes mirror `agent test`: 0 success, 3 `ErrAuthNotConfigured`, 5 `ErrBinaryNotFound` / agent slug not found, 1 generic runtime failure.
- `docs/cli-commands.md` + `CHANGELOG.md` updated per the upkeep rules.

## Sample output (mocked)

```
$ breadbox agent run routine-review
▶  Running Routine Review (routine-review)…

  status     success
  trigger    manual
  short_id   K8kgB4L3
  duration   3210ms
  cost       \$0.0042
  turns      2
  tool calls 2
  transcript /var/lib/breadbox/agent-transcripts/<uuid>.ndjson
```

With `--json` you get the full `AgentRunResponse` shape (matches `GET /api/v1/agents/runs/{shortId}`).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `-tags=headless`, `-tags=lite` — all clean
- [x] `go test ./...` — all unit tests pass
- [x] `go run ./cmd/breadbox agent --help` and `agent run --help` render with the new subcommand + flag + exit-code table
- [x] No drift — no new REST routes; the CLI calls the service layer directly

## Deferred

- **Streaming event output** to stdout as the sidecar emits — current output is the final summary only. Add when there's demand (would require teaching the orchestrator to forward an external event handler).
- **Honoring quiet hours / hard server-side caps** from the CLI invocation — handled at the orchestrator layer when those features ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)