### PR TITLE
feat(agents): per-agent 30d cost on the list page

### DIFF
--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -60,6 +60,21 @@ SET status        = 'skipped',
     error_message = $2
 WHERE id = $1;
 
+-- name: GetAgentCostStats30d :many
+-- Per-definition cost rollup over the last 30 days. Used by the v2 SPA
+-- list page to surface lifetime spend at a glance. Excludes skipped runs
+-- (no real cost incurred) but includes errored runs (often DO incur
+-- partial cost).
+SELECT
+    agent_definition_id,
+    COUNT(*)::int                                        AS run_count,
+    COALESCE(SUM(total_cost_usd), 0)::numeric(10,4)      AS total_cost_usd
+FROM agent_runs
+WHERE agent_definition_id IS NOT NULL
+  AND started_at >= NOW() - INTERVAL '30 days'
+  AND status != 'skipped'
+GROUP BY agent_definition_id;
+
 -- name: SetAgentRunNote :one
 UPDATE agent_runs
 SET operator_note = $2

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -56,8 +56,20 @@ type AgentDefinitionResponse struct {
 	QuietHoursStart *string          `json:"quiet_hours_start,omitempty"`
 	QuietHoursEnd   *string          `json:"quiet_hours_end,omitempty"`
 	LastRun         *AgentRunSummary `json:"last_run,omitempty"`
-	CreatedAt       string           `json:"created_at"`
-	UpdatedAt       string           `json:"updated_at"`
+	// CostStats30d is populated only by ListAgentDefinitions (the surface
+	// where users want to compare spend at a glance). Single-row
+	// GetAgentDefinition leaves it nil so the edit-page hot path doesn't
+	// pay for an extra aggregation query.
+	CostStats30d *AgentCostStats `json:"cost_stats_30d,omitempty"`
+	CreatedAt    string          `json:"created_at"`
+	UpdatedAt    string          `json:"updated_at"`
+}
+
+// AgentCostStats is the per-agent cost rollup over the last 30 days.
+// run_count excludes 'skipped' rows (no real spend incurred).
+type AgentCostStats struct {
+	RunCount     int     `json:"run_count"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
 }
 
 // AgentRunSummary is the inline last-run shape on list/detail responses.
@@ -147,13 +159,35 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 	if err != nil {
 		return nil, fmt.Errorf("list agent definitions: %w", err)
 	}
+	// Cost stats are a single aggregation query keyed by definition id —
+	// fetch once outside the per-row loop.
+	statsRows, err := s.Queries.GetAgentCostStats30d(ctx)
+	if err != nil {
+		// Soft-fail: a stats query hiccup shouldn't block the list page.
+		// Log + render without cost columns.
+		s.Logger.Warn("list agent definitions: cost stats query failed", "error", err)
+		statsRows = nil
+	}
+	statsByID := make(map[string]AgentCostStats, len(statsRows))
+	for _, r := range statsRows {
+		cost, _ := pgconv.NumericToFloat(r.TotalCostUsd)
+		statsByID[pgconv.FormatUUID(r.AgentDefinitionID)] = AgentCostStats{
+			RunCount:     int(r.RunCount),
+			TotalCostUSD: cost,
+		}
+	}
+
 	out := make([]AgentDefinitionResponse, 0, len(rows))
 	for _, row := range rows {
 		last, err := s.lastRunSummary(ctx, row.ID)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, agentDefinitionFromRow(row, last))
+		resp := agentDefinitionFromRow(row, last)
+		if stats, ok := statsByID[resp.ID]; ok {
+			resp.CostStats30d = &stats
+		}
+		out = append(out, resp)
 	}
 	return out, nil
 }

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -8,7 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"breadbox/internal/appconfig"
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 )
 
@@ -279,6 +283,97 @@ func TestUpdateAgentSettings_ClearTokenWithEmptyString(t *testing.T) {
 	}
 	if cleared.SubscriptionToken != nil {
 		t.Errorf("expected SubscriptionToken nil after clearing, got %v", *cleared.SubscriptionToken)
+	}
+}
+
+func TestListAgentDefinitions_PopulatesCostStats30d(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	def := mustCreateAgentDefinition(t, svc, "svc-cost-stats", true)
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		t.Fatalf("parse uuid: %v", err)
+	}
+	_ = pool // pool is plumbed for parity with other tests in this file
+
+	// 2 success runs ($0.0123 + $0.0042) + 1 skipped (should NOT count).
+	mustInsertCompletedRun(t, q, defUUID, "0.0123")
+	mustInsertCompletedRun(t, q, defUUID, "0.0042")
+	mustInsertSkippedRun(t, q, defUUID)
+
+	list, err := svc.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var got *service.AgentDefinitionResponse
+	for i := range list {
+		if list[i].Slug == def.Slug {
+			got = &list[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("created agent missing from list response")
+	}
+	if got.CostStats30d == nil {
+		t.Fatal("expected CostStats30d on the response, got nil")
+	}
+	if got.CostStats30d.RunCount != 2 {
+		t.Errorf("RunCount = %d, want 2 (skipped row should be excluded)", got.CostStats30d.RunCount)
+	}
+	wantCost := 0.0165
+	if got.CostStats30d.TotalCostUSD < wantCost-0.0001 || got.CostStats30d.TotalCostUSD > wantCost+0.0001 {
+		t.Errorf("TotalCostUSD = %v, want ~%v", got.CostStats30d.TotalCostUSD, wantCost)
+	}
+}
+
+func mustInsertCompletedRun(t *testing.T, q *db.Queries, defID pgtype.UUID, costStr string) {
+	t.Helper()
+	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
+		AgentDefinitionID: defID,
+		Trigger:           "manual",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	var cost pgtype.Numeric
+	if err := cost.Scan(costStr); err != nil {
+		t.Fatalf("numeric scan: %v", err)
+	}
+	if _, err := q.CompleteAgentRun(context.Background(), db.CompleteAgentRunParams{
+		ID:                  run.ID,
+		Status:              "success",
+		DurationMs:          pgtype.Int4{Int32: 100, Valid: true},
+		TotalCostUsd:        cost,
+		InputTokens:         pgtype.Int4{Int32: 10, Valid: true},
+		OutputTokens:        pgtype.Int4{Int32: 5, Valid: true},
+		CacheReadTokens:     pgtype.Int4{Int32: 0, Valid: true},
+		CacheCreationTokens: pgtype.Int4{Int32: 0, Valid: true},
+		TurnCount:           pgtype.Int4{Int32: 1, Valid: true},
+		MaxTurnsUsed:        pgtype.Int4{Int32: 10, Valid: true},
+		NumToolCalls:        pgtype.Int4{Int32: 0, Valid: true},
+		TranscriptPath:      pgtype.Text{},
+		SessionID:           pgtype.Text{},
+	}); err != nil {
+		t.Fatalf("complete run: %v", err)
+	}
+}
+
+func mustInsertSkippedRun(t *testing.T, q *db.Queries, defID pgtype.UUID) {
+	t.Helper()
+	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
+		AgentDefinitionID: defID,
+		Trigger:           "cron",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := q.MarkAgentRunSkipped(context.Background(), db.MarkAgentRunSkippedParams{
+		ID:           run.ID,
+		ErrorMessage: pgtype.Text{String: "quiet hours", Valid: true},
+	}); err != nil {
+		t.Fatalf("mark skipped: %v", err)
 	}
 }
 

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -15,6 +15,11 @@ export interface AgentRunSummary {
   total_cost_usd?: number | null;
 }
 
+export interface AgentCostStats {
+  run_count: number;
+  total_cost_usd: number;
+}
+
 export interface AgentDefinition {
   id: string;
   short_id: string;
@@ -32,6 +37,7 @@ export interface AgentDefinition {
   quiet_hours_start?: string | null; // "HH:MM" 24-hour; nil disables window
   quiet_hours_end?: string | null;
   last_run?: AgentRunSummary | null;
+  cost_stats_30d?: AgentCostStats | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -8,6 +8,7 @@ import {
   Bot,
   CheckCircle2,
   Clock,
+  Coins,
   History,
   KeyRound,
   Pencil,
@@ -55,6 +56,7 @@ import {
   useDeleteAgent,
   useRunAgentNow,
   useToggleAgent,
+  type AgentCostStats,
   type AgentDefinition,
 } from "@/api/queries/agents";
 import { openModal } from "@/lib/modals";
@@ -409,6 +411,7 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
             </span>
             <span>Model: {agent.model}</span>
             <span>Max turns: {agent.max_turns}</span>
+            <CostStatsPill stats={agent.cost_stats_30d} />
             <LastRunPill run={agent.last_run} />
           </div>
         </div>
@@ -454,6 +457,24 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
         </div>
       </div>
     </Card>
+  );
+}
+
+function CostStatsPill({
+  stats,
+}: {
+  stats?: AgentCostStats | null;
+}) {
+  if (!stats || stats.run_count === 0) {
+    return null;
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1"
+      title={`${stats.run_count} run${stats.run_count === 1 ? "" : "s"} in the last 30 days`}
+    >
+      <Coins className="size-3" />${stats.total_cost_usd.toFixed(2)} / 30d
+    </span>
   );
 }
 


### PR DESCRIPTION
## Iteration 19 of the Claude Agent SDK integration sprint

Cost dashboard, smallest useful version. Each agent on `/v2/agents` now shows total spend + run count over the last 30 days next to the existing metadata line. Becomes load-bearing once a self-hoster has been running real agents for a few weeks.

Targets the sprint branch.

## Sample row metadata (mocked, after seeding 4 successful runs)

```
🕐 Cron: 0 9 * * 1   ·   Model: claude-opus-4-7   ·   Max turns: 10   ·   🪙 \$0.12 / 30d   ·   ✓ success · 5 minutes ago
```

The pill auto-hides when `run_count == 0` (nothing to show).

## What's in

**Backend**
- `internal/db/queries/agent_runs.sql` — new `GetAgentCostStats30d :many` aggregating `SUM(total_cost_usd) + COUNT(*)` grouped by `agent_definition_id` over the last 30 days. Excludes `'skipped'` (no real cost); keeps errored runs (often DO incur partial cost).
- `internal/service/agents.go` — new `AgentCostStats { run_count, total_cost_usd }` + `AgentDefinitionResponse.CostStats30d` (omitempty, list-only). `ListAgentDefinitions` fetches the rollup once outside the per-row loop, maps by id, populates each response. Soft-fail on stats query error (logs + renders without the column). `GetAgentDefinition` leaves `CostStats30d` nil so the edit-page hot path doesn't pay for an extra aggregation.

**SPA**
- `web/src/api/queries/agents.ts` — `AgentCostStats` type + optional `cost_stats_30d` field on `AgentDefinition`.
- `web/src/routes/agents.tsx` — `CostStatsPill` (Coins icon + "$X.XX / 30d") between Max turns and the `LastRunPill` on `AgentRow`. Hidden when stats are nil OR `run_count === 0`.

**Tests**
- `internal/service/agents_test.go` — new integration test seeds 2 successful + 1 skipped run, asserts `RunCount == 2` (skipped excluded) and total cost matches the sum.

## Test plan

- [x] `bun run lint` + `bun run build` clean
- [x] `go build` / `vet` / `-tags=headless` / `-tags=lite` clean
- [x] New `TestListAgentDefinitions_PopulatesCostStats30d` passes
- [x] Existing 30+ agent integration tests still pass
- [ ] **Screenshot:** captured locally; `img402.dev` was unreachable for the upload (HTTP 000 — same outage hit iter 14). Local verification confirmed `$0.12 / 30d` pill renders on a 4-run seeded agent. Future iters resume normal evidence flow once img402 recovers.

## Deferred

- **Per-agent sparkline / trend graph** — punted; the single 30d stat is the 90% signal. A dedicated `/v2/agents/cost` page with charts is a future iter when there's real spend history to plot.
- **Lifetime total** alongside the 30d window. YAGNI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)