### PR TITLE
feat(agents): per-agent quiet hours

### DIFF
--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -20,31 +20,35 @@ import (
 // --- Request envelopes ---
 
 type createAgentRequest struct {
-	Name         string   `json:"name"`
-	Slug         string   `json:"slug"`
-	Prompt       string   `json:"prompt"`
-	SystemPrompt *string  `json:"system_prompt"`
-	ScheduleCron *string  `json:"schedule_cron"`
-	ToolScope    string   `json:"tool_scope"`
-	AllowedTools []string `json:"allowed_tools"`
-	Model        string   `json:"model"`
-	MaxTurns     int      `json:"max_turns"`
-	MaxBudgetUSD *float64 `json:"max_budget_usd"`
-	Enabled      bool     `json:"enabled"`
+	Name            string   `json:"name"`
+	Slug            string   `json:"slug"`
+	Prompt          string   `json:"prompt"`
+	SystemPrompt    *string  `json:"system_prompt"`
+	ScheduleCron    *string  `json:"schedule_cron"`
+	ToolScope       string   `json:"tool_scope"`
+	AllowedTools    []string `json:"allowed_tools"`
+	Model           string   `json:"model"`
+	MaxTurns        int      `json:"max_turns"`
+	MaxBudgetUSD    *float64 `json:"max_budget_usd"`
+	Enabled         bool     `json:"enabled"`
+	QuietHoursStart *string  `json:"quiet_hours_start"`
+	QuietHoursEnd   *string  `json:"quiet_hours_end"`
 }
 
 type updateAgentRequest struct {
-	Name         *string   `json:"name"`
-	Slug         *string   `json:"slug"`
-	Prompt       *string   `json:"prompt"`
-	SystemPrompt *string   `json:"system_prompt"`
-	ScheduleCron *string   `json:"schedule_cron"`
-	ToolScope    *string   `json:"tool_scope"`
-	AllowedTools *[]string `json:"allowed_tools"`
-	Model        *string   `json:"model"`
-	MaxTurns     *int      `json:"max_turns"`
-	MaxBudgetUSD *float64  `json:"max_budget_usd"`
-	Enabled      *bool     `json:"enabled"`
+	Name            *string   `json:"name"`
+	Slug            *string   `json:"slug"`
+	Prompt          *string   `json:"prompt"`
+	SystemPrompt    *string   `json:"system_prompt"`
+	ScheduleCron    *string   `json:"schedule_cron"`
+	ToolScope       *string   `json:"tool_scope"`
+	AllowedTools    *[]string `json:"allowed_tools"`
+	Model           *string   `json:"model"`
+	MaxTurns        *int      `json:"max_turns"`
+	MaxBudgetUSD    *float64  `json:"max_budget_usd"`
+	Enabled         *bool     `json:"enabled"`
+	QuietHoursStart *string   `json:"quiet_hours_start"`
+	QuietHoursEnd   *string   `json:"quiet_hours_end"`
 }
 
 type updateAgentSettingsRequest struct {
@@ -92,17 +96,19 @@ func CreateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 		out, err := svc.CreateAgentDefinition(r.Context(), service.CreateAgentDefinitionParams{
-			Name:         req.Name,
-			Slug:         req.Slug,
-			Prompt:       req.Prompt,
-			SystemPrompt: req.SystemPrompt,
-			ScheduleCron: req.ScheduleCron,
-			ToolScope:    req.ToolScope,
-			AllowedTools: req.AllowedTools,
-			Model:        req.Model,
-			MaxTurns:     req.MaxTurns,
-			MaxBudgetUSD: req.MaxBudgetUSD,
-			Enabled:      req.Enabled,
+			Name:            req.Name,
+			Slug:            req.Slug,
+			Prompt:          req.Prompt,
+			SystemPrompt:    req.SystemPrompt,
+			ScheduleCron:    req.ScheduleCron,
+			ToolScope:       req.ToolScope,
+			AllowedTools:    req.AllowedTools,
+			Model:           req.Model,
+			MaxTurns:        req.MaxTurns,
+			MaxBudgetUSD:    req.MaxBudgetUSD,
+			Enabled:         req.Enabled,
+			QuietHoursStart: req.QuietHoursStart,
+			QuietHoursEnd:   req.QuietHoursEnd,
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
@@ -130,17 +136,19 @@ func UpdateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 		out, err := svc.UpdateAgentDefinition(r.Context(), slug, service.UpdateAgentDefinitionParams{
-			Name:         req.Name,
-			Slug:         req.Slug,
-			Prompt:       req.Prompt,
-			SystemPrompt: req.SystemPrompt,
-			ScheduleCron: req.ScheduleCron,
-			ToolScope:    req.ToolScope,
-			AllowedTools: req.AllowedTools,
-			Model:        req.Model,
-			MaxTurns:     req.MaxTurns,
-			MaxBudgetUSD: req.MaxBudgetUSD,
-			Enabled:      req.Enabled,
+			Name:            req.Name,
+			Slug:            req.Slug,
+			Prompt:          req.Prompt,
+			SystemPrompt:    req.SystemPrompt,
+			ScheduleCron:    req.ScheduleCron,
+			ToolScope:       req.ToolScope,
+			AllowedTools:    req.AllowedTools,
+			Model:           req.Model,
+			MaxTurns:        req.MaxTurns,
+			MaxBudgetUSD:    req.MaxBudgetUSD,
+			Enabled:         req.Enabled,
+			QuietHoursStart: req.QuietHoursStart,
+			QuietHoursEnd:   req.QuietHoursEnd,
 		})
 		if err != nil {
 			writeAgentError(w, err, "agent not found")

--- a/internal/db/migrations/20260517093525_agent_quiet_hours.sql
+++ b/internal/db/migrations/20260517093525_agent_quiet_hours.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Per-agent quiet hours — when set, the scheduler silently skips cron
+-- fires that land inside the window. Both columns are "HH:MM" 24-hour
+-- strings (TEXT not TIME) for simpler JSON wire shape; the scheduler
+-- parses + compares against local clock. NULL on either side disables
+-- the window.
+ALTER TABLE agent_definitions
+    ADD COLUMN quiet_hours_start TEXT NULL,
+    ADD COLUMN quiet_hours_end   TEXT NULL;
+
+-- +goose Down
+ALTER TABLE agent_definitions
+    DROP COLUMN quiet_hours_start,
+    DROP COLUMN quiet_hours_end;

--- a/internal/db/queries/agent_definitions.sql
+++ b/internal/db/queries/agent_definitions.sql
@@ -1,9 +1,10 @@
 -- name: CreateAgentDefinition :one
 INSERT INTO agent_definitions (
     name, slug, prompt, system_prompt, schedule_cron,
-    tool_scope, allowed_tools, model, max_turns, max_budget_usd, enabled
+    tool_scope, allowed_tools, model, max_turns, max_budget_usd, enabled,
+    quiet_hours_start, quiet_hours_end
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 RETURNING *;
 
 -- name: GetAgentDefinition :one
@@ -26,18 +27,20 @@ ORDER BY created_at DESC;
 
 -- name: UpdateAgentDefinition :one
 UPDATE agent_definitions
-SET name           = $2,
-    slug           = $3,
-    prompt         = $4,
-    system_prompt  = $5,
-    schedule_cron  = $6,
-    tool_scope     = $7,
-    allowed_tools  = $8,
-    model          = $9,
-    max_turns      = $10,
-    max_budget_usd = $11,
-    enabled        = $12,
-    updated_at     = NOW()
+SET name              = $2,
+    slug              = $3,
+    prompt            = $4,
+    system_prompt     = $5,
+    schedule_cron     = $6,
+    tool_scope        = $7,
+    allowed_tools     = $8,
+    model             = $9,
+    max_turns         = $10,
+    max_budget_usd    = $11,
+    enabled           = $12,
+    quiet_hours_start = $13,
+    quiet_hours_end   = $14,
+    updated_at        = NOW()
 WHERE id = $1
 RETURNING *;
 

--- a/internal/service/agent_quiet_hours_test.go
+++ b/internal/service/agent_quiet_hours_test.go
@@ -1,0 +1,48 @@
+//go:build !lite
+
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsWithinQuietHours(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	at := func(h, m int) time.Time {
+		return time.Date(2026, 5, 17, h, m, 0, 0, time.Local)
+	}
+	tests := []struct {
+		name      string
+		now       time.Time
+		start     *string
+		end       *string
+		want      bool
+	}{
+		{"nil bounds = never quiet", at(3, 0), nil, nil, false},
+		{"empty bounds = never quiet", at(3, 0), strPtr(""), strPtr(""), false},
+		{"unparseable = never quiet", at(3, 0), strPtr("bogus"), strPtr("07:00"), false},
+		{"equal bounds = never quiet", at(3, 0), strPtr("07:00"), strPtr("07:00"), false},
+
+		// Same-day window 09:00–17:00 (work hours).
+		{"same-day before window", at(8, 0), strPtr("09:00"), strPtr("17:00"), false},
+		{"same-day at start (inclusive)", at(9, 0), strPtr("09:00"), strPtr("17:00"), true},
+		{"same-day middle", at(13, 30), strPtr("09:00"), strPtr("17:00"), true},
+		{"same-day at end (exclusive)", at(17, 0), strPtr("09:00"), strPtr("17:00"), false},
+		{"same-day after window", at(17, 30), strPtr("09:00"), strPtr("17:00"), false},
+
+		// Wrap-midnight window 22:00–07:00 (overnight quiet).
+		{"wraps at evening start (inclusive)", at(22, 0), strPtr("22:00"), strPtr("07:00"), true},
+		{"wraps middle of night", at(2, 30), strPtr("22:00"), strPtr("07:00"), true},
+		{"wraps at morning end (exclusive)", at(7, 0), strPtr("22:00"), strPtr("07:00"), false},
+		{"wraps during day", at(13, 0), strPtr("22:00"), strPtr("07:00"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsWithinQuietHours(tc.now, tc.start, tc.end); got != tc.want {
+				t.Errorf("got %v, want %v (now=%s start=%v end=%v)", got, tc.want,
+					tc.now.Format("15:04"), tc.start, tc.end)
+			}
+		})
+	}
+}

--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -117,6 +117,14 @@ func (s *AgentScheduler) fireCronJob(defID pgtype.UUID, slug string) {
 	if !def.Enabled {
 		return
 	}
+	if IsWithinQuietHours(time.Now(), def.QuietHoursStart, def.QuietHoursEnd) {
+		s.logger.Info("agent scheduler: run skipped (quiet hours)",
+			"agent", slug,
+			"quiet_start", derefString(def.QuietHoursStart),
+			"quiet_end", derefString(def.QuietHoursEnd),
+		)
+		return
+	}
 	_, runErr := s.orch.RunOrSkip(ctx, def, "cron")
 	if errors.Is(runErr, agent.ErrConcurrencyLocked) {
 		s.logger.Warn("agent scheduler: run skipped (concurrency locked)", "agent", slug)

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -40,22 +40,24 @@ var validAgentSlug = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$`
 
 // AgentDefinitionResponse is the API shape for an agent_definition row.
 type AgentDefinitionResponse struct {
-	ID           string           `json:"id"`
-	ShortID      string           `json:"short_id"`
-	Name         string           `json:"name"`
-	Slug         string           `json:"slug"`
-	Prompt       string           `json:"prompt"`
-	SystemPrompt *string          `json:"system_prompt,omitempty"`
-	ScheduleCron *string          `json:"schedule_cron,omitempty"`
-	ToolScope    string           `json:"tool_scope"`
-	AllowedTools []string         `json:"allowed_tools"`
-	Model        string           `json:"model"`
-	MaxTurns     int              `json:"max_turns"`
-	MaxBudgetUSD *float64         `json:"max_budget_usd,omitempty"`
-	Enabled      bool             `json:"enabled"`
-	LastRun      *AgentRunSummary `json:"last_run,omitempty"`
-	CreatedAt    string           `json:"created_at"`
-	UpdatedAt    string           `json:"updated_at"`
+	ID              string           `json:"id"`
+	ShortID         string           `json:"short_id"`
+	Name            string           `json:"name"`
+	Slug            string           `json:"slug"`
+	Prompt          string           `json:"prompt"`
+	SystemPrompt    *string          `json:"system_prompt,omitempty"`
+	ScheduleCron    *string          `json:"schedule_cron,omitempty"`
+	ToolScope       string           `json:"tool_scope"`
+	AllowedTools    []string         `json:"allowed_tools"`
+	Model           string           `json:"model"`
+	MaxTurns        int              `json:"max_turns"`
+	MaxBudgetUSD    *float64         `json:"max_budget_usd,omitempty"`
+	Enabled         bool             `json:"enabled"`
+	QuietHoursStart *string          `json:"quiet_hours_start,omitempty"`
+	QuietHoursEnd   *string          `json:"quiet_hours_end,omitempty"`
+	LastRun         *AgentRunSummary `json:"last_run,omitempty"`
+	CreatedAt       string           `json:"created_at"`
+	UpdatedAt       string           `json:"updated_at"`
 }
 
 // AgentRunSummary is the inline last-run shape on list/detail responses.
@@ -102,34 +104,38 @@ type AgentRunListResult struct {
 
 // CreateAgentDefinitionParams holds validated inputs for definition creation.
 type CreateAgentDefinitionParams struct {
-	Name         string
-	Slug         string
-	Prompt       string
-	SystemPrompt *string
-	ScheduleCron *string
-	ToolScope    string
-	AllowedTools []string
-	Model        string
-	MaxTurns     int
-	MaxBudgetUSD *float64
-	Enabled      bool
+	Name            string
+	Slug            string
+	Prompt          string
+	SystemPrompt    *string
+	ScheduleCron    *string
+	ToolScope       string
+	AllowedTools    []string
+	Model           string
+	MaxTurns        int
+	MaxBudgetUSD    *float64
+	Enabled         bool
+	QuietHoursStart *string // "HH:MM" 24-hour; nil disables window
+	QuietHoursEnd   *string
 }
 
 // UpdateAgentDefinitionParams uses pointer fields for PATCH semantics:
 // nil = don't touch; non-nil = replace. Slug is mutable here; if you want
 // it pinned, omit Slug from your PATCH body.
 type UpdateAgentDefinitionParams struct {
-	Name         *string
-	Slug         *string
-	Prompt       *string
-	SystemPrompt *string
-	ScheduleCron *string
-	ToolScope    *string
-	AllowedTools *[]string
-	Model        *string
-	MaxTurns     *int
-	MaxBudgetUSD *float64
-	Enabled      *bool
+	Name            *string
+	Slug            *string
+	Prompt          *string
+	SystemPrompt    *string
+	ScheduleCron    *string
+	ToolScope       *string
+	AllowedTools    *[]string
+	Model           *string
+	MaxTurns        *int
+	MaxBudgetUSD    *float64
+	Enabled         *bool
+	QuietHoursStart *string
+	QuietHoursEnd   *string
 }
 
 // ListAgentDefinitions returns all definitions ordered by created_at DESC,
@@ -193,18 +199,23 @@ func (s *Service) CreateAgentDefinition(ctx context.Context, p CreateAgentDefini
 		budget = &def
 	}
 
+	if err := validateQuietHours(p.QuietHoursStart, p.QuietHoursEnd); err != nil {
+		return nil, err
+	}
 	row, err := s.Queries.CreateAgentDefinition(ctx, db.CreateAgentDefinitionParams{
-		Name:         p.Name,
-		Slug:         p.Slug,
-		Prompt:       p.Prompt,
-		SystemPrompt: pgconv.TextPtrIfNotEmpty(p.SystemPrompt),
-		ScheduleCron: pgconv.TextPtrIfNotEmpty(p.ScheduleCron),
-		ToolScope:    toolScope,
-		AllowedTools: allowedJSON,
-		Model:        model,
-		MaxTurns:     int32(maxTurns),
-		MaxBudgetUsd: agentNumericFromFloat(budget),
-		Enabled:      p.Enabled,
+		Name:            p.Name,
+		Slug:            p.Slug,
+		Prompt:          p.Prompt,
+		SystemPrompt:    pgconv.TextPtrIfNotEmpty(p.SystemPrompt),
+		ScheduleCron:    pgconv.TextPtrIfNotEmpty(p.ScheduleCron),
+		ToolScope:       toolScope,
+		AllowedTools:    allowedJSON,
+		Model:           model,
+		MaxTurns:        int32(maxTurns),
+		MaxBudgetUsd:    agentNumericFromFloat(budget),
+		Enabled:         p.Enabled,
+		QuietHoursStart: pgconv.TextPtrIfNotEmpty(p.QuietHoursStart),
+		QuietHoursEnd:   pgconv.TextPtrIfNotEmpty(p.QuietHoursEnd),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create agent definition: %w", err)
@@ -256,8 +267,17 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 	if p.Enabled != nil {
 		merged.Enabled = *p.Enabled
 	}
+	if p.QuietHoursStart != nil {
+		merged.QuietHoursStart = emptyToNil(*p.QuietHoursStart)
+	}
+	if p.QuietHoursEnd != nil {
+		merged.QuietHoursEnd = emptyToNil(*p.QuietHoursEnd)
+	}
 
 	if err := validateAgentDefinitionFields(merged.Name, merged.Slug, merged.Prompt, merged.ToolScope, merged.Model, merged.MaxTurns, merged.MaxBudgetUSD, merged.ScheduleCron); err != nil {
+		return nil, err
+	}
+	if err := validateQuietHours(merged.QuietHoursStart, merged.QuietHoursEnd); err != nil {
 		return nil, err
 	}
 	allowedJSON, err := agentAllowedToolsToBytes(merged.AllowedTools)
@@ -271,18 +291,20 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 	}
 
 	row, err := s.Queries.UpdateAgentDefinition(ctx, db.UpdateAgentDefinitionParams{
-		ID:           existing.ID,
-		Name:         merged.Name,
-		Slug:         merged.Slug,
-		Prompt:       merged.Prompt,
-		SystemPrompt: pgconv.TextPtrIfNotEmpty(merged.SystemPrompt),
-		ScheduleCron: pgconv.TextPtrIfNotEmpty(merged.ScheduleCron),
-		ToolScope:    merged.ToolScope,
-		AllowedTools: allowedJSON,
-		Model:        merged.Model,
-		MaxTurns:     int32(merged.MaxTurns),
-		MaxBudgetUsd: agentNumericFromFloat(budget),
-		Enabled:      merged.Enabled,
+		ID:              existing.ID,
+		Name:            merged.Name,
+		Slug:            merged.Slug,
+		Prompt:          merged.Prompt,
+		SystemPrompt:    pgconv.TextPtrIfNotEmpty(merged.SystemPrompt),
+		ScheduleCron:    pgconv.TextPtrIfNotEmpty(merged.ScheduleCron),
+		ToolScope:       merged.ToolScope,
+		AllowedTools:    allowedJSON,
+		Model:           merged.Model,
+		MaxTurns:        int32(merged.MaxTurns),
+		MaxBudgetUsd:    agentNumericFromFloat(budget),
+		Enabled:         merged.Enabled,
+		QuietHoursStart: pgconv.TextPtrIfNotEmpty(merged.QuietHoursStart),
+		QuietHoursEnd:   pgconv.TextPtrIfNotEmpty(merged.QuietHoursEnd),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update agent definition: %w", err)
@@ -738,22 +760,24 @@ func agentIntFromInt4(n pgtype.Int4) *int {
 
 func agentDefinitionFromRow(row db.AgentDefinition, lastRun *AgentRunSummary) AgentDefinitionResponse {
 	return AgentDefinitionResponse{
-		ID:           pgconv.FormatUUID(row.ID),
-		ShortID:      row.ShortID,
-		Name:         row.Name,
-		Slug:         row.Slug,
-		Prompt:       row.Prompt,
-		SystemPrompt: pgconv.TextPtr(row.SystemPrompt),
-		ScheduleCron: pgconv.TextPtr(row.ScheduleCron),
-		ToolScope:    row.ToolScope,
-		AllowedTools: agentAllowedToolsFromBytes(row.AllowedTools),
-		Model:        row.Model,
-		MaxTurns:     int(row.MaxTurns),
-		MaxBudgetUSD: agentFloatFromNumeric(row.MaxBudgetUsd),
-		Enabled:      row.Enabled,
-		LastRun:      lastRun,
-		CreatedAt:    pgconv.TimestampStr(row.CreatedAt),
-		UpdatedAt:    pgconv.TimestampStr(row.UpdatedAt),
+		ID:              pgconv.FormatUUID(row.ID),
+		ShortID:         row.ShortID,
+		Name:            row.Name,
+		Slug:            row.Slug,
+		Prompt:          row.Prompt,
+		SystemPrompt:    pgconv.TextPtr(row.SystemPrompt),
+		ScheduleCron:    pgconv.TextPtr(row.ScheduleCron),
+		ToolScope:       row.ToolScope,
+		AllowedTools:    agentAllowedToolsFromBytes(row.AllowedTools),
+		Model:           row.Model,
+		MaxTurns:        int(row.MaxTurns),
+		MaxBudgetUSD:    agentFloatFromNumeric(row.MaxBudgetUsd),
+		Enabled:         row.Enabled,
+		QuietHoursStart: pgconv.TextPtr(row.QuietHoursStart),
+		QuietHoursEnd:   pgconv.TextPtr(row.QuietHoursEnd),
+		LastRun:         lastRun,
+		CreatedAt:       pgconv.TimestampStr(row.CreatedAt),
+		UpdatedAt:       pgconv.TimestampStr(row.UpdatedAt),
 	}
 }
 
@@ -803,4 +827,74 @@ func derefString(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+func emptyToNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	out := s
+	return &out
+}
+
+// validateQuietHours enforces both bounds are valid "HH:MM" 24-hour
+// strings, or both nil. One-sided is rejected — a quiet window needs both edges.
+func validateQuietHours(start, end *string) error {
+	startSet := start != nil && *start != ""
+	endSet := end != nil && *end != ""
+	if !startSet && !endSet {
+		return nil
+	}
+	if startSet != endSet {
+		return fmt.Errorf("%w: quiet_hours_start and quiet_hours_end must both be set or both empty", ErrInvalidParameter)
+	}
+	if _, ok := parseHHMM(*start); !ok {
+		return fmt.Errorf("%w: quiet_hours_start must be HH:MM (24-hour)", ErrInvalidParameter)
+	}
+	if _, ok := parseHHMM(*end); !ok {
+		return fmt.Errorf("%w: quiet_hours_end must be HH:MM (24-hour)", ErrInvalidParameter)
+	}
+	return nil
+}
+
+// parseHHMM returns minutes-from-midnight and ok=true for a valid "HH:MM"
+// 24-hour string.
+func parseHHMM(s string) (int, bool) {
+	if len(s) != 5 || s[2] != ':' {
+		return 0, false
+	}
+	h, err := strconv.Atoi(s[:2])
+	if err != nil || h < 0 || h > 23 {
+		return 0, false
+	}
+	m, err := strconv.Atoi(s[3:])
+	if err != nil || m < 0 || m > 59 {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+// IsWithinQuietHours reports whether `now` falls inside the [start, end)
+// window. False on unset/unparseable. Handles windows that wrap midnight
+// (e.g. start=22:00, end=07:00 → quiet 10 PM through 7 AM next morning).
+func IsWithinQuietHours(now time.Time, start, end *string) bool {
+	if start == nil || end == nil || *start == "" || *end == "" {
+		return false
+	}
+	startMin, ok := parseHHMM(*start)
+	if !ok {
+		return false
+	}
+	endMin, ok := parseHHMM(*end)
+	if !ok {
+		return false
+	}
+	if startMin == endMin {
+		return false
+	}
+	cur := now.Hour()*60 + now.Minute()
+	if startMin < endMin {
+		return cur >= startMin && cur < endMin
+	}
+	return cur >= startMin || cur < endMin
 }

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -29,6 +29,8 @@ export interface AgentDefinition {
   max_turns: number;
   max_budget_usd?: number | null;
   enabled: boolean;
+  quiet_hours_start?: string | null; // "HH:MM" 24-hour; nil disables window
+  quiet_hours_end?: string | null;
   last_run?: AgentRunSummary | null;
   created_at: string;
   updated_at: string;
@@ -85,6 +87,8 @@ export interface CreateAgentInput {
   max_turns?: number;
   max_budget_usd?: number | null;
   enabled?: boolean;
+  quiet_hours_start?: string | null;
+  quiet_hours_end?: string | null;
 }
 
 export type UpdateAgentInput = Partial<CreateAgentInput>;

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -54,6 +54,16 @@ const agentEditSchema = z.object({
     (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
     z.number().positive().nullable(),
   ),
+  quiet_hours_start: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
+    .optional()
+    .or(z.literal("")),
+  quiet_hours_end: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
+    .optional()
+    .or(z.literal("")),
 });
 type AgentEditForm = z.input<typeof agentEditSchema>;
 
@@ -75,6 +85,8 @@ export function AgentEditPage() {
       model: "claude-opus-4-7",
       max_turns: 10,
       max_budget_usd: null,
+      quiet_hours_start: "",
+      quiet_hours_end: "",
     },
   });
 
@@ -93,6 +105,8 @@ export function AgentEditPage() {
       model: agent.model,
       max_turns: agent.max_turns,
       max_budget_usd: agent.max_budget_usd ?? null,
+      quiet_hours_start: agent.quiet_hours_start ?? "",
+      quiet_hours_end: agent.quiet_hours_end ?? "",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentQuery.data?.short_id]);
@@ -114,6 +128,12 @@ export function AgentEditPage() {
           model: values.model,
           max_turns: values.max_turns as unknown as number,
           max_budget_usd: values.max_budget_usd as unknown as number | null,
+          quiet_hours_start: values.quiet_hours_start
+            ? values.quiet_hours_start
+            : null,
+          quiet_hours_end: values.quiet_hours_end
+            ? values.quiet_hours_end
+            : null,
         }),
       {
         success: "Agent saved",
@@ -352,6 +372,48 @@ export function AgentEditPage() {
                             ref={field.ref}
                           />
                         </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="quiet_hours_start"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Quiet hours start</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="time"
+                            placeholder="22:00"
+                            {...field}
+                            value={field.value ?? ""}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="quiet_hours_end"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Quiet hours end</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="time"
+                            placeholder="07:00"
+                            {...field}
+                            value={field.value ?? ""}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Cron fires inside the window are silently skipped.
+                          Leave both blank to disable.
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}


### PR DESCRIPTION
## Iteration 15 of the Claude Agent SDK integration sprint

Strengthens the main control loop. Each `agent_definition` gets an optional `[quiet_hours_start, quiet_hours_end)` window during which cron fires silently skip. "Don't ping Claude at 3am", "only run during business hours", etc.

Targets the sprint branch.

## What's in

**Schema**
- `internal/db/migrations/20260517093525_agent_quiet_hours.sql` — adds `quiet_hours_start` + `quiet_hours_end` (`TEXT NULL`, `"HH:MM"` 24-hour). Additive — safe under the shared dev DB.
- sqlc query updates for the INSERT and UPDATE paths.

**Service layer**
- Response + Create/Update params gain the two new fields.
- `validateQuietHours` — both edges set or both empty; `parseHHMM` rejects malformed strings.
- `IsWithinQuietHours(now, start, end) bool` — pure, exported. Handles **same-day** windows AND **wraps-midnight** windows (start > end, e.g. 22:00 → 07:00).

**Scheduler**
- `fireCronJob` checks `IsWithinQuietHours` BEFORE calling `RunOrSkip`. Inside the window = silent log + return; no `agent_runs` row, no semaphore acquire.
- **Manual + webhook triggers ignore quiet hours by design** — operator intent overrides the policy.

**HTTP**
- Create + update request shapes thread the new fields through.

**SPA**
- `web/src/routes/agents.$slug.edit.tsx` — two `<Input type="time">` fields in a 2-col row below max_turns/max_budget_usd. Zod regex catches malformed input client-side; server validates again.

## Test plan

- [x] 13 new `TestIsWithinQuietHours` sub-tests pass (nil / empty / unparseable / equal bounds; same-day window edges inclusive/exclusive; midnight-wrap window edges)
- [x] Existing 30+ agent integration tests still pass
- [x] `TestOpenAPIDrift` green (no new routes)
- [x] `bun run lint` + `bun run build` clean
- [x] `go build` / `vet` / `-tags=headless` / `-tags=lite` clean

## Deferred

- **"Next-fire" preview that accounts for quiet hours** — could show "next: tomorrow 8am" instead of the raw cron preview on the v2 SPA list. Polish item.
- **Per-day-of-week quiet windows** — current implementation is a single daily recurring window. YAGNI for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)