### PR TITLE
feat(agents): inline run notes

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -268,6 +268,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200) |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
+| PATCH | `/agents/runs/{shortId}` | W | Set/clear the operator note on a run. Body `{ "note": "..." }`; empty string clears. Capped at 2000 chars |
 | GET | `/agents/runs/{shortId}/transcript` | R | Streams the NDJSON transcript; 404 when not yet written |
 | GET | `/agents/settings` | R | Agent subsystem config; token fields returned masked, never plaintext |
 | GET | `/agents/status` | R | Cheap readiness probe — `{auth_configured, binary_present, ready}` for onboarding hints (no API call) |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -435,6 +435,29 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 	}
 }
 
+type updateAgentRunNoteRequest struct {
+	Note string `json:"note"`
+}
+
+// UpdateAgentRunNoteHandler sets/clears the operator note on one run.
+// Body: { "note": "..." }; empty string clears the field. Capped at 2000
+// chars server-side (matches the SPA textarea cap).
+func UpdateAgentRunNoteHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "shortId")
+		var req updateAgentRunNoteRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		out, err := svc.SetAgentRunNote(r.Context(), id, req.Note)
+		if err != nil {
+			writeAgentError(w, err, "run not found")
+			return
+		}
+		writeData(w, out)
+	}
+}
+
 // agentTestResponse mirrors agent.SmokeResult for the JSON wire format.
 type agentTestResponse struct {
 	AuthMode     string  `json:"auth_mode"`

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -195,6 +195,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/agents/{slug}/disable", DisableAgentHandler(svc))
 			r.Post("/agents/{slug}/run", RunAgentNowHandler(svc, a.AgentOrchestrator))
 			r.Post("/agents/test", SmokeTestAgentHandler(a.AgentOrchestrator))
+			r.Patch("/agents/runs/{shortId}", UpdateAgentRunNoteHandler(svc))
 			r.Post("/providers/{name}/test", TestProviderHandler(a))
 			r.Delete("/providers/{name}", DisableProviderHandler(a))
 			r.Get("/config", ListConfigHandler(a))

--- a/internal/db/migrations/20260517094621_agent_runs_operator_note.sql
+++ b/internal/db/migrations/20260517094621_agent_runs_operator_note.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Operator-editable note attached to each agent_run. Used by humans to
+-- record context around a manual fire ("triggered to test category X
+-- changes") or annotate a cron run after the fact ("known false-positive
+-- run; investigating"). Free-form TEXT; no constraints — UI caps length.
+ALTER TABLE agent_runs
+    ADD COLUMN operator_note TEXT NULL;
+
+-- +goose Down
+ALTER TABLE agent_runs
+    DROP COLUMN operator_note;

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -60,6 +60,12 @@ SET status        = 'skipped',
     error_message = $2
 WHERE id = $1;
 
+-- name: SetAgentRunNote :one
+UPDATE agent_runs
+SET operator_note = $2
+WHERE id = $1
+RETURNING *;
+
 -- name: CleanupOrphanedAgentRuns :execresult
 UPDATE agent_runs
 SET status        = 'error',

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -92,6 +92,7 @@ type AgentRunResponse struct {
 	ErrorMessage        *string  `json:"error_message,omitempty"`
 	TranscriptPath      *string  `json:"transcript_path,omitempty"`
 	SessionID           *string  `json:"session_id,omitempty"`
+	OperatorNote        *string  `json:"operator_note,omitempty"`
 }
 
 // AgentRunListResult is the paginated envelope for run lists.
@@ -456,6 +457,32 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 	}, nil
 }
 
