### PR TITLE
docs+ui(agents): 3 PAPER-CUT fixes from end-user journey audit

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,6 +24,8 @@ Recurring AI-powered workflows that run via the Claude Agent SDK and call breadb
    - **Quick Review** — fast batch-categorize, prioritizes speed.
    - **Routine Review** — daily/weekly pass over fresh transactions.
    - **Spending Report** — weekly category-grouped summary with anomalies.
+
+   All five seed with `claude-opus-4-7` for maximum reasoning. Edit the **Model** field on any agent's edit page to switch to a cheaper/faster variant — Haiku for short routine passes, Sonnet for everyday work, Opus for setup or complex analysis. The model picker covers every supported Claude model the SDK accepts.
 4. **Edit prompt + schedule**, click Save, then flip the Enabled toggle. The agent fires on its cron schedule and shows up in the Runs page.
 5. **Hit Run now** in the list page to trigger immediately. The result lands in the run history with a full transcript (tool calls + cost + token usage).
 
@@ -99,6 +101,7 @@ The five seeded starter agents are direct ports of the v1 wizard's prompts. Edit
 ## See also
 
 - `docs/api-endpoints.md` — REST catalog for `/api/v1/agents/*`
+- `docs/cli-commands.md` — CLI surface for the `breadbox agent` subcommands (`test`, `run`, `list`)
 - `internal/agent/seed.go` — list of starter agents and their prompt mappings
 - `prompts/agents/` — the markdown source for every seeded prompt
 - `.claude/sprint-state.md` — sprint history and design decisions

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -350,7 +350,18 @@ export function AgentsSection() {
               <Alert variant="destructive">
                 <XCircle className="size-4" />
                 <AlertTitle>Test failed — {testError.code}</AlertTitle>
-                <AlertDescription>{testError.message}</AlertDescription>
+                <AlertDescription className="space-y-1">
+                  <p>{testError.message}</p>
+                  <p className="text-xs">
+                    For deeper diagnostics run{" "}
+                    <code className="rounded bg-background/40 px-1 py-0.5 font-mono">
+                      breadbox agent test
+                    </code>{" "}
+                    in a shell (exit codes 3 / 5 / 1 distinguish auth /
+                    binary / runtime failures) or check the server logs
+                    for the sidecar stderr.
+                  </p>
+                </AlertDescription>
               </Alert>
             )}
           </form>


### PR DESCRIPTION
## Summary

Iteration 44 — bundles the final 3 PAPER-CUT findings from the iter-40 journey audit.

**All-time score: 10 of 10 audit findings closed.** (3 BLOCKING in iter-41, 4 ANNOYING in iter-42, 3 PAPER-CUT here.)

## What's in

### #8 — Smoke test failure surface lacked a deeper-debug CTA

`web/src/features/settings/agents-section.tsx` — the destructive Alert that fires when the in-SPA Test connection button fails now includes a one-line "for deeper diagnostics" note pointing to `breadbox agent test` (with its exit-code reference distinguishing auth / binary / runtime failures) + server logs. Mirrors the iter-41 docs/agents.md exit-code table.

### #9 — Seed agents' Opus model choice was undocumented

`docs/agents.md` Quick start — "Pick a starter agent" now notes all five seed with `claude-opus-4-7` for maximum reasoning, and the operator can edit Model on any agent's edit page to switch to Haiku for routine passes or Sonnet for everyday work. Closes the "why is my bill higher than expected" question.

### #10 — `docs/agents.md` had no cross-reference to `docs/cli-commands.md`

Added a bullet in the "See also" section pointing to the CLI catalog for the `breadbox agent` subcommands (test / run / list). Self-hosters reaching the docs page looking for CLI usage now have a signpost.

## Why this design

- Three independent ~1-line fixes; bundling avoids trivial-PR overhead without making any single one harder to review.
- All read-only / copy-only — zero risk to existing behavior, no schema or API contract changes.
- Docs + UI both touched because the audit findings span both surfaces; keeping them in one PR makes the "all audit findings closed" milestone easier to communicate.

## Test plan

- [x] `bun run lint` + `bun run build` clean
- No Go test impact (markdown-only on backend; SPA changes are AlertDescription copy expansion)

## Audit follow-ups

**All 10 closed** across iters 41, 42, 44. End-user-journey path now matches the docs from `git pull` through "first run."
