### PR TITLE
feat(agents): daily GC for orphaned NDJSON transcripts

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -69,7 +69,7 @@ Exit code 3 = no Anthropic credential; exit code 5 = sidecar binary not found.
 
 ## Operational notes
 
-- **Cleanup**: completed runs older than `agent.run_retention_days` (default 30) are pruned daily at 3:15 AM local time.
+- **Cleanup**: completed runs older than `agent.run_retention_days` (default 30) are pruned daily at 3:15 AM local time. The matching on-disk transcript files (`<agent.transcript_dir>/<runID>.ndjson`) are pruned in the same pass using the same retention so the two surfaces stay in sync.
 - **Orphan recovery**: in-progress runs from a previous boot are marked `error` at startup so the run history doesn't lie.
 - **Auth precedence trap**: if both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are in the sidecar's env, the API key wins. The sidecar scrubs the unused var before invoking the SDK so this can't bite you accidentally.
 

--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -45,7 +48,9 @@ func NewAgentScheduler(orch *Orchestrator, svc *Service, logger *slog.Logger) *A
 func (s *AgentScheduler) Start(ctx context.Context) {
 	s.registerAll(ctx)
 	_, err := s.cron.AddFunc("15 3 * * *", func() {
-		s.cleanupAgentRuns(context.Background())
+		bg := context.Background()
+		s.cleanupAgentRuns(bg)
+		s.cleanupTranscriptFiles(bg)
 	})
 	if err != nil {
 		s.logger.Error("agent scheduler: add cleanup job failed", "error", err)
@@ -185,9 +190,73 @@ func nextMinuteAfterQuietEnd(now time.Time, end string) time.Time {
 	return candidate
 }
 
+// cleanupTranscriptFiles prunes NDJSON transcript files older than the
+// retention window. Reuses the same `agent.run_retention_days` setting as
+// the agent_runs cleanup, so the two surfaces stay aligned — deleting a
+// run row but keeping its transcript on disk (or vice versa) would be
+// confusing. Skips silently when transcript_dir is unset or retention=0.
+func (s *AgentScheduler) cleanupTranscriptFiles(ctx context.Context) {
+	transcriptDir := appconfig.String(ctx, s.svc.Queries, appconfig.KeyAgentTranscriptDir, "")
+	if transcriptDir == "" {
+		return
+	}
+	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
+	if retentionDays <= 0 {
+		s.logger.Debug("agent transcript cleanup disabled", "retention_days", retentionDays)
+		return
+	}
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	deleted, scanned, err := pruneTranscriptFiles(transcriptDir, cutoff)
+	if err != nil {
+		s.logger.Error("agent transcript cleanup failed",
+			"dir", transcriptDir, "error", err)
+		return
+	}
+	if deleted > 0 {
+		s.logger.Info("agent transcript cleanup completed",
+			"dir", transcriptDir, "deleted", deleted,
+			"scanned", scanned, "retention_days", retentionDays)
+	}
+}
+
+// pruneTranscriptFiles is the pure file-walking pass — split out so tests
+// can exercise it against a tempdir without a scheduler. Deletes `*.ndjson`
+// files in `dir` whose mtime is before `cutoff`. Returns (deleted, scanned,
+// first-error). Non-NDJSON entries and subdirectories are left untouched
+// so an operator who points transcript_dir at a shared folder doesn't lose
+// adjacent files.
+func pruneTranscriptFiles(dir string, cutoff time.Time) (deleted, scanned int, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(e.Name(), ".ndjson") {
+			continue
+		}
+		scanned++
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			if rerr := os.Remove(filepath.Join(dir, e.Name())); rerr == nil {
+				deleted++
+			}
+		}
+	}
+	return deleted, scanned, nil
+}
+
 // cleanupAgentRuns prunes completed agent_runs older than the retention
