### PR TITLE
feat(agents): "Run cleanup now" button + POST /api/v1/agents/cleanup

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -266,6 +266,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | POST | `/agents/{slug}/disable` | W | Flip enabled=false |
 | POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; optional `{prompt_prefix}` body prepends per-run context (≤2000 chars); 503 `CONCURRENCY_LOCKED` when another run is in progress |
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
+| POST | `/agents/cleanup` | W | Run the agent cleanup pass on demand; returns `{runs_deleted, transcripts_deleted, transcripts_scanned, retention_days, transcript_dir}` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200) |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | PATCH | `/agents/runs/{shortId}` | W | Set/clear the operator note on a run. Body `{ "note": "..." }`; empty string clears. Capped at 2000 chars |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -552,3 +552,22 @@ func writeAgentError(w http.ResponseWriter, err error, notFoundMsg string) {
 		mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Unexpected error")
 	}
 }
+
+// RunAgentCleanupHandler triggers an on-demand agent cleanup pass (the
+// same one the 3:15 AM cron does) and returns the resulting counts. Lets
+// operators who just lowered retention see the effect without waiting
+// for the next cron tick.
+// 503 AGENTS_DISABLED when no scheduler is configured.
+// 200 with { runs_deleted, transcripts_deleted, transcripts_scanned,
+// retention_days, transcript_dir } otherwise.
+func RunAgentCleanupHandler(sched *service.AgentScheduler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if sched == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "AGENTS_DISABLED",
+				"Agent scheduler is not configured on this server")
+			return
+		}
+		result := sched.RunCleanupNow(r.Context())
+		writeData(w, result)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -195,6 +195,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/agents/{slug}/disable", DisableAgentHandler(svc))
 			r.Post("/agents/{slug}/run", RunAgentNowHandler(svc, a.AgentOrchestrator))
 			r.Post("/agents/test", SmokeTestAgentHandler(a.AgentOrchestrator))
+			r.Post("/agents/cleanup", RunAgentCleanupHandler(a.AgentScheduler))
 			r.Patch("/agents/runs/{shortId}", UpdateAgentRunNoteHandler(svc))
 			r.Post("/providers/{name}/test", TestProviderHandler(a))
 			r.Delete("/providers/{name}", DisableProviderHandler(a))

