### PR TITLE
fix(v2): reshape tx-row click — focus → select-mode; title → detail

### DIFF
--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -6,6 +6,13 @@ import type { Transaction } from "@/api/types";
 
 interface TransactionPrimaryProps {
   transaction: Transaction;
+  /**
+   * When provided, the merchant title becomes a click target that fires
+   * this callback (and stops propagation so the surrounding row click
+   * — typically focus / enter-select — doesn't also fire). Used by the
+   * transactions list row to open the detail page from the title only.
+   */
+  onTitleClick?: (transaction: Transaction) => void;
   className?: string;
 }
 
@@ -17,8 +24,29 @@ interface TransactionPrimaryProps {
 // just adds visual noise.
 export function TransactionPrimary({
   transaction: t,
+  onTitleClick,
   className,
 }: TransactionPrimaryProps) {
+  const titleClasses = "truncate font-medium";
+  const title = onTitleClick ? (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onTitleClick(t);
+      }}
+      // Subtle hover hint that the title is the navigation affordance —
+      // doesn't dress it up as a full link.
+      className={cn(
+        titleClasses,
+        "hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
+      )}
+    >
+      {t.provider_name}
+    </button>
+  ) : (
+    <span className={titleClasses}>{t.provider_name}</span>
+  );
   return (
     <div className={cn("flex min-w-0 items-center gap-3", className)}>
       <CategoryIconTile
@@ -28,7 +56,7 @@ export function TransactionPrimary({
       />
       <div className="min-w-0">
         <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{t.provider_name}</span>
+          {title}
           {t.pending && (
             <span className="text-muted-foreground shrink-0 text-xs">
               Pending

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -11,6 +11,8 @@ import type { Transaction } from "@/api/types";
 export interface TransactionTableMeta {
   onRangeSelect?: (toIndex: number) => void;
   setLastIndex?: (index: number) => void;
+  /** Fired from the merchant-title click in the description column. */
+  onOpenDetail?: (transaction: Transaction) => void;
 }
 
 const selectionColumn: ColumnDef<Transaction> = {
@@ -63,7 +65,15 @@ const baseColumns: ColumnDef<Transaction>[] = [
     // `truncate` actually clamp. Without this, a long merchant name expands
     // the column and pushes the amount off-screen on narrow viewports.
     meta: { className: "max-w-0 w-full" },
-    cell: ({ row }) => <TransactionPrimary transaction={row.original} />,
+    cell: ({ row, table }) => {
+      const meta = table.options.meta as TransactionTableMeta | undefined;
+      return (
+        <TransactionPrimary
+          transaction={row.original}
+          onTitleClick={meta?.onOpenDetail}
+        />
+      );
+    },
   },
   {
     id: "category",

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -162,6 +162,12 @@ export function TransactionsPage() {
   // Keyboard-navigated row focus (j/k). Index into `rows`; null = no focus.
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 
+  const openTransaction = useCallback(
+    (t: Transaction) =>
+      navigate({ to: "/transactions/$id", params: { id: t.short_id } }),
+    [navigate],
+  );
+
   const columns = useMemo(
     () => buildTransactionColumns({ selection: selectMode }),
     [selectMode],
@@ -179,6 +185,31 @@ export function TransactionsPage() {
   const toggleRowSelection = useCallback((t: Transaction) => {
     setRowSelection((prev) => ({ ...prev, [t.id]: !prev[t.id] }));
   }, []);
+
+  // Row click outside select mode is a two-stage interaction:
+  //   1st tap → focus the row (same affordance as j/k)
+  //   2nd tap on the already-focused row → enter select mode + select it
+  //     (same affordance as the `x` shortcut)
+  // The merchant title remains the dedicated open-detail target — its
+  // own onClick stops propagation so it never lands here.
+  const handleRowClick = useCallback(
+    (t: Transaction) => {
+      if (selectMode) {
+        toggleRowSelection(t);
+        return;
+      }
+      const idx = rows.findIndex((r) => r.id === t.id);
+      if (idx === -1) return;
+      if (focusedIndex === idx) {
+        setSelectMode(true);
+        setRowSelection((prev) => ({ ...prev, [t.id]: true }));
+        lastIndexRef.current = idx;
+        return;
+      }
+      setFocusedIndex(idx);
+    },
+    [selectMode, toggleRowSelection, rows, focusedIndex],
+  );
 
   const toggleSelectMode = useCallback(() => {
     if (selectMode) exitSelectMode();
@@ -211,18 +242,13 @@ export function TransactionsPage() {
           return next;
         });
       },
+      onOpenDetail: openTransaction,
     }),
-    [rows],
+    [rows, openTransaction],
   );
 
   const focusedRowId =
     focusedIndex != null ? rows[focusedIndex]?.id : undefined;
-
-  const openTransaction = useCallback(
-    (t: Transaction) =>
-      navigate({ to: "/transactions/$id", params: { id: t.short_id } }),
-    [navigate],
-  );
 
   // --- Keyboard shortcuts (registered while this page is mounted) ---
   useShortcut(
@@ -427,7 +453,7 @@ export function TransactionsPage() {
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
         focusedRowId={focusedRowId}
-        onRowClick={selectMode ? toggleRowSelection : openTransaction}
+        onRowClick={handleRowClick}
         stickyHeader
         refinedHeader
         emptyState={


### PR DESCRIPTION
Default row click used to navigate straight to the detail page (and only toggle selection while in select mode). Reshape so the row body is the selection/focus surface and the merchant title is the dedicated open-detail target:

- **1st row tap** → focuses the row (same affordance as j/k navigation).
- **2nd tap on the focused row** → enters select mode + selects it (same affordance as the `x` shortcut).
- **Title click** → navigates to the detail page; stops propagation so the row's focus/select handler never fires for that click. Title gets a subtle `hover:underline` hint so the affordance is discoverable.

Wiring:
- `TransactionPrimary` accepts `onTitleClick` — renders title as a button when set, plain span otherwise.
- `TransactionTableMeta` gains `onOpenDetail`; columns thread it into TransactionPrimary so column defs stay presentation-only.
- transactions.tsx routes `openTransaction` into the meta and adds `handleRowClick` for the focus → enter-select flow.

## Test plan
- [x] Click row body once → focus ring appears, no navigation.
- [x] Click same row again → select mode active.
- [x] Click title → navigates to detail.
- [ ] j/k navigation still works; Enter on focused row still navigates.
- [ ] Select mode in flight: row clicks toggle selection as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)