### PR TITLE
feat(agents): run-history filtering (status, trigger, date range)

### DIFF
--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"breadbox/internal/agent"
 	"breadbox/internal/app"
@@ -185,7 +186,8 @@ func setAgentEnabled(svc *service.Service, enabled bool) http.HandlerFunc {
 
 // --- Handlers: runs ---
 
-// ListAgentRunsHandler returns paginated runs for one agent.
+// ListAgentRunsHandler returns paginated runs for one agent. Supports
+// optional status / trigger / date-range filters via query params.
 func ListAgentRunsHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := chi.URLParam(r, "slug")
@@ -200,13 +202,73 @@ func ListAgentRunsHandler(svc *service.Service) http.HandlerFunc {
 			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
-		out, err := svc.ListAgentRuns(r.Context(), slug, limit, offset)
+		params := service.AgentRunListParams{
+			Limit:   limit,
+			Offset:  offset,
+			Status:  q.Get("status"),
+			Trigger: q.Get("trigger"),
+		}
+		if s := q.Get("start"); s != "" {
+			t, perr := parseDateOrRFC3339(s)
+			if perr != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "start must be YYYY-MM-DD or RFC3339")
+				return
+			}
+			params.Start = &t
+		}
+		if s := q.Get("end"); s != "" {
+			t, perr := parseDateOrRFC3339(s)
+			if perr != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "end must be YYYY-MM-DD or RFC3339")
+				return
+			}
+			// YYYY-MM-DD inputs land at 00:00; bump to end-of-day so the
+			// inclusive bound matches user expectation ("through Friday").
+			if len(s) == 10 {
+				t = t.Add(24*time.Hour - time.Second)
+			}
+			params.End = &t
+		}
+		if !isAllowedRunStatus(params.Status) {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"status must be one of: success, error, in_progress, skipped, timeout (empty = all)")
+			return
+		}
+		if !isAllowedRunTrigger(params.Trigger) {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"trigger must be one of: cron, manual, webhook (empty = all)")
+			return
+		}
+		out, err := svc.ListAgentRuns(r.Context(), slug, params)
 		if err != nil {
 			writeAgentError(w, err, "agent not found")
 			return
 		}
 		writeData(w, out)
 	}
