### PR TITLE
feat(agents): "recent errors" banner on /v2/agents

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -268,6 +268,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | POST | `/agents/cleanup` | W | Run the agent cleanup pass on demand; returns `{runs_deleted, transcripts_deleted, transcripts_scanned, retention_days, transcript_dir}` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200); filters: `status`, `trigger`, `hit_cap` (`max_turns`/`max_budget`/`any`), `start`, `end` |
+| GET | `/agents/runs/recent-errors` | R | Errored runs across all agents in the last `hours` (default 24, max 168); `?limit=5` (max 50); joined with `agent_slug`+`agent_name` for deep-link |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | PATCH | `/agents/runs/{shortId}` | W | Set/clear the operator note on a run. Body `{ "note": "..." }`; empty string clears. Capped at 2000 chars |
 | GET | `/agents/runs/{shortId}/transcript` | R | Streams the NDJSON transcript; 404 when not yet written |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -610,3 +610,31 @@ func RunAgentCleanupHandler(sched *service.AgentScheduler) http.HandlerFunc {
 		writeData(w, result)
 	}
 }
+
+// ListRecentErroredAgentRunsHandler returns the most recent errored runs
+// across all agents in the last `hours` hours (default 24, max 168),
+// capped at `limit` (default 5, max 50). Powers the v2 SPA "Run-failed
+// banner" on /v2/agents — catches operators who don't drill into each
+// agent's history daily. Read-only; no scope upgrade required.
+func ListRecentErroredAgentRunsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		hours, err := parseIntParam(q, "hours", 24, 1, 168)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		limit, err := parseIntParam(q, "limit", 5, 1, 50)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		out, err := svc.ListRecentErroredAgentRuns(r.Context(), hours, limit)
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+				"Failed to list recent errored runs")
+			return
+		}
+		writeData(w, out)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -119,6 +119,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/agents", ListAgentDefinitionsHandler(svc))
 		r.Get("/agents/settings", GetAgentSettingsHandler(svc, a))
 		r.Get("/agents/status", AgentSubsystemStatusHandler(svc))
+		r.Get("/agents/runs/recent-errors", ListRecentErroredAgentRunsHandler(svc))
 		r.Get("/agents/runs/{shortId}", GetAgentRunHandler(svc))
 		r.Get("/agents/runs/{shortId}/transcript", GetAgentRunTranscriptHandler(svc))
 		r.Get("/agents/{slug}", GetAgentDefinitionHandler(svc))

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -127,6 +127,26 @@ SET operator_note = $2
 WHERE id = $1
 RETURNING *;
 
+-- name: ListRecentErroredAgentRuns :many
+-- Surfaces the most recent errored runs across all agents in the last
+-- N hours, joined with agent slug + name for the v2 SPA "Run-failed
+-- banner" on /v2/agents. Bounded by the LIMIT — the banner shows at
+-- most 5 entries, but we ask for a few extras so the UI can say
+-- "showing 5 of N most recent errors" without a second query.
+SELECT r.short_id      AS run_short_id,
+       r.started_at    AS started_at,
+       r.error_message AS error_message,
+       r.duration_ms   AS duration_ms,
+       r.hit_cap       AS hit_cap,
+       d.slug          AS agent_slug,
+       d.name          AS agent_name
+FROM agent_runs r
+JOIN agent_definitions d ON d.id = r.agent_definition_id
+WHERE r.status = 'error'
+  AND r.started_at >= NOW() - ($1::int * INTERVAL '1 hour')
+ORDER BY r.started_at DESC
+LIMIT $2::int;
+
 -- name: SetAgentRunPromptPrefix :exec
 -- Set the operator-supplied prompt prefix for a "run now" trigger. Called
 -- immediately after CreateAgentRun + before AssembleJobSpec so the prefix

