### PR TITLE
v2 polish sprint: roll up #1277-#1294 (CategoryPicker, sandbox, tx-row, DataTable)

### DIFF
--- a/web/src/components/category-badge.tsx
+++ b/web/src/components/category-badge.tsx
@@ -16,8 +16,18 @@ interface CategoryBadgeProps {
   className?: string;
 }
 
-// Per-size token recipe. Kept inline so the size axis is grep-able alongside
-// TagChip's matching recipe — if one shifts the other should too.
+// Shape tokens — the geometry shared by CategoryBadge, the CategoryPicker
+// empty-state pill, and the picker's pencil overlay. Exported so any
+// caller building a badge-shaped surface can match without re-deriving.
+// Kept in lockstep with TagChip's matching recipe.
+export const CATEGORY_BADGE_SHAPE: Record<"sm" | "md", string> = {
+  sm: "h-5 px-1.5 text-[11px] gap-0.5",
+  md: "h-6 px-2 text-xs gap-1",
+};
+export const CATEGORY_BADGE_ICON: Record<"sm" | "md", string> = {
+  sm: "size-2.5",
+  md: "size-3",
+};
 const SIZE: Record<"sm" | "md", string> = {
   sm: "h-5 px-1.5 text-[11px] gap-0.5 [&>svg]:size-2.5",
   md: "h-6 px-2 text-xs gap-1 [&>svg]:size-3",

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -1,11 +1,15 @@
 import { useState } from "react";
-import { Plus } from "lucide-react";
+import { Pencil, Plus } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { CategoryBadge } from "@/components/category-badge";
+import {
+  CATEGORY_BADGE_ICON,
+  CATEGORY_BADGE_SHAPE,
+  CategoryBadge,
+} from "@/components/category-badge";
 import {
   CategoryCommandList,
   useCategoryEditor,
@@ -19,6 +23,18 @@ interface CategoryPickerProps {
   category: TransactionCategory | null | undefined;
   /** True when the current category was set by a manual override. */
   overridden?: boolean;
+  /**
+   * Badge density. Defaults to `md` (h-6) — the picker only renders inside
+   * the transactions row's category column which is `hidden sm:table-cell`,
+   * so there's room for the comfier size. Pass `sm` for tighter rails.
+   */
+  size?: "sm" | "md";
+  /**
+   * Override the default behaviour (single-tx update mutation + toast).
+   * Used by the sandbox specimen and any future caller that wants to
+   * own the pick handler (bulk flows, dry-run previews, etc.).
+   */
+  onPick?: (pick: CategoryPick) => void | Promise<void>;
   className?: string;
 }
 
@@ -30,6 +46,8 @@ export function CategoryPicker({
   transactionId,
   category,
   overridden,
+  size = "md",
+  onPick: onPickOverride,
   className,
 }: CategoryPickerProps) {
   const [open, setOpen] = useState(false);
@@ -37,8 +55,14 @@ export function CategoryPicker({
 
   const onPick = async (pick: CategoryPick) => {
     setOpen(false);
-    await apply(pick);
+    await (onPickOverride ?? apply)(pick);
   };
+
+  const iconClass = CATEGORY_BADGE_ICON[size];
+  // Width tuned to end at the badge's text edge — wider eats into the
+  // label, narrower leaves the icon's right-side stroke peeking through.
+  const maskClass = size === "sm" ? "h-3 w-3.5" : "h-4 w-5";
+  const hasIcon = !!category?.icon;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -48,7 +72,9 @@ export function CategoryPicker({
           disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
+            "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
+            // Empty-state pill carries its own dashed border — no double-stroke.
+            category?.display_name && "hover:ring-1 hover:ring-border",
             className,
           )}
         >
@@ -56,15 +82,28 @@ export function CategoryPicker({
             <CategoryBadge
               category={category}
               overridden={overridden}
-              size="sm"
+              size={size}
             />
           ) : (
-            // Empty-state pill mirrors the sm CategoryBadge geometry (h-5,
-            // text-[11px], rounded-md) so the column doesn't shift when the
-            // user assigns or clears a category from the row.
-            <span className="text-muted-foreground border-border hover:text-foreground inline-flex h-5 items-center gap-0.5 rounded-md border border-dashed px-1.5 text-[11px]">
-              <Plus className="size-2.5" />
+            <span
+              className={cn(
+                "text-muted-foreground border-border inline-flex items-center rounded-md border border-dashed group-hover/picker:text-foreground group-hover/picker:border-foreground/40",
+                CATEGORY_BADGE_SHAPE[size],
+              )}
+            >
+              <Plus className={iconClass} />
               Category
+            </span>
+          )}
+          {hasIcon && (
+            <span
+              aria-hidden
+              className={cn(
+                "bg-secondary pointer-events-none absolute top-1/2 left-1 flex -translate-y-1/2 items-center justify-center rounded-[2px] opacity-0 transition-opacity group-hover/picker:opacity-100 group-focus-visible/picker:opacity-100",
+                maskClass,
+              )}
+            >
+              <Pencil className={cn("text-muted-foreground", iconClass)} />
             </span>
           )}
         </button>

--- a/web/src/components/color-rail-card.tsx
+++ b/web/src/components/color-rail-card.tsx
@@ -4,10 +4,12 @@ import { cn } from "@/lib/utils";
 
 interface ColorRailCardProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * CSS color value for the 4px left rail. Pass a CSS variable
-   * (`"var(--destructive)"`) or a literal (`"#f97316"`). When omitted
-   * the rail collapses to `--muted` so the card still reads as a hero,
-   * but the colour stops carrying meaning.
+   * @deprecated The 4px coloured left rail was retired during the
+   * design-system polish pass — the eyebrow + icon tile carry enough of
+   * the meaning the rail used to encode, and a flat-edge hero card sits
+   * more quietly next to surrounding sections. Prop is kept as a no-op
+   * so callers don't have to be touched in the same change; clean up in
+   * a follow-up.
    */
   accent?: string | null;
   /** Optional class applied to the bordered card wrapper. */
@@ -24,28 +26,20 @@ interface ColorRailCardProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 // ColorRailCard is the canonical "detail-page hero card" container — a
-// bordered card with a 4px coloured left rail that encodes meaning
-// (category color for transactions, accounting role for accounts,
-// category's own color on the category-detail page). Sibling of
-// `<SectionCard>` and `<ListCard>`; this is the third primitive in the
-// v2 design vocabulary established by iter 5 (TX-detail hero) and iter 6
-// (Account-detail hero, where the iter-5/6 drift note explicitly called
-// for extraction once a third surface adopts it).
+// bordered card that frames the hero content on transaction, account,
+// category, and connection detail pages plus the home stats and provider
+// tiles. The original implementation carried a 4px coloured left rail
+// (category color, accounting role, …) which was retired during a
+// design-system polish pass; the eyebrow + icon tile already carry the
+// meaning. Name kept because consumers reference it across the codebase
+// — rename in a follow-up if the rail-less treatment sticks.
 //
 // Visual contract:
-//   `bg-card relative overflow-hidden rounded-xl border`
-//     `<div aria-hidden className="absolute inset-y-0 left-0 w-1" />`  ← rail
+//   `bg-card overflow-hidden rounded-xl border`
 //     children
 //     optional `<div className="border-t bg-muted/20 ...">footer</div>`
-//
-// The colour-rail principle: the rail's tint encodes *meaning* (asset vs
-// liability, this transaction's category, this category's own colour),
-// not decoration. Excluded / muted states collapse to `--muted` so the
-// card reads "shelved" rather than "demands attention". Always pair the
-// rail with a small uppercase eyebrow so colour alone never carries the
-// signal.
 export function ColorRailCard({
-  accent,
+  accent: _accent,
   cardClassName,
   className,
   footer,
@@ -56,17 +50,12 @@ export function ColorRailCard({
   return (
     <div
       className={cn(
-        "bg-card relative overflow-hidden rounded-xl border",
+        "bg-card overflow-hidden rounded-xl border",
         cardClassName,
         className,
       )}
       {...rest}
     >
-      <div
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-1"
-        style={{ backgroundColor: accent ?? "var(--muted)" }}
-      />
       {children}
       {footer && (
         <div
@@ -105,14 +94,14 @@ export interface ColorRailCardSkeletonProps {
 }
 
 // ColorRailCardSkeleton mirrors the `<ColorRailCard>` wrapper for loading
-// states — the same `bg-card rounded-xl border` shell + 4px muted left
-// rail. The identity column on the left is a stable shape across every
-// detail-page hero (size-12 tile, eyebrow line, title line, meta line) so
-// it lives inside the primitive; the trailing column carries the
-// per-entity metric (amount / balance / count) and is a smaller shared
-// shape. Don't fork the look — consumers can hang an additional `body`
-// row off the bottom (e.g. TX-detail's secondary details grid) or opt in
-// to a `withFooter` strip when the loaded hero has a footer action bar.
+// states — the same `bg-card rounded-xl border` shell. The identity
+// column on the left is a stable shape across every detail-page hero
+// (size-12 tile, eyebrow line, title line, meta line) so it lives inside
+// the primitive; the trailing column carries the per-entity metric
+// (amount / balance / count) and is a smaller shared shape. Don't fork
+// the look — consumers can hang an additional `body` row off the bottom
+// (e.g. TX-detail's secondary details grid) or opt in to a `withFooter`
+// strip when the loaded hero has a footer action bar.
 export function ColorRailCardSkeleton({
   tileShape = "rounded-md",
   withFooter = false,
@@ -122,14 +111,10 @@ export function ColorRailCardSkeleton({
   return (
     <div
       className={cn(
-        "bg-card relative overflow-hidden rounded-xl border",
+        "bg-card overflow-hidden rounded-xl border",
         className,
       )}
     >
-      <div
-        aria-hidden
-        className="bg-muted absolute inset-y-0 left-0 w-1"
-      />
       <div className="grid gap-5 px-5 py-5 sm:gap-6 sm:px-7 sm:py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
         {/* Identity column */}
         <div className="flex items-start gap-3 sm:gap-4">

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -22,6 +22,7 @@ import {
   CommandShortcut,
 } from "@/components/ui/command";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { cn } from "@/lib/utils";
 import { NAV, NAV_LEAVES, navKey, type NavLeaf } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
@@ -110,7 +111,15 @@ function ItemRow({
       {hint ? <CommandShortcut>{hint}</CommandShortcut> : null}
       {trailingChevron ? (
         <ChevronRight
-          className="text-muted-foreground/0 group-data-[selected=true]:text-muted-foreground/70 ml-auto size-3.5 transition-colors"
+          // When a hint is present it already owns `ml-auto` (via
+          // `CommandShortcut`) and pushes itself right; two `ml-auto`
+          // siblings would split the free space and park the hint mid-row.
+          // Drop our own `ml-auto` in that case so the chevron sits flush
+          // against the hint.
+          className={cn(
+            "text-muted-foreground/0 group-data-[selected=true]:text-muted-foreground/70 size-3.5 transition-colors",
+            hint ? "ml-2" : "ml-auto",
+          )}
           aria-hidden
         />
       ) : null}

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -191,15 +191,18 @@ export function DataTable<TData, TValue>({
               // the card's `rounded-lg` at rest, AND so the bottom
               // separator stays visible while stickied (`<tr>` border-b
               // is unreliable in default table-collapse mode).
-              // `shadow-[inset_0_-1px_0_0_var(--border)]` on each cell
-              // gives an always-visible bottom separator that survives
-              // border-collapse merging with the body row below it.
-              "sticky top-14 z-10 [&>tr>th]:bg-muted/40 supports-[backdrop-filter]:[&>tr>th]:bg-muted/30 [&>tr>th]:backdrop-blur-sm [&>tr>th]:shadow-[inset_0_-1px_0_0_var(--border)] [&>tr>th]:transition-[border-radius]",
+              "sticky top-14 z-10 [&>tr>th]:bg-muted/40 supports-[backdrop-filter]:[&>tr>th]:bg-muted/30 [&>tr>th]:backdrop-blur-sm [&>tr>th]:transition-[border-radius]",
             // Flat top corners while stuck — the card has scrolled past
             // so rounded ears would just clip into the shell-header bg.
             stickyHeader &&
               !isStuck &&
               "[&>tr>th:first-child]:rounded-tl-lg [&>tr>th:last-child]:rounded-tr-lg",
+            // Add an explicit bottom separator only while stuck — at
+            // rest the inherited `<tr>` border-b renders fine, and
+            // doubling it produced a visibly heavier line.
+            stickyHeader &&
+              isStuck &&
+              "[&>tr>th]:shadow-[inset_0_-1px_0_0_var(--border)]",
           )}
         >
           {table.getHeaderGroups().map((headerGroup) => (

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   flexRender,
   getCoreRowModel,
@@ -115,6 +115,34 @@ export function DataTable<TData, TValue>({
     focusedRowRef.current?.scrollIntoView({ block: "nearest" });
   }, [focusedRowId]);
 
+  // Detect the sticky header's "stuck" state so the rounded top corners
+  // (which match the card while at rest) flatten once the band is
+  // floating under the app shell header — at that point the card has
+  // scrolled past and the rounded ears would just clip the band into
+  // the bg of the shell behind it.
+  const headerRef = useRef<HTMLTableSectionElement>(null);
+  const [isStuck, setIsStuck] = useState(false);
+  useEffect(() => {
+    if (!stickyHeader) return;
+    const el = headerRef.current;
+    if (!el) return;
+    // Sentinel sits one px above the header. When it scrolls out of view
+    // (past the app shell's 56px top), the header is stuck.
+    const sentinel = document.createElement("div");
+    sentinel.style.height = "1px";
+    sentinel.setAttribute("aria-hidden", "true");
+    el.parentElement?.insertBefore(sentinel, el);
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(!entry.isIntersecting),
+      { rootMargin: "-56px 0px 0px 0px", threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => {
+      observer.disconnect();
+      sentinel.remove();
+    };
+  }, [stickyHeader]);
+
   const table = useReactTable({
     data,
     columns,
@@ -151,13 +179,27 @@ export function DataTable<TData, TValue>({
     >
       <Table containerClassName={stickyHeader ? "overflow-visible" : undefined}>
         <TableHeader
+          ref={headerRef}
           className={cn(
             stickyHeader &&
               // top-14 sits the band flush under the app shell's sticky
               // header (`h-14` in `__root.tsx`) so the column labels stay
               // visible without being obscured. z-10 keeps the band above
               // the table body but well below the app header (z-30).
-              "bg-muted/40 supports-[backdrop-filter]:bg-muted/30 sticky top-14 z-10 backdrop-blur-sm",
+              // Background + border are on the cells (not `<thead>`) so
+              // we can round the first/last cell's top corner to match
+              // the card's `rounded-lg` at rest, AND so the bottom
+              // separator stays visible while stickied (`<tr>` border-b
+              // is unreliable in default table-collapse mode).
+              // `shadow-[inset_0_-1px_0_0_var(--border)]` on each cell
+              // gives an always-visible bottom separator that survives
+              // border-collapse merging with the body row below it.
+              "sticky top-14 z-10 [&>tr>th]:bg-muted/40 supports-[backdrop-filter]:[&>tr>th]:bg-muted/30 [&>tr>th]:backdrop-blur-sm [&>tr>th]:shadow-[inset_0_-1px_0_0_var(--border)] [&>tr>th]:transition-[border-radius]",
+            // Flat top corners while stuck — the card has scrolled past
+            // so rounded ears would just clip into the shell-header bg.
+            stickyHeader &&
+              !isStuck &&
+              "[&>tr>th:first-child]:rounded-tl-lg [&>tr>th:last-child]:rounded-tr-lg",
           )}
         >
           {table.getHeaderGroups().map((headerGroup) => (

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -285,6 +285,13 @@ export function DataTable<TData, TValue>({
                     // or compete with the row's selected/hover background.
                     focused &&
                       "bg-primary/[0.04] shadow-[inset_3px_0_0_0_var(--primary)] outline-none",
+                    // `scroll-mt-*` so the `scrollIntoView({ block: "nearest" })`
+                    // below clears the chrome stacked above the scroll
+                    // container: 56px shell header always, +36px when the
+                    // table's own header is sticky on top of it. Without
+                    // this, scrolling up via `k` lands the focused row
+                    // behind the sticky bands.
+                    stickyHeader ? "scroll-mt-24" : "scroll-mt-16",
                   )}
                 >
                   {row.getVisibleCells().map((cell) => (

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -117,30 +117,28 @@ export function DataTable<TData, TValue>({
 
   // Detect the sticky header's "stuck" state so the rounded top corners
   // (which match the card while at rest) flatten once the band is
-  // floating under the app shell header — at that point the card has
-  // scrolled past and the rounded ears would just clip the band into
-  // the bg of the shell behind it.
+  // floating under the app shell header, and the explicit bottom
+  // separator only renders while floating.
+  //
+  // Observe the `<thead>` directly with a `rootMargin` that excludes the
+  // 56px the shell header occupies: while the thead is below that line
+  // it's fully inside the (reduced) root → `ratio === 1` → not stuck.
+  // The moment it hits the line and `position:sticky` pins it at top:56,
+  // its top is above the root and `ratio < 1` → stuck. Sentinels don't
+  // work here — a `<div>` directly inside `<table>` gets relocated by
+  // the browser and ends up below the thead.
   const headerRef = useRef<HTMLTableSectionElement>(null);
   const [isStuck, setIsStuck] = useState(false);
   useEffect(() => {
     if (!stickyHeader) return;
     const el = headerRef.current;
     if (!el) return;
-    // Sentinel sits one px above the header. When it scrolls out of view
-    // (past the app shell's 56px top), the header is stuck.
-    const sentinel = document.createElement("div");
-    sentinel.style.height = "1px";
-    sentinel.setAttribute("aria-hidden", "true");
-    el.parentElement?.insertBefore(sentinel, el);
     const observer = new IntersectionObserver(
-      ([entry]) => setIsStuck(!entry.isIntersecting),
-      { rootMargin: "-56px 0px 0px 0px", threshold: 0 },
+      ([entry]) => setIsStuck(entry.intersectionRatio < 1),
+      { rootMargin: "-57px 0px 0px 0px", threshold: [1] },
     );
-    observer.observe(sentinel);
-    return () => {
-      observer.disconnect();
-      sentinel.remove();
-    };
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [stickyHeader]);
 
   const table = useReactTable({

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -55,6 +55,16 @@ export interface DataTableProps<TData, TValue> {
   /** Optional row click handler — e.g. navigate to a detail page. */
   onRowClick?: (row: TData) => void;
   /**
+   * Whether to render the row body with a pointer cursor on hover.
+   * Defaults to `true` whenever an `onRowClick` is set — the right call
+   * for tables where row click is a navigation/CTA (tags, api-keys).
+   * Pass `false` for tables where the row body is a focus/select target
+   * and a specific child carries the navigation (transactions, where the
+   * merchant title is the deeplink) — a row-level pointer there would
+   * overpromise that any click anywhere navigates.
+   */
+  pointerRows?: boolean;
+  /**
    * Controlled row selection. Like sorting, the state lives in the calling
    * route; DataTable just renders it. `getRowId` should return a stable id
    * (not the array index) so a selection survives pagination/refetch.
@@ -101,6 +111,7 @@ export function DataTable<TData, TValue>({
   sorting,
   onSortingChange,
   onRowClick,
+  pointerRows,
   enableRowSelection,
   rowSelection,
   onRowSelectionChange,
@@ -276,7 +287,7 @@ export function DataTable<TData, TValue>({
                     onRowClick ? () => onRowClick(row.original) : undefined
                   }
                   className={cn(
-                    onRowClick && "cursor-pointer",
+                    (pointerRows ?? !!onRowClick) && "cursor-pointer",
                     // Keyboard-focus indicator: a 3px primary accent bar on
                     // the left edge plus a faint primary tint, layered via
                     // inset box-shadow so it doesn't shift the row geometry

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -287,6 +287,10 @@ export function DataTable<TData, TValue>({
                     onRowClick ? () => onRowClick(row.original) : undefined
                   }
                   className={cn(
+                    // `group/row` lets row children opt into a hover state
+                    // driven by the whole row (e.g. underline a title when
+                    // the row is hovered) via `group-hover/row:*`.
+                    "group/row",
                     (pointerRows ?? !!onRowClick) && "cursor-pointer",
                     // Keyboard-focus indicator: a 3px primary accent bar on
                     // the left edge plus a faint primary tint, layered via

--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -108,7 +108,7 @@ function ThemeSubmenu() {
   const { theme, setTheme } = useTheme();
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger className="gap-2">
+      <DropdownMenuSubTrigger className="gap-2 [&>svg:last-child]:ml-0">
         <Palette className="text-muted-foreground" />
         <span>Theme</span>
         <span className="text-muted-foreground ml-auto text-[11px] capitalize">

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -44,7 +44,7 @@ export function PageHeader({
         // with its own `gap-*`, so an `mb-*` here stacks with that gap and
         // produces a ~44px void on mobile (visible because the action chip
         // wraps below the description). Let the parent layout own spacing.
-        "flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end sm:gap-4",
+        "flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-start sm:gap-4",
         className,
       )}
     >

--- a/web/src/components/status-panel.tsx
+++ b/web/src/components/status-panel.tsx
@@ -13,11 +13,11 @@ interface StatusPanelProps {
   className?: string;
 }
 
-// StatusPanel renders the canonical inline tone-tinted status block: 3px
-// left rail in the tone colour + tinted icon tile + heading + body. Same
-// "colour encodes meaning" principle as ColorRailCard, but inline-only and
-// smaller — meant for "this surface is in state X" notices that aren't the
-// primary hero.
+// StatusPanel renders the canonical inline tone-tinted status block:
+// tinted icon tile + heading + body on a muted surface. Tone is carried
+// by the icon tile alone — the earlier 3px tone-tinted left rail was
+// removed once the icon proved to be the dominant signal and the rail
+// added visual weight without adding scannability.
 //
 // Originally established inline in `routes/setup-account.tsx` (iter 14) for
 // already-setup + invalid-token states. Promoted in iter 16 once the
@@ -25,28 +25,20 @@ interface StatusPanelProps {
 // warnings. Don't fork the look — change this primitive.
 //
 // Visual contract:
-//   `bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5`
-//     `before:` 3px tone-tinted left rail
+//   `bg-muted/30 overflow-hidden rounded-md border p-4`
 //     row: tinted icon tile (size-8) + heading + body
 //     optional trailing slot at the right edge
-const PALETTES: Record<
-  StatusPanelTone,
-  { rail: string; iconBg: string }
-> = {
+const PALETTES: Record<StatusPanelTone, { iconBg: string }> = {
   success: {
-    rail: "before:bg-success",
     iconBg: "bg-success/12 text-success",
   },
   destructive: {
-    rail: "before:bg-destructive",
     iconBg: "bg-destructive/10 text-destructive",
   },
   warning: {
-    rail: "before:bg-amber-500",
     iconBg: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
   },
   info: {
-    rail: "before:bg-muted-foreground/40",
     iconBg: "bg-muted text-muted-foreground",
   },
 };
@@ -63,8 +55,7 @@ export function StatusPanel({
   return (
     <div
       className={cn(
-        "bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5 before:absolute before:top-0 before:bottom-0 before:left-0 before:w-[3px]",
-        palette.rail,
+        "bg-muted/30 overflow-hidden rounded-md border p-4",
         className,
       )}
     >

--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -14,16 +14,18 @@ interface TagChipProps {
   onRemove?: () => void;
   /**
    * Visual density.
+   * - `xs` — inline inside a meta row (16px text line); does not grow the row
    * - `sm` — table rows / dense list cells (parity with `CategoryBadge size="sm"`)
    * - `md` — default; detail-page hero actions, sandbox, rule-display
    */
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
   className?: string;
 }
 
 // Per-size token recipe — mirrors CategoryBadge's recipe so the two share a
 // rhythm when rendered side-by-side in a transaction row. Adjust as a pair.
-const SIZE: Record<"sm" | "md", string> = {
+const SIZE: Record<"xs" | "sm" | "md", string> = {
+  xs: "h-4 px-1.5 text-[10px] leading-none gap-0.5 [&>svg]:size-2.5",
   sm: "h-5 px-1.5 text-[11px] gap-0.5 [&>svg]:size-2.5",
   md: "h-6 px-2 text-xs gap-1 [&>svg]:size-3",
 };
@@ -61,7 +63,7 @@ interface TagListProps {
   /** Cap the chips shown; the remainder collapse into a "+N" badge. */
   max?: number;
   /** Forwarded to every `TagChip` and the overflow badge for density parity. */
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
   className?: string;
 }
 

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -66,7 +66,7 @@ function TransactionMeta({ transaction: t }: { transaction: Transaction }) {
             {t.tags!.length}
           </span>
           <span className="hidden sm:inline-flex">
-            <TagList slugs={t.tags} max={2} size="sm" />
+            <TagList slugs={t.tags} max={2} size="xs" />
           </span>
         </>
       )}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -35,13 +35,13 @@ export function TransactionPrimary({
         e.stopPropagation();
         onTitleClick(t);
       }}
-      // Subtle hover hint that the title is the navigation affordance —
-      // doesn't dress it up as a full link. Pointer cursor sells the
-      // deeplink even though the surrounding row body uses the default
-      // cursor (it's a focus / select target, not a navigation CTA).
+      // Subtle navigation hint: title underlines on its own hover AND when
+      // the surrounding row is hovered (the whole row is a click target
+      // that navigates to detail, so the title is the visual anchor for
+      // that affordance). `group-hover/row:` is set up on TableRow.
       className={cn(
         titleClasses,
-        "cursor-pointer hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
+        "cursor-pointer underline-offset-2 decoration-muted-foreground/50 hover:underline group-hover/row:underline focus-visible:outline-none focus-visible:underline text-left",
       )}
     >
       {t.provider_name}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -36,10 +36,12 @@ export function TransactionPrimary({
         onTitleClick(t);
       }}
       // Subtle hover hint that the title is the navigation affordance —
-      // doesn't dress it up as a full link.
+      // doesn't dress it up as a full link. Pointer cursor sells the
+      // deeplink even though the surrounding row body uses the default
+      // cursor (it's a focus / select target, not a navigation CTA).
       className={cn(
         titleClasses,
-        "hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
+        "cursor-pointer hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
       )}
     >
       {t.provider_name}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -6,6 +6,13 @@ import type { Transaction } from "@/api/types";
 
 interface TransactionPrimaryProps {
   transaction: Transaction;
+  /**
+   * When provided, the merchant title becomes a click target that fires
+   * this callback (and stops propagation so the surrounding row click
+   * — typically focus / enter-select — doesn't also fire). Used by the
+   * transactions list row to open the detail page from the title only.
+   */
+  onTitleClick?: (transaction: Transaction) => void;
   className?: string;
 }
 
@@ -17,8 +24,29 @@ interface TransactionPrimaryProps {
 // just adds visual noise.
 export function TransactionPrimary({
   transaction: t,
+  onTitleClick,
   className,
 }: TransactionPrimaryProps) {
+  const titleClasses = "truncate font-medium";
+  const title = onTitleClick ? (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onTitleClick(t);
+      }}
+      // Subtle hover hint that the title is the navigation affordance —
+      // doesn't dress it up as a full link.
+      className={cn(
+        titleClasses,
+        "hover:underline underline-offset-2 decoration-muted-foreground/50 focus-visible:outline-none focus-visible:underline text-left",
+      )}
+    >
+      {t.provider_name}
+    </button>
+  ) : (
+    <span className={titleClasses}>{t.provider_name}</span>
+  );
   return (
     <div className={cn("flex min-w-0 items-center gap-3", className)}>
       <CategoryIconTile
@@ -28,7 +56,7 @@ export function TransactionPrimary({
       />
       <div className="min-w-0">
         <div className="flex items-center gap-2">
-          <span className="truncate font-medium">{t.provider_name}</span>
+          {title}
           {t.pending && (
             <span className="text-muted-foreground shrink-0 text-xs">
               Pending

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -1,6 +1,5 @@
-import { Clock, Tag as TagIcon } from "lucide-react";
+import { Tag as TagIcon } from "lucide-react";
 import { CategoryIconTile } from "@/components/category-icon-tile";
-import { MetaBadge } from "@/components/meta-badge";
 import { TagList } from "@/components/tag-chip";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
@@ -11,10 +10,11 @@ interface TransactionPrimaryProps {
 }
 
 // Identity block for a transaction: category icon tile, bank description
-// with an inline `Pending` MetaBadge, and a secondary line of metadata
-// (account · member · tags). Pending rides MetaBadge so it joins the
-// secondary-state chip family (System / Hidden / Excluded / Linked /
-// Re-auth) instead of an orphan muted span.
+// with an inline muted `Pending` label, and a secondary line of metadata
+// (account · member · tags). Pending is plain text — it's the only
+// secondary signal in the primary line and the surrounding row already
+// hosts pill-shaped tags + category badges, so an additional pill here
+// just adds visual noise.
 export function TransactionPrimary({
   transaction: t,
   className,
@@ -27,12 +27,12 @@ export function TransactionPrimary({
         size="sm"
       />
       <div className="min-w-0">
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-2">
           <span className="truncate font-medium">{t.provider_name}</span>
           {t.pending && (
-            <MetaBadge muted icon={Clock} className="shrink-0">
+            <span className="text-muted-foreground shrink-0 text-xs">
               Pending
-            </MetaBadge>
+            </span>
           )}
         </div>
         <TransactionMeta transaction={t} />

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -8,17 +8,13 @@ import {
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
-// Sonner Toaster customized to match the v2 design vocabulary established by
-// <StatusPanel>: a 3px tone-tinted left rail + a tone-tinted icon tile + the
-// existing popover surface. Tone is encoded in the rail/icon colour so
-// success/error/warning/info are scannable at a glance without changing the
-// background fill (which keeps the toast quiet enough to live next to dense
-// surfaces like the transactions table).
-//
-// All polish lives here; `lib/mutation-toast.ts` and direct `toast.*` calls
-// stay one-liners. Default position bottom-right, expand-on-hover, and a
-// close button on every toast (mutation results are often quick reads and
-// dismissing them feels right).
+// Tracks the shadcn sonner registry verbatim (theme inheritance + lucide
+// icon overrides + popover-themed CSS vars), then layers v2-specific
+// chrome on top: a 3px tone-tinted left rail and a tone-tinted icon
+// tile, both echoing <StatusPanel> so the toast/panel pair speaks the
+// same vocabulary. Everything else (positioning, dismiss behaviour,
+// close affordance) is left at sonner's defaults so the surface matches
+// the shadcn reference.
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
@@ -26,10 +22,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
-      position="bottom-right"
-      expand
-      closeButton
-      visibleToasts={4}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,
@@ -38,7 +30,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       toastOptions={{
-        // Class hooks are concatenated by Sonner onto each toast/element.
         // The base toast keeps `pl-5` so the absolute `before:` rail and
         // the icon both clear the left edge. `data-[type=*]` selectors
         // tint the rail and the icon tile per variant; "message" (the
@@ -47,8 +38,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             "group/toast toast relative overflow-hidden " +
-            "!bg-popover !text-popover-foreground !border !border-border !rounded-md " +
-            "!gap-3 !p-4 !pl-5 " +
+            "!pl-5 " +
             "before:absolute before:inset-y-0 before:left-0 before:w-[3px] " +
             "data-[type=success]:before:bg-success " +
             "data-[type=error]:before:bg-destructive " +
@@ -72,20 +62,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group-data-[type=default]/toast:!text-muted-foreground " +
             "group-data-[type=loading]/toast:!bg-muted " +
             "group-data-[type=loading]/toast:!text-muted-foreground",
-          content: "!gap-0.5",
-          title: "!text-sm !font-medium !text-foreground !leading-snug",
-          description:
-            "!text-xs !text-muted-foreground !leading-relaxed !mt-0.5",
-          actionButton:
-            "!bg-primary !text-primary-foreground hover:!bg-primary/90 " +
-            "!h-7 !rounded-md !px-2.5 !text-xs !font-medium",
-          cancelButton:
-            "!bg-transparent !text-muted-foreground hover:!text-foreground " +
-            "!h-7 !rounded-md !px-2 !text-xs",
-          closeButton:
-            "!bg-popover !border !border-border !text-muted-foreground " +
-            "hover:!bg-muted hover:!text-foreground " +
-            "!left-auto !right-2 !top-2 !translate-x-0 !translate-y-0",
         },
       }}
       style={

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -10,11 +10,10 @@ import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 // Tracks the shadcn sonner registry verbatim (theme inheritance + lucide
 // icon overrides + popover-themed CSS vars), then layers v2-specific
-// chrome on top: a 3px tone-tinted left rail and a tone-tinted icon
-// tile, both echoing <StatusPanel> so the toast/panel pair speaks the
-// same vocabulary. Everything else (positioning, dismiss behaviour,
-// close affordance) is left at sonner's defaults so the surface matches
-// the shadcn reference.
+// chrome on top: a tone-tinted icon tile echoing <StatusPanel> so the
+// toast/panel pair speaks the same vocabulary. Everything else
+// (positioning, dismiss behaviour, close affordance) is left at sonner's
+// defaults so the surface matches the shadcn reference.
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
@@ -30,22 +29,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       toastOptions={{
-        // The base toast keeps `pl-5` so the absolute `before:` rail and
-        // the icon both clear the left edge. `data-[type=*]` selectors
-        // tint the rail and the icon tile per variant; "message" (the
-        // default toast.message call) falls through to the neutral
-        // info-style rail.
+        // `data-[type=*]` selectors tint the icon tile per variant.
+        // "message" (the default toast.message call) falls through to
+        // the neutral default style.
         classNames: {
-          toast:
-            "group/toast toast relative overflow-hidden " +
-            "!pl-5 " +
-            "before:absolute before:inset-y-0 before:left-0 before:w-[3px] " +
-            "data-[type=success]:before:bg-success " +
-            "data-[type=error]:before:bg-destructive " +
-            "data-[type=warning]:before:bg-amber-500 " +
-            "data-[type=info]:before:bg-sky-500 " +
-            "data-[type=default]:before:bg-muted-foreground/40 " +
-            "data-[type=loading]:before:bg-muted-foreground/40",
+          toast: "group/toast toast",
           icon:
             "!m-0 !size-8 !shrink-0 !rounded-md !flex !items-center !justify-center " +
             "group-data-[type=success]/toast:!bg-success/12 " +

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -11,6 +11,8 @@ import type { Transaction } from "@/api/types";
 export interface TransactionTableMeta {
   onRangeSelect?: (toIndex: number) => void;
   setLastIndex?: (index: number) => void;
+  /** Fired from the merchant-title click in the description column. */
+  onOpenDetail?: (transaction: Transaction) => void;
 }
 
 const selectionColumn: ColumnDef<Transaction> = {
@@ -63,7 +65,15 @@ const baseColumns: ColumnDef<Transaction>[] = [
     // `truncate` actually clamp. Without this, a long merchant name expands
     // the column and pushes the amount off-screen on narrow viewports.
     meta: { className: "max-w-0 w-full" },
-    cell: ({ row }) => <TransactionPrimary transaction={row.original} />,
+    cell: ({ row, table }) => {
+      const meta = table.options.meta as TransactionTableMeta | undefined;
+      return (
+        <TransactionPrimary
+          transaction={row.original}
+          onTitleClick={meta?.onOpenDetail}
+        />
+      );
+    },
   },
   {
     id: "category",

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -124,3 +124,21 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* shadcn's CardHeader is designed for title + description (stacked) with
+   an optional trailing action that row-spans 2 to clear room for the
+   description. When the description is absent, those defaults leave a
+   phantom 8px gap below the title and pin both the title and the action
+   to the top of the band — so a header with an action looks visibly
+   top-heavy. Collapse to a single, vertically-centered row in that case.
+   Outside @layer base so it outranks Tailwind utility classes. */
+[data-slot="card-header"]:not(:has([data-slot="card-description"])) {
+  grid-template-rows: auto;
+  row-gap: 0;
+  align-items: center;
+}
+[data-slot="card-header"]:not(:has([data-slot="card-description"]))
+  [data-slot="card-action"] {
+  grid-row: auto;
+  align-self: center;
+}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -142,3 +142,14 @@
   grid-row: auto;
   align-self: center;
 }
+
+/* shadcn's Button primitive deliberately ships no cursor class, so it
+   inherits the underlying element's native cursor — `<button>` is
+   `default` in modern Chromium, which is what shadcn's docs assume. But
+   `asChild` swaps in `<a>` (e.g. `<Button asChild><Link/></Button>`),
+   which inherits the anchor's `pointer` and breaks the convention.
+   Pin the cursor on the slot itself so SoftBackButton, JumpToPill,
+   Button-as-Link, etc. all stay consistent with the rest of the app. */
+[data-slot="button"] {
+  cursor: default;
+}

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -63,6 +63,13 @@ export interface UseShortcutOptions {
    * toggle from anywhere — never for bare-letter shortcuts.
    */
   global?: boolean;
+  /**
+   * Fire on key-repeat (holding the key). Default false — single-press
+   * shortcuts (open, submit, toggle…) should not blast as the user holds.
+   * Opt in for navigation shortcuts (j/k) where continuous movement is the
+   * desired affordance.
+   */
+  repeat?: boolean;
 }
 
 export function useShortcut(
@@ -70,7 +77,13 @@ export function useShortcut(
   handler: (event: KeyboardEvent) => void,
   options: UseShortcutOptions,
 ): void {
-  const { label, group, enabled = true, global = false } = options;
+  const {
+    label,
+    group,
+    enabled = true,
+    global = false,
+    repeat = false,
+  } = options;
   const id = `${group ?? "global"}:${label}`;
   // Both `keys` (inline array literal) and `handler` (inline arrow) are
   // referentially unstable across renders. Without this, the effect tears
@@ -87,9 +100,11 @@ export function useShortcut(
     const unregister = registerShortcut({ id, keys: parsedKeys, label, group });
     const match = parseKeys(parsedKeys);
     const onKey = (event: KeyboardEvent) => {
-      // Holding a key down repeats keydown — let single-press shortcuts
-      // (j/k navigation especially) fire once per press, not per frame.
-      if (event.repeat) return;
+      // Holding a key down repeats keydown. Default to single-press so
+      // shortcuts like Enter / x don't blast as the user holds; opt
+      // explicit `repeat: true` callers (j/k row navigation) into the
+      // OS key-repeat cadence.
+      if (event.repeat && !repeat) return;
       if (event.key.toLowerCase() !== match.key) return;
       if (!!match.meta !== (event.metaKey || event.ctrlKey)) return;
       if (!!match.shift !== event.shiftKey) return;
@@ -116,5 +131,5 @@ export function useShortcut(
       window.removeEventListener("keydown", onKey);
       unregister();
     };
-  }, [enabled, id, keysKey, label, group, global]);
+  }, [enabled, id, keysKey, label, group, global, repeat]);
 }

--- a/web/src/routes/placeholder.tsx
+++ b/web/src/routes/placeholder.tsx
@@ -6,13 +6,11 @@ import {
   Sparkles,
 } from "lucide-react";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { Button } from "@/components/ui/button";
 import { ComingSoonPill } from "@/components/coming-soon-pill";
 import { JumpToPill } from "@/components/jump-to-pill";
 import { PageHeader } from "@/components/page-header";
 import { SectionCard } from "@/components/section-card";
 import { StatusPanel } from "@/components/status-panel";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { NAV_LEAVES } from "@/lib/nav";
 
 interface PlannedFeature {
@@ -96,10 +94,6 @@ const DEFAULT_CONTENT: PlaceholderContent = {
   related: [],
 };
 
-function openCommandPalette() {
-  window.dispatchEvent(new CustomEvent("breadbox:command-palette:open"));
-}
-
 // Placeholder is the canonical "page not yet implemented" surface used by
 // main.tsx for any nav leaf without a PAGE_OVERRIDES entry (today: Reports
 // and Agents). It is NOT an empty-state — `<EmptyState>` (in
@@ -134,28 +128,6 @@ export function Placeholder({ title }: { title: string }) {
         eyebrow={eyebrow}
         title={title}
         description={content.description}
-        actions={
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={openCommandPalette}
-              className="gap-2"
-            >
-              <span>Jump to…</span>
-              <KbdGroup>
-                <Kbd>⌘</Kbd>
-                <Kbd>K</Kbd>
-              </KbdGroup>
-            </Button>
-            <Button asChild size="sm">
-              <Link to="/">
-                Back to Home
-                <ArrowRight className="size-4" />
-              </Link>
-            </Button>
-          </>
-        }
       />
 
       <div className="flex flex-col gap-4">

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { SandboxIsolationProvider } from "@/sandbox/kit";
 import { FoundationsSection } from "@/sandbox/sections/foundations";
 import { PrimitivesSection } from "@/sandbox/sections/primitives";
 import { ComponentsSection } from "@/sandbox/sections/components";
@@ -37,7 +38,23 @@ export function SandboxPage() {
     return null;
   });
 
-  const [active, setActive] = useState<SectionId>("foundations");
+  // `?only=<slug>` isolates a single specimen for clean before/after or
+  // variant screenshots. `?section=<id>` scopes which section's tree
+  // mounts in isolation mode — defaults to `components` since that's the
+  // bulk of the gallery. Scoping matters because mounting every section
+  // would mount every Specimen wrapper (and their lazy children), and
+  // some of those side-mount via popover triggers that can hit the API.
+  const { only, scopedSection } = useMemo(() => {
+    if (typeof window === "undefined")
+      return { only: null as string | null, scopedSection: null as SectionId | null };
+    const params = new URLSearchParams(window.location.search);
+    const onlyParam = params.get("only");
+    const sectionParam = params.get("section");
+    const matched = SECTIONS.find((s) => s.id === sectionParam)?.id ?? null;
+    return { only: onlyParam, scopedSection: matched };
+  }, []);
+
+  const [active, setActive] = useState<SectionId>("components");
   // The theme toggle is a scoped preview: it flips the global `.dark` class
   // so the whole gallery re-themes, but restores the original mode on
   // unmount so it never leaks out to the rest of the app.
@@ -61,8 +78,44 @@ export function SandboxPage() {
   const ActiveSection =
     SECTIONS.find((s) => s.id === active)?.Component ?? FoundationsSection;
 
+  // In isolation mode, drop the section nav + outline and mount ONLY the
+  // scoped section (default `components`). Specimen / SandboxGroup
+  // self-filter so only the matching specimen actually renders. We mount
+  // a single section (not all five) because Specimen wrappers + their lazy
+  // popover triggers can side-fetch live data — scoping keeps the page
+  // entirely fixture-backed.
+  if (only) {
+    const exitHref = window.location.pathname;
+    const sectionId = scopedSection ?? "components";
+    const Scoped =
+      SECTIONS.find((s) => s.id === sectionId)?.Component ?? ComponentsSection;
+    return (
+      <SandboxIsolationProvider only={only}>
+        <div className="mx-auto w-full max-w-3xl">
+          <div className="text-muted-foreground mb-4 flex items-center justify-between text-xs">
+            <span>
+              Isolating <code className="font-mono">{only}</code>
+              <span className="text-muted-foreground/60 ml-2">
+                in <code className="font-mono">{sectionId}</code>
+              </span>
+            </span>
+            <a
+              href={exitHref}
+              className="hover:text-foreground inline-flex items-center gap-1 underline-offset-2 hover:underline"
+            >
+              <X className="size-3" />
+              Exit isolation
+            </a>
+          </div>
+          <Scoped />
+        </div>
+      </SandboxIsolationProvider>
+    );
+  }
+
   return (
-    <div className="mx-auto max-w-5xl">
+    <SandboxIsolationProvider only={null}>
+    <div className="w-full">
       <div className="mb-6 flex items-start justify-between gap-4">
         <div className="space-y-1">
           <h1 className="text-xl font-semibold tracking-tight">
@@ -126,16 +179,28 @@ export function SandboxPage() {
         </div>
       </div>
     </div>
+    </SandboxIsolationProvider>
   );
+}
+
+interface OutlineSpecimen {
+  id: string;
+  label: string;
+}
+interface OutlineGroup {
+  id: string;
+  title: string;
+  items: OutlineSpecimen[];
 }
 
 // SectionWithOutline pairs an active sandbox section with a sticky right-rail
 // outline of its specimens. Specimens self-register via `data-specimen-label`
-// from the `<Specimen>` primitive — we scan the section's DOM after each
-// section change (and on resize) so the outline reflects whatever lives in
-// the gallery without per-section wiring. Active item highlights via
-// IntersectionObserver: whichever specimen is closest to the top of the
-// viewport (under the 56px shell header) wins.
+// from the `<Specimen>` primitive; `<SandboxGroup>` wraps clusters and emits
+// `data-specimen-group="Title"`. The outline walks the section in document
+// order, grouping every specimen under its nearest preceding group (an
+// implicit "General" bucket catches specimens that live outside any group).
+// Active item highlights via IntersectionObserver — whichever specimen is
+// closest to the top of the viewport (under the 56px shell header) wins.
 function SectionWithOutline({
   sectionId,
   children,
@@ -144,77 +209,106 @@ function SectionWithOutline({
   children: React.ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const [items, setItems] = useState<Array<{ id: string; label: string }>>([]);
+  const [groups, setGroups] = useState<OutlineGroup[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  // Rebuild the outline on section change. `useEffect` runs after children
-  // commit, so specimens are mounted and queryable.
   useEffect(() => {
     const root = contentRef.current;
     if (!root) return;
-    const next = [...root.querySelectorAll<HTMLElement>("[data-specimen-label]")].map(
-      (el) => ({
-        id: el.id,
-        label: el.getAttribute("data-specimen-label") ?? el.id,
-      }),
+    const nodes = root.querySelectorAll<HTMLElement>(
+      "[data-specimen-group], [data-specimen-label]",
     );
-    setItems(next);
-    setActiveId(next[0]?.id ?? null);
+    const next: OutlineGroup[] = [];
+    let current: OutlineGroup | null = null;
+    const ungrouped: OutlineSpecimen[] = [];
+    for (const el of Array.from(nodes)) {
+      const groupTitle = el.getAttribute("data-specimen-group");
+      if (groupTitle) {
+        current = { id: el.id, title: groupTitle, items: [] };
+        next.push(current);
+        continue;
+      }
+      const label = el.getAttribute("data-specimen-label");
+      if (!label) continue;
+      const item: OutlineSpecimen = { id: el.id, label };
+      if (current) current.items.push(item);
+      else ungrouped.push(item);
+    }
+    setGroups(
+      ungrouped.length
+        ? [{ id: "outline-general", title: "General", items: ungrouped }, ...next]
+        : next,
+    );
+    setActiveId(ungrouped[0]?.id ?? next[0]?.items[0]?.id ?? null);
   }, [sectionId]);
 
-  // Highlight whichever specimen is closest to the top under the 56px shell
-  // header. Rebuild when the item list changes (new section).
   useEffect(() => {
-    if (items.length === 0) return;
     const root = contentRef.current;
     if (!root) return;
-    const els = items
+    const all = groups.flatMap((g) => g.items);
+    if (all.length === 0) return;
+    const els = all
       .map((i) => root.querySelector<HTMLElement>(`#${CSS.escape(i.id)}`))
       .filter((el): el is HTMLElement => !!el);
     const observer = new IntersectionObserver(
       (entries) => {
-        // Collect the entries that are currently intersecting and pick the
-        // one with the smallest `top` — i.e. nearest the top of the root.
         const visible = entries
           .filter((e) => e.isIntersecting)
-          .sort(
-            (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
-          );
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
         if (visible[0]) setActiveId(visible[0].target.id);
       },
       { rootMargin: "-56px 0px -60% 0px", threshold: 0 },
     );
     els.forEach((el) => observer.observe(el));
     return () => observer.disconnect();
-  }, [items]);
+  }, [groups]);
+
+  const hasItems = groups.some((g) => g.items.length > 0);
 
   return (
     <div className="flex gap-8">
       <div ref={contentRef} className="min-w-0 flex-1">
         {children}
       </div>
-      {items.length > 0 && (
-        <aside className="sticky top-20 hidden h-fit w-48 shrink-0 lg:block">
+      {hasItems && (
+        <aside className="sticky top-20 hidden h-[calc(100vh-6rem)] w-52 shrink-0 overflow-y-auto pr-2 lg:block">
           <p className="text-muted-foreground mb-2 px-2 text-[10px] font-semibold tracking-wider uppercase">
             On this page
           </p>
-          <ul className="space-y-0.5">
-            {items.map((i) => (
-              <li key={i.id}>
-                <a
-                  href={`#${i.id}`}
-                  className={cn(
-                    "block truncate rounded-md px-2 py-1 text-xs transition-colors",
-                    activeId === i.id
-                      ? "text-foreground bg-accent/50 font-medium"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/30",
-                  )}
-                >
-                  {i.label}
-                </a>
-              </li>
+          <div className="space-y-3">
+            {groups.map((g) => (
+              <div key={g.id}>
+                {/* Only render group label when there are real groups —
+                    the implicit "General" bucket is unlabeled. */}
+                {g.id !== "outline-general" && (
+                  <p className="text-muted-foreground/80 mb-1 px-2 text-[10px] font-semibold tracking-wider uppercase">
+                    {g.title}
+                  </p>
+                )}
+                <ul className="space-y-0.5">
+                  {g.items.map((i) => (
+                    <li key={i.id}>
+                      <a
+                        href={`#${i.id}`}
+                        className={cn(
+                          "block truncate rounded-md py-1 pr-2 text-xs transition-colors",
+                          // Indent subitems under a real group label so the
+                          // outline reads as a hierarchy; ungrouped fallback
+                          // keeps the flush left edge.
+                          g.id === "outline-general" ? "pl-2" : "pl-4",
+                          activeId === i.id
+                            ? "text-foreground bg-accent/50 font-medium"
+                            : "text-muted-foreground hover:text-foreground hover:bg-accent/30",
+                        )}
+                      >
+                        {i.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
-          </ul>
+          </div>
         </aside>
       )}
     </div>

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -120,9 +120,103 @@ export function SandboxPage() {
               </Button>
             ))}
           </div>
-          <ActiveSection />
+          <SectionWithOutline sectionId={active}>
+            <ActiveSection />
+          </SectionWithOutline>
         </div>
       </div>
+    </div>
+  );
+}
+
+// SectionWithOutline pairs an active sandbox section with a sticky right-rail
+// outline of its specimens. Specimens self-register via `data-specimen-label`
+// from the `<Specimen>` primitive — we scan the section's DOM after each
+// section change (and on resize) so the outline reflects whatever lives in
+// the gallery without per-section wiring. Active item highlights via
+// IntersectionObserver: whichever specimen is closest to the top of the
+// viewport (under the 56px shell header) wins.
+function SectionWithOutline({
+  sectionId,
+  children,
+}: {
+  sectionId: string;
+  children: React.ReactNode;
+}) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [items, setItems] = useState<Array<{ id: string; label: string }>>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  // Rebuild the outline on section change. `useEffect` runs after children
+  // commit, so specimens are mounted and queryable.
+  useEffect(() => {
+    const root = contentRef.current;
+    if (!root) return;
+    const next = [...root.querySelectorAll<HTMLElement>("[data-specimen-label]")].map(
+      (el) => ({
+        id: el.id,
+        label: el.getAttribute("data-specimen-label") ?? el.id,
+      }),
+    );
+    setItems(next);
+    setActiveId(next[0]?.id ?? null);
+  }, [sectionId]);
+
+  // Highlight whichever specimen is closest to the top under the 56px shell
+  // header. Rebuild when the item list changes (new section).
+  useEffect(() => {
+    if (items.length === 0) return;
+    const root = contentRef.current;
+    if (!root) return;
+    const els = items
+      .map((i) => root.querySelector<HTMLElement>(`#${CSS.escape(i.id)}`))
+      .filter((el): el is HTMLElement => !!el);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Collect the entries that are currently intersecting and pick the
+        // one with the smallest `top` — i.e. nearest the top of the root.
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort(
+            (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
+          );
+        if (visible[0]) setActiveId(visible[0].target.id);
+      },
+      { rootMargin: "-56px 0px -60% 0px", threshold: 0 },
+    );
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [items]);
+
+  return (
+    <div className="flex gap-8">
+      <div ref={contentRef} className="min-w-0 flex-1">
+        {children}
+      </div>
+      {items.length > 0 && (
+        <aside className="sticky top-20 hidden h-fit w-48 shrink-0 lg:block">
+          <p className="text-muted-foreground mb-2 px-2 text-[10px] font-semibold tracking-wider uppercase">
+            On this page
+          </p>
+          <ul className="space-y-0.5">
+            {items.map((i) => (
+              <li key={i.id}>
+                <a
+                  href={`#${i.id}`}
+                  className={cn(
+                    "block truncate rounded-md px-2 py-1 text-xs transition-colors",
+                    activeId === i.id
+                      ? "text-foreground bg-accent/50 font-medium"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent/30",
+                  )}
+                >
+                  {i.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      )}
     </div>
   );
 }

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -162,6 +162,12 @@ export function TransactionsPage() {
   // Keyboard-navigated row focus (j/k). Index into `rows`; null = no focus.
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 
+  const openTransaction = useCallback(
+    (t: Transaction) =>
+      navigate({ to: "/transactions/$id", params: { id: t.short_id } }),
+    [navigate],
+  );
+
   const columns = useMemo(
     () => buildTransactionColumns({ selection: selectMode }),
     [selectMode],
@@ -179,6 +185,31 @@ export function TransactionsPage() {
   const toggleRowSelection = useCallback((t: Transaction) => {
     setRowSelection((prev) => ({ ...prev, [t.id]: !prev[t.id] }));
   }, []);
+
+  // Row click outside select mode is a two-stage interaction:
+  //   1st tap → focus the row (same affordance as j/k)
+  //   2nd tap on the already-focused row → enter select mode + select it
+  //     (same affordance as the `x` shortcut)
+  // The merchant title remains the dedicated open-detail target — its
+  // own onClick stops propagation so it never lands here.
+  const handleRowClick = useCallback(
+    (t: Transaction) => {
+      if (selectMode) {
+        toggleRowSelection(t);
+        return;
+      }
+      const idx = rows.findIndex((r) => r.id === t.id);
+      if (idx === -1) return;
+      if (focusedIndex === idx) {
+        setSelectMode(true);
+        setRowSelection((prev) => ({ ...prev, [t.id]: true }));
+        lastIndexRef.current = idx;
+        return;
+      }
+      setFocusedIndex(idx);
+    },
+    [selectMode, toggleRowSelection, rows, focusedIndex],
+  );
 
   const toggleSelectMode = useCallback(() => {
     if (selectMode) exitSelectMode();
@@ -211,18 +242,13 @@ export function TransactionsPage() {
           return next;
         });
       },
+      onOpenDetail: openTransaction,
     }),
-    [rows],
+    [rows, openTransaction],
   );
 
   const focusedRowId =
     focusedIndex != null ? rows[focusedIndex]?.id : undefined;
-
-  const openTransaction = useCallback(
-    (t: Transaction) =>
-      navigate({ to: "/transactions/$id", params: { id: t.short_id } }),
-    [navigate],
-  );
 
   // --- Keyboard shortcuts (registered while this page is mounted) ---
   useShortcut(
@@ -427,7 +453,7 @@ export function TransactionsPage() {
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
         focusedRowId={focusedRowId}
-        onRowClick={selectMode ? toggleRowSelection : openTransaction}
+        onRowClick={handleRowClick}
         stickyHeader
         refinedHeader
         emptyState={

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -97,6 +97,12 @@ export function TransactionsPage() {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    // Gate on the live URL: if the user already navigated away (e.g. j/k +
+    // Enter into a transaction detail before the 300ms debounce fires),
+    // skip. Without this, `navigate({ to: "." })` resolves to this
+    // component's matched route (`/transactions`) and pushes us back to
+    // the list, flashing the URL away from the detail page we just opened.
+    if (!window.location.pathname.endsWith("/transactions")) return;
     const q = debounced.trim() || undefined;
     navigate({
       to: ".",

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -454,6 +454,7 @@ export function TransactionsPage() {
         meta={tableMeta}
         focusedRowId={focusedRowId}
         onRowClick={handleRowClick}
+        pointerRows={selectMode}
         stickyHeader
         refinedHeader
         emptyState={

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -239,12 +239,12 @@ export function TransactionsPage() {
       setFocusedIndex((i) =>
         i == null ? 0 : Math.min(i + 1, rows.length - 1),
       ),
-    { label: "Move focus down", group: "Transactions" },
+    { label: "Move focus down", group: "Transactions", repeat: true },
   );
   useShortcut(
     ["k"],
     () => setFocusedIndex((i) => (i == null ? 0 : Math.max(i - 1, 0))),
-    { label: "Move focus up", group: "Transactions" },
+    { label: "Move focus up", group: "Transactions", repeat: true },
   );
   useShortcut(
     ["enter"],

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -181,35 +181,12 @@ export function TransactionsPage() {
   }, []);
 
   // In select mode a click anywhere on the row toggles its selection — the
-  // checkbox cell stops propagation so it doesn't double-toggle.
+  // checkbox cell stops propagation so it doesn't double-toggle. Outside
+  // select mode, the row body navigates (same as a title click) — see
+  // `onRowClick` below.
   const toggleRowSelection = useCallback((t: Transaction) => {
     setRowSelection((prev) => ({ ...prev, [t.id]: !prev[t.id] }));
   }, []);
-
-  // Row click outside select mode is a two-stage interaction:
-  //   1st tap → focus the row (same affordance as j/k)
-  //   2nd tap on the already-focused row → enter select mode + select it
-  //     (same affordance as the `x` shortcut)
-  // The merchant title remains the dedicated open-detail target — its
-  // own onClick stops propagation so it never lands here.
-  const handleRowClick = useCallback(
-    (t: Transaction) => {
-      if (selectMode) {
-        toggleRowSelection(t);
-        return;
-      }
-      const idx = rows.findIndex((r) => r.id === t.id);
-      if (idx === -1) return;
-      if (focusedIndex === idx) {
-        setSelectMode(true);
-        setRowSelection((prev) => ({ ...prev, [t.id]: true }));
-        lastIndexRef.current = idx;
-        return;
-      }
-      setFocusedIndex(idx);
-    },
-    [selectMode, toggleRowSelection, rows, focusedIndex],
-  );
 
   const toggleSelectMode = useCallback(() => {
     if (selectMode) exitSelectMode();
@@ -453,8 +430,7 @@ export function TransactionsPage() {
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
         focusedRowId={focusedRowId}
-        onRowClick={handleRowClick}
-        pointerRows={selectMode}
+        onRowClick={selectMode ? toggleRowSelection : openTransaction}
         stickyHeader
         refinedHeader
         emptyState={

--- a/web/src/sandbox/kit.tsx
+++ b/web/src/sandbox/kit.tsx
@@ -26,6 +26,18 @@ export function SandboxSection({
   );
 }
 
+// `data-specimen-label` + an id derived from the label make every Specimen
+// addressable for the per-section outline rendered in `routes/sandbox.tsx`.
+// Keep it on the wrapper (not the heading) so the scroll anchor sits just
+// above the label, not flush with it.
+export function specimenSlug(label: string): string {
+  return label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
 // A single labeled example. `code` names the component/token so the gallery
 // doubles as a quick "what's it called" reference.
 export function Specimen({
@@ -42,7 +54,11 @@ export function Specimen({
   className?: string;
 }) {
   return (
-    <div className="space-y-2">
+    <div
+      id={specimenSlug(label)}
+      data-specimen-label={label}
+      className="scroll-mt-20 space-y-2"
+    >
       <div className="flex items-baseline gap-2">
         <h3 className="text-sm font-medium">{label}</h3>
         {code && (

--- a/web/src/sandbox/kit.tsx
+++ b/web/src/sandbox/kit.tsx
@@ -1,28 +1,92 @@
-import type { ReactNode } from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 // Shared layout primitives for the design-system sandbox. Kept deliberately
 // plain — they frame the real components without competing with them.
 
+// Isolation context: when set to a specimen slug (via `?only=<slug>` on
+// /v2/sandbox), only the matching <Specimen> renders — used to produce
+// clean before/after or variant screenshots of a single component.
+const IsolationContext = createContext<string | null>(null);
+
+export function SandboxIsolationProvider({
+  only,
+  children,
+}: {
+  only: string | null;
+  children: ReactNode;
+}) {
+  return (
+    <IsolationContext.Provider value={only}>
+      {children}
+    </IsolationContext.Provider>
+  );
+}
+
+function useIsolation() {
+  return useContext(IsolationContext);
+}
+
+// SectionContext lets Specimens know which top-level section they live in
+// so the per-specimen "Isolate" link can encode `?section=<id>` and the
+// isolation render path mounts just that one section's tree.
+const SectionContext = createContext<string | null>(null);
+
 export function SandboxSection({
+  id,
   title,
   description,
   children,
 }: {
+  id?: string;
   title: string;
   description?: string;
   children: ReactNode;
 }) {
   return (
-    <section className="space-y-6">
-      <div className="space-y-1">
-        <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
-        {description && (
-          <p className="text-muted-foreground text-sm">{description}</p>
-        )}
-      </div>
+    <SectionContext.Provider value={id ?? null}>
+      <section className="space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+          {description && (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          )}
+        </div>
+        {children}
+      </section>
+    </SectionContext.Provider>
+  );
+}
+
+// SandboxGroup wraps a cluster of specimens under a small sub-heading. The
+// section outline in `routes/sandbox.tsx` walks the DOM and groups every
+// Specimen under the nearest preceding SandboxGroup, so the outline mirrors
+// the visible structure. Use it to give long sections (Components,
+// Patterns) a navigable shape — Foundations / Primitives may not need it.
+//
+// In isolation mode (single-specimen view via `?only=…`) the group heading
+// hides itself but children render through; specimens then self-filter.
+export function SandboxGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  const slug = specimenSlug(title);
+  const isolated = useIsolation();
+  if (isolated) return <>{children}</>;
+  return (
+    <div
+      id={`group-${slug}`}
+      data-specimen-group={title}
+      className="scroll-mt-20 space-y-6 pt-2"
+    >
+      <h3 className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
+        {title}
+      </h3>
       {children}
-    </section>
+    </div>
   );
 }
 
@@ -40,6 +104,8 @@ export function specimenSlug(label: string): string {
 
 // A single labeled example. `code` names the component/token so the gallery
 // doubles as a quick "what's it called" reference.
+//
+// In isolation mode (`?only=<slug>`) only the matching specimen renders.
 export function Specimen({
   label,
   code,
@@ -53,11 +119,18 @@ export function Specimen({
   children: ReactNode;
   className?: string;
 }) {
+  const slug = specimenSlug(label);
+  const isolated = useIsolation();
+  const sectionId = useContext(SectionContext);
+  if (isolated && isolated !== slug) return null;
+  const isolateHref = sectionId
+    ? `?only=${slug}&section=${sectionId}`
+    : `?only=${slug}`;
   return (
     <div
-      id={specimenSlug(label)}
+      id={slug}
       data-specimen-label={label}
-      className="scroll-mt-20 space-y-2"
+      className="group/specimen scroll-mt-20 space-y-2"
     >
       <div className="flex items-baseline gap-2">
         <h3 className="text-sm font-medium">{label}</h3>
@@ -65,6 +138,15 @@ export function Specimen({
           <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 font-mono text-xs">
             {code}
           </code>
+        )}
+        {!isolated && (
+          <a
+            href={isolateHref}
+            className="text-muted-foreground/60 hover:text-foreground ml-auto text-[10px] uppercase tracking-wider opacity-0 transition-opacity group-hover/specimen:opacity-100 focus:opacity-100"
+            title="Isolate this specimen"
+          >
+            Isolate
+          </a>
         )}
       </div>
       {description && (

--- a/web/src/sandbox/sections/amounts.tsx
+++ b/web/src/sandbox/sections/amounts.tsx
@@ -51,6 +51,7 @@ const AMOUNT_ROWS = sampleTransactions.slice(0, 3);
 export function AmountsSection() {
   return (
     <SandboxSection
+      id="amounts"
       title="Amounts"
       description="How money is displayed in v2. One sign convention, one formatter, one component — applied everywhere a balance or transaction amount appears."
     >

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -54,6 +54,7 @@ import { DataTable } from "@/components/data-table";
 import { CategoryBadge } from "@/components/category-badge";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { CategoryCommandList } from "@/components/category-command";
+import { CategoryPicker } from "@/components/category-picker";
 import { DateRangeFilter } from "@/components/date-range-filter";
 import type { DateRangeValue } from "@/components/date-range-filter";
 import { TagChip, TagList } from "@/components/tag-chip";
@@ -104,7 +105,7 @@ import { ProviderPicker } from "@/features/connections/provider-picker";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
-import { SandboxSection, Specimen } from "@/sandbox/kit";
+import { SandboxGroup, SandboxSection, Specimen } from "@/sandbox/kit";
 import {
   sampleTags,
   sampleTranscriptEvents,
@@ -160,9 +161,11 @@ export function ComponentsSection() {
 
   return (
     <SandboxSection
+      id="components"
       title="Components"
       description="Composed, reusable v2 components — the layer built on top of the primitives. Shared across the transactions list, detail page, and (soon) elsewhere."
     >
+      <SandboxGroup title="Page layout">
       <Specimen
         label="PageHeader"
         code="components/page-header"
@@ -423,7 +426,9 @@ export function ComponentsSection() {
           />
         </div>
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Pills & inline">
       <Specimen
         label="IdPill"
         code="components/id-pill"
@@ -712,7 +717,9 @@ export function ComponentsSection() {
           <ViewAllPill to="/">See all transactions</ViewAllPill>
         </div>
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Forms & overlays">
       <Specimen
         label="SearchInput"
         code="components/search-input"
@@ -1049,7 +1056,9 @@ export function ComponentsSection() {
           }}
         />
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Shells & states">
       <Specimen
         label="DangerZone"
         code="components/danger-zone"
@@ -1248,7 +1257,9 @@ export function ComponentsSection() {
           </div>
         </div>
       </Specimen>
+      </SandboxGroup>
 
+      <SandboxGroup title="Domain & data">
       <Specimen
         label="TimelineRail"
         code="components/timeline-rail"
@@ -1470,6 +1481,68 @@ export function ComponentsSection() {
           </div>
         ))}
       </Specimen>
+      </SandboxGroup>
+
+      <SandboxGroup title="Pickers & specialty">
+      <Specimen
+        label="CategoryPicker"
+        code="components/category-picker"
+        description="The inline category picker that lives in the transactions list's category column. Renders the assigned `CategoryBadge` (or a dashed `+ Category` empty pill) over a popover-hosted `CategoryCommandList`. Hover/focus reveals a small chevron + a 1px ring around the trigger so the affordance reads even when the badge already carries a coloured tint. The `onPick` override here keeps the sandbox a no-op — production wires it to the single-tx update mutation via `useCategoryEditor`."
+        className="block"
+      >
+        <div className="flex flex-wrap items-center gap-6 rounded-lg border p-4">
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Assigned
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={coffeeCategory ?? null}
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Override (ring)
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={gasCategory ?? null}
+              overridden
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              Uncategorized
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={null}
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div className="text-muted-foreground text-[11px] tracking-wide uppercase">
+              sm
+            </div>
+            <CategoryPicker
+              transactionId="sandbox"
+              category={coffeeCategory ?? null}
+              size="sm"
+              onPick={(p) => {
+                toast.message(`Picked: ${p.category_slug ?? "—"}`);
+              }}
+            />
+          </div>
+        </div>
+      </Specimen>
 
       <Specimen
         label="CategoryCommandList"
@@ -1671,6 +1744,7 @@ export function ComponentsSection() {
           />
         </div>
       </Specimen>
+      </SandboxGroup>
     </SandboxSection>
   );
 }

--- a/web/src/sandbox/sections/foundations.tsx
+++ b/web/src/sandbox/sections/foundations.tsx
@@ -72,6 +72,7 @@ function Swatch({ cls, name }: { cls: string; name: string }) {
 export function FoundationsSection() {
   return (
     <SandboxSection
+      id="foundations"
       title="Foundations"
       description="Theme tokens, shape, type, and the icon system — the layer everything else is built on. Toggle the theme (top right) to check both modes."
     >

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -86,6 +86,7 @@ export function PatternsSection() {
 
   return (
     <SandboxSection
+      id="patterns"
       title="Patterns"
       description="Cross-cutting behaviors — not components, but the shared building blocks every feature reaches for."
     >

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -420,7 +420,12 @@ export function PrimitivesSection() {
         description="The searchable list behind the command palette and every picker."
         className="block"
       >
-        <Command className="max-w-sm rounded-lg border">
+        {/* `value=""` keeps cmdk from auto-selecting the first item on mount;
+            its built-in `selected → scrollIntoView` would otherwise scroll the
+            whole sandbox page to land on this specimen every time the
+            Primitives tab opens. cmdk reverts to its normal "highlight as you
+            type" behavior once the user interacts. */}
+        <Command className="max-w-sm rounded-lg border" value="">
           <CommandInput placeholder="Search…" />
           <CommandList>
             <CommandEmpty>No results.</CommandEmpty>

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -115,6 +115,7 @@ import { SandboxSection, Specimen } from "@/sandbox/kit";
 export function PrimitivesSection() {
   return (
     <SandboxSection
+      id="primitives"
       title="Primitives"
       description="shadcn/ui components as themed for v2. Generated into components/ui/* — never hand-edited; variants come from theme tokens."
     >


### PR DESCRIPTION
## Summary

Rolls up the `sprint/ui-polish-2026-05-17` work — 19 merged sub-PRs (#1277–#1294) plus the final batch-3 commits — into `main`. All changes are v2 SPA polish in `web/src/`; no Go, schema, or migration changes.

Highlights:

- **CategoryPicker affordance** — hover-revealed pencil over a `bg-secondary` scrim, ring suppressed on uncategorized + on `CategoryBadge`-as-trigger; shared badge shape tokens with `CategoryBadge` (#1294 / final batch).
- **Sandbox rework** — scoped sandbox isolation with per-specimen "Isolate" links, full-width layout, scrollable grouped outline, per-section jump nav (#1292, batch-3 commits).
- **Transaction row** — restored single-tap row navigation (revert of two-tap), cursor reflects select mode, title underlines on hover, badge bumped to `md`, Pending pill → muted text label, tighter tag pills (#1289–#1293, batch-3 commits).
- **DataTable sticky header** — separator + corner polish that only engages while actually stuck; thead-level stuck detection; j/k-focused rows stay visible under sticky chrome (#1284–#1287).
- **Search / shortcuts** — debounced search no longer drops `j/k+Enter`; `j/k` repeats while held (#1283, #1288).
- **Misc polish** — drop tone/coloured rails across panels, toasts, hero cards; PageHeader + sonner reset + cursor consistency rollup; placeholder-page action cleanup; CardHeader phantom row collapsed when no description; right-aligned command-palette + theme submenu rows (#1277–#1282).

23 files changed, +695 / −196.

## Test plan

- [ ] `cd web && pnpm typecheck` is clean.
- [ ] Smoke `/v2/transactions`: row click navigates, select mode flips cursor, j/k navigation stays visible under sticky header.
- [ ] Smoke `/v2/sandbox`: grouped outline scrolls, per-section jump nav works, Isolate link on a specimen scopes correctly.
- [ ] Hover over a CategoryPicker trigger (categorized + uncategorized states) — pencil reveals over scrim without icon bleed; no double-ring with `CategoryBadge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
