### PR TITLE
feat(agents): "Use last prefix" affordance on Run now dialog

### DIFF
--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -111,6 +111,19 @@ UPDATE agent_runs
 SET prompt_prefix = $2
 WHERE id = $1;
 
+-- name: GetAgentLastPromptPrefixes :many
+-- Per-definition most recent non-null prompt_prefix. Skipped + null-prefix
+-- rows don't shadow earlier prefixes — only runs that actually carried a
+-- prefix are eligible. Used by the v2 SPA "Use last prefix" button on the
+-- Run now dialog to pre-fill the operator's prior context.
+SELECT DISTINCT ON (agent_definition_id)
+       agent_definition_id, prompt_prefix
+FROM agent_runs
+WHERE agent_definition_id IS NOT NULL
+  AND prompt_prefix IS NOT NULL
+  AND prompt_prefix <> ''
+ORDER BY agent_definition_id, started_at DESC;
+
 -- name: CleanupOrphanedAgentRuns :execresult
 UPDATE agent_runs
 SET status        = 'error',

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -69,8 +69,12 @@ type AgentDefinitionResponse struct {
 	// runs. Used by the v2 SPA to surface a warning when 3+ recent runs
 	// failed. List-only; nil when the agent has no run history.
 	RecentErrorStats *AgentRecentErrorStats `json:"recent_error_stats,omitempty"`
-	CreatedAt        string                 `json:"created_at"`
-	UpdatedAt        string                 `json:"updated_at"`
+	// LastPromptPrefix is the most recent non-null prompt_prefix this agent
+	// was ever run with. Powers the "Use last prefix" affordance in the v2
+	// SPA's Run now dialog. List-only; nil when no prefixed run exists.
+	LastPromptPrefix *string `json:"last_prompt_prefix,omitempty"`
+	CreatedAt        string  `json:"created_at"`
+	UpdatedAt        string  `json:"updated_at"`
 }
 
 // AgentRecentErrorStats is the "is this agent broken right now?" signal —
@@ -207,6 +211,21 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		}
 	}
 
