### PR TITLE
fix(v2): tx row cursor — default unless select mode; title always pointer

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -55,6 +55,16 @@ export interface DataTableProps<TData, TValue> {
   /** Optional row click handler — e.g. navigate to a detail page. */
   onRowClick?: (row: TData) => void;
   /**
+   * Whether to render the row body with a pointer cursor on hover.
+   * Defaults to `true` whenever an `onRowClick` is set — the right call
+   * for tables where row click is a navigation/CTA (tags, api-keys).
+   * Pass `false` for tables where the row body is a focus/select target
+   * and a specific child carries the navigation (transactions, where the
+   * merchant title is the deeplink) — a row-level pointer there would
+   * overpromise that any click anywhere navigates.
+   */
+  pointerRows?: boolean;
+  /**
    * Controlled row selection. Like sorting, the state lives in the calling
    * route; DataTable just renders it. `getRowId` should return a stable id
    * (not the array index) so a selection survives pagination/refetch.
@@ -101,6 +111,7 @@ export function DataTable<TData, TValue>({
   sorting,
   onSortingChange,
   onRowClick,
+  pointerRows,
   enableRowSelection,
   rowSelection,
   onRowSelectionChange,
@@ -276,7 +287,7 @@ export function DataTable<TData, TValue>({
                     onRowClick ? () => onRowClick(row.original) : undefined
                   }
                   className={cn(
-                    onRowClick && "cursor-pointer",
+                    (pointerRows ?? !!onRowClick) && "cursor-pointer",
                     // Keyboard-focus indicator: a 3px primary accent bar on
                     // the left edge plus a faint primary tint, layered via
                     // inset box-shadow so it doesn't shift the row geometry

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -36,10 +36,12 @@ export function TransactionPrimary({
         onTitleClick(t);
       }}
       // Subtle hover hint that the title is the navigation affordance —
-      // doesn't dress it up as a full link.
+      // doesn't dress it up as a full link. Pointer cursor sells the
+      // deeplink even though the surrounding row body uses the default
+      // cursor (it's a focus / select target, not a navigation CTA).
       className={cn(
         titleClasses,
-        "hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
+        "cursor-pointer hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
       )}
     >
       {t.provider_name}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -454,6 +454,7 @@ export function TransactionsPage() {
         meta={tableMeta}
         focusedRowId={focusedRowId}
         onRowClick={handleRowClick}
+        pointerRows={selectMode}
         stickyHeader
         refinedHeader
         emptyState={


### PR DESCRIPTION
After reshaping the row click to focus-then-select (#1291), a pointer cursor on the row body overpromised. Add a `pointerRows` prop on DataTable (defaults to current `!!onRowClick` behavior so tags/api-keys are unchanged) and have transactions pass `pointerRows={selectMode}`. The merchant title gets an explicit `cursor-pointer` so the deeplink affordance still reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)