### PR TITLE
fix(v2): right-align command-palette hint+chevron rows

### DIFF
--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -22,6 +22,7 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { cn } from "@/lib/utils";
 import { NAV, NAV_LEAVES, navKey, type NavLeaf } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
@@ -110,7 +111,15 @@ function ItemRow({
       {hint ? <CommandShortcut>{hint}</CommandShortcut> : null}
       {trailingChevron ? (
         <ChevronRight
-          className="text-muted-foreground/0 group-data-[selected=true]:text-muted-foreground/70 ml-auto size-3.5 transition-colors"
+          // When a hint is present it already owns `ml-auto` (via
+          // `CommandShortcut`) and pushes itself right; two `ml-auto`
+          // siblings would split the free space and park the hint mid-row.
+          // Drop our own `ml-auto` in that case so the chevron sits flush
+          // against the hint.
+          className={cn(
+            "text-muted-foreground/0 group-data-[selected=true]:text-muted-foreground/70 size-3.5 transition-colors",
+            hint ? "ml-2" : "ml-auto",
+          )}
           aria-hidden
         />
       ) : null}


### PR DESCRIPTION
## Summary
Same shape as #1277. The Recent group in the command palette renders both a `CommandShortcut` (group label, e.g. "Money") and a trailing `ChevronRight`. `CommandShortcut` ships with `ml-auto`; the chevron also had `ml-auto`. Two `ml-auto` siblings in a flex row split the free space — the hint parked mid-row instead of sitting beside the chevron.

Drop the chevron's `ml-auto` when a hint is present (the hint owns the auto margin); fall back to `ml-auto` when the chevron is alone.

## Test plan
- [x] Open ⌘K with at least one recent: group label sits flush against the chevron.
- [x] Jump-to rows (no hint) keep the chevron right-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)