### PR TITLE
fix(agents): two audit HIGH findings — webhook ctx + dup-slug on update

### DIFF
--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -115,16 +115,9 @@ func CreateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 			TriggerOnSyncComplete: req.TriggerOnSyncComplete,
 		})
 		if err != nil {
-			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+			if writeAgentDefinitionMutationError(w, err, "Failed to create agent") {
 				return
 			}
-			if strings.Contains(strings.ToLower(err.Error()), "duplicate key") || strings.Contains(strings.ToLower(err.Error()), "unique constraint") {
-				mw.WriteError(w, http.StatusConflict, "CONFLICT", "An agent with this slug already exists")
-				return
-			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create agent")
-			return
 		}
 		w.WriteHeader(http.StatusCreated)
 		writeData(w, out)
@@ -156,11 +149,39 @@ func UpdateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 			TriggerOnSyncComplete: req.TriggerOnSyncComplete,
 		})
 		if err != nil {
-			writeAgentError(w, err, "agent not found")
-			return
+			// Try not-found / validation first, then mutation-shaped errors
+			// (duplicate slug from a rename → 409 CONFLICT, otherwise 500).
+			// Before iter-35 the dup-slug branch only existed on Create;
+			// Update fell through to a generic 500.
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "agent not found")
+				return
+			}
+			if writeAgentDefinitionMutationError(w, err, "Failed to update agent") {
+				return
+			}
 		}
 		writeData(w, out)
 	}
+}
+
+// writeAgentDefinitionMutationError maps the shared shape of Create +
+// Update errors: ErrInvalidParameter → 400 VALIDATION_ERROR, Postgres
+// unique-constraint failure → 409 CONFLICT (the slug column is the only
+// unique field), everything else → 500 with the supplied message.
+// Returns true if a response was written (caller should `return`).
+func writeAgentDefinitionMutationError(w http.ResponseWriter, err error, fallbackMsg string) bool {
+	if errors.Is(err, service.ErrInvalidParameter) {
+		mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+		return true
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "duplicate key") || strings.Contains(lower, "unique constraint") {
+		mw.WriteError(w, http.StatusConflict, "CONFLICT", "An agent with this slug already exists")
+		return true
+	}
+	mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", fallbackMsg)
+	return true
 }
 
 // DeleteAgentDefinitionHandler deletes an agent (runs preserved).

--- a/internal/api/agents_mutation_error_test.go
+++ b/internal/api/agents_mutation_error_test.go
@@ -1,0 +1,78 @@
+//go:build !lite
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestWriteAgentDefinitionMutationError pins the iter-35 fix for audit
+// HIGH #4: before iter-35 only CreateAgentDefinitionHandler mapped the
+// Postgres unique-constraint failure to 409 CONFLICT — the Update path
+// fell through to a generic 500. The shared helper now serves both
+// handlers, so a slug-rename collision returns 409 consistently.
+//
+// Tests run against the helper directly (no router setup needed), which
+// also makes the validation-error and generic-error branches cheap to
+// pin.
+func TestWriteAgentDefinitionMutationError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "validation error → 400",
+			err:        fmt.Errorf("max_turns: %w", service.ErrInvalidParameter),
+			wantStatus: 400,
+			wantCode:   "VALIDATION_ERROR",
+		},
+		{
+			name:       "duplicate key → 409",
+			err:        errors.New(`ERROR: duplicate key value violates unique constraint "agent_definitions_slug_key" (SQLSTATE 23505)`),
+			wantStatus: 409,
+			wantCode:   "CONFLICT",
+		},
+		{
+			name:       "unique constraint wording → 409",
+			err:        errors.New("postgres: row violates unique constraint"),
+			wantStatus: 409,
+			wantCode:   "CONFLICT",
+		},
+		{
+			name:       "generic error → 500",
+			err:        errors.New("connection refused"),
+			wantStatus: 500,
+			wantCode:   "INTERNAL_ERROR",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			if !writeAgentDefinitionMutationError(rr, tc.err, "fallback msg") {
+				t.Fatal("helper returned false; expected true (response was written)")
+			}
+			if rr.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rr.Code, tc.wantStatus)
+			}
+			var body struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode body: %v\nbody: %s", err, rr.Body.String())
+			}
+			if body.Error.Code != tc.wantCode {
+				t.Errorf("code = %q, want %q", body.Error.Code, tc.wantCode)
+			}
+		})
+	}
+}

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -119,7 +119,15 @@ func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse,
 // immediately. Concurrency is bounded by the orchestrator's existing
 // semaphore (iter-29 default: 3) — excess fires roll into skipped rows.
 func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
