### PR TITLE
feat(agents): aggregate "recent caps hit" pill on /v2/agents list

### DIFF
--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -60,6 +60,30 @@ SET status        = 'skipped',
     error_message = $2
 WHERE id = $1;
 
+-- name: GetAgentRecentCapStats :many
+-- Per-definition "is this agent regularly hitting its safety ceilings?"
+-- signal: count of runs in the last 5 non-skipped that had hit_cap set
+-- (either max_turns OR max_budget). Mirrors GetAgentRecentErrorStats —
+-- the v2 SPA list page renders a warning pill at 2+ recent cap hits so
+-- the operator knows to raise max_turns / max_budget_usd or split the
+-- prompt.
+WITH ranked AS (
+    SELECT agent_definition_id, hit_cap,
+           ROW_NUMBER() OVER (
+               PARTITION BY agent_definition_id
+               ORDER BY started_at DESC
+           ) AS rn
+    FROM agent_runs
+    WHERE agent_definition_id IS NOT NULL
+      AND status != 'skipped'
+)
+SELECT agent_definition_id,
+       COUNT(*) FILTER (WHERE hit_cap IS NOT NULL)::int AS cap_count,
+       COUNT(*)::int                                     AS run_count
+FROM ranked
+WHERE rn <= 5
+GROUP BY agent_definition_id;
+
 -- name: GetAgentRecentErrorStats :many
 -- Per-definition "is this agent broken right now?" signal: error count
 -- in the last 5 non-skipped runs. Skipped runs (quiet hours, concurrency

--- a/internal/service/agent_recent_cap_test.go
+++ b/internal/service/agent_recent_cap_test.go
@@ -1,0 +1,115 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestListAgentDefinitions_PopulatesRecentCapStats pins the iter-32
+// aggregate rollup: the list response carries recent_cap_stats based on
+// the last 5 non-skipped runs, with skipped rows excluded. Seeds a mix
+// of clean, capped, and skipped runs and verifies the totals.
+func TestListAgentDefinitions_PopulatesRecentCapStats(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	def := mustCreateAgentDefinition(t, svc, "svc-cap-stats", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+
+	// 4 non-skipped runs: 2 capped, 2 clean. Plus 1 skipped (should not
+	// affect the count or window).
+	for i := 0; i < 4; i++ {
+		mustInsertCompletedRun(t, q, defUUID, "0.01")
+	}
+	mustInsertSkippedRun(t, q, defUUID)
+
+	// Mark the two most-recent rows as capped.
+	rows, err := q.ListAgentRuns(ctx, db.ListAgentRunsParams{
+		AgentDefinitionID: defUUID,
+		Limit:             5,
+		Offset:            0,
+	})
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(rows) < 4 {
+		t.Fatalf("expected >=4 rows, got %d", len(rows))
+	}
+	// Skip any skipped row when marking caps.
+	capped := 0
+	for _, r := range rows {
+		if r.Status == "skipped" {
+			continue
+		}
+		if capped >= 2 {
+			break
+		}
+		if _, err := q.SetAgentRunHitCap(ctx, db.SetAgentRunHitCapParams{
+			ID:     r.ID,
+			HitCap: pgtype.Text{String: "max_turns", Valid: true},
+		}); err != nil {
+			t.Fatalf("set hit_cap: %v", err)
+		}
+		capped++
+	}
+
+	list, err := svc.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("list defs: %v", err)
+	}
+	for i := range list {
+		if list[i].Slug != def.Slug {
+			continue
+		}
+		got := list[i].RecentCapStats
+		if got == nil {
+			t.Fatal("RecentCapStats nil, want non-nil")
+		}
+		if got.CapCount != 2 {
+			t.Errorf("CapCount = %d, want 2", got.CapCount)
+		}
+		// 4 non-skipped runs; window is last 5 so all 4 are eligible.
+		if got.RunCount != 4 {
+			t.Errorf("RunCount = %d, want 4 (skipped excluded)", got.RunCount)
+		}
+		return
+	}
+	t.Fatal("created agent missing from list response")
+}
+
+// TestListAgentDefinitions_RecentCapStats_NoCapped_LeavesZero verifies
+// agents with no cap-exhausted runs surface cap_count=0 (not nil) so the
+// SPA threshold check works the same way regardless of history depth.
+func TestListAgentDefinitions_RecentCapStats_NoCapped_LeavesZero(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	def := mustCreateAgentDefinition(t, svc, "svc-cap-none", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+
+	mustInsertCompletedRun(t, q, defUUID, "0.01")
+
+	list, err := svc.ListAgentDefinitions(ctx)
+	if err != nil {
+		t.Fatalf("list defs: %v", err)
+	}
+	for i := range list {
+		if list[i].Slug != def.Slug {
+			continue
+		}
+		if list[i].RecentCapStats == nil {
+			t.Fatal("expected RecentCapStats non-nil (with cap_count=0) once history exists")
+		}
+		if list[i].RecentCapStats.CapCount != 0 {
+			t.Errorf("CapCount = %d, want 0", list[i].RecentCapStats.CapCount)
+		}
+		return
+	}
+	t.Fatal("created agent missing from list response")
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -76,6 +76,10 @@ type AgentDefinitionResponse struct {
 	// was ever run with. Powers the "Use last prefix" affordance in the v2
 	// SPA's Run now dialog. List-only; nil when no prefixed run exists.
 	LastPromptPrefix *string `json:"last_prompt_prefix,omitempty"`
+	// RecentCapStats is the count of cap-exhausted runs among the last 5
+	// non-skipped runs. Used by the v2 SPA to surface a warning when 2+
+	// recent runs hit a safety ceiling. List-only; nil when no run history.
+	RecentCapStats *AgentRecentCapStats `json:"recent_cap_stats,omitempty"`
 	CreatedAt        string  `json:"created_at"`
 	UpdatedAt        string  `json:"updated_at"`
 }
@@ -85,6 +89,15 @@ type AgentDefinitionResponse struct {
 type AgentRecentErrorStats struct {
 	ErrorCount int `json:"error_count"`
 	RunCount   int `json:"run_count"` // up to 5; less when there's less history
+}
+
+// AgentRecentCapStats is the "is this agent regularly hitting its safety
+// ceilings?" signal — cap-exhausted (max_turns OR max_budget) runs among
+// the last 5 non-skipped. Surfaced as a warning pill on the v2 SPA list
+// when CapCount >= 2 (threshold tuned to avoid flagging one-off cap hits).
+type AgentRecentCapStats struct {
+	CapCount int `json:"cap_count"`
+	RunCount int `json:"run_count"` // up to 5
 }
 
 // AgentCostStats is the per-agent cost rollup over the last 30 days.
@@ -235,6 +248,21 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		}
 	}
 
+	// Recent cap rollup — count of cap-exhausted runs in the last 5
+	// non-skipped. Mirrors the error-rollup pattern.
+	capStatsRows, err := s.Queries.GetAgentRecentCapStats(ctx)
+	if err != nil {
+		s.Logger.Warn("list agent definitions: recent cap stats query failed", "error", err)
+		capStatsRows = nil
+	}
+	capStatsByID := make(map[string]AgentRecentCapStats, len(capStatsRows))
+	for _, r := range capStatsRows {
+		capStatsByID[pgconv.FormatUUID(r.AgentDefinitionID)] = AgentRecentCapStats{
+			CapCount: int(r.CapCount),
+			RunCount: int(r.RunCount),
+		}
+	}
+
 	// Last-prefix rollup — feeds the "Use last prefix" button in the v2 SPA's
 	// Run now dialog. One row per definition (the most recent non-null
 	// prompt_prefix); definitions that never had a prefixed run won't appear.
@@ -262,6 +290,9 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 		}
 		if errStats, ok := errStatsByID[resp.ID]; ok {
 			resp.RecentErrorStats = &errStats
+		}
+		if capStats, ok := capStatsByID[resp.ID]; ok {
+			resp.RecentCapStats = &capStats
 		}
 		if prefix, ok := prefixByID[resp.ID]; ok {
 			p := prefix

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -25,6 +25,11 @@ export interface AgentRecentErrorStats {
   run_count: number; // up to 5
 }
 
+export interface AgentRecentCapStats {
+  cap_count: number;
+  run_count: number; // up to 5
+}
+
 export interface AgentDefinition {
   id: string;
   short_id: string;
@@ -45,6 +50,7 @@ export interface AgentDefinition {
   cost_stats_30d?: AgentCostStats | null;
   next_fire_at?: string | null; // RFC3339; nil when no schedule, disabled, or unparseable
   recent_error_stats?: AgentRecentErrorStats | null;
+  recent_cap_stats?: AgentRecentCapStats | null;
   last_prompt_prefix?: string | null; // most recent non-null prompt_prefix; powers "Use last prefix"
   trigger_on_sync_complete: boolean; // fire after every successful sync
 

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -69,6 +69,7 @@ import {
   PROMPT_PREFIX_MAX_LEN,
   type AgentCostStats,
   type AgentDefinition,
+  type AgentRecentCapStats,
   type AgentRecentErrorStats,
 } from "@/api/queries/agents";
 import { openModal } from "@/lib/modals";
@@ -417,6 +418,7 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
             <span>Max turns: {agent.max_turns}</span>
             <CostStatsPill stats={agent.cost_stats_30d} />
             <RecentErrorPill stats={agent.recent_error_stats} />
+            <RecentCapPill stats={agent.recent_cap_stats} />
             <LastRunPill run={agent.last_run} />
           </div>
         </div>
@@ -575,6 +577,31 @@ function RunNowDialog({
 // RECENT_ERROR_WARN_THRESHOLD is the number of errors in the last 5 runs
 // that triggers the warning pill. Bump if it turns out noisy.
 const RECENT_ERROR_WARN_THRESHOLD = 3;
+
+// RECENT_CAP_WARN_THRESHOLD is the number of cap-exhausted runs in the
+// last 5 that triggers the amber "caps hit" pill. Lower than the error
+// threshold because cap-hits indicate the agent's plan exceeds what was
+// budgeted for it — even occasional hits are worth noticing.
+const RECENT_CAP_WARN_THRESHOLD = 2;
+
+function RecentCapPill({
+  stats,
+}: {
+  stats?: AgentRecentCapStats | null;
+}) {
+  if (!stats || stats.cap_count < RECENT_CAP_WARN_THRESHOLD) {
+    return null;
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+      title={`${stats.cap_count} of last ${stats.run_count} runs hit max_turns or max_budget — consider raising the caps or splitting the prompt`}
+    >
+      <AlertCircle className="size-3" />
+      {stats.cap_count}/{stats.run_count} hit cap
+    </span>
+  );
+}
 
 function RecentErrorPill({
   stats,


### PR DESCRIPTION
## Summary

Iteration 32 — list-level signal complementing iter-27's per-row `HitCapPill`. An operator scanning `/v2/agents` now sees an amber "N/M hit cap" pill on any agent whose last 5 non-skipped runs include **2+** cap-exhausted runs (either `max_turns` or `max_budget`). The per-row pill is still on the runs page for drilldown; this is the at-a-glance "this agent keeps hitting its ceiling" surface.

## What's in

- **New sqlc** `GetAgentRecentCapStats` — DISTINCT-style window over the last 5 non-skipped runs per definition, returning `cap_count` + `run_count`. Mirrors `GetAgentRecentErrorStats` from iter-21 exactly.
- **Service**: new `AgentRecentCapStats` type + `RecentCapStats` field on `AgentDefinitionResponse` (list-only, same `omitempty` pattern as cost/error/next-fire/last-prefix rollups). `ListAgentDefinitions` fetches the rollup once + zips; soft-fails on query error.
- **SPA**: `AgentRecentCapStats` TS type + `recent_cap_stats` field. New `RecentCapPill` renders only when `cap_count >= 2` (lower threshold than the error pill since caps signal "agent's plan exceeds budget" — even occasional hits are worth noticing). Slots between `RecentErrorPill` and `LastRunPill` in the metadata row.
- **2 new integration tests**:
  1. `PopulatesRecentCapStats`: 4 non-skipped + 1 skipped seeded, 2 most recent marked capped → `cap_count=2`, `run_count=4` (skipped excluded).
  2. `RecentCapStats_NoCapped_LeavesZero`: agent with history but no caps → `RecentCapStats` non-nil with `cap_count=0`, so the SPA's threshold check works uniformly regardless of history depth.

## Design notes

- **Mirror the iter-21 `RecentErrorStats` shape exactly.** Operators learn one mental model for "is this agent OK lately?" surfaced via multiple pills.
- **Threshold 2 (not 3 like errors).** Cap-hits indicate plan-exceeds-budget, which is structural — operators want early signal, not wait for repeated failures.
- **"Hit any cap" — single pill covers both `max_turns` and `max_budget`.** Drilldown to specific kind via the iter-31 filter chip on the runs page.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new integration tests pass
- [x] All 30+ existing agent tests still pass
- [x] `bun run lint` + `bun run build` clean

## Bonus

Spawned a code-reviewer subagent in parallel with this iter to audit the full 31-iter diff. Found 2 BLOCKERS + 3 HIGH + 2 LOW. **Top blocker queued for iter-33**: `agent_runs.max_turns_used` always mirrors `turn_count` rather than the cap itself — the SPA shows "7/7" for both a clean 7-turn run and a capped run that hit `max_turns=7-of-10`. Real bug, will fix next.

Other audit findings will roll into subsequent iters: scheduler.Reload race on concurrent CRUD (potential cron-entry leak), `FireSyncCompleteAgents` using cancelled ctx for the DB lookup, update handler not mapping duplicate-slug to 409, transcript-path inconsistency between short_id and RunID.
