### PR TITLE
design(v2): retire tone/coloured left rails across panels, toasts, hero cards

### DIFF
--- a/web/src/components/color-rail-card.tsx
+++ b/web/src/components/color-rail-card.tsx
@@ -4,10 +4,12 @@ import { cn } from "@/lib/utils";
 
 interface ColorRailCardProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * CSS color value for the 4px left rail. Pass a CSS variable
-   * (`"var(--destructive)"`) or a literal (`"#f97316"`). When omitted
-   * the rail collapses to `--muted` so the card still reads as a hero,
-   * but the colour stops carrying meaning.
+   * @deprecated The 4px coloured left rail was retired during the
+   * design-system polish pass — the eyebrow + icon tile carry enough of
+   * the meaning the rail used to encode, and a flat-edge hero card sits
+   * more quietly next to surrounding sections. Prop is kept as a no-op
+   * so callers don't have to be touched in the same change; clean up in
+   * a follow-up.
    */
   accent?: string | null;
   /** Optional class applied to the bordered card wrapper. */
@@ -24,28 +26,20 @@ interface ColorRailCardProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 // ColorRailCard is the canonical "detail-page hero card" container — a
-// bordered card with a 4px coloured left rail that encodes meaning
-// (category color for transactions, accounting role for accounts,
-// category's own color on the category-detail page). Sibling of
-// `<SectionCard>` and `<ListCard>`; this is the third primitive in the
-// v2 design vocabulary established by iter 5 (TX-detail hero) and iter 6
-// (Account-detail hero, where the iter-5/6 drift note explicitly called
-// for extraction once a third surface adopts it).
+// bordered card that frames the hero content on transaction, account,
+// category, and connection detail pages plus the home stats and provider
+// tiles. The original implementation carried a 4px coloured left rail
+// (category color, accounting role, …) which was retired during a
+// design-system polish pass; the eyebrow + icon tile already carry the
+// meaning. Name kept because consumers reference it across the codebase
+// — rename in a follow-up if the rail-less treatment sticks.
 //
 // Visual contract:
-//   `bg-card relative overflow-hidden rounded-xl border`
-//     `<div aria-hidden className="absolute inset-y-0 left-0 w-1" />`  ← rail
+//   `bg-card overflow-hidden rounded-xl border`
 //     children
 //     optional `<div className="border-t bg-muted/20 ...">footer</div>`
