### PR TITLE
fix(v2): shrink tag pills in tx-row meta line so rows stay uniform

### DIFF
--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -14,16 +14,18 @@ interface TagChipProps {
   onRemove?: () => void;
   /**
    * Visual density.
+   * - `xs` — inline inside a meta row (16px text line); does not grow the row
    * - `sm` — table rows / dense list cells (parity with `CategoryBadge size="sm"`)
    * - `md` — default; detail-page hero actions, sandbox, rule-display
    */
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
   className?: string;
 }
 
 // Per-size token recipe — mirrors CategoryBadge's recipe so the two share a
 // rhythm when rendered side-by-side in a transaction row. Adjust as a pair.
-const SIZE: Record<"sm" | "md", string> = {
+const SIZE: Record<"xs" | "sm" | "md", string> = {
+  xs: "h-4 px-1.5 text-[10px] leading-none gap-0.5 [&>svg]:size-2.5",
   sm: "h-5 px-1.5 text-[11px] gap-0.5 [&>svg]:size-2.5",
   md: "h-6 px-2 text-xs gap-1 [&>svg]:size-3",
 };
@@ -61,7 +63,7 @@ interface TagListProps {
   /** Cap the chips shown; the remainder collapse into a "+N" badge. */
   max?: number;
   /** Forwarded to every `TagChip` and the overflow badge for density parity. */
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
   className?: string;
 }
 

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -66,7 +66,7 @@ function TransactionMeta({ transaction: t }: { transaction: Transaction }) {
             {t.tags!.length}
           </span>
           <span className="hidden sm:inline-flex">
-            <TagList slugs={t.tags} max={2} size="sm" />
+            <TagList slugs={t.tags} max={2} size="xs" />
           </span>
         </>
       )}


### PR DESCRIPTION
Rows with tag chips were 63px tall vs 59px for rows without. Add `xs` TagChip variant (h-4, 10px text, leading-none) for inline meta use. CategoryBadge `sm` stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)