### PR TITLE
fix(v2): make settings modal sub-pages scrollable

### DIFF
--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -56,7 +56,7 @@ export function SettingsShell() {
   if (isDesktop) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="h-[600px] max-w-3xl gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogContent className="flex h-[600px] max-w-3xl flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
           <DialogHeader className="sr-only">
             <DialogTitle>Settings</DialogTitle>
             <DialogDescription>Manage your account and app preferences.</DialogDescription>
@@ -94,7 +94,7 @@ interface SettingsBodyProps {
 function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
   if (desktop) {
     return (
-      <div className="flex h-full">
+      <div className="flex min-h-0 flex-1">
         <nav className="bg-sidebar text-sidebar-foreground w-56 shrink-0 border-r p-3">
           <Eyebrow
             as="p"


### PR DESCRIPTION
## Summary

- The v2 settings modal sub-pages (Household, Backups) couldn't be scrolled — content past the 600px-tall dialog was unreachable.
- Root cause: `DialogContent` defaults to `display: grid`. With a single auto-sized row, the row tracked content instead of filling the 600px container, so the inner `<section overflow-y-auto>` never had a constrained height.
- Fix: override `grid` → `flex flex-col` on the desktop `DialogContent`, and switch the inner body from `h-full` to `flex-1 min-h-0` so the scroll panel is properly bounded. Mobile sheet already used flex column and was unaffected.

## Evidence

Backups section, scrolled to bottom — previously-hidden "Stored backups / No backups yet" panel is now reachable, dialog remains the same 600px size.

<table>
  <tr><th>Top</th><th>Scrolled to bottom</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/gxprn30lzy.png" width="400" alt="settings backups — top"></td>
    <td><img src="https://i.img402.dev/zvea82vll1.png" width="400" alt="settings backups — scrolled"></td>
  </tr>
</table>

Programmatic scroll check across all sections (desktop 1280×800 + mobile 390×844):

```
[desktop] household: clientHeight=598 scrollHeight=668  → scrolls
[desktop] backups:   clientHeight=598 scrollHeight=979  → scrolls
[mobile]  household: clientHeight=647 scrollHeight=692  → scrolls
[mobile]  backups:   clientHeight=647 scrollHeight=1229 → scrolls
```

Account and Security sections fit within the dialog, so they correctly have no scroll.

## Test plan

- [ ] Open `/v2/` → Settings → Backups, scroll the right pane; "Stored backups" panel is reachable.
- [ ] Open `/v2/` → Settings → Household, scroll the right pane; full household list is reachable.
- [ ] Mobile (≤768px): bottom sheet still scrolls; the section pill nav stays sticky at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
