### PR TITLE
chore(web): keep dist/.gitkeep across builds

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && touch dist/.gitkeep",
     "preview": "vite preview",
     "lint": "tsc -b --noEmit",
     "validate": "bun run scripts/validate.ts"


### PR DESCRIPTION
## Iteration 18 of the Claude Agent SDK integration sprint

Tiny infra fix. Kills the recurring "amend the .gitkeep back" footgun that every sprint iter has been tripping over (5+ times so far).

Targets the sprint branch.

## Problem

`vite build` wipes `web/dist/` and rewrites it without the `.gitkeep` sentinel. Go's `//go:embed all:dist` needs a non-empty directory at compile time, so `.gitkeep` is committed as that sentinel — but every iter commit since iter 4 has either had to amend the deletion back or accidentally shipped it.

## Fix

Append `&& touch dist/.gitkeep` to the `build` script in `web/package.json`. The sentinel now survives regardless of entrypoint (`make web`, CI, or ad-hoc `cd web && bun run build`).

## Verification

```
$ rm -f web/dist/.gitkeep
$ cd web && bun run build
✓ built in 3.92s
$ ls -la dist/.gitkeep
-rw-r--r-- … 0 May 17 03:05 dist/.gitkeep   # restored
```

One-line change; no behavioral effect on the produced bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)