### PR TITLE
fix(agents): list runs scan was missing operator_note/prompt_prefix/hit_cap + add hit_cap filter

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -267,7 +267,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; optional `{prompt_prefix}` body prepends per-run context (≤2000 chars); 503 `CONCURRENCY_LOCKED` when another run is in progress |
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | POST | `/agents/cleanup` | W | Run the agent cleanup pass on demand; returns `{runs_deleted, transcripts_deleted, transcripts_scanned, retention_days, transcript_dir}` |
-| GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200) |
+| GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200); filters: `status`, `trigger`, `hit_cap` (`max_turns`/`max_budget`/`any`), `start`, `end` |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | PATCH | `/agents/runs/{shortId}` | W | Set/clear the operator note on a run. Body `{ "note": "..." }`; empty string clears. Capped at 2000 chars |
 | GET | `/agents/runs/{shortId}/transcript` | R | Streams the NDJSON transcript; 404 when not yet written |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -220,6 +220,7 @@ func ListAgentRunsHandler(svc *service.Service) http.HandlerFunc {
 			Offset:  offset,
 			Status:  q.Get("status"),
 			Trigger: q.Get("trigger"),
+			HitCap:  q.Get("hit_cap"),
 		}
 		if s := q.Get("start"); s != "" {
 			t, perr := parseDateOrRFC3339(s)
@@ -252,6 +253,11 @@ func ListAgentRunsHandler(svc *service.Service) http.HandlerFunc {
 				"trigger must be one of: cron, manual, webhook (empty = all)")
 			return
 		}
