### PR TITLE
docs+ui(agents): 4 ANNOYING fixes from end-user journey audit

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -83,9 +83,9 @@ Exit codes (full reference):
 
 ## Operational notes
 
-- **Cleanup**: completed runs older than `agent.run_retention_days` (default 30) are pruned daily at 3:15 AM local time. The matching on-disk transcript files (`<agent.transcript_dir>/<runID>.ndjson`) are pruned in the same pass using the same retention so the two surfaces stay in sync.
+- **Cleanup**: completed runs older than `agent.run_retention_days` (default 30) are pruned daily at 3:15 AM local time. The matching on-disk transcript files (`<agent.transcript_dir>/<runID>.ndjson`) are pruned in the same pass using the same retention so the two surfaces stay in sync. **Disk sizing**: transcripts run ~50 KB–500 KB each depending on the agent's verbosity (review-style agents are smaller; rules-and-tools agents with many MCP calls are larger). For 3 agents running daily on the default 30-day retention, budget roughly 50–500 MB of transcript storage steady-state. Settings → Agents → "Run cleanup now" forces an immediate prune if you just lowered the retention.
 - **Orphan recovery**: in-progress runs from a previous boot are marked `error` at startup so the run history doesn't lie.
-- **Auth precedence trap**: if both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are in the sidecar's env, the API key wins. The sidecar scrubs the unused var before invoking the SDK so this can't bite you accidentally.
+- **Auth precedence trap**: if both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are in the sidecar's env, the API key wins. The sidecar scrubs the unused var before invoking the SDK so this can't bite you accidentally — but the cleaner setup is to only set one in your `breadbox serve` environment. If you switch auth modes via Settings → Agents, also unset the unused env var on the host so future operators looking at `printenv` don't get confused.
 
 ## What replaced what
 

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -271,7 +271,7 @@ export function AgentsSection() {
                   <FormLabel>breadbox-agent binary path</FormLabel>
                   <FormControl>
                     <Input
-                      placeholder="auto-detected (./bin/breadbox-agent or PATH)"
+                      placeholder="auto: $BREADBOX_AGENT_BIN, ./bin/breadbox-agent, or PATH"
                       {...field}
                     />
                   </FormControl>

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -157,6 +157,15 @@ export function AgentsPage() {
               The seeded starter agents below won't fire until two pieces
               are in place. Status checked without any API call:
             </p>
+            {!status.auth_configured && (
+              <p className="text-muted-foreground text-xs">
+                <strong>New here?</strong> Pick the subscription token
+                option (free under your Claude plan credits, runs{" "}
+                <code>claude setup-token</code> once on any machine).
+                Switch to an Anthropic API key later if you need
+                pay-as-you-go billing past the 2026-06-15 cutover.
+              </p>
+            )}
             <ul className="text-sm">
               <li className="flex items-center gap-2">
                 {status.auth_configured ? (


### PR DESCRIPTION
## Summary

Iteration 42 — bundles all 4 ANNOYING findings from the iter-40 journey audit. Mix of one-line UI tweaks and docs improvements.

## What's in

### #4 — Vague onboarding banner when auth_mode not set

`web/src/routes/agents.tsx` onboarding Alert now shows an inline recommendation when auth isn't configured: *"New here? Pick the subscription token option (free under your Claude plan credits...)"* with a one-line nod to the 2026-06-15 cutover.

### #5 — Auth precedence trap docs improvement

`docs/agents.md` — same warning as before, plus practical guidance: *"the cleaner setup is to only set one in your `breadbox serve` environment. If you switch auth modes via Settings → Agents, also unset the unused env var so future operators looking at `printenv` don't get confused."* The sidecar's iter-1 scrub still mitigates accidents, but operators doing audits don't have to guess which token will win.

### #6 — Disk-usage guidance for retention setting

`docs/agents.md` Cleanup bullet now sizes the transcript footprint: *"transcripts run ~50 KB–500 KB each... budget roughly 50–500 MB steady-state for 3 agents on the default 30-day retention."* Plus pointer to iter-28's "Run cleanup now" button for immediate effect after lowering retention.

### #7 — runtime_path placeholder mismatch

`web/src/features/settings/agents-section.tsx` — placeholder used to say `"auto-detected (./bin/breadbox-agent or PATH)"` which omitted `$BREADBOX_AGENT_BIN`. Now matches the real discovery order: **`"auto: $BREADBOX_AGENT_BIN, ./bin/breadbox-agent, or PATH"`** — consistent with the FormDescription right below it.

## What's NOT in this PR

The 3 PAPER-CUT findings (smoke-test failure CTA, model-choice doc, docs cross-links). Cheap individually; will pick up opportunistically if a related iter touches the surface.

## Test plan

- [x] `bun run lint` + `bun run build` clean
- No backend changes; no Go test impact

## Bonus

Spawned comparable-product subagent in parallel (iter-32 cycle step 4). Returned 3 ideas; **top pick "Run replay / interactive transcript drill-down"** (LangSmith-style) queued for iter-43. Builds on iter-5's TranscriptViewer to make tool-call MCP responses inspectable inline.