-// period (default 30 days; 0 disables). Transcript file GC is deferred
-// to a later iteration.
+// period (default 30 days; 0 disables). The matching on-disk transcript
+// files are pruned by cleanupTranscriptFiles using the same retention.
 func (s *AgentScheduler) cleanupAgentRuns(ctx context.Context) {
 	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
 	if retentionDays <= 0 {

--- a/internal/service/agent_transcript_gc_test.go
+++ b/internal/service/agent_transcript_gc_test.go
@@ -1,0 +1,79 @@
+//go:build !lite
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPruneTranscriptFiles(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+
+	mkFile := func(name string, mtime time.Time) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if err := os.Chtimes(p, mtime, mtime); err != nil {
+			t.Fatalf("chtimes %s: %v", name, err)
+		}
+		return p
+	}
+
+	oldNDJSON := mkFile("aaaa1111.ndjson", now.Add(-40*24*time.Hour))
+	newNDJSON := mkFile("bbbb2222.ndjson", now.Add(-1*24*time.Hour))
+	oldOther := mkFile("aaaa1111.log", now.Add(-40*24*time.Hour))
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cutoff := now.AddDate(0, 0, -30)
+	deleted, scanned, err := pruneTranscriptFiles(dir, cutoff)
+	if err != nil {
+		t.Fatalf("pruneTranscriptFiles: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1 (only the old .ndjson)", deleted)
+	}
+	if scanned != 2 {
+		t.Errorf("scanned = %d, want 2 (both .ndjson files)", scanned)
+	}
+	if _, err := os.Stat(oldNDJSON); !os.IsNotExist(err) {
+		t.Errorf("expected old .ndjson removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(newNDJSON); err != nil {
+		t.Errorf("recent .ndjson should remain, stat err = %v", err)
+	}
+	if _, err := os.Stat(oldOther); err != nil {
+		t.Errorf("non-ndjson file should be left alone, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subdir")); err != nil {
+		t.Errorf("subdirectory should be left alone, stat err = %v", err)
+	}
+}
+
+func TestPruneTranscriptFiles_MissingDirIsNotAnError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	deleted, scanned, err := pruneTranscriptFiles(dir, time.Now())
+	if err != nil {
+		t.Errorf("missing dir should not error, got %v", err)
+	}
+	if deleted != 0 || scanned != 0 {
+		t.Errorf("expected zero counts, got deleted=%d scanned=%d", deleted, scanned)
+	}
+}
+
+func TestPruneTranscriptFiles_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	deleted, scanned, err := pruneTranscriptFiles(dir, time.Now())
+	if err != nil {
+		t.Errorf("empty dir should not error, got %v", err)
+	}
+	if deleted != 0 || scanned != 0 {
+		t.Errorf("expected zero counts, got deleted=%d scanned=%d", deleted, scanned)
+	}
+}


### PR DESCRIPTION
## Summary

Iteration 25 — closes the unbounded-disk-growth gap that's been deferred since iter-7. The daily cleanup tick (3:15 AM) now prunes on-disk transcript files in the same pass that prunes `agent_runs` rows, using the same retention window so the two surfaces stay aligned.

Previously: completed run rows were pruned but `<agent.transcript_dir>/<runID>.ndjson` files lived forever. A self-hoster running multiple agents over months would accumulate hundreds of MB of orphan NDJSON with no in-product way to clean it up.

## What's in

- **Scheduler**: new `cleanupTranscriptFiles` tick reads `agent.transcript_dir` + `agent.run_retention_days` from `app_config` and prunes `*.ndjson` files older than the cutoff. Skips silently when `transcript_dir` is unset or `retention <= 0` (consistent with the run-row GC's disable semantics).
- **Pure helper** `pruneTranscriptFiles(dir, cutoff)` returns `(deleted, scanned, err)` — split out so tests can exercise every branch against a tempdir without spinning up Postgres or the scheduler.
- **3 unit tests**:
  1. Happy path: one old `.ndjson` removed; recent `.ndjson` preserved; non-NDJSON files and subdirectories left untouched
  2. Missing directory is not an error (returns `0,0,nil`)
  3. Empty directory returns zeros
- **Docs**: `docs/agents.md` operational-notes bullet documents that transcripts are pruned in the same daily pass.

## Design notes

- **Reuse the existing retention setting.** Separate knobs would invite an inconsistent state (deleted run row, kept transcript → confusing audit gap).
- **`.ndjson`-suffix gate**, not "delete every file in the directory" — protects operators who repurpose the directory for adjacent files.
- **No recursion.** Bounded by what `os.ReadDir` returns; subdirectories are skipped on purpose so a deliberate folder structure stays intact.
- **Per-file `os.Remove` is best-effort.** A single failure doesn't stop the pass; the counters reflect actual successes.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 3 new `TestPruneTranscriptFiles` cases pass
- [x] All 30+ existing agent service tests still pass

## Deferred

- A "force cleanup" admin button on Settings → Agents — easy to add (one button calls `cleanupTranscriptFiles` synchronously) but the daily tick covers the common case. Worth a follow-up if a self-hoster wants instant cleanup after lowering the retention setting.
- Transcript compression (gzip files older than N days but younger than retention). YAGNI until disk-space complaints surface.
