### PR TITLE
feat(agents): lift default max_concurrent 1 → 3, with contention test

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -62,7 +62,7 @@ Exit code 3 = no Anthropic credential; exit code 5 = sidecar binary not found.
 
 - **Per-agent caps**: `max_turns` and `max_budget_usd` on every definition.
 - **Global ceiling**: `agent.global_max_budget_usd` in Settings → Agents.
-- **Concurrency**: `agent.max_concurrent` (default 1). Excess cron fires log as `skipped` rows; manual runs return 503 `CONCURRENCY_LOCKED`.
+- **Concurrency**: `agent.max_concurrent` (default 3 since iter-29; was 1 in iter-1 as a v1 safety net, lifted after the orchestrator's mint-and-revoke proved out under contention). Excess cron fires log as `skipped` rows; manual runs return 503 `CONCURRENCY_LOCKED`. Raise (or drop back to 1) in Settings → Agents.
 - **Scope**: per-agent `tool_scope` is `read_only` or `read_write`. Read-only agents mint a read-only API key that the MCP server rejects writes on.
 - **Mint-and-revoke**: every run gets a fresh, scoped API key named `agent:<slug>:<runShortID>`. It's revoked the instant the run completes (or errors).
 - **Encrypted at rest**: subscription tokens and API keys are AES-256-GCM encrypted in `app_config`. The full value never leaves the server after you save it — `GET /api/v1/agents/settings` returns a masked display string.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -125,7 +125,11 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	} else if n := cleanupResult.RowsAffected(); n > 0 {
 		logger.Info("cleaned up orphaned agent runs", "count", n)
 	}
-	agentMaxConcurrent := appconfig.Int(ctx, a.Queries, appconfig.KeyAgentMaxConcurrent, 1)
+	// Default was 1 in iter-1 as a v1 safety net. Lifted to 3 in iter-29 after
+	// 28 iterations of dogfood proved the semaphore + mint-and-revoke survive
+	// concurrent contention. Operators can raise (or lower back to 1) in
+	// Settings → Agents.
+	agentMaxConcurrent := appconfig.Int(ctx, a.Queries, appconfig.KeyAgentMaxConcurrent, 3)
 	agentRuntimePath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
 	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "")
 	agentSidecar := &agent.Sidecar{

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"breadbox/internal/agent"
@@ -398,5 +399,86 @@ func TestOrchestratorRunNow_CleanSuccess_LeavesHitCapNil(t *testing.T) {
 	}
 	if runResp.HitCap != nil {
 		t.Errorf("HitCap should be nil on clean success, got %q", *runResp.HitCap)
+	}
+}
+
+// TestOrchestratorRunNow_TripleConcurrency exercises the iter-29 default
+// (max_concurrent=3). Fires 3 RunNow calls concurrently; all should
+// complete cleanly with no semaphore lockout. Verifies mint-and-revoke,
+// per-run row creation, and end-state run count all behave under
+// contention. The 4th concurrent attempt should still lock — the cap is
+// a real ceiling, not a no-op.
+func TestOrchestratorRunNow_TripleConcurrency(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-3x", true)
+
+	var running atomic.Int32
+	var maxObserved atomic.Int32
+	release := make(chan struct{})
+	started := make(chan struct{}, 4)
+
+	runner := agent.RunnerFunc(func(ctx context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		now := running.Add(1)
+		defer running.Add(-1)
+		for {
+			old := maxObserved.Load()
+			if now <= old || maxObserved.CompareAndSwap(old, now) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
+	})
+
+	// Cap=3 — should let the first three Runs all run in parallel.
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+
+	var wg sync.WaitGroup
+	results := make([]error, 3)
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := orch.RunNow(context.Background(), def, "")
+			results[idx] = err
+		}(i)
+	}
+
+	// Wait for all three goroutines to enter the runner before releasing.
+	for i := 0; i < 3; i++ {
+		<-started
+	}
+
+	// A 4th concurrent attempt should hit ErrConcurrencyLocked while the
+	// other three are still running.
+	_, fourthErr := orch.RunNow(context.Background(), def, "")
+	if !errors.Is(fourthErr, agent.ErrConcurrencyLocked) {
+		t.Errorf("4th RunNow under cap=3 should return ErrConcurrencyLocked, got %v", fourthErr)
+	}
+
+	close(release)
+	wg.Wait()
+
+	for i, err := range results {
+		if err != nil {
+			t.Errorf("RunNow #%d err = %v, want nil", i, err)
+		}
+	}
+	if got := maxObserved.Load(); got != 3 {
+		t.Errorf("max concurrent runs observed = %d, want 3 (cap=3 should NOT serialize)", got)
+	}
+
+	// Every successful run minted an api_key and revoked it. After all three
+	// complete, no `agent:orch-3x:*` key should remain unrevoked.
+	keys, err := svc.ListAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	for _, k := range keys {
+		if strings.HasPrefix(k.Name, "agent:orch-3x:") && k.RevokedAt == nil {
+			t.Errorf("unrevoked minted key after concurrent runs: %s", k.Name)
+		}
 	}
 }

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -61,7 +61,8 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSe
 		return nil, fmt.Errorf("read anthropic api key: %w", err)
 	}
 
