### PR TITLE
feat(agents): "Run now" accepts an optional operator prompt prefix

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -264,7 +264,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | DELETE | `/agents/{slug}` | W | Delete the definition; historical runs preserved (FK SET NULL) |
 | POST | `/agents/{slug}/enable` | W | Flip enabled=true |
 | POST | `/agents/{slug}/disable` | W | Flip enabled=false |
-| POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; 503 `CONCURRENCY_LOCKED` when another run is in progress |
+| POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; optional `{prompt_prefix}` body prepends per-run context (≤2000 chars); 503 `CONCURRENCY_LOCKED` when another run is in progress |
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200) |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -381,12 +382,30 @@ func UpdateAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFu
 	}
 }
 
+// runAgentNowRequest is the optional JSON body for "run now". An empty
+// body — common for the v2 SPA's bare-button click — leaves prompt_prefix
+// unset, which the orchestrator treats as no prefix.
+type runAgentNowRequest struct {
+	PromptPrefix string `json:"prompt_prefix,omitempty"`
+}
+
+// PromptPrefixMaxLen caps operator-supplied prefixes so a runaway paste
+// can't bloat the prompt past the model's effective context. Matches the
+// 2000-char ceiling used for operator notes — the two surfaces feel
+// related from the operator's POV.
+const PromptPrefixMaxLen = 2000
+
 // RunAgentNowHandler triggers an immediate synchronous run of the named agent.
 // 503 CONCURRENCY_LOCKED when another run is in progress (no DB row written).
 // 422 AUTH_NOT_CONFIGURED when no Anthropic credentials are set.
 // 422 AGENT_BINARY_NOT_FOUND when the sidecar binary can't be located.
+// 400 PROMPT_PREFIX_TOO_LONG when prompt_prefix exceeds PromptPrefixMaxLen.
 // 200 with the agent_runs row otherwise (status may be 'error' if the run
 // itself failed — the row contains error_message).
+//
+// Body is optional: { "prompt_prefix": "Focus on …" } prepends the supplied
+// text to the agent's stored prompt for this fire only. An empty body or an
+// empty prefix is equivalent to the v1 bare-button behavior.
 func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if orch == nil {
@@ -400,7 +419,18 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 			writeAgentError(w, err, "agent not found")
 			return
 		}
-		runResp, runErr := orch.RunNow(r.Context(), def)
+		var req runAgentNowRequest
+		if r.ContentLength > 0 {
+			if !decodeJSON(w, r, &req) {
+				return
+			}
+		}
+		if len(req.PromptPrefix) > PromptPrefixMaxLen {
+			mw.WriteError(w, http.StatusBadRequest, "PROMPT_PREFIX_TOO_LONG",
+				fmt.Sprintf("prompt_prefix must be at most %d characters", PromptPrefixMaxLen))
+			return
+		}
+		runResp, runErr := orch.RunNow(r.Context(), def, req.PromptPrefix)
 		if errors.Is(runErr, agent.ErrConcurrencyLocked) {
 			mw.WriteError(w, http.StatusServiceUnavailable,
 				"CONCURRENCY_LOCKED",

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -86,16 +86,18 @@ Exit codes:
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jsonOut, _ := cmd.Flags().GetBool("json")
-			return runAgentRun(cmd.Context(), args[0], jsonOut)
+			prefix, _ := cmd.Flags().GetString("prefix")
+			return runAgentRun(cmd.Context(), args[0], jsonOut, prefix)
 		},
 	}
 	run.Flags().Bool("json", false, "emit the run result as JSON instead of human-readable")
+	run.Flags().String("prefix", "", "optional operator prompt prefix to prepend for this run only")
 	parent.AddCommand(run)
 
 	root.AddCommand(parent)
 }
 
