### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -4,7 +4,6 @@ package agent
 
 import "encoding/json"
 
-// EventType constants for the sidecar's NDJSON stream.
 const (
 	EventTypeAssistantMessage = "assistant_message"
 	EventTypeToolUse          = "tool_use"
@@ -63,10 +62,8 @@ func ParseEvent(line []byte) (Event, error) {
 	return Event{Type: env.Type, TS: env.TS, Raw: raw}, nil
 }
 
-// ParseResult unmarshals the raw JSON into a ResultPayload.
-// Only meaningful when e.Type == EventTypeResult — but ResultPayload's
-// fields live alongside the envelope, not nested under "data", so the
-// raw bytes work as-is.
+// ParseResult unmarshals the raw JSON into a ResultPayload. Only meaningful
+// when e.Type == EventTypeResult.
 func (e Event) ParseResult() (ResultPayload, error) {
 	// The sidecar emits {type, ts, data: {...payload...}}. Unwrap data.
 	var wrapper struct {

--- a/internal/agent/sidecar.go
+++ b/internal/agent/sidecar.go
@@ -143,7 +143,8 @@ func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (
 			continue
 		}
 		if transcript != nil {
-			_, _ = transcript.Write(append(append([]byte{}, line...), '\n'))
+			_, _ = transcript.Write(line)
+			_, _ = transcript.Write([]byte{'\n'})
 		}
 		evt, err := ParseEvent(line)
 		if err != nil {

--- a/web/src/components/auth-shell.tsx
+++ b/web/src/components/auth-shell.tsx
@@ -9,26 +9,13 @@ import {
 import { cn } from "@/lib/utils";
 
 // Two-pane shell for unauthenticated pages (login + setup-account). Left
-// pane is a brand panel that echoes the sidebar lockup so signing in feels
-// like stepping into the same product, not a separate marketing site. The
-// pane collapses on small screens — `lg:` is the breakpoint for showing the
-// full split. Right pane carries the page-specific form/card.
+// pane is a brand panel that echoes the in-app sidebar so signing in feels
+// like stepping into the same product; collapses below `lg`. Right pane
+// carries the page-specific form (`eyebrow` + `title` + `description`
+// echo PageHeader's vocabulary).
 //
-// Visual contract:
-// - Outer container: `min-h-screen bg-background` with a soft grid pattern
-//   in the brand panel; the rest of the chrome (header, footer note) lives
-//   in the form pane so the brand never has to know about the page state.
-// - Brand pane: bg-sidebar (matches the in-app sidebar surface so it reads
-//   as "Breadbox") + tinted accents (`primary/12`, `primary/5`) for the
-//   glow + feature pills. Decorative dot grid uses `mask-image` so it fades
-//   to the edges, avoiding the "tablecloth" effect.
-// - Form pane: the page passes `eyebrow` + `title` + `description` (echoes
-//   PageHeader vocabulary) and any form body / footer node. Optional
-//   `secondaryAction` slot sits on the right of the title row for things
-//   like "Need help?" or "Switch account".
-//
-// Keep this primitive simple — it does layout + brand, not state. State
-// (loading, success, error) belongs in the consumer.
+// Keep this primitive simple — layout + brand, not state. Loading /
+// success / error belong in the consumer.
 
 export interface AuthShellProps {
   eyebrow?: React.ReactNode;

--- a/web/src/components/coming-soon-pill.tsx
+++ b/web/src/components/coming-soon-pill.tsx
@@ -4,33 +4,13 @@ import { Clock, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
- * ComingSoonPill — the canonical muted "Coming soon" status pill rendered
- * in the trailing slot of a `<StatusPanel tone="info">` for unbuilt
- * surfaces.
+ * ComingSoonPill — the canonical muted "Coming soon" status pill, used in
+ * the trailing slot of `<StatusPanel tone="info">` for unbuilt surfaces.
  *
- * Vocabulary: muted background + muted-foreground label, fully-rounded
- * pill (`rounded-full`), `px-2.5 py-1 text-[11px]`, uppercase + wide
- * tracking, leading `Clock` icon at `size-3`. Distinct from the iter-37
- * `<Eyebrow>` (no chip, used as a section/page micro-label) and from
- * shadcn `<Badge>` (rectangular, semantic-tone variants) — this is a
- * neutral inline status chip whose only job is to caption "not yet."
- *
- * Two consumers share it today: `routes/placeholder.tsx` (the canonical
- * unbuilt-nav-leaf shell, iter 21) and `components/settings-shell.tsx`
- * (the in-the-works settings section panel, iter 78). Both previously
- * hand-rolled a 10-class span — promoted in iter 102 so the pill shape,
- * padding, and rhythm live in one place. Sibling of `<JumpToPill>` in
- * the iter-30 "primary-tinted pill triad" drift note: when a new
- * surface needs the muted variant, reach for this; when it needs the
- * primary-tinted v2-chip variant, that one is still inlined in
- * `BrandHeader` / `AuthShell` until the third surface adopts it.
- *
- * `icon` defaults to `Clock` (matches both live consumers); pass a
- * different `LucideIcon` if a new caller wants a different leading
- * glyph without losing the chip rhythm. `children` is the label —
- * keep it short ("Coming soon", "In review", "Beta"). If a non-muted
- * tone is ever needed, add a `tone` prop here rather than forking the
- * className — keep the vocabulary in one file.
+ * Neutral inline status chip whose only job is to caption "not yet." Don't
+ * fork the look — pass `icon` / `children` to vary the leading glyph or
+ * label; if a non-muted tone is ever needed, add a `tone` prop here rather
+ * than forking the className.
  */
 export interface ComingSoonPillProps
   extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {

--- a/web/src/components/detail-page-skeleton.tsx
+++ b/web/src/components/detail-page-skeleton.tsx
@@ -38,23 +38,13 @@ interface DetailPageSkeletonProps {
 }
 
 // DetailPageSkeleton is the canonical loading shell for every v2 detail
-// page (transaction, account, category, connection). It composes the
-// existing iter-10 `<ColorRailCardSkeleton>` hero with the iter-75
+// page. It composes a `<ColorRailCardSkeleton>` hero with a
 // `<JumpToRow>`-shaped pill strip and a two-column grid of `rounded-xl`
 // block placeholders matching `<SectionCard>` / `<ListCard>` chrome.
 //
-// Sibling of `<PageError>` (iter 82 #1196) — three states, three
-// vocabularies, one visual system: error → `<PageError>`, loading →
-// `<DetailPageSkeleton>`, empty → `<EmptyState>`. Every v2 detail page
-// already routes its error state through `<PageError>`; this primitive
-// gives the loading state the same one-place-to-edit treatment.
-//
-// Before this primitive landed, every detail route hand-rolled its own
-// `function DetailSkeleton()` with copy-pasted layout markup that drifted
-// in subtle ways (gap spacing, sidebar widths, pill widths). Four
-// surfaces now route through it: transaction-detail, account-detail,
-// category-detail, connection-detail. Don't fork — extend this
-// primitive if a fifth consumer needs a new layout knob.
+// Three loading vocabularies, one visual system: error → `<PageError>`,
+// loading → `<DetailPageSkeleton>`, empty → `<EmptyState>`. Don't fork —
+// extend this primitive if a new layout knob is needed.
 export function DetailPageSkeleton({
   hero,
   jumpPills = 0,

--- a/web/src/components/empty-state.tsx
+++ b/web/src/components/empty-state.tsx
@@ -28,9 +28,8 @@ export interface EmptyStateProps {
   className?: string;
 }
 
-// Zero-data state for a page or section that loaded fine but has nothing to
-// show. Distinct from routes/placeholder.tsx, which marks a page that hasn't
-// been built yet.
+// Zero-data state for a page or section that loaded fine but has nothing
+// to show. (Use `routes/placeholder.tsx` instead for an unbuilt page.)
 //
 // Visual contract:
 // - Always centered, icon tile → title → description → action.

--- a/web/src/components/eyebrow.tsx
+++ b/web/src/components/eyebrow.tsx
@@ -39,15 +39,11 @@ interface EyebrowProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 // Eyebrow is the canonical uppercase micro-label used across detail pages,
-// hero cards, timeline rails, AND sidebar/menu group labels:
+// hero cards, timeline rails, and sidebar/menu group labels:
 // `text-muted-foreground text-[10px] font-medium tracking-[0.1em]
 // uppercase` is the default; `font-semibold` cousins live behind the
-// `nav` variant. The pattern was open-coded across ten files in five
-// subtly different sizes/trackings before iter 37 consolidated them, and
-// the `nav`-scale `font-semibold` cousins (sidebar group labels +
-// shortcut-sheet group headers) were unified onto the primitive in
-// iter 95. Don't reach for raw `text-[10px] font-medium/semibold
-// tracking-* uppercase` markup again — extend this primitive with a new
+// `nav` variant. Don't reach for raw `text-[10px] font-medium/semibold
+// tracking-* uppercase` markup — extend this primitive with a new
 // variant if a host needs a different rhythm.
 export function Eyebrow({
   as: Tag = "span",

--- a/web/src/components/jump-to-pill.tsx
+++ b/web/src/components/jump-to-pill.tsx
@@ -7,16 +7,9 @@ import { cn } from "@/lib/utils";
 /**
  * JumpToPill — the canonical detail-page "Jump to" pill button.
  *
- * Vocabulary: ghost-outline pill (`variant="outline"`, `size="sm"`,
- * `h-7 px-2.5`), 11px label text (`text-xs`), `size-3` leading icon.
- * Reads as a labelled lateral link from the hero of a detail page —
- * different from a primary CTA (`size="sm"` default), different from
- * a toolbar pill (`size="xs"` -> h-6), different from the action strip
- * inside `<ColorRailCard footer>` slot (real `size="sm"` buttons).
- *
- * Composition is intentionally identical to the open-coded markup that
- * was duplicated across TX-detail, Account-detail, Category-detail,
- * Connection-detail "Jump to" rows. Don't fork the look — pass props.
+ * Ghost-outline pill (`variant="outline"`, `size="sm"`, `h-7 px-2.5`),
+ * 11px label text, `size-3` leading icon. Reads as a labelled lateral
+ * link from a detail-page hero. Don't fork the look — pass props.
  *
  * `asChild` forwards to shadcn `Button.asChild` so consumers can wrap
  * a `<Link>` (the most common case) without losing keyboard ergonomics.
@@ -48,8 +41,6 @@ export function JumpToPill({
 /**
  * JumpToRow — the labelled "Jump to" eyebrow + pill cluster used in
  * detail-page hero columns. Children should be `<JumpToPill>` elements.
- * The eyebrow itself is the iter-37 `<Eyebrow>` primitive, so the row
- * inherits the canonical uppercase micro-label vocabulary.
  */
 export function JumpToRow({
   label = "Jump to",

--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -61,16 +61,9 @@ interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "c
 // off. Row padding is consumer-supplied (typically `px-5 py-3` or
 // `px-5 py-3.5`), one stride below the header.
 //
-// Header alignment (iter 105): same fix as `SectionCard`. The shadcn
-// `CardHeader` grid defaults to `items-start` plus a `[.border-b]:pb-6`
-// rule that injects 24px of bottom padding when the header has a divider.
-// On `ListCard`'s "Recent activity" / "Connections" headers — title on
-// the left, `ViewAllPill` / "Manage" pill on the right — the result was
-// a crooked baseline (title pinned to top, action protruding 8px below)
-// AND a too-tall header band (24px below the title instead of 16px,
-// breaking symmetry with the 20px row stride below). `!pb-4` matches
-// `SectionCard`'s long-standing override; `items-center` plus title
-// `font-semibold` cures the baseline.
+// Header overrides shadcn's default `items-start` to `items-center` and
+// `!pb-4` to neutralize the `[.border-b]:pb-6` rule — same fix as
+// `SectionCard`, so the two primitives' headers stay symmetric.
 //
 // When `rows.length === 0`, the `empty` slot replaces the `<ul>`. Pass
 // `<EmptyState>` for first-class look + CTA, or a short muted string for a

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -29,10 +29,9 @@ interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "t
 
 // SectionCard is the canonical "page section in a card" container — bordered
 // header that names the section, optional trailing action, body that hosts
-// the content. Established across the v2 design pass on Home (recent
-// activity / connections), Transaction-detail (Activity / Details), and now
-// Account-detail (Settings / Links / Recent transactions / Details). Wraps
-// shadcn `Card` so every surface speaks the same vocabulary.
+// the content. Wraps shadcn `Card` so every surface speaks the same
+// vocabulary. Pair with `ListCard` (same header rhythm) when the body is a
+// list. Don't fork the look — change this primitive.
 //
 // Visual contract:
 //   `<Card className="gap-0 py-0">`
@@ -40,20 +39,9 @@ interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "t
 //     `<CardContent className="px-5 py-5">` content (or px-0 py-0 when flushBody)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
 //
-// Vertical rhythm: header `py-4` (16px) + body `py-5` (20px) reads as a
-// slight density step from chrome to content. Matched by `ListCard` so the
-// two cards visually align when they sit on the same page. Don't fork the
-// look — change this primitive.
-//
-// Header alignment (iter 105): the shadcn `CardHeader` grid defaults to
-// `items-start`, which pinned the 20px title to the top of the row while a
-// 28-32px action (ViewAllPill / Button size="sm") protruded downward by
-// 8-12px. That asymmetry — title's baseline higher than the action's
-// vertical center — was the "header looks crooked" complaint. We override
-// to `items-center` so the title and action sit on the same vertical
-// midline regardless of action height. The title weight bump from
-// `font-medium` → `font-semibold` gives it enough anchor that it doesn't
-// read as a caption next to the action button.
+// The header overrides shadcn's default `items-start` to `items-center` so
+// mixed-height children (20px title vs 28-32px trailing action) sit on the
+// same midline.
 export function SectionCard({
   title,
   action,

--- a/web/src/components/settings-section-header.tsx
+++ b/web/src/components/settings-section-header.tsx
@@ -37,16 +37,13 @@ interface SettingsSectionHeaderProps {
  *   - `sub`     → `<h3>` `text-sm font-semibold`, action centered to title
  *     row, `space-y-1` description.
  *
- * Iter 107 ripple from iter 106's `SectionCard` / `ListCard` baseline polish:
- * bumped both heading tokens from `font-medium` to `font-semibold` so the
- * title carries enough anchor next to a real action button (`Button size="sm"`,
- * `Add member` etc.) instead of reading as a caption. The vocabulary now
- * matches `PageHeader` (`text-2xl font-semibold`) and the canonical card
- * header recipe (`text-sm font-semibold`).
+ * Both heading tokens use `font-semibold` to match `PageHeader` and the
+ * canonical card-header recipe — the title needs anchor weight next to a
+ * real action button instead of reading as a caption.
  *
- * Don't fork the look — extend the primitive. If a fourth weight is needed
- * (e.g. a "field group" rhythm tighter than `sub`), add it as a new token
- * here rather than open-coding another `<h4>` block in a feature file.
+ * Don't fork the look — extend the primitive. If a fourth weight is needed,
+ * add it as a new token here rather than open-coding another `<h4>` block
+ * in a feature file.
  */
 export function SettingsSectionHeader({
   level = "section",

--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -9,22 +9,16 @@ import { cn } from "@/lib/utils";
 // the card background so it "punches through" the line. Headings (day
 // labels, week labels, run-status labels) sit outside the rail as anchors.
 //
-// Promoted in iter 26 from `features/transactions/activity-timeline.tsx`
-// (open-coded since iter 5). Reworked in iter 56 to fix the rail-tail bug
-// flagged by iter 55's audit: the per-group rail used `<ol border-l>`,
-// which made the line visibly extend past the last row's icon disc — the
-// disc was inset with negative margin so the `<ol>`'s left border kept
-// going past the centred icon. We now draw the rail per-row via an
-// `::before` pseudo-element on each `<li>` and clip it to the disc centre
-// on the first and last row of each group via `:first-of-type` /
-// `:last-of-type`. Middle rows draw a full-height segment so the line
-// reads as continuous within each group.
+// The rail is drawn per-row via an `::before` pseudo-element on each `<li>`
+// and clipped to the disc centre on the first and last row of each group via
+// `:first-of-type` / `:last-of-type`. Middle rows draw a full-height segment
+// so the line reads as continuous within each group. (A previous `<ol
+// border-l>` implementation made the line extend past the last disc.)
 //
-// Composition (unchanged consumer API): <TimelineRail> renders the wrapper
-// spacing; nest <TimelineRail.Group> children with optional `label` (day
-// heading); inside the group render any number of <TimelineRail.Row>
-// children. Each row takes an `icon` (Lucide component) and arbitrary
-// children for the content.
+// Composition: <TimelineRail> renders the wrapper spacing; nest
+// <TimelineRail.Group> children with optional `label` (day heading); inside
+// the group render any number of <TimelineRail.Row> children. Each row takes
+// an `icon` (Lucide component) and arbitrary children for the content.
 
 interface TimelineRailProps extends React.HTMLAttributes<HTMLDivElement> {
   // Vertical rhythm between groups. Defaults to `space-y-5` — matches the
@@ -172,11 +166,6 @@ function TimelineRailRow({
         "relative flex gap-3 pl-3.5",
         // Rail line drawn via `::before`. 1px wide, centred on the disc
         // centre at x=14px → left = 14px - 0.5px = calc(0.875rem - 0.5px).
-        // Iter 56 introduced this pseudo-element rail (replacing
-        // `<ol border-l>`) but anchored it at `left-0`, which sat the rail
-        // 13.5px to the left of the disc centre — a regression caught in
-        // iter 77 and fixed here. The pseudo gets the same
-        // `border-border/60` token as the previous border.
         "before:content-[''] before:absolute before:left-[calc(0.875rem-0.5px)] before:w-px before:bg-border/60",
         // Middle rows: full height; the row's `space-y-3` (12px) gap with
         // the next sibling is bridged by `bottom: -12px` so the rail
@@ -282,10 +271,4 @@ export const TimelineRail = Object.assign(TimelineRailRoot, {
   RowSkeleton: TimelineRailRowSkeleton,
 });
 
-export type {
-  TimelineRailProps,
-  TimelineRailGroupProps,
-  TimelineRailRowProps,
-  TimelineRailRowSkeletonProps,
-  TimelineRailTone,
-};
+export type { TimelineRailTone };

--- a/web/src/components/transaction-amount.tsx
+++ b/web/src/components/transaction-amount.tsx
@@ -7,17 +7,10 @@ interface TransactionAmountProps {
   className?: string;
 }
 
-// TransactionAmount is the reusable right-aligned amount block — the signed
-// amount with the transaction date beneath it.
-//
-// Sign vocabulary: inflows (negative amounts) render in the success color.
-//
-// Pending vocabulary (iter 103): when the transaction has not posted yet
-// (`t.pending`), the amount renders italic + at 70% opacity so a scanning eye
-// reads the row as tentative. Pairs with the `Pending` `<MetaBadge>` in
-// `<TransactionPrimary>` — once a row is settled the visual settles down too.
-// Title attribute carries the contract for keyboard/sighted hover; the badge
-// alongside the description carries the screen-reader text.
+// Inflows (negative amounts) render in the success color. Pending rows
+// (`t.pending`) render italic + 70% opacity to read as tentative; the
+// matching `Pending` MetaBadge in <TransactionPrimary> carries the
+// screen-reader text.
 export function TransactionAmount({
   transaction: t,
   className,

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -10,17 +10,11 @@ interface TransactionPrimaryProps {
   className?: string;
 }
 
-// TransactionPrimary is the reusable identity block for a transaction — the
-// category icon tile, the bank description as the title with an inline
-// "Pending" marker, and a secondary line of metadata (account · member · tags).
-// Shared by the transactions table and any future transaction list.
-//
-// Pending vocabulary (iter 103): the inline "Pending" marker now rides
-// `<MetaBadge muted icon={Clock}>` so it reads as part of the v2
-// secondary-state chip family (System / Hidden / Excluded / Linked / Re-auth)
-// instead of an orphan muted span. Pairs with the italic + opacity
-// treatment in `<TransactionAmount>` so both columns communicate
-// "not yet settled" at a glance.
+// Identity block for a transaction: category icon tile, bank description
+// with an inline `Pending` MetaBadge, and a secondary line of metadata
+// (account · member · tags). Pending rides MetaBadge so it joins the
+// secondary-state chip family (System / Hidden / Excluded / Linked /
+// Re-auth) instead of an orphan muted span.
 export function TransactionPrimary({
   transaction: t,
   className,

--- a/web/src/features/categories/category-form.tsx
+++ b/web/src/features/categories/category-form.tsx
@@ -57,7 +57,7 @@ const baseSchema = z.object({
   hidden: z.boolean(),
 });
 
-export type CategoryFormValues = z.infer<typeof baseSchema>;
+type CategoryFormValues = z.infer<typeof baseSchema>;
 
 interface CategoryFormProps {
   mode: "create" | "edit";

--- a/web/src/features/connections/csv-import-form.tsx
+++ b/web/src/features/connections/csv-import-form.tsx
@@ -20,7 +20,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { StatusPanel } from "@/components/status-panel";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
   TableBody,
@@ -680,14 +679,3 @@ function ColumnSelect({
   );
 }
 
-// CsvImportFormSkeleton renders an approximate skeleton for the form — used
-// by the sandbox specimen so the layout shows up without needing a live file
-// preview.
-export function CsvImportFormSkeleton() {
-  return (
-    <div className="flex flex-col gap-4">
-      <Skeleton className="h-32 w-full rounded-lg" />
-      <Skeleton className="h-10 w-full" />
-    </div>
-  );
-}

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -81,10 +81,6 @@ export function ReauthSheet({
   const conn = connQuery.data;
   const institutionName = conn?.institution_name ?? "Untitled connection";
 
-  function handleSheetChange(next: boolean) {
-    onOpenChange(next);
-  }
-
   async function onReconnect() {
     if (!conn) return;
     setErrorMessage(null);
@@ -141,7 +137,7 @@ export function ReauthSheet({
       toast.success(`Reconnected ${institutionName}.`, {
         description: "Sync resumed — accounts will refresh on the next webhook.",
       });
-      handleSheetChange(false);
+      onOpenChange(false);
     } catch (err) {
       const msg =
         err instanceof ApiError
@@ -162,7 +158,7 @@ export function ReauthSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={handleSheetChange}>
+    <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="flex flex-col gap-0 p-0">
         <DetailSheetHeader
           density="accent"
@@ -243,7 +239,7 @@ export function ReauthSheet({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => handleSheetChange(false)}
+              onClick={() => onOpenChange(false)}
               disabled={reauthStart.isPending}
             >
               Cancel
@@ -266,7 +262,7 @@ export function ReauthSheet({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => handleSheetChange(false)}
+              onClick={() => onOpenChange(false)}
             >
               Close
             </Button>

--- a/web/src/features/providers/provider-status.tsx
+++ b/web/src/features/providers/provider-status.tsx
@@ -1,4 +1,4 @@
-import { Activity, AlertTriangle, CheckCircle2, CircleDashed, Loader2 } from "lucide-react";
+import { AlertTriangle, CheckCircle2, CircleDashed } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Eyebrow } from "@/components/eyebrow";
 import { cn } from "@/lib/utils";
@@ -85,51 +85,6 @@ export function ProviderStatusBadge({ health, configured }: ProviderStatusBadgeP
   );
 }
 
-interface ProviderStatsProps {
-  health: ProviderHealthResponse | undefined;
-}
-
-// ProviderStats renders the connections / accounts / last-sync row under the
-// card header. Hides itself entirely if there's no data — empty stats look
-// like a loading state and confuse users.
-export function ProviderStats({ health }: ProviderStatsProps) {
-  if (!health) return null;
-  const inProgress = health.last_sync_status === "in_progress";
-  return (
-    <dl className="text-muted-foreground flex flex-wrap items-center gap-x-6 gap-y-1.5 text-xs">
-      <Stat label="Connections" value={String(health.connection_count)} />
-      <Stat label="Accounts" value={String(health.account_count)} />
-      {health.last_sync_time && (
-        <div className="flex items-center gap-1.5">
-          <Activity className="size-3" />
-          <dt>Last sync</dt>
-          <dd
-            className={cn(
-              "text-foreground font-medium",
-              health.last_sync_status === "success" && "text-emerald-600 dark:text-emerald-400",
-              health.last_sync_status === "error" && "text-destructive",
-            )}
-          >
-            {health.last_sync_status === "error" ? `failed ${health.last_sync_time}` : health.last_sync_time}
-          </dd>
-        </div>
-      )}
-      {!health.last_sync_time && health.connection_count > 0 && (
-        <div className="flex items-center gap-1.5">
-          <Activity className="size-3" />
-          <span>Never synced</span>
-        </div>
-      )}
-      {inProgress && (
-        <div className="text-foreground flex items-center gap-1.5 font-medium">
-          <Loader2 className="size-3 animate-spin" />
-          In progress
-        </div>
-      )}
-    </dl>
-  );
-}
-
 interface ProviderScoreboardProps {
   health: ProviderHealthResponse | undefined;
   tone: ProviderTone;
@@ -199,11 +154,3 @@ function ScoreCell({ label, value }: { label: string; value: string }) {
   );
 }
 
-function Stat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-center gap-1.5">
-      <dt>{label}</dt>
-      <dd className="text-foreground font-medium">{value}</dd>
-    </div>
-  );
-}

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -152,7 +152,7 @@ const ruleFormSchema = z
     }
   });
 
-export type RuleFormValues = z.infer<typeof ruleFormSchema>;
+type RuleFormValues = z.infer<typeof ruleFormSchema>;
 
 export interface RuleFormSubmit {
   name: string;

--- a/web/src/features/tags/tag-form.tsx
+++ b/web/src/features/tags/tag-form.tsx
@@ -44,7 +44,7 @@ const createSchema = z.object({
   color: z.string().nullable(),
 });
 
-export type TagFormValues = z.infer<typeof createSchema>;
+type TagFormValues = z.infer<typeof createSchema>;
 
 interface TagFormProps {
   mode: "create" | "edit";

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -35,7 +35,7 @@ export const accountsSearchSchema = z.object({
   group: z.enum(["institution", "type"]).optional(),
 });
 
-export type AccountsSearch = z.infer<typeof accountsSearchSchema>;
+type AccountsSearch = z.infer<typeof accountsSearchSchema>;
 
 export function AccountsPage() {
   const search = useSearch({ strict: false }) as AccountsSearch;

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -442,7 +442,7 @@ function DetailBody({
         />
       )}
 
-      <QuickActions conn={conn} />
+      <QuickActions />
 
       {/* Two-column body: primary content on the left, settings + details
           on the right. Mirrors the Account-detail layout (which inverted
@@ -725,11 +725,11 @@ function Hero({
   );
 }
 
-// QuickActions matches the iter-5/6 "Jump to" pill row used on TX and
-// Account detail — labelled lateral navigation that surfaces concrete
-// targets (the connection's accounts, the global sync-logs feed) rather
-// than just verbs.
-function QuickActions(_props: { conn: ConnectionDetail }) {
+// QuickActions matches the "Jump to" pill row used on TX and Account
+// detail — labelled lateral navigation that surfaces concrete targets
+// (the connection's accounts, the global sync-logs feed) rather than
+// just verbs.
+function QuickActions() {
   return (
     <JumpToRow>
       <JumpToPill asChild>

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -38,7 +38,7 @@ export const connectionsSearchSchema = z.object({
   reauth: z.string().optional(),
 });
 
-export type ConnectionsSearch = z.infer<typeof connectionsSearchSchema>;
+type ConnectionsSearch = z.infer<typeof connectionsSearchSchema>;
 
 export function ConnectionsPage() {
   const search = useSearch({ strict: false }) as ConnectionsSearch;

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -38,7 +38,7 @@ export const rulesSearchSchema = z.object({
   p: z.coerce.number().int().min(1).optional(),
 });
 
-export type RulesSearch = z.infer<typeof rulesSearchSchema>;
+type RulesSearch = z.infer<typeof rulesSearchSchema>;
 
 // Title-bar widths rotate per-row so the skeleton stack reads as a stack of
 // varied-length rules instead of a metronome. Five rows matches the page-size


### PR DESCRIPTION
## Summary

Daily simplify-drift review of PRs merged in the last 24 hours. Net **-180 LOC** across 24 files; no behaviour changes.

## PRs reviewed

- #1228 — design(v2) rollup #4: 8 PRs — 2 more primitives, header baseline polish, table sticky fix
- #1223 — feat(agents): foundation — schema, appconfig, Node sidecar runner
- #1219 — fix(v2): expose Teller app id on reauth response so reconnect Sheet works
- #1216 — design(v2) rollup #3: 22 PRs — 7 more primitives, real type-check, state/error polish
- #1199 — fix(main): repair type errors from rollup #1192 — restore Docker build
- #1192 — design(v2) rollup #2: 45 PRs — 8 more primitives, dark mode polish, mobile + a11y sweeps
- #1146 — design(v2): full SPA redesign — 11 shared primitives, dark mode, mobile sweep

## Changes

**Dead code removal**
- `web/src/features/connections/csv-import-form.tsx` — delete unused `CsvImportFormSkeleton` (no importers; comment claimed sandbox usage but sandbox never imported it) + unused `Skeleton` import
- `web/src/features/providers/provider-status.tsx` — delete unused `ProviderStats` + `ProviderStatsProps` (superseded by `ProviderScoreboard`) and the `Stat` helper that only it used; prune `Activity`/`Loader2` imports
- `web/src/routes/connection-detail.tsx:732` — drop unused `conn` prop from `QuickActions` and the matching `conn={conn}` at the call site
- `web/src/components/timeline-rail.tsx` — drop 4 unused re-exported types (`TimelineRailProps`, `TimelineRailGroupProps`, `TimelineRailRowProps`, `TimelineRailRowSkeletonProps`); `TimelineRailTone` kept (used externally)
- Drop unnecessary `export` keywords on same-file-only types: `CategoryFormValues`, `TagFormValues`, `RuleFormValues`, `AccountsSearch`, `ConnectionsSearch`, `RulesSearch`

**Small simplification**
- `web/src/features/connections/reauth-sheet.tsx` — inline the `handleSheetChange` pass-through (was `(next) => onOpenChange(next)`); 4 call sites collapsed to `onOpenChange`

**Comment cleanup (WHY-only, no sprint/iter narration)**
- Trim "iter 5/26/37/55/56/77/95/102/105/107", "#1196", and caller-name list noise from 11 component doc comments while keeping the load-bearing WHY (visual contracts, the `::before` rail constraint, the `items-center` override rationale, etc.). Files: `transaction-amount.tsx`, `transaction-primary.tsx`, `timeline-rail.tsx`, `section-card.tsx`, `list-card.tsx`, `settings-section-header.tsx`, `empty-state.tsx`, `coming-soon-pill.tsx`, `jump-to-pill.tsx`, `detail-page-skeleton.tsx`, `eyebrow.tsx`, `auth-shell.tsx`

**Go**
- `internal/agent/event.go:66` — fix actively misleading `ParseResult` doc: it claimed payload fields "live alongside the envelope, not nested under 'data'" while the code below explicitly unwraps `data:` from a wrapper struct
- `internal/agent/event.go:7` — drop redundant `// EventType constants for the sidecar's NDJSON stream.` above an `EventType*` const block
- `internal/agent/sidecar.go:146` — replace `transcript.Write(append(append([]byte{}, line...), '\n'))` (a per-line allocation just to append `\n`) with two `Write` calls

## Skipped (noted for the record)

- Forward-declared API surface in `internal/agent/*` and `internal/appconfig/{keys,encrypted}.go` — exported types/constants with zero callers today (e.g. `Writer`, `ReadEncrypted`, `WriteEncrypted`, several `KeyAgent*` consts, `AuthMode*` consts, `StatusSkipped`, four `EventType*` consts). All are the agent-foundation PR's intentional scaffolding for the next iteration. Don't delete in a simplify pass.
- Stringly-typed `"plaid"`/`"teller"`/`"csv"` in `reauth-sheet.tsx` and `provider-picker.tsx` — fixing would require introducing a shared union; out of scope per "no new abstractions."
- `internal/agent/sidecar.go` `DurationMs` duplication across early-return branches — a `defer` would fold it, but the timing semantics shift slightly and the file is brand-new with likely follow-ups. Skipping to avoid churn.
- `internal/agent/sidecar.go:48-54` TOCTOU stat-before-exec — flagged but changing it shifts the error class (`ErrBinaryNotFound` vs `exec.LookPath` errors). Out of scope.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `bun run lint` (`tsc -b --noEmit`) in `web/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DUbSPrsnHXhMX2ZVBmXG25)_