### PR TITLE
polish batch 2: PageHeader, sonner reset, cursor consistency

### DIFF
--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -44,7 +44,7 @@ export function PageHeader({
         // with its own `gap-*`, so an `mb-*` here stacks with that gap and
         // produces a ~44px void on mobile (visible because the action chip
         // wraps below the description). Let the parent layout own spacing.
-        "flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end sm:gap-4",
+        "flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-start sm:gap-4",
         className,
       )}
     >

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -82,10 +82,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
           cancelButton:
             "!bg-transparent !text-muted-foreground hover:!text-foreground " +
             "!h-7 !rounded-md !px-2 !text-xs",
+          // Match the shadcn ghost icon-button vocabulary: no border, no
+          // background until hover, foreground-tinted icon at hover. Sonner's
+          // default close (bordered + popover-bg) reads as a separate floating
+          // badge stuck to the corner — out of place next to the rest of v2's
+          // close affordances. Override the inline svg sizing/stroke so the
+          // icon matches the weight of lucide icons elsewhere (sonner ships a
+          // 12×12, stroke-1.5 svg by default).
           closeButton:
-            "!bg-popover !border !border-border !text-muted-foreground " +
+            "!bg-transparent !border-0 !text-muted-foreground/70 " +
             "hover:!bg-muted hover:!text-foreground " +