+}
+
+func parseDateOrRFC3339(s string) (time.Time, error) {
+	if len(s) == 10 { // YYYY-MM-DD
+		return time.Parse("2006-01-02", s)
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func isAllowedRunStatus(s string) bool {
+	switch s {
+	case "", "success", "error", "in_progress", "skipped", "timeout":
+		return true
+	}
+	return false
+}
+
+func isAllowedRunTrigger(s string) bool {
+	switch s {
+	case "", "cron", "manual", "webhook":
+		return true
+	}
+	return false
 }
 
 // GetAgentRunHandler resolves by short_id or UUID.

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"breadbox/internal/agent"
 	"breadbox/internal/appconfig"
@@ -327,11 +328,28 @@ func (s *Service) SetAgentDefinitionEnabled(ctx context.Context, slugOrID string
 	return &resp, nil
 }
 
-// ListAgentRuns returns offset-paginated runs for one definition.
-func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, limit, offset int) (*AgentRunListResult, error) {
+// AgentRunListParams carries the optional filters for ListAgentRuns. Empty
+// fields mean "don't filter on this dimension."
+type AgentRunListParams struct {
+	Limit   int
+	Offset  int
+	Status  string // "" | "success" | "error" | "in_progress" | "skipped" | "timeout"
+	Trigger string // "" | "cron" | "manual" | "webhook"
+	// Start / End are inclusive bounds on started_at. RFC3339 or YYYY-MM-DD
+	// values from the API layer get parsed at the handler boundary.
+	Start *time.Time
+	End   *time.Time
+}
+
+// ListAgentRuns returns offset-paginated runs for one definition with
+// optional status / trigger / date-range filters. Hand-rolled SQL keeps
+// the conditional WHERE clauses composable.
+func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p AgentRunListParams) (*AgentRunListResult, error) {
+	limit := p.Limit
 	if limit <= 0 || limit > 200 {
 		limit = 50
 	}
+	offset := p.Offset
 	if offset < 0 {
 		offset = 0
 	}
@@ -339,21 +357,74 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, limit
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.Queries.ListAgentRuns(ctx, db.ListAgentRunsParams{
-		AgentDefinitionID: def.ID,
-		Limit:             int32(limit + 1), // peek for has_more
-		Offset:            int32(offset),
-	})
+
+	args := []any{def.ID}
+	where := []string{"agent_definition_id = $1"}
+	idx := 2
+	if p.Status != "" {
+		where = append(where, fmt.Sprintf("status = $%d", idx))
+		args = append(args, p.Status)
+		idx++
+	}
+	if p.Trigger != "" {
+		where = append(where, fmt.Sprintf(`"trigger" = $%d`, idx))
+		args = append(args, p.Trigger)
+		idx++
+	}
+	if p.Start != nil {
+		where = append(where, fmt.Sprintf("started_at >= $%d", idx))
+		args = append(args, *p.Start)
+		idx++
+	}
+	if p.End != nil {
+		where = append(where, fmt.Sprintf("started_at <= $%d", idx))
+		args = append(args, *p.End)
+		idx++
+	}
+
+	// Peek for has_more by asking for limit+1.
+	args = append(args, limit+1, offset)
+	query := fmt.Sprintf(`
+		SELECT id, short_id, agent_definition_id, "trigger", status, started_at, completed_at,
+		       duration_ms, total_cost_usd, input_tokens, output_tokens, cache_read_tokens,
+		       cache_creation_tokens, turn_count, max_turns_used, num_tool_calls,
+		       error_message, transcript_path, session_id
+		FROM agent_runs
+		WHERE %s
+		ORDER BY started_at DESC
+		LIMIT $%d OFFSET $%d`,
+		strings.Join(where, " AND "), idx, idx+1)
+
+	rows, err := s.Pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list agent runs: %w", err)
 	}
-	hasMore := len(rows) > limit
-	if hasMore {
-		rows = rows[:limit]
-	}
-	out := make([]AgentRunResponse, 0, len(rows))
-	for _, r := range rows {
+	defer rows.Close()
+
+	var out []AgentRunResponse
+	for rows.Next() {
+		var r db.AgentRun
+		if scanErr := rows.Scan(
+			&r.ID, &r.ShortID, &r.AgentDefinitionID, &r.Trigger, &r.Status,
+			&r.StartedAt, &r.CompletedAt, &r.DurationMs, &r.TotalCostUsd,
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens,
+			&r.CacheCreationTokens, &r.TurnCount, &r.MaxTurnsUsed,
+			&r.NumToolCalls, &r.ErrorMessage, &r.TranscriptPath, &r.SessionID,
+		); scanErr != nil {
+			return nil, fmt.Errorf("scan agent run: %w", scanErr)
+		}
 		out = append(out, agentRunFromRow(r))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate agent runs: %w", err)
+	}
+
+	hasMore := len(out) > limit
+	if hasMore {
+		out = out[:limit]
+	}
+	if out == nil {
+		out = []AgentRunResponse{}
 	}
 	return &AgentRunListResult{
 		Runs:    out,

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -184,13 +184,33 @@ export function useRunAgentNow() {
 
 // --- Run queries ---
 
-export function useAgentRuns(slug: string | undefined, limit = 50, offset = 0) {
+export interface AgentRunsFilters {
+  status?: string; // "" | "success" | "error" | "in_progress" | "skipped" | "timeout"
+  trigger?: string; // "" | "cron" | "manual" | "webhook"
+  start?: string; // YYYY-MM-DD or RFC3339
+  end?: string;
+}
+
+export function useAgentRuns(
+  slug: string | undefined,
+  filters: AgentRunsFilters = {},
+  limit = 50,
+  offset = 0,
+) {
   return useQuery({
-    queryKey: ["agents", slug, "runs", { limit, offset }],
-    queryFn: () =>
-      api<AgentRunListResult>(
-        `/api/v1/agents/${slug}/runs?limit=${limit}&offset=${offset}`,
-      ),
+    queryKey: ["agents", slug, "runs", { limit, offset, ...filters }],
+    queryFn: () => {
+      const qs = new URLSearchParams();
+      qs.set("limit", String(limit));
+      qs.set("offset", String(offset));
+      if (filters.status) qs.set("status", filters.status);
+      if (filters.trigger) qs.set("trigger", filters.trigger);
+      if (filters.start) qs.set("start", filters.start);
+      if (filters.end) qs.set("end", filters.end);
+      return api<AgentRunListResult>(
+        `/api/v1/agents/${slug}/runs?${qs.toString()}`,
+      );
+    },
     enabled: Boolean(slug),
   });
 }

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -1,9 +1,16 @@
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { ArrowLeft, Clock, Loader2 } from "lucide-react";
+import { ArrowLeft, Clock, FilterX, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Sheet,
   SheetContent,
@@ -15,10 +22,15 @@ import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
 import { EmptyState } from "@/components/empty-state";
 import {
+  DateRangeFilter,
+  type DateRangeValue,
+} from "@/components/date-range-filter";
+import {
   useAgent,
   useAgentRuns,
   useTranscript,
   type AgentRun,
+  type AgentRunsFilters,
 } from "@/api/queries/agents";
 import { formatDuration, formatRelativeTime } from "@/lib/format";
 import { RunStatusPill } from "@/features/agents/run-status-pill";
@@ -27,10 +39,18 @@ import { TranscriptViewer } from "@/features/agents/transcript-viewer";
 export const agentRunsSearchSchema = z.object({
   run: z.string().optional(),
   page: z.number().int().positive().optional(),
+  status: z
+    .enum(["success", "error", "in_progress", "skipped", "timeout"])
+    .optional(),
+  trigger: z.enum(["cron", "manual", "webhook"]).optional(),
+  start: z.string().optional(),
+  end: z.string().optional(),
 });
 type AgentRunsSearch = z.infer<typeof agentRunsSearchSchema>;
 
 const PAGE_SIZE = 25;
+
+const ANY_VALUE = "__any__";
 
 export function AgentRunsPage() {
   const { slug } = useParams({ strict: false }) as { slug: string };
@@ -38,8 +58,42 @@ export function AgentRunsPage() {
   const navigate = useNavigate();
   const page = search.page ?? 1;
 
+  const filters: AgentRunsFilters = {
+    status: search.status ?? "",
+    trigger: search.trigger ?? "",
+    start: search.start,
+    end: search.end,
+  };
+  const hasActiveFilters = Boolean(
+    search.status || search.trigger || search.start || search.end,
+  );
+
+  const setFilter = (patch: Partial<AgentRunsSearch>) => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        ...patch,
+        page: undefined, // reset pagination on filter change
+      }),
+    });
+  };
+  const clearFilters = () => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        status: undefined,
+        trigger: undefined,
+        start: undefined,
+        end: undefined,
+        page: undefined,
+      }),
+    });
+  };
+
   const agentQuery = useAgent(slug);