+// AgentRunNoteMaxLen caps the operator note size both in the SPA textarea
+// and on the server. Free-form text but bounded so we don't accidentally
+// host arbitrarily-large blobs.
+const AgentRunNoteMaxLen = 2000
+
+// SetAgentRunNote updates the operator note on one run. Empty string
+// clears the field. Returns the updated row.
+func (s *Service) SetAgentRunNote(ctx context.Context, shortIDOrUUID, note string) (*AgentRunResponse, error) {
+	if len(note) > AgentRunNoteMaxLen {
+		return nil, fmt.Errorf("%w: operator note must be <= %d chars", ErrInvalidParameter, AgentRunNoteMaxLen)
+	}
+	existing, err := s.resolveAgentRun(ctx, shortIDOrUUID)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.Queries.SetAgentRunNote(ctx, db.SetAgentRunNoteParams{
+		ID:           existing.ID,
+		OperatorNote: pgconv.TextIfNotEmpty(note),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("set agent run note: %w", err)
+	}
+	resp := agentRunFromRow(row)
+	return &resp, nil
+}
+
 // GetAgentRun resolves by short_id or UUID.
 func (s *Service) GetAgentRun(ctx context.Context, shortIDOrUUID string) (*AgentRunResponse, error) {
 	row, err := s.resolveAgentRun(ctx, shortIDOrUUID)
@@ -807,6 +834,7 @@ func agentRunFromRow(row db.AgentRun) AgentRunResponse {
 		ErrorMessage:        pgconv.TextPtr(row.ErrorMessage),
 		TranscriptPath:      pgconv.TextPtr(row.TranscriptPath),
 		SessionID:           pgconv.TextPtr(row.SessionID),
+		OperatorNote:        pgconv.TextPtr(row.OperatorNote),
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2460,6 +2460,29 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/runs/{shortId}:
+    parameters:
+      - { name: shortId, in: path, required: true, schema: { type: string } }
+    patch:
+      tags: [Agents]
+      summary: Set or clear the operator note on a run
+      description: |
+        Body: `{ "note": "..." }`. Empty string clears the field. Capped
+        at 2000 chars. **Requires `full_access` scope.**
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note: { type: string, maxLength: 2000 }
+      responses:
+        "200":
+          description: Updated run.
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
   /api/v1/agents/runs/{shortId}/transcript:
     parameters:
       - { name: shortId, in: path, required: true, schema: { type: string } }

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -56,7 +56,10 @@ export interface AgentRun {
   error_message?: string | null;
   transcript_path?: string | null;
   session_id?: string | null;
+  operator_note?: string | null;
 }
+
+export const AGENT_RUN_NOTE_MAX_LEN = 2000;
 
 export interface AgentRunListResult {
   runs: AgentRun[];
@@ -246,6 +249,21 @@ export function useUpdateAgentSettings() {
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents", "settings"] });
+    },
+  });
+}
+
+export function useUpdateAgentRunNote() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ shortId, note }: { shortId: string; note: string }) =>
+      api<AgentRun>(`/api/v1/agents/runs/${shortId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ note }),
+      }),
+    onSuccess: (_run, { shortId }) => {
+      qc.invalidateQueries({ queryKey: ["agents", "runs", shortId] });
+      qc.invalidateQueries({ queryKey: ["agents"] }); // any list referencing this run
     },
   });
 }

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -1,6 +1,7 @@
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { ArrowLeft, Clock, FilterX, Loader2 } from "lucide-react";
+import { ArrowLeft, Clock, FilterX, Loader2, StickyNote } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -26,12 +27,17 @@ import {
   type DateRangeValue,
 } from "@/components/date-range-filter";
 import {
+  AGENT_RUN_NOTE_MAX_LEN,
   useAgent,
+  useAgentRun,
   useAgentRuns,
   useTranscript,
+  useUpdateAgentRunNote,
   type AgentRun,
   type AgentRunsFilters,
 } from "@/api/queries/agents";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { Textarea } from "@/components/ui/textarea";
 import { formatDuration, formatRelativeTime } from "@/lib/format";
 import { RunStatusPill } from "@/features/agents/run-status-pill";
 import { TranscriptViewer } from "@/features/agents/transcript-viewer";
@@ -232,6 +238,82 @@ export function AgentRunsPage() {
   );
 }
 
+interface OperatorNoteEditorProps {
+  shortId: string;
+  storedNote: string;
+  loading: boolean;
+}
+
+function OperatorNoteEditor({
+  shortId,
+  storedNote,
+  loading,
+}: OperatorNoteEditorProps) {
+  const update = useUpdateAgentRunNote();
+  const [draft, setDraft] = useState(storedNote);
+
+  // Re-hydrate when the loaded note changes (e.g. opening a different run
+  // in the same Sheet instance after navigating).
+  useEffect(() => {
+    setDraft(storedNote);
+  }, [storedNote, shortId]);
+
+  const dirty = draft !== storedNote;
+  const tooLong = draft.length > AGENT_RUN_NOTE_MAX_LEN;
+  const onSave = () => {
+    if (tooLong) return;
+    void withMutationToast(
+      () => update.mutateAsync({ shortId, note: draft }),
+      {
+        success: storedNote === "" ? "Note added" : draft === "" ? "Note cleared" : "Note saved",
+        error: "Failed to save note",
+      },
+    );
+  };
+
+  return (
+    <div className="mb-4 rounded-md border p-3">
+      <label
+        htmlFor={`note-${shortId}`}
+        className="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs uppercase tracking-wider"
+      >
+        <StickyNote className="size-3.5" />
+        Operator note
+      </label>
+      <Textarea
+        id={`note-${shortId}`}
+        rows={2}
+        placeholder={
+          loading ? "Loading…" : "Add context — why this fired, what you're investigating, follow-ups…"
+        }
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={loading}
+        aria-invalid={tooLong}
+      />
+      <div className="mt-1.5 flex items-center justify-between">
+        <span
+          className={`text-xs ${tooLong ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {draft.length} / {AGENT_RUN_NOTE_MAX_LEN}
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant={dirty ? "default" : "outline"}
+          onClick={onSave}
+          disabled={!dirty || tooLong || update.isPending}
+        >
+          {update.isPending ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : null}
+          {draft === "" && storedNote !== "" ? "Clear note" : "Save note"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
   return (
     <button
@@ -266,11 +348,8 @@ interface TranscriptSheetProps {
 
 function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
   const open = Boolean(shortId);
-  const runQuery = useAgentRuns; // unused — kept here as a reminder that the
-  // single-run detail comes via useTranscript; the run summary is in the
-  // parent's runs list.
-  void runQuery;
   const transcript = useTranscript(shortId ?? undefined);
+  const runDetail = useAgentRun(shortId ?? undefined);
 
   return (
     <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
@@ -284,6 +363,13 @@ function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
           </SheetDescription>
         </SheetHeader>
         <div className="flex-1 overflow-y-auto px-6 py-4">
+          {shortId && (
+            <OperatorNoteEditor
+              shortId={shortId}
+              storedNote={runDetail.data?.operator_note ?? ""}
+              loading={runDetail.isLoading}
+            />
+          )}
           {transcript.isLoading ? (
             <div className="space-y-3">
               <Skeleton className="h-20 w-full" />


### PR DESCRIPTION
## Iteration 16 of the Claude Agent SDK integration sprint

Operator-editable note attached to each `agent_run` so manual fires can carry context ("testing categorization fix", "investigating this false positive", "follow-up: see report #123"). Rendered in the transcript drawer; appears next to every run automatically.

Targets the sprint branch.

## What's in

**Schema**
- Migration `20260517094621_agent_runs_operator_note.sql` — adds `operator_note TEXT NULL`. Additive.
- sqlc `SetAgentRunNote` query (`:one`, returns the updated row).

**Service**
- `SetAgentRunNote(ctx, shortIDOrUUID, note)` with `AgentRunNoteMaxLen=2000` cap (`ErrInvalidParameter` on over).
- `AgentRunResponse.OperatorNote` field threaded through `agentRunFromRow`.

**HTTP**
- `PATCH /api/v1/agents/runs/{shortId}` body `{ "note": "..." }`. Empty string clears. Server validates length.
- `docs/api-endpoints.md` + `openapi.yaml` updated; drift test green.

**SPA**
- `useUpdateAgentRunNote` mutation hook + `AGENT_RUN_NOTE_MAX_LEN` constant.
- TranscriptSheet now fetches the single-run detail via `useAgentRun` (the existing transcript path didn't need it).
- New `OperatorNoteEditor` component at the top of the drawer body:
  - Local draft state so typing doesn't fire the network.
  - Char counter with destructive styling when over cap.
  - "Save note" / "Clear note" button — variant flips to `default` when dirty, disabled when clean or over cap.
  - mutation-toast on save with context-aware message (added/saved/cleared).

## Test plan

- [x] `bun run lint` + `bun run build` clean
- [x] `go build` / `vet` / `-tags=headless` / `-tags=lite` clean
- [x] All Go unit tests pass
- [x] `TestOpenAPIDrift` green

## Deferred

- **📝 indicator on run-history rows** that have a note (small polish; only the drawer shows the note today).
- **Note history / audit trail** — single-value field for now; history can layer on if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)