### PR TITLE
feat(agents): "Test this prompt" button + prompt-override on /run

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -264,7 +264,7 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | DELETE | `/agents/{slug}` | W | Delete the definition; historical runs preserved (FK SET NULL) |
 | POST | `/agents/{slug}/enable` | W | Flip enabled=true |
 | POST | `/agents/{slug}/disable` | W | Flip enabled=false |
-| POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; optional `{prompt_prefix}` body prepends per-run context (≤2000 chars); 503 `CONCURRENCY_LOCKED` when another run is in progress |
+| POST | `/agents/{slug}/run` | W | Trigger an immediate synchronous run; optional body fields `{prompt_prefix}` (prepend, ≤2000) and `{prompt}` (full override, ≤40000) — `prompt` wins when both set; 503 `CONCURRENCY_LOCKED` when another run is in progress |
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | POST | `/agents/cleanup` | W | Run the agent cleanup pass on demand; returns `{runs_deleted, transcripts_deleted, transcripts_scanned, retention_days, transcript_dir}` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200); filters: `status`, `trigger`, `hit_cap` (`max_turns`/`max_budget`/`any`), `start`, `end` |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -422,10 +422,17 @@ func UpdateAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFu
 }
 
 // runAgentNowRequest is the optional JSON body for "run now". An empty
-// body — common for the v2 SPA's bare-button click — leaves prompt_prefix
-// unset, which the orchestrator treats as no prefix.
+// body — common for the v2 SPA's bare-button click — leaves both fields
+// unset, which the orchestrator treats as "use the saved def.Prompt
+// verbatim."
 type runAgentNowRequest struct {
 	PromptPrefix string `json:"prompt_prefix,omitempty"`
+	// PromptOverride replaces def.Prompt entirely for this fire. Powers
+	// the iter-45 "Test this prompt" button on the agent edit page so an
+	// operator can dry-fire an unsaved prompt without round-tripping
+	// through Save. Mutually exclusive with PromptPrefix at apply time
+	// (override wins) per Orchestrator.RunNowWith.
+	PromptOverride string `json:"prompt,omitempty"`
 }
 
 // PromptPrefixMaxLen caps operator-supplied prefixes so a runaway paste
@@ -433,6 +440,12 @@ type runAgentNowRequest struct {
 // 2000-char ceiling used for operator notes — the two surfaces feel
 // related from the operator's POV.
 const PromptPrefixMaxLen = 2000
+
+// PromptOverrideMaxLen caps the iter-45 full-prompt override. 20× the
+// prefix cap because real agent prompts are long-form markdown (the
+// seeded starters run 1000-2500 chars each). 40 KB is well under any
+// model's effective context but blocks pathological pastes.
+const PromptOverrideMaxLen = 40_000
 
 // RunAgentNowHandler triggers an immediate synchronous run of the named agent.
 // 503 CONCURRENCY_LOCKED when another run is in progress (no DB row written).
@@ -469,7 +482,15 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 				fmt.Sprintf("prompt_prefix must be at most %d characters", PromptPrefixMaxLen))
 			return
 		}
