### PR TITLE
feat(agents): webhook trigger — fire agents after every successful sync

### DIFF
--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -40,6 +40,10 @@ If both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are set in the sidecar
 
 Every run mints a scoped `actor_type='agent'` API key (name format `agent:<slug>:<runShortID>`) and revokes it in a `defer` with a fresh context. Never leave a key valid past the run that minted it. If you add a new entry point that runs an agent, wrap it in `Orchestrator.RunNow` or `Orchestrator.RunOrSkip` — don't reimplement the mint-revoke dance.
 
+### Sync-completion webhook is a hook, not a dependency
+
+`sync.Engine.OnSyncComplete` is a function pointer the engine fires after each successful sync. The agent orchestrator wires itself up in `serve.go` — the engine itself has no knowledge of agents (no import cycle, no agents-subsystem coupling). When you add another post-sync responsibility, prefer extending the hook (or stacking another one) over importing the agent package into `internal/sync/`.
+
 ### Concurrency split
 
 - `RunNow` (manual trigger from HTTP): `ErrConcurrencyLocked` returns WITHOUT creating an `agent_runs` row. Caller maps to 503; user can retry without polluting history.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -63,6 +63,7 @@ Exit code 3 = no Anthropic credential; exit code 5 = sidecar binary not found.
 - **Per-agent caps**: `max_turns` and `max_budget_usd` on every definition.
 - **Global ceiling**: `agent.global_max_budget_usd` in Settings → Agents.
 - **Concurrency**: `agent.max_concurrent` (default 3 since iter-29; was 1 in iter-1 as a v1 safety net, lifted after the orchestrator's mint-and-revoke proved out under contention). Excess cron fires log as `skipped` rows; manual runs return 503 `CONCURRENCY_LOCKED`. Raise (or drop back to 1) in Settings → Agents.
+- **Triggers**: `cron` (schedule_cron), `manual` (Run now / API /run), and `webhook` (iter-30 — opt-in per agent via `trigger_on_sync_complete`, fires after every successful bank sync). The orchestrator surfaces the trigger on every run row so the history shows which path fired it.
 - **Scope**: per-agent `tool_scope` is `read_only` or `read_write`. Read-only agents mint a read-only API key that the MCP server rejects writes on.
 - **Mint-and-revoke**: every run gets a fresh, scoped API key named `agent:<slug>:<runShortID>`. It's revoked the instant the run completes (or errors).
 - **Encrypted at rest**: subscription tokens and API keys are AES-256-GCM encrypted in `app_config`. The full value never leaves the server after you save it — `GET /api/v1/agents/settings` returns a masked display string.

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -21,35 +21,37 @@ import (
 // --- Request envelopes ---
 
 type createAgentRequest struct {
-	Name            string   `json:"name"`
-	Slug            string   `json:"slug"`
-	Prompt          string   `json:"prompt"`
-	SystemPrompt    *string  `json:"system_prompt"`
-	ScheduleCron    *string  `json:"schedule_cron"`
-	ToolScope       string   `json:"tool_scope"`
-	AllowedTools    []string `json:"allowed_tools"`
-	Model           string   `json:"model"`
-	MaxTurns        int      `json:"max_turns"`
-	MaxBudgetUSD    *float64 `json:"max_budget_usd"`
-	Enabled         bool     `json:"enabled"`
-	QuietHoursStart *string  `json:"quiet_hours_start"`
-	QuietHoursEnd   *string  `json:"quiet_hours_end"`
+	Name                  string   `json:"name"`
+	Slug                  string   `json:"slug"`
+	Prompt                string   `json:"prompt"`
+	SystemPrompt          *string  `json:"system_prompt"`
+	ScheduleCron          *string  `json:"schedule_cron"`
+	ToolScope             string   `json:"tool_scope"`
+	AllowedTools          []string `json:"allowed_tools"`
+	Model                 string   `json:"model"`
+	MaxTurns              int      `json:"max_turns"`
+	MaxBudgetUSD          *float64 `json:"max_budget_usd"`
+	Enabled               bool     `json:"enabled"`
+	QuietHoursStart       *string  `json:"quiet_hours_start"`
+	QuietHoursEnd         *string  `json:"quiet_hours_end"`
+	TriggerOnSyncComplete bool     `json:"trigger_on_sync_complete"`
 }
 
 type updateAgentRequest struct {
-	Name            *string   `json:"name"`
-	Slug            *string   `json:"slug"`
-	Prompt          *string   `json:"prompt"`
-	SystemPrompt    *string   `json:"system_prompt"`
-	ScheduleCron    *string   `json:"schedule_cron"`
-	ToolScope       *string   `json:"tool_scope"`
-	AllowedTools    *[]string `json:"allowed_tools"`
-	Model           *string   `json:"model"`
-	MaxTurns        *int      `json:"max_turns"`
-	MaxBudgetUSD    *float64  `json:"max_budget_usd"`
-	Enabled         *bool     `json:"enabled"`
-	QuietHoursStart *string   `json:"quiet_hours_start"`
-	QuietHoursEnd   *string   `json:"quiet_hours_end"`
+	Name                  *string   `json:"name"`
+	Slug                  *string   `json:"slug"`
+	Prompt                *string   `json:"prompt"`
+	SystemPrompt          *string   `json:"system_prompt"`
+	ScheduleCron          *string   `json:"schedule_cron"`
+	ToolScope             *string   `json:"tool_scope"`
+	AllowedTools          *[]string `json:"allowed_tools"`
+	Model                 *string   `json:"model"`
+	MaxTurns              *int      `json:"max_turns"`
+	MaxBudgetUSD          *float64  `json:"max_budget_usd"`
+	Enabled               *bool     `json:"enabled"`
+	QuietHoursStart       *string   `json:"quiet_hours_start"`
+	QuietHoursEnd         *string   `json:"quiet_hours_end"`
+	TriggerOnSyncComplete *bool     `json:"trigger_on_sync_complete"`
 }
 
 type updateAgentSettingsRequest struct {
@@ -97,19 +99,20 @@ func CreateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 		out, err := svc.CreateAgentDefinition(r.Context(), service.CreateAgentDefinitionParams{
-			Name:            req.Name,
-			Slug:            req.Slug,
-			Prompt:          req.Prompt,
-			SystemPrompt:    req.SystemPrompt,
-			ScheduleCron:    req.ScheduleCron,
-			ToolScope:       req.ToolScope,
-			AllowedTools:    req.AllowedTools,
-			Model:           req.Model,
-			MaxTurns:        req.MaxTurns,
-			MaxBudgetUSD:    req.MaxBudgetUSD,
-			Enabled:         req.Enabled,
-			QuietHoursStart: req.QuietHoursStart,
-			QuietHoursEnd:   req.QuietHoursEnd,
+			Name:                  req.Name,
+			Slug:                  req.Slug,
+			Prompt:                req.Prompt,
+			SystemPrompt:          req.SystemPrompt,
+			ScheduleCron:          req.ScheduleCron,
+			ToolScope:             req.ToolScope,
+			AllowedTools:          req.AllowedTools,
+			Model:                 req.Model,
+			MaxTurns:              req.MaxTurns,
+			MaxBudgetUSD:          req.MaxBudgetUSD,
+			Enabled:               req.Enabled,
+			QuietHoursStart:       req.QuietHoursStart,
+			QuietHoursEnd:         req.QuietHoursEnd,
+			TriggerOnSyncComplete: req.TriggerOnSyncComplete,
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
@@ -137,19 +140,20 @@ func UpdateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 		out, err := svc.UpdateAgentDefinition(r.Context(), slug, service.UpdateAgentDefinitionParams{
-			Name:            req.Name,
-			Slug:            req.Slug,
-			Prompt:          req.Prompt,
-			SystemPrompt:    req.SystemPrompt,
-			ScheduleCron:    req.ScheduleCron,
-			ToolScope:       req.ToolScope,
-			AllowedTools:    req.AllowedTools,
-			Model:           req.Model,
-			MaxTurns:        req.MaxTurns,
-			MaxBudgetUSD:    req.MaxBudgetUSD,
-			Enabled:         req.Enabled,
-			QuietHoursStart: req.QuietHoursStart,
-			QuietHoursEnd:   req.QuietHoursEnd,
+			Name:                  req.Name,
+			Slug:                  req.Slug,
+			Prompt:                req.Prompt,
+			SystemPrompt:          req.SystemPrompt,
+			ScheduleCron:          req.ScheduleCron,
+			ToolScope:             req.ToolScope,
+			AllowedTools:          req.AllowedTools,
+			Model:                 req.Model,
+			MaxTurns:              req.MaxTurns,
+			MaxBudgetUSD:          req.MaxBudgetUSD,
+			Enabled:               req.Enabled,
+			QuietHoursStart:       req.QuietHoursStart,
+			QuietHoursEnd:         req.QuietHoursEnd,
+			TriggerOnSyncComplete: req.TriggerOnSyncComplete,
 		})
 		if err != nil {
 			writeAgentError(w, err, "agent not found")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -23,6 +23,7 @@ import (
 	"breadbox/internal/sync"
 	versionpkg "breadbox/internal/version"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/spf13/cobra"
 )
 
@@ -139,6 +140,12 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	agentOrch := service.NewOrchestrator(a.Service, agentSidecar, agentMaxConcurrent, cfg.EncryptionKey, logger)
 	agentSched := service.NewAgentScheduler(agentOrch, a.Service, logger)
 	agentOrch.AttachScheduler(agentSched)
+	// Wire the post-sync hook so trigger_on_sync_complete agents fire
+	// after every successful sync. The orchestrator dispatches asynchronously
+	// so the sync engine returns immediately.
+	a.SyncEngine.OnSyncComplete = func(ctx context.Context, _ pgtype.UUID) {
+		agentOrch.FireSyncCompleteAgents(ctx)
+	}
 	if err := agent.SeedDefaults(ctx, a.Queries, logger); err != nil {
 		logger.Warn("agent seed failed", "error", err)
 	}

--- a/internal/db/migrations/20260517122605_agent_definitions_trigger_on_sync_complete.sql
+++ b/internal/db/migrations/20260517122605_agent_definitions_trigger_on_sync_complete.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- trigger_on_sync_complete flips an agent into "fire after each successful
+-- sync" mode. Useful for keep-up agents like "re-categorize freshly synced
+-- transactions" — the operator wires the agent to a sync-finished event
+-- instead of (or in addition to) a cron schedule. Defaults to false so
+-- existing agents are unaffected; opt-in per definition via the v2 SPA
+-- edit form.
+ALTER TABLE agent_definitions
+    ADD COLUMN trigger_on_sync_complete BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Lookup index: post-sync hook reads "all enabled agents with this flag".
+CREATE INDEX agent_definitions_trigger_on_sync_complete_idx
+    ON agent_definitions (trigger_on_sync_complete)
+    WHERE trigger_on_sync_complete = TRUE AND enabled = TRUE;
+
+-- +goose Down
+DROP INDEX IF EXISTS agent_definitions_trigger_on_sync_complete_idx;
+ALTER TABLE agent_definitions
+    DROP COLUMN trigger_on_sync_complete;

--- a/internal/db/queries/agent_definitions.sql
+++ b/internal/db/queries/agent_definitions.sql
@@ -2,9 +2,9 @@
 INSERT INTO agent_definitions (
     name, slug, prompt, system_prompt, schedule_cron,
     tool_scope, allowed_tools, model, max_turns, max_budget_usd, enabled,
-    quiet_hours_start, quiet_hours_end
+    quiet_hours_start, quiet_hours_end, trigger_on_sync_complete
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 RETURNING *;
 
 -- name: GetAgentDefinition :one
@@ -27,22 +27,30 @@ ORDER BY created_at DESC;
 
 -- name: UpdateAgentDefinition :one
 UPDATE agent_definitions
-SET name              = $2,
-    slug              = $3,
-    prompt            = $4,
-    system_prompt     = $5,
-    schedule_cron     = $6,
-    tool_scope        = $7,
-    allowed_tools     = $8,
-    model             = $9,
-    max_turns         = $10,
-    max_budget_usd    = $11,
-    enabled           = $12,
-    quiet_hours_start = $13,
-    quiet_hours_end   = $14,
-    updated_at        = NOW()
+SET name                     = $2,
+    slug                     = $3,
+    prompt                   = $4,
+    system_prompt            = $5,
+    schedule_cron            = $6,
+    tool_scope               = $7,
+    allowed_tools            = $8,
+    model                    = $9,
+    max_turns                = $10,
+    max_budget_usd           = $11,
+    enabled                  = $12,
+    quiet_hours_start        = $13,
+    quiet_hours_end          = $14,
+    trigger_on_sync_complete = $15,
+    updated_at               = NOW()
 WHERE id = $1
 RETURNING *;
+
+-- name: ListAgentDefinitionsForSyncWebhook :many
+-- Used by the post-sync hook to find agents that should fire after a
+-- successful sync. Filtered by the partial index for cheap lookup.
+SELECT * FROM agent_definitions
+WHERE enabled = TRUE AND trigger_on_sync_complete = TRUE
+ORDER BY created_at DESC;
 
 -- name: SetAgentDefinitionEnabled :one
 UPDATE agent_definitions

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -109,6 +109,40 @@ func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse,
 	return o.runLocked(ctx, def, "manual", promptPrefix)
 }
 
+// FireSyncCompleteAgents dispatches a webhook-triggered run for every
+// agent definition with trigger_on_sync_complete=true. Called by the sync
+// engine's OnSyncComplete hook after a successful sync. Each agent fires
+// through RunOrSkip with trigger="webhook" so a busy semaphore leaves a
+// skipped row in the history rather than dropping the event silently.
+//
+// Runs each agent in its own goroutine so the sync engine returns
+// immediately. Concurrency is bounded by the orchestrator's existing
+// semaphore (iter-29 default: 3) — excess fires roll into skipped rows.
+func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
+	defs, err := o.svc.ListAgentDefinitionsForSyncWebhook(ctx)
+	if err != nil {
+		o.logger.Warn("orchestrator: list sync-webhook agents failed", "error", err)
+		return
+	}
+	if len(defs) == 0 {
+		return
+	}
+	o.logger.Info("orchestrator: dispatching sync-webhook agents",
+		"agent_count", len(defs))
+	for i := range defs {
+		def := defs[i] // capture range value before goroutine
+		go func() {
+			// New ctx with timeout so a stuck run doesn't outlive shutdown.
+			runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+			if _, rerr := o.RunOrSkip(runCtx, &def, "webhook"); rerr != nil {
+				o.logger.Warn("orchestrator: sync-webhook run failed",
+					"agent", def.Slug, "error", rerr)
+			}
+		}()
+	}
+}
+
 // RunOrSkip is the entry point for scheduled (cron) runs. Always leaves
 // a row in agent_runs — either completed/errored, or 'skipped' when the
 // semaphore was full. Returns ErrConcurrencyLocked alongside the skipped

--- a/internal/service/agent_webhook_trigger_test.go
+++ b/internal/service/agent_webhook_trigger_test.go
@@ -1,0 +1,107 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/service"
+)
+
+// TestFireSyncCompleteAgents_OnlyFiresEligible confirms the post-sync hook
+// dispatches the agents that opted in (enabled + trigger_on_sync_complete)
+// and ignores everyone else. Builds a mix of three agents:
+//   - one eligible (enabled=true, trigger_on_sync_complete=true)
+//   - one disabled (enabled=false, trigger_on_sync_complete=true)
+//   - one no-webhook (enabled=true, trigger_on_sync_complete=false)
+// Verifies exactly one run lands.
+func TestFireSyncCompleteAgents_OnlyFiresEligible(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+
+	enabledWebhook := mustCreateWebhookAgent(t, svc, "wh-enabled", true, true)
+	mustCreateWebhookAgent(t, svc, "wh-disabled", false, true)
+	mustCreateWebhookAgent(t, svc, "wh-cron-only", true, false)
+
+	fired := make(chan string, 4)
+	runner := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		fired <- spec.AgentDefinitionID
+		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
+	})
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+
+	orch.FireSyncCompleteAgents(context.Background())
+
+	// FireSyncCompleteAgents dispatches per-goroutine; give them a moment to
+	// land + complete.
+	deadline := time.After(2 * time.Second)
+	var got []string
+loop:
+	for {
+		select {
+		case agentID := <-fired:
+			got = append(got, agentID)
+		case <-time.After(150 * time.Millisecond):
+			break loop
+		case <-deadline:
+			break loop
+		}
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 webhook fire, got %d: %v", len(got), got)
+	}
+	if got[0] != enabledWebhook.ID {
+		t.Errorf("fired agent ID = %q, want %q (the enabled+webhook one)",
+			got[0], enabledWebhook.ID)
+	}
+}
+
+// TestFireSyncCompleteAgents_NoEligibleAgents_NoOp verifies the hook is
+// silent when no agents are configured for it. Confirms the cheap path
+// doesn't spawn goroutines or log noise.
+func TestFireSyncCompleteAgents_NoEligibleAgents_NoOp(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	mustCreateWebhookAgent(t, svc, "wh-none-cron", true, false)
+
+	fired := make(chan struct{}, 1)
+	runner := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		fired <- struct{}{}
+		return agent.RunResult{}, nil
+	})
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+
+	orch.FireSyncCompleteAgents(context.Background())
+
+	select {
+	case <-fired:
+		t.Fatal("runner fired for an agent that didn't opt in")
+	case <-time.After(200 * time.Millisecond):
+		// pass — no goroutines fired
+	}
+}
+
+func mustCreateWebhookAgent(t *testing.T, svc *service.Service, slug string, enabled, webhook bool) *service.AgentDefinitionResponse {
+	t.Helper()
+	def, err := svc.CreateAgentDefinition(context.Background(), service.CreateAgentDefinitionParams{
+		Name:                  strings.ToUpper(slug),
+		Slug:                  slug,
+		Prompt:                "Webhook test prompt for " + slug + " — needs >50 characters to pass validation, padding here.",
+		ToolScope:             "read_only",
+		AllowedTools:          []string{},
+		Model:                 "claude-haiku-4-5",
+		MaxTurns:              1,
+		Enabled:               enabled,
+		TriggerOnSyncComplete: webhook,
+	})
+	if err != nil {
+		t.Fatalf("create %s: %v", slug, err)
+	}
+	return def
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -52,10 +52,13 @@ type AgentDefinitionResponse struct {
 	Model           string           `json:"model"`
 	MaxTurns        int              `json:"max_turns"`
 	MaxBudgetUSD    *float64         `json:"max_budget_usd,omitempty"`
-	Enabled         bool             `json:"enabled"`
-	QuietHoursStart *string          `json:"quiet_hours_start,omitempty"`
-	QuietHoursEnd   *string          `json:"quiet_hours_end,omitempty"`
-	LastRun         *AgentRunSummary `json:"last_run,omitempty"`
+	Enabled               bool             `json:"enabled"`
+	QuietHoursStart       *string          `json:"quiet_hours_start,omitempty"`
+	QuietHoursEnd         *string          `json:"quiet_hours_end,omitempty"`
+	// TriggerOnSyncComplete fires this agent after every successful sync
+	// (in addition to any cron schedule). Disabled by default.
+	TriggerOnSyncComplete bool             `json:"trigger_on_sync_complete"`
+	LastRun               *AgentRunSummary `json:"last_run,omitempty"`
 	// CostStats30d is populated only by ListAgentDefinitions (the surface
 	// where users want to compare spend at a glance). Single-row
 	// GetAgentDefinition leaves it nil so the edit-page hot path doesn't
@@ -141,38 +144,55 @@ type AgentRunListResult struct {
 
 // CreateAgentDefinitionParams holds validated inputs for definition creation.
 type CreateAgentDefinitionParams struct {
-	Name            string
-	Slug            string
-	Prompt          string
-	SystemPrompt    *string
-	ScheduleCron    *string
-	ToolScope       string
-	AllowedTools    []string
-	Model           string
-	MaxTurns        int
-	MaxBudgetUSD    *float64
-	Enabled         bool
-	QuietHoursStart *string // "HH:MM" 24-hour; nil disables window
-	QuietHoursEnd   *string
+	Name                  string
+	Slug                  string
+	Prompt                string
+	SystemPrompt          *string
+	ScheduleCron          *string
+	ToolScope             string
+	AllowedTools          []string
+	Model                 string
+	MaxTurns              int
+	MaxBudgetUSD          *float64
+	Enabled               bool
+	QuietHoursStart       *string // "HH:MM" 24-hour; nil disables window
+	QuietHoursEnd         *string
+	TriggerOnSyncComplete bool // fire after each successful sync completes
 }
 
 // UpdateAgentDefinitionParams uses pointer fields for PATCH semantics:
 // nil = don't touch; non-nil = replace. Slug is mutable here; if you want
 // it pinned, omit Slug from your PATCH body.
 type UpdateAgentDefinitionParams struct {
-	Name            *string
-	Slug            *string
-	Prompt          *string
-	SystemPrompt    *string
-	ScheduleCron    *string
-	ToolScope       *string
-	AllowedTools    *[]string
-	Model           *string
-	MaxTurns        *int
-	MaxBudgetUSD    *float64
-	Enabled         *bool
-	QuietHoursStart *string
-	QuietHoursEnd   *string
+	Name                  *string
+	Slug                  *string
+	Prompt                *string
+	SystemPrompt          *string
+	ScheduleCron          *string
+	ToolScope             *string
+	AllowedTools          *[]string
+	Model                 *string
+	MaxTurns              *int
+	MaxBudgetUSD          *float64
+	Enabled               *bool
+	QuietHoursStart       *string
+	QuietHoursEnd         *string
+	TriggerOnSyncComplete *bool
+}
+
+// ListAgentDefinitionsForSyncWebhook returns enabled definitions with
+// trigger_on_sync_complete=true. Used by the post-sync hook in the
+// orchestrator to dispatch webhook-triggered runs.
+func (s *Service) ListAgentDefinitionsForSyncWebhook(ctx context.Context) ([]AgentDefinitionResponse, error) {
+	rows, err := s.Queries.ListAgentDefinitionsForSyncWebhook(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list sync-webhook agents: %w", err)
+	}
+	out := make([]AgentDefinitionResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, agentDefinitionFromRow(row, nil))
+	}
+	return out, nil
 }
 
 // ListAgentDefinitions returns all definitions ordered by created_at DESC,
@@ -304,19 +324,20 @@ func (s *Service) CreateAgentDefinition(ctx context.Context, p CreateAgentDefini
 		return nil, err
 	}
 	row, err := s.Queries.CreateAgentDefinition(ctx, db.CreateAgentDefinitionParams{
-		Name:            p.Name,
-		Slug:            p.Slug,
-		Prompt:          p.Prompt,
-		SystemPrompt:    pgconv.TextPtrIfNotEmpty(p.SystemPrompt),
-		ScheduleCron:    pgconv.TextPtrIfNotEmpty(p.ScheduleCron),
-		ToolScope:       toolScope,
-		AllowedTools:    allowedJSON,
-		Model:           model,
-		MaxTurns:        int32(maxTurns),
-		MaxBudgetUsd:    agentNumericFromFloat(budget),
-		Enabled:         p.Enabled,
-		QuietHoursStart: pgconv.TextPtrIfNotEmpty(p.QuietHoursStart),
-		QuietHoursEnd:   pgconv.TextPtrIfNotEmpty(p.QuietHoursEnd),
+		Name:                  p.Name,
+		Slug:                  p.Slug,
+		Prompt:                p.Prompt,
+		SystemPrompt:          pgconv.TextPtrIfNotEmpty(p.SystemPrompt),
+		ScheduleCron:          pgconv.TextPtrIfNotEmpty(p.ScheduleCron),
+		ToolScope:             toolScope,
+		AllowedTools:          allowedJSON,
+		Model:                 model,
+		MaxTurns:              int32(maxTurns),
+		MaxBudgetUsd:          agentNumericFromFloat(budget),
+		Enabled:               p.Enabled,
+		QuietHoursStart:       pgconv.TextPtrIfNotEmpty(p.QuietHoursStart),
+		QuietHoursEnd:         pgconv.TextPtrIfNotEmpty(p.QuietHoursEnd),
+		TriggerOnSyncComplete: p.TriggerOnSyncComplete,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create agent definition: %w", err)
@@ -374,6 +395,9 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 	if p.QuietHoursEnd != nil {
 		merged.QuietHoursEnd = emptyToNil(*p.QuietHoursEnd)
 	}
+	if p.TriggerOnSyncComplete != nil {
+		merged.TriggerOnSyncComplete = *p.TriggerOnSyncComplete
+	}
 
 	if err := validateAgentDefinitionFields(merged.Name, merged.Slug, merged.Prompt, merged.ToolScope, merged.Model, merged.MaxTurns, merged.MaxBudgetUSD, merged.ScheduleCron); err != nil {
 		return nil, err
@@ -392,20 +416,21 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 	}
 
 	row, err := s.Queries.UpdateAgentDefinition(ctx, db.UpdateAgentDefinitionParams{
-		ID:              existing.ID,
-		Name:            merged.Name,
-		Slug:            merged.Slug,
-		Prompt:          merged.Prompt,
-		SystemPrompt:    pgconv.TextPtrIfNotEmpty(merged.SystemPrompt),
-		ScheduleCron:    pgconv.TextPtrIfNotEmpty(merged.ScheduleCron),
-		ToolScope:       merged.ToolScope,
-		AllowedTools:    allowedJSON,
-		Model:           merged.Model,
-		MaxTurns:        int32(merged.MaxTurns),
-		MaxBudgetUsd:    agentNumericFromFloat(budget),
-		Enabled:         merged.Enabled,
-		QuietHoursStart: pgconv.TextPtrIfNotEmpty(merged.QuietHoursStart),
-		QuietHoursEnd:   pgconv.TextPtrIfNotEmpty(merged.QuietHoursEnd),
+		ID:                    existing.ID,
+		Name:                  merged.Name,
+		Slug:                  merged.Slug,
+		Prompt:                merged.Prompt,
+		SystemPrompt:          pgconv.TextPtrIfNotEmpty(merged.SystemPrompt),
+		ScheduleCron:          pgconv.TextPtrIfNotEmpty(merged.ScheduleCron),
+		ToolScope:             merged.ToolScope,
+		AllowedTools:          allowedJSON,
+		Model:                 merged.Model,
+		MaxTurns:              int32(merged.MaxTurns),
+		MaxBudgetUsd:          agentNumericFromFloat(budget),
+		Enabled:               merged.Enabled,
+		QuietHoursStart:       pgconv.TextPtrIfNotEmpty(merged.QuietHoursStart),
+		QuietHoursEnd:         pgconv.TextPtrIfNotEmpty(merged.QuietHoursEnd),
+		TriggerOnSyncComplete: merged.TriggerOnSyncComplete,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update agent definition: %w", err)
@@ -921,9 +946,10 @@ func agentDefinitionFromRow(row db.AgentDefinition, lastRun *AgentRunSummary) Ag
 		MaxTurns:        int(row.MaxTurns),
 		MaxBudgetUSD:    agentFloatFromNumeric(row.MaxBudgetUsd),
 		Enabled:         row.Enabled,
-		QuietHoursStart: pgconv.TextPtr(row.QuietHoursStart),
-		QuietHoursEnd:   pgconv.TextPtr(row.QuietHoursEnd),
-		LastRun:         lastRun,
+		QuietHoursStart:       pgconv.TextPtr(row.QuietHoursStart),
+		QuietHoursEnd:         pgconv.TextPtr(row.QuietHoursEnd),
+		TriggerOnSyncComplete: row.TriggerOnSyncComplete,
+		LastRun:               lastRun,
 		CreatedAt:       pgconv.TimestampStr(row.CreatedAt),
 		UpdatedAt:       pgconv.TimestampStr(row.UpdatedAt),
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -60,6 +60,13 @@ type Engine struct {
 	locks             gosync.Map // connection ID string -> *gosync.Mutex
 	matcher           *Matcher
 	balanceRetryDelay time.Duration // delay between balance fetch retries (default 2s)
+
+	// OnSyncComplete fires after each SUCCESSFUL sync. Wired by the app
+	// layer to dispatch agent-runs that have trigger_on_sync_complete=true.
+	// Nil-safe — engine ignores when unset. Called with the connection's UUID
+	// so the hook can correlate; runs in the same goroutine as Sync so the
+	// hook should hand off async if it might block.
+	OnSyncComplete func(ctx context.Context, connectionID pgtype.UUID)
 }
 
 // NewEngine creates a new sync engine.
@@ -155,6 +162,13 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	logger.Info("sync completed", "added", added, "modified", modified, "removed", removed, "unchanged", unchanged)
+
+	// Post-sync hook: agent webhook triggers, matcher reconciliation, etc.
+	// Engine doesn't know what's wired here — it's the app layer's job to
+	// keep the hook fast (or hand off to a goroutine).
+	if e.OnSyncComplete != nil {
+		e.OnSyncComplete(ctx, connectionID)
+	}
 	return nil
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2385,7 +2385,12 @@ paths:
     post:
       tags: [Agents]
       summary: Create agent definition
-      description: Creates a Claude Agent SDK definition. **Requires `full_access` scope.**
+      description: |
+        Creates a Claude Agent SDK definition. Body includes the usual
+        `name`, `slug`, `prompt`, `model`, `max_turns`, `max_budget_usd`,
+        `tool_scope`, `allowed_tools`, `schedule_cron`, and the iter-30
+        `trigger_on_sync_complete` flag (fire after every successful
+        sync, in addition to any cron schedule). **Requires `full_access` scope.**
       requestBody:
         required: true
         content:

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -46,6 +46,8 @@ export interface AgentDefinition {
   next_fire_at?: string | null; // RFC3339; nil when no schedule, disabled, or unparseable
   recent_error_stats?: AgentRecentErrorStats | null;
   last_prompt_prefix?: string | null; // most recent non-null prompt_prefix; powers "Use last prefix"
+  trigger_on_sync_complete: boolean; // fire after every successful sync
+
   created_at: string;
   updated_at: string;
 }
@@ -115,6 +117,7 @@ export interface CreateAgentInput {
   enabled?: boolean;
   quiet_hours_start?: string | null;
   quiet_hours_end?: string | null;
+  trigger_on_sync_complete?: boolean;
 }
 
 export type UpdateAgentInput = Partial<CreateAgentInput>;

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -65,6 +65,7 @@ const agentEditSchema = z.object({
     .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
     .optional()
     .or(z.literal("")),
+  trigger_on_sync_complete: z.boolean(),
 });
 type AgentEditForm = z.input<typeof agentEditSchema>;
 
@@ -88,6 +89,7 @@ export function AgentEditPage() {
       max_budget_usd: null,
       quiet_hours_start: "",
       quiet_hours_end: "",
+      trigger_on_sync_complete: false,
     },
   });
 
@@ -108,6 +110,7 @@ export function AgentEditPage() {
       max_budget_usd: agent.max_budget_usd ?? null,
       quiet_hours_start: agent.quiet_hours_start ?? "",
       quiet_hours_end: agent.quiet_hours_end ?? "",
+      trigger_on_sync_complete: agent.trigger_on_sync_complete,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentQuery.data?.short_id]);
@@ -135,6 +138,7 @@ export function AgentEditPage() {
           quiet_hours_end: values.quiet_hours_end
             ? values.quiet_hours_end
             : null,
+          trigger_on_sync_complete: values.trigger_on_sync_complete,
         }),
       {
         success: "Agent saved",
@@ -421,6 +425,34 @@ export function AgentEditPage() {
                     )}
                   />
                 </div>
+                <FormField
+                  control={form.control}
+                  name="trigger_on_sync_complete"
+                  render={({ field }) => (
+                    <FormItem className="mt-4 flex items-start gap-3 rounded-md border p-3">
+                      <FormControl>
+                        <input
+                          type="checkbox"
+                          className="mt-1 size-4"
+                          checked={field.value}
+                          onChange={(e) => field.onChange(e.target.checked)}
+                        />
+                      </FormControl>
+                      <div className="space-y-1">
+                        <FormLabel className="font-medium">
+                          Run after every successful sync
+                        </FormLabel>
+                        <FormDescription>
+                          Fires this agent (trigger=webhook) whenever a bank
+                          sync completes. Useful for keep-up agents like
+                          "re-categorize freshly synced transactions" — pairs
+                          with cron OR replaces it.
+                        </FormDescription>
+                        <FormMessage />
+                      </div>
+                    </FormItem>
+                  )}
+                />
               </Card>
 
               <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary

Iteration 30 — the biggest remaining capability. Per-agent opt-in flag `trigger_on_sync_complete` makes an agent fire (trigger=`webhook`) every time a bank sync finishes successfully, in addition to (or instead of) any cron schedule.

Useful for keep-up agents like "re-categorize freshly synced transactions" so the SPA is fresh without waiting for the next cron tick.

## What's in

- **Migration** `20260517122605`: `agent_definitions.trigger_on_sync_complete BOOLEAN NOT NULL DEFAULT FALSE` + a partial index on (enabled, flag) so the post-sync lookup is cheap.
- **sqlc**: `CreateAgentDefinition` + `UpdateAgentDefinition` extended; new `ListAgentDefinitionsForSyncWebhook` query.
- **Service**: `CreateAgentDefinitionParams` + `UpdateAgentDefinitionParams` + `AgentDefinitionResponse` all carry `TriggerOnSyncComplete`. New `Service.ListAgentDefinitionsForSyncWebhook` helper.
- **Orchestrator**: new `FireSyncCompleteAgents(ctx)` — fetches eligible defs, dispatches each as a webhook trigger via `RunOrSkip` in its own goroutine. Bounded by the existing semaphore (default 3 since iter-29); excess fires roll into skipped rows. 10-minute context timeout per dispatched run.
- **Sync engine**: new `OnSyncComplete func(ctx, connectionID)` hook fired from `Sync()` after a successful pass. Engine doesn't import the agent subsystem — `serve.go` wires the hook to `agentOrch.FireSyncCompleteAgents`. New rule in `.claude/rules/agents.md` documents the no-import-cycle invariant.
- **API**: `createAgentRequest` + `updateAgentRequest` carry the new field; handlers propagate.
- **SPA**: `AgentDefinition` + `CreateAgentInput` surface `trigger_on_sync_complete`; agent edit page renders a labeled checkbox under the quiet-hours card. Form hydrates + persists.
- **openapi.yaml** + **docs/agents.md** updated.
- **2 new integration tests**:
  1. `OnlyFiresEligible`: mix of enabled+webhook / disabled+webhook / enabled+no-webhook → only the first fires
  2. `NoEligibleAgents_NoOp`: hook is silent when no agents are configured for it

## Design notes

- **Hook over import.** `internal/sync` stays agent-unaware. Adding more post-sync responsibilities (notifications, metrics) extends the hook the same way.
- **Webhook trigger (not "cron-like").** Excess fires land as skipped rows in the run history so the audit trail shows what was missed vs what dropped.
- **Per-agent flag (not a global toggle).** One agent can be webhook-only while another stays cron-only; mixing is fine.
- **Partial index.** The lookup is "enabled AND flag" — partial keeps the index small even as agents accumulate.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new `FireSyncCompleteAgents` integration tests pass
- [x] All 30+ existing agent tests still pass
- [x] OpenAPI drift test green
- [x] `bun run lint` + `bun run build` clean

## Screenshot

Not included this round — the checkbox is a single labeled control under the existing quiet-hours card on `/v2/agents/<slug>/edit`. No new layout; the structural change is the new orchestrator/sync-engine wiring (covered by tests).

## Deferred

- "Webhook" filter chip on the run history page — small follow-up (the `trigger` column already exists, just needs a chip option).
- Pause-aware semantics: paused connection skips the post-sync hook automatically because its sync never completes. Same for failed syncs (hook fires only on the success path). Worth a follow-up doc note if dogfooding reveals confusion.
