### PR TITLE
feat(agents): persist hit_cap and surface "max turns" / "over budget" pills

### DIFF
--- a/internal/db/migrations/20260517115556_agent_runs_hit_cap.sql
+++ b/internal/db/migrations/20260517115556_agent_runs_hit_cap.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- hit_cap records WHICH safety ceiling a run bumped into when it terminated.
+-- Values:
+--   NULL          — run finished normally (clean success, or a non-cap error)
+--   'max_turns'   — sidecar reported stop_reason=max_turns (clean term within bounds)
+--   'max_budget'  — sidecar reported stop_reason=budget_exceeded (mid-run abort)
+-- Lets the v2 SPA flag "ran into the ceiling" runs separately from clean
+-- successes; an operator who sees a max_turns row knows the work is
+-- probably incomplete and may want to raise max_turns or split the prompt.
+ALTER TABLE agent_runs
+    ADD COLUMN hit_cap TEXT NULL CHECK (hit_cap IN ('max_turns', 'max_budget'));
+
+-- +goose Down
+ALTER TABLE agent_runs
+    DROP COLUMN hit_cap;

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -111,6 +111,17 @@ UPDATE agent_runs
 SET prompt_prefix = $2
 WHERE id = $1;
 
+-- name: SetAgentRunHitCap :one
+-- Record which safety cap (if any) terminated the run. Called by the
+-- orchestrator immediately after CompleteAgentRun when the sidecar signaled
+-- max_turns or budget_exceeded via the returned RunResult error. Returns
+-- the updated row so AgentRunFromRow can rebuild the response with the
+-- new field populated.
+UPDATE agent_runs
+SET hit_cap = $2
+WHERE id = $1
+RETURNING *;
+
 -- name: GetAgentLastPromptPrefixes :many
 -- Per-definition most recent non-null prompt_prefix. Skipped + null-prefix
 -- rows don't shadow earlier prefixes — only runs that actually carried a

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -26,6 +26,22 @@ func applyPromptPrefix(prefix, original string) string {
 	return "Operator note for this run:\n" + prefix + "\n\n" + original
 }
 
+// capFromRunErr maps the sidecar's safety-cap sentinels onto the discrete
+// hit_cap string the DB stores. Returns "" for any other error (or nil).
+// max_turns is success-tagged by the sidecar (clean termination); budget
+// is error-tagged (mid-run abort) — capFromRunErr preserves that nuance
+// by leaving status untouched and only adding the hit_cap signal.
+func capFromRunErr(err error) string {
+	switch {
+	case errors.Is(err, agent.ErrMaxTurnsReached):
+		return "max_turns"
+	case errors.Is(err, agent.ErrBudgetExceeded):
+		return "max_budget"
+	default:
+		return ""
+	}
+}
+
 // Orchestrator drives one agent run end-to-end: acquires concurrency,
 // mints a scoped API key, assembles the JobSpec, runs the sidecar, persists
 // the resulting agent_runs row, and revokes the key.
@@ -189,6 +205,19 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 			return &runResp, runErr
 		}
 		return &runResp, completeErr
+	}
+
+	// Detect cap exhaustion. The sidecar surfaces it through runErr after
+	// having already classified status (max_turns → success, budget → error),
+	// so we record the cap separately for the audit trail without rewriting
+	// status.
+	if cap := capFromRunErr(runErr); cap != "" {
+		if capRow, err := o.svc.SetAgentRunHitCapDB(ctx, runRow.ID, cap); err == nil {
+			completedRow = capRow
+		} else {
+			o.logger.Warn("orchestrator: persist hit_cap failed",
+				"agent", def.Slug, "run", runResp.ShortID, "cap", cap, "error", err)
+		}
 	}
 
 	finalResp := AgentRunFromRow(completedRow)

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -308,3 +308,95 @@ func TestOrchestratorRunNow_EmptyPrefix_LeavesPromptUnchanged(t *testing.T) {
 		t.Errorf("PromptPrefix should be nil when none supplied, got %v", *runResp.PromptPrefix)
 	}
 }
