### PR TITLE
feat(agents): human-readable cron + "After sync" indicator on /v2/agents

### DIFF
--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -18,7 +18,9 @@ import {
   Terminal,
   Trash2,
   XCircle,
+  Zap,
 } from "lucide-react";
+import { cronToProseLabel } from "@/lib/cron-prose";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { PageError } from "@/components/page-error";
@@ -407,12 +409,26 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
             {agent.prompt}
           </p>
           <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-            <span className="inline-flex items-center gap-1">
+            <span
+              className="inline-flex items-center gap-1"
+              title={
+                agent.schedule_cron
+                  ? `Cron expression: ${agent.schedule_cron}`
+                  : undefined
+              }
+            >
               <Clock className="size-3" />
-              {agent.schedule_cron
-                ? `Cron: ${agent.schedule_cron}`
-                : "Manual only"}
+              {cronToProseLabel(agent.schedule_cron)}
             </span>
+            {agent.trigger_on_sync_complete && (
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 font-medium text-blue-700 dark:bg-blue-950/40 dark:text-blue-300"
+                title="Also fires after every successful bank sync (trigger=webhook)"
+              >
+                <Zap className="size-3" />
+                After sync
+              </span>
+            )}
             <NextFirePill at={agent.next_fire_at} />
             <span>Model: {agent.model}</span>
             <span>Max turns: {agent.max_turns}</span>


### PR DESCRIPTION
## Summary

Iteration 37 — small UX polish bundle. Two visible improvements to the agent row metadata that close discoverability gaps surfaced by dogfooding.

## Screenshot

<img src="https://i.img402.dev/mw958npuxf.jpg" width="800" alt="/v2/agents — seeded agents showing 'Manual trigger only' (cron-prose) and pill placement">

## What's in

- **cron → prose**: agent rows now render schedules via `cronToProseLabel` from the helper iter-5 added for the `CronField` live preview. Row used to show opaque `Cron: 0 9 * * *`; now shows `Daily at 9 AM` with the raw expression available as a native `title` for power users.
- **"After sync" indicator**: when `trigger_on_sync_complete=true` (iter-30), a blue `Zap` pill renders on the row metadata line. Previously this flag was invisible until you clicked into the edit page — operators had no way to tell at a glance which agents fired after each sync vs cron-only. Native title: *"Also fires after every successful bank sync"*.

## Design notes

- **No new shadcn install, no new helper.** Pure composition of iter-5's `cronToProseLabel` + iter-30's `trigger_on_sync_complete` field + existing iconography (`Zap` from lucide).
- **Pills mirror the same shape iter-21/27/32 use** for the warning pills — operators learn one mental model.
- **Raw cron in `title`** preserves the previous information density for anyone who wants to verify the exact expression at-a-glance.

## Test plan

- [x] `bun run lint` + `bun run build` clean
- [x] Manual: captured `/v2/agents` screenshot showing the 5 seeded agents (default "Manual trigger only"); the After-sync pill renders correctly when the flag is set.
- No backend changes; no Go test impact.

## Bonus

Spawned a feature-extension subagent in parallel (iter-32 cycle step 2). Returned 3 proposals; **top pick "Run-failed banner on /v2/agents" queued for iter-38** — compounds iter-21 `RecentErrorStats` + iter-14 onboarding-banner pattern to surface recent errors at the list level without needing to click into each agent.