-func runAgentRun(parent context.Context, slug string, jsonOut bool) error {
+func runAgentRun(parent context.Context, slug string, jsonOut bool, promptPrefix string) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -131,7 +133,7 @@ func runAgentRun(parent context.Context, slug string, jsonOut bool) error {
 	if !jsonOut {
 		fmt.Fprintf(os.Stdout, "▶  Running %s (%s)…\n", def.Name, def.Slug)
 	}
-	runResp, runErr := orch.RunNow(ctx, def)
+	runResp, runErr := orch.RunNow(ctx, def, promptPrefix)
 	if runErr != nil {
 		switch {
 		case errors.Is(runErr, agent.ErrAuthNotConfigured):

--- a/internal/db/migrations/20260517110629_agent_runs_prompt_prefix.sql
+++ b/internal/db/migrations/20260517110629_agent_runs_prompt_prefix.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- Operator-supplied prompt prefix for "run now" — the orchestrator prepends
+-- this string to the agent's stored prompt for a single manual fire, letting
+-- the operator scope the run ("focus on Amazon Prime transactions only")
+-- without editing the agent definition. Free-form TEXT; the API/UI caps
+-- length; cron runs leave it NULL.
+ALTER TABLE agent_runs
+    ADD COLUMN prompt_prefix TEXT NULL;
+
+-- +goose Down
+ALTER TABLE agent_runs
+    DROP COLUMN prompt_prefix;

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -103,6 +103,14 @@ SET operator_note = $2
 WHERE id = $1
 RETURNING *;
 
+-- name: SetAgentRunPromptPrefix :exec
+-- Set the operator-supplied prompt prefix for a "run now" trigger. Called
+-- immediately after CreateAgentRun + before AssembleJobSpec so the prefix
+-- is captured in the audit trail even if the run fails to assemble.
+UPDATE agent_runs
+SET prompt_prefix = $2
+WHERE id = $1;
+
 -- name: CleanupOrphanedAgentRuns :execresult
 UPDATE agent_runs
 SET status        = 'error',

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -12,7 +12,19 @@ import (
 	"breadbox/internal/agent"
 	"breadbox/internal/appconfig"
 	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// applyPromptPrefix renders the operator-supplied prefix in front of the
+// agent's stored prompt. Split out so tests can pin the exact format and
+// the orchestrator stays readable.
+func applyPromptPrefix(prefix, original string) string {
+	if prefix == "" {
+		return original
+	}
+	return "Operator note for this run:\n" + prefix + "\n\n" + original
+}
 
 // Orchestrator drives one agent run end-to-end: acquires concurrency,
 // mints a scoped API key, assembles the JobSpec, runs the sidecar, persists
@@ -69,12 +81,16 @@ func (o *Orchestrator) SmokeTest(ctx context.Context) (*agent.SmokeResult, error
 // Returns ErrConcurrencyLocked WITHOUT creating a run row when the semaphore
 // is full — the caller (HTTP handler) maps to 503 and the user retries.
 // Returns the resulting agent_runs row on any other outcome (success or error).
-func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse) (*AgentRunResponse, error) {
+//
+// promptPrefix is the operator-supplied per-run prefix that gets prepended to
+// the agent's stored prompt for this fire only. Empty string disables the
+// prefix; cron callers always pass "".
+func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse, promptPrefix string) (*AgentRunResponse, error) {
 	if err := o.sem.Acquire(ctx); err != nil {
 		return nil, err
 	}
 	defer o.sem.Release()
-	return o.runLocked(ctx, def, "manual")
+	return o.runLocked(ctx, def, "manual", promptPrefix)
 }
 
 // RunOrSkip is the entry point for scheduled (cron) runs. Always leaves
@@ -98,11 +114,11 @@ func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionRespon
 		return &resp, err
 	}
 	defer o.sem.Release()
-	return o.runLocked(ctx, def, trigger)
+	return o.runLocked(ctx, def, trigger, "")
 }
 
 // runLocked assumes the caller holds the semaphore.
-func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionResponse, trigger string) (*AgentRunResponse, error) {
+func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionResponse, trigger, promptPrefix string) (*AgentRunResponse, error) {
 	defUUID, err := pgconv.ParseUUID(def.ID)
 	if err != nil {
 		return nil, fmt.Errorf("orchestrator: parse def id: %w", err)
@@ -111,6 +127,14 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
 	if err != nil {
 		return nil, fmt.Errorf("orchestrator: create run row: %w", err)
+	}
+	if promptPrefix != "" {
+		if perr := o.svc.SetAgentRunPromptPrefixDB(ctx, runRow.ID, promptPrefix); perr != nil {
+			o.logger.Warn("orchestrator: persist prompt prefix failed",
+				"agent", def.Slug, "run", runRow.ShortID, "error", perr)
+		} else {
+			runRow.PromptPrefix = pgtype.Text{String: promptPrefix, Valid: true}
+		}
 	}
 	runResp := AgentRunFromRow(runRow)
 
@@ -134,6 +158,9 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	}()
 
 	spec, err := o.svc.AssembleJobSpec(ctx, def, &runResp, keyResult.PlaintextKey, o.encKey)
+	if err == nil && promptPrefix != "" {
+		spec.Prompt = applyPromptPrefix(promptPrefix, spec.Prompt)
+	}
 	if err != nil {
 		o.logger.Warn("orchestrator: assemble spec failed",
 			"agent", def.Slug, "run", runResp.ShortID, "error", err)

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 
@@ -46,7 +47,7 @@ func TestOrchestratorRunNow_Success(t *testing.T) {
 	})
 
 	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
-	runResp, err := orch.RunNow(context.Background(), def)
+	runResp, err := orch.RunNow(context.Background(), def, "")
 	if err != nil {
 		t.Fatalf("RunNow: %v", err)
 	}
@@ -92,12 +93,12 @@ func TestOrchestratorRunNow_ConcurrencyLocked(t *testing.T) {
 	var firstErr error
 	go func() {
 		defer wg.Done()
-		firstRun, firstErr = orch.RunNow(context.Background(), def)
+		firstRun, firstErr = orch.RunNow(context.Background(), def, "")
 	}()
 
 	<-started // first goroutine holds the slot
 
-	_, secondErr := orch.RunNow(context.Background(), def)
+	_, secondErr := orch.RunNow(context.Background(), def, "")
 	if !errors.Is(secondErr, agent.ErrConcurrencyLocked) {
 		t.Errorf("second RunNow err = %v, want ErrConcurrencyLocked", secondErr)
 	}
@@ -132,7 +133,7 @@ func TestOrchestratorRunOrSkip_LeavesSkippedRow(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, _ = orch.RunNow(context.Background(), def)
+		_, _ = orch.RunNow(context.Background(), def, "")
 	}()
 	<-started
 
@@ -172,7 +173,7 @@ func TestOrchestratorRunNow_AuthNotConfigured(t *testing.T) {
 		return agent.RunResult{}, nil
 	})
 	orch := service.NewOrchestrator(svc, fake, 1, devEncKey, slog.Default())
-	_, err := orch.RunNow(context.Background(), def)
+	_, err := orch.RunNow(context.Background(), def, "")
 	if !errors.Is(err, agent.ErrAuthNotConfigured) {
 		t.Errorf("err = %v, want ErrAuthNotConfigured", err)
 	}
@@ -192,7 +193,7 @@ func TestOrchestratorRunNow_RunnerErrorPersisted(t *testing.T) {
 	})
 	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
 
-	runResp, err := orch.RunNow(context.Background(), def)
+	runResp, err := orch.RunNow(context.Background(), def, "")
 	if err == nil {
 		t.Fatal("expected error from RunNow on runner failure")
 	}
@@ -216,7 +217,7 @@ func TestOrchestratorRunNow_MintRevokeRoundTrip(t *testing.T) {
 	})
 	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
 
-	runResp, err := orch.RunNow(context.Background(), def)
+	runResp, err := orch.RunNow(context.Background(), def, "")
 	if err != nil {
 		t.Fatalf("RunNow: %v", err)
 	}
@@ -238,4 +239,72 @@ func TestOrchestratorRunNow_MintRevokeRoundTrip(t *testing.T) {
 	// Touch the unused appconfig reader to keep the import live in case
 	// the test file evolves to read settings directly.
 	_ = appconfig.String(context.Background(), svc.Queries, appconfig.KeyAgentAuthMode, "")
+}
+
+func TestOrchestratorRunNow_PromptPrefix_PrependsToSpecAndPersists(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-prefix", true)
+	const prefix = "Focus on Amazon Prime transactions only — ignore the rest."
+
+	var capturedPrompt string
+	fake := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		capturedPrompt = spec.Prompt
+		return agent.RunResult{
+			Status:       agent.StatusSuccess,
+			TotalCostUSD: 0.01,
+			TurnCount:    1,
+			DurationMs:   10,
+		}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	runResp, err := orch.RunNow(context.Background(), def, prefix)
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+
+	// The sidecar saw a prompt with our prefix at the top.
+	if !strings.HasPrefix(capturedPrompt, "Operator note for this run:\n"+prefix+"\n\n") {
+		t.Errorf("spec.Prompt missing expected operator-note header:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, def.Prompt) {
+		t.Errorf("spec.Prompt should still contain the agent's stored prompt; got:\n%s", capturedPrompt)
+	}
+
+	// The run row carries the prefix for the audit trail.
+	if runResp.PromptPrefix == nil || *runResp.PromptPrefix != prefix {
+		t.Errorf("response PromptPrefix = %v, want %q", runResp.PromptPrefix, prefix)
+	}
+	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if persisted.PromptPrefix == nil || *persisted.PromptPrefix != prefix {
+		t.Errorf("persisted PromptPrefix = %v, want %q", persisted.PromptPrefix, prefix)
+	}
+}
+
+func TestOrchestratorRunNow_EmptyPrefix_LeavesPromptUnchanged(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-no-prefix", true)
+
+	var capturedPrompt string
+	fake := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		capturedPrompt = spec.Prompt
+		return agent.RunResult{Status: agent.StatusSuccess, TurnCount: 1, DurationMs: 5}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	runResp, err := orch.RunNow(context.Background(), def, "")
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	if capturedPrompt != def.Prompt {
+		t.Errorf("empty prefix should leave prompt untouched; got %q, want %q", capturedPrompt, def.Prompt)
+	}
+	if runResp.PromptPrefix != nil {
+		t.Errorf("PromptPrefix should be nil when none supplied, got %v", *runResp.PromptPrefix)
+	}
 }

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -120,6 +120,7 @@ type AgentRunResponse struct {
 	TranscriptPath      *string  `json:"transcript_path,omitempty"`
 	SessionID           *string  `json:"session_id,omitempty"`
 	OperatorNote        *string  `json:"operator_note,omitempty"`
+	PromptPrefix        *string  `json:"prompt_prefix,omitempty"`
 }
 
 // AgentRunListResult is the paginated envelope for run lists.
@@ -600,6 +601,16 @@ func (s *Service) MarkAgentRunSkippedDB(ctx context.Context, runID pgtype.UUID, 
 	})
 }
 