+
+func TestOrchestratorRunNow_MaxTurnsHit_PersistedAsHitCap(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-cap-turns", true)
+
+	fake := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		// Sidecar's contract: max_turns → success status + ErrMaxTurnsReached on err.
+		return agent.RunResult{
+			Status:     agent.StatusSuccess,
+			TurnCount:  10,
+			DurationMs: 50,
+		}, agent.ErrMaxTurnsReached
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	runResp, runErr := orch.RunNow(context.Background(), def, "")
+	// Orchestrator returns the runner's error untouched — but the row should
+	// be persisted with hit_cap set.
+	if !errors.Is(runErr, agent.ErrMaxTurnsReached) {
+		t.Fatalf("RunNow err = %v, want ErrMaxTurnsReached", runErr)
+	}
+	if runResp == nil {
+		t.Fatal("expected run row")
+	}
+	if runResp.HitCap == nil || *runResp.HitCap != "max_turns" {
+		t.Errorf("HitCap = %v, want max_turns", runResp.HitCap)
+	}
+	// Status stays success — the sidecar terminated cleanly within bounds.
+	if runResp.Status != agent.StatusSuccess {
+		t.Errorf("Status = %q, want success", runResp.Status)
+	}
+
+	// Verify the row was actually persisted.
+	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if persisted.HitCap == nil || *persisted.HitCap != "max_turns" {
+		t.Errorf("persisted HitCap = %v, want max_turns", persisted.HitCap)
+	}
+}
+
+func TestOrchestratorRunNow_BudgetHit_PersistedAsHitCap(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-cap-budget", true)
+
+	fake := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		// Sidecar's contract: budget_exceeded → error status + ErrBudgetExceeded.
+		return agent.RunResult{
+			Status:       agent.StatusError,
+			TotalCostUSD: 1.5,
+			DurationMs:   30,
+		}, agent.ErrBudgetExceeded
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	runResp, runErr := orch.RunNow(context.Background(), def, "")
+	if !errors.Is(runErr, agent.ErrBudgetExceeded) {
+		t.Fatalf("RunNow err = %v, want ErrBudgetExceeded", runErr)
+	}
+	if runResp == nil {
+		t.Fatal("expected run row")
+	}
+	if runResp.HitCap == nil || *runResp.HitCap != "max_budget" {
+		t.Errorf("HitCap = %v, want max_budget", runResp.HitCap)
+	}
+	// Status is error — the cap aborted the run mid-way.
+	if runResp.Status != agent.StatusError {
+		t.Errorf("Status = %q, want error", runResp.Status)
+	}
+}
+
+func TestOrchestratorRunNow_CleanSuccess_LeavesHitCapNil(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-no-cap", true)
+
+	fake := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{Status: agent.StatusSuccess, TurnCount: 3, DurationMs: 12}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	runResp, err := orch.RunNow(context.Background(), def, "")
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	if runResp.HitCap != nil {
+		t.Errorf("HitCap should be nil on clean success, got %q", *runResp.HitCap)
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -125,6 +125,10 @@ type AgentRunResponse struct {
 	SessionID           *string  `json:"session_id,omitempty"`
 	OperatorNote        *string  `json:"operator_note,omitempty"`
 	PromptPrefix        *string  `json:"prompt_prefix,omitempty"`
+	// HitCap names the safety ceiling this run bumped into when it
+	// terminated, if any: "max_turns" | "max_budget" | nil. Lets the v2
+	// SPA flag "ran into the ceiling" runs separately from clean successes.
+	HitCap *string `json:"hit_cap,omitempty"`
 }
 
 // AgentRunListResult is the paginated envelope for run lists.
@@ -634,6 +638,17 @@ func (s *Service) SetAgentRunPromptPrefixDB(ctx context.Context, runID pgtype.UU
 	})
 }
 
+// SetAgentRunHitCapDB records which safety ceiling terminated the run.
+// Called by the orchestrator after CompleteAgentRunDB when the runner
+// surfaces ErrMaxTurnsReached / ErrBudgetExceeded. cap must be one of
+// "max_turns", "max_budget" — the DB CHECK rejects others.
+func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, cap string) (db.AgentRun, error) {
+	return s.Queries.SetAgentRunHitCap(ctx, db.SetAgentRunHitCapParams{
+		ID:     runID,
+		HitCap: pgtype.Text{String: cap, Valid: cap != ""},
+	})
+}
+
 // CompleteAgentRunDB persists a terminal RunResult onto the run row.
 // Used by the orchestrator after Runner.Run returns.
 func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult) (db.AgentRun, error) {
@@ -942,6 +957,7 @@ func agentRunFromRow(row db.AgentRun) AgentRunResponse {
 		SessionID:           pgconv.TextPtr(row.SessionID),
 		OperatorNote:        pgconv.TextPtr(row.OperatorNote),
 		PromptPrefix:        pgconv.TextPtr(row.PromptPrefix),
+		HitCap:              pgconv.TextPtr(row.HitCap),
 	}
 }
 

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -72,6 +72,10 @@ export interface AgentRun {
   session_id?: string | null;
   operator_note?: string | null;
   prompt_prefix?: string | null;
+  // hit_cap names the safety ceiling this run bumped into when it
+  // terminated: "max_turns" | "max_budget" | null. Surfaces a "ran into
+  // the ceiling" pill on the run history row.
+  hit_cap?: "max_turns" | "max_budget" | null;
 }
 
 export const AGENT_RUN_NOTE_MAX_LEN = 2000;

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import {
+  AlertTriangle,
   ArrowLeft,
   Clock,
   FilterX,
@@ -337,6 +338,34 @@ function PromptPrefixBlock({ prefix }: { prefix: string }) {
   );
 }
 
