### PR TITLE
design(v2): redesign error surfaces — ErrorPage hero + PageError card

### DIFF
--- a/web/src/components/page-error.tsx
+++ b/web/src/components/page-error.tsx
@@ -1,6 +1,5 @@
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { StatusPanel } from "@/components/status-panel";
 import { cn } from "@/lib/utils";
 
 export type PageErrorVariant = "panel" | "inline";
@@ -16,40 +15,30 @@ interface PageErrorProps {
   retrying?: boolean;
   /**
    * Visual shell.
-   * - `panel` (default): bordered StatusPanel with the destructive rail.
-   *   Use for top-level page errors that own the whole route body.
+   * - `panel` (default): centred card with a destructive icon tile, heading,
+   *   body, and a retry CTA beneath. Use for top-level page errors that
+   *   own the whole route body.
    * - `inline`: chrome-less variant for nesting inside an existing bordered
-   *   host (a SectionCard body, a ListCard slot). Keeps the destructive icon
-   *   tile + heading + body + retry vocabulary, but drops the panel border +
-   *   rail so two nested borders don't read heavy.
+   *   host (a SectionCard body, a ListCard slot). Keeps the destructive tile
+   *   + heading + body + retry vocabulary, but drops the panel border so two
+   *   nested borders don't read heavy.
    */
   variant?: PageErrorVariant;
   className?: string;
 }
 
 // PageError renders the canonical page-level "this page couldn't fetch its
-// data" state — destructive-toned StatusPanel with an AlertTriangle icon, a
-// concrete heading, the error message (or a fallback), and an optional
-// inline Retry button.
+// data" state — destructive-toned card with an AlertTriangle icon, a concrete
+// heading, the error message (or a fallback), and an optional Retry button.
 //
-// Until iter 82 every page hand-rolled its own `<Alert variant="destructive">
-// + AlertTitle + AlertDescription` for this state. Six pages now route
-// through this primitive: accounts, connections, providers, rules, rule-form,
-// rule-detail. Don't fork — extend this primitive if a seventh consumer
-// needs a new variant.
+// The `panel` variant is shaped like an empty-state hero (centred,
+// generous padding, dashed border) but destructive-toned — a clear signal
+// that the surface is in a failure state, not just empty. The `inline`
+// variant strips the border so it can sit inside an already-bordered host
+// without doubling up chrome.
 //
