### PR TITLE
feat(agents): note indicator on run-history rows

### DIFF
--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -315,6 +315,10 @@ function OperatorNoteEditor({
 }
 
 function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
+  const hasNote = Boolean(run.operator_note && run.operator_note.trim() !== "");
+  const notePreview = hasNote
+    ? (run.operator_note ?? "").trim().slice(0, 80)
+    : "";
   return (
     <button
       type="button"
@@ -328,6 +332,16 @@ function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
       <span className="flex-1 text-xs">
         {formatRelativeTime(run.started_at)}
       </span>
+      {hasNote && (
+        <span
+          className="text-muted-foreground inline-flex items-center gap-1 text-xs"
+          title={notePreview}
+          aria-label={`Operator note: ${notePreview}`}
+        >
+          <StickyNote className="size-3.5" />
+          note
+        </span>
+      )}
       <span className="text-muted-foreground text-xs">
         {formatDuration(run.duration_ms)}
       </span>


### PR DESCRIPTION
## Iteration 17 of the Claude Agent SDK integration sprint

Surfaces iter-16's operator notes on the run-history list so users can spot annotated runs at a glance without opening each transcript drawer.

Targets the sprint branch. Single-file UI tweak; no backend / API / schema changes.

## What's in

- `web/src/routes/agents.$slug.runs.tsx` — `RunRow` renders a small `StickyNote` icon + `note` label between the `started_at` column and the duration column when `run.operator_note` is non-empty (after trim).
- `title` attribute carries the first 80 chars of the note as a native hover preview; `aria-label` exposes the same to screen readers.

## Test plan

- [x] `bun run lint` + `bun run build` clean
- [x] No Go touched
- [x] Skipped screenshot upload — single-component polish, diff is the evidence

## Why a native tooltip

`title=...` is the cheapest hover preview we can ship. If/when the surface grows beyond "operator notes" we can promote to shadcn `Tooltip` — adding it now for one row indicator is over-engineering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)