### PR TITLE
chore(agents): close out audit findings — transcript path, max_turns wording, test polling

### DIFF
--- a/internal/agent/sidecar.go
+++ b/internal/agent/sidecar.go
@@ -98,6 +98,13 @@ func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (
 			result.DurationMs = time.Since(start).Milliseconds()
 			return result, result.Err
 		}
+		// Sidecar.Run is the single source of truth for the transcript
+		// path. Built from (TranscriptDir, spec.RunID — the UUID, not
+		// the short_id) so it's stable across the run's lifecycle. The
+		// result.TranscriptPath we surface back to the orchestrator and
+		// the spec.TranscriptPath we forward to the TS sidecar process
+		// both reference this exact `p` — DO NOT set spec.TranscriptPath
+		// elsewhere (it gets clobbered here just before json.Marshal).
 		p := filepath.Join(s.TranscriptDir, spec.RunID+".ndjson")
 		f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {

--- a/internal/service/agent_webhook_trigger_test.go
+++ b/internal/service/agent_webhook_trigger_test.go
@@ -37,25 +37,27 @@ func TestFireSyncCompleteAgents_OnlyFiresEligible(t *testing.T) {
 
 	orch.FireSyncCompleteAgents(context.Background())
 
-	// FireSyncCompleteAgents dispatches per-goroutine; give them a moment to
-	// land + complete.
-	deadline := time.After(2 * time.Second)
+	// Deterministic wait: we expect exactly 1 fire (only the eligible
+	// agent qualifies). Block until it lands or fail after a generous
+	// timeout. Then sweep the channel briefly to catch any unexpected
+	// extra fires the bug-this-test-pins might produce. Replaces the
+	// iter-30 time.After polling pattern flagged as LOW #6 in iter-32
+	// audit — the previous shape was timing-sensitive under CI load.
 	var got []string
-loop:
-	for {
-		select {
-		case agentID := <-fired:
-			got = append(got, agentID)
-		case <-time.After(150 * time.Millisecond):
-			break loop
-		case <-deadline:
-			break loop
-		}
+	select {
+	case agentID := <-fired:
+		got = append(got, agentID)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for the eligible webhook fire; got %v", got)
+	}
+	// Tight tail to catch extras (if any agent that shouldn't fire does).
+	select {
+	case extra := <-fired:
+		t.Fatalf("unexpected extra fire from agent %q (only enabled+webhook should run)", extra)
+	case <-time.After(200 * time.Millisecond):
+		// pass — no extras
 	}
 
-	if len(got) != 1 {
-		t.Fatalf("expected exactly 1 webhook fire, got %d: %v", len(got), got)
-	}
 	if got[0] != enabledWebhook.ID {
 		t.Errorf("fired agent ID = %q, want %q (the enabled+webhook one)",
 			got[0], enabledWebhook.ID)

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -803,7 +803,8 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 		return nil, fmt.Errorf("agent: unknown auth_mode %q", authMode)
 	}
 
-	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, "")
+	// (transcript_dir is read by the Sidecar layer; see Sidecar.Run for
+	// the authoritative path assembly — iter-36 audit HIGH #5 cleanup.)
 
 	mcpServers := map[string]agent.MCPServerConfig{
 		"breadbox": {
@@ -839,9 +840,13 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 	if run.SessionID != nil {
 		spec.SessionID = *run.SessionID
 	}
-	if transcriptDir != "" {
-		spec.TranscriptPath = transcriptDir + "/" + run.ShortID + ".ndjson"
-	}
+	// Note: transcript path is set by Sidecar.Run from (TranscriptDir,
+	// spec.RunID) and overwrites whatever's here on the spec. Don't try
+	// to control it from this side — keeping the assignment authority
+	// in one place avoids the iter-36 audit HIGH #5 inconsistency where
+	// AssembleJobSpec set `<dir>/<short_id>.ndjson` and Sidecar.Run
+	// then opened `<dir>/<RunID>.ndjson`, leaving the spec field briefly
+	// inconsistent before marshal.
 	return spec, nil
 }
 
@@ -925,8 +930,11 @@ func validateAgentDefinitionFields(name, slug, prompt, toolScope, model string, 
 	if model != "" && strings.TrimSpace(model) == "" {
 		return fmt.Errorf("%w: model cannot be blank", ErrInvalidParameter)
 	}
+	// 0 is accepted and falls back to DefaultAgentMaxTurns in the caller —
+	// the docstring used to say "1-100" but the actual behavior allowed
+	// 0 silently. iter-36 audit LOW #7 reworded for accuracy.
 	if maxTurns < 0 || maxTurns > 100 {
-		return fmt.Errorf("%w: max_turns must be 1-100", ErrInvalidParameter)
+		return fmt.Errorf("%w: max_turns must be 0-100 (0 falls back to the default)", ErrInvalidParameter)
 	}
 	if maxBudget != nil && (*maxBudget < 0 || *maxBudget > 1000) {
 		return fmt.Errorf("%w: max_budget_usd must be 0-1000", ErrInvalidParameter)


### PR DESCRIPTION
## Summary

Iteration 36 — closes the last audit HIGH and both LOWs from iter-32's code-reviewer pass. Pure cleanup; no behavior change for end users.

### HIGH #5 — transcript path inconsistency

`AssembleJobSpec` was setting `spec.TranscriptPath = "<dir>/<short_id>.ndjson"` but `Sidecar.Run` then overwrote it with `"<dir>/<RunID>.ndjson"` right before `json.Marshal`. **The set in `AssembleJobSpec` was dead code — clobbered before use.** Worse, `spec.TranscriptPath` was briefly inconsistent with what the sidecar process eventually saw, which would bite future contributors.

**Fix**: remove the dead set in `AssembleJobSpec` + comment in `Sidecar.Run` noting it's the single source of truth for the path.

### LOW #6 — webhook test polling

`TestFireSyncCompleteAgents_OnlyFiresEligible` used a 2-second deadline + 150ms inter-event poll loop. Under CI load this could flake. **Replaced** with a deterministic "wait for 1 fire, then sweep tail for extras" shape. Still bounded; never longer than 2.2s.

### LOW #7 — `max_turns=0` wording

Validator rejected `<0 || >100` but allowed 0. `CreateAgentDefinition` silently mapped 0 to `DefaultAgentMaxTurns`. The error message said `"must be 1-100"` but the actual contract was `"0 = use default."` **Reworded** to `"must be 0-100 (0 falls back to the default)"`.

## What's in

- `internal/service/agents.go`: drop dead `spec.TranscriptPath = …` set in `AssembleJobSpec`; drop the now-unused `transcript_dir` local; comment points to `Sidecar.Run` as the path source. Validator message updated.
- `internal/agent/sidecar.go`: comment on the transcript-path block documenting it's the single source of truth.
- `internal/service/agent_webhook_trigger_test.go`: deterministic wait pattern.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] Both `FireSyncComplete` tests pass with the new wait shape
- [x] All 30+ existing agent service + api tests still pass

## Audit follow-ups

**All 7 findings closed.** 2 BLOCKERS (iters 33-34), 3 HIGH (iters 35-36), 2 LOW (iter 36). Sprint diff is clean per the iter-32 reviewer's bar.