-		runResp, runErr := orch.RunNow(r.Context(), def, req.PromptPrefix)
+		if len(req.PromptOverride) > PromptOverrideMaxLen {
+			mw.WriteError(w, http.StatusBadRequest, "PROMPT_TOO_LONG",
+				fmt.Sprintf("prompt must be at most %d characters", PromptOverrideMaxLen))
+			return
+		}
+		runResp, runErr := orch.RunNowWith(r.Context(), def, service.RunOverrides{
+			PromptPrefix:   req.PromptPrefix,
+			PromptOverride: req.PromptOverride,
+		})
 		if errors.Is(runErr, agent.ErrConcurrencyLocked) {
 			mw.WriteError(w, http.StatusServiceUnavailable,
 				"CONCURRENCY_LOCKED",

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -93,6 +93,24 @@ func (o *Orchestrator) SmokeTest(ctx context.Context) (*agent.SmokeResult, error
 	return agent.SmokeTest(ctx, o.svc.Queries, o.encKey, o.runner, binaryPath)
 }
 
+// RunOverrides carries the optional per-call mutations the operator may
+// apply to a manual run. Both fields default to "use the def value"; set
+// them sparingly:
+//
+//   - PromptPrefix prepends to def.Prompt for this fire only (iter-23).
+//   - PromptOverride replaces def.Prompt entirely for this fire (iter-45),
+//     enabling the "Test this prompt" flow on the edit form. Takes
+//     precedence over PromptPrefix when both are set — the override is
+//     the full prompt the operator wants to test, and prepending a prefix
+//     wouldn't match the typed value any longer.
+//
+// Cron + webhook paths always pass the zero value; only manual runs from
+// the v2 SPA / CLI / HTTP API construct non-empty overrides.
+type RunOverrides struct {
+	PromptPrefix   string
+	PromptOverride string
+}
+
 // RunNow executes one agent run synchronously, for "run now" requests.
 // Returns ErrConcurrencyLocked WITHOUT creating a run row when the semaphore
 // is full — the caller (HTTP handler) maps to 503 and the user retries.
@@ -100,13 +118,22 @@ func (o *Orchestrator) SmokeTest(ctx context.Context) (*agent.SmokeResult, error
 //
 // promptPrefix is the operator-supplied per-run prefix that gets prepended to
 // the agent's stored prompt for this fire only. Empty string disables the
-// prefix; cron callers always pass "".
+// prefix; cron callers always pass "". For a full prompt override (the
+// iter-45 "Test this prompt" flow), use RunNowWith instead.
 func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse, promptPrefix string) (*AgentRunResponse, error) {
+	return o.RunNowWith(ctx, def, RunOverrides{PromptPrefix: promptPrefix})
+}
+
+// RunNowWith is the full-shape variant of RunNow that accepts the operator's
+// RunOverrides struct. Used by the iter-45 "Test this prompt" button on
+// the agent edit page to dry-fire an unsaved prompt without mutating the
+// stored definition.
+func (o *Orchestrator) RunNowWith(ctx context.Context, def *AgentDefinitionResponse, ov RunOverrides) (*AgentRunResponse, error) {
 	if err := o.sem.Acquire(ctx); err != nil {
 		return nil, err
 	}
 	defer o.sem.Release()
-	return o.runLocked(ctx, def, "manual", promptPrefix)
+	return o.runLocked(ctx, def, "manual", ov)
 }
 
 // FireSyncCompleteAgents dispatches a webhook-triggered run for every
@@ -172,11 +199,12 @@ func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionRespon
 		return &resp, err
 	}
 	defer o.sem.Release()
-	return o.runLocked(ctx, def, trigger, "")
+	return o.runLocked(ctx, def, trigger, RunOverrides{})
 }
 
 // runLocked assumes the caller holds the semaphore.
