### PR TITLE
feat(agents): collapsible Rule DSL quick reference on agent edit

### DIFF
--- a/web/src/features/agents/rule-dsl-help.tsx
+++ b/web/src/features/agents/rule-dsl-help.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { BookOpen, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+// RuleDslHelp is a collapsible cheat-sheet for the transaction-rule DSL,
+// shown under the prompt textarea on the agent edit page. The full grammar
+// lives in `docs/rule-dsl.md`; this card surfaces the common fields and
+// operators an operator needs when authoring a rule-creating prompt.
+//
+// Closed by default — opens only when an operator asks for the reference,
+// so the form stays compact for prompt-only edits.
+export function RuleDslHelp() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="rounded-md border bg-muted/30"
+    >
+      <CollapsibleTrigger className="hover:bg-muted/50 flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-sm">
+        <span className="inline-flex items-center gap-2 font-medium">
+          <BookOpen className="size-4" />
+          Rule DSL quick reference
+        </span>
+        <span className="text-muted-foreground inline-flex items-center gap-1 text-xs">
+          {open ? (
+            <ChevronDown className="size-4" />
+          ) : (
+            <ChevronRight className="size-4" />
+          )}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-4 px-3 pb-3 pt-1 text-sm">
+        <p className="text-muted-foreground text-xs">
+          When your agent calls{" "}
+          <code className="rounded bg-background px-1 py-0.5 text-[11px]">
+            create_transaction_rule
+          </code>{" "}
+          (or its bulk/preview siblings), the rule is shaped like this. Full
+          grammar:{" "}
+          <code className="rounded bg-background px-1 py-0.5 text-[11px]">
+            docs/rule-dsl.md
+          </code>{" "}
+          (engineering doc — link out from your prompt if helpful).
+        </p>
+
+        <div>
+          <div className="text-muted-foreground mb-1 text-xs font-semibold uppercase tracking-wide">
+            Shape
+          </div>
+          <pre className="bg-background overflow-x-auto rounded border p-2 font-mono text-[11px] leading-relaxed">
+{`{
+  "name": "Dining categorization",
+  "conditions": { "field": "provider_merchant_name",
+                  "op": "contains", "value": "Starbucks" },
+  "actions": [{ "type": "set_category",
+                "category_slug": "food_and_drink_coffee" }],
+  "trigger": "on_create",
+  "priority": 10
+}`}
+          </pre>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <div className="text-muted-foreground mb-1 text-xs font-semibold uppercase tracking-wide">
+              Common fields
+            </div>
+            <ul className="space-y-0.5 font-mono text-[11px]">
+              <li>provider_merchant_name <span className="text-muted-foreground">string</span></li>
+              <li>provider_name <span className="text-muted-foreground">string</span></li>
+              <li>provider_category_primary <span className="text-muted-foreground">string</span></li>
+              <li>provider_category_detailed <span className="text-muted-foreground">string</span></li>
+              <li>category <span className="text-muted-foreground">string (assigned)</span></li>
+              <li>amount <span className="text-muted-foreground">numeric</span></li>
+              <li>tags <span className="text-muted-foreground">tags</span></li>
+              <li>provider <span className="text-muted-foreground">plaid|teller|csv</span></li>
+              <li>account_id, user_id <span className="text-muted-foreground">string</span></li>
+            </ul>
+          </div>
+          <div>
+            <div className="text-muted-foreground mb-1 text-xs font-semibold uppercase tracking-wide">
+              Operators by type
+            </div>
+            <ul className="space-y-0.5 font-mono text-[11px]">
+              <li>string: eq, neq, contains, not_contains,</li>
+              <li className="pl-8">matches (RE2), in</li>
+              <li>numeric: eq, neq, gt, gte, lt, lte</li>
+              <li>bool: eq, neq</li>
+              <li>tags: contains, not_contains, in</li>
+            </ul>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-muted-foreground mb-1 text-xs font-semibold uppercase tracking-wide">
+            Combinators
+          </div>
+          <pre className="bg-background overflow-x-auto rounded border p-2 font-mono text-[11px] leading-relaxed">
+{`{ "and": [ <condition>, <condition>, ... ] }
+{ "or":  [ <condition>, <condition>, ... ] }
+{ "not": <condition> }`}
+          </pre>
+          <p className="text-muted-foreground mt-1 text-[11px]">
+            Max nesting depth: 10. Empty <code>{"{}"}</code> matches every
+            transaction (rarely what you want — instruct the agent to always
+            scope rules).
+          </p>
+        </div>
+
+        <div>
+          <div className="text-muted-foreground mb-1 text-xs font-semibold uppercase tracking-wide">
+            Actions + triggers
+          </div>
+          <ul className="space-y-0.5 text-xs">
+            <li>
+              <code className="font-mono">set_category</code>,{" "}
+              <code className="font-mono">add_tag</code>,{" "}
+              <code className="font-mono">set_attribution</code> — at least
+              one per rule, can stack.
+            </li>
+            <li>
+              <code className="font-mono">trigger</code>:{" "}
+              <code className="font-mono">on_create</code> (new sync rows
+              only) or <code className="font-mono">on_change</code> (also
+              re-evaluates on update).
+            </li>
+            <li>
+              <code className="font-mono">priority</code>: lower runs first.
+              Rules chain — earlier <code className="font-mono">add_tag</code>{" "}
+              / <code className="font-mono">set_category</code> writes
+              feed later condition evaluation.
+            </li>
+            <li>
+              <code className="font-mono">apply_retroactively=true</code> on
+              create/update sweeps the existing table — use sparingly, only
+              during initial setup.
+            </li>
+          </ul>
+        </div>
+
+        <p className="text-muted-foreground text-[11px]">
+          Tip: instruct your agent to call{" "}
+          <code className="font-mono">preview_rule</code> before
+          <code className="font-mono"> create_transaction_rule</code> to
+          verify the match set.
+        </p>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -34,6 +34,7 @@ import {
   TOOL_SCOPES,
 } from "@/features/agents/agent-constants";
 import { CronField } from "@/features/agents/cron-field";
+import { RuleDslHelp } from "@/features/agents/rule-dsl-help";
 
 // Use z.preprocess (not z.coerce) for numerics to dodge the iter-4 resolver
 // bug where coerce.number leaves the input type as `unknown`. Preprocess
@@ -210,6 +211,7 @@ export function AgentEditPage() {
                     </FormItem>
                   )}
                 />