+// SetAgentRunPromptPrefixDB stores the operator-supplied per-run prompt prefix
+// alongside an existing in_progress run row. Called right after CreateAgentRunDB
+// so the audit trail captures the prefix even when AssembleJobSpec fails.
+func (s *Service) SetAgentRunPromptPrefixDB(ctx context.Context, runID pgtype.UUID, prefix string) error {
+	return s.Queries.SetAgentRunPromptPrefix(ctx, db.SetAgentRunPromptPrefixParams{
+		ID:           runID,
+		PromptPrefix: pgtype.Text{String: prefix, Valid: prefix != ""},
+	})
+}
+
 // CompleteAgentRunDB persists a terminal RunResult onto the run row.
 // Used by the orchestrator after Runner.Run returns.
 func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult) (db.AgentRun, error) {
@@ -907,6 +918,7 @@ func agentRunFromRow(row db.AgentRun) AgentRunResponse {
 		TranscriptPath:      pgconv.TextPtr(row.TranscriptPath),
 		SessionID:           pgconv.TextPtr(row.SessionID),
 		OperatorNote:        pgconv.TextPtr(row.OperatorNote),
+		PromptPrefix:        pgconv.TextPtr(row.PromptPrefix),
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2599,13 +2599,28 @@ paths:
       summary: Trigger an immediate agent run
       description: |
         Synchronously runs the named agent. Returns the resulting `agent_runs`
-        row. Status may be `success`, `error`, or `timeout`. **Requires `full_access` scope.**
+        row. Status may be `success`, `error`, or `timeout`. Optional body
+        `{ "prompt_prefix": "..." }` prepends operator-supplied context to
+        the agent's stored prompt for this fire only. **Requires `full_access` scope.**
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                prompt_prefix:
+                  type: string
+                  maxLength: 2000
+                  description: Optional per-run prefix prepended to the agent's prompt; cron runs leave it unset.
       responses:
         "201":
           description: Run completed (may be in error state — see `status` and `error_message`).
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+        "400":
+          description: PROMPT_PREFIX_TOO_LONG when prompt_prefix exceeds 2000 chars.
         "422":
           description: Auth or binary not configured.
         "503":

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -70,9 +70,14 @@ export interface AgentRun {
   transcript_path?: string | null;
   session_id?: string | null;
   operator_note?: string | null;
+  prompt_prefix?: string | null;
 }
 
 export const AGENT_RUN_NOTE_MAX_LEN = 2000;
+
+// PROMPT_PREFIX_MAX_LEN matches the server-side cap in
+// internal/api/agents.go::PromptPrefixMaxLen. Bump both together.
+export const PROMPT_PREFIX_MAX_LEN = 2000;
 
 export interface AgentRunListResult {
   runs: AgentRun[];
@@ -191,11 +196,22 @@ export function useToggleAgent() {
   });
 }
 
+export interface RunAgentNowParams {
+  slug: string;
+  promptPrefix?: string; // operator-supplied per-run prefix; max 2000 chars
+}
+
 export function useRunAgentNow() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (slug: string) =>
-      api<AgentRun>(`/api/v1/agents/${slug}/run`, { method: "POST" }),
+    mutationFn: ({ slug, promptPrefix }: RunAgentNowParams) =>
+      api<AgentRun>(`/api/v1/agents/${slug}/run`, {
+        method: "POST",
+        body:
+          promptPrefix && promptPrefix.length > 0
+            ? JSON.stringify({ prompt_prefix: promptPrefix })
+            : undefined,
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { ArrowLeft, Clock, FilterX, Loader2, StickyNote } from "lucide-react";
+import {
+  ArrowLeft,
+  Clock,
+  FilterX,
+  Loader2,
+  StickyNote,
+  Sparkles,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -314,10 +321,32 @@ function OperatorNoteEditor({
   );
 }
 
+// PromptPrefixBlock surfaces the operator-supplied per-run prefix as a
+// read-only blockquote at the top of the transcript drawer. Unlike the
+// operator note, the prefix can't be edited after the fact — it's an
+// audit-trail item showing what the operator actually sent to the model.
+function PromptPrefixBlock({ prefix }: { prefix: string }) {
+  return (
+    <div className="mb-4 rounded-md border border-dashed bg-muted/40 p-3">
+      <div className="text-muted-foreground mb-1 inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide">
+        <Sparkles className="size-3.5" />
+        Prompt prefix (this run only)
+      </div>
+      <p className="whitespace-pre-wrap text-sm leading-relaxed">{prefix}</p>
+    </div>
+  );
+}
+
 function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
   const hasNote = Boolean(run.operator_note && run.operator_note.trim() !== "");
   const notePreview = hasNote
     ? (run.operator_note ?? "").trim().slice(0, 80)
+    : "";
+  const hasPrefix = Boolean(
+    run.prompt_prefix && run.prompt_prefix.trim() !== "",
+  );
+  const prefixPreview = hasPrefix
+    ? (run.prompt_prefix ?? "").trim().slice(0, 80)
     : "";
   return (
     <button
@@ -332,6 +361,16 @@ function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
       <span className="flex-1 text-xs">
         {formatRelativeTime(run.started_at)}
       </span>
+      {hasPrefix && (
+        <span
+          className="text-muted-foreground inline-flex items-center gap-1 text-xs"
+          title={prefixPreview}
+          aria-label={`Prompt prefix: ${prefixPreview}`}
+        >
+          <Sparkles className="size-3.5" />
+          prefix
+        </span>
+      )}
       {hasNote && (
         <span
           className="text-muted-foreground inline-flex items-center gap-1 text-xs"
@@ -377,6 +416,9 @@ function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
           </SheetDescription>
         </SheetHeader>
         <div className="flex-1 overflow-y-auto px-6 py-4">
+          {runDetail.data?.prompt_prefix && (
+            <PromptPrefixBlock prefix={runDetail.data.prompt_prefix} />
+          )}
           {shortId && (
             <OperatorNoteEditor
               shortId={shortId}

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -37,6 +37,15 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
   Form,
   FormControl,
   FormDescription,
@@ -56,6 +65,7 @@ import {
   useDeleteAgent,
   useRunAgentNow,
   useToggleAgent,
+  PROMPT_PREFIX_MAX_LEN,
   type AgentCostStats,
   type AgentDefinition,
   type AgentRecentErrorStats,
@@ -362,7 +372,6 @@ interface AgentRowProps {
 
 function AgentRow({ agent, onDelete }: AgentRowProps) {
   const toggle = useToggleAgent();
-  const runNow = useRunAgentNow();
 
   const handleToggle = (enable: boolean) => {
     void withMutationToast(
@@ -372,14 +381,6 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
         error: "Toggle failed",
       },
     );
-  };
-
-  const handleRunNow = () => {
-    void withMutationToast(() => runNow.mutateAsync(agent.slug), {
-      success: `Run started for ${agent.name}`,
-      error:
-        "Run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
-    });
   };
 
   return (
@@ -430,15 +431,7 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
               {agent.enabled ? "Enabled" : "Disabled"}
             </span>
           </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={runNow.isPending}
-            onClick={handleRunNow}
-          >
-            <Play className="size-3.5" />
-            Run now
-          </Button>
+          <RunNowDialog slug={agent.slug} name={agent.name} />
           <Button asChild variant="ghost" size="icon" aria-label="Run history">
             <Link to="/agents/$slug/runs" params={{ slug: agent.slug }}>
               <History className="size-4" />
@@ -460,6 +453,92 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
         </div>
       </div>
     </Card>
+  );
+}
+
+function RunNowDialog({ slug, name }: { slug: string; name: string }) {
+  const [open, setOpen] = useState(false);
+  const [prefix, setPrefix] = useState("");
+  const runNow = useRunAgentNow();
+
+  const submit = async () => {
+    const ok = await withMutationToast(
+      () => runNow.mutateAsync({ slug, promptPrefix: prefix }),
+      {
+        success: prefix
+          ? `Run started for ${name} (with prefix)`
+          : `Run started for ${name}`,
+        error:
+          "Run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
+      },
+    );
+    if (ok) {
+      setOpen(false);
+      setPrefix("");
+    }
+  };
+
+  const tooLong = prefix.length > PROMPT_PREFIX_MAX_LEN;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!runNow.isPending) setOpen(next);
+        if (!next) setPrefix("");
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="secondary" size="sm" disabled={runNow.isPending}>
+          <Play className="size-3.5" />
+          Run now
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Run {name} now</DialogTitle>
+          <DialogDescription>
+            Fires the agent synchronously. Optionally prepend a one-off note —
+            useful for scoped runs like "focus on Amazon Prime transactions
+            only".
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="run-now-prefix">
+            Prompt prefix{" "}
+            <span className="text-muted-foreground font-normal">(optional)</span>
+          </label>
+          <Textarea
+            id="run-now-prefix"
+            placeholder="Leave blank to use the agent's stored prompt as-is."
+            value={prefix}
+            onChange={(e) => setPrefix(e.target.value)}
+            rows={4}
+            disabled={runNow.isPending}
+          />
+          <p
+            className={`text-xs ${
+              tooLong ? "text-destructive" : "text-muted-foreground"
+            }`}
+          >
+            {prefix.length} / {PROMPT_PREFIX_MAX_LEN} characters
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={runNow.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={runNow.isPending || tooLong}>
+            <Play className="size-3.5" />
+            Run now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary

Iteration 23 of the `agents/claude-agent-sdk-sprint` series. Operators can now scope a single "Run now" without editing the agent definition.

The "Run now" button on `/v2/agents` now opens a small dialog with an optional textarea. Whatever the operator types gets prepended (as `Operator note for this run:\n<prefix>\n\n<stored prompt>`) to the agent's stored prompt for that fire only — useful for dogfooding flows like "focus on Amazon Prime transactions only" or "only categorize January 2026." Cron runs are untouched.

## Screenshots

**Desktop dialog (1280×900):**

<img src="https://i.img402.dev/q7crnkr1uc.jpg" width="800" alt="/v2/agents — Run now dialog with prompt prefix">

**Mobile dialog (390×844):**

<img src="https://i.img402.dev/dqhiyy64zz.jpg" width="320" alt="/v2/agents — Run now dialog (mobile)">

## What's in

- **Migration** `20260517110629_agent_runs_prompt_prefix.sql`: `agent_runs.prompt_prefix TEXT NULL`. Additive only.
- **sqlc**: new `SetAgentRunPromptPrefix` query, called right after `CreateAgentRun` so the audit trail captures the prefix even if `AssembleJobSpec` later fails.
- **Service**: `Orchestrator.RunNow` gains a third arg (`promptPrefix string`). `RunOrSkip` always passes `""`. CLI + HTTP handler thread the operator-supplied prefix through. New `applyPromptPrefix` helper formats the prepend in one testable place.
- **Service response**: `AgentRunResponse.PromptPrefix` surfaces the field on every run row.
- **API**: `POST /api/v1/agents/{slug}/run` accepts optional `{ "prompt_prefix": "..." }`. Empty/missing body preserves the bare-button behavior. Returns 400 `PROMPT_PREFIX_TOO_LONG` when >2000 chars (matches the operator-note cap).
- **CLI**: `breadbox agent run <slug> --prefix "..."` mirrors the HTTP flag.
- **SPA**:
  - "Run now" Button → Dialog with optional Textarea + live char counter
  - Run history rows show a `Sparkles "prefix"` indicator (mirrors the StickyNote operator-note pattern)
  - TranscriptSheet shows a read-only `PromptPrefixBlock` at the top of any run that carried one — distinct from the post-hoc editable operator note since prefixes are an audit-trail artifact
- **Docs**: `openapi.yaml` documents the request body and 400. `docs/api-endpoints.md` row updated per the upkeep rule.

## Design notes

- **One change point.** All prefix formatting flows through `applyPromptPrefix`, so the wire shape is locked in one place. If we want to change separators later, we change them there.
- **Audit-trail first.** Prefix lands in the DB before `AssembleJobSpec` is even invoked, so a failed run still shows what the operator asked for.
- **Cap matches `operator_note`.** Both surfaces feel related from the user's POV — one bump moves both. Server enforces, SPA shows the counter.
- **Prefix is read-only in the transcript drawer.** Distinct primitive from the editable operator note: operators can't rewrite history, only annotate it.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new prefix-specific orchestrator integration tests pass (prefix prepends + persists; empty prefix leaves spec untouched)
- [x] 7 existing orchestrator tests pass after signature update
- [x] OpenAPI drift test green
- [x] `bun run lint` + `bun run build` clean
- [x] Manual: opened the dialog, filled the textarea, hit Run now — see screenshots above

## Deferred

- Saved prefix presets (a shortcuts library). YAGNI until there's evidence operators want the same prefix twice.
- Allowing a prefix from the cron config. Out of scope; one focused iteration per PR.
