### PR TITLE
fix(v2): right-align theme submenu value next to chevron

### DIFF
--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -108,7 +108,7 @@ function ThemeSubmenu() {
   const { theme, setTheme } = useTheme();
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger className="gap-2">
+      <DropdownMenuSubTrigger className="gap-2 [&>svg:last-child]:ml-0">
         <Palette className="text-muted-foreground" />
         <span>Theme</span>
         <span className="text-muted-foreground ml-auto text-[11px] capitalize">


### PR DESCRIPTION
## Summary
- The `DropdownMenuSubTrigger` primitive appends a `ChevronRightIcon` with `ml-auto`. The "Theme" submenu's value badge (e.g. `System`) also used `ml-auto`, so the two siblings split the available free space and parked the badge mid-row.
- Neutralize the chevron's auto margin via a scoped `[&>svg:last-child]:ml-0` selector on the trigger so the badge pushes right and sits flush against the chevron.

## Test plan
- [x] Open the avatar dropdown → hover **Theme**: value badge ("System") sits next to the chevron, not centered.
- [ ] Switch to Light / Dark — value updates and stays right-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)