+                <RuleDslHelp />
                 <FormField
                   control={form.control}
                   name="system_prompt"


### PR DESCRIPTION
## Summary

Iteration 26 — operator authoring win. The agent edit page now shows a collapsible **"Rule DSL quick reference"** card directly under the prompt textarea, so an operator authoring a rule-creating agent prompt doesn't have to alt-tab to `docs/rule-dsl.md` to remember the field/operator matrix.

Closed by default; opens when the operator asks for it.

## Screenshot

<img src="https://i.img402.dev/22tkq26295.jpg" width="800" alt="/v2/agents/spending-report/edit — Rule DSL quick reference expanded">

## What's in

- **New** `web/src/features/agents/rule-dsl-help.tsx` — shadcn `Collapsible` wrapping a concise reference:
  - Shape skeleton (`{name, conditions, actions, trigger, priority}`)
  - Common fields (`provider_merchant_name`, `provider_category_primary`, `amount`, `tags`, …)
  - Operator matrix per type (string / numeric / bool / tags)
  - Combinators (`and` / `or` / `not`) with the max-depth note
  - Actions + triggers + a chaining hint
  - "Tip: instruct your agent to call `preview_rule` before `create_transaction_rule`"
- **Edit page** imports + renders `<RuleDslHelp />` immediately after the Prompt FormField.

## Design notes

- Feature-only component (lives under `features/agents/*`), so per the v2-frontend rule it doesn't need a sandbox specimen.
- Closed by default — pure additive surface; operators who don't care about rule-authoring never see it expanded.
- Concise reference, not the full docs. Operators read shape + operators in seconds without leaving the page.
- Native `Collapsible` primitive — no new shadcn install.

## Test plan

- [x] `bun run lint` + `bun run build` clean
- [x] Manual: opened on `/v2/agents/spending-report/edit`, scrolled card into view, captured screenshot (above)

## Deferred

- A "validate prompt mentions rule DSL terms" lint pass — too smart, too brittle. The static reference is enough.
- Auto-generating this from `docs/rule-dsl.md` — not worth a markdown parser inside the SPA bundle for this much content.