+// HitCapPill flags runs that bumped into a safety ceiling. max_turns is
+// amber (clean termination but probably incomplete work — operator may
+// want to raise the cap or split the prompt); max_budget is red (mid-run
+// abort — the agent's plan exceeded what was budgeted).
+function HitCapPill({ cap }: { cap: "max_turns" | "max_budget" | null }) {
+  if (!cap) return null;
+  if (cap === "max_turns") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+        title="Run hit max_turns — work may be incomplete. Consider raising max_turns or splitting the prompt."
+      >
+        <AlertTriangle className="size-3" />
+        max turns
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-950/40 dark:text-red-300"
+      title="Run exceeded max_budget_usd — terminated mid-task. Consider raising the budget cap or narrowing the agent's scope."
+    >
+      <AlertTriangle className="size-3" />
+      over budget
+    </span>
+  );
+}
+
 function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
   const hasNote = Boolean(run.operator_note && run.operator_note.trim() !== "");
   const notePreview = hasNote
@@ -371,6 +400,7 @@ function RunRow({ run, onClick }: { run: AgentRun; onClick: () => void }) {
           prefix
         </span>
       )}
+      <HitCapPill cap={run.hit_cap ?? null} />
       {hasNote && (
         <span
           className="text-muted-foreground inline-flex items-center gap-1 text-xs"


### PR DESCRIPTION
## Summary

Iteration 27 — closes the gap where runs that hit `max_turns` or `max_budget` terminated without leaving a visible trace. The orchestrator already received the right signal from the sidecar (`ErrMaxTurnsReached` / `ErrBudgetExceeded`), but the `agent_runs` row only stored the resulting `status` — so an operator scanning history couldn't distinguish a clean success from a `max_turns` ceiling hit, or a generic error from a budget-exceeded abort.

## What's in

- **Migration** `20260517115556_agent_runs_hit_cap.sql`: adds `hit_cap TEXT NULL` with a `CHECK (hit_cap IN ('max_turns', 'max_budget'))`. Additive only.
- **sqlc** `SetAgentRunHitCap :one` returns the full row so the orchestrator can rebuild the response without a re-read.
- **Service**: `AgentRunResponse.HitCap` surfaces the field via `agentRunFromRow`. `SetAgentRunHitCapDB` helper mirrors the other DB helpers.
- **Orchestrator**: new `capFromRunErr()` maps the sidecar's sentinels to the discrete `hit_cap` string. Called after `CompleteAgentRunDB` so the cap signal layers **on top of** the existing status — `max_turns` stays `success`-tagged, `max_budget` stays `error`-tagged.
- **SPA**: `AgentRun.hit_cap` typed union mirror. New `HitCapPill` renders **amber "max turns"** for the soft cap (work probably incomplete) and **red "over budget"** for the hard cap (mid-run abort). Each pill carries a remediation hint in its native `title`.
- **3 new orchestrator integration tests** covering all three branches: `max_turns` persists with `status=success`; `max_budget` persists with `status=error`; clean success leaves `hit_cap` nil.

## Design notes

- **Cap stored as a discrete TEXT column with a CHECK** — easier to filter in SQL than parsing `error_message`, and the CHECK keeps drift out of the DB if a new cap kind shows up later.
- **Status untouched.** `max_turns` IS a successful termination from the SDK's POV (clean stop); `max_budget` IS an error (mid-run abort). The pill is an additional "ran into the ceiling" signal layered on top, not a replacement.
- **Two distinct visual treatments** mirror the trust gradient: amber warns that more work might be needed; red flags that something aborted.
- **Operator-actionable title text** on each pill names the lever to pull (raise `max_turns` / raise `max_budget_usd`).

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 3 new `HitCap` orchestrator integration tests pass
- [x] All 30+ existing agent tests still pass
- [x] OpenAPI drift test green (no router changes — pure response-shape addition)
- [x] `bun run lint` + `bun run build` clean

## Screenshot

Intentionally omitted — the pill only renders when an actual run has hit a cap (a non-trivial state to seed against the shared dev DB without fabricating writes — see iter-24 lesson). The implementation is straightforward and the design is documented in the PR body + code comments; it'll appear naturally during dogfooding when an agent first bumps into a ceiling.

## Deferred

- Aggregate list-level "recent caps hit" pill on `/v2/agents` (like iter-21's error pill). Cheap follow-up if dogfooding reveals caps-hit clusters worth flagging at the list level.
- Filter chip on the run history page for `hit_cap`. Tiny add later if needed.
