### PR TITLE
feat(agents): breadbox doctor --with-live runs the agent smoke test

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -42,7 +42,7 @@ These commands operate on the local box (filesystem, DB, embedded migrations) �
 | `breadbox mcp-stdio` | L | *deprecated — use `breadbox mcp` instead*. Hidden alias kept so existing Claude Desktop configs keep working |
 | `breadbox init` | L | First-run setup: encryption key, first login account, first API key |
 | `breadbox migrate [--down] [--to N]` | L | Run goose migrations against `DATABASE_URL` (local-only — there is no remote migration endpoint by design) |
-| `breadbox doctor [--skip-external]` | R/L | Remote mode (when a host is configured) consumes `GET /api/v1/headless/bootstrap`; local mode (no host) keeps the env/DB/provider preflight checks |
+| `breadbox doctor [--skip-external] [--with-live]` | R/L | Remote mode (when a host is configured) consumes `GET /api/v1/headless/bootstrap`; local mode (no host) keeps the env/DB/provider preflight checks. `--with-live` additionally fires the agent SDK round-trip (~$0.01, local-mode only) |
 | `breadbox agent test` | L | End-to-end smoke test of the Claude Agent SDK subsystem — verifies credential is configured, sidecar binary is discoverable, and a tiny "say OK" prompt round-trips through the SDK. Cost-bounded to ~5¢. Exit 3 = no auth; exit 5 = no binary |
 | `breadbox agent run <slug> [--json]` | L | Trigger an immediate run of the named agent — same path as the v2 SPA "Run now" button. Mints a scoped API key, spawns the sidecar, persists the agent_runs row, revokes the key. Output is a human-readable summary; `--json` switches to the full AgentRunResponse JSON |
 | `breadbox version` | — | Print build version, commit, and upgrade check |

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -44,6 +44,7 @@ type doctorReport struct {
 //     `GET /api/v1/headless/bootstrap` and renders a readable report.
 func AddDoctorCmd(root *cobra.Command) {
 	var skipExternal bool
+	var withLive bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Health check: local environment or remote /headless/bootstrap",
@@ -52,10 +53,11 @@ func AddDoctorCmd(root *cobra.Command) {
 			if flags.Host != "" || hostConfigured() {
 				return runDoctorRemote(cmd.Context(), flags)
 			}
-			return runDoctorLocal(cmd.Context(), flags.JSON, skipExternal)
+			return runDoctorLocal(cmd.Context(), flags.JSON, skipExternal, withLive)
 		},
 	}
 	cmd.Flags().BoolVar(&skipExternal, "skip-external", false, "skip DNS/HTTP reachability checks (local-mode only)")
+	cmd.Flags().BoolVar(&withLive, "with-live", false, "additionally run a live agent smoke test (~$0.01, local-mode only)")
 	root.AddCommand(cmd)
 }
 

--- a/internal/cli/doctor_local_full.go
+++ b/internal/cli/doctor_local_full.go
@@ -7,6 +7,7 @@ import (
 	"crypto/aes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -27,7 +28,7 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-func runDoctorLocal(ctx context.Context, jsonOut bool, skipExternal bool) error {
+func runDoctorLocal(ctx context.Context, jsonOut bool, skipExternal bool, withLive bool) error {
 	cfg, cfgErr := bbconfig.Load()
 	checks := []doctorCheck{}
 
@@ -79,7 +80,12 @@ func runDoctorLocal(ctx context.Context, jsonOut bool, skipExternal bool) error 
 	}
 	checks = append(checks, checkCronConfig(cfg))
 	checks = append(checks, checkPublicURL(skipExternal))
-	checks = append(checks, checkAgentSubsystem(ctx, pool))
+	subsystem := checkAgentSubsystem(ctx, pool)
+	checks = append(checks, subsystem)
+
+	if withLive {
+		checks = append(checks, runAgentSmokeCheck(ctx, pool, cfg, subsystem.Status))
+	}
 
 	return emitDoctor(checks, jsonOut)
 }