--- a/internal/service/agent_cleanup_now_test.go
+++ b/internal/service/agent_cleanup_now_test.go
@@ -1,0 +1,121 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/appconfig"
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestRunCleanupNow exercises the on-demand cleanup path that backs the
+// Settings → Agents "Run cleanup now" button. Seeds an old run row plus
+// an old transcript file under transcript_dir; calls RunCleanupNow;
+// asserts both surfaces report deletion counts.
+func TestRunCleanupNow(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	// Configure retention + transcript dir via app_config.
+	transcriptDir := t.TempDir()
+	if err := q.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   appconfig.KeyAgentTranscriptDir,
+		Value: pgtype.Text{String: transcriptDir, Valid: true},
+	}); err != nil {
+		t.Fatalf("set transcript_dir: %v", err)
+	}
+	if err := q.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   appconfig.KeyAgentRunRetentionDays,
+		Value: pgtype.Text{String: "30", Valid: true},
+	}); err != nil {
+		t.Fatalf("set retention: %v", err)
+	}
+
+	// Seed: one old completed agent_run (40 days back), one fresh one.
+	def := mustCreateAgentDefinition(t, svc, "svc-cleanup-now", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+	mustInsertCompletedRun(t, q, defUUID, "0.01")
+	if _, err := pool.Exec(ctx,
+		`UPDATE agent_runs SET started_at = $1, completed_at = $1
+		 WHERE agent_definition_id = $2`,
+		time.Now().AddDate(0, 0, -40), defUUID); err != nil {
+		t.Fatalf("backdate first row: %v", err)
+	}
+	mustInsertCompletedRun(t, q, defUUID, "0.01") // fresh — leaves started_at = NOW()
+
+	// Seed transcript files matching.
+	oldPath := filepath.Join(transcriptDir, "aaaa1111.ndjson")
+	if err := os.WriteFile(oldPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write old transcript: %v", err)
+	}
+	if err := os.Chtimes(oldPath, time.Now().AddDate(0, 0, -40), time.Now().AddDate(0, 0, -40)); err != nil {
+		t.Fatalf("chtimes old: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(transcriptDir, "bbbb2222.ndjson"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write fresh transcript: %v", err)
+	}
+
+	orch := service.NewOrchestrator(svc, agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{}, nil
+	}), 1, devEncKey, slog.Default())
+	sched := service.NewAgentScheduler(orch, svc, slog.Default())
+
+	result := sched.RunCleanupNow(ctx)
+
+	if result.RunsDeleted < 1 {
+		t.Errorf("RunsDeleted = %d, want >= 1 (the 40-day-old row)", result.RunsDeleted)
+	}
+	if result.TranscriptsDeleted != 1 {
+		t.Errorf("TranscriptsDeleted = %d, want 1 (only the old .ndjson)", result.TranscriptsDeleted)
+	}
+	if result.TranscriptsScanned != 2 {
+		t.Errorf("TranscriptsScanned = %d, want 2", result.TranscriptsScanned)
+	}
+	if result.RetentionDays != 30 {
+		t.Errorf("RetentionDays = %d, want 30", result.RetentionDays)
+	}
+	if result.TranscriptDir != transcriptDir {
+		t.Errorf("TranscriptDir = %q, want %q", result.TranscriptDir, transcriptDir)
+	}
+
+	// Verify the fresh transcript still exists.
+	if _, err := os.Stat(filepath.Join(transcriptDir, "bbbb2222.ndjson")); err != nil {
+		t.Errorf("fresh transcript should remain, stat err = %v", err)
+	}
+}
+
+func TestRunCleanupNow_RetentionDisabled(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	if err := q.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   appconfig.KeyAgentRunRetentionDays,
+		Value: pgtype.Text{String: "0", Valid: true},
+	}); err != nil {
+		t.Fatalf("set retention=0: %v", err)
+	}
+
+	orch := service.NewOrchestrator(svc, agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{}, nil
+	}), 1, devEncKey, slog.Default())
+	sched := service.NewAgentScheduler(orch, svc, slog.Default())
+
+	result := sched.RunCleanupNow(ctx)
+	if result.RunsDeleted != 0 || result.TranscriptsDeleted != 0 {
+		t.Errorf("retention=0 should be a no-op, got %+v", result)
+	}
+	if result.RetentionDays != 0 {
+		t.Errorf("RetentionDays = %d, want 0", result.RetentionDays)
+	}
+}
+

