### PR TITLE
feat(agents): error-rate alert pill on agents list

### DIFF
--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -60,6 +60,28 @@ SET status        = 'skipped',
     error_message = $2
 WHERE id = $1;
 
+-- name: GetAgentRecentErrorStats :many
+-- Per-definition "is this agent broken right now?" signal: error count
+-- in the last 5 non-skipped runs. Skipped runs (quiet hours, concurrency
+-- lock) are excluded — they aren't agent failures. The v2 SPA list
+-- renders a warning pill when error_count >= 3.
+WITH ranked AS (
+    SELECT agent_definition_id, status,
+           ROW_NUMBER() OVER (
+               PARTITION BY agent_definition_id
+               ORDER BY started_at DESC
+           ) AS rn
+    FROM agent_runs
+    WHERE agent_definition_id IS NOT NULL
+      AND status != 'skipped'
+)
+SELECT agent_definition_id,
+       COUNT(*) FILTER (WHERE status = 'error')::int AS error_count,
+       COUNT(*)::int                                  AS run_count
+FROM ranked
+WHERE rn <= 5
+GROUP BY agent_definition_id;
+
 -- name: GetAgentCostStats30d :many
 -- Per-definition cost rollup over the last 30 days. Used by the v2 SPA
 -- list page to surface lifetime spend at a glance. Excludes skipped runs

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -65,8 +65,19 @@ type AgentDefinitionResponse struct {
 	// hours, populated by ListAgentDefinitions only (list-only like
 	// CostStats30d — single-row Get leaves nil). RFC3339 string when set.
 	NextFireAt *string `json:"next_fire_at,omitempty"`
-	CreatedAt  string  `json:"created_at"`
-	UpdatedAt  string  `json:"updated_at"`
+	// RecentErrorStats is the count of errors among the last 5 non-skipped
+	// runs. Used by the v2 SPA to surface a warning when 3+ recent runs
+	// failed. List-only; nil when the agent has no run history.
+	RecentErrorStats *AgentRecentErrorStats `json:"recent_error_stats,omitempty"`
+	CreatedAt        string                 `json:"created_at"`
+	UpdatedAt        string                 `json:"updated_at"`
+}
+
+// AgentRecentErrorStats is the "is this agent broken right now?" signal —
+// errors among the last 5 non-skipped runs.
+type AgentRecentErrorStats struct {
+	ErrorCount int `json:"error_count"`
+	RunCount   int `json:"run_count"` // up to 5; less when there's less history
 }
 
 // AgentCostStats is the per-agent cost rollup over the last 30 days.
@@ -181,6 +192,20 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		}
 	}
 