-// The `panel` variant reuses the StatusPanel vocabulary (3px tone-tinted left
-// rail + tinted icon tile + heading + body + trailing slot) so destructive
-// page errors speak the same language as warnings, success notices, and
-// env-locked states (see iter 16). The retry button lands in StatusPanel's
-// `trailing` slot so it sits on the right edge, aligned with the icon row.
-//
-// The `inline` variant (iter 88) drops the panel chrome — same icon tile +
-// heading + body + retry, but no border / rail / muted background. Used by
-// the activity-timeline inside a SectionCard, where nesting a second
-// bordered destructive panel inside the section's bordered card read heavy.
-// Two nested borders → one tile + text block aligned with the rest of the
-// section body.
+// Sibling of `<EmptyState>` (no-data) and `<DetailPageSkeleton>` (loading).
+// Don't fork — extend this primitive.
 export function PageError({
   resource,
   error,
@@ -82,13 +71,8 @@ export function PageError({
 
   if (variant === "inline") {
     return (
-      <div
-        className={cn(
-          "flex items-start gap-3",
-          className,
-        )}
-      >
-        <span className="bg-destructive/10 text-destructive flex size-8 shrink-0 items-center justify-center rounded-md">
+      <div className={cn("flex items-start gap-3", className)}>
+        <span className="bg-destructive/10 text-destructive flex size-9 shrink-0 items-center justify-center rounded-xl">
           <AlertTriangle className="size-4" />
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -107,13 +91,21 @@ export function PageError({
   }
 
   return (
-    <StatusPanel
-      tone="destructive"
-      icon={AlertTriangle}
-      heading={`Couldn't load ${resource}`}
-      body={message}
-      trailing={retryButton ?? undefined}
-      className={className}
-    />
+    <div
+      className={cn(
+        "border-destructive/25 bg-destructive/[0.02] flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-6 py-10 text-center",
+        className,
+      )}
+      role="alert"
+    >
+      <div className="bg-destructive/10 text-destructive mb-2 flex size-11 items-center justify-center rounded-xl">
+        <AlertTriangle className="size-5" />
+      </div>
+      <h3 className="text-foreground text-sm font-medium">
+        {`Couldn't load ${resource}`}
+      </h3>
+      <p className="text-muted-foreground max-w-sm text-sm">{message}</p>
+      {retryButton && <div className="mt-3">{retryButton}</div>}
+    </div>
   );
 }

--- a/web/src/routes/error.tsx
+++ b/web/src/routes/error.tsx
@@ -1,19 +1,19 @@
-import { useState } from "react";
 import {
   AlertTriangle,
   ArrowRight,
   ChevronDown,
-  ChevronRight,
+  Home,
   RotateCw,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { ActionPill } from "@/components/action-pill";
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/page-header";
-import { SectionCard } from "@/components/section-card";
-import { StatusPanel } from "@/components/status-panel";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Eyebrow } from "@/components/eyebrow";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
-import { cn } from "@/lib/utils";
 
 interface ErrorPageProps {
   /** The error thrown during render — typed loosely to match TanStack
@@ -50,28 +50,67 @@ function readError(err: unknown): { message: string; stack?: string } {
 // and command palette stay live, so the user has a way out without a hard
 // reload.
 //
-// Visual contract (matches NotFoundPage / Placeholder):
-//   <PageHeader eyebrow="500 · ERROR" title="Something went wrong" />
-//   <StatusPanel tone="destructive" />  ← human-readable message
-//   <SectionCard title="Technical details">
-//     collapsible details payload with the raw stack trace (dev affordance)
-//   </SectionCard>
-//
-// Reset wiring: the router passes a `reset` callback that re-renders the
-// failing route. We expose it as "Try again" alongside a "Reload" fallback
-// (full-page) and a Home link.
+// Single-card hero (not PageHeader + StatusPanel + SectionCard): the
+// previous layout repeated the same destructive message in three stacked
+// containers. Now the error message itself IS the heading; the surrounding
+// "Something went wrong" framing lives as a small eyebrow above it. The
+// recovery actions cluster directly under the message, and the raw stack
+// trace lives behind a collapsible disclosure so debugging context is one
+// click away without dominating the surface for end users.
 export function ErrorPage({ error, reset }: ErrorPageProps) {
-  const [showDetails, setShowDetails] = useState(false);
   const { message, stack } = readError(error);
 
   return (
-    <>
-      <PageHeader
-        eyebrow="500 · ERROR"
-        title="Something went wrong"
-        description="The page hit an unexpected error while rendering. The shell is still healthy — try again, or jump to another page."
-        actions={
-          <>
+    <div className="mx-auto w-full max-w-2xl">
+      <div
+        className="border-destructive/30 bg-card relative overflow-hidden rounded-xl border shadow-sm"
+        role="alert"
+      >
+        {/* Destructive accent stripe along the top. Same tone vocabulary as
+            <StatusPanel destructive> but a top-rail instead of a left-rail
+            so the card reads as the page hero, not an inline notice. */}
+        <div className="bg-destructive/80 absolute top-0 right-0 left-0 h-[3px]" />
+
+        <div className="flex flex-col items-center gap-4 px-6 pt-10 pb-8 text-center sm:px-10">
+          <div className="bg-destructive/10 text-destructive ring-destructive/20 flex size-14 items-center justify-center rounded-2xl ring-1">
+            <AlertTriangle className="size-7" />
+          </div>
+
+          <Eyebrow as="p" variant="page" className="text-destructive/80">
+            500 · Server error
+          </Eyebrow>
+
+          <h1 className="text-foreground text-2xl font-semibold tracking-tight">
+            Something went wrong
+          </h1>
+
+          <p className="text-muted-foreground max-w-md text-sm leading-relaxed">
+            The page hit an unexpected error while rendering. The shell is
+            still healthy — try again, or jump to another page.
+          </p>
+
+          {/* The raw error message in monospace so it stands apart from the
+              copy. Selectable + wraps long messages cleanly. */}
+          <code className="bg-muted/60 text-foreground border-border/60 mt-1 max-w-full overflow-x-auto rounded-md border px-3 py-2 text-left font-mono text-xs leading-relaxed break-words whitespace-pre-wrap">
+            {message}
+          </code>
+
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+            {reset ? (
+              <Button size="sm" onClick={reset} className="gap-1.5">
+                <RotateCw className="size-3.5" />
+                Try again
+              </Button>
+            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.location.reload()}
+              className="gap-1.5"
+            >
+              <RotateCw className="size-3.5" />
+              Reload page
+            </Button>
             <Button
               variant="outline"
               size="sm"
@@ -84,76 +123,41 @@ export function ErrorPage({ error, reset }: ErrorPageProps) {
                 <Kbd>K</Kbd>
               </KbdGroup>
             </Button>
-            {reset ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={reset}
-                className="gap-1.5"
-              >
-                <RotateCw className="size-3.5" />
-                Try again
-              </Button>
-            ) : null}
-            <Button asChild size="sm">
+            <Button asChild variant="outline" size="sm" className="gap-1.5">
               <Link to="/">
-                Back to Home
-                <ArrowRight className="size-4" />
+                <Home className="size-3.5" />
+                Home
+                <ArrowRight className="size-3.5" />
               </Link>
             </Button>
-          </>
-        }
-      />
-
-      <div className="flex flex-col gap-4">
-        <StatusPanel
-          tone="destructive"
-          icon={AlertTriangle}
-          heading={message}
-          body="If this keeps happening, reload the page or check the browser console for more context."
-          trailing={
-            <ActionPill onClick={() => window.location.reload()}>
-              <RotateCw className="size-3.5" />
-              Reload
-            </ActionPill>
-          }
-        />
+          </div>
+        </div>
 
         {stack ? (
-          <SectionCard
-            title="Technical details"
-            icon={
-              <AlertTriangle className="text-muted-foreground size-4" />
-            }
-            action={
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setShowDetails((v) => !v)}
-                className="h-7 gap-1 px-2 text-xs"
-              >
-                {showDetails ? (
-                  <ChevronDown className="size-3.5" />
-                ) : (
-                  <ChevronRight className="size-3.5" />
-                )}
-                {showDetails ? "Hide" : "Show"}
-              </Button>
-            }
-          >
-            <div
-              className={cn(
-                "overflow-hidden transition-all duration-200 ease-out",
-                showDetails ? "max-h-[480px]" : "max-h-0",
-              )}
-            >
-              <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed">
-                {stack}
-              </pre>
+          <Collapsible>
+            <div className="border-t">
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="group hover:bg-muted/30 flex w-full items-center justify-between gap-2 px-6 py-3 text-left transition-colors sm:px-10"
+                >
+                  <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                    Technical details
+                  </span>
+                  <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[state=open]:rotate-180" />
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="px-6 pb-6 sm:px-10">
+                  <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed">
+                    {stack}
+                  </pre>
+                </div>
+              </CollapsibleContent>
             </div>
-          </SectionCard>
+          </Collapsible>
         ) : null}
       </div>
-    </>
+    </div>
   );
 }

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -83,6 +83,7 @@ import {
 import { MetaBadge } from "@/components/meta-badge";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { PageError } from "@/components/page-error";
+import { ErrorPage } from "@/routes/error";
 import { DetailPageSkeleton } from "@/components/detail-page-skeleton";
 import { DetailSheetHeader } from "@/components/detail-sheet-header";
 import { DetailDialogHeader } from "@/components/detail-dialog-header";
@@ -1163,7 +1164,7 @@ export function ComponentsSection() {
       <Specimen
         label="PageError"
         code="components/page-error"
-        description="The canonical page-level 'this page couldn't fetch its data' state. Two variants. `panel` (default) composes `<StatusPanel tone='destructive'>` — AlertTriangle icon, `Couldn't load {resource}` heading, the error's `message` (or a fallback) as body, and an outline `RefreshCw` Retry button in the trailing slot that swaps to a spinning icon + `Retrying…` label while in-flight. `inline` (iter 88) drops the bordered StatusPanel chrome so the same icon tile + heading + body + retry sits flush inside an already-bordered host (a SectionCard body, a ListCard slot) — used by the transaction-detail activity-timeline. Sibling of `<EmptyState>` (no-data) and `<DetailPageSkeleton>` (loading) — three states, three vocabularies, one visual system. Seven surfaces share it today: accounts, connections, providers, rules, rule-form, rule-detail, activity-timeline (inline). Don't fork — extend this primitive."
+        description="The canonical page-level 'this page couldn't fetch its data' state. Two variants. `panel` (default) is a centred destructive-toned hero card — dashed `destructive/25` border, `bg-destructive/[0.02]` wash, `size-11` destructive icon tile, `Couldn't load {resource}` heading, the error's `message` (or a fallback) as body, and a `RefreshCw` Retry button beneath that swaps to a spinning icon + `Retrying…` label while in-flight. Shaped like `<EmptyState variant='card'>` but tone-tinted destructive so the surface reads as a failure state, not just an empty one. `inline` drops the panel chrome so the same icon tile + heading + body + retry sits flush inside an already-bordered host (a SectionCard body, a ListCard slot) — used by the transaction-detail activity-timeline. Sibling of `<EmptyState>` (no-data) and `<DetailPageSkeleton>` (loading) — three states, three vocabularies, one visual system. Don't fork — extend this primitive."
         className="block"
       >
         <div className="space-y-6">
@@ -1212,6 +1213,24 @@ export function ComponentsSection() {
             </div>
           </div>
         </div>
+      </Specimen>
+
+      <Specimen
+        label="ErrorPage"
+        code="routes/error"
+        description="The route-level error-boundary surface — wired into `createRouter({ defaultErrorComponent })`, so it renders in place of `<Outlet/>` whenever a route throws during render. Single hero card (not PageHeader + StatusPanel + SectionCard) with a top destructive accent stripe, a `size-14` destructive icon tile, `500 · Server error` eyebrow, `Something went wrong` H1, framing copy, the raw error message in a monospace `<code>` block, and a wrap-friendly action cluster: Try again (primary, when the router passes `reset`), Reload page, Jump to (⌘K), Home. The stack trace lives behind a `<Collapsible>` 'Technical details' disclosure at the foot of the card so it stays one click away without dominating the surface for end users. The sidebar, topbar, and command palette stay live behind it so the user always has a way out without a hard reload."
+        className="block"
+      >
+        <ErrorPage
+          error={
+            new Error(
+              "Failed to fetch /api/v1/transactions: Network request failed (ECONNRESET).",
+            )
+          }
+          reset={() => {
+            /* sandbox no-op */
+          }}
+        />
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
## Summary

Redesigns the two v2 error surfaces — the route-level **`ErrorPage`** ("Something went wrong" boundary) and the section-level **`PageError`** ("Couldn't load X" data fetch error). Both inherited their sizing from `<StatusPanel>`, which is built for inline notices — when the entire content body is a failure state, that vocabulary undersold the moment.

The route-level `ErrorPage` also stacked `PageHeader + StatusPanel + SectionCard`, each restating "this is an error" — the redundancy you flagged.

### What changed

- **`ErrorPage`** is now a single hero card with a destructive top accent stripe, a `size-14` ringed icon tile, eyebrow + H1 + framing copy, the raw error in a monospace `<code>` block, and a wrap-friendly action cluster (Try again primary · Reload · Jump to ⌘K · Home). Stack trace lives in a `<Collapsible>` "Technical details" disclosure at the foot — debugging context is one click away without dominating the surface for end users.
- **`PageError` `panel`** becomes a destructive-toned hero card (dashed border, subtle `bg-destructive/[0.02]` wash, centred icon tile + heading + body + retry below) shaped like `<EmptyState variant='card'>` so the three load-state vocabularies (error / empty / loading) read as siblings at the same visual scale.
- **`PageError` `inline`** keeps the compact left-aligned shape but adopts the `rounded-xl` icon tile so it harmonises with `EmptyState` / the new panel.
- **Sandbox** gains an `ErrorPage` specimen and a refreshed `PageError` description so `/v2/sandbox#components` stays in sync.

### No redundant components

- No new primitives. Reuses `<Button>`, `<Collapsible>`, `<Eyebrow>`, `<Kbd>` — already in the system.
- API stable: the 7+ `PageError` consumers (accounts, connections, providers, rules, rule-form, rule-detail, activity-timeline) keep their existing props (`resource`, `error`, `onRetry`, `retrying`, `variant`) — only the visual shape changes.
- The old `ErrorPage` reached for `StatusPanel` *and* `SectionCard` *and* `PageHeader` to assemble what is now one focused card. Net: three composed components down to zero (just a `<div>` with the right tokens).

## Evidence

### `PageError` — before vs after (light + dark)

<img src="https://i.img402.dev/xtfzlwf3b2.jpg" width="900" alt="PageError before vs after, light and dark">

### `ErrorPage` — redesigned (light + dark)

The route-level error boundary wasn't previously in the sandbox so there's no before-screenshot, but the diff against `routes/error.tsx` shows the collapse from `PageHeader + StatusPanel + SectionCard` down to a single bordered card.

<img src="https://i.img402.dev/zyxwl0149t.jpg" width="900" alt="ErrorPage redesigned, light and dark">

<details>
<summary>Individual screenshots</summary>

| Light | Dark |
| --- | --- |
| <img src="https://i.img402.dev/6jgza5igjy.jpg" width="420" alt="ErrorPage light"> | <img src="https://i.img402.dev/wrcka6jc7u.jpg" width="420" alt="ErrorPage dark"> |
| <img src="https://i.img402.dev/oyohtzoumr.jpg" width="420" alt="PageError light"> | <img src="https://i.img402.dev/hh5cb3e85h.jpg" width="420" alt="PageError dark"> |

</details>

## Test plan

- [x] `bun run lint` (tsc -b --noEmit) clean
- [x] `bun run build` clean
- [x] Visual: rendered both error surfaces in `/v2/sandbox` under Components, light + dark, via Playwright
- [ ] Manual: trigger a real route error (e.g. throw in any `routes/*.tsx` loader) and confirm the boundary still mounts inside the authenticated shell with sidebar / topbar / ⌘K live
- [ ] Manual: visit a page that 5xx's (kill the backend mid-session) and confirm the `PageError` panel + retry handler still work on `rules`, `accounts`, `connections`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
