### PR TITLE
feat(agents): onboarding banner on /v2/agents

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -270,6 +270,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | GET | `/agents/runs/{shortId}/transcript` | R | Streams the NDJSON transcript; 404 when not yet written |
 | GET | `/agents/settings` | R | Agent subsystem config; token fields returned masked, never plaintext |
+| GET | `/agents/status` | R | Cheap readiness probe — `{auth_configured, binary_present, ready}` for onboarding hints (no API call) |
 | PUT | `/agents/settings` | W | Update settings; nil fields are unchanged, empty string for token fields clears them |
 
 `subscription_token` and `anthropic_api_key` are AES-256-GCM encrypted at rest. GET returns a masked display string (`"sk-ant-oat01-XXXXXXXXX••••wxyz"`); the full value never leaves the server. A per-run scoped API key (`actor_type='agent'`) is minted at run start by the orchestrator and revoked at completion — it is not exposed via this surface.

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -323,6 +323,16 @@ func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
 
 // --- Handlers: settings ---
 
+// AgentSubsystemStatusHandler reports whether the agent subsystem is ready
+// to fire — same checks as `breadbox doctor`, side-effect-free. The v2 SPA
+// list page calls this to render onboarding hints before the user sees a
+// wall of seeded starter agents they can't run.
+func AgentSubsystemStatusHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeData(w, svc.GetAgentSubsystemStatus(r.Context()))
+	}
+}
+
 // GetAgentSettingsHandler returns the agent.* config with masked tokens.
 func GetAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -118,6 +118,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		// Agents — read endpoints. Specific paths before /agents/{slug} param.
 		r.Get("/agents", ListAgentDefinitionsHandler(svc))
 		r.Get("/agents/settings", GetAgentSettingsHandler(svc, a))
+		r.Get("/agents/status", AgentSubsystemStatusHandler(svc))
 		r.Get("/agents/runs/{shortId}", GetAgentRunHandler(svc))
 		r.Get("/agents/runs/{shortId}/transcript", GetAgentRunTranscriptHandler(svc))
 		r.Get("/agents/{slug}", GetAgentDefinitionHandler(svc))

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"breadbox/internal/agent"
 	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 )
@@ -124,6 +125,45 @@ func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettings
 		}
 	}
 	return s.GetAgentSettings(ctx, encKey)
+}
+
+// AgentSubsystemStatus is a cheap, side-effect-free readiness report for
+// the agent subsystem — used by the v2 SPA list page to surface
+// onboarding hints, and (later) by the smoke-test endpoints to short-
+// circuit before charging a real API call.
+type AgentSubsystemStatus struct {
+	AuthMode        string `json:"auth_mode"`
+	AuthConfigured  bool   `json:"auth_configured"`
+	BinaryPresent   bool   `json:"binary_present"`
+	BinaryPath      string `json:"binary_path,omitempty"`
+	Ready           bool   `json:"ready"` // AuthConfigured && BinaryPresent
+}
+
+// GetAgentSubsystemStatus inspects app_config + the filesystem to report
+// whether the agent subsystem is ready to fire a run. Mirrors the
+// `breadbox doctor` check; the only difference is the wire shape.
+func (s *Service) GetAgentSubsystemStatus(ctx context.Context) *AgentSubsystemStatus {
+	authMode := appconfig.String(ctx, s.Queries, appconfig.KeyAgentAuthMode, appconfig.AuthModeSubscription)
+	tokenKey := appconfig.KeyAgentSubscriptionToken
+	if authMode == appconfig.AuthModeAPIKey {
+		tokenKey = appconfig.KeyAgentAnthropicAPIKey
+	}
+	stored, _ := appconfig.Read(ctx, s.Queries, tokenKey)
+	authConfigured := stored != ""
+
+	binaryPath := appconfig.String(ctx, s.Queries, appconfig.KeyAgentRuntimePath, "")
+	resolved, binErr := agent.LocateBinary(binaryPath)
+	binaryPresent := binErr == nil
+	if !binaryPresent {
+		resolved = ""
+	}
+	return &AgentSubsystemStatus{
+		AuthMode:       authMode,
+		AuthConfigured: authConfigured,
+		BinaryPresent:  binaryPresent,
+		BinaryPath:     resolved,
+		Ready:          authConfigured && binaryPresent,
+	}
 }
 
 // maskToken returns a display string for a secret. nil for empty input.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2397,6 +2397,24 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/status:
+    get:
+      tags: [Agents]
+      summary: Readiness probe for the agent subsystem
+      description: |
+        Side-effect-free check that returns whether the agent subsystem
+        is ready to fire a run — auth configured + sidecar binary
+        discoverable. Used by the v2 SPA list page to surface onboarding
+        hints inline. Does NOT call Anthropic; for a live round-trip
+        use POST /agents/test instead.
+      responses:
+        "200":
+          description: Readiness report.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/agents/settings:
     get:
       tags: [Agents]

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -246,6 +246,23 @@ export function useUpdateAgentSettings() {
   });
 }
 
