### PR TITLE
design(v2): unify page-spacing contract on <main>

### DIFF
--- a/.claude/rules/v2-frontend.md
+++ b/.claude/rules/v2-frontend.md
@@ -77,6 +77,7 @@ There's a living component gallery at `/v2/sandbox` (`web/src/sandbox/`, route i
 - **Tailwind classes only.** No inline `style={}` except dynamic values that can't be expressed in Tailwind (computed colors, animations).
 - Use shadcn theme variables (`bg-primary`, `text-muted-foreground`, `border-border`). Never raw colors (`bg-blue-500`).
 - Spacing: Tailwind defaults (`gap-2`, `p-4`).
+- **Page layout: `<main>` in `routes/__root.tsx` is `flex flex-col gap-5`.** Pages return a fragment (`<>`) so each section (PageHeader, toolbar, content, dialogs) sits as a direct child and inherits the 20px rhythm — do NOT wrap the page in your own `<div className="flex flex-col gap-*">`. The only exception is width-constrained pages (detail / form pages), which wrap once with `mx-auto flex max-w-{2xl,5xl} flex-col gap-5` so the constraint and the rhythm live on the same element. Never add `mb-*` to a direct child of the page wrapper — it stacks with the parent gap and produces a visible void.
 - **No CSS modules, no styled-components, no `@apply` outside `globals.css`.**
 - **Never import `static/css/styles.css`** or any v1 stylesheet. The v2 design system is shadcn theme tokens + Tailwind utilities. v1 grew unboundedly — we're not paying that cost again.
 - **Do not commit changes to `web/src/components/ui/*` styling.** If a primitive looks wrong, theme tokens in `globals.css` are the lever.

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -40,10 +40,11 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        // No outer margin — every caller wraps PageHeader in a flex column
-        // with its own `gap-*`, so an `mb-*` here stacks with that gap and
-        // produces a ~44px void on mobile (visible because the action chip
-        // wraps below the description). Let the parent layout own spacing.
+        // No outer margin — <main> is a flex column with gap-5 (see the
+        // contract comment in routes/__root.tsx) so the gap below PageHeader
+        // comes from the parent layout. Adding `mb-*` here stacks with that
+        // gap and produces a ~44px void on mobile (visible because the
+        // action chip wraps below the description).
         "flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end sm:gap-4",
         className,
       )}