+	// Recent error rollup — same soft-fail pattern.
+	errStatsRows, err := s.Queries.GetAgentRecentErrorStats(ctx)
+	if err != nil {
+		s.Logger.Warn("list agent definitions: recent error stats query failed", "error", err)
+		errStatsRows = nil
+	}
+	errStatsByID := make(map[string]AgentRecentErrorStats, len(errStatsRows))
+	for _, r := range errStatsRows {
+		errStatsByID[pgconv.FormatUUID(r.AgentDefinitionID)] = AgentRecentErrorStats{
+			ErrorCount: int(r.ErrorCount),
+			RunCount:   int(r.RunCount),
+		}
+	}
+
 	out := make([]AgentDefinitionResponse, 0, len(rows))
 	for _, row := range rows {
 		last, err := s.lastRunSummary(ctx, row.ID)
@@ -190,6 +215,9 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		resp := agentDefinitionFromRow(row, last)
 		if stats, ok := statsByID[resp.ID]; ok {
 			resp.CostStats30d = &stats
+		}
+		if errStats, ok := errStatsByID[resp.ID]; ok {
+			resp.RecentErrorStats = &errStats
 		}
 		if resp.Enabled {
 			if nextFire := ComputeNextFire(&resp, time.Now()); nextFire != nil {

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -20,6 +20,11 @@ export interface AgentCostStats {
   total_cost_usd: number;
 }
 
+export interface AgentRecentErrorStats {
+  error_count: number;
+  run_count: number; // up to 5
+}
+
 export interface AgentDefinition {
   id: string;
   short_id: string;
@@ -39,6 +44,7 @@ export interface AgentDefinition {
   last_run?: AgentRunSummary | null;
   cost_stats_30d?: AgentCostStats | null;
   next_fire_at?: string | null; // RFC3339; nil when no schedule, disabled, or unparseable
+  recent_error_stats?: AgentRecentErrorStats | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -58,6 +58,7 @@ import {
   useToggleAgent,
   type AgentCostStats,
   type AgentDefinition,
+  type AgentRecentErrorStats,
 } from "@/api/queries/agents";
 import { openModal } from "@/lib/modals";
 import { useNavigate } from "@tanstack/react-router";
@@ -413,6 +414,7 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
             <span>Model: {agent.model}</span>
             <span>Max turns: {agent.max_turns}</span>
             <CostStatsPill stats={agent.cost_stats_30d} />
+            <RecentErrorPill stats={agent.recent_error_stats} />
             <LastRunPill run={agent.last_run} />
           </div>
         </div>
@@ -458,6 +460,29 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
         </div>
       </div>
     </Card>
+  );
+}
+
+// RECENT_ERROR_WARN_THRESHOLD is the number of errors in the last 5 runs
+// that triggers the warning pill. Bump if it turns out noisy.
+const RECENT_ERROR_WARN_THRESHOLD = 3;
+
+function RecentErrorPill({
+  stats,
+}: {
+  stats?: AgentRecentErrorStats | null;
+}) {
+  if (!stats || stats.error_count < RECENT_ERROR_WARN_THRESHOLD) {
+    return null;
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 font-medium text-red-700 dark:bg-red-950/40 dark:text-red-300"
+      title={`${stats.error_count} of last ${stats.run_count} runs errored — check the run history`}
+    >
+      <AlertCircle className="size-3" />
+      {stats.error_count}/{stats.run_count} errored
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Iteration 21 of the `agents/claude-agent-sdk-sprint` series. Adds a low-cost "is this agent broken?" signal to the agents list.

Any agent whose last 5 non-skipped runs include 3 or more errors now renders a red `N/5 errored` pill on its row in `/v2/agents`. Skipped runs (quiet hours, concurrency lock) are excluded because they aren't agent failures.

## What's in

- **DB**: `GetAgentRecentErrorStats` — a `ROW_NUMBER` window over the last 5 non-skipped runs per agent, returning `(agent_definition_id, error_count, run_count)`.
- **Service**: `AgentRecentErrorStats` type + `AgentDefinitionResponse.RecentErrorStats` (list-only, `omitempty`, same pattern as the iter-19 cost stats and iter-20 next-fire fields). `ListAgentDefinitions` fetches the rollup once outside the per-agent loop; soft-fails on query error so the page still renders.
- **SPA**: matching `AgentRecentErrorStats` TS type + `recent_error_stats` field on `AgentDefinition`. New `RecentErrorPill` component renders only when `error_count >= RECENT_ERROR_WARN_THRESHOLD` (3); slots between the cost pill and the last-run pill in the metadata row.

## Why this design

Cheapest possible alert surface for a problem that otherwise only shows up by clicking into the run history. Threshold is a constant rather than per-agent config — if it gets noisy we can bump it or make it configurable in a follow-up. Window size of 5 keeps the signal responsive (one bad afternoon doesn't poison a healthy agent for a week).

## Test plan

- [x] `bun run lint` clean (`tsc -b --noEmit`)
- [x] `bun run build` clean
- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] All existing 30+ agent service tests still pass against the test DB

## Screenshots

Not included — the pill only renders when an agent has actually accumulated 3+ errors in the last 5 runs, and seeding error runs requires real API calls (would burn through the subscription quota for cosmetic evidence). The component is straightforward and the existing list layout is unchanged in the healthy case. Will appear naturally in dogfooding once an agent starts misbehaving.

## Deferred

- A proactive notification (push / report) when an agent crosses the threshold. The current surface is "passively visible when you visit `/v2/agents`". Worth a follow-up if Ricardo wants alerting.
- Per-agent configurable threshold. Global constant for now (YAGNI until we have a counter-example).
