### PR TITLE
fix(v2): keep j/k-focused row visible under shell+sticky-header chrome

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -285,6 +285,13 @@ export function DataTable<TData, TValue>({
                     // or compete with the row's selected/hover background.
                     focused &&
                       "bg-primary/[0.04] shadow-[inset_3px_0_0_0_var(--primary)] outline-none",
+                    // `scroll-mt-*` so the `scrollIntoView({ block: "nearest" })`
+                    // below clears the chrome stacked above the scroll
+                    // container: 56px shell header always, +36px when the
+                    // table's own header is sticky on top of it. Without
+                    // this, scrolling up via `k` lands the focused row
+                    // behind the sticky bands.
+                    stickyHeader ? "scroll-mt-24" : "scroll-mt-16",
                   )}
                 >
                   {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
`scrollIntoView({ block: "nearest" })` aligns the row's top with the scroll container's top — but the scroll container is the document, not the table card. The shell header (h-14 = 56px) and, when enabled, the DataTable's sticky header (h-9 ≈ 36px) sit pinned over that top, so pressing **k** to focus a row above the viewport lands it *behind* the sticky chrome.

Apply `scroll-margin-top` on rows so the browser aligns *below* the chrome:
- `scroll-mt-16` (64px) when only the shell header is sticky
- `scroll-mt-24` (96px) when the table header is also sticky

Verified: focused row lands at y=96 (4px below the 92px chrome stack) after pressing k from below the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)