### PR TITLE
fix(v2): collapse CardHeader phantom row when no description

### DIFF
--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -124,3 +124,21 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* shadcn's CardHeader is designed for title + description (stacked) with
+   an optional trailing action that row-spans 2 to clear room for the
+   description. When the description is absent, those defaults leave a
+   phantom 8px gap below the title and pin both the title and the action
+   to the top of the band — so a header with an action looks visibly
+   top-heavy. Collapse to a single, vertically-centered row in that case.
+   Outside @layer base so it outranks Tailwind utility classes. */
+[data-slot="card-header"]:not(:has([data-slot="card-description"])) {
+  grid-template-rows: auto;
+  row-gap: 0;
+  align-items: center;
+}
+[data-slot="card-header"]:not(:has([data-slot="card-description"]))
+  [data-slot="card-action"] {
+  grid-row: auto;
+  align-self: center;
+}


### PR DESCRIPTION
## Summary
shadcn's `CardHeader` primitive is designed around **title + description + action** with the action spanning both grid rows. When the description is absent — true for **9 of 10** `CardHeader` usages in this app — the defaults leave visible artifacts:

1. **8px phantom gap below the title** (from the unused row's `gap-2`).
2. **Top-heavy header when an action is present** — `CardAction`'s `row-span-2 row-start-1 self-start` grows the band to fit the taller action, but the title sits in row 1 with `items-start`, leaving dead space beneath it (most visible in the sandbox **Components → SectionCard → Details (with Edit button)** example).

The `ui/` primitives are sacred per `.claude/rules/v2-frontend.md` (and editing them would block future `shadcn add` updates). Patch via a scoped global `:has()` rule in `globals.css` so the no-description branch collapses to a **single, vertically-centered row**.

```css
[data-slot="card-header"]:not(:has([data-slot="card-description"])) {
  grid-template-rows: auto;
  row-gap: 0;
  align-items: center;
}
[data-slot="card-header"]:not(:has([data-slot="card-description"]))
  [data-slot="card-action"] {
  grid-row: auto;
  align-self: center;
}
```

The rule sits outside `@layer base` so it outranks Tailwind utility classes.

## Verified
| Case | Before | After |
|---|---|---|
| Notes (no action, no description) | header 61px, `grid-rows: 20px 0px`, 8px gap | header **53px**, `grid-rows: auto`, gap **0** |
| Details (Edit action, no description) | title pinned top, action top, ~13px dead space below title | title + action both vertically centered |
| With-description card (sandbox Primitives) | `grid-rows: 16px 20px`, 8px gap | **unchanged** |

Browser support: `:has()` is fine in every browser this SPA targets (Chrome 105+, Safari 15.4+, Firefox 121+).

## Test plan
- [x] Sandbox → Components → SectionCard (Details / Notes) visually balanced.
- [x] Sandbox → Primitives → Card with description: unchanged.
- [x] Connections page renders cleanly.
- [ ] Sanity-check Home, Accounts, Categories detail pages for any unexpected collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)