### PR TITLE
fix(agents): serialize AgentScheduler.Reload to prevent duplicate cron entries

### DIFF
--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -30,6 +30,15 @@ type AgentScheduler struct {
 
 	mu       sync.Mutex
 	entryIDs map[string]cron.EntryID // slug → entry id
+
+	// reloadMu serializes the WHOLE Reload critical section
+	// (remove-all + DB read + AddFunc loop) so concurrent CRUD mutations
+	// can't interleave their reloads and produce duplicate cron entries
+	// with leaked EntryIDs. Separate from `mu` (which protects the
+	// entryIDs map for single-statement read/write) because Reload spans
+	// multiple cron-library calls plus a DB query — holding `mu` for that
+	// long would block fireCronJob lookups longer than needed.
+	reloadMu sync.Mutex
 }
 
 // NewAgentScheduler constructs the scheduler. Call Start to begin firing.
@@ -117,6 +126,15 @@ func (s *AgentScheduler) logCleanupResult(r AgentCleanupResult, source string) {
 		"retention_days", r.RetentionDays)
 }
 
+// EntryCountForTest returns the live count of cron entries — agent
+// registrations PLUS the singleton cleanup tick added in Start. Exposed
+// for the iter-34 concurrent-Reload regression test; the cron library
+// has no other way to verify "no duplicate entries leaked." Do not call
+// from production code.
+func (s *AgentScheduler) EntryCountForTest() int {
+	return len(s.cron.Entries())
+}
+
 // Stop gracefully halts the scheduler, waiting for any in-flight jobs.
 func (s *AgentScheduler) Stop() {
 	stopCtx := s.cron.Stop()
@@ -126,7 +144,14 @@ func (s *AgentScheduler) Stop() {
 
 // Reload removes all per-definition cron entries and re-registers from DB.
 // Called after any agent_definition CRUD mutation.
+//
+// Holds reloadMu for the entire span so two concurrent CRUD-triggered
+// reloads can't both pass the "remove all" phase and then both call
+// AddFunc, producing duplicate cron entries whose EntryIDs are leaked
+// (entryIDs[slug] can only store one ID). Cf. iter-32 audit BLOCKER #2.
 func (s *AgentScheduler) Reload(ctx context.Context) {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
 	s.mu.Lock()
 	for slug, id := range s.entryIDs {
 		s.cron.Remove(id)

--- a/internal/service/agent_scheduler_reload_race_test.go
+++ b/internal/service/agent_scheduler_reload_race_test.go
@@ -1,0 +1,84 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/service"
+)
+
+// TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries pins the
+// iter-34 fix for audit BLOCKER #2. Before iter-34, two concurrent
+// Reload() calls could interleave their "remove all + re-register"
+// phases such that AddFunc ran twice per slug, producing duplicate
+// cron entries whose EntryIDs were silently leaked (entryIDs[slug]
+// could only store the last one — the others fired forever, no way to
+// cancel them).
+//
+// The fix serializes the whole Reload critical section with reloadMu.
+// This test fires N concurrent Reloads against the live scheduler +
+// service and asserts the underlying cron.Cron has exactly the same
+// number of per-agent entries it would have after one sequential
+// Reload — no duplicates, no leaks.
+func TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+
+	// Seed 3 enabled, cron-scheduled agents — each adds one cron entry
+	// per Reload pass.
+	for _, slug := range []string{"sched-race-a", "sched-race-b", "sched-race-c"} {
+		cron := "0 * * * *"
+		_, err := svc.CreateAgentDefinition(context.Background(), service.CreateAgentDefinitionParams{
+			Name:         slug,
+			Slug:         slug,
+			Prompt:       "Concurrent reload race test prompt for " + slug + " — padding to satisfy validation length requirement.",
+			ScheduleCron: &cron,
+			ToolScope:    "read_only",
+			AllowedTools: []string{},
+			Model:        "claude-haiku-4-5",
+			MaxTurns:     1,
+			Enabled:      true,
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", slug, err)
+		}
+	}
+
+	orch := service.NewOrchestrator(svc, agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{}, nil
+	}), 1, encKey, slog.Default())
+	sched := service.NewAgentScheduler(orch, svc, slog.Default())
+
+	// Start the cron loop so AddFunc/Remove actually take effect.
+	sched.Start(context.Background())
+	defer sched.Stop()
+
+	// Baseline: after Start, cron has 1 cleanup entry + 3 agent entries = 4.
+	const expectedAgentEntries = 3
+	const cleanupEntries = 1
+
+	// Fire 8 concurrent Reload calls — simulates a burst of CRUD
+	// mutations all triggering OnDefinitionChanged at once. Before
+	// iter-34 this routinely produced duplicate cron entries.
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sched.Reload(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	gotEntries := sched.EntryCountForTest()
+	wantEntries := expectedAgentEntries + cleanupEntries
+	if gotEntries != wantEntries {
+		t.Errorf("after 8 concurrent Reloads, cron has %d entries (want %d) — likely duplicate-entry leak from concurrent CRUD",
+			gotEntries, wantEntries)
+	}
+}


### PR DESCRIPTION
## Summary

Iteration 34 — **audit BLOCKER #2** from iter-32's code-reviewer pass.

Before this fix, `AgentScheduler.Reload` had a critical-section gap between the "remove all entries" phase (held `mu`) and the "registerAll re-acquires `mu` and AddFuncs" phase. Two concurrent CRUD mutations both triggering `OnDefinitionChanged` would race:

```
T1: lock mu, Remove all (now empty), unlock mu
T2: lock mu, Remove all (already empty), unlock mu
T1: registerAll → lock mu, query DB, AddFunc x3, store IDs, unlock
T2: registerAll → lock mu, query DB, AddFunc x3, store IDs (overwriting T1's), unlock
```

End state: **6 cron entries in `cron.Cron`, but `entryIDs` map only holds 3.** T1's 3 entries are silently leaked — they fire forever, no way to cancel via `Reload` (`entryIDs[slug]` now points at T2's ID, so the next Remove only cancels T2). Bursts of CRUD mutations would produce duplicate runs per fire, doubling spend.

## Bug verified end-to-end

With the fix temporarily reverted, the new regression test produced **25 cron entries from 8 concurrent Reloads** (21 leaked). With the fix, the expected **4** (3 agents + 1 cleanup tick).

## What's in

- **`AgentScheduler`** gains `reloadMu sync.Mutex`, separate from the existing `mu` (which protects `entryIDs` map access for single-statement read/write). `reloadMu` serializes the WHOLE `Reload` critical section (remove + DB read + `AddFunc` loop) so concurrent callers queue rather than interleave.
- Held for the full `Reload` span via `Lock` + `defer Unlock`.
- New `EntryCountForTest` helper exposes `cron.Entries()` length for the regression test (cron library has no other way to verify "no duplicates leaked").
- **`TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries`** fires 8 concurrent `Reload`s against a 3-agent setup; asserts the live entry count matches the expected 3 agents + 1 cleanup = 4.

## Design notes

- **Separate `reloadMu`, not extending `mu`'s hold.** The reload critical section includes a DB query plus N `cron.AddFunc` calls — holding `mu` that long would block `fireCronJob` lookups longer than needed. Two-mutex pattern: `mu` = "map snapshot integrity" (short), `reloadMu` = "reload serialization" (potentially long).
- **Defer Unlock** so a panic in the DB query or cron call doesn't permanently lock subsequent reloads.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] New regression test passes; **verified it FAILS without the fix** (25 entries instead of 4)
- [x] All existing scheduler + orchestrator tests still pass