--- a/web/src/components/soft-back-button.tsx
+++ b/web/src/components/soft-back-button.tsx
@@ -23,9 +23,11 @@ interface SoftBackButtonProps {
 // new — promoted to a primitive in the iter-13 api-keys pass).
 //
 // Visual contract:
-//   `<Button variant="ghost" size="sm" className="-ml-2 mb-3 h-7 px-2 text-xs">`
+//   `<Button variant="ghost" size="sm" className="-ml-2 h-7 px-2 text-xs">`
 //
-// Don't fork the look — change this primitive instead.
+// No bottom margin — the page layout (<main> or a constrained-width wrapper)
+// is a flex column with gap-5 that owns the rhythm between the back-link and
+// the PageHeader below it. Don't fork the look — change this primitive instead.
 export function SoftBackButton({
   to,
   children,
@@ -38,7 +40,7 @@ export function SoftBackButton({
       size="sm"
       asChild
       className={cn(
-        "text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs",
+        "text-muted-foreground hover:text-foreground -ml-2 h-7 px-2 text-xs",
         className,
       )}
     >

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -162,7 +162,14 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             </div>
           </div>
         </header>
-        <main className="min-w-0 flex-1 p-3 sm:p-6">
+        {/* Page layout contract: <main> is a flex column with gap-5. Every
+            section a page renders (PageHeader, toolbars, content, dialogs)
+            becomes a direct child and inherits the 20px rhythm. Pages must
+            NOT add their own `flex flex-col gap-*` wrapper — return a
+            fragment (`<>`) so children sit directly under <main>. Pages that
+            need a width constraint (`mx-auto max-w-2xl|5xl`) wrap once and
+            apply `flex flex-col gap-5` on that wrapper themselves. */}
+        <main className="flex min-w-0 flex-1 flex-col gap-5 p-3 sm:p-6">
           <Outlet />
         </main>
       </SidebarInset>

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -92,7 +92,7 @@ export function AccountDetailPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="mx-auto flex max-w-5xl flex-col gap-5">
       <SoftBackButton to="/accounts">Back to accounts</SoftBackButton>
 
       {acctQuery.isLoading ? (

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -120,7 +120,7 @@ export function AccountsPage() {
           : `Showing ${visible.length} of ${totalCount}`;
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
         eyebrow={eyebrow}
         title="Accounts"
@@ -240,6 +240,6 @@ export function AccountsPage() {
           })}
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -2,7 +2,7 @@ import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ArrowLeft, Loader2, Play } from "lucide-react";
+import { Loader2, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -26,6 +26,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useAgent,
@@ -90,11 +91,7 @@ export function AgentEditPage() {
   if (agentQuery.isLoading || !agentQuery.data) {
     return (
       <>
-        <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
-          <Link to="/agents">
-            <ArrowLeft className="size-4" /> Back to agents
-          </Link>
-        </Button>
+        <SoftBackButton to="/agents">Back to agents</SoftBackButton>
         <PageHeader
           eyebrow="Agent"
           title="Edit agent"
@@ -180,11 +177,7 @@ function AgentEditFormView({
 
   return (
     <>
-      <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
-        <Link to="/agents">
-          <ArrowLeft className="size-4" /> Back to agents
-        </Link>
-      </Button>
+      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
       <PageHeader
         eyebrow="Agent"
         title={agent.name}

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import {
   AlertTriangle,
-  ArrowLeft,
   Clock,
   FilterX,
   Loader2,
@@ -30,6 +29,7 @@ import {
 import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
 import { EmptyState } from "@/components/empty-state";
+import { SoftBackButton } from "@/components/soft-back-button";
 import {
   DateRangeFilter,
   type DateRangeValue,
@@ -138,18 +138,14 @@ export function AgentRunsPage() {
 
   return (
     <>
-      <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
-        <Link to="/agents">
-          <ArrowLeft className="size-4" /> Back to agents
-        </Link>
-      </Button>
+      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
       <PageHeader
         eyebrow="Agent runs"
         title={agentQuery.data ? `${agentQuery.data.name} — runs` : "Run history"}
         description="Every fire of this agent (cron or manual). Click any row to view its transcript."
       />
 
-      <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Select
           value={search.status ?? ANY_VALUE}
           onValueChange={(v) =>

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -149,7 +149,7 @@ export function AgentsPage() {
       />
 
       {showOnboardingBanner && status && (
-        <Alert className="mb-4">
+        <Alert>
           <Bot className="size-4" />
           <AlertTitle>Finish setting up the agent subsystem</AlertTitle>
           <AlertDescription className="space-y-2">
@@ -517,7 +517,7 @@ function RecentErrorsBanner() {
   };
 
   return (
-    <Alert variant="destructive" className="mb-4">
+    <Alert variant="destructive">
       <AlertCircle className="size-4" />
       <AlertTitle>
         {rows.length === 1

--- a/web/src/routes/api-key-created.tsx
+++ b/web/src/routes/api-key-created.tsx
@@ -69,7 +69,7 @@ export function APIKeyCreatedPage() {
   };
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto flex max-w-2xl flex-col gap-5">
       <PageHeader
         eyebrow="Key created"
         title={pending.name}
@@ -127,7 +127,7 @@ export function APIKeyCreatedPage() {
         </div>
       </SectionCard>
 
-      <div className="mt-6 flex items-center justify-between gap-2">
+      <div className="flex items-center justify-between gap-2">
         <Button variant="ghost" size="sm" asChild>
           <Link to="/api-keys/new">Mint another</Link>
         </Button>

--- a/web/src/routes/api-key-new.tsx
+++ b/web/src/routes/api-key-new.tsx
@@ -6,7 +6,7 @@ import { APIKeyForm } from "@/features/api-keys/api-key-form";
 
 export function APIKeyNewPage() {
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto flex max-w-2xl flex-col gap-5">
       <SoftBackButton to="/api-keys">Back to API keys</SoftBackButton>
       <PageHeader
         eyebrow="New credential"

--- a/web/src/routes/api-keys.tsx
+++ b/web/src/routes/api-keys.tsx
@@ -105,7 +105,7 @@ export function APIKeysPage() {
   const emptyState = renderEmptyState({ tab, query, newKeyButton });
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
         eyebrow={eyebrow}
         title="API keys"
@@ -148,7 +148,7 @@ export function APIKeysPage() {
           emptyState={emptyState}
         />
       </div>
-    </div>
+    </>
   );
 }
 

--- a/web/src/routes/categories.tsx
+++ b/web/src/routes/categories.tsx
@@ -60,7 +60,7 @@ export function CategoriesPage() {
   })();
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
         eyebrow={eyebrow}
         title="Categories"
@@ -136,6 +136,6 @@ export function CategoriesPage() {
           />
         )}
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -57,7 +57,7 @@ export function CategoryDetailPage() {
   );
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="mx-auto flex max-w-5xl flex-col gap-5">
       <SoftBackButton to="/categories">Back to categories</SoftBackButton>
 
       {isLoading ? (

--- a/web/src/routes/category-new.tsx
+++ b/web/src/routes/category-new.tsx
@@ -6,7 +6,7 @@ import { CategoryForm } from "@/features/categories/category-form";
 
 export function CategoryNewPage() {
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto flex max-w-2xl flex-col gap-5">
       <SoftBackButton to="/categories">Back to categories</SoftBackButton>
       <PageHeader
         eyebrow="New category"

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -208,7 +208,7 @@ export function ConnectionDetailPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="mx-auto flex max-w-5xl flex-col gap-5">
       <SoftBackButton to="/connections">Back to connections</SoftBackButton>
 
       {connQuery.isLoading ? (

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -214,7 +214,7 @@ export function ConnectionsPage() {
           : `Showing ${visible.length} of ${connections.length}`;
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
         eyebrow={eyebrow}
         title="Connections"
@@ -383,6 +383,6 @@ export function ConnectionsPage() {
         }}
         connectionShortId={search.reauth}
       />
-    </div>
+    </>
   );
 }

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -52,7 +52,7 @@ export function HomePage() {
     accountsQuery.isLoading || connectionsQuery.isLoading;
 
   return (
-    <div className="flex flex-col gap-6">
+    <>
       <PageHeader
         eyebrow={lastSyncedAt ? `Synced ${relativeTime(lastSyncedAt)}` : "Overview"}
         title={me ? `Welcome back, ${greetingName(me.username)}` : "Welcome"}
@@ -101,6 +101,6 @@ export function HomePage() {
           />
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/routes/rule-detail.tsx
+++ b/web/src/routes/rule-detail.tsx
@@ -234,7 +234,7 @@ export function RuleDetailPage() {
 
   function RuleHeader({ rule }: { rule: TransactionRule }) {
     return (
-      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
           <RuleAvatar rule={rule} size="lg" />
           <div className="space-y-1">

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -262,7 +262,7 @@ export function RulesPage() {
 
 function CountLine({ count, fetching }: { count: number; fetching: boolean }) {
   return (
-    <div className="text-muted-foreground mb-3 flex items-center gap-2 text-sm">
+    <div className="text-muted-foreground flex items-center gap-2 text-sm">
       <span className="tabular-nums">
         {count.toLocaleString()} rule{count === 1 ? "" : "s"} found
       </span>
@@ -287,7 +287,7 @@ function RulesToolbar({
   onSortChange: (v: string) => void;
 }) {
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       <Input
         type="search"
         value={query}

--- a/web/src/routes/tag-detail.tsx
+++ b/web/src/routes/tag-detail.tsx
@@ -25,7 +25,7 @@ export function TagDetailPage() {
   );
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto flex max-w-2xl flex-col gap-5">
       <SoftBackButton to="/tags">Back to tags</SoftBackButton>
 
       {isLoading ? (

--- a/web/src/routes/tag-new.tsx
+++ b/web/src/routes/tag-new.tsx
@@ -6,7 +6,7 @@ import { TagForm } from "@/features/tags/tag-form";
 
 export function TagNewPage() {
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto flex max-w-2xl flex-col gap-5">
       <SoftBackButton to="/tags">Back to tags</SoftBackButton>
       <PageHeader
         eyebrow="New tag"

--- a/web/src/routes/tags.tsx
+++ b/web/src/routes/tags.tsx
@@ -42,7 +42,7 @@ export function TagsPage() {
   })();
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
         eyebrow={eyebrow}
         title="Tags"
@@ -96,6 +96,6 @@ export function TagsPage() {
           }
         />
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -47,7 +47,7 @@ export function TransactionDetailPage() {
   const notFound = isError && error instanceof ApiError && error.status === 404;
 
   return (
-    <div className="mx-auto max-w-5xl">
+    <div className="mx-auto flex max-w-5xl flex-col gap-5">
       <SoftBackButton to="/transactions">Back to transactions</SoftBackButton>
 
       {isLoading ? (

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -375,7 +375,7 @@ export function TransactionsPage() {
   })();
 
   return (
-    <div className="flex flex-col gap-5">
+    <>
       <PageHeader
         eyebrow={eyebrow}
         title="Transactions"
@@ -513,6 +513,6 @@ export function TransactionsPage() {
       >
         <TagCommandList onPick={handleTagPick} />
       </CommandDialog>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- `/v2/rules` and `/v2/agents` were missing the 20px gap between PageHeader and the content below — they wrapped in a bare `<>` while sibling pages (transactions, accounts, …) wrapped in `<div className="flex flex-col gap-5">`. The parent `<main>` only set padding, so fragment pages collapsed to zero spacing.
- Fix it once and lock it in: `<main>` in `routes/__root.tsx` is now `flex flex-col gap-5`. Every section a page returns becomes a direct flex child and inherits the 20px rhythm — pages can no longer drift by forgetting the wrapper.
- Stripped the now-redundant per-page wrappers (accounts, api-keys, categories, connections, tags, transactions, home). Constrained-width pages (`mx-auto max-w-{2xl,5xl}`) keep their wrapper and add `flex flex-col gap-5` to it so they own the same rhythm internally.
- Dropped `mb-3` from `SoftBackButton` (parent owns the gap), removed stacking `mb-*` from anything that became a direct flex child (rules' CountLine + toolbar, agents' onboarding/errors alerts, RuleHeader, agents-runs filter bar), and swapped the two ad-hoc inline ghost back-buttons on `agents.$slug.{edit,runs}` for `SoftBackButton`.
- Documented the contract in `.claude/rules/v2-frontend.md` and on `PageHeader` / `SoftBackButton` / `__root.tsx` comments so new pages adopt it by default.

Net diff: 25 files, +56/-56 — a balanced normalization pass.

## Screens

`/v2/rules` — desktop · tablet · mobile

<img src="https://i.img402.dev/h47h5sgqhq.jpg" width="900" alt="/v2/rules — after">

`/v2/agents` — desktop · tablet · mobile

<img src="https://i.img402.dev/fv6bdn34pk.jpg" width="900" alt="/v2/agents — after">

## Test plan

- [ ] `make web` (tsc + vite build) passes — verified locally
- [ ] Spot-check `/v2/rules` and `/v2/agents` — header → toolbar/alert → content now reads with the same 20px rhythm as `/v2/transactions`, `/v2/accounts`, `/v2/connections`
- [ ] Spot-check a constrained-width form page (`/v2/api-keys/new`, `/v2/categories/new`, `/v2/tags/new`) — back button → header → section card still spaced correctly
- [ ] Spot-check a detail page (`/v2/transactions/<id>`, `/v2/accounts/<id>`, `/v2/connections/<id>`) — back button → hero/content has consistent gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