+	// Last-prefix rollup — feeds the "Use last prefix" button in the v2 SPA's
+	// Run now dialog. One row per definition (the most recent non-null
+	// prompt_prefix); definitions that never had a prefixed run won't appear.
+	prefixRows, err := s.Queries.GetAgentLastPromptPrefixes(ctx)
+	if err != nil {
+		s.Logger.Warn("list agent definitions: last prefix query failed", "error", err)
+		prefixRows = nil
+	}
+	prefixByID := make(map[string]string, len(prefixRows))
+	for _, r := range prefixRows {
+		if r.PromptPrefix.Valid && r.PromptPrefix.String != "" {
+			prefixByID[pgconv.FormatUUID(r.AgentDefinitionID)] = r.PromptPrefix.String
+		}
+	}
+
 	out := make([]AgentDefinitionResponse, 0, len(rows))
 	for _, row := range rows {
 		last, err := s.lastRunSummary(ctx, row.ID)
@@ -219,6 +238,10 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		}
 		if errStats, ok := errStatsByID[resp.ID]; ok {
 			resp.RecentErrorStats = &errStats
+		}
+		if prefix, ok := prefixByID[resp.ID]; ok {
+			p := prefix
+			resp.LastPromptPrefix = &p
 		}
 		if resp.Enabled {
 			if nextFire := ComputeNextFire(&resp, time.Now()); nextFire != nil {

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -386,4 +387,95 @@ func TestUpdateAgentSettings_RejectsInvalidAuthMode(t *testing.T) {
 	if !errors.Is(err, service.ErrInvalidParameter) {
 		t.Errorf("err = %v, want ErrInvalidParameter", err)
 	}
+}
+
+func TestListAgentDefinitions_PopulatesLastPromptPrefix(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	def := mustCreateAgentDefinition(t, svc, "svc-last-prefix", true)
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		t.Fatalf("parse uuid: %v", err)
+	}
+
+	// Insert three runs: one with an older prefix, one with no prefix (the
+	// most recent overall), one with the prefix we expect to surface.
+	mustInsertRunWithPrefix(t, q, defUUID, "older context — pre-Christmas")
+	mustInsertRunWithPrefix(t, q, defUUID, "focus on Amazon Prime Jan only")
+	mustInsertRunWithPrefix(t, q, defUUID, "") // no prefix → should not shadow
+
+	list, err := svc.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var got *service.AgentDefinitionResponse
+	for i := range list {
+		if list[i].Slug == def.Slug {
+			got = &list[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("created agent missing from list response")
+	}
+	if got.LastPromptPrefix == nil {
+		t.Fatal("expected LastPromptPrefix on response, got nil")
+	}
+	// The most recent NON-EMPTY prefix wins, regardless of any newer empty run.
+	if *got.LastPromptPrefix != "focus on Amazon Prime Jan only" {
+		t.Errorf("LastPromptPrefix = %q, want the most recent non-empty value",
+			*got.LastPromptPrefix)
+	}
+}
+
+func TestListAgentDefinitions_NoPrefixedRuns_LeavesLastPromptPrefixNil(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	def := mustCreateAgentDefinition(t, svc, "svc-no-prefix-ever", true)
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		t.Fatalf("parse uuid: %v", err)
+	}
+	// One un-prefixed run — list should still set LastPromptPrefix=nil.
+	mustInsertRunWithPrefix(t, q, defUUID, "")
+
+	list, err := svc.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for i := range list {
+		if list[i].Slug == def.Slug {
+			if list[i].LastPromptPrefix != nil {
+				t.Errorf("LastPromptPrefix should be nil, got %q",
+					*list[i].LastPromptPrefix)
+			}
+			return
+		}
+	}
+	t.Fatal("created agent missing from list response")
+}
+
+func mustInsertRunWithPrefix(t *testing.T, q *db.Queries, defID pgtype.UUID, prefix string) {
+	t.Helper()
+	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
+		AgentDefinitionID: defID,
+		Trigger:           "manual",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if prefix != "" {
+		if err := q.SetAgentRunPromptPrefix(context.Background(), db.SetAgentRunPromptPrefixParams{
+			ID:           run.ID,
+			PromptPrefix: pgtype.Text{String: prefix, Valid: true},
+		}); err != nil {
+			t.Fatalf("set prefix: %v", err)
+		}
+	}
+	// Tiny sleep to ensure started_at ordering is deterministic across the
+	// three rows even when the test runs fast — the GetAgentLastPromptPrefixes
+	// query uses started_at DESC to pick the most recent.
+	time.Sleep(10 * time.Millisecond)
 }

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -45,6 +45,7 @@ export interface AgentDefinition {
   cost_stats_30d?: AgentCostStats | null;
   next_fire_at?: string | null; // RFC3339; nil when no schedule, disabled, or unparseable
   recent_error_stats?: AgentRecentErrorStats | null;
+  last_prompt_prefix?: string | null; // most recent non-null prompt_prefix; powers "Use last prefix"
   created_at: string;
   updated_at: string;
 }

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -14,6 +14,7 @@ import {
   Pencil,
   Play,
   Plus,
+  Sparkles,
   Terminal,
   Trash2,
   XCircle,
@@ -431,7 +432,11 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
               {agent.enabled ? "Enabled" : "Disabled"}
             </span>
           </div>
-          <RunNowDialog slug={agent.slug} name={agent.name} />
+          <RunNowDialog
+            slug={agent.slug}
+            name={agent.name}
+            lastPrefix={agent.last_prompt_prefix ?? null}
+          />
           <Button asChild variant="ghost" size="icon" aria-label="Run history">
             <Link to="/agents/$slug/runs" params={{ slug: agent.slug }}>
               <History className="size-4" />
@@ -456,10 +461,19 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
   );
 }
 
-function RunNowDialog({ slug, name }: { slug: string; name: string }) {
+function RunNowDialog({
+  slug,
+  name,
+  lastPrefix,
+}: {
+  slug: string;
+  name: string;
+  lastPrefix: string | null;
+}) {
   const [open, setOpen] = useState(false);
   const [prefix, setPrefix] = useState("");
   const runNow = useRunAgentNow();
+  const hasLastPrefix = Boolean(lastPrefix && lastPrefix.length > 0);
 
   const submit = async () => {
     const ok = await withMutationToast(
@@ -516,13 +530,29 @@ function RunNowDialog({ slug, name }: { slug: string; name: string }) {
             rows={4}
             disabled={runNow.isPending}
           />
-          <p
-            className={`text-xs ${
-              tooLong ? "text-destructive" : "text-muted-foreground"
-            }`}
-          >
-            {prefix.length} / {PROMPT_PREFIX_MAX_LEN} characters
-          </p>
+          <div className="flex items-center justify-between gap-2">
+            <p
+              className={`text-xs ${
+                tooLong ? "text-destructive" : "text-muted-foreground"
+              }`}
+            >
+              {prefix.length} / {PROMPT_PREFIX_MAX_LEN} characters
+            </p>
+            {hasLastPrefix && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setPrefix(lastPrefix ?? "")}
+                disabled={runNow.isPending || prefix === lastPrefix}
+                title={lastPrefix ?? ""}
+              >
+                <Sparkles className="size-3" />
+                Use last prefix
+              </Button>
+            )}
+          </div>
         </div>
         <DialogFooter>
           <Button


### PR DESCRIPTION
## Summary

Iteration 24 — tiny follow-up to iter-23 ("Run now" prompt prefix). When an agent has a prior prefixed run on record, the Run now dialog now shows a "Use last prefix" button that pre-fills the textarea with the most recent non-null prefix.

Useful for operators iterating on a scoped run: "focus on Amazon Prime Jan only" → click Run now → tweak → fire again. No retyping.

## What's in

- **sqlc** `GetAgentLastPromptPrefixes`: `DISTINCT ON (agent_definition_id)` returning the most recent non-null/non-empty `prompt_prefix` per definition. Bulk-keyed like the iter-19 cost rollup — one query, no N+1.
- **Service**: `ListAgentDefinitions` zips it in; soft-fails on query error consistent with cost-stats / error-stats / next-fire.
- **Service response**: new `AgentDefinitionResponse.LastPromptPrefix` (`*string`, list-only, omitempty). Edit-page single-row Get leaves it nil — hot path doesn't pay for the extra aggregation.
- **SPA**: `AgentDefinition.last_prompt_prefix` mirror. `RunNowDialog` accepts `lastPrefix` prop; renders a small Ghost "Use last prefix" button (Sparkles icon, mirroring the iter-23 run-history prefix indicator) next to the char counter when a prior prefix exists. Native title attribute shows the full prior prefix. Disabled when the textarea already matches.
- **2 new service integration tests**:
  1. Most-recent-non-empty wins — newer empty runs don't shadow earlier prefixed ones
  2. Definitions with zero prefixed runs leave `LastPromptPrefix` nil

## Design notes

- **Zero schema change.** iter-23 already stored the prefix; iter-24 just surfaces the most recent one through a new aggregation.
- **One bulk query per page load.** Mirrors the iter-19 cost-stats pattern.
- **SQL-level filtering** for non-empty prefixes — a newer un-prefixed run does NOT shadow an earlier prefixed one. The test pins this.
- **Button-disabled-when-already-matching** keeps the affordance feeling intentional, not noisy.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new `LastPromptPrefix` service integration tests pass
- [x] All existing 30+ agent tests still pass
- [x] `bun run lint` + `bun run build` clean

## Screenshot

Intentionally omitted — the button only renders when an agent has a prior non-null prefix, and seeding rows would require fabricating writes to the shared dev DB. The iter-23 PR (#1249) shows the Run now dialog baseline; this PR only adds a conditionally-rendered Ghost button next to the existing char counter (visible inline in `web/src/routes/agents.tsx::RunNowDialog`).

## Deferred

- Persisted "preset library" of common prefixes — YAGNI until operators ask for it.