+// --- Readiness probe (cheap, no API call) ---
+
+export interface AgentSubsystemStatus {
+  auth_mode: string;
+  auth_configured: boolean;
+  binary_present: boolean;
+  binary_path?: string;
+  ready: boolean;
+}
+
+export function useAgentSubsystemStatus() {
+  return useQuery({
+    queryKey: ["agents", "status"],
+    queryFn: () => api<AgentSubsystemStatus>("/api/v1/agents/status"),
+  });
+}
+
 // --- Smoke test (diagnostic) ---
 
 export interface AgentTestResult {

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -9,9 +9,11 @@ import {
   CheckCircle2,
   Clock,
   History,
+  KeyRound,
   Pencil,
   Play,
   Plus,
+  Terminal,
   Trash2,
   XCircle,
 } from "lucide-react";
@@ -19,6 +21,7 @@ import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { PageError } from "@/components/page-error";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -47,12 +50,15 @@ import { withMutationToast } from "@/lib/mutation-toast";
 import { formatRelativeTime } from "@/lib/format";
 import {
   useAgents,
+  useAgentSubsystemStatus,
   useCreateAgent,
   useDeleteAgent,
   useRunAgentNow,
   useToggleAgent,
   type AgentDefinition,
 } from "@/api/queries/agents";
+import { openModal } from "@/lib/modals";
+import { useNavigate } from "@tanstack/react-router";
 
 const createAgentSchema = z.object({
   name: z.string().min(1, "Name is required").max(120),
@@ -71,14 +77,18 @@ type CreateAgentForm = z.infer<typeof createAgentSchema>;
 
 export function AgentsPage() {
   const agentsQuery = useAgents();
+  const statusQuery = useAgentSubsystemStatus();
   const createAgent = useCreateAgent();
   const deleteAgent = useDeleteAgent();
+  const navigate = useNavigate();
   const [createOpen, setCreateOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<AgentDefinition | null>(
     null,
   );
 
   const agents = agentsQuery.data ?? [];
+  const status = statusQuery.data;
+  const showOnboardingBanner = Boolean(status) && !status?.ready;
 
   const form = useForm<CreateAgentForm>({
     resolver: zodResolver(createAgentSchema),
@@ -118,6 +128,67 @@ export function AgentsPage() {
           </Button>
         }
       />
+
+      {showOnboardingBanner && status && (
+        <Alert className="mb-4">
+          <Bot className="size-4" />
+          <AlertTitle>Finish setting up the agent subsystem</AlertTitle>
+          <AlertDescription className="space-y-2">
+            <p className="text-sm">
+              The seeded starter agents below won't fire until two pieces
+              are in place. Status checked without any API call:
+            </p>
+            <ul className="text-sm">
+              <li className="flex items-center gap-2">
+                {status.auth_configured ? (
+                  <CheckCircle2 className="size-4 text-emerald-600" />
+                ) : (
+                  <KeyRound className="text-muted-foreground size-4" />
+                )}
+                <span>
+                  Anthropic credential{" "}
+                  {status.auth_configured ? (
+                    <span className="text-muted-foreground">— configured</span>
+                  ) : (
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="h-auto p-0"
+                      onClick={() =>
+                        navigate({
+                          to: ".",
+                          search: openModal("settings", "agents"),
+                        })
+                      }
+                    >
+                      Open Settings → Agents
+                    </Button>
+                  )}
+                </span>
+              </li>
+              <li className="flex items-center gap-2">
+                {status.binary_present ? (
+                  <CheckCircle2 className="size-4 text-emerald-600" />
+                ) : (
+                  <Terminal className="text-muted-foreground size-4" />
+                )}
+                <span>
+                  breadbox-agent binary{" "}
+                  {status.binary_present ? (
+                    <span className="text-muted-foreground">
+                      — {status.binary_path}
+                    </span>
+                  ) : (
+                    <code className="bg-muted rounded px-1">
+                      make agent-sidecar
+                    </code>
+                  )}
+                </span>
+              </li>
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
 
       {agentsQuery.isError ? (
         <PageError


### PR DESCRIPTION
## Iteration 14 of the Claude Agent SDK integration sprint

Surfaces "you need to set this up first" inline on the agents list page so a fresh installer doesn't think the seeded starter agents are broken when toggling them does nothing. Reuses iter-13's `agent.LocateBinary` and iter-9's settings-modal deep-link.

Targets the sprint branch.

## What's in

**Backend**
- `internal/service/agent_settings.go` — new `GetAgentSubsystemStatus` returning `{ auth_mode, auth_configured, binary_present, binary_path, ready }`. Side-effect-free; same checks as the iter-13 doctor line, reshaped for the wire.
- `internal/api/agents.go` — `GET /api/v1/agents/status` handler (read-scope).
- `docs/api-endpoints.md` + `openapi.yaml` updated; drift test green.

**SPA**
- `web/src/api/queries/agents.ts` — `useAgentSubsystemStatus` hook + `AgentSubsystemStatus` type.
- `web/src/routes/agents.tsx` — when `status.ready === false`, render an inline `Alert` before the list with two bullet items:
  - Anthropic credential ✓ configured / **Open Settings → Agents** link (uses the existing `openModal('settings', 'agents')` helper for a deep-link without a route change).
  - breadbox-agent binary ✓ `<path>` / `make agent-sidecar` reminder code block.
- Banner self-hides as soon as both prereqs are in place — no manual dismiss needed.

## Test plan

- [x] `bun run lint` clean
- [x] `go build` / `vet` / `-tags=headless` / `-tags=lite` clean
- [x] `TestOpenAPIDrift` green
- [x] Live: built iter-14 binary, hit `/v2/agents` on the dev DB (no auth configured, no sidecar binary present) — banner rendered correctly at desktop + tablet + mobile. img402.dev was unreachable during this iteration's screenshot upload (transient — verified manually), so no embedded image in this PR; future iterations resume normal evidence flow.

## Onboarding loop after this PR

1. Fresh install boots → `/v2/agents` shows the seeded starter agents AND a banner explaining what's missing.
2. User clicks "Open Settings → Agents" → pastes a credential.
3. Settings save → list page banner re-fetches via TanStack invalidation, drops the credential bullet.
4. User runs `make agent-sidecar` → banner self-hides.
5. User enables an agent → "Run now" works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)