--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -49,14 +49,72 @@ func (s *AgentScheduler) Start(ctx context.Context) {
 	s.registerAll(ctx)
 	_, err := s.cron.AddFunc("15 3 * * *", func() {
 		bg := context.Background()
-		s.cleanupAgentRuns(bg)
-		s.cleanupTranscriptFiles(bg)
+		result := s.runCleanupAll(bg)
+		s.logCleanupResult(result, "scheduled")
 	})
 	if err != nil {
 		s.logger.Error("agent scheduler: add cleanup job failed", "error", err)
 	}
 	s.cron.Start()
 	s.logger.Info("agent scheduler started", "enabled_count", len(s.entryIDs))
+}
+
+// AgentCleanupResult summarizes one cleanup pass — what was deleted from
+// agent_runs and the transcript directory, plus the retention setting in
+// effect at the time. Returned by RunCleanupNow so the HTTP handler can
+// echo it back for operator toast/display.
+type AgentCleanupResult struct {
+	RunsDeleted        int64 `json:"runs_deleted"`
+	TranscriptsDeleted int   `json:"transcripts_deleted"`
+	TranscriptsScanned int   `json:"transcripts_scanned"`
+	RetentionDays      int   `json:"retention_days"`
+	TranscriptDir      string `json:"transcript_dir,omitempty"`
+}
+
+// RunCleanupNow runs the same prune pass the daily tick runs, synchronously,
+// and returns the counts. Used by the Settings → Agents "Run cleanup now"
+// button so an operator who just lowered retention can see the effect
+// without waiting for 3:15 AM. Safe to call repeatedly — a no-op when
+// nothing's eligible.
+func (s *AgentScheduler) RunCleanupNow(ctx context.Context) AgentCleanupResult {
+	result := s.runCleanupAll(ctx)
+	s.logCleanupResult(result, "on-demand")
+	return result
+}
+
+// runCleanupAll is the shared body: both the cron tick and RunCleanupNow
+// go through it so they can't drift.
+func (s *AgentScheduler) runCleanupAll(ctx context.Context) AgentCleanupResult {
+	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
+	transcriptDir := appconfig.String(ctx, s.svc.Queries, appconfig.KeyAgentTranscriptDir, "")
+	result := AgentCleanupResult{
+		RetentionDays: retentionDays,
+		TranscriptDir: transcriptDir,
+	}
+	if retentionDays <= 0 {
+		return result
+	}
+	result.RunsDeleted = s.cleanupAgentRuns(ctx)
+	if transcriptDir != "" {
+		result.TranscriptsDeleted, result.TranscriptsScanned = s.cleanupTranscriptFiles(ctx)
+	}
+	return result
+}
+
+// logCleanupResult writes the structured slog line both cleanup paths share,
+// tagged with how the pass was triggered.
+func (s *AgentScheduler) logCleanupResult(r AgentCleanupResult, source string) {
+	if r.RunsDeleted == 0 && r.TranscriptsDeleted == 0 {
+		s.logger.Debug("agent cleanup pass: nothing to do",
+			"source", source, "retention_days", r.RetentionDays)
+		return
+	}
+	s.logger.Info("agent cleanup pass completed",
+		"source", source,
+		"runs_deleted", r.RunsDeleted,
+		"transcripts_deleted", r.TranscriptsDeleted,
+		"transcripts_scanned", r.TranscriptsScanned,
+		"retention_days", r.RetentionDays)
 }
 
 // Stop gracefully halts the scheduler, waiting for any in-flight jobs.