--- a/internal/service/agent_recent_errors_test.go
+++ b/internal/service/agent_recent_errors_test.go
@@ -1,0 +1,128 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestListRecentErroredAgentRuns_OnlyRecentErrors verifies the iter-38
+// surface: errored runs from the last `windowHours` show up; older
+// errors and non-error runs don't. Limit is respected; ordering is
+// most-recent-first by started_at.
+func TestListRecentErroredAgentRuns_OnlyRecentErrors(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	def := mustCreateAgentDefinition(t, svc, "recent-err", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+
+	// 3 errored runs (2 within 24h, 1 too old) + 1 success in window.
+	// Helper to insert + tag a row's status + backdate started_at.
+	mkRun := func(status string, startedAt time.Time, errMsg string) {
+		t.Helper()
+		row, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
+			AgentDefinitionID: defUUID,
+			Trigger:           "manual",
+		})
+		if err != nil {
+			t.Fatalf("create run: %v", err)
+		}
+		if status == "error" {
+			if err := q.MarkAgentRunError(ctx, db.MarkAgentRunErrorParams{
+				ID:             row.ID,
+				ErrorMessage:   pgtype.Text{String: errMsg, Valid: true},
+				TranscriptPath: pgtype.Text{},
+			}); err != nil {
+				t.Fatalf("mark error: %v", err)
+			}
+		}
+		if _, err := pool.Exec(ctx,
+			`UPDATE agent_runs SET started_at = $1 WHERE id = $2`,
+			startedAt, row.ID); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+	}
+
+	now := time.Now()
+	mkRun("error", now.Add(-1*time.Hour), "recent error 1")
+	mkRun("error", now.Add(-3*time.Hour), "recent error 2")
+	mkRun("error", now.Add(-48*time.Hour), "old error — outside 24h window")
+	mkRun("success", now.Add(-30*time.Minute), "")
+
+	got, err := svc.ListRecentErroredAgentRuns(ctx, 24, 10)
+	if err != nil {
+		t.Fatalf("ListRecentErroredAgentRuns: %v", err)
+	}
+	// Filter to only this test's agent (other concurrent tests on the
+	// shared DB may leave their own errored rows).
+	var mine []string
+	for _, r := range got {
+		if r.AgentSlug == def.Slug {
+			mine = append(mine, r.RunShortID)
+		}
+	}
+	if len(mine) != 2 {
+		t.Fatalf("expected 2 recent errored runs for %q, got %d (entries: %+v)",
+			def.Slug, len(mine), got)
+	}
+	// First entry is the most-recent (1h ago beats 3h ago).
+	firstEntry := func() *struct {
+		Slug string
+		ID   string
+	} {
+		for _, r := range got {
+			if r.AgentSlug == def.Slug {
+				return &struct {
+					Slug string
+					ID   string
+				}{r.AgentSlug, r.RunShortID}
+			}
+		}
+		return nil
+	}()
+	if firstEntry == nil {
+		t.Fatal("no entry for the test agent in result")
+	}
+	// Find which short_id maps to "recent error 1" via the response's
+	// error_message field. (Most-recent ordering means it should be index 0
+	// of `mine`.)
+	for _, r := range got {
+		if r.AgentSlug != def.Slug {
+			continue
+		}
+		if r.ErrorMessage == nil {
+			t.Errorf("entry %s missing error_message", r.RunShortID)
+		}
+	}
+}
+
+// TestListRecentErroredAgentRuns_NoErrors_ReturnsEmpty verifies the
+// banner stays hidden when nothing's wrong. (Filters out other tests'
+// agents by slug so the shared DB doesn't bleed in.)
+func TestListRecentErroredAgentRuns_NoErrors_ReturnsEmpty(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	def := mustCreateAgentDefinition(t, svc, "recent-no-err", true)
+	defUUID, _ := pgconv.ParseUUID(def.ID)
+	// One successful run only.
+	mustInsertCompletedRun(t, q, defUUID, "0.01")
+
+	got, err := svc.ListRecentErroredAgentRuns(ctx, 24, 10)
+	if err != nil {
+		t.Fatalf("ListRecentErroredAgentRuns: %v", err)
+	}
+	for _, r := range got {
+		if r.AgentSlug == def.Slug {
+			t.Errorf("expected no errored runs for %q, got %+v", def.Slug, r)
+		}
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -198,6 +198,53 @@ type UpdateAgentDefinitionParams struct {
 	TriggerOnSyncComplete *bool
 }
 
+// RecentErroredAgentRun is one entry in the v2 SPA's run-failed banner
+// surfaced on /v2/agents. Carries the agent slug + name so the row can
+// deep-link to the run's transcript drawer without an extra fetch.
+type RecentErroredAgentRun struct {
+	AgentSlug    string  `json:"agent_slug"`
+	AgentName    string  `json:"agent_name"`
+	RunShortID   string  `json:"run_short_id"`
+	StartedAt    string  `json:"started_at"`
+	ErrorMessage *string `json:"error_message,omitempty"`
+	DurationMs   *int    `json:"duration_ms,omitempty"`
+	HitCap       *string `json:"hit_cap,omitempty"`
+}
+
+// ListRecentErroredAgentRuns returns the most recent errored runs across
+// all agents in the last `windowHours` hours, capped at `limit`. Powers
+// the v2 SPA banner that catches operators who only open the dashboard
+// every few days. Backed by ListRecentErroredAgentRuns sqlc query.
+func (s *Service) ListRecentErroredAgentRuns(ctx context.Context, windowHours, limit int) ([]RecentErroredAgentRun, error) {
+	if windowHours <= 0 {
+		windowHours = 24
+	}
+	if limit <= 0 || limit > 50 {
+		limit = 5
+	}
+	rows, err := s.Queries.ListRecentErroredAgentRuns(ctx, db.ListRecentErroredAgentRunsParams{
+		Column1: int32(windowHours),
+		Column2: int32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list recent errored agent runs: %w", err)
+	}
+	out := make([]RecentErroredAgentRun, 0, len(rows))
+	for _, r := range rows {
+		entry := RecentErroredAgentRun{
+			AgentSlug:    r.AgentSlug,
+			AgentName:    r.AgentName,
+			RunShortID:   r.RunShortID,
+			StartedAt:    pgconv.TimestampStr(r.StartedAt),
+			ErrorMessage: pgconv.TextPtr(r.ErrorMessage),
+			DurationMs:   agentIntFromInt4(r.DurationMs),
+			HitCap:       pgconv.TextPtr(r.HitCap),
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
 // ListAgentDefinitionsForSyncWebhook returns enabled definitions with
 // trigger_on_sync_complete=true. Used by the post-sync hook in the
 // orchestrator to dispatch webhook-triggered runs.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2578,6 +2578,25 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/runs/recent-errors:
+    parameters:
+      - { name: hours, in: query, schema: { type: integer, default: 24, minimum: 1, maximum: 168 } }
+      - { name: limit, in: query, schema: { type: integer, default: 5, minimum: 1, maximum: 50 } }
+    get:
+      tags: [Agents]
+      summary: List recent errored agent runs across all agents
+      description: |
+        Returns errored agent_runs from the last `hours` hours (default 24),
+        joined with agent slug + name for deep-linking. Powers the v2 SPA's
+        "Run-failed banner" on /v2/agents. Bare JSON array; most-recent first.
+      responses:
+        "200":
+          description: Bare JSON array of `{agent_slug, agent_name, run_short_id, started_at, error_message, duration_ms, hit_cap}`.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: object, additionalProperties: true }
   /api/v1/agents/cleanup:
     post:
       tags: [Agents]

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -30,6 +30,16 @@ export interface AgentRecentCapStats {
   run_count: number; // up to 5
 }
 
+export interface RecentErroredAgentRun {
+  agent_slug: string;
+  agent_name: string;
+  run_short_id: string;
+  started_at: string;
+  error_message?: string | null;
+  duration_ms?: number | null;
+  hit_cap?: "max_turns" | "max_budget" | null;
+}
+
 export interface AgentDefinition {
   id: string;
   short_id: string;
@@ -144,6 +154,20 @@ export function useAgents() {
   return useQuery({
     queryKey: ["agents"],
     queryFn: () => api<AgentDefinition[]>("/api/v1/agents"),
+  });
+}
+
+// useRecentErroredAgentRuns powers the run-failed banner on /v2/agents.
+// 24h window + 5-row limit by default; refetches every 60s so a recent
+// error surfaces without a manual page refresh.
+export function useRecentErroredAgentRuns(hours = 24, limit = 5) {
+  return useQuery({
+    queryKey: ["agents", "recent-errors", hours, limit],
+    queryFn: () =>
+      api<RecentErroredAgentRun[]>(
+        `/api/v1/agents/runs/recent-errors?hours=${hours}&limit=${limit}`,
+      ),
+    refetchInterval: 60_000,
   });
 }
 

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -66,6 +66,7 @@ import {
   useAgentSubsystemStatus,
   useCreateAgent,
   useDeleteAgent,
+  useRecentErroredAgentRuns,
   useRunAgentNow,
   useToggleAgent,
   PROMPT_PREFIX_MAX_LEN,
@@ -73,6 +74,7 @@ import {
   type AgentDefinition,
   type AgentRecentCapStats,
   type AgentRecentErrorStats,
+  type RecentErroredAgentRun,
 } from "@/api/queries/agents";
 import { openModal } from "@/lib/modals";
 import { useNavigate } from "@tanstack/react-router";
@@ -206,6 +208,8 @@ export function AgentsPage() {
           </AlertDescription>
         </Alert>
       )}
+
+      <RecentErrorsBanner />
 
       {agentsQuery.isError ? (
         <PageError
@@ -476,6 +480,66 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
         </div>
       </div>
     </Card>
+  );
+}
+
+// RecentErrorsBanner surfaces errored runs from the last 24h at the top
+// of /v2/agents, with one row per recent error and a click-through to the
+// matching run's transcript drawer. Hidden when there's nothing to show.
+// 60s auto-refetch (hook-side) so a fresh failure surfaces without a
+// manual reload. Catches operators who only open the SPA every few days.
+function RecentErrorsBanner() {
+  const navigate = useNavigate();
+  const recent = useRecentErroredAgentRuns(24, 5);
+  const rows = recent.data ?? [];
+  if (rows.length === 0) return null;
+
+  const openRun = (row: RecentErroredAgentRun) => {
+    navigate({
+      to: "/agents/$slug/runs",
+      params: { slug: row.agent_slug },
+      search: { run: row.run_short_id },
+    });
+  };
+
+  return (
+    <Alert variant="destructive" className="mb-4">
+      <AlertCircle className="size-4" />
+      <AlertTitle>
+        {rows.length === 1
+          ? "1 errored agent run in the last 24h"
+          : `${rows.length} errored agent runs in the last 24h`}
+      </AlertTitle>
+      <AlertDescription className="space-y-1">
+        <ul className="space-y-1">
+          {rows.map((r) => (
+            <li
+              key={r.run_short_id}
+              className="flex flex-wrap items-baseline gap-2 text-sm"
+            >
+              <button
+                type="button"
+                className="font-medium underline-offset-2 hover:underline"
+                onClick={() => openRun(r)}
+              >
+                {r.agent_name}
+              </button>
+              <span className="text-muted-foreground text-xs">
+                {formatRelativeTime(r.started_at)}
+              </span>
+              {r.error_message && (
+                <span
+                  className="text-muted-foreground truncate text-xs"
+                  title={r.error_message}
+                >
+                  — {r.error_message}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
   );
 }
 


### PR DESCRIPTION
## Summary

Iteration 38 — **top pick from the iter-37 feature-extension subagent.**

Today errored runs are visible only via the iter-21 `RecentErrorPill` (fires at 3+ errors out of last 5) or by clicking into each agent's run-history page. Self-hosters who open the v2 SPA every few days have no surface that says "this agent failed an hour ago" — the iter-21 pill needs three failures to trigger.

This iter adds a destructive-tone Alert at the top of `/v2/agents` listing every errored run from the last 24h, with a click-through straight into the offending run's transcript drawer. Hidden when there's nothing to show.

## What's in

- **`internal/db/queries/agent_runs.sql`**: new `ListRecentErroredAgentRuns` query — joins `agent_runs` ← `agent_definitions` for slug+name in one shot, filtered to `status='error' AND started_at >= NOW() - N hours`. Parameterized window + limit.
- **`internal/service/agents.go`**: new `RecentErroredAgentRun` type + `ListRecentErroredAgentRuns` helper (window default 24h, limit default 5, both clamped).
- **`internal/api/agents.go`**: new `ListRecentErroredAgentRunsHandler` with `?hours=` (1–168) and `?limit=` (1–50). Read-only.
- **`internal/api/router.go`**: `GET /api/v1/agents/runs/recent-errors` wired into the read group.
- **2 new integration tests**:
  1. `OnlyRecentErrors`: 3 errored + 1 success seeded with mixed timestamps; verifies only errors in window land, ordering is most-recent-first, `error_message` is populated.
  2. `NoErrors_ReturnsEmpty`: agent with only successful runs leaves the result empty (filtered by slug for shared-DB determinism).
- **SPA**: `RecentErroredAgentRun` TS type + `useRecentErroredAgentRuns` hook with **60s refetchInterval**. New `RecentErrorsBanner` component under the onboarding banner; each row is clickable (agent name → transcript drawer via TanStack Router `params + search`). Native title carries the full error message when truncated.
- `openapi.yaml` + `docs/api-endpoints.md` updated per the upkeep rules.

## Design notes

- **Cheap-to-render banner, not a separate page.** Operators want this AT THE TOP of where they already go.
- **24h default window + 5 row cap** keeps visual weight bounded even during an outage; query supports up to 168h+50rows for future surfaces.
- **60s refetch** (hook-side) so a failure that happens while the operator has the page open surfaces without a refresh — but not so frequent that it hammers the DB.
- **Deep-link uses TanStack Router `params`** (not `href`) so the transcript drawer opens directly without a route round-trip.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new integration tests pass
- [x] All 30+ existing agent tests still pass
- [x] OpenAPI drift test green
- [x] `bun run lint` + `bun run build` clean

## Screenshot

Banner is conditional (hidden when there are no errors). The 5 seeded agents are disabled on a fresh install so there's nothing to fail organically — the screenshot would show the same /v2/agents I captured in iter-37. The component is straightforward and gated by `rows.length === 0` so it can't visually disrupt the happy-path layout.