-  const runsQuery = useAgentRuns(slug, PAGE_SIZE, (page - 1) * PAGE_SIZE);
+  const runsQuery = useAgentRuns(slug, filters, PAGE_SIZE, (page - 1) * PAGE_SIZE);
 
   const openRunShortId = search.run ?? null;
 
@@ -77,6 +131,57 @@ export function AgentRunsPage() {
         title={agentQuery.data ? `${agentQuery.data.name} — runs` : "Run history"}
         description="Every fire of this agent (cron or manual). Click any row to view its transcript."
       />
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Select
+          value={search.status ?? ANY_VALUE}
+          onValueChange={(v) =>
+            setFilter({ status: v === ANY_VALUE ? undefined : (v as AgentRunsSearch["status"]) })
+          }
+        >
+          <SelectTrigger size="sm" className="w-40">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ANY_VALUE}>All statuses</SelectItem>
+            <SelectItem value="success">Success</SelectItem>
+            <SelectItem value="error">Error</SelectItem>
+            <SelectItem value="in_progress">Running</SelectItem>
+            <SelectItem value="skipped">Skipped</SelectItem>
+            <SelectItem value="timeout">Timeout</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={search.trigger ?? ANY_VALUE}
+          onValueChange={(v) =>
+            setFilter({ trigger: v === ANY_VALUE ? undefined : (v as AgentRunsSearch["trigger"]) })
+          }
+        >
+          <SelectTrigger size="sm" className="w-40">
+            <SelectValue placeholder="All triggers" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ANY_VALUE}>All triggers</SelectItem>
+            <SelectItem value="cron">Cron</SelectItem>
+            <SelectItem value="manual">Manual</SelectItem>
+            <SelectItem value="webhook">Webhook</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <DateRangeFilter
+          value={{ start: search.start, end: search.end } as DateRangeValue}
+          onChange={(v) => setFilter({ start: v.start, end: v.end })}
+          label="Started"
+        />
+
+        {hasActiveFilters && (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            <FilterX className="size-3.5" />
+            Clear filters
+          </Button>
+        )}
+      </div>
 
       {runsQuery.isError ? (
         <PageError


### PR DESCRIPTION
## Iteration 11 of the Claude Agent SDK integration sprint

Polish pass on `/v2/agents/$slug/runs` — add filter controls so users can slice run history without scrolling. Status select, trigger select, date-range picker, clear-filters button.

Targets the sprint branch.

## Evidence

**Unfiltered (4 mixed-status seeded runs):**

<img src="https://i.img402.dev/lztpomcg48.jpg" width="900" alt="Runs page unfiltered — 2 success, 1 error, 1 skipped">

**Filtered by status = Success (2 rows remain, Clear filters appears):**

<img src="https://i.img402.dev/xtyx09kpce.jpg" width="900" alt="Runs page filtered by status=success">

## What's in

**Backend**
- `internal/service/agents.go` — `ListAgentRuns` swapped from sqlc to dynamic SQL via `pool.Query`. New `AgentRunListParams` struct carries optional `Status`, `Trigger`, `Start`, `End` (`*time.Time`). Composable WHERE clauses follow the existing transactions/rules pattern (`.claude/rules/service.md`).
- `internal/api/agents.go` — `ListAgentRunsHandler` parses `status` / `trigger` / `start` / `end` query params. Date strings accept `YYYY-MM-DD` (auto-bumped to end-of-day on `end`) or RFC3339. Whitelist validation on `status` / `trigger` returns 400 `INVALID_PARAMETER` for unknown values.

**SPA**
- `web/src/api/queries/agents.ts` — `useAgentRuns(slug, filters, limit, offset)`. Cache key includes filters so navigation between views doesn't share stale results.
- `web/src/routes/agents.$slug.runs.tsx` — filter row with two Selects (status, trigger) + the existing `DateRangeFilter` primitive + a "Clear filters" button that appears only when at least one filter is active. URL state via the extended `agentRunsSearchSchema` so filters are shareable / back-button-restorable.

## Test plan

- [x] `go build` / `vet` clean across default + headless + lite
- [x] Existing 30+ agent integration tests pass — the `ListAgentRuns` signature change is the only API break; only the single handler caller was affected
- [x] `TestOpenAPIDrift` green (no new routes; same path, more query params)
- [x] `cd web && bun run lint` + `bun run build` clean
- [x] Local end-to-end: seeded 4 mixed-status runs, captured unfiltered + status=success screenshots at desktop+tablet+mobile composite

## Deferred

- **Search across `error_message` text** — small follow-up; would want a trigram index at scale.
- **Multi-select on status / trigger** — single-value is plenty for typical usage; bump only if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)