+		if !isAllowedRunHitCap(params.HitCap) {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"hit_cap must be one of: max_turns, max_budget, any (empty = all)")
+			return
+		}
 		out, err := svc.ListAgentRuns(r.Context(), slug, params)
 		if err != nil {
 			writeAgentError(w, err, "agent not found")
@@ -271,6 +277,14 @@ func parseDateOrRFC3339(s string) (time.Time, error) {
 func isAllowedRunStatus(s string) bool {
 	switch s {
 	case "", "success", "error", "in_progress", "skipped", "timeout":
+		return true
+	}
+	return false
+}
+
+func isAllowedRunHitCap(s string) bool {
+	switch s {
+	case "", "max_turns", "max_budget", "any":
 		return true
 	}
 	return false

--- a/internal/service/agent_runs_filter_test.go
+++ b/internal/service/agent_runs_filter_test.go
@@ -1,0 +1,130 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestListAgentRuns_ScansNewColumns is a regression test for an iter-22
+// through iter-27 bug: ListAgentRuns' hand-rolled SELECT was missing
+// operator_note, prompt_prefix, and hit_cap, so the v2 SPA run history
+// never showed those pills even when the underlying row had them. The
+// fix landed in iter-31 (this iteration); this test pins it.
+func TestListAgentRuns_ScansNewColumns(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	def := mustCreateAgentDefinition(t, svc, "list-scan-fix", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+
+	// Seed one run with all three of the previously-missing fields set.
+	mustInsertCompletedRun(t, q, defUUID, "0.05")
+	// Backfill the new fields on the latest row.
+	row, err := q.GetLatestAgentRun(ctx, defUUID)
+	if err != nil {
+		t.Fatalf("get latest: %v", err)
+	}
+	if err := q.SetAgentRunPromptPrefix(ctx, db.SetAgentRunPromptPrefixParams{
+		ID:           row.ID,
+		PromptPrefix: pgtype.Text{String: "iter-23 prefix payload", Valid: true},
+	}); err != nil {
+		t.Fatalf("set prefix: %v", err)
+	}
+	if _, err := q.SetAgentRunNote(ctx, db.SetAgentRunNoteParams{
+		ID:           row.ID,
+		OperatorNote: pgtype.Text{String: "iter-22 note payload", Valid: true},
+	}); err != nil {
+		t.Fatalf("set note: %v", err)
+	}
+	if _, err := q.SetAgentRunHitCap(ctx, db.SetAgentRunHitCapParams{
+		ID:     row.ID,
+		HitCap: pgtype.Text{String: "max_turns", Valid: true},
+	}); err != nil {
+		t.Fatalf("set hit_cap: %v", err)
+	}
+
+	list, err := svc.ListAgentRuns(ctx, def.Slug, service.AgentRunListParams{})
+	if err != nil {
+		t.Fatalf("ListAgentRuns: %v", err)
+	}
+	if len(list.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(list.Runs))
+	}
+	got := list.Runs[0]
+	if got.PromptPrefix == nil || *got.PromptPrefix != "iter-23 prefix payload" {
+		t.Errorf("PromptPrefix from list = %v, want \"iter-23 prefix payload\"", got.PromptPrefix)
+	}
+	if got.OperatorNote == nil || *got.OperatorNote != "iter-22 note payload" {
+		t.Errorf("OperatorNote from list = %v, want \"iter-22 note payload\"", got.OperatorNote)
+	}
+	if got.HitCap == nil || *got.HitCap != "max_turns" {
+		t.Errorf("HitCap from list = %v, want \"max_turns\"", got.HitCap)
+	}
+}
+
+// TestListAgentRuns_HitCapFilter exercises the new hit_cap filter param.
+// Seeds a mix of runs (clean, max_turns, max_budget) and verifies each
+// filter mode (specific value, "any", and empty=all) returns the right
+// subset.
+func TestListAgentRuns_HitCapFilter(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	def := mustCreateAgentDefinition(t, svc, "list-hitcap", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+
+	// Three runs: clean, max_turns, max_budget. Order matters for the
+	// scan ordering check (DESC by started_at).
+	mustInsertCompletedRun(t, q, defUUID, "0.01") // clean
+	cleanRow, _ := q.GetLatestAgentRun(ctx, defUUID)
+
+	mustInsertCompletedRun(t, q, defUUID, "0.01")
+	maxTurnsRow, _ := q.GetLatestAgentRun(ctx, defUUID)
+	if _, err := q.SetAgentRunHitCap(ctx, db.SetAgentRunHitCapParams{
+		ID:     maxTurnsRow.ID,
+		HitCap: pgtype.Text{String: "max_turns", Valid: true},
+	}); err != nil {
+		t.Fatalf("set max_turns cap: %v", err)
+	}
+
+	mustInsertCompletedRun(t, q, defUUID, "0.01")
+	budgetRow, _ := q.GetLatestAgentRun(ctx, defUUID)
+	if _, err := q.SetAgentRunHitCap(ctx, db.SetAgentRunHitCapParams{
+		ID:     budgetRow.ID,
+		HitCap: pgtype.Text{String: "max_budget", Valid: true},
+	}); err != nil {
+		t.Fatalf("set max_budget cap: %v", err)
+	}
+	_ = cleanRow // (silence unused — useful for debugging assertions if they fail)
+
+	cases := []struct {
+		name      string
+		filter    string
+		wantCount int
+	}{
+		{"empty filter returns all 3", "", 3},
+		{"any returns 2 capped runs", "any", 2},
+		{"max_turns returns 1", "max_turns", 1},
+		{"max_budget returns 1", "max_budget", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			list, err := svc.ListAgentRuns(ctx, def.Slug, service.AgentRunListParams{
+				HitCap: tc.filter,
+			})
+			if err != nil {
+				t.Fatalf("ListAgentRuns: %v", err)
+			}
+			if len(list.Runs) != tc.wantCount {
+				t.Errorf("got %d runs, want %d (filter=%q)",
+					len(list.Runs), tc.wantCount, tc.filter)
+			}
+		})
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -483,6 +483,7 @@ type AgentRunListParams struct {
 	Offset  int
 	Status  string // "" | "success" | "error" | "in_progress" | "skipped" | "timeout"
 	Trigger string // "" | "cron" | "manual" | "webhook"
+	HitCap  string // "" | "max_turns" | "max_budget" | "any"
 	// Start / End are inclusive bounds on started_at. RFC3339 or YYYY-MM-DD
 	// values from the API layer get parsed at the handler boundary.
 	Start *time.Time
@@ -519,6 +520,16 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 		args = append(args, p.Trigger)
 		idx++
 	}
+	switch p.HitCap {
+	case "max_turns", "max_budget":
+		where = append(where, fmt.Sprintf("hit_cap = $%d", idx))
+		args = append(args, p.HitCap)
+		idx++
+	case "any":
+		where = append(where, "hit_cap IS NOT NULL")
+	case "":
+		// no-op
+	}
 	if p.Start != nil {
 		where = append(where, fmt.Sprintf("started_at >= $%d", idx))
 		args = append(args, *p.Start)
@@ -536,7 +547,8 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 		SELECT id, short_id, agent_definition_id, "trigger", status, started_at, completed_at,
 		       duration_ms, total_cost_usd, input_tokens, output_tokens, cache_read_tokens,
 		       cache_creation_tokens, turn_count, max_turns_used, num_tool_calls,
-		       error_message, transcript_path, session_id
+		       error_message, transcript_path, session_id,
+		       operator_note, prompt_prefix, hit_cap
 		FROM agent_runs
 		WHERE %s
 		ORDER BY started_at DESC
@@ -558,6 +570,7 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens,
 			&r.CacheCreationTokens, &r.TurnCount, &r.MaxTurnsUsed,
 			&r.NumToolCalls, &r.ErrorMessage, &r.TranscriptPath, &r.SessionID,
+			&r.OperatorNote, &r.PromptPrefix, &r.HitCap,
 		); scanErr != nil {
 			return nil, fmt.Errorf("scan agent run: %w", scanErr)
 		}

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -231,6 +231,7 @@ export function useRunAgentNow() {
 export interface AgentRunsFilters {
   status?: string; // "" | "success" | "error" | "in_progress" | "skipped" | "timeout"
   trigger?: string; // "" | "cron" | "manual" | "webhook"
+  hit_cap?: string; // "" | "max_turns" | "max_budget" | "any"
   start?: string; // YYYY-MM-DD or RFC3339
   end?: string;
 }
@@ -249,6 +250,7 @@ export function useAgentRuns(
       qs.set("offset", String(offset));
       if (filters.status) qs.set("status", filters.status);
       if (filters.trigger) qs.set("trigger", filters.trigger);
+      if (filters.hit_cap) qs.set("hit_cap", filters.hit_cap);
       if (filters.start) qs.set("start", filters.start);
       if (filters.end) qs.set("end", filters.end);
       return api<AgentRunListResult>(

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -57,6 +57,7 @@ export const agentRunsSearchSchema = z.object({
     .enum(["success", "error", "in_progress", "skipped", "timeout"])
     .optional(),
   trigger: z.enum(["cron", "manual", "webhook"]).optional(),
+  hit_cap: z.enum(["max_turns", "max_budget", "any"]).optional(),
   start: z.string().optional(),
   end: z.string().optional(),
 });
@@ -75,11 +76,12 @@ export function AgentRunsPage() {
   const filters: AgentRunsFilters = {
     status: search.status ?? "",
     trigger: search.trigger ?? "",
+    hit_cap: search.hit_cap ?? "",
     start: search.start,
     end: search.end,
   };
   const hasActiveFilters = Boolean(
-    search.status || search.trigger || search.start || search.end,
+    search.status || search.trigger || search.hit_cap || search.start || search.end,
   );
 
   const setFilter = (patch: Partial<AgentRunsSearch>) => {
@@ -99,6 +101,7 @@ export function AgentRunsPage() {
         ...prev,
         status: undefined,
         trigger: undefined,
+        hit_cap: undefined,
         start: undefined,
         end: undefined,
         page: undefined,
@@ -180,6 +183,23 @@ export function AgentRunsPage() {
             <SelectItem value="cron">Cron</SelectItem>
             <SelectItem value="manual">Manual</SelectItem>
             <SelectItem value="webhook">Webhook</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={search.hit_cap ?? ANY_VALUE}
+          onValueChange={(v) =>
+            setFilter({ hit_cap: v === ANY_VALUE ? undefined : (v as AgentRunsSearch["hit_cap"]) })
+          }
+        >
+          <SelectTrigger size="sm" className="w-40">
+            <SelectValue placeholder="All caps" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ANY_VALUE}>Any cap state</SelectItem>
+            <SelectItem value="any">Hit any cap</SelectItem>
+            <SelectItem value="max_turns">Hit max turns</SelectItem>
+            <SelectItem value="max_budget">Over budget</SelectItem>
           </SelectContent>
         </Select>
 


### PR DESCRIPTION
## Summary

Iteration 31 — bug fix bundled with the natural follow-up.

**The bug**: `ListAgentRuns`' hand-rolled SELECT had been frozen since iter-3, but `agent_runs` picked up new columns in iter-22 (`operator_note`), iter-23 (`prompt_prefix`), and iter-27 (`hit_cap`). The scan didn't pull those columns, so the v2 SPA history page **never surfaced their pills** even though every record was correctly populated and the single-row `GetAgentRun` path did show them. Operators looking at the run list were silently missing audit signal.

**The follow-up**: closes iter-27 + iter-30 deferred items by adding a `hit_cap` filter chip on the run history page (the `trigger=webhook` chip already shipped via iter-30's schema, the dropdown option just landed unused).

## What's in

- **Bug fix** — `ListAgentRuns` SELECT + scan extended to include `operator_note`, `prompt_prefix`, `hit_cap`. Three columns at the end of the projection; same conversion path via `agentRunFromRow` that `GetAgentRun` already used.
- **New filter** — `AgentRunListParams.HitCap` accepts `""` | `"max_turns"` | `"max_budget"` | `"any"`. `"any"` maps to `hit_cap IS NOT NULL` so operators can pull every capped run in one click; the two specific values drill down.
- **API** — handler accepts `hit_cap` query param; new `isAllowedRunHitCap` validator; 400 `INVALID_PARAMETER` on bad values.
- **SPA** — typed for `hit_cap`. New Select chip on the run history page between Trigger and the date range. Clear-all wipes it too.
- **2 new integration tests** (5 sub-cases total):
  1. `ListAgentRuns_ScansNewColumns` — the regression test. Seeds all three previously-missing fields, asserts they surface through the list path.
  2. `ListAgentRuns_HitCapFilter` — covers all four filter modes (`""`, `"any"`, `"max_turns"`, `"max_budget"`) against a mixed seed.
- **docs/api-endpoints.md** row updated to list the new filter and the existing ones (status/trigger/start/end) for discoverability.

## Design notes

- **Bug fix gets the dominant share of the PR.** The follow-on filter is the natural close to iter-27's deferred chip; bundling avoids a one-line iter-32.
- **`"any"` filter, not just per-cap.** Operators usually want "show me the broken runs," not "show me the budget-exceeded runs specifically." The per-cap values stay for drilldown.
- **Backend-side filter, not client-side.** The page is offset-paginated; client-side filtering would silently miss capped runs past the first page.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 5 new sub-tests (1 regression + 4 filter modes) pass
- [x] All 30+ existing agent tests still pass
- [x] OpenAPI drift test green
- [x] `bun run lint` + `bun run build` clean
