### PR TITLE
feat(agents): next-fire preview honoring quiet hours

### DIFF
--- a/internal/service/agent_quiet_hours_test.go
+++ b/internal/service/agent_quiet_hours_test.go
@@ -46,3 +46,94 @@ func TestIsWithinQuietHours(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeNextFire(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	at := func(year int, month time.Month, day, h, m int) time.Time {
+		return time.Date(year, month, day, h, m, 0, 0, time.Local)
+	}
+
+	t.Run("nil schedule returns nil", func(t *testing.T) {
+		def := &AgentDefinitionResponse{ScheduleCron: nil}
+		if got := ComputeNextFire(def, at(2026, 5, 17, 12, 0)); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("empty schedule returns nil", func(t *testing.T) {
+		def := &AgentDefinitionResponse{ScheduleCron: strPtr("")}
+		if got := ComputeNextFire(def, at(2026, 5, 17, 12, 0)); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("malformed cron returns nil", func(t *testing.T) {
+		def := &AgentDefinitionResponse{ScheduleCron: strPtr("not a cron")}
+		if got := ComputeNextFire(def, at(2026, 5, 17, 12, 0)); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("hourly cron without quiet hours fires next hour", func(t *testing.T) {
+		def := &AgentDefinitionResponse{ScheduleCron: strPtr("0 * * * *")}
+		now := at(2026, 5, 17, 12, 30)
+		got := ComputeNextFire(def, now)
+		if got == nil {
+			t.Fatal("got nil")
+		}
+		want := at(2026, 5, 17, 13, 0)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("daily 9am cron lands at 9am", func(t *testing.T) {
+		def := &AgentDefinitionResponse{ScheduleCron: strPtr("0 9 * * *")}
+		now := at(2026, 5, 17, 7, 0)
+		got := ComputeNextFire(def, now)
+		if got == nil {
+			t.Fatal("got nil")
+		}
+		want := at(2026, 5, 17, 9, 0)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("hourly cron skips past quiet hours 22-07", func(t *testing.T) {
+		// Hourly fires at :00; quiet 22:00-07:00. From 23:30, the next
+		// schedule.Next is 00:00 (in quiet) → jump to 07:00 → cron Next
+		// from there yields 07:00 (exclusive end means 07:00 is OK).
+		def := &AgentDefinitionResponse{
+			ScheduleCron:    strPtr("0 * * * *"),
+			QuietHoursStart: strPtr("22:00"),
+			QuietHoursEnd:   strPtr("07:00"),
+		}
+		now := at(2026, 5, 17, 23, 30)
+		got := ComputeNextFire(def, now)
+		if got == nil {
+			t.Fatal("got nil")
+		}
+		want := at(2026, 5, 18, 7, 0)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("hourly cron outside quiet hours fires normally", func(t *testing.T) {
+		def := &AgentDefinitionResponse{
+			ScheduleCron:    strPtr("0 * * * *"),
+			QuietHoursStart: strPtr("22:00"),
+			QuietHoursEnd:   strPtr("07:00"),
+		}
+		now := at(2026, 5, 17, 10, 30)
+		got := ComputeNextFire(def, now)
+		if got == nil {
+			t.Fatal("got nil")
+		}
+		want := at(2026, 5, 17, 11, 0)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}

--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -135,6 +135,56 @@ func (s *AgentScheduler) fireCronJob(defID pgtype.UUID, slug string) {
 	}
 }
 
+// ComputeNextFire returns the next time the scheduler would fire `def`
+// after `now`, accounting for quiet hours. Returns nil when the schedule
+// is absent (manual-only), unparseable, or no non-quiet slot is found
+// within the safety-limit window.
+func ComputeNextFire(def *AgentDefinitionResponse, now time.Time) *time.Time {
+	if def == nil || def.ScheduleCron == nil || *def.ScheduleCron == "" {
+		return nil
+	}
+	schedule, err := cron.ParseStandard(*def.ScheduleCron)
+	if err != nil {
+		return nil
+	}
+	next := schedule.Next(now)
+	// Up to 100 iterations of "next fire lands in quiet hours → advance
+	// past the quiet window → re-ask cron." Bounded so a misconfigured
+	// 24-hour quiet window can't infinite-loop.
+	for i := 0; i < 100; i++ {
+		if !IsWithinQuietHours(next, def.QuietHoursStart, def.QuietHoursEnd) {
+			return &next
+		}
+		// Subtract one second so a cron that fires AT the quiet-end
+		// minute still gets returned by schedule.Next (which excludes
+		// the supplied time). Otherwise we'd skip past a valid first
+		// fire — e.g. quiet 22-07 + hourly cron should report 07:00,
+		// not 08:00.
+		jumped := nextMinuteAfterQuietEnd(next, *def.QuietHoursEnd).Add(-time.Second)
+		next = schedule.Next(jumped)
+	}
+	return nil
+}
+
+// nextMinuteAfterQuietEnd returns the first concrete time >= `now` that
+// lands at the end of the quiet window. Used by ComputeNextFire to skip
+// past the quiet period and resume cron evaluation.
+func nextMinuteAfterQuietEnd(now time.Time, end string) time.Time {
+	endMin, ok := parseHHMM(end)
+	if !ok {
+		// Fallback so the outer loop's bound prevents infinite recursion.
+		return now.Add(time.Hour)
+	}
+	endHour := endMin / 60
+	endMinute := endMin % 60
+	candidate := time.Date(now.Year(), now.Month(), now.Day(),
+		endHour, endMinute, 0, 0, now.Location())
+	if !candidate.After(now) {
+		candidate = candidate.Add(24 * time.Hour)
+	}
+	return candidate
+}
+
 // cleanupAgentRuns prunes completed agent_runs older than the retention
 // period (default 30 days; 0 disables). Transcript file GC is deferred
 // to a later iteration.

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -61,8 +61,12 @@ type AgentDefinitionResponse struct {
 	// GetAgentDefinition leaves it nil so the edit-page hot path doesn't
 	// pay for an extra aggregation query.
 	CostStats30d *AgentCostStats `json:"cost_stats_30d,omitempty"`
-	CreatedAt    string          `json:"created_at"`
-	UpdatedAt    string          `json:"updated_at"`
+	// NextFireAt is the next scheduled fire time accounting for quiet
+	// hours, populated by ListAgentDefinitions only (list-only like
+	// CostStats30d — single-row Get leaves nil). RFC3339 string when set.
+	NextFireAt *string `json:"next_fire_at,omitempty"`
+	CreatedAt  string  `json:"created_at"`
+	UpdatedAt  string  `json:"updated_at"`
 }
 
 // AgentCostStats is the per-agent cost rollup over the last 30 days.
@@ -186,6 +190,12 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		resp := agentDefinitionFromRow(row, last)
 		if stats, ok := statsByID[resp.ID]; ok {
 			resp.CostStats30d = &stats
+		}
+		if resp.Enabled {
+			if nextFire := ComputeNextFire(&resp, time.Now()); nextFire != nil {
+				s := nextFire.Format(time.RFC3339)
+				resp.NextFireAt = &s
+			}
 		}
 		out = append(out, resp)
 	}

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -38,6 +38,7 @@ export interface AgentDefinition {
   quiet_hours_end?: string | null;
   last_run?: AgentRunSummary | null;
   cost_stats_30d?: AgentCostStats | null;
+  next_fire_at?: string | null; // RFC3339; nil when no schedule, disabled, or unparseable
   created_at: string;
   updated_at: string;
 }

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -409,6 +409,7 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
                 ? `Cron: ${agent.schedule_cron}`
                 : "Manual only"}
             </span>
+            <NextFirePill at={agent.next_fire_at} />
             <span>Model: {agent.model}</span>
             <span>Max turns: {agent.max_turns}</span>
             <CostStatsPill stats={agent.cost_stats_30d} />
@@ -457,6 +458,19 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
         </div>
       </div>
     </Card>
+  );
+}
+
+function NextFirePill({ at }: { at?: string | null }) {
+  if (!at) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1"
+      title={`Next scheduled fire: ${new Date(at).toLocaleString()}`}
+    >
+      <Clock className="size-3" />
+      Next: {formatRelativeTime(at)}
+    </span>
   );
 }
 


### PR DESCRIPTION
## Iteration 20 of the Claude Agent SDK integration sprint

Small UX follow-up to iter 15. Each agent on `/v2/agents` now shows when its next scheduled fire will actually happen, accounting for quiet-hours skipping. Closes the iter-15 loop: "I configured a quiet window — when's the next real run?"

Targets the sprint branch.

## What's in

**Backend**
- `internal/service/agent_scheduler.go` — `ComputeNextFire(def, now)` reuses robfig/cron's `ParseStandard`. Loops "next fire → in quiet? → jump past quiet-end → re-ask cron" up to 100 times so a malformed 24-hour quiet window can't infinite-loop. Returns nil for nil/empty/malformed schedules.
- The `-1 second` offset on the quiet-end jump is load-bearing: cron's `Next()` excludes the supplied time, so without it we'd report 08:00 instead of 07:00 for an hourly cron + 22-07 quiet window.
- `internal/service/agents.go` — new `AgentDefinitionResponse.NextFireAt` (RFC3339, omitempty, **list-only** per iter-19 hot-path policy). `ListAgentDefinitions` populates it for enabled definitions; disabled ones get nil.

**SPA**
- `web/src/api/queries/agents.ts` — `next_fire_at?: string | null` on `AgentDefinition`.
- `web/src/routes/agents.tsx` — new `NextFirePill` renders "Next: 2h" between the cron and model labels via `formatRelativeTime`; native `title` attribute shows the absolute local time on hover.

## Test plan

- [x] 7 new `TestComputeNextFire` sub-cases pass: nil / empty / malformed → nil; hourly without quiet; daily 9am exact; **hourly skipped past 22-07 quiet → 07:00 next day**; hourly outside the window fires normally
- [x] Existing 13 `TestIsWithinQuietHours` sub-cases still pass
- [x] `go build` / `vet` / `-tags=headless` / `-tags=lite` clean
- [x] `TestOpenAPIDrift` green (no new routes)
- [x] `bun run lint` + `bun run build` clean

## Sample row metadata (mocked, after this PR)

```
🕐 Cron: 0 9 * * 1   ·   🕐 Next: 2 days   ·   Model: claude-opus-4-7   ·   Max turns: 10   ·   🪙 \$0.12 / 30d   ·   ✓ success · 5m ago
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)