-func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionResponse, trigger, promptPrefix string) (*AgentRunResponse, error) {
+func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionResponse, trigger string, ov RunOverrides) (*AgentRunResponse, error) {
+	promptPrefix := ov.PromptPrefix
 	defUUID, err := pgconv.ParseUUID(def.ID)
 	if err != nil {
 		return nil, fmt.Errorf("orchestrator: parse def id: %w", err)
@@ -216,8 +244,16 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	}()
 
 	spec, err := o.svc.AssembleJobSpec(ctx, def, &runResp, keyResult.PlaintextKey, o.encKey)
-	if err == nil && promptPrefix != "" {
-		spec.Prompt = applyPromptPrefix(promptPrefix, spec.Prompt)
+	if err == nil {
+		// Override semantics: a full PromptOverride wins outright (the
+		// operator is testing a freshly-typed prompt, not annotating the
+		// stored one). Otherwise fall through to the iter-23 prefix prepend.
+		switch {
+		case ov.PromptOverride != "":
+			spec.Prompt = ov.PromptOverride
+		case promptPrefix != "":
+			spec.Prompt = applyPromptPrefix(promptPrefix, spec.Prompt)
+		}
 	}
 	if err != nil {
 		o.logger.Warn("orchestrator: assemble spec failed",

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -482,3 +482,63 @@ func TestOrchestratorRunNow_TripleConcurrency(t *testing.T) {
 		}
 	}
 }
+
+// TestOrchestratorRunNowWith_PromptOverride_ReplacesDefPrompt pins the
+// iter-45 "Test this prompt" flow: when an operator passes
+// RunOverrides.PromptOverride, the sidecar receives THAT text as
+// spec.Prompt instead of def.Prompt. Operator can dry-fire an unsaved
+// edit-form prompt without round-tripping through Save.
+func TestOrchestratorRunNowWith_PromptOverride_ReplacesDefPrompt(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-prompt-override", true)
+	const override = "Operator's unsaved test prompt — definitely not the stored one, used for dry-fire only."
+
+	var capturedPrompt string
+	fake := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		capturedPrompt = spec.Prompt
+		return agent.RunResult{Status: agent.StatusSuccess, TurnCount: 1, DurationMs: 10}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	_, err := orch.RunNowWith(context.Background(), def, service.RunOverrides{
+		PromptOverride: override,
+	})
+	if err != nil {
+		t.Fatalf("RunNowWith: %v", err)
+	}
+	if capturedPrompt != override {
+		t.Errorf("spec.Prompt = %q, want override exactly (no prefix wrapping)", capturedPrompt)
+	}
+}
+
+// TestOrchestratorRunNowWith_OverrideBeatsPrefix verifies the precedence
+// rule: when both PromptOverride AND PromptPrefix are set, the override
+// wins (the operator is testing a freshly-typed prompt, prepending a
+// prefix wouldn't match what they actually want to test).
+func TestOrchestratorRunNowWith_OverrideBeatsPrefix(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "orch-prompt-prec", true)
+
+	var capturedPrompt string
+	fake := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		capturedPrompt = spec.Prompt
+		return agent.RunResult{Status: agent.StatusSuccess, TurnCount: 1, DurationMs: 5}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, fake, 1, encKey, slog.Default())
+	_, err := orch.RunNowWith(context.Background(), def, service.RunOverrides{
+		PromptPrefix:   "this prefix should be ignored",
+		PromptOverride: "and the override should win clean",
+	})
+	if err != nil {
+		t.Fatalf("RunNowWith: %v", err)
+	}
+	if capturedPrompt != "and the override should win clean" {
+		t.Errorf("override should win exactly; got %q", capturedPrompt)
+	}
+	if strings.Contains(capturedPrompt, "this prefix should be ignored") {
+		t.Errorf("prefix leaked through despite override being set: %q", capturedPrompt)
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2642,8 +2642,11 @@ paths:
       description: |
         Synchronously runs the named agent. Returns the resulting `agent_runs`
         row. Status may be `success`, `error`, or `timeout`. Optional body
-        `{ "prompt_prefix": "..." }` prepends operator-supplied context to
-        the agent's stored prompt for this fire only. **Requires `full_access` scope.**
+        accepts `prompt_prefix` (prepends operator context to the saved
+        prompt for this fire only) and `prompt` (replaces the saved prompt
+        entirely for this fire — powers the iter-45 "Test this prompt"
+        button on the edit page). When both are set, `prompt` wins.
+        **Requires `full_access` scope.**
       requestBody:
         required: false
         content:
@@ -2655,6 +2658,10 @@ paths:
                   type: string
                   maxLength: 2000
                   description: Optional per-run prefix prepended to the agent's prompt; cron runs leave it unset.
+                prompt:
+                  type: string
+                  maxLength: 40000
+                  description: Optional full-prompt override for this fire only. Takes precedence over `prompt_prefix` when both are set.
       responses:
         "201":
           description: Run completed (may be in error state — see `status` and `error_message`).
@@ -2662,7 +2669,7 @@ paths:
             application/json:
               schema: { type: object, additionalProperties: true }
         "400":
-          description: PROMPT_PREFIX_TOO_LONG when prompt_prefix exceeds 2000 chars.
+          description: PROMPT_PREFIX_TOO_LONG / PROMPT_TOO_LONG when the body exceeds the cap.
         "422":
           description: Auth or binary not configured.
         "503":

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -237,19 +237,24 @@ export function useToggleAgent() {
 export interface RunAgentNowParams {
   slug: string;
   promptPrefix?: string; // operator-supplied per-run prefix; max 2000 chars
+  // promptOverride replaces def.Prompt entirely for this fire; max 40000 chars.
+  // Powers the iter-45 "Test this prompt" button on the edit page. When both
+  // promptPrefix and promptOverride are set, override wins on the server.
+  promptOverride?: string;
 }
 
 export function useRunAgentNow() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ slug, promptPrefix }: RunAgentNowParams) =>
-      api<AgentRun>(`/api/v1/agents/${slug}/run`, {
+    mutationFn: ({ slug, promptPrefix, promptOverride }: RunAgentNowParams) => {
+      const body: Record<string, string> = {};
+      if (promptPrefix && promptPrefix.length > 0) body.prompt_prefix = promptPrefix;
+      if (promptOverride && promptOverride.length > 0) body.prompt = promptOverride;
+      return api<AgentRun>(`/api/v1/agents/${slug}/run`, {
         method: "POST",
-        body:
-          promptPrefix && promptPrefix.length > 0
-            ? JSON.stringify({ prompt_prefix: promptPrefix })
-            : undefined,
-      }),
+        body: Object.keys(body).length > 0 ? JSON.stringify(body) : undefined,
+      });
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -28,7 +28,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
 import { withMutationToast } from "@/lib/mutation-toast";
-import { useAgent, useUpdateAgent } from "@/api/queries/agents";
+import { useAgent, useRunAgentNow, useUpdateAgent } from "@/api/queries/agents";
 import {
   AGENT_MODELS,
   TOOL_SCOPES,
@@ -455,10 +455,15 @@ export function AgentEditPage() {
                 />
               </Card>
 
-              <div className="flex justify-end gap-2">
+              <div className="flex flex-wrap items-center justify-end gap-2">
                 <Button type="button" variant="outline" asChild>
                   <Link to="/agents">Cancel</Link>
                 </Button>
+                <TestPromptButton
+                  slug={slug}
+                  promptValue={form.watch("prompt")}
+                  disabled={updateAgent.isPending}
+                />
                 <Button type="submit" disabled={updateAgent.isPending}>
                   {updateAgent.isPending && (
                     <Loader2 className="size-4 animate-spin" />
@@ -471,5 +476,74 @@ export function AgentEditPage() {
         </Form>
       )}
     </>
+  );
+}
+
+// TestPromptButton dry-fires the in-edit-form prompt via the iter-45
+// prompt_override path on POST /api/v1/agents/:slug/run. Lets operators
+// iterate on prompts without round-tripping through Save (which would
+// mutate the stored definition + fire every cron from that point onward
+// with the new prompt). Disabled when the form is mid-save or the prompt
+// field is empty.
+//
+// On success, navigates to the agent's run history with the new run's
+// transcript drawer pre-opened, so operators can immediately read the
+// model's response.
+function TestPromptButton({
+  slug,
+  promptValue,
+  disabled,
+}: {
+  slug: string;
+  promptValue: string | undefined;
+  disabled: boolean;
+}) {
+  const runNow = useRunAgentNow();
+  const navigate = useNavigate();
+  const empty = !promptValue || promptValue.trim().length === 0;
+  const onClick = async () => {
+    const trimmed = (promptValue ?? "").trim();
+    if (!trimmed) return;
+    const ok = await withMutationToast(
+      async () => {
+        const run = await runNow.mutateAsync({
+          slug,
+          promptOverride: trimmed,
+        });
+        navigate({
+          to: "/agents/$slug/runs",
+          params: { slug },
+          search: { run: run.short_id },
+        });
+        return run;
+      },
+      {
+        success: "Test run dispatched — opening transcript…",
+        error:
+          "Test run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
+      },
+    );
+    // navigate() above triggers regardless of toast result; no-op here.
+    void ok;
+  };
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      onClick={onClick}
+      disabled={disabled || runNow.isPending || empty}
+      title={
+        empty
+          ? "Fill in the prompt above to dry-fire it without saving"
+          : "Dry-fire this prompt now without saving the definition"
+      }
+    >
+      {runNow.isPending ? (
+        <Loader2 className="size-4 animate-spin" />
+      ) : (
+        <Play className="size-4" />
+      )}
+      Test this prompt
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary

Iteration 45 — feature-extension subagent #3, the last of the "propose 3 extensions" picks from iter-37.

**What it does**: while editing an agent's prompt on `/v2/agents/{slug}/edit`, click **"Test this prompt"** to dry-fire the unsaved prompt as a real run (mint-and-revoke key, full transcript, hit_cap detection, caps applied per def). On success, the user lands on the agent's run history with the new run's transcript drawer pre-opened.

Operators can iterate on prompt wording without round-tripping through Save — which would mutate the stored definition AND fire every cron with the new wording from that point onward.

## What's in

- **`internal/service/agent_orchestrator.go`**: new `RunOverrides` struct + `RunNowWith(ctx, def, ov)` method. Old `RunNow(ctx, def, prefix)` is preserved as a thin wrapper — every existing caller and test stays unchanged. Precedence: `PromptOverride` wins over `PromptPrefix` when both are set.
- **`internal/api/agents.go`**: `runAgentNowRequest` gains `prompt` body field. New `PromptOverrideMaxLen = 40_000` (20× the iter-23 prefix cap). New 400 `PROMPT_TOO_LONG`. Handler routes through `RunNowWith`.
- **`web/src/api/queries/agents.ts`**: `RunAgentNowParams` extended with `promptOverride`; mutation body builds either/both fields.
- **`web/src/routes/agents.$slug.edit.tsx`**: new `TestPromptButton` component in the form footer. Disabled when prompt textarea is empty or form is mid-save. On success, navigates to the run's transcript drawer via TanStack Router `params+search`.
- **2 new orchestrator integration tests**:
  1. `PromptOverride_ReplacesDefPrompt` — `spec.Prompt` carries the override exactly (no prefix wrapping)
  2. `OverrideBeatsPrefix` — when both are set, override wins clean; prefix doesn't leak
- `openapi.yaml` + `docs/api-endpoints.md` updated.

## Design notes

- **`RunOverrides` struct over a fourth string arg** — forward-compatible (model/max_turns/etc. overrides can land later in the same struct without churn). Existing `RunNow` signature preserved as a wrapper so the iter-23 / 29 / 30 / 33 / 34 / 38 / 44 test sites don't need to change.
- **40 KB ceiling on the override** — 20× the iter-23 prefix cap. Real agent prompts ARE long-form markdown (seeded starters run 1000–2500 chars). Bigger than any plausible operator paste but small enough to block server-side OOM.
- **Override wins over prefix at apply time.** The override is the verbatim prompt the operator wants to test.
- **On-success navigate to the transcript drawer** (not stay on the edit form). The whole point of "test" is to see the result; forcing a second click defeats the purpose.

## Test plan

- [x] `go build / vet` clean for default, `-tags=headless`, `-tags=lite`
- [x] 2 new orchestrator integration tests pass
- [x] All existing agent tests still pass with the wrapper-preserved `RunNow` signature
- [x] OpenAPI drift test green
- [x] `bun run lint` + `bun run build` clean

## Subagent backlog status

All three iter-37 feature-extension picks now shipped:
- ✅ #2 Run-failed banner (iter-38)
- ✅ #3 Test this prompt (this PR)
- Audit page (#1) deferred — bigger M effort linking agent_run → DB changes via the MCP audit-session pipeline; would need a new join query and a new tab on the runs page.