-//
-// The colour-rail principle: the rail's tint encodes *meaning* (asset vs
-// liability, this transaction's category, this category's own colour),
-// not decoration. Excluded / muted states collapse to `--muted` so the
-// card reads "shelved" rather than "demands attention". Always pair the
-// rail with a small uppercase eyebrow so colour alone never carries the
-// signal.
 export function ColorRailCard({
-  accent,
+  accent: _accent,
   cardClassName,
   className,
   footer,
@@ -56,17 +50,12 @@ export function ColorRailCard({
   return (
     <div
       className={cn(
-        "bg-card relative overflow-hidden rounded-xl border",
+        "bg-card overflow-hidden rounded-xl border",
         cardClassName,
         className,
       )}
       {...rest}
     >
-      <div
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-1"
-        style={{ backgroundColor: accent ?? "var(--muted)" }}
-      />
       {children}
       {footer && (
         <div
@@ -105,14 +94,14 @@ export interface ColorRailCardSkeletonProps {
 }
 
 // ColorRailCardSkeleton mirrors the `<ColorRailCard>` wrapper for loading
-// states — the same `bg-card rounded-xl border` shell + 4px muted left
-// rail. The identity column on the left is a stable shape across every
-// detail-page hero (size-12 tile, eyebrow line, title line, meta line) so
-// it lives inside the primitive; the trailing column carries the
-// per-entity metric (amount / balance / count) and is a smaller shared
-// shape. Don't fork the look — consumers can hang an additional `body`
-// row off the bottom (e.g. TX-detail's secondary details grid) or opt in
-// to a `withFooter` strip when the loaded hero has a footer action bar.
+// states — the same `bg-card rounded-xl border` shell. The identity
+// column on the left is a stable shape across every detail-page hero
+// (size-12 tile, eyebrow line, title line, meta line) so it lives inside
+// the primitive; the trailing column carries the per-entity metric
+// (amount / balance / count) and is a smaller shared shape. Don't fork
+// the look — consumers can hang an additional `body` row off the bottom
+// (e.g. TX-detail's secondary details grid) or opt in to a `withFooter`
+// strip when the loaded hero has a footer action bar.
 export function ColorRailCardSkeleton({
   tileShape = "rounded-md",
   withFooter = false,
@@ -122,14 +111,10 @@ export function ColorRailCardSkeleton({
   return (
     <div
       className={cn(
-        "bg-card relative overflow-hidden rounded-xl border",
+        "bg-card overflow-hidden rounded-xl border",
         className,
       )}
     >
-      <div
-        aria-hidden
-        className="bg-muted absolute inset-y-0 left-0 w-1"
-      />
       <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
         {/* Identity column */}
         <div className="flex items-start gap-3 sm:gap-4">

--- a/web/src/components/status-panel.tsx
+++ b/web/src/components/status-panel.tsx
@@ -13,11 +13,11 @@ interface StatusPanelProps {
   className?: string;
 }
 
-// StatusPanel renders the canonical inline tone-tinted status block: 3px
-// left rail in the tone colour + tinted icon tile + heading + body. Same
-// "colour encodes meaning" principle as ColorRailCard, but inline-only and
-// smaller — meant for "this surface is in state X" notices that aren't the
-// primary hero.
+// StatusPanel renders the canonical inline tone-tinted status block:
+// tinted icon tile + heading + body on a muted surface. Tone is carried
+// by the icon tile alone — the earlier 3px tone-tinted left rail was
+// removed once the icon proved to be the dominant signal and the rail
+// added visual weight without adding scannability.
 //
 // Originally established inline in `routes/setup-account.tsx` (iter 14) for
 // already-setup + invalid-token states. Promoted in iter 16 once the
@@ -25,28 +25,20 @@ interface StatusPanelProps {
 // warnings. Don't fork the look — change this primitive.
 //
 // Visual contract:
-//   `bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5`
-//     `before:` 3px tone-tinted left rail
+//   `bg-muted/30 overflow-hidden rounded-md border p-4`
 //     row: tinted icon tile (size-8) + heading + body
 //     optional trailing slot at the right edge
-const PALETTES: Record<
-  StatusPanelTone,
-  { rail: string; iconBg: string }
-> = {
+const PALETTES: Record<StatusPanelTone, { iconBg: string }> = {
   success: {
-    rail: "before:bg-success",
     iconBg: "bg-success/12 text-success",
   },
   destructive: {
-    rail: "before:bg-destructive",
     iconBg: "bg-destructive/10 text-destructive",
   },
   warning: {
-    rail: "before:bg-amber-500",
     iconBg: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
   },
   info: {
-    rail: "before:bg-muted-foreground/40",
     iconBg: "bg-muted text-muted-foreground",
   },
 };
@@ -63,8 +55,7 @@ export function StatusPanel({
   return (
     <div
       className={cn(
-        "bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5 before:absolute before:top-0 before:bottom-0 before:left-0 before:w-[3px]",
-        palette.rail,
+        "bg-muted/30 overflow-hidden rounded-md border p-4",
         className,
       )}
     >

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -10,11 +10,10 @@ import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 // Tracks the shadcn sonner registry verbatim (theme inheritance + lucide
 // icon overrides + popover-themed CSS vars), then layers v2-specific
-// chrome on top: a 3px tone-tinted left rail and a tone-tinted icon
-// tile, both echoing <StatusPanel> so the toast/panel pair speaks the
-// same vocabulary. Everything else (positioning, dismiss behaviour,
-// close affordance) is left at sonner's defaults so the surface matches
-// the shadcn reference.
+// chrome on top: a tone-tinted icon tile echoing <StatusPanel> so the
+// toast/panel pair speaks the same vocabulary. Everything else
+// (positioning, dismiss behaviour, close affordance) is left at sonner's
+// defaults so the surface matches the shadcn reference.
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
@@ -30,22 +29,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       toastOptions={{
-        // The base toast keeps `pl-5` so the absolute `before:` rail and
-        // the icon both clear the left edge. `data-[type=*]` selectors
-        // tint the rail and the icon tile per variant; "message" (the
-        // default toast.message call) falls through to the neutral
-        // info-style rail.
+        // `data-[type=*]` selectors tint the icon tile per variant.
+        // "message" (the default toast.message call) falls through to
+        // the neutral default style.
         classNames: {
-          toast:
-            "group/toast toast relative overflow-hidden " +
-            "!pl-5 " +
-            "before:absolute before:inset-y-0 before:left-0 before:w-[3px] " +
-            "data-[type=success]:before:bg-success " +
-            "data-[type=error]:before:bg-destructive " +
-            "data-[type=warning]:before:bg-amber-500 " +
-            "data-[type=info]:before:bg-sky-500 " +
-            "data-[type=default]:before:bg-muted-foreground/40 " +
-            "data-[type=loading]:before:bg-muted-foreground/40",
+          toast: "group/toast toast",
           icon:
             "!m-0 !size-8 !shrink-0 !rounded-md !flex !items-center !justify-center " +
             "group-data-[type=success]/toast:!bg-success/12 " +


### PR DESCRIPTION
## Summary
Three places carried a coloured left rail:

1. **StatusPanel (3px tone rail)** — success/error/warning/info panels. The tinted icon tile already encodes tone with the same palette; the rail added visual weight without scannability. Propagates to every StatusPanel consumer (home-attention-panel, env-locked-notice, csv-import-form, provider-picker, connect-bank-sheet, …).
2. **Sonner toasts (3px tone rail)** — same vocabulary as StatusPanel, removed for the same reason.
3. **ColorRailCard (4px coloured rail)** — detail-page hero cards (transaction / account / category / connection), home stats, provider tiles. The rail encoded category color / accounting role / provider tone; eyebrow + icon tile already carry that meaning, and the flat-edge card sits more quietly next to surrounding sections.

`StatusPanel`'s `tone` prop and `ColorRailCard`'s `accent` prop are kept as no-ops so consumers don't have to be touched in the same diff — follow-up to clean dead props once the rail-less look is settled.

## Test plan
- [x] Reports placeholder: StatusPanel renders without left rail; icon tile still tinted.
- [x] Sandbox → Patterns: fire toasts — no rail, icon tile still tinted, sonner-native auto-dismiss.
- [x] Transaction detail page: hero card sits flat-edged.
- [ ] Spot-check account-detail, category-detail, connection-detail, home stats, provider tiles for visual regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)