### PR TITLE
fix(agents): iter-47 runtime dogfooding — MCP discovery, tool perms, async run, transcript

### DIFF
--- a/.claude/v2-design-sprint.md
+++ b/.claude/v2-design-sprint.md
@@ -2920,3 +2920,309 @@ Cross-cutting components:
     `optimizeDeps.force=true` queue item in iter 91 is still the
     right durable fix; logged here so the next iteration that hits
     this pain has more evidence to motivate the change.
+
+- **Iter 101 — DetailDialogHeader primitive (4 household-section dialogs)** ([#1217](https://github.com/canalesb93/breadbox/pull/1217))
+  - Closed the gap iter 100 explicitly flagged. The four form-bearing
+    `<Dialog>` consumers in `household-section` (AddMember,
+    CreateLogin, ShareLink inline, ShareLink standalone) all
+    hand-rolled `<DialogHeader>` + `<DialogTitle>` +
+    `<DialogDescription>` with no icon affordance — sibling sheets
+    have ridden `<DetailSheetHeader>` (iter 41) since they grew a
+    second consumer. Four sites is above the "third consumer"
+    promotion gate, so promoted to a primitive.
+  - New `<DetailDialogHeader>` at
+    `web/src/components/detail-dialog-header.tsx` — sibling of
+    `<DetailSheetHeader>`. Same icon-tile (`bg-muted
+    text-muted-foreground rounded-lg border size-9`) + optional
+    eyebrow + title + description + optional trailing slot lockup,
+    just routed through `<DialogTitle>` / `<DialogDescription>` so
+    it composes with shadcn `<Dialog>` instead of `<Sheet>`. 27th
+    shared primitive in the v2 vocabulary.
+  - Visual win: each form-bearing dialog now leads with a
+    rounded-lg icon tile (UserPlus for member-add flows, Link2 for
+    share-link flows) — matches the iter 41 sheet header vocabulary
+    exactly so the system reads as a coherent family across both
+    surface modes (slide-in Sheet vs centered Dialog) instead of
+    sheets feeling "designed" and dialogs feeling "stock shadcn".
+  - Sandbox specimen at `/v2/sandbox?section=components` right
+    after `<DetailSheetHeader>` so the sibling pair reads
+    top-to-bottom (default density + with-eyebrow-and-trailing
+    presets, matching the live consumers).
+  - No `density` variant yet — the four live consumers all want
+    the default rhythm. If a future surface needs the heavier
+    `accent` rhythm (the iter 41 sheet header's `size-10 + p-6 +
+    text-lg` shape), add a `density` prop here mirroring that API
+    rather than re-opening `<DialogHeader>`. The two primitives
+    should keep their props in lockstep.
+  - Remaining centered `<Dialog>` consumers in `web/src/`:
+    `settings-shell` (sr-only chrome on the settings modal itself —
+    intentionally not a candidate; the modal *is* the chrome),
+    `confirm-dialog` (composes `AlertDialog` for yes/no
+    confirmations). The form-bearing gap iter 100 left open is now
+    fully closed.
+  - Process note: stomped the sprint state on first push attempt by
+    redirecting python output to the temp file *after* `cat >>`
+    appended to it (the python `open(...).write(...)` ran in the
+    same subshell as the curl pipe and clobbered the appended
+    file before the base64 step). Always (a) keep fetch output in
+    a distinct path from the working file, (b) verify with
+    `wc -c` immediately before piping through `base64`, and (c)
+    if the base64 is over ~100k, build a JSON payload and
+    `curl -d @payload.json` instead of passing through `gh api -f
+    content=...` which can silently truncate.
+
+- **Iter 102 — ComingSoonPill primitive (2 in-the-works surfaces unified)** ([#1218](https://github.com/canalesb93/breadbox/pull/1218))
+  - Pure drift retirement on a small but byte-identical lockup.
+    `routes/placeholder.tsx` (iter 21 unbuilt-nav-leaf shell) and
+    `components/settings-shell.tsx` (iter 78 in-the-works settings
+    panel) both hand-rolled the same 10-class span for the muted
+    "Coming soon" status pill that rides the `<StatusPanel
+    tone="info">` trailing slot. Promoted to `<ComingSoonPill>`
+    at `web/src/components/coming-soon-pill.tsx` — 28th shared
+    primitive in the v2 vocabulary.
+  - Visual contract preserved exactly: `bg-muted text-muted-foreground
+    rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide
+    uppercase` + leading `Clock size-3`. The two consumer surfaces
+    render byte-equivalent pixels after the migration — the win is
+    in the code: one place to evolve the chip's rounding / padding
+    / rhythm instead of two, and a clear name for the "not yet"
+    vocabulary that distinguishes it from sibling primitives
+    (`<Eyebrow>` for section/page micro-labels, `<Badge>` for
+    semantic-tone rectangular chips, `<JumpToPill>` / `<ActionPill>`
+    for the labelled-lateral-nav / labelled-action vocabulary).
+  - API: `icon` defaults to `Clock` (matches both live consumers);
+    pass a different `LucideIcon` for a future caller without losing
+    the chip rhythm. `children` defaults to `"Coming soon"` and is
+    the label. Sandbox specimen at `/v2/sandbox?section=components`
+    right after `<ActionPill>` shows the default + an icon override
+    (`Sparkles` + "Beta") + a label override ("In review").
+  - **Two consumers is below the iter-30-style "third surface" gate**
+    on principle, but this case is byte-identical lockup duplication
+    rather than a recipe convergence — when the *next* StatusPanel
+    surface (or any new "not yet" caption) lands, it'll reach for
+    this primitive instead of accreting a third hand-rolled site.
+    Promote-on-duplication is the right call when the duplicated
+    chunk is a literal 10-class string with a leading icon.
+  - **Iter-30 drift note "primary-tinted pill triad" is still open.**
+    The *primary*-tinted recipe (`bg-primary/15 text-primary`) lives
+    in three surfaces: `auth-shell` ("V2" chip), `brand-header` ("V2"
+    chip, byte-identical), `nav-user` (admin RoleBadge in
+    `ROLE_TONE`). When a fourth surface adopts the primary recipe,
+    promote to a `<PrimaryPill>` / `<VersionPill>` mirroring this
+    primitive's API. The muted variant (this PR) and the primary
+    variant carry different signal (muted = "not yet" status caption;
+    primary = brand/version/role chrome) so they belong in separate
+    primitives, not a single tone-prop'd one.
+  - Process note: sandbox needed a fresh icon import (`Sparkles`)
+    alongside the existing `Clock` / `Wand2`. The
+    `coming-soon-pill.tsx` primitive itself imports `Clock` from
+    `lucide-react` as its default value — when migrating each
+    consumer, the local `Clock` import becomes unused, so dropping it
+    is mandatory or `bun run lint` will fail (`tsc --noEmit` flags
+    unused imports under the project's `noUnusedLocals` config).
+    Caught both removals in the same diff to keep the tip green.
+
+- **Iter 103 — Pending vocabulary for TransactionAmount + TransactionPrimary** ([#1220](https://github.com/canalesb93/breadbox/pull/1220))
+  - Pairs the two reusable transaction-row blocks so a row reads as
+    tentative until it settles. `TransactionAmount` renders italic +
+    `opacity-70` when `t.pending`, with a `title` attribute carrying
+    "Pending — amount may change once posted" for hover/keyboard;
+    `TransactionPrimary` upgrades the bare `text-muted-foreground
+    text-xs` "Pending" span to `<MetaBadge muted icon={Clock}>
+    Pending</MetaBadge>` so the chip lands inside the v2 secondary-
+    state chip family (System / Hidden / Excluded / Linked / Re-auth)
+    instead of being an orphan text fragment.
+  - No new primitive — both blocks already existed, `<MetaBadge>` is
+    the canonical low-emphasis chip. Pure consumer migration. The
+    primitive count stays at 28. The win is that every transaction
+    list (Transactions page, Home recent activity, Account-detail
+    recent transactions) picks up the pending treatment for free
+    because they all route through these two shared blocks.
+  - Visual contract: settled rows render exactly as before; pending
+    rows now have **two** synchronised cues (italic+dim amount on the
+    right, muted chip with leading Clock glyph in the description on
+    the left) so a scanning eye spots them without reading either
+    column in full. Inflow `text-success` tinting still wins on the
+    tone axis, so a pending inflow stays green-but-italic.
+  - Sandbox `Amounts` specimen description updated to document the
+    pending treatment; the existing fixture at
+    `web/src/sandbox/fixtures.ts` already includes a pending row
+    (`pending: true` on one of the three demo transactions) so the
+    live `TransactionAmount` specimen picks up the new vocabulary
+    without a fixture edit.
+  - **Existing `<TransactionPrimary>`/`<TransactionAmount>` doc
+    comments updated** to spell out the pending vocabulary so future
+    edits don't drift apart. Both files now reference each other in
+    the comment so a change to one prompts a review of the other —
+    they're a pair, not two independent components.
+
+- **Iter 104 — MetaBadge sweep across accounts family** ([#1221](https://github.com/canalesb93/breadbox/pull/1221))
+  - Pure drift retirement on the v2 tiny-chip vocabulary. Five
+    hand-rolled `<Badge text-[10px] px-1.5 py-0>` sites in the
+    accounts family now route through `<MetaBadge>` (iter 17
+    primitive). Two surfaces touched: `account-row.tsx`
+    (statusBadge for `error` → destructive, `disconnected` →
+    outline) and `account-links-section.tsx` (Primary/Dependent
+    role chip + Disabled marker on the link rows).
+  - **Zero-pixel refactor.** MetaBadge already owned the exact
+    density tokens (`text-[10px]` + `gap-1` + `px-1.5 py-0` +
+    `[&>svg]:size-2.5`); the hand-rolled sites carried the same
+    classes inline. The win is single-source-of-truth — extending
+    `MetaBadge` now flows to all seven sharing surfaces (was six),
+    instead of skipping these two callsites.
+  - Sandbox specimen extended with the three new tones now in use
+    (`default` for Primary, `secondary` for Dependent / pre-existing,
+    `destructive` for Error, plain outline for Disconnected + Disabled).
+    Description updated to enumerate the closed tone set:
+    `System` · `Hidden` (muted) · `Excluded` · `Linked` · `Paused` ·
+    **`Primary`** · **`Dependent`** · **`Error`** · **`Disconnected`** ·
+    **`Disabled`** · `Re-auth`. Same Specimen position as before
+    (next to IdPill / DetailList) — readers see the full chip
+    vocabulary at a glance.
+  - Two `Badge` imports dropped from the accounts feature; one
+    `MetaBadge` import added to `account-links-section.tsx`. The
+    primitive count stays at 28.
+  - **Drift status: tiny-chip vocabulary is now closed.** One
+    legitimate `Badge text-[10px]` site stays in `category-detail.tsx`
+    as a `SectionCard` action count (`{children.length}`) — that's
+    a count chip in a header action slot, not a meta status, so it
+    correctly stays on `Badge` directly. Same shape lives in
+    `transactions-toolbar.tsx` line 458 (count chip inside a filter
+    button trigger). Any new tiny *status* chip should reach for
+    `<MetaBadge>` first; if it carries a count or lives inside a
+    button trigger, `<Badge>` direct is still right.
+
+
+- **Iter 105 — SyncHistoryList onto TimelineRail (+ destructive tone)** ([#1222](https://github.com/canalesb93/breadbox/pull/1222))
+  - The per-connection Sync history feed was the only timeline-shaped
+    surface in v2 still hand-rolling its own row geometry (size-6 chip +
+    custom status tiles + flat `divide-y` list) — the iter-26 promotion of
+    `<TimelineRail>` originally queued sync logs as the second consumer,
+    iter 93 added the semantic-tone vocabulary the migration depended on,
+    and this iteration finally closes the loop. Now routes through
+    `<TimelineRail>` with day-group headings ("Today" / "Yesterday" /
+    weekday-month-day) so the per-connection sync feed reads as the same
+    temporal vocabulary as the transaction-detail Activity feed.
+  - **`destructive` tone added to `TimelineRailTone`** (parity with
+    StatusPanel / ColorRailCard / Sonner). Status → tone mapping:
+    `success` → `success` (emerald), `error` → **`destructive`** (red),
+    `in_progress` → `primary` (spinner). The iter-93 vocabulary missed a
+    destructive tier — the nearest semantic match was `warning` (amber),
+    which already encoded "soft / removed" (`tag_removed`). Errored sync
+    runs deserve the same destructive-red that StatusPanel and
+    ColorRailCard use for hard-failure surfaces. Token uses the standard
+    `border-destructive/40` + `text-destructive` shadcn pair so the v2
+    visual system reads as one across rail / panel / card / toast.
+  - **In-progress rows** route the spin animation via
+    `iconClassName="[&>svg]:animate-spin"` — the disc target the Lucide
+    svg child without forking the primitive. The previous open-coded row
+    threaded `animate-spin` directly on `<Loader2>` because it didn't go
+    through `<TimelineRail.Row>`; the new flow needed the indirection
+    because the primitive renders the icon itself. Clean enough — a
+    `spin` prop on the primitive would be over-fitting (one consumer,
+    one usage).
+  - Loading skeleton in `connection-detail.tsx` swapped from four
+    `h-12` `<Skeleton>` blocks to `<TimelineRail.RowSkeleton>`s — disc +
+    rail visible in the loading state too, so the loaded data lands
+    without a layout jump. Same vocabulary as the transaction-detail
+    Activity feed's loading state.
+  - Sandbox specimen extended with a destructive-tone row alongside the
+    existing success/primary/info/warning rows so the full tone
+    vocabulary is browseable; description updated to enumerate the seven
+    tones (`neutral` · `primary` · `success` · `warning` ·
+    **`destructive`** · `info` · `muted`) and to drop the "queued for
+    per-connection sync logs" note (this PR ships that consumer).
+  - **TimelineRail is now used by two consumers** — TX-detail Activity
+    feed (iter 26 / iter 93) + Connection-detail Sync history (this
+    iter). The remaining queued consumer from iter 26 ("rule run
+    history") still hasn't landed as a surface yet; when it does, it'll
+    inherit the same vocabulary. The primitive count stays at 28 — this
+    is a consumer migration plus a richer tone prop, not a new component.
+  - Tiny day-grouping helper (`dayLabel` / `groupByDay`) duplicates the
+    one in `activity-timeline.tsx` because the two feeds shouldn't yet
+    share a `lib/format` export — a third timeline consumer is the right
+    promotion gate. Until then, copy is cheaper than a one-call-site
+    shared util.
+
+
+- **Iter 106 — SectionCard + ListCard header baseline polish** ([#1225](https://github.com/canalesb93/breadbox/pull/1225))
+  - Detail-attention iteration in response to Ricardo's "the cards still
+    feel wrong-ish" call: title looked too small, the action button
+    (`ViewAllPill` / `Button size="sm"`) on the right looked too big,
+    visible baseline mismatch, and the gap between header-bottom and
+    body-top was asymmetric vs the side padding. Diagnosed against the
+    sandbox specimens and the live Home / Account-detail consumers with
+    Chrome DevTools measurements.
+  - **Three targeted fixes to the canonical card-header recipe** —
+    nothing more, nothing less:
+    1. **`ListCard` was missing the `\!pb-4` override** that `SectionCard`
+       has carried since iter 33. Without it, the shadcn primitive's
+       `[.border-b]:pb-6` rule injected 24px of bottom padding (vs the
+       intentional 16px top padding) whenever the header had a divider.
+       Measured on Home: header padding `16px / 24px` before, `16px /
+       16px` after — the asymmetric gap Ricardo flagged was real and
+       traceable to one line.
+    2. **Header alignment `items-start` → `items-center`** (plus
+       `CardAction self-center`). The shadcn `CardHeader` grid defaults
+       to `items-start` and `CardAction` carries `self-start`. With a
+       20px title and a 28px `ViewAllPill` / 32px `Button size="sm"`,
+       the title got pinned to the top of the row while the action
+       protruded 8-12px below — title baseline visibly higher than the
+       action's vertical center, exactly the "crooked" feel.
+    3. **Title weight `text-sm font-medium` → `text-sm font-semibold`**
+       so the title carries enough anchor next to a real action button
+       instead of reading as a caption. Same `text-sm` size — the bump
+       is weight-only, the eye picks up the difference because the
+       action button stays at `text-xs font-medium`.
+  - **What I left alone (with rationale):** card body padding (`px-5
+    py-5`) and footer rhythm (`px-5 py-3`) — iter 33's tightening is
+    right; this was a header-row issue. `ColorRailCard` (footer already
+    `flex items-center justify-end`), `StatusPanel` (no title+action
+    header row; trailing slot is already `flex items-center`),
+    `FormFooter` (already `flex items-center`), `EmptyState`,
+    `PageHeader`, the five other header primitives — none of them
+    surface the same shadcn-grid `self-start` mismatch. Resisted
+    touching `CardTitle` in `ui/card.tsx` (would propagate the
+    semibold + alignment to non-header callers we haven't audited).
+  - **Zero new primitives, no consumer changes.** The fixes are
+    contained to `section-card.tsx` (already had `\!pb-4`; added
+    `items-center` + `self-center` + `font-semibold`) and
+    `list-card.tsx` (added all four: `\!pb-4`, `items-center`,
+    `self-center`, `font-semibold`). Primitive count stays at 28.
+  - **Drift status:** the canonical card-header pattern now has one
+    settled recipe — `border-b px-5 py-4 \!pb-4 items-center` on the
+    header div, `text-sm font-semibold` on the title, `self-center` on
+    the action. Any new card-header surface should reach for
+    `<SectionCard>` or `<ListCard>` and inherit the recipe; if a future
+    consumer needs a taller / shorter header, extend the primitive
+    rather than open-coding `<CardHeader>` directly.
+
+
+- **Iter 107 — SettingsSectionHeader baseline polish ripple** ([#1226](https://github.com/canalesb93/breadbox/pull/1226))
+  - Ripple from iter 106's `SectionCard` + `ListCard` header polish.
+    The settings shell uses `SettingsSectionHeader` for every section
+    title (Account / Household / Backups, plus the inline sub-sections
+    like Change password / Actions / Stored backups / Automatic
+    schedule). It was the next-most-visible title+action lockup in the
+    v2 vocabulary that hadn't picked up the iter 106 recipe.
+  - **Two targeted fixes:**
+    1. **Heading weight `font-medium` → `font-semibold`** for both
+       `section` (h2 `text-lg`) and `sub` (h3 `text-sm`) tokens.
+       Now matches `PageHeader` (`text-2xl font-semibold`) and the
+       iter 106 card-header recipe (`text-sm font-semibold`) — every
+       page-/section-/card-level title in the v2 shell is one weight.
+    2. **Action alignment `sm:items-end` → `sm:items-center`** so a
+       `Button size="sm"` (Add member CTA, etc.) sits centered to
+       the title row instead of bottom-docking under the description.
+       Same 8-12px baseline mismatch as iter 106; same fix.
+  - **Zero new primitives, no consumer changes.** Contained to
+    `settings-section-header.tsx` (5 lines changed) + the sandbox
+    specimen description. Four consumers benefit immediately:
+    `AccountSection`, `HouseholdSection`, `BackupsSection`, and
+    the settings-shell placeholder fallback. Primitive count stays at 28.
+  - **Drift status:** page-level / section-level / card-header title
+    weights are now all `font-semibold` across the SPA. The iter 106
+    recipe ripple is complete for shared primitives. If a future
+    surface needs a lighter caption-weight title, add it as a new
+    `SettingsSectionHeader` token (e.g. `field`) rather than
+    forking the rhythm again.

--- a/agent/sidecar/events.ts
+++ b/agent/sidecar/events.ts
@@ -1,5 +1,3 @@
-import { appendFileSync } from "node:fs";
-
 export type SidecarEventType =
   | "assistant_message"
   | "tool_use"
@@ -16,19 +14,16 @@ export interface SidecarEvent {
 }
 
 /**
- * Emit one NDJSON event to stdout and (if configured) append to the
- * transcript file. Writes are synchronous so they survive a crash.
+ * Emit one NDJSON event to stdout. The Go orchestrator (sidecar.go) is the
+ * sole writer of the transcript file on disk — it reads each line off our
+ * stdout and persists it. Letting both processes touch the same file races
+ * and interleaves mid-JSON bytes (the malformed-line bug we hit in iter-47
+ * dogfooding). The transcriptPath argument is kept on the signature for
+ * call-site compatibility but is intentionally unused.
  */
-export function emit(event: SidecarEvent, transcriptPath?: string): void {
+export function emit(event: SidecarEvent, _transcriptPath?: string): void {
   const line = JSON.stringify(event) + "\n";
   process.stdout.write(line);
-  if (transcriptPath) {
-    try {
-      appendFileSync(transcriptPath, line, "utf8");
-    } catch {
-      // Best-effort: don't fail the run if the transcript file is unwritable.
-    }
-  }
 }
 
 export function emitError(

--- a/agent/sidecar/events.ts
+++ b/agent/sidecar/events.ts
@@ -1,3 +1,5 @@
+import { writeSync } from "node:fs";
+
 export type SidecarEventType =
   | "assistant_message"
   | "tool_use"
@@ -20,10 +22,17 @@ export interface SidecarEvent {
  * and interleaves mid-JSON bytes (the malformed-line bug we hit in iter-47
  * dogfooding). The transcriptPath argument is kept on the signature for
  * call-site compatibility but is intentionally unused.
+ *
+ * Uses writeSync(1, …) instead of process.stdout.write because Bun pipes
+ * stdout in non-blocking mode and may delay actual flushes until the next
+ * I/O tick. For a streaming run watched live in the SPA, that delay turned
+ * up as "events only appear at the end" (iter-47 dogfooding finding #7).
+ * Sync writes are fine here — each line is small (<1 KB typical) and we
+ * emit on the order of dozens per run, not thousands per second.
  */
 export function emit(event: SidecarEvent, _transcriptPath?: string): void {
   const line = JSON.stringify(event) + "\n";
-  process.stdout.write(line);
+  writeSync(1, line);
 }
 
 export function emitError(

--- a/agent/sidecar/events.ts
+++ b/agent/sidecar/events.ts
@@ -15,24 +15,65 @@ export interface SidecarEvent {
   data: Record<string, unknown>;
 }
 
+// Switch stdout to blocking mode at module load. Without this, writeSync on
+// a pipe whose kernel buffer is full throws EAGAIN (Bun pipes stdout in
+// O_NONBLOCK by default). We hit this in iter-47 dogfooding: an MCP tool
+// returned ~64 KB of JSON (list_categories), writeSync wrote up to the
+// pipe boundary and then threw EAGAIN on the next call — the line got
+// truncated at byte 65538 and the subsequent error event's bytes were
+// concatenated onto the tail with no newline, producing one corrupted
+// line that dropped the tool_result and made the viewer show the call
+// as "pending" forever.
+//
+// setBlocking(true) makes writeSync block until the kernel accepts every
+// byte — the natural single-writer behavior we want for an NDJSON stream
+// where each line is one event.
+(process.stdout as unknown as { _handle?: { setBlocking?: (b: boolean) => void } })?._handle?.setBlocking?.(true);
+
+/**
+ * writeAll loops writeSync until every byte is on the wire. Even with
+ * blocking stdout, writeSync may still return short (e.g. interrupted
+ * syscall) and may rarely throw EAGAIN if blocking didn't take effect —
+ * so the loop is the robust shape regardless.
+ */
+function writeAll(fd: number, str: string): void {
+  const buf = Buffer.from(str, "utf8");
+  let offset = 0;
+  while (offset < buf.length) {
+    try {
+      const n = writeSync(fd, buf, offset, buf.length - offset);
+      if (n <= 0) break;
+      offset += n;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code === "EAGAIN" || code === "EWOULDBLOCK" || code === "EINTR") {
+        // Pipe wasn't ready; give the reader a tick to drain and retry.
+        // Bun.sleepSync is synchronous — fine here because we're already
+        // blocking and don't yield to the event loop during emit().
+        try {
+          // @ts-expect-error Bun global at runtime
+          Bun.sleepSync(1);
+        } catch {
+          // ignore if not running under Bun
+        }
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
 /**
  * Emit one NDJSON event to stdout. The Go orchestrator (sidecar.go) is the
  * sole writer of the transcript file on disk — it reads each line off our
- * stdout and persists it. Letting both processes touch the same file races
- * and interleaves mid-JSON bytes (the malformed-line bug we hit in iter-47
- * dogfooding). The transcriptPath argument is kept on the signature for
- * call-site compatibility but is intentionally unused.
+ * stdout and persists it.
  *
- * Uses writeSync(1, …) instead of process.stdout.write because Bun pipes
- * stdout in non-blocking mode and may delay actual flushes until the next
- * I/O tick. For a streaming run watched live in the SPA, that delay turned
- * up as "events only appear at the end" (iter-47 dogfooding finding #7).
- * Sync writes are fine here — each line is small (<1 KB typical) and we
- * emit on the order of dozens per run, not thousands per second.
+ * Synchronous so the line lands in the kernel pipe immediately (the SPA
+ * polls live), and loops on short writes / EAGAIN so events larger than
+ * the kernel pipe buffer never truncate.
  */
 export function emit(event: SidecarEvent, _transcriptPath?: string): void {
-  const line = JSON.stringify(event) + "\n";
-  writeSync(1, line);
+  writeAll(1, JSON.stringify(event) + "\n");
 }
 
 export function emitError(

--- a/agent/sidecar/index.ts
+++ b/agent/sidecar/index.ts
@@ -9,8 +9,28 @@
  * when both are set. We scrub the unused var before invoking the SDK.
  */
 import { query } from "@anthropic-ai/claude-agent-sdk";
+import cliAsset from "@anthropic-ai/claude-agent-sdk/cli.js" with { type: "file" };
+import { existsSync, mkdirSync, writeFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { JobSpecSchema, type JobSpec } from "./spec";
 import { emit, emitError } from "./events";
+
+// resolveCliPath extracts the bundled cli.js to a real path on disk so the
+// SDK's fs.existsSync check can see it. Inside a `bun build --compile`
+// binary, cliAsset resolves to a bunfs path that the SDK's spawn helper
+// cannot read. We materialize once per process startup, cached by mtime+
+// size so repeated cold-starts on the same binary reuse the extracted copy.
+async function resolveCliPath(): Promise<string> {
+  const dir = join(tmpdir(), "breadbox-agent-sidecar");
+  mkdirSync(dir, { recursive: true });
+  const bytes = await Bun.file(cliAsset).bytes();
+  const cached = join(dir, `cli-${bytes.length}.js`);
+  if (!existsSync(cached) || statSync(cached).size !== bytes.length) {
+    writeFileSync(cached, bytes);
+  }
+  return cached;
+}
 
 async function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -59,6 +79,11 @@ async function main() {
   let turnCount = 0;
   let numToolCalls = 0;
 
+  // SDK spawns `node cli.js` under the hood and fs.existsSync's the path.
+  // bun --compile bundles cli.js into bunfs which fs.existsSync can't read,
+  // so we extract to a tmp file first. See resolveCliPath above.
+  const pathToClaudeCodeExecutable = await resolveCliPath();
+
   try {
     const stream = query({
       prompt: spec.prompt,
@@ -73,6 +98,7 @@ async function main() {
         mcpServers: spec.mcpServers,
         permissionMode: "dontAsk",
         resume: spec.sessionId,
+        pathToClaudeCodeExecutable,
       },
     });
 

--- a/agent/sidecar/index.ts
+++ b/agent/sidecar/index.ts
@@ -104,9 +104,25 @@ async function main() {
 
     for await (const message of stream as AsyncIterable<any>) {
       const ts = Date.now();
-      const type = (message?.type as string | undefined) ?? "system";
+      const rawType = (message?.type as string | undefined) ?? "system";
 
-      if (type === "tool_use") numToolCalls += 1;
+      // Normalize SDK type names to the breadbox-side contract documented in
+      // internal/agent/event.go and consumed by web/src/features/agents/
+      // transcript-viewer.tsx. The SDK currently emits "assistant" /
+      // "user" for content events; iter-1's spec named these "assistant_message"
+      // / "user_message" assuming an earlier SDK shape. Tool_use blocks
+      // arrive as content blocks INSIDE the assistant event, not as their
+      // own top-level events — counting them is handled below by inspecting
+      // the nested message content.
+      let type = rawType;
+      if (rawType === "assistant") type = "assistant_message";
+      else if (rawType === "user") type = "user_message";
+
+      if (rawType === "assistant" && Array.isArray(message?.message?.content)) {
+        for (const block of message.message.content) {
+          if (block?.type === "tool_use") numToolCalls += 1;
+        }
+      }
 
       emit({ type: type as any, ts, data: message }, transcriptPath);
 

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -487,7 +487,7 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 				fmt.Sprintf("prompt must be at most %d characters", PromptOverrideMaxLen))
 			return
 		}
-		runResp, runErr := orch.RunNowWith(r.Context(), def, service.RunOverrides{
+		runResp, runErr := orch.RunNowAsyncWith(r.Context(), def, service.RunOverrides{
 			PromptPrefix:   req.PromptPrefix,
 			PromptOverride: req.PromptOverride,
 		})

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"breadbox/internal/agent"
 	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
@@ -333,6 +335,13 @@ func GetAgentRunHandler(svc *service.Service) http.HandlerFunc {
 }
 
 // GetAgentRunTranscriptHandler streams the NDJSON transcript file.
+//
+// Falls back to the deterministic path (<transcript_dir>/<run.ID>.ndjson) when
+// agent_runs.transcript_path is still NULL — that column is only persisted on
+// CompleteAgentRunDB, so without the fallback an in-progress run's transcript
+// 404s the whole way to completion. The SPA then sits on "Run starting…"
+// until the run finishes and shows the whole thing at once instead of
+// streaming. The fallback gives the polling loop something to read live.
 func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "shortId")
@@ -341,17 +350,28 @@ func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
 			writeAgentError(w, err, "run not found")
 			return
 		}
-		if run.TranscriptPath == nil || *run.TranscriptPath == "" {
+		path := ""
+		if run.TranscriptPath != nil {
+			path = *run.TranscriptPath
+		}
+		if path == "" && run.ID != "" {
+			dir := appconfig.String(r.Context(), svc.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
+			if dir != "" {
+				path = filepath.Join(dir, run.ID+".ndjson")
+			}
+		}
+		if path == "" {
 			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transcript not available for this run")
 			return
 		}
-		f, err := os.Open(*run.TranscriptPath)
+		f, err := os.Open(path)
 		if err != nil {
 			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transcript file missing on disk")
 			return
 		}
 		defer f.Close()
 		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusOK)
 		// Best-effort copy; partial reads are OK for a viewer.
 		buf := make([]byte, 32*1024)

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -150,7 +150,7 @@ func runAgentRun(parent context.Context, slug string, jsonOut bool, promptPrefix
 	// process; the in-memory semaphore is just belt-and-suspenders).
 	sidecar := &agent.Sidecar{
 		BinaryPath:    appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, ""),
-		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, ""),
+		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents"),
 	}
 	orch := service.NewOrchestrator(a.Service, sidecar, 1, cfg.EncryptionKey, logger)
 
@@ -232,7 +232,7 @@ func runAgentTest(parent context.Context) error {
 	defer a.DB.Close()
 
 	binaryPath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
-	transcriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "")
+	transcriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
 	sidecar := &agent.Sidecar{
 		BinaryPath:    binaryPath,
 		TranscriptDir: transcriptDir,

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -132,7 +132,14 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	// Settings → Agents.
 	agentMaxConcurrent := appconfig.Int(ctx, a.Queries, appconfig.KeyAgentMaxConcurrent, 3)
 	agentRuntimePath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
-	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "")
+	// Default transcripts to ./transcripts/agents (relative to the cwd
+	// `breadbox serve` was launched from). Iter-1 left this empty, which
+	// silently dropped transcripts — every run row had transcript_path=""
+	// and the v2 SPA's "open transcript" hit 404. Operators can override
+	// via Settings → Agents → "breadbox-agent transcripts dir" if they
+	// want them elsewhere. Daily cleanup (iter-25) still prunes whatever
+	// path is in effect.
+	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
 	agentSidecar := &agent.Sidecar{
 		BinaryPath:    agentRuntimePath,
 		TranscriptDir: agentTranscriptDir,

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -202,6 +202,153 @@ func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionRespon
 	return o.runLocked(ctx, def, trigger, RunOverrides{})
 }
 
+// RunNowAsyncWith is the non-blocking variant of RunNowWith for the v2 SPA's
+// "Run now" button. It does enough work synchronously to fail fast for
+// operator-visible mistakes (auth missing, binary missing, concurrency locked),
+// then spawns a goroutine for the sidecar invocation + completion + revoke.
+// The caller gets back the in_progress agent_runs row right away so the UI
+// can close the dialog and stream the live transcript.
+//
+// Returned errors mirror RunNowWith's: ErrConcurrencyLocked, ErrAuthNotConfigured,
+// ErrBinaryNotFound, or a generic spec-assembly failure. Any post-spawn
+// failure (sidecar crash, model error, hit-cap) lands on the agent_runs row
+// instead — the HTTP request has already returned 201.
+func (o *Orchestrator) RunNowAsyncWith(ctx context.Context, def *AgentDefinitionResponse, ov RunOverrides) (*AgentRunResponse, error) {
+	// Preflight: surface the obvious operator misconfigurations (no token,
+	// no binary) as a typed error here so the HTTP handler can map to 422
+	// instead of returning an in_progress row that's destined to fail.
+	binaryPath := appconfig.String(ctx, o.svc.Queries, appconfig.KeyAgentRuntimePath, "")
+	if _, err := agent.LocateBinary(binaryPath); err != nil {
+		return nil, err
+	}
+
+	if err := o.sem.Acquire(ctx); err != nil {
+		return nil, err
+	}
+
+	resp, prepErr, runFn := o.prepareRun(ctx, def, "manual", ov)
+	if prepErr != nil {
+		// Prep failed before we handed control to the goroutine — release
+		// the semaphore inline so we don't deadlock subsequent runs.
+		o.sem.Release()
+		return resp, prepErr
+	}
+
+	// Hand the slow work off. The goroutine owns: sidecar invocation,
+	// row completion, semaphore release, key revoke. A fresh context with
+	// a generous timeout decouples the run from the HTTP request lifecycle
+	// (the SPA closes the dialog and starts polling the transcript).
+	go func() {
+		runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
+		defer o.sem.Release()
+		runFn(runCtx)
+	}()
+	return resp, nil
+}
+
+// prepareRun does the synchronous prep portion of runLocked and returns a
+// closure that does the slow work. Used by RunNowAsyncWith so the HTTP
+// request can return as soon as the run row exists.
+//
+// The returned closure assumes the orchestrator already holds the semaphore;
+// it does NOT release it (the caller wraps the goroutine with the release).
+func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionResponse, trigger string, ov RunOverrides) (*AgentRunResponse, error, func(context.Context)) {
+	promptPrefix := ov.PromptPrefix
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		return nil, fmt.Errorf("orchestrator: parse def id: %w", err), nil
+	}
+
+	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+	if err != nil {
+		return nil, fmt.Errorf("orchestrator: create run row: %w", err), nil
+	}
+	if promptPrefix != "" {
+		if perr := o.svc.SetAgentRunPromptPrefixDB(ctx, runRow.ID, promptPrefix); perr != nil {
+			o.logger.Warn("orchestrator: persist prompt prefix failed",
+				"agent", def.Slug, "run", runRow.ShortID, "error", perr)
+		} else {
+			runRow.PromptPrefix = pgtype.Text{String: promptPrefix, Valid: true}
+		}
+	}
+	runResp := AgentRunFromRow(runRow)
+
+	keyResult, err := o.svc.MintRunAPIKey(ctx, def, runResp.ShortID)
+	if err != nil {
+		o.logger.Warn("orchestrator: mint api key failed",
+			"agent", def.Slug, "run", runResp.ShortID, "error", err)
+		_ = o.svc.MarkAgentRunErrorDB(ctx, runRow.ID, fmt.Sprintf("mint api key: %v", err), "")
+		return &runResp, fmt.Errorf("orchestrator: mint api key: %w", err), nil
+	}
+
+	spec, err := o.svc.AssembleJobSpec(ctx, def, &runResp, keyResult.PlaintextKey, o.encKey)
+	if err != nil {
+		o.logger.Warn("orchestrator: assemble spec failed",
+			"agent", def.Slug, "run", runResp.ShortID, "error", err)
+		_ = o.svc.MarkAgentRunErrorDB(ctx, runRow.ID, fmt.Sprintf("assemble spec: %v", err), "")
+		// Revoke the key we just minted before bailing.
+		revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = o.svc.RevokeAPIKey(revokeCtx, keyResult.ID)
+		return &runResp, fmt.Errorf("orchestrator: assemble spec: %w", err), nil
+	}
+
+	switch {
+	case ov.PromptOverride != "":
+		spec.Prompt = ov.PromptOverride
+	case promptPrefix != "":
+		spec.Prompt = applyPromptPrefix(promptPrefix, spec.Prompt)
+	}
+
+	run := func(runCtx context.Context) {
+		defer func() {
+			revokeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if rerr := o.svc.RevokeAPIKey(revokeCtx, keyResult.ID); rerr != nil {
+				o.logger.Warn("orchestrator: revoke api key failed",
+					"agent", def.Slug, "run", runResp.ShortID,
+					"key_id", keyResult.ID, "error", rerr)
+			}
+		}()
+
+		o.logger.Info("orchestrator: run starting",
+			"agent", def.Slug, "run", runResp.ShortID, "trigger", trigger, "model", def.Model)
+
+		handler := func(ev agent.Event) error {
+			o.logger.Debug("orchestrator: sidecar event",
+				"agent", def.Slug, "run", runResp.ShortID, "event_type", ev.Type)
+			return nil
+		}
+		result, runErr := o.runner.Run(runCtx, *spec, handler)
+
+		completedRow, completeErr := o.svc.CompleteAgentRunDB(runCtx, runRow.ID, result, def.MaxTurns)
+		if completeErr != nil {
+			o.logger.Error("orchestrator: persist completed run failed",
+				"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)
+			return
+		}
+		if cap := capFromRunErr(runErr); cap != "" {
+			if _, err := o.svc.SetAgentRunHitCapDB(runCtx, runRow.ID, cap); err != nil {
+				o.logger.Warn("orchestrator: persist hit_cap failed",
+					"agent", def.Slug, "run", runResp.ShortID, "cap", cap, "error", err)
+			}
+		}
+		_ = completedRow
+		if runErr != nil {
+			o.logger.Warn("orchestrator: run finished with error",
+				"agent", def.Slug, "run", runResp.ShortID,
+				"status", result.Status, "error", runErr)
+			return
+		}
+		o.logger.Info("orchestrator: run finished",
+			"agent", def.Slug, "run", runResp.ShortID,
+			"status", result.Status, "cost_usd", result.TotalCostUSD,
+			"duration_ms", result.DurationMs, "turns", result.TurnCount)
+	}
+	return &runResp, nil, run
+}
+
 // runLocked assumes the caller holds the semaphore.
 func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionResponse, trigger string, ov RunOverrides) (*AgentRunResponse, error) {
 	promptPrefix := ov.PromptPrefix

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -64,7 +64,9 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSe
 	// Default lifted from 1 → 3 in iter-29; see serve.go for the rationale.
 	maxConcurrent := appconfig.Int(ctx, s.Queries, appconfig.KeyAgentMaxConcurrent, 3)
 	runtimePath := appconfig.String(ctx, s.Queries, appconfig.KeyAgentRuntimePath, "")
-	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, "")
+	// Default matches serve.go fallback — keeps the Settings → Agents
+	// form showing the active path on a fresh install rather than blank.
+	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
 	globalBudget := readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)
 
 	return &AgentSettingsResponse{

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -853,14 +854,44 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 	// (transcript_dir is read by the Sidecar layer; see Sidecar.Run for
 	// the authoritative path assembly — iter-36 audit HIGH #5 cleanup.)
 
+	// Resolve to the currently-running breadbox binary so the SDK's MCP
+	// child spawn works regardless of $PATH. The TS SDK calls
+	// fs.existsSync(command) before spawning; a bare "breadbox" fails
+	// when the server was started from an out-of-PATH location (a worktree
+	// build, /tmp/<name>, air's hot-reload temp dir, etc.). os.Executable
+	// returns the live process path in all of those cases.
+	breadboxBin, exeErr := os.Executable()
+	if exeErr != nil || breadboxBin == "" {
+		breadboxBin = "breadbox"
+	}
 	mcpServers := map[string]agent.MCPServerConfig{
 		"breadbox": {
-			Command: "breadbox",
+			Command: breadboxBin,
 			Args:    []string{"mcp"},
 			Env: map[string]string{
 				"BREADBOX_API_KEY": apiKeyPlaintext,
 			},
 		},
+	}
+
+	// The TS sidecar runs with permissionMode: "dontAsk", which auto-denies
+	// any tool call NOT in allowedTools. An empty allowedTools therefore
+	// disables every breadbox MCP tool — i.e. the whole point of the
+	// integration. Always inject "mcp__breadbox" (which the SDK treats as
+	// the "all tools from the breadbox MCP server" wildcard) so the
+	// breadbox tools are callable regardless of operator customization.
+	// Permission inside breadbox is still gated by the minted API key's
+	// scope and the MCP server's read_only/read_write mode.
+	allowedTools := append([]string{}, def.AllowedTools...)
+	hasBreadbox := false
+	for _, t := range allowedTools {
+		if t == "mcp__breadbox" || strings.HasPrefix(t, "mcp__breadbox__") {
+			hasBreadbox = true
+			break
+		}
+	}
+	if !hasBreadbox {
+		allowedTools = append([]string{"mcp__breadbox"}, allowedTools...)
 	}
 
 	maxBudget := 1.0
@@ -877,7 +908,7 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 		MaxTurns:          def.MaxTurns,
 		MaxBudgetUsd:      maxBudget,
 		ToolScope:         def.ToolScope,
-		AllowedTools:      def.AllowedTools,
+		AllowedTools:      allowedTools,
 		MCPServers:        mcpServers,
 		Auth: agent.AuthConfig{
 			Mode:  authMode,

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -440,6 +440,20 @@ export interface ToolResultData {
   is_error?: boolean;
 }
 
+// SDK shape: user-role messages whose content carries tool_result blocks
+// (one per tool_use the assistant fired). The breadbox sidecar normalizes
+// the raw "user" SDK message-type to "user_message" before forwarding.
+export type UserContent =
+  | { type: "text"; text: string }
+  | ({ type: "tool_result" } & ToolResultData);
+
+export interface UserMessageData {
+  message: {
+    role: "user";
+    content: UserContent[];
+  };
+}
+
 export interface ResultData {
   totalCostUsd: number;
   inputTokens: number;
@@ -473,6 +487,7 @@ interface EventBase {
 
 export type TranscriptEvent =
   | (EventBase & { type: "assistant_message"; data: AssistantMessageData })
+  | (EventBase & { type: "user_message"; data: UserMessageData })
   | (EventBase & { type: "tool_use"; data: ToolUseData })
   | (EventBase & { type: "tool_result"; data: ToolResultData })
   | (EventBase & { type: "result"; data: ResultData })
@@ -490,7 +505,11 @@ export interface TranscriptResult {
 // browser. Above this the viewer renders a banner linking to the raw file.
 const TRANSCRIPT_MAX_EVENTS = 500;
 
-export function useTranscript(shortId: string | undefined) {
+export function useTranscript(
+  shortId: string | undefined,
+  opts: { inProgress?: boolean } = {},
+) {
+  const { inProgress = false } = opts;
   return useQuery({
     queryKey: ["agents", "runs", shortId, "transcript"],
     queryFn: async (): Promise<TranscriptResult> => {
@@ -515,8 +534,12 @@ export function useTranscript(shortId: string | undefined) {
       };
     },
     enabled: Boolean(shortId),
-    // Transcripts are immutable once a run completes — keep them cached
-    // across Sheet open/close.
-    staleTime: 5 * 60 * 1000,
+    // Completed transcripts are immutable — cache them across Sheet open/close.
+    // While the run is still in flight, poll every 2s and treat the
+    // file-not-yet-on-disk window as a transient miss rather than an error
+    // (the consumer renders a friendly "still warming up" state).
+    staleTime: inProgress ? 0 : 5 * 60 * 1000,
+    refetchInterval: inProgress ? 2000 : false,
+    retry: inProgress ? false : 1,
   });
 }

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -293,6 +293,14 @@ export function useAgentRuns(
       );
     },
     enabled: Boolean(slug),
+    // Poll while ANY visible run is in_progress so the row's status pill
+    // flips to success/error as soon as the sidecar finishes (the
+    // orchestrator runs async post-iter-47 and doesn't push status into
+    // the cache). Stops automatically once no in-flight runs remain.
+    refetchInterval: (q) =>
+      (q.state.data?.runs ?? []).some((r) => r.status === "in_progress")
+        ? 2000
+        : false,
   });
 }
 
@@ -301,6 +309,12 @@ export function useAgentRun(shortId: string | undefined) {
     queryKey: ["agents", "runs", shortId],
     queryFn: () => api<AgentRun>(`/api/v1/agents/runs/${shortId}`),
     enabled: Boolean(shortId),
+    // Same in_progress polling story as useAgentRuns — the transcript
+    // drawer's "Run in progress" banner pivots on runDetail.data.status,
+    // so without this the banner would stay forever after the sidecar
+    // exited.
+    refetchInterval: (q) =>
+      q.state.data?.status === "in_progress" ? 2000 : false,
   });
 }
 

--- a/web/src/components/coming-soon-pill.tsx
+++ b/web/src/components/coming-soon-pill.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { Clock, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * ComingSoonPill — the canonical muted "Coming soon" status pill rendered
+ * in the trailing slot of a `<StatusPanel tone="info">` for unbuilt
+ * surfaces.
+ *
+ * Vocabulary: muted background + muted-foreground label, fully-rounded
+ * pill (`rounded-full`), `px-2.5 py-1 text-[11px]`, uppercase + wide
+ * tracking, leading `Clock` icon at `size-3`. Distinct from the iter-37
+ * `<Eyebrow>` (no chip, used as a section/page micro-label) and from
+ * shadcn `<Badge>` (rectangular, semantic-tone variants) — this is a
+ * neutral inline status chip whose only job is to caption "not yet."
+ *
+ * Two consumers share it today: `routes/placeholder.tsx` (the canonical
+ * unbuilt-nav-leaf shell, iter 21) and `components/settings-shell.tsx`
+ * (the in-the-works settings section panel, iter 78). Both previously
+ * hand-rolled a 10-class span — promoted in iter 102 so the pill shape,
+ * padding, and rhythm live in one place. Sibling of `<JumpToPill>` in
+ * the iter-30 "primary-tinted pill triad" drift note: when a new
+ * surface needs the muted variant, reach for this; when it needs the
+ * primary-tinted v2-chip variant, that one is still inlined in
+ * `BrandHeader` / `AuthShell` until the third surface adopts it.
+ *
+ * `icon` defaults to `Clock` (matches both live consumers); pass a
+ * different `LucideIcon` if a new caller wants a different leading
+ * glyph without losing the chip rhythm. `children` is the label —
+ * keep it short ("Coming soon", "In review", "Beta"). If a non-muted
+ * tone is ever needed, add a `tone` prop here rather than forking the
+ * className — keep the vocabulary in one file.
+ */
+export interface ComingSoonPillProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Leading lucide icon; defaults to `Clock`. */
+  icon?: LucideIcon;
+  /** The pill label — defaults to "Coming soon". */
+  children?: React.ReactNode;
+}
+
+export function ComingSoonPill({
+  icon: Icon = Clock,
+  className,
+  children = "Coming soon",
+  ...rest
+}: ComingSoonPillProps) {
+  return (
+    <span
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase",
+        className,
+      )}
+      {...rest}
+    >
+      <Icon className="size-3" />
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -134,11 +134,22 @@ export function DataTable<TData, TValue>({
   const colCount = columns.length;
 
   return (
-    // The shadcn Table primitive already wraps the <table> in its own
-    // overflow-x-auto container, so narrow viewports scroll horizontally
-    // without a second scroll container here.
-    <div className="bg-card overflow-hidden rounded-lg border">
-      <Table>
+    // The shadcn Table primitive normally wraps the <table> in an
+    // `overflow-x-auto` container for narrow-viewport horizontal scrolling.
+    // That wrapper (plus our own `overflow-hidden` container) creates a
+    // scrolling containing block that traps `position: sticky` inside the
+    // table — `top-14` is then measured from the inner box, not the
+    // viewport, and the header floats inside the table card instead of
+    // pinning under the app shell header. When `stickyHeader` is on we
+    // suppress both overflow layers so the page itself becomes the sticky
+    // ancestor and `top-14` lands flush under the `h-14` app header.
+    <div
+      className={cn(
+        "bg-card rounded-lg border",
+        !stickyHeader && "overflow-hidden",
+      )}
+    >
+      <Table containerClassName={stickyHeader ? "overflow-visible" : undefined}>
         <TableHeader
           className={cn(
             stickyHeader &&

--- a/web/src/components/detail-dialog-header.tsx
+++ b/web/src/components/detail-dialog-header.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import {
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Eyebrow } from "@/components/eyebrow";
+import { cn } from "@/lib/utils";
+
+interface DetailDialogHeaderProps {
+  /**
+   * Lucide icon component rendered inside the leading icon tile. The tile uses
+   * the same `bg-muted text-muted-foreground rounded-lg border` vocabulary as
+   * `DetailSheetHeader`, `StatusPanel`, `EmptyState`, and `SectionCard` so
+   * every v2 form-bearing Dialog reads as part of the system instead of a
+   * stock shadcn surface.
+   */
+  icon: React.ComponentType<{ className?: string }>;
+  /** Optional uppercase eyebrow above the title (e.g. "Household"). */
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Optional trailing slot (e.g. a small status pill). */
+  trailing?: React.ReactNode;
+  className?: string;
+}
+
+// DetailDialogHeader is the canonical icon-tile header for v2 centered
+// Dialogs that host a form or a multi-step payload (Add member, Create
+// login, Share setup link, etc.). Sibling of `<DetailSheetHeader>` (which
+// owns the icon-tile header for slide-in Sheets) — same lockup, same icon
+// tile vocabulary, just routed through `<DialogTitle>` / `<DialogDescription>`
+// so it composes with shadcn `<Dialog>` rather than `<Sheet>`.
+//
+// Promoted in the iter 100 sweep that retired the destructive `<Dialog>`
+// holdouts onto `<ConfirmDialog>` (which is for yes/no confirmations). The
+// remaining centered `<Dialog>` consumers are the form-bearing modals
+// (household-section's AddMember / CreateLogin / ShareLink) — they don't
+// belong on `<ConfirmDialog>`, so this primitive gives them the same
+// visual lift as the iter 41 `<DetailSheetHeader>` family. 27th shared
+// primitive in the v2 vocabulary.
+//
+// Visual contract:
+//   <DialogHeader class="gap-3 sm:text-left">
+//     row: icon-tile (size-9 rounded-lg bg-muted border)
+//        + (eyebrow ↳ title ↳ description) column
+//        + optional trailing slot
+//
+// Don't fork the lockup — pass `trailing` / `eyebrow` rather than
+// re-opening `<DialogHeader>` inline. If a new surface needs a stronger
+// accent density, add a `density` prop here (mirroring the iter 41
+// `<DetailSheetHeader>` `accent` shape) instead of bespoke chrome.
+export function DetailDialogHeader({
+  icon: Icon,
+  eyebrow,
+  title,
+  description,
+  trailing,
+  className,
+}: DetailDialogHeaderProps) {
+  return (
+    <DialogHeader className={cn("gap-3 sm:text-left", className)}>
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden
+          className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-lg border"
+        >
+          <Icon className="size-4" />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {eyebrow ? <Eyebrow as="p">{eyebrow}</Eyebrow> : null}
+          <DialogTitle className="text-base leading-tight">{title}</DialogTitle>
+          {description ? (
+            <DialogDescription className="mt-0.5 text-xs">
+              {description}
+            </DialogDescription>
+          ) : null}
+        </div>
+        {trailing ? (
+          <div className="ms-2 flex shrink-0 items-start">{trailing}</div>
+        ) : null}
+      </div>
+    </DialogHeader>
+  );
+}

--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -51,7 +51,7 @@ interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "c
 // Visual contract — identical to SectionCard but the body is always a
 // `<ul className="divide-y">`:
 //   `<Card className="gap-0 py-0">`
-//     optional `<CardHeader className="border-b px-5 py-4">` title + action
+//     optional `<CardHeader className="border-b px-5 py-4 items-center">` title + action
 //     optional `<div className="border-b px-5 py-2">` toolbar slot
 //     `<ul className="divide-y">` rows (each `renderRow` result wrapped in `<li>`)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
@@ -60,6 +60,17 @@ interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "c
 // primitives must share vertical rhythm or pages that stack them feel
 // off. Row padding is consumer-supplied (typically `px-5 py-3` or
 // `px-5 py-3.5`), one stride below the header.
+//
+// Header alignment (iter 105): same fix as `SectionCard`. The shadcn
+// `CardHeader` grid defaults to `items-start` plus a `[.border-b]:pb-6`
+// rule that injects 24px of bottom padding when the header has a divider.
+// On `ListCard`'s "Recent activity" / "Connections" headers — title on
+// the left, `ViewAllPill` / "Manage" pill on the right — the result was
+// a crooked baseline (title pinned to top, action protruding 8px below)
+// AND a too-tall header band (24px below the title instead of 16px,
+// breaking symmetry with the 20px row stride below). `!pb-4` matches
+// `SectionCard`'s long-standing override; `items-center` plus title
+// `font-semibold` cures the baseline.
 //
 // When `rows.length === 0`, the `empty` slot replaces the `<ul>`. Pass
 // `<EmptyState>` for first-class look + CTA, or a short muted string for a
@@ -94,14 +105,21 @@ export function ListCard<T>({
       {...rest}
     >
       {showHeader && (
-        <CardHeader className={cn("border-b px-5 py-4", headerClassName)}>
+        <CardHeader
+          className={cn(
+            "items-center border-b px-5 py-4 !pb-4",
+            headerClassName,
+          )}
+        >
           {title !== undefined && (
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <CardTitle className="flex items-center gap-2 text-sm font-semibold">
               {icon}
               {title}
             </CardTitle>
           )}
-          {action !== undefined && <CardAction>{action}</CardAction>}
+          {action !== undefined && (
+            <CardAction className="self-center">{action}</CardAction>
+          )}
         </CardHeader>
       )}
       {toolbar && (

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -36,7 +36,7 @@ interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "t
 //
 // Visual contract:
 //   `<Card className="gap-0 py-0">`
-//     `<CardHeader className="border-b px-5 py-4">` title (text-sm font-medium)
+//     `<CardHeader className="border-b px-5 py-4 items-center">` title (text-sm font-semibold)
 //     `<CardContent className="px-5 py-5">` content (or px-0 py-0 when flushBody)
 //     optional `<div className="border-t px-5 py-3 text-right">` footer
 //
@@ -44,6 +44,16 @@ interface SectionCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "t
 // slight density step from chrome to content. Matched by `ListCard` so the
 // two cards visually align when they sit on the same page. Don't fork the
 // look — change this primitive.
+//
+// Header alignment (iter 105): the shadcn `CardHeader` grid defaults to
+// `items-start`, which pinned the 20px title to the top of the row while a
+// 28-32px action (ViewAllPill / Button size="sm") protruded downward by
+// 8-12px. That asymmetry — title's baseline higher than the action's
+// vertical center — was the "header looks crooked" complaint. We override
+// to `items-center` so the title and action sit on the same vertical
+// midline regardless of action height. The title weight bump from
+// `font-medium` → `font-semibold` gives it enough anchor that it doesn't
+// read as a caption next to the action button.
 export function SectionCard({
   title,
   action,
@@ -67,15 +77,18 @@ export function SectionCard({
           a SectionCard header carries the divider the primitive injects an
           extra 24px of bottom padding, which on top of our intentional
           `py-4` produced an empty band before the body. `!pb-4` keeps the
-          density we designed for and matches the `pt-4` on top. */}
+          density we designed for and matches the `pt-4` on top.
+          `items-center` overrides the grid's default `items-start` so the
+          title sits on the same midline as a taller action button
+          (ViewAllPill / Button size="sm") — see header note above. */}
       <CardHeader
-        className={cn("border-b px-5 py-4 !pb-4", headerClassName)}
+        className={cn("items-center border-b px-5 py-4 !pb-4", headerClassName)}
       >
-        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+        <CardTitle className="flex items-center gap-2 text-sm font-semibold">
           {icon}
           {title}
         </CardTitle>
-        {action && <CardAction>{action}</CardAction>}
+        {action && <CardAction className="self-center">{action}</CardAction>}
       </CardHeader>
       <CardContent
         className={cn(

--- a/web/src/components/settings-section-header.tsx
+++ b/web/src/components/settings-section-header.tsx
@@ -32,10 +32,17 @@ interface SettingsSectionHeaderProps {
  * line-height, action alignment — stays in one place.
  *
  * Vocabulary tokens:
- *   - `section` → `<h2>` `text-lg font-medium`, baseline-aligned action,
- *     `space-y-1` description.
- *   - `sub`     → `<h3>` `text-sm font-medium`, baseline-aligned action,
- *     `space-y-1` description.
+ *   - `section` → `<h2>` `text-lg font-semibold`, action centered to title
+ *     row, `space-y-1` description.
+ *   - `sub`     → `<h3>` `text-sm font-semibold`, action centered to title
+ *     row, `space-y-1` description.
+ *
+ * Iter 107 ripple from iter 106's `SectionCard` / `ListCard` baseline polish:
+ * bumped both heading tokens from `font-medium` to `font-semibold` so the
+ * title carries enough anchor next to a real action button (`Button size="sm"`,
+ * `Add member` etc.) instead of reading as a caption. The vocabulary now
+ * matches `PageHeader` (`text-2xl font-semibold`) and the canonical card
+ * header recipe (`text-sm font-semibold`).
  *
  * Don't fork the look — extend the primitive. If a fourth weight is needed
  * (e.g. a "field group" rhythm tighter than `sub`), add it as a new token
@@ -51,13 +58,20 @@ export function SettingsSectionHeader({
   const Heading = level === "section" ? "h2" : "h3";
   const headingClass =
     level === "section"
-      ? "text-lg font-medium tracking-tight"
-      : "text-sm font-medium";
+      ? "text-lg font-semibold tracking-tight"
+      : "text-sm font-semibold";
 
   return (
     <div
       className={cn(
-        "flex flex-col items-start gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-4",
+        // Iter 107: when an action is present and the title row is the
+        // visual anchor, `sm:items-center` keeps the button vertically
+        // centered relative to the title+description block instead of
+        // bottom-docked under the description (which protruded the button
+        // below the title baseline by 8-12px — the same mismatch iter 106
+        // fixed on `SectionCard` / `ListCard`). When there's no action the
+        // alignment is moot — `flex-col` collapses to a single column.
+        "flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4",
         className,
       )}
     >

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { Clock, Hammer } from "lucide-react";
+import { Hammer } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -23,6 +23,7 @@ import { BackupsSection } from "@/features/settings/backups-section";
 import { HouseholdSection } from "@/features/settings/household-section";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
 import { StatusPanel } from "@/components/status-panel";
+import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { Eyebrow } from "@/components/eyebrow";
 
 const SETTINGS_MODAL_KEY = "settings";
@@ -223,12 +224,7 @@ function SectionContent({ section }: { section: SettingsSection }) {
         icon={Hammer}
         heading={`${section.title} settings are in the works`}
         body="We're still building this surface. The configuration that lives here will land in a follow-up PR — for now, the panel is wired but empty."
-        trailing={
-          <span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase">
-            <Clock className="size-3" />
-            Coming soon
-          </span>
-        }
+        trailing={<ComingSoonPill />}
       />
     </div>
   );

--- a/web/src/components/timeline-rail.tsx
+++ b/web/src/components/timeline-rail.tsx
@@ -97,13 +97,18 @@ function TimelineRailGroup({
 // look — switch to a tinted variant when the event carries a clear
 // semantic role (sync, rule fire, classification change, etc.). Tones
 // adapt to light/dark themes via the standard shadcn vocabulary
-// (primary / emerald / amber / sky) used elsewhere in v2 (StatusPanel,
-// ColorRailCard, MetaBadge). Iter 93.
+// (primary / emerald / amber / sky / destructive) used elsewhere in v2
+// (StatusPanel, ColorRailCard, MetaBadge). Iter 93; `destructive` added
+// in iter 105 to give sync-history rows a "this run failed" disc accent
+// that matches StatusPanel's destructive vocabulary — `warning` (amber)
+// is the wrong colour for an *errored* sync run; it belongs to "tag
+// removed" / "soft warning" semantics.
 type TimelineRailTone =
   | "neutral"
   | "primary"
   | "success"
   | "warning"
+  | "destructive"
   | "info"
   | "muted";
 
@@ -118,6 +123,10 @@ const TONE_CLASSES: Record<TimelineRailTone, string> = {
   primary: "border-primary/40 text-primary",
   success: "border-emerald-500/40 text-emerald-600 dark:text-emerald-400",
   warning: "border-amber-500/40 text-amber-600 dark:text-amber-400",
+  // `destructive` matches StatusPanel / ColorRailCard's destructive tone
+  // (failed-state vocabulary). Use for hard failure rows (errored sync
+  // runs, failed rule runs) — distinct from `warning` (soft / removed).
+  destructive: "border-destructive/40 text-destructive",
   info: "border-sky-500/40 text-sky-600 dark:text-sky-400",
   muted: "border-border/60 text-muted-foreground/70",
 };

--- a/web/src/components/transaction-amount.tsx
+++ b/web/src/components/transaction-amount.tsx
@@ -8,20 +8,31 @@ interface TransactionAmountProps {
 }
 
 // TransactionAmount is the reusable right-aligned amount block — the signed
-// amount with the transaction date beneath it. Inflows (negative amounts)
-// render in the success color.
+// amount with the transaction date beneath it.
+//
+// Sign vocabulary: inflows (negative amounts) render in the success color.
+//
+// Pending vocabulary (iter 103): when the transaction has not posted yet
+// (`t.pending`), the amount renders italic + at 70% opacity so a scanning eye
+// reads the row as tentative. Pairs with the `Pending` `<MetaBadge>` in
+// `<TransactionPrimary>` — once a row is settled the visual settles down too.
+// Title attribute carries the contract for keyboard/sighted hover; the badge
+// alongside the description carries the screen-reader text.
 export function TransactionAmount({
   transaction: t,
   className,
 }: TransactionAmountProps) {
   const isInflow = t.amount < 0;
+  const isPending = t.pending;
   return (
     <div className={cn("text-right whitespace-nowrap", className)}>
       <div
         className={cn(
           "font-medium tabular-nums",
           isInflow && "text-success",
+          isPending && "italic opacity-70",
         )}
+        title={isPending ? "Pending — amount may change once posted" : undefined}
       >
         {formatAmount(t.amount, t.iso_currency_code)}
       </div>

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -1,5 +1,6 @@
-import { Tag as TagIcon } from "lucide-react";
+import { Clock, Tag as TagIcon } from "lucide-react";
 import { CategoryIconTile } from "@/components/category-icon-tile";
+import { MetaBadge } from "@/components/meta-badge";
 import { TagList } from "@/components/tag-chip";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
@@ -13,6 +14,13 @@ interface TransactionPrimaryProps {
 // category icon tile, the bank description as the title with an inline
 // "Pending" marker, and a secondary line of metadata (account · member · tags).
 // Shared by the transactions table and any future transaction list.
+//
+// Pending vocabulary (iter 103): the inline "Pending" marker now rides
+// `<MetaBadge muted icon={Clock}>` so it reads as part of the v2
+// secondary-state chip family (System / Hidden / Excluded / Linked / Re-auth)
+// instead of an orphan muted span. Pairs with the italic + opacity
+// treatment in `<TransactionAmount>` so both columns communicate
+// "not yet settled" at a glance.
 export function TransactionPrimary({
   transaction: t,
   className,
@@ -28,9 +36,9 @@ export function TransactionPrimary({
         <div className="flex items-center gap-1.5">
           <span className="truncate font-medium">{t.provider_name}</span>
           {t.pending && (
-            <span className="text-muted-foreground shrink-0 text-xs">
+            <MetaBadge muted icon={Clock} className="shrink-0">
               Pending
-            </span>
+            </MetaBadge>
           )}
         </div>
         <TransactionMeta transaction={t} />

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -2,11 +2,15 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<"table"> & { containerClassName?: string }) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className={cn("relative w-full overflow-x-auto", containerClassName)}
     >
       <table
         data-slot="table"

--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -10,13 +10,13 @@ import {
   RotateCw,
   Unlink,
 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { MetaBadge } from "@/components/meta-badge";
 import { RowActionsMenu } from "@/components/row-actions-menu";
 import { SectionCard } from "@/components/section-card";
 import { ConfirmDialog } from "@/components/confirm-dialog";
@@ -199,9 +199,9 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
     <li className="bg-muted/30 flex items-start gap-3 rounded-md border p-3 text-sm">
       <div className="flex-1 space-y-1.5">
         <div className="flex flex-wrap items-center gap-1.5">
-          <Badge variant={isPrimary ? "default" : "secondary"} className="text-[10px]">
+          <MetaBadge variant={isPrimary ? "default" : "secondary"}>
             {isPrimary ? "Primary" : "Dependent"}
-          </Badge>
+          </MetaBadge>
           <span className="text-muted-foreground text-xs">
             {isPrimary ? "Covers" : "Attributed to"}
           </span>
@@ -229,7 +229,7 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
             </span>
           )}
           <span>± {link.match_tolerance_days}d tolerance</span>
-          {!link.enabled && <Badge variant="outline" className="text-[10px]">Disabled</Badge>}
+          {!link.enabled && <MetaBadge>Disabled</MetaBadge>}
         </div>
       </div>
       <RowActionsMenu

--- a/web/src/features/accounts/account-row.tsx
+++ b/web/src/features/accounts/account-row.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@tanstack/react-router";
 import { AlertTriangle, ChevronRight, Link2 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { MetaBadge } from "@/components/meta-badge";
 import { formatBalance } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -121,18 +120,10 @@ function statusBadge(status: string | null) {
     );
   }
   if (status === "error") {
-    return (
-      <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
-        Error
-      </Badge>
-    );
+    return <MetaBadge variant="destructive">Error</MetaBadge>;
   }
   if (status === "disconnected") {
-    return (
-      <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
-        Disconnected
-      </Badge>
-    );
+    return <MetaBadge>Disconnected</MetaBadge>;
   }
   return null;
 }

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -157,10 +157,20 @@ export function TranscriptViewer({
     () => groupIntoTurns(matchingEvents),
     [matchingEvents],
   );
-  const resultEvent = useMemo(
-    () => events.find((e) => e.type === "result"),
-    [events],
-  );
+  const resultEvent = useMemo(() => {
+    // The sidecar emits two `result` events per run: the raw SDK message
+    // (snake_case fields, nested `usage`) plus a normalized breadbox-shape
+    // event with camelCase fields. We always want the normalized one — pick
+    // the first event whose `data` has the expected `totalCostUsd` field,
+    // falling back to the last `result` event for forward compatibility.
+    const resultEvents = events.filter((e) => e.type === "result");
+    const normalized = resultEvents.find(
+      (e) =>
+        e.type === "result" &&
+        typeof (e.data as Partial<ResultData>).totalCostUsd === "number",
+    );
+    return normalized ?? resultEvents[resultEvents.length - 1];
+  }, [events]);
   const errorEvent = useMemo(
     () => events.find((e) => e.type === "error"),
     [events],
@@ -462,21 +472,29 @@ function ResultFooter({ data }: { data: ResultData }) {
         <FooterStat
           icon={Coins}
           label="Cost"
-          value={`$${data.totalCostUsd.toFixed(4)}`}
+          value={
+            typeof data.totalCostUsd === "number"
+              ? `$${data.totalCostUsd.toFixed(4)}`
+              : "—"
+          }
         />
-        <FooterStat icon={Cpu} label="Turns" value={String(data.turnCount)} />
+        <FooterStat
+          icon={Cpu}
+          label="Turns"
+          value={data.turnCount != null ? String(data.turnCount) : "—"}
+        />
         <FooterStat
           icon={Wrench}
           label="Tool calls"
-          value={String(data.numToolCalls)}
+          value={data.numToolCalls != null ? String(data.numToolCalls) : "—"}
         />
         <FooterStat
           icon={Cpu}
           label="Tokens"
-          value={`${data.inputTokens.toLocaleString()} in / ${data.outputTokens.toLocaleString()} out`}
+          value={`${(data.inputTokens ?? 0).toLocaleString()} in / ${(data.outputTokens ?? 0).toLocaleString()} out`}
           sub={
-            data.cacheReadTokens + data.cacheCreationTokens > 0
-              ? `cache: ${(data.cacheReadTokens + data.cacheCreationTokens).toLocaleString()}`
+            (data.cacheReadTokens ?? 0) + (data.cacheCreationTokens ?? 0) > 0
+              ? `cache: ${((data.cacheReadTokens ?? 0) + (data.cacheCreationTokens ?? 0)).toLocaleString()}`
               : undefined
           }
         />

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -29,6 +29,7 @@ import type {
   ToolResultData,
   ToolUseData,
   TranscriptEvent,
+  UserContent,
 } from "@/api/queries/agents";
 
 interface TranscriptViewerProps {
@@ -47,6 +48,50 @@ interface TurnGroup {
   toolResults: Array<ToolResultData & { ts: number }>;
 }
 
+// extractToolUses pulls tool_use content blocks out of an assistant message.
+// The SDK nests them inside `message.content[]`; earlier viewer iterations
+// expected standalone top-level "tool_use" events that never actually
+// appeared on the wire (iter-46 finding, fixed in iter-48).
+function extractToolUses(
+  data: AssistantMessageData,
+  ts: number,
+): Array<ToolUseData & { ts: number }> {
+  const out: Array<ToolUseData & { ts: number }> = [];
+  for (const block of data.message?.content ?? []) {
+    if (block.type === "tool_use") {
+      out.push({
+        ts,
+        type: "tool_use",
+        id: block.id,
+        name: block.name,
+        input: (block.input ?? {}) as Record<string, unknown>,
+      });
+    }
+  }
+  return out;
+}
+
+// extractToolResults pulls tool_result content blocks out of a user message.
+// Same nesting story as extractToolUses.
+function extractToolResults(
+  content: UserContent[] | undefined,
+  ts: number,
+): Array<ToolResultData & { ts: number }> {
+  const out: Array<ToolResultData & { ts: number }> = [];
+  for (const block of content ?? []) {
+    if (block.type === "tool_result") {
+      out.push({
+        ts,
+        type: "tool_result",
+        tool_use_id: block.tool_use_id,
+        content: block.content,
+        is_error: block.is_error,
+      });
+    }
+  }
+  return out;
+}
+
 function groupIntoTurns(events: TranscriptEvent[]): TurnGroup[] {
   const turns: TurnGroup[] = [];
   let current: TurnGroup = { assistant: null, toolUses: [], toolResults: [] };
@@ -57,6 +102,11 @@ function groupIntoTurns(events: TranscriptEvent[]): TurnGroup[] {
         current = { assistant: null, toolUses: [], toolResults: [] };
       }
       current.assistant = { ...ev.data, ts: ev.ts };
+      current.toolUses.push(...extractToolUses(ev.data, ev.ts));
+    } else if (ev.type === "user_message") {
+      current.toolResults.push(
+        ...extractToolResults(ev.data.message?.content, ev.ts),
+      );
     } else if (ev.type === "tool_use") {
       current.toolUses.push({ ...ev.data, ts: ev.ts });
     } else if (ev.type === "tool_result") {
@@ -79,10 +129,31 @@ function eventMatchesQuery(ev: TranscriptEvent, q: string): boolean {
   switch (ev.type) {
     case "assistant_message": {
       const blocks = ev.data.message?.content ?? [];
-      return blocks.some(
-        (b) =>
-          b.type === "text" && b.text.toLowerCase().includes(needle),
-      );
+      return blocks.some((b) => {
+        if (b.type === "text") return b.text.toLowerCase().includes(needle);
+        if (b.type === "tool_use") {
+          if (b.name?.toLowerCase().includes(needle)) return true;
+          try {
+            return JSON.stringify(b.input).toLowerCase().includes(needle);
+          } catch {
+            return false;
+          }
+        }
+        return false;
+      });
+    }
+    case "user_message": {
+      const blocks = ev.data.message?.content ?? [];
+      return blocks.some((b) => {
+        if (b.type === "tool_result") {
+          try {
+            return JSON.stringify(b.content).toLowerCase().includes(needle);
+          } catch {
+            return false;
+          }
+        }
+        return false;
+      });
     }
     case "tool_use":
       if (ev.data.name?.toLowerCase().includes(needle)) return true;
@@ -123,30 +194,59 @@ export function TranscriptViewer({
       filtered = filtered.filter((ev) => eventMatchesQuery(ev, trimmed));
     }
     if (toolsOnly) {
-      // Keep tool_use + tool_result so input/output pairs render together;
-      // also keep error/cost_cap_hit so the headline Alerts up top still
-      // fire — those aren't part of the noise the chip suppresses.
-      filtered = filtered.filter(
-        (ev) =>
-          ev.type === "tool_use" ||
-          ev.type === "tool_result" ||
-          ev.type === "error" ||
-          ev.type === "cost_cap_hit",
-      );
+      // Tool-use lives in assistant_message.content; tool_result lives in
+      // user_message.content. Keep those messages when they carry any tool
+      // block (a text-only assistant_message gets dropped). Also keep
+      // standalone tool_use/tool_result (forward compat) and the headline
+      // error/cost_cap_hit events so the Alerts up top still fire.
+      filtered = filtered.filter((ev) => {
+        if (ev.type === "tool_use" || ev.type === "tool_result") return true;
+        if (ev.type === "error" || ev.type === "cost_cap_hit") return true;
+        if (ev.type === "assistant_message") {
+          return (ev.data.message?.content ?? []).some(
+            (b) => b.type === "tool_use",
+          );
+        }
+        if (ev.type === "user_message") {
+          return (ev.data.message?.content ?? []).some(
+            (b) => b.type === "tool_result",
+          );
+        }
+        return false;
+      });
     }
     if (errorsOnly) {
-      // Keep errored tool_results + the error/cost_cap_hit events. Skip
-      // tool_use entries whose matching result didn't error (they'd render
-      // as orphan "pending" badges).
-      const errResultIds = new Set(
-        filtered
-          .filter((ev) => ev.type === "tool_result" && ev.data.is_error === true)
-          .map((ev) => (ev.type === "tool_result" ? ev.data.tool_use_id : "")),
-      );
+      // Collect erroring tool_result block IDs (nested in user_message
+      // content, plus any legacy top-level events). Then keep assistant_
+      // messages that fired any of those IDs, the user_messages that carry
+      // the errors, and the headline error/cost_cap_hit alerts.
+      const errResultIds = new Set<string>();
+      for (const ev of filtered) {
+        if (ev.type === "tool_result" && ev.data.is_error) {
+          errResultIds.add(ev.data.tool_use_id);
+        }
+        if (ev.type === "user_message") {
+          for (const b of ev.data.message?.content ?? []) {
+            if (b.type === "tool_result" && b.is_error) {
+              errResultIds.add(b.tool_use_id);
+            }
+          }
+        }
+      }
       filtered = filtered.filter((ev) => {
         if (ev.type === "error" || ev.type === "cost_cap_hit") return true;
         if (ev.type === "tool_result") return ev.data.is_error === true;
         if (ev.type === "tool_use") return errResultIds.has(ev.data.id);
+        if (ev.type === "user_message") {
+          return (ev.data.message?.content ?? []).some(
+            (b) => b.type === "tool_result" && b.is_error === true,
+          );
+        }
+        if (ev.type === "assistant_message") {
+          return (ev.data.message?.content ?? []).some(
+            (b) => b.type === "tool_use" && errResultIds.has(b.id),
+          );
+        }
         return false;
       });
     }

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -23,7 +23,6 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/format";
 import type {
-  AssistantContent,
   AssistantMessageData,
   ResultData,
   ToolResultData,
@@ -39,13 +38,28 @@ interface TranscriptViewerProps {
   shortId: string;
 }
 
-// Grouped representation of one assistant turn: the assistant's message
-// plus any tool_use blocks and matching tool_result blocks before the next
-// assistant_message.
+// Grouped representation of one model turn. The SDK splits a single model
+// turn into MULTIPLE assistant_message events — typically one with the text
+// (reasoning) block and a separate one with the tool_use block. The viewer
+// groups consecutive assistant_messages together so one turn = one card,
+// matching the SDK's `num_turns` count in the footer.
 interface TurnGroup {
-  assistant: (AssistantMessageData & { ts: number }) | null;
+  ts: number;
+  text: string;
   toolUses: Array<ToolUseData & { ts: number }>;
   toolResults: Array<ToolResultData & { ts: number }>;
+}
+
+function emptyTurn(ts: number): TurnGroup {
+  return { ts, text: "", toolUses: [], toolResults: [] };
+}
+
+function turnHasContent(t: TurnGroup): boolean {
+  return (
+    t.text.length > 0 ||
+    t.toolUses.length > 0 ||
+    t.toolResults.length > 0
+  );
 }
 
 // extractToolUses pulls tool_use content blocks out of an assistant message.
@@ -92,30 +106,45 @@ function extractToolResults(
   return out;
 }
 
+function extractText(data: AssistantMessageData): string {
+  const parts: string[] = [];
+  for (const block of data.message?.content ?? []) {
+    if (block.type === "text" && block.text) parts.push(block.text);
+  }
+  return parts.join("\n\n");
+}
+
 function groupIntoTurns(events: TranscriptEvent[]): TurnGroup[] {
   const turns: TurnGroup[] = [];
-  let current: TurnGroup = { assistant: null, toolUses: [], toolResults: [] };
+  let current = emptyTurn(0);
+  // sawUserSinceLastAssistant tracks whether the next assistant_message
+  // should open a new turn. The SDK splits one model turn into multiple
+  // assistant_message events (text + tool_use as separate messages); only
+  // a user_message (tool_results coming back) marks the end of a turn.
+  let sawUserSinceLastAssistant = true;
   for (const ev of events) {
     if (ev.type === "assistant_message") {
-      if (current.assistant !== null || current.toolUses.length > 0) {
-        turns.push(current);
-        current = { assistant: null, toolUses: [], toolResults: [] };
+      if (sawUserSinceLastAssistant) {
+        if (turnHasContent(current)) turns.push(current);
+        current = emptyTurn(ev.ts);
+        sawUserSinceLastAssistant = false;
       }
-      current.assistant = { ...ev.data, ts: ev.ts };
+      const text = extractText(ev.data);
+      if (text) current.text = current.text ? `${current.text}\n\n${text}` : text;
       current.toolUses.push(...extractToolUses(ev.data, ev.ts));
     } else if (ev.type === "user_message") {
       current.toolResults.push(
         ...extractToolResults(ev.data.message?.content, ev.ts),
       );
+      sawUserSinceLastAssistant = true;
     } else if (ev.type === "tool_use") {
       current.toolUses.push({ ...ev.data, ts: ev.ts });
     } else if (ev.type === "tool_result") {
       current.toolResults.push({ ...ev.data, ts: ev.ts });
+      sawUserSinceLastAssistant = true;
     }
   }
-  if (current.assistant !== null || current.toolUses.length > 0) {
-    turns.push(current);
-  }
+  if (turnHasContent(current)) turns.push(current);
   return turns;
 }
 
@@ -387,7 +416,7 @@ function TurnBlock({ turn, index }: { turn: TurnGroup; index: number }) {
       <div className="text-muted-foreground text-[10px] uppercase tracking-wider">
         Turn {index + 1}
       </div>
-      {turn.assistant && <MessageBubble data={turn.assistant} />}
+      {turn.text && <MessageBubble text={turn.text} />}
       {turn.toolUses.map((tu) => {
         const result = turn.toolResults.find(
           (tr) => tr.tool_use_id === tu.id,
@@ -400,8 +429,7 @@ function TurnBlock({ turn, index }: { turn: TurnGroup; index: number }) {
   );
 }
 
-function MessageBubble({ data }: { data: AssistantMessageData }) {
-  const text = useMemo(() => extractText(data.message.content), [data]);
+function MessageBubble({ text }: { text: string }) {
   if (!text) return null;
   return (
     <div className="bg-muted/40 rounded-md p-3">
@@ -410,13 +438,6 @@ function MessageBubble({ data }: { data: AssistantMessageData }) {
       </pre>
     </div>
   );
-}
-
-function extractText(content: AssistantContent[]): string {
-  return content
-    .filter((b): b is { type: "text"; text: string } => b.type === "text")
-    .map((b) => b.text)
-    .join("\n\n");
 }
 
 interface ToolCallPairProps {

--- a/web/src/features/connections/sync-history-list.tsx
+++ b/web/src/features/connections/sync-history-list.tsx
@@ -1,6 +1,16 @@
-import { Check, Loader2, RefreshCw, X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { useMemo } from "react";
+import {
+  AlertCircle,
+  Check,
+  Loader2,
+  RefreshCw,
+  type LucideIcon,
+} from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
+import {
+  TimelineRail,
+  type TimelineRailTone,
+} from "@/components/timeline-rail";
 import { relativeTime } from "./connection-utils";
 import type { SyncLog } from "@/api/queries/sync-logs";
 
@@ -8,13 +18,73 @@ interface SyncHistoryListProps {
   logs: SyncLog[];
 }
 
-const STATUS_TILE: Record<string, string> = {
-  success: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-  error: "bg-destructive/10 text-destructive",
-  in_progress: "bg-primary/10 text-primary",
+// Sync-history rows speak the same TimelineRail vocabulary as the
+// transaction-detail activity feed (iter 26 + iter 93). Status maps to
+// tone so the disc accent reads at a glance — no need to parse the
+// status text to find the failed runs.
+//   - success     → success    (emerald — run landed cleanly)
+//   - error       → destructive(red    — hard failure, demands action)
+//   - in_progress → primary    (run is mid-flight; spinner reinforces)
+// Iter 105 added the `destructive` tone to TimelineRail specifically so
+// errored sync runs don't have to fall back to the softer amber/warning
+// tint used for "tag removed" / soft-warning vocabulary.
+const STATUS_TONE: Record<string, TimelineRailTone> = {
+  success: "success",
+  error: "destructive",
+  in_progress: "primary",
 };
 
+const STATUS_ICON: Record<string, LucideIcon> = {
+  success: Check,
+  error: AlertCircle,
+  in_progress: Loader2,
+};
+
+const dayHeadingFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+
+function dayLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (d.toDateString() === today.toDateString()) return "Today";
+  if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return dayHeadingFormatter.format(d);
+}
+
+interface DayGroup {
+  label: string;
+  rows: SyncLog[];
+}
+
+// Buckets newest-first sync logs into calendar days, preserving order
+// within each day. Logs without any timestamp fall under an "Unknown
+// time" group so they don't silently drop. Mirrors the
+// activity-timeline `groupByDay` shape so the two feeds read as one
+// system.
+function groupByDay(logs: SyncLog[]): DayGroup[] {
+  const groups: DayGroup[] = [];
+  for (const log of logs) {
+    const ts = log.completed_at ?? log.started_at ?? null;
+    const label = ts ? dayLabel(ts) : "Unknown time";
+    const tail = groups[groups.length - 1];
+    if (tail && tail.label === label) {
+      tail.rows.push(log);
+    } else {
+      groups.push({ label, rows: [log] });
+    }
+  }
+  return groups;
+}
+
 export function SyncHistoryList({ logs }: SyncHistoryListProps) {
+  const groups = useMemo(() => groupByDay(logs), [logs]);
+
   if (logs.length === 0) {
     return (
       <EmptyState
@@ -27,17 +97,23 @@ export function SyncHistoryList({ logs }: SyncHistoryListProps) {
   }
 
   return (
-    <div className="divide-border/40 divide-y">
-      {logs.map((log) => (
-        <SyncHistoryRow key={log.id} log={log} />
+    <TimelineRail>
+      {groups.map((group) => (
+        <TimelineRail.Group key={group.label} label={group.label}>
+          {group.rows.map((log) => (
+            <SyncHistoryRow key={log.id} log={log} />
+          ))}
+        </TimelineRail.Group>
       ))}
-    </div>
+    </TimelineRail>
   );
 }
 
 function SyncHistoryRow({ log }: { log: SyncLog }) {
   const ts = log.completed_at ?? log.started_at ?? null;
-  const tile = STATUS_TILE[log.status] ?? STATUS_TILE.in_progress;
+  const tone = STATUS_TONE[log.status] ?? "neutral";
+  const Icon = STATUS_ICON[log.status] ?? RefreshCw;
+  const spin = log.status === "in_progress";
   const counts = formatCounts(log);
   const errorMessage =
     log.status === "error"
@@ -45,42 +121,42 @@ function SyncHistoryRow({ log }: { log: SyncLog }) {
       : null;
 
   return (
-    <div className="flex gap-3 py-3">
-      <div className={cn("flex size-6 shrink-0 items-center justify-center rounded-full", tile)}>
-        {log.status === "success" ? (
-          <Check className="size-3" />
-        ) : log.status === "error" ? (
-          <X className="size-3" />
-        ) : (
-          <Loader2 className="size-3 animate-spin" />
-        )}
-      </div>
-      <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
-        <div className="min-w-0">
+    <TimelineRail.Row
+      icon={Icon}
+      tone={tone}
+      iconClassName={spin ? "[&>svg]:animate-spin" : undefined}
+    >
+      <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
+        <div className="min-w-0 space-y-0.5">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-medium capitalize">{log.trigger}</span>
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {ts ? relativeTime(ts) : ""}
+            <span className="text-sm font-medium capitalize">
+              {log.trigger}
             </span>
             {log.duration && (
-              <span className="text-muted-foreground bg-muted/60 rounded-full px-1.5 py-0.5 text-[0.6rem] tabular-nums">
+              <span className="text-muted-foreground bg-muted/60 rounded-full px-1.5 py-0.5 text-[10px] tabular-nums">
                 {log.duration}
               </span>
             )}
           </div>
+          <p className="text-muted-foreground text-xs tabular-nums">
+            {ts ? relativeTime(ts) : "Unknown time"}
+          </p>
           {errorMessage && (
-            <p className="text-destructive/80 mt-0.5 truncate text-xs" title={log.error_message ?? errorMessage}>
+            <p
+              className="text-destructive/80 mt-1 text-xs"
+              title={log.error_message ?? errorMessage}
+            >
               {errorMessage}
             </p>
           )}
         </div>
         {counts && (
-          <div className="text-muted-foreground shrink-0 text-xs tabular-nums">
+          <div className="text-muted-foreground shrink-0 pt-0.5 text-xs tabular-nums">
             {counts}
           </div>
         )}
       </div>
-    </div>
+    </TimelineRail.Row>
   );
 }
 

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -18,13 +18,11 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { DetailDialogHeader } from "@/components/detail-dialog-header";
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -352,13 +350,11 @@ function AddMemberDialog({ onDone }: { onDone: () => void }) {
   if (shareToken) {
     return (
       <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Share their setup link</DialogTitle>
-          <DialogDescription>
-            {memberName} can use this one-time link to set their password. It
-            expires in 7 days.
-          </DialogDescription>
-        </DialogHeader>
+        <DetailDialogHeader
+          icon={Link2}
+          title="Share their setup link"
+          description={`${memberName} can use this one-time link to set their password. It expires in 7 days.`}
+        />
         <SetupLinkBox token={shareToken} />
         <DialogFooter>
           <Button onClick={onDone}>Done</Button>
@@ -371,13 +367,11 @@ function AddMemberDialog({ onDone }: { onDone: () => void }) {
 
   return (
     <DialogContent className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>Add a household member</DialogTitle>
-        <DialogDescription>
-          New members are added without a login by default. Invite them to sign
-          in to share read or edit access.
-        </DialogDescription>
-      </DialogHeader>
+      <DetailDialogHeader
+        icon={UserPlus}
+        title="Add a household member"
+        description="New members are added without a login by default. Invite them to sign in to share read or edit access."
+      />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormField
@@ -532,12 +526,11 @@ function CreateLoginDialog({
 
   return (
     <DialogContent className="sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>Invite {user.name} to sign in</DialogTitle>
-        <DialogDescription>
-          We'll create a login and give you a one-time setup link to share.
-        </DialogDescription>
-      </DialogHeader>
+      <DetailDialogHeader
+        icon={UserPlus}
+        title={`Invite ${user.name} to sign in`}
+        description="We'll create a login and give you a one-time setup link to share."
+      />
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormField
@@ -615,13 +608,11 @@ function ShareLinkDialog({
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Share their setup link</DialogTitle>
-          <DialogDescription>
-            {memberName} can use this one-time link to set their password. It
-            expires in 7 days.
-          </DialogDescription>
-        </DialogHeader>
+        <DetailDialogHeader
+          icon={Link2}
+          title="Share their setup link"
+          description={`${memberName} can use this one-time link to set their password. It expires in 7 days.`}
+        />
         {token && <SetupLinkBox token={token} />}
         <DialogFooter>
           <Button onClick={onClose}>Done</Button>

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,7 +27,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
 import { withMutationToast } from "@/lib/mutation-toast";
-import { useAgent, useRunAgentNow, useUpdateAgent } from "@/api/queries/agents";
+import {
+  useAgent,
+  useRunAgentNow,
+  useUpdateAgent,
+  type AgentDefinition,
+} from "@/api/queries/agents";
 import {
   AGENT_MODELS,
   TOOL_SCOPES,
@@ -71,39 +75,66 @@ type AgentEditForm = z.input<typeof agentEditSchema>;
 
 export function AgentEditPage() {
   const { slug } = useParams({ strict: false }) as { slug: string };
-  const navigate = useNavigate();
   const agentQuery = useAgent(slug);
-  const updateAgent = useUpdateAgent(slug);
 
+  if (agentQuery.isError) {
+    return (
+      <PageError
+        resource="agent"
+        error={agentQuery.error}
+        onRetry={() => agentQuery.refetch()}
+        retrying={agentQuery.isFetching}
+      />
+    );
+  }
+  if (agentQuery.isLoading || !agentQuery.data) {
+    return (
+      <>
+        <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+          <Link to="/agents">
+            <ArrowLeft className="size-4" /> Back to agents
+          </Link>
+        </Button>
+        <PageHeader
+          eyebrow="Agent"
+          title="Edit agent"
+          description="Update prompt, schedule, model, and safety caps."
+        />
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-1/2" />
+        </div>
+      </>
+    );
+  }
+  return <AgentEditFormView agent={agentQuery.data} slug={slug} />;
+}
+
+// AgentEditFormView mounts useForm with the loaded agent's values as the
+// actual defaultValues — no post-mount resync, no race with shadcn's
+// controlled Select. Earlier shapes (defaultValues + useEffect form.reset,
+// or `values` prop syncing) reliably left the Model field rendering empty
+// for any agent whose stored model differed from the form's placeholder
+// default (tool_scope was lucky because "read_write" already matched).
+function AgentEditFormView({
+  agent,
+  slug,
+}: {
+  agent: AgentDefinition;
+  slug: string;
+}) {
+  const navigate = useNavigate();
+  const updateAgent = useUpdateAgent(slug);
   const form = useForm<AgentEditForm>({
     resolver: zodResolver(agentEditSchema),
     defaultValues: {
-      name: "",
-      prompt: "",
-      system_prompt: "",
-      schedule_cron: "",
-      tool_scope: "read_write",
-      allowed_tools_raw: "",
-      model: "claude-opus-4-7",
-      max_turns: 10,
-      max_budget_usd: null,
-      quiet_hours_start: "",
-      quiet_hours_end: "",
-      trigger_on_sync_complete: false,
-    },
-  });
-
-  // Hydrate the form once the agent loads. Depend on short_id (immutable)
-  // not the whole object, so a cache refetch doesn't wipe in-flight edits.
-  useEffect(() => {
-    const agent = agentQuery.data;
-    if (!agent) return;
-    form.reset({
       name: agent.name,
       prompt: agent.prompt,
       system_prompt: agent.system_prompt ?? "",
       schedule_cron: agent.schedule_cron ?? "",
-      tool_scope: agent.tool_scope,
+      tool_scope: agent.tool_scope as AgentEditForm["tool_scope"],
       allowed_tools_raw: (agent.allowed_tools ?? []).join(", "),
       model: agent.model,
       max_turns: agent.max_turns,
@@ -111,9 +142,8 @@ export function AgentEditPage() {
       quiet_hours_start: agent.quiet_hours_start ?? "",
       quiet_hours_end: agent.quiet_hours_end ?? "",
       trigger_on_sync_complete: agent.trigger_on_sync_complete,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentQuery.data?.short_id]);
+    },
+  });
 
   const onSubmit = form.handleSubmit(async (values) => {
     const tools = (values.allowed_tools_raw ?? "")
@@ -148,17 +178,6 @@ export function AgentEditPage() {
     if (ok) navigate({ to: "/agents" });
   });
 
-  if (agentQuery.isError) {
-    return (
-      <PageError
-        resource="agent"
-        error={agentQuery.error}
-        onRetry={() => agentQuery.refetch()}
-        retrying={agentQuery.isFetching}
-      />
-    );
-  }
-
   return (
     <>
       <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
@@ -168,19 +187,11 @@ export function AgentEditPage() {
       </Button>
       <PageHeader
         eyebrow="Agent"
-        title={agentQuery.data?.name ?? "Edit agent"}
+        title={agent.name}
         description="Update prompt, schedule, model, and safety caps. Changes take effect on the next scheduled fire or manual run."
       />
 
-      {agentQuery.isLoading ? (
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-32 w-full" />
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-1/2" />
-        </div>
-      ) : (
-        <Form {...form}>
+      <Form {...form}>
           <form onSubmit={onSubmit} className="grid grid-cols-1 gap-6 md:grid-cols-3">
             <div className="space-y-4 md:col-span-2">
               <Card className="space-y-4 p-4">
@@ -474,7 +485,6 @@ export function AgentEditPage() {
             </div>
           </form>
         </Form>
-      )}
     </>
   );
 }

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -451,8 +451,9 @@ interface TranscriptSheetProps {
 
 function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
   const open = Boolean(shortId);
-  const transcript = useTranscript(shortId ?? undefined);
   const runDetail = useAgentRun(shortId ?? undefined);
+  const inProgress = runDetail.data?.status === "in_progress";
+  const transcript = useTranscript(shortId ?? undefined, { inProgress });
 
   return (
     <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
@@ -482,6 +483,8 @@ function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
               <Skeleton className="h-32 w-full" />
               <Skeleton className="h-20 w-full" />
             </div>
+          ) : transcript.isError && inProgress ? (
+            <InProgressTranscriptPlaceholder />
           ) : transcript.isError ? (
             <PageError
               resource="transcript"
@@ -490,15 +493,41 @@ function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
               retrying={transcript.isFetching}
             />
           ) : transcript.data && shortId ? (
-            <TranscriptViewer
-              events={transcript.data.events}
-              rawLength={transcript.data.rawLength}
-              truncated={transcript.data.truncated}
-              shortId={shortId}
-            />
+            <>
+              {inProgress && <InProgressBanner />}
+              <TranscriptViewer
+                events={transcript.data.events}
+                rawLength={transcript.data.rawLength}
+                truncated={transcript.data.truncated}
+                shortId={shortId}
+              />
+            </>
           ) : null}
         </div>
       </SheetContent>
     </Sheet>
+  );
+}
+
+function InProgressTranscriptPlaceholder() {
+  return (
+    <div className="text-muted-foreground flex flex-col items-center gap-3 py-12 text-center text-sm">
+      <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+      <div className="space-y-1">
+        <div className="text-foreground font-medium">Run starting…</div>
+        <p className="max-w-xs">
+          Transcript will appear here as the agent begins streaming events.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function InProgressBanner() {
+  return (
+    <div className="bg-muted/40 text-muted-foreground mb-4 flex items-center gap-2 rounded-md border px-3 py-2 text-xs">
+      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      <span>Run in progress — events will keep arriving below.</span>
+    </div>
   );
 }

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -569,15 +569,21 @@ function RunNowDialog({
   const [open, setOpen] = useState(false);
   const [prefix, setPrefix] = useState("");
   const runNow = useRunAgentNow();
+  const navigate = useNavigate();
   const hasLastPrefix = Boolean(lastPrefix && lastPrefix.length > 0);
 
   const submit = async () => {
+    let startedShortId: string | null = null;
     const ok = await withMutationToast(
-      () => runNow.mutateAsync({ slug, promptPrefix: prefix }),
+      async () => {
+        const result = await runNow.mutateAsync({ slug, promptPrefix: prefix });
+        startedShortId = result.short_id;
+        return result;
+      },
       {
         success: prefix
-          ? `Run started for ${name} (with prefix)`
-          : `Run started for ${name}`,
+          ? `Run started for ${name} (with prefix) — opening transcript`
+          : `Run started for ${name} — opening transcript`,
         error:
           "Run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
       },
@@ -585,6 +591,15 @@ function RunNowDialog({
     if (ok) {
       setOpen(false);
       setPrefix("");
+      // Land on the runs page with the freshly-kicked-off run pre-selected.
+      // The transcript drawer + 2s polling pick up events as they stream in.
+      if (startedShortId) {
+        navigate({
+          to: "/agents/$slug/runs",
+          params: { slug },
+          search: { run: startedShortId },
+        });
+      }
     }
   };
 

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -24,6 +24,7 @@ import {
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TimelineRail } from "@/components/timeline-rail";
 import { EmptyState } from "@/components/empty-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { StatusPanel } from "@/components/status-panel";
@@ -508,11 +509,18 @@ function DetailBody({
             }
           >
             {syncLogsLoading ? (
-              <div className="space-y-2">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <Skeleton key={i} className="h-12 w-full" />
-                ))}
-              </div>
+              // Skeleton mirrors the TimelineRail geometry the loaded
+              // state renders into — disc punched through the rail line,
+              // headline + timestamp lines to the right — so the layout
+              // doesn't shift when sync logs land. Iter 105.
+              <TimelineRail>
+                <TimelineRail.Group>
+                  <TimelineRail.RowSkeleton />
+                  <TimelineRail.RowSkeleton />
+                  <TimelineRail.RowSkeleton />
+                  <TimelineRail.RowSkeleton />
+                </TimelineRail.Group>
+              </TimelineRail>
             ) : (
               <SyncHistoryList logs={syncLogs} />
             )}

--- a/web/src/routes/placeholder.tsx
+++ b/web/src/routes/placeholder.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowRight,
-  Clock,
   FileText,
   Hammer,
   type LucideIcon,
@@ -8,6 +7,7 @@ import {
 } from "lucide-react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
+import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { JumpToPill } from "@/components/jump-to-pill";
 import { PageHeader } from "@/components/page-header";
 import { SectionCard } from "@/components/section-card";
@@ -168,12 +168,7 @@ export function Placeholder({ title }: { title: string }) {
               ? "We're still building this surface. The plan below sketches the shape it'll take — follow the related pages for the data that's live today."
               : "This page is part of the v2 admin shell. The full implementation lands in a follow-up PR."
           }
-          trailing={
-            <span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium tracking-wide uppercase">
-              <Clock className="size-3" />
-              Coming soon
-            </span>
-          }
+          trailing={<ComingSoonPill />}
         />
 
         {hasPlan && (

--- a/web/src/sandbox/sections/amounts.tsx
+++ b/web/src/sandbox/sections/amounts.tsx
@@ -178,7 +178,7 @@ export function AmountsSection() {
       <Specimen
         label="TransactionAmount"
         code="components/transaction-amount"
-        description="The reusable amount block — signed amount over its date, right-aligned, tabular figures. Inflows pick up the success color automatically."
+        description="The reusable amount block — signed amount over its date, right-aligned, tabular figures. Inflows pick up the success color automatically. Pending transactions render italic at 70% opacity so the column reads as tentative until the row settles (pairs with the `Pending` `MetaBadge` chip in `TransactionPrimary`)."
         className="block divide-y"
       >
         {AMOUNT_ROWS.map((t) => (

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
 import {
+  AlertCircle,
   AlertTriangle,
   ArrowUpRight,
   Check,
@@ -28,10 +29,12 @@ import {
   Search,
   Shapes,
   ShieldAlert,
+  Sparkles,
   Sun,
   Tag,
   Trash2,
   Unplug,
+  UserPlus,
   Users,
   Wallet,
   Wand2,
@@ -70,6 +73,7 @@ import { SectionCard } from "@/components/section-card";
 import { IdPill } from "@/components/id-pill";
 import { Eyebrow } from "@/components/eyebrow";
 import { ActionPill } from "@/components/action-pill";
+import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { JumpToPill, JumpToRow } from "@/components/jump-to-pill";
 import { RowActionsMenu } from "@/components/row-actions-menu";
 import {
@@ -81,7 +85,9 @@ import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { PageError } from "@/components/page-error";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import { DetailSheetHeader } from "@/components/detail-sheet-header";
+import { DetailDialogHeader } from "@/components/detail-dialog-header";
 import { Sheet } from "@/components/ui/sheet";
+import { Dialog } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { SoftBackButton } from "@/components/soft-back-button";
 import { StatusPanel } from "@/components/status-panel";
@@ -428,7 +434,7 @@ export function ComponentsSection() {
       <Specimen
         label="MetaBadge"
         code="components/meta-badge"
-        description="Tiny meta chip used in list rows and detail-page hero columns to label a row's secondary state — Hidden, Excluded, Linked, Re-auth, System, Paused, … Owns the v2 density vocabulary (`text-[10px]` + `gap-1` + `px-1.5 py-0` + `[&>svg]:size-2.5`) so the same chip never gets re-derived. Tone routes through the underlying `<Badge>` variant — `outline` by default because a meta label is intentionally calmer than the row's primary classification. `muted` opts into the `text-muted-foreground font-normal` shading the categories list uses so 'System' / 'Hidden' don't compete with the category name. For tone-specific chips (the amber Re-auth pill) pass `className` — the density tokens still apply, which is the whole point. Six surfaces share it: accounts list, accounts detail, categories list (parent + child rows), category detail, connection detail."
+        description="Tiny meta chip used in list rows and detail-page hero columns to label a row's secondary state — Hidden, Excluded, Linked, Re-auth, System, Paused, Primary, Dependent, Error, Disconnected, Disabled, … Owns the v2 density vocabulary (`text-[10px]` + `gap-1` + `px-1.5 py-0` + `[&>svg]:size-2.5`) so the same chip never gets re-derived. Tone routes through the underlying `<Badge>` variant — `outline` by default because a meta label is intentionally calmer than the row's primary classification. `muted` opts into the `text-muted-foreground font-normal` shading the categories list uses so 'System' / 'Hidden' don't compete with the category name. For tone-specific chips (the amber Re-auth pill) pass `className` — the density tokens still apply, which is the whole point. Seven surfaces share it: accounts list (statusBadge for error/disconnected, Linked pill, iter 104), accounts detail, account-links section (Primary/Dependent/Disabled, iter 104), categories list (parent + child rows), category detail, connection detail."
       >
         <MetaBadge icon={Lock} muted>
           System
@@ -443,6 +449,11 @@ export function ComponentsSection() {
         <MetaBadge icon={Pause} variant="secondary">
           Paused
         </MetaBadge>
+        <MetaBadge variant="default">Primary</MetaBadge>
+        <MetaBadge variant="secondary">Dependent</MetaBadge>
+        <MetaBadge variant="destructive">Error</MetaBadge>
+        <MetaBadge>Disconnected</MetaBadge>
+        <MetaBadge>Disabled</MetaBadge>
         <MetaBadge
           icon={AlertTriangle}
           className="border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400"
@@ -597,6 +608,25 @@ export function ComponentsSection() {
               Re-authenticate
             </ActionPill>
           </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="ComingSoonPill"
+        code="components/coming-soon-pill"
+        description="The canonical muted 'Coming soon' status pill rendered in the trailing slot of a `<StatusPanel tone='info'>` for unbuilt surfaces. Fully-rounded pill (`rounded-full`) with muted background + muted-foreground label, `px-2.5 py-1 text-[11px]` uppercase + wide tracking, leading `Clock` icon at `size-3`. Two consumers today: `routes/placeholder.tsx` (the unbuilt-nav-leaf shell, iter 21) and `components/settings-shell.tsx` (the in-the-works settings panel, iter 78) — both previously hand-rolled the 10-class span. Distinct from `<Eyebrow>` (no chip; section/page micro-label) and shadcn `<Badge>` (rectangular, semantic-tone variants). Pass a different `icon` to swap the leading glyph without losing the rhythm; pass `children` to override the label. Promoted in iter 102."
+        className="block"
+      >
+        <div className="flex flex-col gap-3 rounded-lg border p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <ComingSoonPill />
+            <ComingSoonPill icon={Sparkles}>Beta</ComingSoonPill>
+            <ComingSoonPill icon={Wand2}>In review</ComingSoonPill>
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Default leading icon is <code>Clock</code>. Override with the
+            <code> icon</code> prop and the label via <code>children</code>.
+          </p>
         </div>
       </Specimen>
 
@@ -845,6 +875,42 @@ export function ComponentsSection() {
       </Specimen>
 
       <Specimen
+        label="DetailDialogHeader"
+        code="components/detail-dialog-header"
+        description="Sibling of `<DetailSheetHeader>` for centered Dialogs that host a form or multi-step payload (Add member, Create login, Share setup link). Same leading rounded-lg icon tile + optional eyebrow + title + description + optional trailing slot — just routed through `<DialogTitle>` / `<DialogDescription>` so it composes with shadcn `<Dialog>` instead of `<Sheet>`. Promoted in iter 101 to retire the four open-coded `<DialogHeader>` lockups in household-section onto a shared primitive. Wrapped in a hidden `<Dialog open>` here so the radix Dialog context is available."
+        className="block"
+      >
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="overflow-hidden rounded-lg border bg-card p-4">
+            <div className="text-muted-foreground mb-3 text-[11px] tracking-wide uppercase">
+              add-member · title + description
+            </div>
+            <Dialog open onOpenChange={() => {}}>
+              <DetailDialogHeader
+                icon={UserPlus}
+                title="Add a household member"
+                description="New members are added without a login by default. Invite them to sign in to share read or edit access."
+              />
+            </Dialog>
+          </div>
+          <div className="overflow-hidden rounded-lg border bg-card p-4">
+            <div className="text-muted-foreground mb-3 text-[11px] tracking-wide uppercase">
+              share-link · with eyebrow + trailing
+            </div>
+            <Dialog open onOpenChange={() => {}}>
+              <DetailDialogHeader
+                icon={Link2}
+                eyebrow="Household"
+                title="Share their setup link"
+                description="Alex can use this one-time link to set their password. It expires in 7 days."
+                trailing={<Badge variant="secondary">7d</Badge>}
+              />
+            </Dialog>
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen
         label="FormFooter"
         code="components/form-footer"
         description="The flush bordered action strip at the bottom of a form container. Cancel sits left, primary right; optional `hint` slot for an inline validation note. Two insets — `card` (default) flushes to a `<SectionCard>` body (px-5 py-5), `sheet` flushes to a `<Sheet>` body (p-6) and uses `mt-auto` so it sticks to the Sheet bottom. Iter 49 folded the CSV form's bespoke footer onto the `sheet` variant."
@@ -914,7 +980,7 @@ export function ComponentsSection() {
       <Specimen
         label="SettingsSectionHeader"
         code="components/settings-section-header"
-        description="The canonical title + description block used by every section inside the Settings shell. Top-of-pane titles (Account / Household / Backups) and inline sub-sections (Change password / Actions / Stored backups / Automatic schedule) both route through here, so the typographic rhythm — heading size + weight, description colour + line-height, action alignment — stays in one place. Tokens: `section` (h2, text-lg, baseline-aligned action) and `sub` (h3, text-sm). The optional `action` slot is sm:right-aligned and baseline-aligned to the heading so an Add-member CTA sits flush with the title."
+        description="The canonical title + description block used by every section inside the Settings shell. Top-of-pane titles (Account / Household / Backups) and inline sub-sections (Change password / Actions / Stored backups / Automatic schedule) both route through here, so the typographic rhythm — heading size + weight, description colour + line-height, action alignment — stays in one place. Tokens: `section` (h2, text-lg, font-semibold) and `sub` (h3, text-sm, font-semibold). Iter 107 ripple from the iter 106 card-header polish: both heads now share `font-semibold` weight + `items-center` action alignment with `SectionCard` / `ListCard` / `PageHeader`, so an Add-member CTA sits flush with the title midline instead of bottom-docking under the description."
         className="block"
       >
         <div className="grid gap-4 lg:grid-cols-2">
@@ -1182,7 +1248,7 @@ export function ComponentsSection() {
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
-        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Each row accepts a semantic `tone` (`neutral` · `primary` · `success` · `warning` · `info` · `muted`, iter 93) that tints the disc border + icon so the eye can pick out rule fires, classification changes, and sync events without parsing the summary line. Used by the transaction-detail activity feed; queued for rule run history and per-connection sync logs."
+        description="Vertical activity feed primitive: a thin border-l rail anchors a stack of rows; each row's icon disc punches through the line. Group labels render as temporal dividers — a small dot anchored on the rail's x-axis + uppercase eyebrow + hairline rule extending right — so they read as separators *inside* the timeline, distinct from the surrounding section header. `<TimelineRail.RowSkeleton>` (iter 65) mirrors the row geometry exactly so loading-to-loaded transitions don't shift layout. Each row accepts a semantic `tone` (`neutral` · `primary` · `success` · `warning` · `destructive` · `info` · `muted`, iter 93; `destructive` added iter 105 for sync-history errored runs) that tints the disc border + icon so the eye can pick out rule fires, classification changes, and sync events without parsing the summary line. Used by the transaction-detail activity feed and the per-connection sync-history feed."
         className="block"
       >
         <div className="grid gap-6 max-w-3xl sm:grid-cols-2">
@@ -1243,6 +1309,14 @@ export function ComponentsSection() {
                 </p>
                 <p className="text-muted-foreground mt-1 text-[11px]">
                   Yesterday at 4:00 PM
+                </p>
+              </TimelineRail.Row>
+              <TimelineRail.Row icon={AlertCircle} tone="destructive">
+                <p className="text-sm leading-snug">
+                  Sync from Chase failed — credentials expired
+                </p>
+                <p className="text-muted-foreground mt-1 text-[11px]">
+                  Yesterday at 3:58 PM
                 </p>
               </TimelineRail.Row>
               <TimelineRail.Row icon={MessageSquare} muted>


### PR DESCRIPTION
Five real bugs that turned up the moment Ricardo started dogfooding iter-46. Found and fixed live during his test session. Targets the sprint branch.

## What broke

| # | Symptom | Root cause |
| --- | --- | --- |
| 1 | Agent replied *"no financial data or system"* | `mcpServers["breadbox"].command = "breadbox"` requires the binary on `$PATH`; worktree/temp builds aren't. SDK's `fs.existsSync` precheck rejected the spawn → init event showed `mcp_servers: [{status: "failed"}]` |
| 2 | Every tool call auto-denied with *"Permission to use mcp__breadbox__… has been auto-denied in dontAsk mode"* | `permissionMode: "dontAsk"` + empty `allowedTools` = SDK denies everything. Seed agents ship with `allowed_tools = []` |
| 3 | Run-now dialog frozen the whole run; "Run started" toast fired only when it finished | Handler called `orch.RunNowWith` synchronously — HTTP request waited for the full sidecar lifecycle |
| 4 | Corrupted mid-JSON line in NDJSON transcripts | Both Go orchestrator (`transcript.Write` from stdout) and TS sidecar (`appendFileSync`) wrote the same file and raced |
| 5 | *"Couldn't load transcript"* error during in-progress runs | SPA treated the file-not-yet-on-disk 404 as a hard PageError |
| 6 | Run viewer showed empty turns (found with above fixes applied, run lVSfnmEK) | SDK emits `tool_use` blocks **nested inside** `assistant_message.content[]` and `tool_result` blocks inside `user_message.content[]`. Viewer expected top-level standalone events that don't exist on the wire |

## Fixes

1. **MCP path**: `os.Executable()` — always spawn the live process binary
2. **Tool perms**: `AssembleJobSpec` always injects `mcp__breadbox` (SDK wildcard for the whole server) ahead of operator-supplied entries; scope still enforced by the minted API key
3. **Async run**: new `Orchestrator.RunNowAsyncWith` — prep (preflight + sem + row + key + spec) sync so 422/503 still surface, then goroutine for sidecar + completion + revoke with fresh 30-min ctx. SPA navigates to `/agents/$slug/runs?run=<id>` to land on the live transcript
4. **Transcript writer**: removed `appendFileSync` from sidecar; Go is sole writer
5. **In-progress UX**: `useTranscript({ inProgress })` polls every 2s, disables retry, friendly "Run starting…" placeholder; "in progress" banner above the stream
6. **Viewer turn extraction**: `extractToolUses` / `extractToolResults` pull nested blocks during turn grouping. Added `user_message` to the union, extended search + Tools-only/Errors-only filters

## Verification

- `go build ./...`, `bun run lint`, `bun run build` all clean
- Dev server restarted (PID 28575) and tested end-to-end against `test-manual-review` — agent now actually invokes breadbox MCP tools and the viewer renders every turn populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)