-	maxConcurrent := appconfig.Int(ctx, s.Queries, appconfig.KeyAgentMaxConcurrent, 1)
+	// Default lifted from 1 → 3 in iter-29; see serve.go for the rationale.
+	maxConcurrent := appconfig.Int(ctx, s.Queries, appconfig.KeyAgentMaxConcurrent, 3)
 	runtimePath := appconfig.String(ctx, s.Queries, appconfig.KeyAgentRuntimePath, "")
 	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, "")
 	globalBudget := readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -232,8 +232,9 @@ func TestGetAgentSettings_DefaultsWhenUnset(t *testing.T) {
 	if s.SubscriptionToken != nil {
 		t.Errorf("SubscriptionToken should be nil when unset, got %v", *s.SubscriptionToken)
 	}
-	if s.MaxConcurrent != 1 {
-		t.Errorf("MaxConcurrent default = %d, want 1", s.MaxConcurrent)
+	// Default lifted from 1 → 3 in iter-29. See serve.go for rationale.
+	if s.MaxConcurrent != 3 {
+		t.Errorf("MaxConcurrent default = %d, want 3", s.MaxConcurrent)
 	}
 }
 


### PR DESCRIPTION
## Summary

Iteration 29 — closes the iter-3 deferred "Concurrency: 1 for v1" decision. 28 iterations of dogfood proved the orchestrator's mint-and-revoke + semaphore + scheduler reload survive concurrent contention; the v1 safety net is no longer paying for itself.

Default `agent.max_concurrent` lifted from **1 → 3**. Self-hosters who want more or less can adjust in Settings → Agents.

## What's in

- **Default lift**: `internal/cli/serve.go` and `internal/service/agent_settings.go` fallbacks both bump from 1 → 3. The existing app_config key persists user overrides — this only affects fresh installs (or any install that never set the value explicitly).
- **New** `TestOrchestratorRunNow_TripleConcurrency` integration test:
  1. Fires 3 `RunNow` goroutines and blocks them inside the runner
  2. Asserts all three observe the runner concurrently (`maxObserved == 3`) — a degenerate semaphore would fail here
  3. Asserts a **4th attempt hits `ErrConcurrencyLocked`** (cap=3 is a real ceiling, not a no-op)
  4. After release, asserts **all minted `agent:` keys are revoked** — mint/revoke still atomic under contention
- **Settings test** updated to assert the new 3 default.
- **`docs/agents.md`** operational-notes line documents the lift + the v1 rationale + how to drop back to 1.

## Design notes

- **3, not "uncapped".** Bounded blast radius — a misbehaving agent loop can still only burn 3 parallel API calls worth before something blocks. Operators wanting more raise it explicitly.
- **Single-write app_config fallback, not a migration.** Existing installations keep whatever they had set; this only affects fresh installs and operators who never touched the setting.
- **Test pins both correctness branches.** 3 must actually run in parallel (`maxObserved == 3`) AND the cap must still bite (4th blocks). A degenerate semaphore would pass only one of these.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] New `TripleConcurrency` test passes (3 concurrent runs observed; 4th rejected; all minted keys revoked)
- [x] Existing `TestGetAgentSettings_DefaultsWhenUnset` updated for the new default; passes
- [x] All other 30+ agent tests still pass

## Deferred

- Surfacing "3/3 slots used" on `/v2/agents` header — small follow-up if dogfooding suggests operators want the live indicator.
- Removing the `ErrConcurrencyLocked → 503` mapping on `/run` — it stays useful even at higher caps (operator may want to know they hit the ceiling).
