### PR TITLE
fix(v2): stop tx-list search debounce from bouncing j/k+Enter navigation

### DIFF
--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -97,6 +97,12 @@ export function TransactionsPage() {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    // Gate on the live URL: if the user already navigated away (e.g. j/k +
+    // Enter into a transaction detail before the 300ms debounce fires),
+    // skip. Without this, `navigate({ to: "." })` resolves to this
+    // component's matched route (`/transactions`) and pushes us back to
+    // the list, flashing the URL away from the detail page we just opened.
+    if (!window.location.pathname.endsWith("/transactions")) return;
     const q = debounced.trim() || undefined;
     navigate({
       to: ".",


### PR DESCRIPTION
## Summary
When typing in the transactions search and then opening a row via j/k + Enter within the 300ms debounce window, the debounced `navigate({ to: \".\" })` effect (transactions.tsx:99) fires *after* the route has already changed to `/transactions/\$id`. Because the effect lives on the transactions.tsx component (still mounted during the in-flight route transition), `to: \".\"` resolves to its matched route — `/transactions` — and pushes the user back to the list, flashing the URL away from the detail page they just opened. Race-condition flavour: \"sometimes works, not sure why\" → it works whenever Enter is pressed *after* the debounce has already fired and the URL is already in sync.

Gate the effect on `window.location.pathname`: if we're no longer on the transactions list when the debounce fires, skip the sync. Pure defensive guard — the bidirectional query⇄URL sync stays intact for in-page typing.

## Test plan
- [x] Apply fix; existing in-page search typing still updates URL after 300ms.
- [ ] Manually: type a few chars, immediately press Escape then j+Enter — should land on TX detail and stay.
- [ ] Manually: j+Enter without typing — still navigates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)