-            "!left-auto !right-2 !top-2 !translate-x-0 !translate-y-0",
+            "!size-6 !rounded-md !flex !items-center !justify-center transition-colors " +
+            "!left-auto !right-2 !top-2 !translate-x-0 !translate-y-0 " +
+            "[&_svg]:!size-3.5 [&_svg]:!stroke-[2]",
         },
       }}
       style={

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -8,17 +8,13 @@ import {
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
-// Sonner Toaster customized to match the v2 design vocabulary established by
-// <StatusPanel>: a 3px tone-tinted left rail + a tone-tinted icon tile + the
-// existing popover surface. Tone is encoded in the rail/icon colour so
-// success/error/warning/info are scannable at a glance without changing the
-// background fill (which keeps the toast quiet enough to live next to dense
-// surfaces like the transactions table).
-//
-// All polish lives here; `lib/mutation-toast.ts` and direct `toast.*` calls
-// stay one-liners. Default position bottom-right, expand-on-hover, and a
-// close button on every toast (mutation results are often quick reads and
-// dismissing them feels right).
+// Tracks the shadcn sonner registry verbatim (theme inheritance + lucide
+// icon overrides + popover-themed CSS vars), then layers v2-specific
+// chrome on top: a 3px tone-tinted left rail and a tone-tinted icon
+// tile, both echoing <StatusPanel> so the toast/panel pair speaks the
+// same vocabulary. Everything else (positioning, dismiss behaviour,
+// close affordance) is left at sonner's defaults so the surface matches
+// the shadcn reference.
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
@@ -26,9 +22,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
-      position="bottom-right"
-      closeButton
-      visibleToasts={4}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,
@@ -37,7 +30,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       toastOptions={{
-        // Class hooks are concatenated by Sonner onto each toast/element.
         // The base toast keeps `pl-5` so the absolute `before:` rail and
         // the icon both clear the left edge. `data-[type=*]` selectors
         // tint the rail and the icon tile per variant; "message" (the
@@ -46,8 +38,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             "group/toast toast relative overflow-hidden " +
-            "!bg-popover !text-popover-foreground !border !border-border !rounded-md " +
-            "!gap-3 !p-4 !pl-5 " +
+            "!pl-5 " +
             "before:absolute before:inset-y-0 before:left-0 before:w-[3px] " +
             "data-[type=success]:before:bg-success " +
             "data-[type=error]:before:bg-destructive " +
@@ -71,26 +62,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group-data-[type=default]/toast:!text-muted-foreground " +
             "group-data-[type=loading]/toast:!bg-muted " +
             "group-data-[type=loading]/toast:!text-muted-foreground",
-          content: "!gap-0.5",
-          title: "!text-sm !font-medium !text-foreground !leading-snug",
-          description:
-            "!text-xs !text-muted-foreground !leading-relaxed !mt-0.5",
-          actionButton:
-            "!bg-primary !text-primary-foreground hover:!bg-primary/90 " +
-            "!h-7 !rounded-md !px-2.5 !text-xs !font-medium",
-          cancelButton:
-            "!bg-transparent !text-muted-foreground hover:!text-foreground " +
-            "!h-7 !rounded-md !px-2 !text-xs",
-          // Restyle the close affordance to the shadcn ghost icon-button
-          // vocabulary (no border, no fill until hover) but leave sonner's
-          // default positioning alone — its `top-left, slightly overhanging`
-          // placement is what the shadcn sonner reference shows. Override
-          // the inline svg so the X matches the weight of lucide icons
-          // elsewhere (sonner ships a 12×12, stroke-1.5 svg by default).
-          closeButton:
-            "!bg-background !border !border-border !text-muted-foreground " +
-            "hover:!bg-muted hover:!text-foreground transition-colors " +
-            "[&_svg]:!size-3 [&_svg]:!stroke-[2]",
         },
       }}
       style={

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -27,7 +27,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       position="bottom-right"
-      expand
       closeButton
       visibleToasts={4}
       icons={{
@@ -82,19 +81,16 @@ const Toaster = ({ ...props }: ToasterProps) => {
           cancelButton:
             "!bg-transparent !text-muted-foreground hover:!text-foreground " +
             "!h-7 !rounded-md !px-2 !text-xs",
-          // Match the shadcn ghost icon-button vocabulary: no border, no
-          // background until hover, foreground-tinted icon at hover. Sonner's
-          // default close (bordered + popover-bg) reads as a separate floating
-          // badge stuck to the corner — out of place next to the rest of v2's
-          // close affordances. Override the inline svg sizing/stroke so the
-          // icon matches the weight of lucide icons elsewhere (sonner ships a
-          // 12×12, stroke-1.5 svg by default).
+          // Restyle the close affordance to the shadcn ghost icon-button
+          // vocabulary (no border, no fill until hover) but leave sonner's
+          // default positioning alone — its `top-left, slightly overhanging`
+          // placement is what the shadcn sonner reference shows. Override
+          // the inline svg so the X matches the weight of lucide icons
+          // elsewhere (sonner ships a 12×12, stroke-1.5 svg by default).
           closeButton:
-            "!bg-transparent !border-0 !text-muted-foreground/70 " +
-            "hover:!bg-muted hover:!text-foreground " +
-            "!size-6 !rounded-md !flex !items-center !justify-center transition-colors " +
-            "!left-auto !right-2 !top-2 !translate-x-0 !translate-y-0 " +
-            "[&_svg]:!size-3.5 [&_svg]:!stroke-[2]",
+            "!bg-background !border !border-border !text-muted-foreground " +
+            "hover:!bg-muted hover:!text-foreground transition-colors " +
+            "[&_svg]:!size-3 [&_svg]:!stroke-[2]",
         },
       }}
       style={

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -142,3 +142,14 @@
   grid-row: auto;
   align-self: center;
 }
+
+/* shadcn's Button primitive deliberately ships no cursor class, so it
+   inherits the underlying element's native cursor — `<button>` is
+   `default` in modern Chromium, which is what shadcn's docs assume. But
+   `asChild` swaps in `<a>` (e.g. `<Button asChild><Link/></Button>`),
+   which inherits the anchor's `pointer` and breaks the convention.
+   Pin the cursor on the slot itself so SoftBackButton, JumpToPill,
+   Button-as-Link, etc. all stay consistent with the rest of the app. */
+[data-slot="button"] {
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
Five small fixes batched onto the sprint branch.

1. **`fix(v2): top-align PageHeader actions`** — `sm:items-end` sank the header actions to the bottom (lined up with the last line of the description). Switch to `sm:items-start` so actions sit alongside the eyebrow/title — the consistent anchor across pages with and without descriptions.

2. **`fix(v2): align sonner toaster with shadcn reference + v2 tone overlay`** — our sonner.tsx had drifted far from the shadcn registry (custom `closeButton` + `expand` + a stack of `!`-overrides that fought sonner's own stylesheet, producing a broken-looking X). Reset to the upstream shadcn registry (theme + lucide icons + popover CSS vars) and re-layer only the v2 design contract: the 3px tone-tinted left rail + tone-tinted icon tile that echo `<StatusPanel>`. Dismiss is now sonner-native (auto-timeout + swipe); typography, action/cancel buttons, positioning all inherit from sonner — same as the shadcn sonner reference. Commits 2 + 3 in this branch are the two intermediate attempts kept for diff context; the final state is in commit 5.

3. **`fix(v2): pin Button slot to cursor:default for asChild→<a> consistency`** — shadcn's Button ships no cursor class, so it inherits the underlying element's native cursor (`<button>` is `default` in modern Chromium, shadcn's assumed baseline). `asChild` swaps the root for `<a>` (TanStack Router `<Link>`), which inherits the anchor's `pointer` — visible on SoftBackButton, the SectionCard "View all" footer, JumpToPill, etc. Pin `cursor: default` on `[data-slot="button"]` so the behavior is rooted to the slot, not the element. Hand-rolled `<button>` outside the primitive is unaffected; intentional `cursor-pointer` on non-button surfaces (DataTable rows, CSV dropzone, labels, selectable cards) keeps working because the rule is scoped.

## Test plan
- [x] Connections, Accounts, Categories pages: PageHeader actions sit at the top.
- [x] Sandbox → Patterns: fire 3 toasts — they stack instead of expanding, no X, tone rail + icon tile intact.
- [x] Hover SoftBackButton / "View all" pill / JumpToPill: cursor stays default; visible only on real anchors (e.g. raw `<Link>`) and label/checkbox surfaces.
- [x] `bun run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)