### PR TITLE
fix(v2): make Shift+? toggle the keyboard shortcut sheet

### DIFF
--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -25,6 +25,9 @@ export function ShortcutSheet() {
   useShortcut(["shift", "?"], () => setOpen((v) => !v), {
     label: "Show keyboard shortcuts",
     group: "Global",
+    // `global: true` so the same chord can close the sheet — without it, focus
+    // inside the open Radix dialog trips the input/dialog guard in useShortcut.
+    global: true,
   });
 
   // Command palette (and any other surface) can ask us to open without


### PR DESCRIPTION
## Summary

`Shift+?` opens the keyboard shortcut sheet but a second press did nothing — you had to hit `esc` or click outside to close it.

The handler in `ShortcutSheet` already called `setOpen((v) => !v)`, so it should have toggled. The actual blocker was in `useShortcut`: once the sheet is open, focus moves inside the Radix dialog, and the input/dialog guard short-circuits the keydown before reaching the handler.

Fix: mark the shortcut `global: true`. The chord is modifier-guarded (Shift), which is the exact condition the option's doc-comment calls out as safe — same shape as `⌘K`.

The footer already advertises "Toggle this sheet" with the `⇧ ?` pills, so this just makes the UI match what it claims.

## Test plan

- [ ] On any v2 page, press `Shift+?` → sheet opens
- [ ] Press `Shift+?` again → sheet closes
- [ ] `esc` still closes
- [ ] Clicking outside still closes
- [ ] Open the cmdk palette → trigger "Show keyboard shortcuts" → sheet still opens (external open event path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)