### PR TITLE
fix(agents): max_turns_used records the cap snapshot, not turn_count

### DIFF
--- a/internal/service/agent_max_turns_used_test.go
+++ b/internal/service/agent_max_turns_used_test.go
@@ -1,0 +1,79 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/service"
+)
+
+// TestOrchestratorRunNow_MaxTurnsUsed_RecordsCapNotTurnCount is the
+// iter-33 regression test. Before iter-33, max_turns_used was set to
+// result.TurnCount instead of def.MaxTurns, which meant the column
+// was useless: every run looked like it hit the cap (e.g. "7/7" for
+// a clean 7-turn run with a cap of 10). The fix passes def.MaxTurns
+// through CompleteAgentRunDB. This test pins both:
+//   - max_turns_used == def.MaxTurns (the cap snapshot)
+//   - turn_count == result.TurnCount (the actual turns used)
+// so the SPA can render "actual / cap" correctly.
+func TestOrchestratorRunNow_MaxTurnsUsed_RecordsCapNotTurnCount(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+
+	// max_turns cap = 25 (not the seed default of 10, to make the
+	// regression more obvious if it returns).
+	def, err := svc.CreateAgentDefinition(context.Background(), service.CreateAgentDefinitionParams{
+		Name:         "orch-cap-vs-turns",
+		Slug:         "orch-cap-vs-turns",
+		Prompt:       "max-turns vs turn-count regression test prompt — must exceed validation length so this padding is here.",
+		ToolScope:    "read_only",
+		AllowedTools: []string{},
+		Model:        "claude-haiku-4-5",
+		MaxTurns:     25,
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	// Runner reports 7 actual turns; the cap of 25 should land in
+	// max_turns_used; turn_count should be 7.
+	runner := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{
+			Status:     agent.StatusSuccess,
+			TurnCount:  7,
+			DurationMs: 50,
+		}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+	runResp, err := orch.RunNow(context.Background(), def, "")
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+
+	if runResp.TurnCount == nil || *runResp.TurnCount != 7 {
+		t.Errorf("TurnCount = %v, want 7 (actual turns)", runResp.TurnCount)
+	}
+	if runResp.MaxTurnsUsed == nil || *runResp.MaxTurnsUsed != 25 {
+		t.Errorf("MaxTurnsUsed = %v, want 25 (the cap, not the actual count)",
+			runResp.MaxTurnsUsed)
+	}
+
+	// Verify persistence — the regression would otherwise silently flip
+	// back via the row read path.
+	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if persisted.TurnCount == nil || *persisted.TurnCount != 7 {
+		t.Errorf("persisted TurnCount = %v, want 7", persisted.TurnCount)
+	}
+	if persisted.MaxTurnsUsed == nil || *persisted.MaxTurnsUsed != 25 {
+		t.Errorf("persisted MaxTurnsUsed = %v, want 25", persisted.MaxTurnsUsed)
+	}
+}

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -231,7 +231,7 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	}
 	result, runErr := o.runner.Run(ctx, *spec, handler)
 
-	completedRow, completeErr := o.svc.CompleteAgentRunDB(ctx, runRow.ID, result)
+	completedRow, completeErr := o.svc.CompleteAgentRunDB(ctx, runRow.ID, result, def.MaxTurns)
 	if completeErr != nil {
 		o.logger.Error("orchestrator: persist completed run failed",
 			"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -134,6 +134,11 @@ type AgentRunResponse struct {
 	CacheReadTokens     *int     `json:"cache_read_tokens,omitempty"`
 	CacheCreationTokens *int     `json:"cache_creation_tokens,omitempty"`
 	TurnCount           *int     `json:"turn_count,omitempty"`
+	// MaxTurnsUsed is the per-run snapshot of the agent's max_turns cap
+	// at the time the run started. Named for historical reasons; "max
+	// turns at run-start" would be clearer. Pair with turn_count to
+	// render "actual / cap". Until iter-33 this column erroneously
+	// mirrored turn_count, making every run look like it hit the cap.
 	MaxTurnsUsed        *int     `json:"max_turns_used,omitempty"`
 	NumToolCalls        *int     `json:"num_tool_calls,omitempty"`
 	ErrorMessage        *string  `json:"error_message,omitempty"`
@@ -720,7 +725,14 @@ func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, ca
 
 // CompleteAgentRunDB persists a terminal RunResult onto the run row.
 // Used by the orchestrator after Runner.Run returns.
-func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult) (db.AgentRun, error) {
+//
+// maxTurnsCap is the per-run snapshot of the agent's max_turns at the
+// time the run started. Stored separately from turn_count so the SPA
+// can render "turns / cap" — until iter-33 this column mirrored
+// turn_count, which made every run look like a max-turns hit. The cap
+// itself never changes mid-run, so the orchestrator captures it
+// from def.MaxTurns at run-start and passes it through here.
+func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult, maxTurnsCap int) (db.AgentRun, error) {
 	costPtr := result.TotalCostUSD
 	return s.Queries.CompleteAgentRun(ctx, db.CompleteAgentRunParams{
 		ID:                  runID,
@@ -732,7 +744,7 @@ func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, res
 		CacheReadTokens:     pgtype.Int4{Int32: int32(result.CacheReadTokens), Valid: true},
 		CacheCreationTokens: pgtype.Int4{Int32: int32(result.CacheCreationTokens), Valid: true},
 		TurnCount:           pgtype.Int4{Int32: int32(result.TurnCount), Valid: true},
-		MaxTurnsUsed:        pgtype.Int4{Int32: int32(result.TurnCount), Valid: true},
+		MaxTurnsUsed:        pgtype.Int4{Int32: int32(maxTurnsCap), Valid: maxTurnsCap > 0},
 		NumToolCalls:        pgtype.Int4{Int32: int32(result.NumToolCalls), Valid: true},
 		TranscriptPath:      pgtype.Text{String: result.TranscriptPath, Valid: result.TranscriptPath != ""},
 		SessionID:           pgtype.Text{String: result.SessionID, Valid: result.SessionID != ""},


### PR DESCRIPTION
## Summary

Iteration 33 — top **BLOCKER** from the iter-32 code-reviewer audit.

`CompleteAgentRunDB` was writing `result.TurnCount` into BOTH `turn_count` AND `max_turns_used`. The column was useless: every run looked like it hit the cap, regardless of whether it terminated cleanly under budget or actually exhausted `max_turns`. The SPA's "actual / cap" display read **"7/7"** for both a clean 7-turn run and one capped at `max_turns=7-of-10`. Operators couldn't tell the difference without checking `hit_cap` (added in iter-27).

## What's in

- **`internal/service/agents.go`**: `CompleteAgentRunDB` signature gains `maxTurnsCap int`. Writes `int32(maxTurnsCap)` into `max_turns_used`, with `Valid=cap>0` so 0/unset preserves NULL semantics.
- **`internal/service/agent_orchestrator.go`**: `runLocked` passes `def.MaxTurns` into `CompleteAgentRunDB` at completion time. The cap doesn't change mid-run (it's snapshotted into the spec at `AssembleJobSpec`), so writing it at completion preserves the "what cap applied to THIS run" semantic even if the operator changes the cap mid-flight.
- **Doc comment** on `AgentRunResponse.MaxTurnsUsed` clarifies the field name is historical (`max_turns_at_run_start` would be clearer) and documents the iter-33 fix.
- **Regression test** `TestOrchestratorRunNow_MaxTurnsUsed_RecordsCapNotTurnCount` pins both branches:
  - `max_turns_used == def.MaxTurns` (the cap snapshot)
  - `turn_count == result.TurnCount` (the actual turns used)
  Uses cap=25 + actual=7 so the regression bug would produce obviously-wrong **7/7** instead of the correct **7/25**.

## Design notes

- **Snapshot at completion**, not run-start. Keeps the row writes atomic at the end of the run, consistent with where every other terminal field gets written.
- **New signature parameter, not a struct.** The existing `RunResult` has no business carrying the cap — it's an input the runner doesn't need to know about. Adding it to `RunResult` would muddle the producer/consumer split.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] New `MaxTurnsUsed_RecordsCapNotTurnCount` regression test passes
- [x] All 30+ existing agent tests still pass with the new signature
- [x] OpenAPI drift test green (field shape unchanged, only contents)
- [x] SPA contract unchanged (field name + JSON type identical)

## Audit follow-ups still queued

- BLOCKER #2: `AgentScheduler.Reload` race on concurrent CRUD (duplicate cron entries + leaked entry IDs)
- HIGH #3: `FireSyncCompleteAgents` uses cancelled sync ctx for DB lookup → webhook trigger silently no-ops under load
- HIGH #4: `UpdateAgentDefinitionHandler` doesn't map duplicate-slug to 409 (falls through to generic 500)
- HIGH #5: Transcript-path inconsistency (short_id vs RunID in `AssembleJobSpec` vs `Sidecar.Run`)
- LOW: webhook test polling pattern; `max_turns=0` validation quirk
