### PR TITLE
polish batch 3: CategoryPicker affordance + sandbox isolation rework

### DIFF
--- a/web/src/components/category-badge.tsx
+++ b/web/src/components/category-badge.tsx
@@ -16,8 +16,18 @@ interface CategoryBadgeProps {
   className?: string;
 }
 
-// Per-size token recipe. Kept inline so the size axis is grep-able alongside
-// TagChip's matching recipe — if one shifts the other should too.
+// Shape tokens — the geometry shared by CategoryBadge, the CategoryPicker
+// empty-state pill, and the picker's pencil overlay. Exported so any
+// caller building a badge-shaped surface can match without re-deriving.
+// Kept in lockstep with TagChip's matching recipe.
+export const CATEGORY_BADGE_SHAPE: Record<"sm" | "md", string> = {
+  sm: "h-5 px-1.5 text-[11px] gap-0.5",
+  md: "h-6 px-2 text-xs gap-1",
+};
+export const CATEGORY_BADGE_ICON: Record<"sm" | "md", string> = {
+  sm: "size-2.5",
+  md: "size-3",
+};
 const SIZE: Record<"sm" | "md", string> = {
   sm: "h-5 px-1.5 text-[11px] gap-0.5 [&>svg]:size-2.5",
   md: "h-6 px-2 text-xs gap-1 [&>svg]:size-3",

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -104,23 +104,24 @@ export function CategoryPicker({
               Category
             </span>
           )}
-          {/* Chevron on a left-fading gradient strip. The gradient
-              softly masks any badge content underneath so the chevron
-              reads cleanly even when it overlaps a label edge, without
-              having to know the badge's tint. Both fade in together on
-              hover/focus. */}
+          {/* Chevron on a left-fading gradient strip that matches the
+              surface beneath it (badge `bg-secondary` when assigned;
+              the empty-state pill is transparent so the row's `bg-card`
+              shows through). The scrim softly masks any label content
+              under the chevron so it reads cleanly. Both fade in
+              together on hover/focus. */}
           <span
             aria-hidden
             className={cn(
-              "pointer-events-none absolute inset-y-0 right-0 flex items-center rounded-r-md bg-gradient-to-l from-card via-card/85 to-transparent opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+              "pointer-events-none absolute inset-y-0 right-0 flex items-center rounded-r-md bg-gradient-to-l to-transparent opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+              category?.display_name
+                ? "from-secondary via-secondary/85"
+                : "from-card via-card/85",
               size === "sm" ? "w-6 pr-1" : "w-7 pr-1.5",
             )}
           >
             <ChevronDown
-              className={cn(
-                "text-muted-foreground ml-auto drop-shadow-sm",
-                chevronClass,
-              )}
+              className={cn("text-muted-foreground ml-auto", chevronClass)}
             />
           </span>
         </button>

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -19,6 +19,12 @@ interface CategoryPickerProps {
   category: TransactionCategory | null | undefined;
   /** True when the current category was set by a manual override. */
   overridden?: boolean;
+  /**
+   * Badge density. Defaults to `md` (h-6) — the picker only renders inside
+   * the transactions row's category column which is `hidden sm:table-cell`,
+   * so there's room for the comfier size. Pass `sm` for tighter rails.
+   */
+  size?: "sm" | "md";
   className?: string;
 }
 
@@ -30,8 +36,15 @@ export function CategoryPicker({
   transactionId,
   category,
   overridden,
+  size = "md",
   className,
 }: CategoryPickerProps) {
+  // Match the empty-state pill's geometry to the active badge so the column
+  // doesn't shift when the user assigns or clears a category from the row.
+  const emptyPillClass =
+    size === "sm"
+      ? "h-5 px-1.5 text-[11px] gap-0.5"
+      : "h-6 px-2 text-xs gap-1";
   const [open, setOpen] = useState(false);
   const { apply, isPending } = useCategoryEditor(transactionId);
 
@@ -56,14 +69,16 @@ export function CategoryPicker({
             <CategoryBadge
               category={category}
               overridden={overridden}
-              size="sm"
+              size={size}
             />
           ) : (
-            // Empty-state pill mirrors the sm CategoryBadge geometry (h-5,
-            // text-[11px], rounded-md) so the column doesn't shift when the
-            // user assigns or clears a category from the row.
-            <span className="text-muted-foreground border-border hover:text-foreground inline-flex h-5 items-center gap-0.5 rounded-md border border-dashed px-1.5 text-[11px]">
-              <Plus className="size-2.5" />
+            <span
+              className={cn(
+                "text-muted-foreground border-border hover:text-foreground inline-flex items-center rounded-md border border-dashed",
+                emptyPillClass,
+              )}
+            >
+              <Plus className={size === "sm" ? "size-2.5" : "size-3"} />
               Category
             </span>
           )}

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -80,19 +80,10 @@ export function CategoryPicker({
           disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            // Trigger wraps the badge with no extra padding so every hover
-            // signal stays inside the badge bounds.
-            // `[&_[data-slot=badge]]:hover:!ring-0` suppresses CategoryBadge's
-            // own override ring during hover so the hover-state stroke wins.
-            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50 hover:[&_[data-slot=badge]]:!ring-0 focus-visible:[&_[data-slot=badge]]:!ring-0",
-            // Hover ring + icon-swap only when a category is assigned.
-            // The empty-state pill carries its own dashed border that
-            // intensifies on hover — adding a solid ring on top would
-            // double-stroke.
-            category?.display_name &&
-              "hover:ring-1 hover:ring-border",
-            hasIcon &&
-              "[&_[data-slot=badge]>svg:first-child]:transition-opacity group-hover/picker:[&_[data-slot=badge]>svg:first-child]:opacity-0 group-focus-visible/picker:[&_[data-slot=badge]>svg:first-child]:opacity-0",
+            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
+            // Hover ring only when a category is assigned. Empty-state
+            // pill keeps its dashed border alone (no double-stroke).
+            category?.display_name && "hover:ring-1 hover:ring-border",
             className,
           )}
         >
@@ -113,19 +104,22 @@ export function CategoryPicker({
               Category
             </span>
           )}
-          {/* Pencil swap-in: overlays the category icon spot to signal
-              "edit this category". Visible only when the badge has an
-              icon to replace; otherwise the hover ring alone carries
-              the affordance. */}
+          {/* Pencil swap-in: overlays the category icon's spot on hover.
+              The wrapper carries a `bg-secondary` fill (matching the
+              CategoryBadge surface) so it masks the underlying icon —
+              cleaner than trying to fade the badge's own svg via a
+              descendant selector. */}
           {hasIcon && (
-            <Pencil
+            <span
               aria-hidden
               className={cn(
-                "text-muted-foreground pointer-events-none absolute top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+                "bg-secondary pointer-events-none absolute top-1/2 flex -translate-y-1/2 items-center justify-center rounded-[2px] opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
                 chevronLeftClass,
                 chevronClass,
               )}
-            />
+            >
+              <Pencil className={cn("text-muted-foreground", chevronClass)} />
+            </span>
           )}
         </button>
       </PopoverTrigger>

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -83,7 +83,10 @@ export function CategoryPicker({
             // signal (ring + chevron) is confined to the badge's exact
             // bounds. The ring sits flush around the badge edge; the
             // chevron floats inside the badge's right padding.
-            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
+            // `[&_[data-slot=badge]]:hover:!ring-0` suppresses CategoryBadge's
+            // own override ring during hover so the hover-state stroke wins
+            // — without this the two rings would stack on overridden rows.
+            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50 hover:[&_[data-slot=badge]]:!ring-0 focus-visible:[&_[data-slot=badge]]:!ring-0",
             className,
           )}
         >

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -104,26 +104,24 @@ export function CategoryPicker({
               Category
             </span>
           )}
-          {/* Chevron on a left-fading gradient strip that matches the
-              surface beneath it (badge `bg-secondary` when assigned;
-              the empty-state pill is transparent so the row's `bg-card`
-              shows through). The scrim softly masks any label content
-              under the chevron so it reads cleanly. Both fade in
-              together on hover/focus. */}
-          <span
-            aria-hidden
-            className={cn(
-              "pointer-events-none absolute inset-y-0 right-0 flex items-center rounded-r-md bg-gradient-to-l to-transparent opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
-              category?.display_name
-                ? "from-secondary via-secondary/85"
-                : "from-card via-card/85",
-              size === "sm" ? "w-6 pr-1" : "w-7 pr-1.5",
-            )}
-          >
-            <ChevronDown
-              className={cn("text-muted-foreground ml-auto", chevronClass)}
-            />
-          </span>
+          {/* Chevron only on the assigned state — the empty-state pill
+              already carries "+ Category" which is its own affordance.
+              The scrim matches `bg-secondary` (CategoryBadge's bg) so
+              the chevron sits cleanly even when it overlaps a label
+              edge. */}
+          {category?.display_name && (
+            <span
+              aria-hidden
+              className={cn(
+                "pointer-events-none absolute inset-y-0 right-0 flex items-center rounded-r-md bg-gradient-to-l from-secondary via-secondary/85 to-transparent opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+                size === "sm" ? "w-6 pr-1" : "w-7 pr-1.5",
+              )}
+            >
+              <ChevronDown
+                className={cn("text-muted-foreground ml-auto", chevronClass)}
+              />
+            </span>
+          )}
         </button>
       </PopoverTrigger>
       <PopoverContent

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -69,7 +69,12 @@ export function CategoryPicker({
   // overlaps the label. Falls back to a no-op when the category has no
   // icon — the hover ring alone carries the affordance there.
   const chevronClass = size === "sm" ? "size-2.5" : "size-3";
-  const chevronLeftClass = size === "sm" ? "left-1.5" : "left-2";
+  // Mask is intentionally bigger than the icon — and wider than tall —
+  // so stroke/edge bleed and per-icon viewBox variance on the underlying
+  // svg are fully covered (some lucide icons render a px or two past
+  // their nominal width).
+  const maskClass = size === "sm" ? "h-3 w-4" : "h-4 w-5";
+  const chevronLeftClass = size === "sm" ? "left-1" : "left-1";
   const hasIcon = !!category?.icon;
 
   return (
@@ -115,7 +120,7 @@ export function CategoryPicker({
               className={cn(
                 "bg-secondary pointer-events-none absolute top-1/2 flex -translate-y-1/2 items-center justify-center rounded-[2px] opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
                 chevronLeftClass,
-                chevronClass,
+                maskClass,
               )}
             >
               <Pencil className={cn("text-muted-foreground", chevronClass)} />

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -64,12 +64,13 @@ export function CategoryPicker({
     await apply(pick);
   };
 
-  // Chevron sits OUTSIDE the trigger bounds (absolute-positioned just to
-  // its right) so the badge stays flush at rest. It fades in only on
-  // hover / keyboard focus. `relative` on the trigger + a tiny `mr` on
-  // the parent cell aren't needed because the chevron escapes via
-  // negative right offset.
+  // Chevron swaps in for the category icon on hover (cross-fade in the
+  // same spot) so the badge surface stays the same width and nothing
+  // overlaps the label. Falls back to a no-op when the category has no
+  // icon — the hover ring alone carries the affordance there.
   const chevronClass = size === "sm" ? "size-2.5" : "size-3";
+  const chevronLeftClass = size === "sm" ? "left-1.5" : "left-2";
+  const hasIcon = !!category?.icon;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -80,13 +81,14 @@ export function CategoryPicker({
           onClick={(e) => e.stopPropagation()}
           className={cn(
             // Trigger wraps the badge with no extra padding so every hover
-            // signal (ring + chevron) is confined to the badge's exact
-            // bounds. The ring sits flush around the badge edge; the
-            // chevron floats inside the badge's right padding.
+            // signal stays inside the badge bounds.
             // `[&_[data-slot=badge]]:hover:!ring-0` suppresses CategoryBadge's
-            // own override ring during hover so the hover-state stroke wins
-            // — without this the two rings would stack on overridden rows.
+            // own override ring during hover so the hover-state stroke wins.
+            // When the category has an icon, fade it out on hover so the
+            // chevron swap reads as a single-icon replacement (no overlap).
             "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50 hover:[&_[data-slot=badge]]:!ring-0 focus-visible:[&_[data-slot=badge]]:!ring-0",
+            hasIcon &&
+              "[&_[data-slot=badge]>svg:first-child]:transition-opacity group-hover/picker:[&_[data-slot=badge]>svg:first-child]:opacity-0 group-focus-visible/picker:[&_[data-slot=badge]>svg:first-child]:opacity-0",
             className,
           )}
         >
@@ -107,23 +109,18 @@ export function CategoryPicker({
               Category
             </span>
           )}
-          {/* Chevron only on the assigned state — the empty-state pill
-              already carries "+ Category" which is its own affordance.
-              The scrim matches `bg-secondary` (CategoryBadge's bg) so
-              the chevron sits cleanly even when it overlaps a label
-              edge. */}
-          {category?.display_name && (
-            <span
+          {/* Chevron swap-in: overlays the category icon spot. Visible
+              only when the badge has an icon to replace; otherwise the
+              hover ring alone signals the affordance. */}
+          {hasIcon && (
+            <ChevronDown
               aria-hidden
               className={cn(
-                "pointer-events-none absolute inset-y-0 right-0 flex items-center rounded-r-md bg-gradient-to-l from-secondary via-secondary/85 to-transparent opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
-                size === "sm" ? "w-6 pr-1" : "w-7 pr-1.5",
+                "text-muted-foreground pointer-events-none absolute top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+                chevronLeftClass,
+                chevronClass,
               )}
-            >
-              <ChevronDown
-                className={cn("text-muted-foreground ml-auto", chevronClass)}
-              />
-            </span>
+            />
           )}
         </button>
       </PopoverTrigger>

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -59,9 +59,9 @@ export function CategoryPicker({
   };
 
   const iconClass = CATEGORY_BADGE_ICON[size];
-  // Mask is wider than the icon so per-lucide-icon viewBox variance is
-  // fully covered (some render a px or two past their nominal width).
-  const maskClass = size === "sm" ? "h-3 w-4" : "h-4 w-5";
+  // Width tuned to end at the badge's text edge — wider eats into the
+  // label, narrower leaves the icon's right-side stroke peeking through.
+  const maskClass = size === "sm" ? "h-3 w-3.5" : "h-4 w-5";
   const hasIcon = !!category?.icon;
 
   return (

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -5,7 +5,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { CategoryBadge } from "@/components/category-badge";
+import {
+  CATEGORY_BADGE_ICON,
+  CATEGORY_BADGE_SHAPE,
+  CategoryBadge,
+} from "@/components/category-badge";
 import {
   CategoryCommandList,
   useCategoryEditor,
@@ -46,35 +50,18 @@ export function CategoryPicker({
   onPick: onPickOverride,
   className,
 }: CategoryPickerProps) {
-  // Match the empty-state pill's geometry to the active badge so the column
-  // doesn't shift when the user assigns or clears a category from the row.
-  const emptyPillClass =
-    size === "sm"
-      ? "h-5 px-1.5 text-[11px] gap-0.5"
-      : "h-6 px-2 text-xs gap-1";
   const [open, setOpen] = useState(false);
   const { apply, isPending } = useCategoryEditor(transactionId);
 
   const onPick = async (pick: CategoryPick) => {
     setOpen(false);
-    if (onPickOverride) {
-      await onPickOverride(pick);
-      return;
-    }
-    await apply(pick);
+    await (onPickOverride ?? apply)(pick);
   };
 
-  // Chevron swaps in for the category icon on hover (cross-fade in the
-  // same spot) so the badge surface stays the same width and nothing
-  // overlaps the label. Falls back to a no-op when the category has no
-  // icon — the hover ring alone carries the affordance there.
-  const chevronClass = size === "sm" ? "size-2.5" : "size-3";
-  // Mask is intentionally bigger than the icon — and wider than tall —
-  // so stroke/edge bleed and per-icon viewBox variance on the underlying
-  // svg are fully covered (some lucide icons render a px or two past
-  // their nominal width).
+  const iconClass = CATEGORY_BADGE_ICON[size];
+  // Mask is wider than the icon so per-lucide-icon viewBox variance is
+  // fully covered (some render a px or two past their nominal width).
   const maskClass = size === "sm" ? "h-3 w-4" : "h-4 w-5";
-  const chevronLeftClass = size === "sm" ? "left-1" : "left-1";
   const hasIcon = !!category?.icon;
 
   return (
@@ -86,8 +73,7 @@ export function CategoryPicker({
           onClick={(e) => e.stopPropagation()}
           className={cn(
             "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
-            // Hover ring only when a category is assigned. Empty-state
-            // pill keeps its dashed border alone (no double-stroke).
+            // Empty-state pill carries its own dashed border — no double-stroke.
             category?.display_name && "hover:ring-1 hover:ring-border",
             className,
           )}
@@ -102,28 +88,22 @@ export function CategoryPicker({
             <span
               className={cn(
                 "text-muted-foreground border-border inline-flex items-center rounded-md border border-dashed group-hover/picker:text-foreground group-hover/picker:border-foreground/40",
-                emptyPillClass,
+                CATEGORY_BADGE_SHAPE[size],
               )}
             >
-              <Plus className={size === "sm" ? "size-2.5" : "size-3"} />
+              <Plus className={iconClass} />
               Category
             </span>
           )}
-          {/* Pencil swap-in: overlays the category icon's spot on hover.
-              The wrapper carries a `bg-secondary` fill (matching the
-              CategoryBadge surface) so it masks the underlying icon —
-              cleaner than trying to fade the badge's own svg via a
-              descendant selector. */}
           {hasIcon && (
             <span
               aria-hidden
               className={cn(
-                "bg-secondary pointer-events-none absolute top-1/2 flex -translate-y-1/2 items-center justify-center rounded-[2px] opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
-                chevronLeftClass,
+                "bg-secondary pointer-events-none absolute top-1/2 left-1 flex -translate-y-1/2 items-center justify-center rounded-[2px] opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
                 maskClass,
               )}
             >
-              <Pencil className={cn("text-muted-foreground", chevronClass)} />
+              <Pencil className={cn("text-muted-foreground", iconClass)} />
             </span>
           )}
         </button>

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -104,16 +104,25 @@ export function CategoryPicker({
               Category
             </span>
           )}
-          <ChevronDown
+          {/* Chevron on a left-fading gradient strip. The gradient
+              softly masks any badge content underneath so the chevron
+              reads cleanly even when it overlaps a label edge, without
+              having to know the badge's tint. Both fade in together on
+              hover/focus. */}
+          <span
             aria-hidden
             className={cn(
-              // Layered INSIDE the trigger's right edge, overlapping the
-              // badge's natural right padding so we don't reserve any
-              // width at rest. Fades in on hover/focus.
-              "text-muted-foreground pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
-              chevronClass,
+              "pointer-events-none absolute inset-y-0 right-0 flex items-center rounded-r-md bg-gradient-to-l from-card via-card/85 to-transparent opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+              size === "sm" ? "w-6 pr-1" : "w-7 pr-1.5",
             )}
-          />
+          >
+            <ChevronDown
+              className={cn(
+                "text-muted-foreground ml-auto drop-shadow-sm",
+                chevronClass,
+              )}
+            />
+          </span>
         </button>
       </PopoverTrigger>
       <PopoverContent

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -25,6 +25,12 @@ interface CategoryPickerProps {
    * so there's room for the comfier size. Pass `sm` for tighter rails.
    */
   size?: "sm" | "md";
+  /**
+   * Override the default behaviour (single-tx update mutation + toast).
+   * Used by the sandbox specimen and any future caller that wants to
+   * own the pick handler (bulk flows, dry-run previews, etc.).
+   */
+  onPick?: (pick: CategoryPick) => void | Promise<void>;
   className?: string;
 }
 
@@ -37,6 +43,7 @@ export function CategoryPicker({
   category,
   overridden,
   size = "md",
+  onPick: onPickOverride,
   className,
 }: CategoryPickerProps) {
   // Match the empty-state pill's geometry to the active badge so the column
@@ -50,6 +57,10 @@ export function CategoryPicker({
 
   const onPick = async (pick: CategoryPick) => {
     setOpen(false);
+    if (onPickOverride) {
+      await onPickOverride(pick);
+      return;
+    }
     await apply(pick);
   };
 

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, Plus } from "lucide-react";
+import { Pencil, Plus } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -109,11 +109,12 @@ export function CategoryPicker({
               Category
             </span>
           )}
-          {/* Chevron swap-in: overlays the category icon spot. Visible
-              only when the badge has an icon to replace; otherwise the
-              hover ring alone signals the affordance. */}
+          {/* Pencil swap-in: overlays the category icon spot to signal
+              "edit this category". Visible only when the badge has an
+              icon to replace; otherwise the hover ring alone carries
+              the affordance. */}
           {hasIcon && (
-            <ChevronDown
+            <Pencil
               aria-hidden
               className={cn(
                 "text-muted-foreground pointer-events-none absolute top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -64,11 +64,12 @@ export function CategoryPicker({
     await apply(pick);
   };
 
-  // `group/picker` lets the chevron hint reveal only on hover/focus
-  // without taking layout space at rest, so a tx row's category column
-  // reads as a tidy badge until the user shows intent to edit.
-  const chevronClass =
-    size === "sm" ? "size-2.5 -mr-0.5" : "size-3 -mr-0.5";
+  // Chevron sits OUTSIDE the trigger bounds (absolute-positioned just to
+  // its right) so the badge stays flush at rest. It fades in only on
+  // hover / keyboard focus. `relative` on the trigger + a tiny `mr` on
+  // the parent cell aren't needed because the chevron escapes via
+  // negative right offset.
+  const chevronClass = size === "sm" ? "size-2.5" : "size-3";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -78,10 +79,11 @@ export function CategoryPicker({
           disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            // Pickier hover state — bg + ring — than the previous
-            // `hover:bg-accent` alone, so the affordance reads at-a-glance
-            // even when the badge already carries its own coloured tint.
-            "group/picker focus-visible:ring-ring inline-flex items-center gap-1 rounded-md p-0.5 transition-colors hover:bg-accent hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
+            // Trigger wraps the badge with no extra padding so every hover
+            // signal (ring + chevron) is confined to the badge's exact
+            // bounds. The ring sits flush around the badge edge; the
+            // chevron floats inside the badge's right padding.
+            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
             className,
           )}
         >
@@ -105,10 +107,10 @@ export function CategoryPicker({
           <ChevronDown
             aria-hidden
             className={cn(
-              // Hidden at rest, revealed on group hover or keyboard
-              // focus so the picker affordance is discoverable without
-              // adding weight to the badge.
-              "text-muted-foreground opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+              // Layered INSIDE the trigger's right edge, overlapping the
+              // badge's natural right padding so we don't reserve any
+              // width at rest. Fades in on hover/focus.
+              "text-muted-foreground pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
               chevronClass,
             )}
           />

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -53,6 +53,12 @@ export function CategoryPicker({
     await apply(pick);
   };
 
+  // `group/picker` lets the chevron hint reveal only on hover/focus
+  // without taking layout space at rest, so a tx row's category column
+  // reads as a tidy badge until the user shows intent to edit.
+  const chevronClass =
+    size === "sm" ? "size-2.5 -mr-0.5" : "size-3 -mr-0.5";
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -61,7 +67,10 @@ export function CategoryPicker({
           disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
+            // Pickier hover state — bg + ring — than the previous
+            // `hover:bg-accent` alone, so the affordance reads at-a-glance
+            // even when the badge already carries its own coloured tint.
+            "group/picker focus-visible:ring-ring inline-flex items-center gap-1 rounded-md p-0.5 transition-colors hover:bg-accent hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
             className,
           )}
         >
@@ -74,7 +83,7 @@ export function CategoryPicker({
           ) : (
             <span
               className={cn(
-                "text-muted-foreground border-border hover:text-foreground inline-flex items-center rounded-md border border-dashed",
+                "text-muted-foreground border-border inline-flex items-center rounded-md border border-dashed group-hover/picker:text-foreground group-hover/picker:border-foreground/40",
                 emptyPillClass,
               )}
             >
@@ -82,6 +91,16 @@ export function CategoryPicker({
               Category
             </span>
           )}
+          <ChevronDown
+            aria-hidden
+            className={cn(
+              // Hidden at rest, revealed on group hover or keyboard
+              // focus so the picker affordance is discoverable without
+              // adding weight to the badge.
+              "text-muted-foreground opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+              chevronClass,
+            )}
+          />
         </button>
       </PopoverTrigger>
       <PopoverContent

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -84,9 +84,13 @@ export function CategoryPicker({
             // signal stays inside the badge bounds.
             // `[&_[data-slot=badge]]:hover:!ring-0` suppresses CategoryBadge's
             // own override ring during hover so the hover-state stroke wins.
-            // When the category has an icon, fade it out on hover so the
-            // chevron swap reads as a single-icon replacement (no overlap).
-            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow hover:ring-1 hover:ring-border focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50 hover:[&_[data-slot=badge]]:!ring-0 focus-visible:[&_[data-slot=badge]]:!ring-0",
+            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50 hover:[&_[data-slot=badge]]:!ring-0 focus-visible:[&_[data-slot=badge]]:!ring-0",
+            // Hover ring + icon-swap only when a category is assigned.
+            // The empty-state pill carries its own dashed border that
+            // intensifies on hover — adding a solid ring on top would
+            // double-stroke.
+            category?.display_name &&
+              "hover:ring-1 hover:ring-border",
             hasIcon &&
               "[&_[data-slot=badge]>svg:first-child]:transition-opacity group-hover/picker:[&_[data-slot=badge]>svg:first-child]:opacity-0 group-focus-visible/picker:[&_[data-slot=badge]>svg:first-child]:opacity-0",
             className,

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -287,6 +287,10 @@ export function DataTable<TData, TValue>({
                     onRowClick ? () => onRowClick(row.original) : undefined
                   }
                   className={cn(
+                    // `group/row` lets row children opt into a hover state
+                    // driven by the whole row (e.g. underline a title when
+                    // the row is hovered) via `group-hover/row:*`.
+                    "group/row",
                     (pointerRows ?? !!onRowClick) && "cursor-pointer",
                     // Keyboard-focus indicator: a 3px primary accent bar on
                     // the left edge plus a faint primary tint, layered via

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -35,13 +35,13 @@ export function TransactionPrimary({
         e.stopPropagation();
         onTitleClick(t);
       }}
-      // Subtle hover hint that the title is the navigation affordance —
-      // doesn't dress it up as a full link. Pointer cursor sells the
-      // deeplink even though the surrounding row body uses the default
-      // cursor (it's a focus / select target, not a navigation CTA).
+      // Subtle navigation hint: title underlines on its own hover AND when
+      // the surrounding row is hovered (the whole row is a click target
+      // that navigates to detail, so the title is the visual anchor for
+      // that affordance). `group-hover/row:` is set up on TableRow.
       className={cn(
         titleClasses,
-        "cursor-pointer hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
+        "cursor-pointer underline-offset-2 decoration-muted-foreground/50 hover:underline group-hover/row:underline focus-visible:outline-none focus-visible:underline text-left",
       )}
     >
       {t.provider_name}

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -237,7 +237,11 @@ function SectionWithOutline({
                       <a
                         href={`#${i.id}`}
                         className={cn(
-                          "block truncate rounded-md px-2 py-1 text-xs transition-colors",
+                          "block truncate rounded-md py-1 pr-2 text-xs transition-colors",
+                          // Indent subitems under a real group label so the
+                          // outline reads as a hierarchy; ungrouped fallback
+                          // keeps the flush left edge.
+                          g.id === "outline-general" ? "pl-2" : "pl-4",
                           activeId === i.id
                             ? "text-foreground bg-accent/50 font-medium"
                             : "text-muted-foreground hover:text-foreground hover:bg-accent/30",

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { SandboxIsolationProvider } from "@/sandbox/kit";
 import { FoundationsSection } from "@/sandbox/sections/foundations";
 import { PrimitivesSection } from "@/sandbox/sections/primitives";
 import { ComponentsSection } from "@/sandbox/sections/components";
@@ -37,7 +38,23 @@ export function SandboxPage() {
     return null;
   });
 
-  const [active, setActive] = useState<SectionId>("foundations");
+  // `?only=<slug>` isolates a single specimen for clean before/after or
+  // variant screenshots. `?section=<id>` scopes which section's tree
+  // mounts in isolation mode — defaults to `components` since that's the
+  // bulk of the gallery. Scoping matters because mounting every section
+  // would mount every Specimen wrapper (and their lazy children), and
+  // some of those side-mount via popover triggers that can hit the API.
+  const { only, scopedSection } = useMemo(() => {
+    if (typeof window === "undefined")
+      return { only: null as string | null, scopedSection: null as SectionId | null };
+    const params = new URLSearchParams(window.location.search);
+    const onlyParam = params.get("only");
+    const sectionParam = params.get("section");
+    const matched = SECTIONS.find((s) => s.id === sectionParam)?.id ?? null;
+    return { only: onlyParam, scopedSection: matched };
+  }, []);
+
+  const [active, setActive] = useState<SectionId>("components");
   // The theme toggle is a scoped preview: it flips the global `.dark` class
   // so the whole gallery re-themes, but restores the original mode on
   // unmount so it never leaks out to the rest of the app.
@@ -61,7 +78,43 @@ export function SandboxPage() {
   const ActiveSection =
     SECTIONS.find((s) => s.id === active)?.Component ?? FoundationsSection;
 
+  // In isolation mode, drop the section nav + outline and mount ONLY the
+  // scoped section (default `components`). Specimen / SandboxGroup
+  // self-filter so only the matching specimen actually renders. We mount
+  // a single section (not all five) because Specimen wrappers + their lazy
+  // popover triggers can side-fetch live data — scoping keeps the page
+  // entirely fixture-backed.
+  if (only) {
+    const exitHref = window.location.pathname;
+    const sectionId = scopedSection ?? "components";
+    const Scoped =
+      SECTIONS.find((s) => s.id === sectionId)?.Component ?? ComponentsSection;
+    return (
+      <SandboxIsolationProvider only={only}>
+        <div className="mx-auto w-full max-w-3xl">
+          <div className="text-muted-foreground mb-4 flex items-center justify-between text-xs">
+            <span>
+              Isolating <code className="font-mono">{only}</code>
+              <span className="text-muted-foreground/60 ml-2">
+                in <code className="font-mono">{sectionId}</code>
+              </span>
+            </span>
+            <a
+              href={exitHref}
+              className="hover:text-foreground inline-flex items-center gap-1 underline-offset-2 hover:underline"
+            >
+              <X className="size-3" />
+              Exit isolation
+            </a>
+          </div>
+          <Scoped />
+        </div>
+      </SandboxIsolationProvider>
+    );
+  }
+
   return (
+    <SandboxIsolationProvider only={null}>
     <div className="w-full">
       <div className="mb-6 flex items-start justify-between gap-4">
         <div className="space-y-1">
@@ -126,6 +179,7 @@ export function SandboxPage() {
         </div>
       </div>
     </div>
+    </SandboxIsolationProvider>
   );
 }
 

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -62,7 +62,7 @@ export function SandboxPage() {
     SECTIONS.find((s) => s.id === active)?.Component ?? FoundationsSection;
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="w-full">
       <div className="mb-6 flex items-start justify-between gap-4">
         <div className="space-y-1">
           <h1 className="text-xl font-semibold tracking-tight">
@@ -129,13 +129,24 @@ export function SandboxPage() {
   );
 }
 
+interface OutlineSpecimen {
+  id: string;
+  label: string;
+}
+interface OutlineGroup {
+  id: string;
+  title: string;
+  items: OutlineSpecimen[];
+}
+
 // SectionWithOutline pairs an active sandbox section with a sticky right-rail
 // outline of its specimens. Specimens self-register via `data-specimen-label`
-// from the `<Specimen>` primitive — we scan the section's DOM after each
-// section change (and on resize) so the outline reflects whatever lives in
-// the gallery without per-section wiring. Active item highlights via
-// IntersectionObserver: whichever specimen is closest to the top of the
-// viewport (under the 56px shell header) wins.
+// from the `<Specimen>` primitive; `<SandboxGroup>` wraps clusters and emits
+// `data-specimen-group="Title"`. The outline walks the section in document
+// order, grouping every specimen under its nearest preceding group (an
+// implicit "General" bucket catches specimens that live outside any group).
+// Active item highlights via IntersectionObserver — whichever specimen is
+// closest to the top of the viewport (under the 56px shell header) wins.
 function SectionWithOutline({
   sectionId,
   children,
@@ -144,77 +155,102 @@ function SectionWithOutline({
   children: React.ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const [items, setItems] = useState<Array<{ id: string; label: string }>>([]);
+  const [groups, setGroups] = useState<OutlineGroup[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  // Rebuild the outline on section change. `useEffect` runs after children
-  // commit, so specimens are mounted and queryable.
   useEffect(() => {
     const root = contentRef.current;
     if (!root) return;
-    const next = [...root.querySelectorAll<HTMLElement>("[data-specimen-label]")].map(
-      (el) => ({
-        id: el.id,
-        label: el.getAttribute("data-specimen-label") ?? el.id,
-      }),
+    const nodes = root.querySelectorAll<HTMLElement>(
+      "[data-specimen-group], [data-specimen-label]",
     );
-    setItems(next);
-    setActiveId(next[0]?.id ?? null);
+    const next: OutlineGroup[] = [];
+    let current: OutlineGroup | null = null;
+    const ungrouped: OutlineSpecimen[] = [];
+    for (const el of Array.from(nodes)) {
+      const groupTitle = el.getAttribute("data-specimen-group");
+      if (groupTitle) {
+        current = { id: el.id, title: groupTitle, items: [] };
+        next.push(current);
+        continue;
+      }
+      const label = el.getAttribute("data-specimen-label");
+      if (!label) continue;
+      const item: OutlineSpecimen = { id: el.id, label };
+      if (current) current.items.push(item);
+      else ungrouped.push(item);
+    }
+    setGroups(
+      ungrouped.length
+        ? [{ id: "outline-general", title: "General", items: ungrouped }, ...next]
+        : next,
+    );
+    setActiveId(ungrouped[0]?.id ?? next[0]?.items[0]?.id ?? null);
   }, [sectionId]);
 
-  // Highlight whichever specimen is closest to the top under the 56px shell
-  // header. Rebuild when the item list changes (new section).
   useEffect(() => {
-    if (items.length === 0) return;
     const root = contentRef.current;
     if (!root) return;
-    const els = items
+    const all = groups.flatMap((g) => g.items);
+    if (all.length === 0) return;
+    const els = all
       .map((i) => root.querySelector<HTMLElement>(`#${CSS.escape(i.id)}`))
       .filter((el): el is HTMLElement => !!el);
     const observer = new IntersectionObserver(
       (entries) => {
-        // Collect the entries that are currently intersecting and pick the
-        // one with the smallest `top` — i.e. nearest the top of the root.
         const visible = entries
           .filter((e) => e.isIntersecting)
-          .sort(
-            (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
-          );
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
         if (visible[0]) setActiveId(visible[0].target.id);
       },
       { rootMargin: "-56px 0px -60% 0px", threshold: 0 },
     );
     els.forEach((el) => observer.observe(el));
     return () => observer.disconnect();
-  }, [items]);
+  }, [groups]);
+
+  const hasItems = groups.some((g) => g.items.length > 0);
 
   return (
     <div className="flex gap-8">
       <div ref={contentRef} className="min-w-0 flex-1">
         {children}
       </div>
-      {items.length > 0 && (
-        <aside className="sticky top-20 hidden h-fit w-48 shrink-0 lg:block">
+      {hasItems && (
+        <aside className="sticky top-20 hidden h-[calc(100vh-6rem)] w-52 shrink-0 overflow-y-auto pr-2 lg:block">
           <p className="text-muted-foreground mb-2 px-2 text-[10px] font-semibold tracking-wider uppercase">
             On this page
           </p>
-          <ul className="space-y-0.5">
-            {items.map((i) => (
-              <li key={i.id}>
-                <a
-                  href={`#${i.id}`}
-                  className={cn(
-                    "block truncate rounded-md px-2 py-1 text-xs transition-colors",
-                    activeId === i.id
-                      ? "text-foreground bg-accent/50 font-medium"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/30",
-                  )}
-                >
-                  {i.label}
-                </a>
-              </li>
+          <div className="space-y-3">
+            {groups.map((g) => (
+              <div key={g.id}>
+                {/* Only render group label when there are real groups —
+                    the implicit "General" bucket is unlabeled. */}
+                {g.id !== "outline-general" && (
+                  <p className="text-muted-foreground/80 mb-1 px-2 text-[10px] font-semibold tracking-wider uppercase">
+                    {g.title}
+                  </p>
+                )}
+                <ul className="space-y-0.5">
+                  {g.items.map((i) => (
+                    <li key={i.id}>
+                      <a
+                        href={`#${i.id}`}
+                        className={cn(
+                          "block truncate rounded-md px-2 py-1 text-xs transition-colors",
+                          activeId === i.id
+                            ? "text-foreground bg-accent/50 font-medium"
+                            : "text-muted-foreground hover:text-foreground hover:bg-accent/30",
+                        )}
+                      >
+                        {i.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
-          </ul>
+          </div>
         </aside>
       )}
     </div>

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -181,35 +181,12 @@ export function TransactionsPage() {
   }, []);
 
   // In select mode a click anywhere on the row toggles its selection — the
-  // checkbox cell stops propagation so it doesn't double-toggle.
+  // checkbox cell stops propagation so it doesn't double-toggle. Outside
+  // select mode, the row body navigates (same as a title click) — see
+  // `onRowClick` below.
   const toggleRowSelection = useCallback((t: Transaction) => {
     setRowSelection((prev) => ({ ...prev, [t.id]: !prev[t.id] }));
   }, []);
-
-  // Row click outside select mode is a two-stage interaction:
-  //   1st tap → focus the row (same affordance as j/k)
-  //   2nd tap on the already-focused row → enter select mode + select it
-  //     (same affordance as the `x` shortcut)
-  // The merchant title remains the dedicated open-detail target — its
-  // own onClick stops propagation so it never lands here.
-  const handleRowClick = useCallback(
-    (t: Transaction) => {
-      if (selectMode) {
-        toggleRowSelection(t);
-        return;
-      }
-      const idx = rows.findIndex((r) => r.id === t.id);
-      if (idx === -1) return;
-      if (focusedIndex === idx) {
-        setSelectMode(true);
-        setRowSelection((prev) => ({ ...prev, [t.id]: true }));
-        lastIndexRef.current = idx;
-        return;
-      }
-      setFocusedIndex(idx);
-    },
-    [selectMode, toggleRowSelection, rows, focusedIndex],
-  );
 
   const toggleSelectMode = useCallback(() => {
     if (selectMode) exitSelectMode();
@@ -453,8 +430,7 @@ export function TransactionsPage() {
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
         focusedRowId={focusedRowId}
-        onRowClick={handleRowClick}
-        pointerRows={selectMode}
+        onRowClick={selectMode ? toggleRowSelection : openTransaction}
         stickyHeader
         refinedHeader
         emptyState={

--- a/web/src/sandbox/kit.tsx
+++ b/web/src/sandbox/kit.tsx
@@ -1,28 +1,60 @@
-import type { ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 // Shared layout primitives for the design-system sandbox. Kept deliberately
 // plain — they frame the real components without competing with them.
 
+// Isolation context: when set to a specimen slug (via `?only=<slug>` on
+// /v2/sandbox), only the matching <Specimen> renders — used to produce
+// clean before/after or variant screenshots of a single component.
+const IsolationContext = createContext<string | null>(null);
+
+export function SandboxIsolationProvider({
+  only,
+  children,
+}: {
+  only: string | null;
+  children: ReactNode;
+}) {
+  return (
+    <IsolationContext.Provider value={only}>
+      {children}
+    </IsolationContext.Provider>
+  );
+}
+
+function useIsolation() {
+  return useContext(IsolationContext);
+}
+
+// SectionContext lets Specimens know which top-level section they live in
+// so the per-specimen "Isolate" link can encode `?section=<id>` and the
+// isolation render path mounts just that one section's tree.
+const SectionContext = createContext<string | null>(null);
+
 export function SandboxSection({
+  id,
   title,
   description,
   children,
 }: {
+  id?: string;
   title: string;
   description?: string;
   children: ReactNode;
 }) {
   return (
-    <section className="space-y-6">
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
-        {description && (
-          <p className="text-muted-foreground text-sm">{description}</p>
-        )}
-      </div>
-      {children}
-    </section>
+    <SectionContext.Provider value={id ?? null}>
+      <section className="space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+          {description && (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          )}
+        </div>
+        {children}
+      </section>
+    </SectionContext.Provider>
   );
 }
 
@@ -31,6 +63,9 @@ export function SandboxSection({
 // Specimen under the nearest preceding SandboxGroup, so the outline mirrors
 // the visible structure. Use it to give long sections (Components,
 // Patterns) a navigable shape — Foundations / Primitives may not need it.
+//
+// In isolation mode (single-specimen view via `?only=…`) the group heading
+// hides itself but children render through; specimens then self-filter.
 export function SandboxGroup({
   title,
   children,
@@ -39,6 +74,8 @@ export function SandboxGroup({
   children: ReactNode;
 }) {
   const slug = specimenSlug(title);
+  const isolated = useIsolation();
+  if (isolated) return <>{children}</>;
   return (
     <div
       id={`group-${slug}`}
@@ -67,6 +104,8 @@ export function specimenSlug(label: string): string {
 
 // A single labeled example. `code` names the component/token so the gallery
 // doubles as a quick "what's it called" reference.
+//
+// In isolation mode (`?only=<slug>`) only the matching specimen renders.
 export function Specimen({
   label,
   code,
@@ -80,11 +119,18 @@ export function Specimen({
   children: ReactNode;
   className?: string;
 }) {
+  const slug = specimenSlug(label);
+  const isolated = useIsolation();
+  const sectionId = useContext(SectionContext);
+  if (isolated && isolated !== slug) return null;
+  const isolateHref = sectionId
+    ? `?only=${slug}&section=${sectionId}`
+    : `?only=${slug}`;
   return (
     <div
-      id={specimenSlug(label)}
+      id={slug}
       data-specimen-label={label}
-      className="scroll-mt-20 space-y-2"
+      className="group/specimen scroll-mt-20 space-y-2"
     >
       <div className="flex items-baseline gap-2">
         <h3 className="text-sm font-medium">{label}</h3>
@@ -92,6 +138,15 @@ export function Specimen({
           <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 font-mono text-xs">
             {code}
           </code>
+        )}
+        {!isolated && (
+          <a
+            href={isolateHref}
+            className="text-muted-foreground/60 hover:text-foreground ml-auto text-[10px] uppercase tracking-wider opacity-0 transition-opacity group-hover/specimen:opacity-100 focus:opacity-100"
+            title="Isolate this specimen"
+          >
+            Isolate
+          </a>
         )}
       </div>
       {description && (

--- a/web/src/sandbox/kit.tsx
+++ b/web/src/sandbox/kit.tsx
@@ -26,6 +26,33 @@ export function SandboxSection({
   );
 }
 
+// SandboxGroup wraps a cluster of specimens under a small sub-heading. The
+// section outline in `routes/sandbox.tsx` walks the DOM and groups every
+// Specimen under the nearest preceding SandboxGroup, so the outline mirrors
+// the visible structure. Use it to give long sections (Components,
+// Patterns) a navigable shape — Foundations / Primitives may not need it.
+export function SandboxGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  const slug = specimenSlug(title);
+  return (
+    <div
+      id={`group-${slug}`}
+      data-specimen-group={title}
+      className="scroll-mt-20 space-y-6 pt-2"
+    >
+      <h3 className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
 // `data-specimen-label` + an id derived from the label make every Specimen
 // addressable for the per-section outline rendered in `routes/sandbox.tsx`.
 // Keep it on the wrapper (not the heading) so the scroll anchor sits just

--- a/web/src/sandbox/sections/amounts.tsx
+++ b/web/src/sandbox/sections/amounts.tsx
@@ -51,6 +51,7 @@ const AMOUNT_ROWS = sampleTransactions.slice(0, 3);
 export function AmountsSection() {
   return (
     <SandboxSection
+      id="amounts"
       title="Amounts"
       description="How money is displayed in v2. One sign convention, one formatter, one component — applied everywhere a balance or transaction amount appears."
     >

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -54,6 +54,7 @@ import { DataTable } from "@/components/data-table";
 import { CategoryBadge } from "@/components/category-badge";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { CategoryCommandList } from "@/components/category-command";
+import { CategoryPicker } from "@/components/category-picker";
 import { DateRangeFilter } from "@/components/date-range-filter";
 import type { DateRangeValue } from "@/components/date-range-filter";
 import { TagChip, TagList } from "@/components/tag-chip";
@@ -1482,6 +1483,66 @@ export function ComponentsSection() {
       </SandboxGroup>
 
       <SandboxGroup title="Pickers & specialty">
+      <Specimen
+        label="CategoryPicker"
+        code="components/category-picker"
+        description="The inline category picker that lives in the transactions list's category column. Renders the assigned `CategoryBadge` (or a dashed `+ Category` empty pill) over a popover-hosted `CategoryCommandList`. Hover/focus reveals a small chevron + a 1px ring around the trigger so the affordance reads even when the badge already carries a coloured tint. The `onPick` override here keeps the sandbox a no-op — production wires it to the single-tx update mutation via `useCategoryEditor`."
+        className="block"
+      >
+        <div className="flex flex-wrap items-center gap-6 rounded-lg border p-4">
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Assigned
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={coffeeCategory ?? null}
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Override (ring)
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={gasCategory ?? null}
+              overridden
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Uncategorized
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={null}
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              sm
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={coffeeCategory ?? null}
+              size="sm"
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+        </div>
+      </Specimen>
+
       <Specimen
         label="CategoryCommandList"
         code="components/category-command"

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -161,6 +161,7 @@ export function ComponentsSection() {
 
   return (
     <SandboxSection
+      id="components"
       title="Components"
       description="Composed, reusable v2 components — the layer built on top of the primitives. Shared across the transactions list, detail page, and (soon) elsewhere."
     >

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -104,7 +104,7 @@ import { ProviderPicker } from "@/features/connections/provider-picker";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
-import { SandboxSection, Specimen } from "@/sandbox/kit";
+import { SandboxGroup, SandboxSection, Specimen } from "@/sandbox/kit";
 import {
   sampleTags,
   sampleTranscriptEvents,
@@ -163,6 +163,7 @@ export function ComponentsSection() {
       title="Components"
       description="Composed, reusable v2 components — the layer built on top of the primitives. Shared across the transactions list, detail page, and (soon) elsewhere."
     >
+      <SandboxGroup title="Page layout">
       <Specimen
         label="PageHeader"
         code="components/page-header"
@@ -423,7 +424,9 @@ export function ComponentsSection() {
           />
         </div>
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Pills & inline">
       <Specimen
         label="IdPill"
         code="components/id-pill"
@@ -712,7 +715,9 @@ export function ComponentsSection() {
           <ViewAllPill to="/">See all transactions</ViewAllPill>
         </div>
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Forms & overlays">
       <Specimen
         label="SearchInput"
         code="components/search-input"
@@ -1049,7 +1054,9 @@ export function ComponentsSection() {
           }}
         />
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Shells & states">
       <Specimen
         label="DangerZone"
         code="components/danger-zone"
@@ -1248,7 +1255,9 @@ export function ComponentsSection() {
           </div>
         </div>
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Domain & data">
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
@@ -1470,7 +1479,9 @@ export function ComponentsSection() {
           </div>
         ))}
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Pickers & specialty">
       <Specimen
         label="CategoryCommandList"
         code="components/category-command"
@@ -1671,6 +1682,7 @@ export function ComponentsSection() {
           />
         </div>
       </Specimen>
+      </SandboxGroup>
     </SandboxSection>
   );
 }

--- a/web/src/sandbox/sections/foundations.tsx
+++ b/web/src/sandbox/sections/foundations.tsx
@@ -72,6 +72,7 @@ function Swatch({ cls, name }: { cls: string; name: string }) {
 export function FoundationsSection() {
   return (
     <SandboxSection
+      id="foundations"
       title="Foundations"
       description="Theme tokens, shape, type, and the icon system — the layer everything else is built on. Toggle the theme (top right) to check both modes."
     >

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -86,6 +86,7 @@ export function PatternsSection() {
 
   return (
     <SandboxSection
+      id="patterns"
       title="Patterns"
       description="Cross-cutting behaviors — not components, but the shared building blocks every feature reaches for."
     >

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -115,6 +115,7 @@ import { SandboxSection, Specimen } from "@/sandbox/kit";
 export function PrimitivesSection() {
   return (
     <SandboxSection
+      id="primitives"
       title="Primitives"
       description="shadcn/ui components as themed for v2. Generated into components/ui/* — never hand-edited; variants come from theme tokens."
     >


### PR DESCRIPTION
Batch 3 of the v2 UI polish sprint — 19 commits, mostly the CategoryPicker affordance series plus a sandbox isolation rework.

## Summary

**CategoryPicker affordance** (the bulk of the work): the picker badge in the transactions row was visually indistinguishable from a plain CategoryBadge, so users couldn't tell it was clickable. This PR lands the final design after ~10 iterations:

- Resting state is pixel-identical to a standalone `<CategoryBadge>` (no extra padding, no decoration)
- On hover: 1px ring around the badge + the category icon swaps to a pencil (cross-fade in the same spot, badge width never changes)
- Uncategorized empty-state pill keeps its dashed border alone (no double-stroke)
- New `size` prop (`sm` | `md`, default `md`) and an `onPick` override so the sandbox can demo it without writing to live data
- Empty pill + pencil mask now derive their geometry from new exported `CATEGORY_BADGE_SHAPE` / `CATEGORY_BADGE_ICON` tokens — one source of truth for badge sizing

**Sandbox `?only=<slug>` isolation rework:**

- Previously mounted all five section trees and let Specimen filter; this side-mounted popover triggers that could fire live data fetches
- Now scoped to a single section via `?section=<id>` (defaults to `components`); each Specimen header carries a hover-revealed "Isolate" link that encodes the section + slug pair
- One-click path from the gallery to a clean fixture-only render of any single specimen

**Smaller polish:**

- Tx-row category badge bumped to `md` size (matches the picker default)
- Tx-row two-tap reverted — row navigates on click; hover the row → title underlines
- `/sandbox` outline subitems indent under their group label so the right-rail reads as a hierarchy
- `/sandbox` content area runs full-width with a scrollable outline rail

## Test plan

- [ ] Hover a transaction row's category cell — pencil swaps in over the icon, 1px ring appears, badge width doesn't shift
- [ ] Click an uncategorized cell — empty `+ Category` pill opens the picker; no double-border on hover
- [ ] Visit `/v2/sandbox` — section nav still works, no outline regressions
- [ ] Click "Isolate" on any specimen — URL becomes `?only=<slug>&section=<id>`, only that specimen renders, no spurious API calls in the network tab
- [ ] At `sm` size in the sandbox: hover the picker — pencil mask stops at the text edge, doesn't cover the label
