### PR TITLE
fix(v2): stop duplicating comment body in transaction activity timeline

### DIFF
--- a/web/src/features/transactions/activity-timeline.tsx
+++ b/web/src/features/transactions/activity-timeline.tsx
@@ -164,14 +164,20 @@ function TimelineRow({ annotation }: { annotation: Annotation }) {
   // neutral for unmapped kinds.
   const tone: TimelineRailTone = deleted ? "neutral" : (KIND_TONE[annotation.kind] ?? "neutral");
 
+  // For live comment rows the bubble below carries the full body, so the
+  // header line collapses to "<actor> commented" — otherwise the
+  // server-built `summary` ("Alice commented: hello world") would duplicate
+  // the bubble text. Mirrors v1's TimelineCommentRow shape.
+  const headerLine = showBody
+    ? `${annotation.actor_name} commented`
+    : deleted
+      ? `${annotation.actor_name} deleted a comment`
+      : (annotation.summary ??
+        `${annotation.actor_name} ${annotation.action ?? annotation.kind}`);
+
   return (
     <TimelineRail.Row icon={Icon} tone={tone} muted={deleted ? true : false}>
-      <p className="text-sm leading-snug">
-        {deleted
-          ? `${annotation.actor_name} deleted a comment`
-          : (annotation.summary ??
-            `${annotation.actor_name} ${annotation.action ?? annotation.kind}`)}
-      </p>
+      <p className="text-sm leading-snug">{headerLine}</p>
       {showBody && (
         <p className="text-muted-foreground bg-muted/50 mt-1.5 rounded-md px-2.5 py-1.5 text-sm whitespace-pre-wrap">
           {annotation.content}


### PR DESCRIPTION
## Summary

On `/v2/transactions/{id}`, the activity timeline rendered each comment's text **twice**:

- the header line came from the server-built `summary` field, which already inlines a one-line preview (`"Alice commented: hello world"`)
- the bubble underneath rendered the full `content` (`"hello world"`)

For short comments (the common case — no truncation), both lines said the same thing.

Fix: when we're going to render the bubble (`showBody`), collapse the header line to `"<actor> commented"` instead. Matches v1's `TimelineCommentRow` shape (`internal/templates/components/timeline.templ:269-297`).

The server's `summary` field is left untouched — MCP and any other single-line consumer still get the preview-included version. Only the v2 React row composes its own short header.

Deleted-comment tombstones and non-comment rows are unchanged.

## Test plan

- [x] `bun run lint` clean (`tsc -b --noEmit`)
- [ ] Open `/v2/transactions/{id}` for a transaction with a comment — header reads "<actor> commented", bubble shows the body once
- [ ] Add a multiline comment, confirm bubble preserves linebreaks and header is still single-line
- [ ] Delete a comment, confirm tombstone still reads "<actor> deleted a comment" (no bubble)
- [ ] Non-comment rows (rule_applied, tag_added, category_set, sync_*) unchanged

> Screenshot not attached: this worktree couldn't acquire Chrome DevTools MCP (in use by another parallel session), and Playwright fallback isn't configured locally. The change is purely the rendered header text for the comment branch — the diff is 12 LOC and behavior matches the v1 templ timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)