-	defs, err := o.svc.ListAgentDefinitionsForSyncWebhook(ctx)
+	// Use a fresh context for the lookup — the incoming ctx is the sync
+	// engine's, and a cancelled webhook request or timed-out sync would
+	// silently no-op the entire webhook trigger here (audit HIGH #3 from
+	// iter-32). Per-dispatched goroutine below ALSO uses a fresh ctx for
+	// the same reason. 30s is plenty for the unindexed-by-default lookup
+	// even with a few dozen agents.
+	lookupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	defs, err := o.svc.ListAgentDefinitionsForSyncWebhook(lookupCtx)
 	if err != nil {
 		o.logger.Warn("orchestrator: list sync-webhook agents failed", "error", err)
 		return


### PR DESCRIPTION
## Summary

Iteration 35 — bundles audit **HIGH #3** and **HIGH #4** from the iter-32 code-reviewer pass. Both are 1-method fixes with the same shape: an incorrect default behavior in an error path.

### HIGH #3 — webhook trigger silently no-ops under load

`FireSyncCompleteAgents` used the sync engine's context to read the eligible-agents list. If the sync ctx was cancelled (webhook request timed out, or sync hit its own deadline), the DB lookup failed silently with a warning log and the **webhook trigger no-op'd for that sync**. Under load, the feature would silently stop working.

**Fix**: use a fresh 30s-timeout context for the lookup, matching the per-dispatch-goroutine pattern already used below.

### HIGH #4 — Update doesn't return 409 on slug collision

`UpdateAgentDefinitionHandler` had no special case for the Postgres unique-constraint failure on the slug column — a rename collision returned generic 500 `INTERNAL_ERROR` instead of 409 `CONFLICT`. `CreateAgentDefinitionHandler` had the right mapping; the two paths had drifted.

**Fix**: extract `writeAgentDefinitionMutationError` as a shared helper and wire both handlers through it. Update also gets explicit `ErrNotFound → 404` handling before falling into the mutation-error path.

## What's in

- **`internal/service/agent_orchestrator.go`**: `FireSyncCompleteAgents` uses `context.WithTimeout(context.Background(), 30s)` for the `ListAgentDefinitionsForSyncWebhook` call.
- **`internal/api/agents.go`**: new `writeAgentDefinitionMutationError` helper; `CreateAgentDefinitionHandler` and `UpdateAgentDefinitionHandler` both route through it.
- **`internal/api/agents_mutation_error_test.go`**: 4 sub-tests pinning the helper's branches (validation → 400, duplicate key → 409, unique-constraint wording → 409, generic → 500). Uses `httptest.ResponseRecorder` — no router setup needed.

## Design notes

- **Fresh ctx for the lookup, not the dispatched run.** The 10-minute per-run timeout already exists in the dispatch goroutine; the lookup is fast (one indexed query) and 30s is generous safety.
- **Helper-based extraction** rather than mid-handler duplication. Future mutation handlers can route through the same shape without re-implementing the dup-slug check.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 4 new mutation-error sub-tests pass
- [x] All existing 30+ agent service + api tests still pass
- [x] OpenAPI drift test green (no router changes — just response codes on existing routes)

## Audit follow-ups still queued

- HIGH #5: Transcript-path inconsistency (short_id vs RunID in `AssembleJobSpec` vs `Sidecar.Run`)
- LOW: webhook test polling pattern; `max_turns=0` validation quirk
