### PR TITLE
docs(agents): close 3 BLOCKING findings from end-user-journey audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ chmod +x breadbox
 export DATABASE_URL="postgres://user:pass@localhost:5432/breadbox?sslmode=disable"
 export ENCRYPTION_KEY="$(openssl rand -hex 32)"
 
+# First-time setup: pick an admin email + password (password is typed, not echoed).
+# Skip if you already have an admin account.
+./breadbox init
+
 ./breadbox serve
 # Visit http://localhost:8080
 ```
@@ -135,6 +139,9 @@ go install ./cmd/breadbox
 # Requires a running PostgreSQL instance
 export DATABASE_URL="postgres://user:pass@localhost:5432/breadbox?sslmode=disable"
 export ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+# First-time setup: pick an admin email + password (password is typed, not echoed).
+breadbox init
 
 breadbox serve
 # Visit http://localhost:8080

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -12,6 +12,12 @@ Recurring AI-powered workflows that run via the Claude Agent SDK and call breadb
    make agent-sidecar
    ```
    Outputs `bin/breadbox-agent`. Set `agent.runtime_path` in Settings → Agents if you put it elsewhere.
+
+   **Prerequisite: `bun`.** The sidecar is a TypeScript binary compiled via `bun build --compile`. If you don't have `bun` installed, the Makefile prints the install command — paste it into your shell:
+   ```sh
+   curl -fsSL https://bun.sh/install | bash
+   ```
+   No other Node/npm setup is required.
 3. **Pick a starter agent** from the v2 SPA at `/v2/agents`. Five defaults are seeded on fresh installs (disabled):
    - **Initial Setup** — broad rule + category mapping after first sync.
    - **Bulk Review** — thorough categorization pass over a large queue.
@@ -44,7 +50,14 @@ It spawns the sidecar with a tiny "say OK" prompt (no MCP servers, no agent defi
 Smoke test passed. The agent subsystem is ready to run real definitions.
 ```
 
-Exit code 3 = no Anthropic credential; exit code 5 = sidecar binary not found.
+Exit codes (full reference):
+
+| Exit | Meaning                                                  | Remediation                                                                 |
+| ---- | -------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 0    | Test succeeded — agent subsystem is ready                | None                                                                        |
+| 3    | No Anthropic credential configured                       | Paste a token in Settings → Agents (subscription or API key)                |
+| 5    | Sidecar binary not found                                 | Run `make agent-sidecar`, or set `agent.runtime_path` if it's already built |
+| 1    | Test ran but the sidecar crashed or the model errored    | Re-run with `--verbose` (planned) or check server logs for the sidecar stderr |
 
 ## Architecture (one-line view per layer)
 


### PR DESCRIPTION
## Summary

Iteration 41 — docs-only bundle. Addresses the three **BLOCKING** friction points the iter-40 end-user-journey subagent surfaced for new self-hosters.

## What's in

### 1. Undocumented `bun` requirement for `make agent-sidecar`

`docs/agents.md` Quick start now calls out `bun` as a prerequisite with the install command verbatim. New self-hosters were bouncing off the cryptic Makefile error.

### 2. `breadbox init` missing from README

`README.md` "Binary download" + "Go install" sections now show `breadbox init` as the first-time setup step before `breadbox serve`. Includes the "password is typed, not echoed" note since the init prompt is plain stdin (operators were assuming a TTY bug).

### 3. Exit-code gap in `docs/agents.md`

Replaced the one-line "exit 3 = no creds, exit 5 = no binary" note with a full 4-row table covering 0 / 1 / 3 / 5 + per-code remediation. Mirrors `internal/cli/agent.go`'s `RunE` Long help.

## What's NOT in this PR

The 4 ANNOYING findings (auth-mode banner copy, OAUTH-vs-API-key precedence warning, retention disk-usage guidance, runtime_path placeholder wording) and 3 PAPER-CUT findings (smoke-test failure CTA, model choice doc, docs cross-links). Will land across iter-42+ if dogfooding confirms they're worth picking up.

## Why this design

- **Docs-only.** Zero risk to merging, no CI impact beyond markdown.
- **Bundle the three BLOCKERS together** because they're all first-five-minutes-of-the-experience issues — a self-hoster hits them sequentially, so the fix should land sequentially.

## Test plan

No code changes; CI runs lint/build/test on markdown by reflex and they should be no-ops.