@@ -106,6 +112,96 @@ func checkAgentSubsystem(ctx context.Context, pool *pgxpool.Pool) doctorCheck {
 	binaryPath := appconfig.String(ctx, queries, appconfig.KeyAgentRuntimePath, "")
 	resolved, binErr := agent.LocateBinary(binaryPath)
 	return agentSubsystemCheck(authMode, stored != "", resolved, binErr == nil)
+}
+
+// runAgentSmokeCheck fires the agent smoke test through the same Sidecar
+// path the orchestrator uses, surfacing the result as a doctor row. When the
+// cheap subsystem check already reported warn/skip, this short-circuits to
+// a skip row so the operator sees one clear message instead of a duplicate
+// failure pair.
+func runAgentSmokeCheck(ctx context.Context, pool *pgxpool.Pool, cfg *bbconfig.Config, subsystemStatus string) doctorCheck {
+	if subsystemStatus != doctorStatusPass {
+		return doctorCheck{
+			Name:    "agent smoke test",
+			Status:  doctorStatusSkip,
+			Message: "skipped — agent subsystem check did not pass",
+		}
+	}
+	if pool == nil {
+		return doctorCheck{
+			Name:    "agent smoke test",
+			Status:  doctorStatusSkip,
+			Message: "skipped — no database connection",
+		}
+	}
+	if cfg.EncryptionKey == nil {
+		return doctorCheck{
+			Name:        "agent smoke test",
+			Status:      doctorStatusWarn,
+			Message:     "skipped — ENCRYPTION_KEY not set, cannot decrypt stored credential",
+			Remediation: "export ENCRYPTION_KEY before running with --with-live",
+		}
+	}
+	queries := db.New(pool)
+	binaryPath := appconfig.String(ctx, queries, appconfig.KeyAgentRuntimePath, "")
+	resolved, err := agent.LocateBinary(binaryPath)
+	if err != nil {
+		return doctorCheck{
+			Name:        "agent smoke test",
+			Status:      doctorStatusFail,
+			Message:     "binary lookup failed: " + err.Error(),
+			Remediation: "build with `make agent-sidecar` or set agent.runtime_path in Settings → Agents",
+		}
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	result, runErr := agent.SmokeTest(runCtx, queries, cfg.EncryptionKey, &agent.Sidecar{}, resolved)
+	return liveSmokeCheck(result, runErr)
+}
+
+// liveSmokeCheck is the pure decision logic separated for testability. The
+// result/err pair mirrors what agent.SmokeTest returns; producing a one-line
+// pass/fail row keyed off the error category.
+func liveSmokeCheck(result *agent.SmokeResult, err error) doctorCheck {
+	if err != nil {
+		switch {
+		case errors.Is(err, agent.ErrAuthNotConfigured):
+			return doctorCheck{
+				Name:        "agent smoke test",
+				Status:      doctorStatusFail,
+				Message:     "auth not configured: " + err.Error(),
+				Remediation: "paste a credential in Settings → Agents",
+			}
+		case errors.Is(err, agent.ErrBinaryNotFound):
+			return doctorCheck{
+				Name:        "agent smoke test",
+				Status:      doctorStatusFail,
+				Message:     "binary not found: " + err.Error(),
+				Remediation: "build with `make agent-sidecar` or set agent.runtime_path",
+			}
+		default:
+			return doctorCheck{
+				Name:        "agent smoke test",
+				Status:      doctorStatusFail,
+				Message:     "live run failed: " + err.Error(),
+				Remediation: "verify the auth token is still valid and api.anthropic.com is reachable",
+			}
+		}
+	}
+	if result == nil {
+		return doctorCheck{
+			Name:    "agent smoke test",
+			Status:  doctorStatusFail,
+			Message: "no result returned (runner produced nil with no error)",
+		}
+	}
+	return doctorCheck{
+		Name: "agent smoke test",
+		Status: doctorStatusPass,
+		Message: fmt.Sprintf("OK — %s in %dms (cost $%.4f, %d→%d tokens, auth=%s)",
+			result.Model, result.DurationMs, result.TotalCostUSD,
+			result.InputTokens, result.OutputTokens, result.AuthMode),
+	}
 }
 
 // agentSubsystemCheck is the pure decision logic separated for testability.

--- a/internal/cli/doctor_local_lite.go
+++ b/internal/cli/doctor_local_lite.go
@@ -10,6 +10,6 @@ import (
 // runDoctorLocal is unreachable from CLI-only builds — db/service/sync/etc.
 // are stripped. Operators on a lite build configure a host and rely on the
 // remote-mode doctor.
-func runDoctorLocal(_ context.Context, _ bool, _ bool) error {
+func runDoctorLocal(_ context.Context, _ bool, _ bool, _ bool) error {
 	return fmt.Errorf("local doctor mode is unavailable in the CLI-only build; configure a host with `breadbox auth login --host=...` and re-run `breadbox doctor`")
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,10 +3,13 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 
+	"breadbox/internal/agent"
 	"breadbox/internal/config"
 	"breadbox/internal/db"
 )
@@ -231,6 +234,63 @@ func TestCheckPublicURL(t *testing.T) {
 		t.Setenv("PUBLIC_URL", "https://example.com")
 		if got := checkPublicURL(true).Status; got != doctorStatusSkip {
 			t.Fatalf("status: got %q, want skip", got)
+		}
+	})
+}
+
+func TestLiveSmokeCheck(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		got := liveSmokeCheck(&agent.SmokeResult{
+			AuthMode:     "subscription",
+			Model:        "claude-haiku-4-5",
+			DurationMs:   1234,
+			TotalCostUSD: 0.0042,
+			InputTokens:  12,
+			OutputTokens: 3,
+		}, nil)
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status = %q, want pass", got.Status)
+		}
+		for _, want := range []string{"claude-haiku-4-5", "1234ms", "$0.0042", "12→3", "subscription"} {
+			if !strings.Contains(got.Message, want) {
+				t.Errorf("message %q missing %q", got.Message, want)
+			}
+		}
+	})
+	t.Run("auth-not-configured wraps to fail with remediation", func(t *testing.T) {
+		got := liveSmokeCheck(nil, fmt.Errorf("smoke: %w", agent.ErrAuthNotConfigured))
+		if got.Status != doctorStatusFail {
+			t.Fatalf("status = %q, want fail", got.Status)
+		}
+		if !strings.Contains(got.Remediation, "Settings → Agents") {
+			t.Errorf("remediation %q missing settings hint", got.Remediation)
+		}
+	})
+	t.Run("binary-not-found wraps to fail with build hint", func(t *testing.T) {
+		got := liveSmokeCheck(nil, fmt.Errorf("smoke: %w", agent.ErrBinaryNotFound))
+		if got.Status != doctorStatusFail {
+			t.Fatalf("status = %q, want fail", got.Status)
+		}
+		if !strings.Contains(got.Remediation, "make agent-sidecar") {
+			t.Errorf("remediation %q missing build hint", got.Remediation)
+		}
+	})
+	t.Run("generic error falls through to upstream check hint", func(t *testing.T) {
+		got := liveSmokeCheck(nil, errors.New("kaboom"))
+		if got.Status != doctorStatusFail {
+			t.Fatalf("status = %q, want fail", got.Status)
+		}
+		if !strings.Contains(got.Message, "kaboom") {
+			t.Errorf("message %q missing error text", got.Message)
+		}
+		if !strings.Contains(got.Remediation, "api.anthropic.com") {
+			t.Errorf("remediation %q missing network hint", got.Remediation)
+		}
+	})
+	t.Run("nil result with nil error guards against runner bug", func(t *testing.T) {
+		got := liveSmokeCheck(nil, nil)
+		if got.Status != doctorStatusFail {
+			t.Fatalf("status = %q, want fail", got.Status)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Iteration 22 of the `agents/claude-agent-sdk-sprint` series. Adds an opt-in live round-trip to `breadbox doctor`.

`breadbox doctor` already reports whether the agent subsystem is *configured* (auth token present + sidecar binary discoverable). It does not say whether the configured setup actually *works* — that requires the existing `breadbox agent test` command. With `--with-live`, the doctor runs both: cheap preflight first, then the same smoke test as a follow-on check, surfacing model / duration / cost / tokens / auth-mode in one report.

```
ok  agent subsystem    ready (auth=subscription, binary=…/breadbox-agent) — `breadbox agent test` for live diagnostic
ok  agent smoke test   OK — claude-haiku-4-5 in 1234ms (cost $0.0042, 12→3 tokens, auth=subscription)
```

## Why

- Self-hosters following the install path want one command that answers "am I ready to schedule an agent?" — the cheap check answers half of that, the live test answers the other half.
- `breadbox agent test` already exists but is buried under the agent noun. Surfacing it via `--with-live` puts it in the same spot operators already look (`doctor`).

## Design

- **One pure helper, `liveSmokeCheck(result, err) doctorCheck`** — testable without Postgres or the sidecar. Maps `ErrAuthNotConfigured`, `ErrBinaryNotFound`, and generic errors to targeted remediation hints.
- **Short-circuit on the cheap check's verdict.** If the subsystem row already reported warn/skip (e.g. "binary not found"), running the live test would produce a confusing duplicate failure row. Skip-on-not-pass keeps output coherent.
- **Warn (not fail) when `ENCRYPTION_KEY` is unset.** The smoke test can't decrypt the stored token, but that's a config issue distinct from a real failure.
- **60s context timeout** wrapping the smoke run, so a hung sidecar doesn't hang the entire `doctor` invocation.
- **No new sidecar entry point.** Reuses `agent.SmokeTest` verbatim — same prompt, same model (`claude-haiku-4-5`), same ~5¢ ceiling.

## Test plan

- [x] 5 new `TestLiveSmokeCheck` sub-cases — success row, each error classification, nil-result guard
- [x] 4 existing `TestAgentSubsystemCheck` cases still pass
- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] Lite build's `runDoctorLocal` signature updated; lite still compiles
- [x] `docs/cli-commands.md` updated per the cli-commands upkeep rule

## Deferred

- Wiring `--with-live` into the remote (HTTP) doctor — needs a new endpoint that fires the orchestrator's smoke test. Out of scope; the cheap subsystem check via `/headless/bootstrap` gives most of the remote signal.
- Surfacing the smoke result's `AssistantText` (the "OK" reply itself) in the doctor row. Available on `SmokeResult` but not very informative for the table format; skipping for now.