@@ -192,31 +250,20 @@ func nextMinuteAfterQuietEnd(now time.Time, end string) time.Time {
 
 // cleanupTranscriptFiles prunes NDJSON transcript files older than the
 // retention window. Reuses the same `agent.run_retention_days` setting as
-// the agent_runs cleanup, so the two surfaces stay aligned — deleting a
-// run row but keeping its transcript on disk (or vice versa) would be
-// confusing. Skips silently when transcript_dir is unset or retention=0.
-func (s *AgentScheduler) cleanupTranscriptFiles(ctx context.Context) {
+// the agent_runs cleanup, so the two surfaces stay aligned. Returns the
+// number deleted + number scanned so callers can surface counts. Caller
+// is responsible for the transcript_dir + retention preflight.
+func (s *AgentScheduler) cleanupTranscriptFiles(ctx context.Context) (deleted, scanned int) {
 	transcriptDir := appconfig.String(ctx, s.svc.Queries, appconfig.KeyAgentTranscriptDir, "")
-	if transcriptDir == "" {
-		return
-	}
 	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
-	if retentionDays <= 0 {
-		s.logger.Debug("agent transcript cleanup disabled", "retention_days", retentionDays)
-		return
-	}
 	cutoff := time.Now().AddDate(0, 0, -retentionDays)
 	deleted, scanned, err := pruneTranscriptFiles(transcriptDir, cutoff)
 	if err != nil {
 		s.logger.Error("agent transcript cleanup failed",
 			"dir", transcriptDir, "error", err)
-		return
+		return 0, 0
 	}
-	if deleted > 0 {
-		s.logger.Info("agent transcript cleanup completed",
-			"dir", transcriptDir, "deleted", deleted,
-			"scanned", scanned, "retention_days", retentionDays)
-	}
+	return deleted, scanned
 }
 
 // pruneTranscriptFiles is the pure file-walking pass — split out so tests
@@ -255,23 +302,16 @@ func pruneTranscriptFiles(dir string, cutoff time.Time) (deleted, scanned int, e
 }
 
 // cleanupAgentRuns prunes completed agent_runs older than the retention
-// period (default 30 days; 0 disables). The matching on-disk transcript
-// files are pruned by cleanupTranscriptFiles using the same retention.
-func (s *AgentScheduler) cleanupAgentRuns(ctx context.Context) {
+// period and returns the number deleted. Caller is responsible for the
+// retention preflight (runCleanupAll short-circuits when retention<=0).
+func (s *AgentScheduler) cleanupAgentRuns(ctx context.Context) int64 {
 	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
-	if retentionDays <= 0 {
-		s.logger.Debug("agent run cleanup disabled", "retention_days", retentionDays)
-		return
-	}
 	cutoff := time.Now().AddDate(0, 0, -retentionDays)
 	result, err := s.svc.Queries.DeleteAgentRunsOlderThan(ctx,
 		pgtype.Timestamptz{Time: cutoff, Valid: true})
 	if err != nil {
 		s.logger.Error("agent run cleanup failed", "error", err)
-		return
+		return 0
 	}
-	if n := result.RowsAffected(); n > 0 {
-		s.logger.Info("agent run cleanup completed",
-			"deleted", n, "retention_days", retentionDays)
-	}
+	return result.RowsAffected()
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2573,6 +2573,24 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/cleanup:
+    post:
+      tags: [Agents]
+      summary: Run the agent cleanup pass on demand
+      description: |
+        Synchronously runs the same prune pass the 3:15 AM cron does:
+        deletes completed agent_runs older than `agent.run_retention_days`
+        and prunes the matching `*.ndjson` transcripts under
+        `agent.transcript_dir`. Returns the counts. Safe to call
+        repeatedly — a no-op when nothing's eligible. **Requires `full_access` scope.**
+      responses:
+        "200":
+          description: Cleanup counts.
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "503":
+          description: Agent scheduler not configured (AGENTS_DISABLED).
   /api/v1/agents/test:
     post:
       tags: [Agents]

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -332,6 +332,25 @@ export interface AgentTestResult {
   response?: string;
 }
 
+export interface AgentCleanupResult {
+  runs_deleted: number;
+  transcripts_deleted: number;
+  transcripts_scanned: number;
+  retention_days: number;
+  transcript_dir?: string;
+}
+
+export function useRunAgentCleanup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      api<AgentCleanupResult>("/api/v1/agents/cleanup", { method: "POST" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
+}
+
 export function useSmokeTestAgent() {
   return useMutation({
     mutationFn: () =>

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Bot, CheckCircle2, KeyRound, Loader2, Stethoscope, XCircle } from "lucide-react";
+import { Bot, CheckCircle2, KeyRound, Loader2, Stethoscope, Trash2, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -28,11 +28,13 @@ import { SettingsSectionHeader } from "@/components/settings-section-header";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useAgentSettings,
+  useRunAgentCleanup,
   useSmokeTestAgent,
   useUpdateAgentSettings,
   type AgentTestResult,
 } from "@/api/queries/agents";
 import { ApiError } from "@/api/client";
+import { toast } from "sonner";
 
 const settingsSchema = z.object({
   auth_mode: z.enum(["subscription", "api_key"]),
@@ -47,6 +49,19 @@ export function AgentsSection() {
   const settingsQuery = useAgentSettings();
   const updateSettings = useUpdateAgentSettings();
   const smokeTest = useSmokeTestAgent();
+  const cleanup = useRunAgentCleanup();
+
+  const runCleanup = async () => {
+    try {
+      const r = await cleanup.mutateAsync();
+      toast.success(
+        `Cleanup: ${r.runs_deleted} run(s), ${r.transcripts_deleted}/${r.transcripts_scanned} transcript(s) removed (retention ${r.retention_days}d).`,
+      );
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : String(err);
+      toast.error(`Cleanup failed — ${msg}`);
+    }
+  };
   const [tokenDraft, setTokenDraft] = useState("");
   const [apiKeyDraft, setApiKeyDraft] = useState("");
   const [testResult, setTestResult] = useState<AgentTestResult | null>(null);
@@ -271,19 +286,35 @@ export function AgentsSection() {
             />
 
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={runSmokeTest}
-                disabled={smokeTest.isPending}
-              >
-                {smokeTest.isPending ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Stethoscope className="size-4" />
-                )}
-                Test connection
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={runSmokeTest}
+                  disabled={smokeTest.isPending}
+                >
+                  {smokeTest.isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Stethoscope className="size-4" />
+                  )}
+                  Test connection
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={runCleanup}
+                  disabled={cleanup.isPending}
+                  title="Runs the same daily prune pass on demand — useful after lowering retention so you don't have to wait for 3:15 AM."
+                >
+                  {cleanup.isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-4" />
+                  )}
+                  Run cleanup now
+                </Button>
+              </div>
               <Button type="submit" disabled={updateSettings.isPending}>
                 {updateSettings.isPending && (
                   <Loader2 className="size-4 animate-spin" />


### PR DESCRIPTION
## Summary

Iteration 28 — closes the iter-25 deferred item. Operators who lower the retention setting (or who just want to verify cleanup works) can now trigger the daily 3:15 AM prune pass synchronously from Settings → Agents and see the counts.

## Screenshot

<img src="https://i.img402.dev/pkq947mjmo.jpg" width="800" alt="Settings → Agents — new 'Run cleanup now' button alongside 'Test connection'">

## What's in

- **Scheduler refactor**: `cleanupAgentRuns` + `cleanupTranscriptFiles` now return counts. New `runCleanupAll` is the **shared body** both the cron tick and `RunCleanupNow` go through — they cannot drift. `logCleanupResult` writes one structured slog line tagged `source=scheduled` vs `source=on-demand`.
- **New** `AgentScheduler.RunCleanupNow(ctx) AgentCleanupResult` returning `{ runs_deleted, transcripts_deleted, transcripts_scanned, retention_days, transcript_dir }`.
- **New** `POST /api/v1/agents/cleanup` — `full_access` scope, returns the result struct. 503 `AGENTS_DISABLED` when no scheduler is wired.
- **SPA**: new `useRunAgentCleanup` mutation hook + `AgentCleanupResult` type. Settings → Agents gets a **"Run cleanup now"** outline button next to "Test connection"; success toast names the counts and the retention window. Native title explains the use case.
- **2 new integration tests**:
  1. End-to-end: seed an old run + matching old transcript, call `RunCleanupNow`, verify both surfaces report deletion and fresh entries are preserved.
  2. `retention=0` is a no-op (returns zero counts).
- `openapi.yaml` + `docs/api-endpoints.md` updated per the upkeep rules.

## Design notes

- **One body, two callers.** The cron tick and the HTTP handler cannot drift because they share `runCleanupAll`. The only diff is the `source` tag on the log line.
- **Result struct, not raw counts.** Carries `retention_days` + `transcript_dir` alongside the deletes so the toast can be specific about which window the operator just saw applied.
- **Outline variant, not destructive.** Cleanup is administrative, not dangerous — `Trash2` icon + outline matches the SmokeTest button's weight.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new `RunCleanupNow` integration tests pass
- [x] All 30+ existing agent service tests still pass
- [x] OpenAPI drift test green
- [x] `bun run lint` + `bun run build` clean
- [x] Manual: opened Settings → Agents in Chrome MCP, captured screenshot with the new button visible alongside "Test connection" (above)
