### PR TITLE
feat(v2): agents redesign + prompt builder + presets

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -268,6 +268,8 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | POST | `/agents/test` | W | Run the diagnostic smoke test (tiny "say OK" prompt, no MCP servers, ~5¢ cap); 422 `AUTH_NOT_CONFIGURED` / `AGENT_BINARY_NOT_FOUND` |
 | POST | `/agents/cleanup` | W | Run the agent cleanup pass on demand; returns `{runs_deleted, transcripts_deleted, transcripts_scanned, retention_days, transcript_dir}` |
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200); filters: `status`, `trigger`, `hit_cap` (`max_turns`/`max_budget`/`any`), `start`, `end` |
+| GET | `/agents/runs` | R | Cross-agent run history with `agent_slug`+`agent_name` per row; same filters as `/agents/{slug}/runs` plus optional `agent=<slug>` to narrow to one definition; powers v2 `/v2/agents/runs` global view |
+| GET | `/agents/prompt-blocks` | R | Parsed view of the embedded `prompts/agents/*.md` library — id, title, description, group (`strategy`/`depth`/`integration`/`knowledge`), and full markdown content. Backs the v2 `/v2/prompts/build` assembly-bench prompt builder |
 | GET | `/agents/runs/recent-errors` | R | Errored runs across all agents in the last `hours` (default 24, max 168); `?limit=5` (max 50); joined with `agent_slug`+`agent_name` for deep-link |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | PATCH | `/agents/runs/{shortId}` | W | Set/clear the operator note on a run. Body `{ "note": "..." }`; empty string clears. Capped at 2000 chars |

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -290,6 +290,76 @@ func ListAgentRunsHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// ListAllAgentRunsHandler returns paginated runs across every agent,
+// joined against agent_definitions so each row carries agent_slug +
+// agent_name. Powers the v2 SPA's global "/agents/runs" view. Supports
+// the same status/trigger/hit_cap/date filters as ListAgentRunsHandler,
+// plus an optional `agent=<slug|uuid>` filter to narrow to one definition
+// (a slimmer form of /agents/{slug}/runs that uses the same UI table).
+func ListAllAgentRunsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		limit, err := parseIntParam(q, "limit", 50, 1, 200)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		offset, err := parseIntParam(q, "offset", 0, 0, 1<<20)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		params := service.AllAgentRunListParams{
+			Limit:         limit,
+			Offset:        offset,
+			AgentSlugOrID: q.Get("agent"),
+			Status:        q.Get("status"),
+			Trigger:       q.Get("trigger"),
+			HitCap:        q.Get("hit_cap"),
+		}
+		if s := q.Get("start"); s != "" {
+			t, perr := parseDateOrRFC3339(s)
+			if perr != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "start must be YYYY-MM-DD or RFC3339")
+				return
+			}
+			params.Start = &t
+		}
+		if s := q.Get("end"); s != "" {
+			t, perr := parseDateOrRFC3339(s)
+			if perr != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "end must be YYYY-MM-DD or RFC3339")
+				return
+			}
+			if len(s) == 10 {
+				t = t.Add(24*time.Hour - time.Second)
+			}
+			params.End = &t
+		}
+		if !isAllowedRunStatus(params.Status) {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"status must be one of: success, error, in_progress, skipped, timeout (empty = all)")
+			return
+		}
+		if !isAllowedRunTrigger(params.Trigger) {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"trigger must be one of: cron, manual, webhook (empty = all)")
+			return
+		}
+		if !isAllowedRunHitCap(params.HitCap) {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"hit_cap must be one of: max_turns, max_budget, any (empty = all)")
+			return
+		}
+		out, err := svc.ListAllAgentRuns(r.Context(), params)
+		if err != nil {
+			writeAgentError(w, err, "agent not found")
+			return
+		}
+		writeData(w, out)
+	}
+}
+
 func parseDateOrRFC3339(s string) (time.Time, error) {
 	if len(s) == 10 { // YYYY-MM-DD
 		return time.Parse("2006-01-02", s)
@@ -674,6 +744,23 @@ func ListRecentErroredAgentRunsHandler(svc *service.Service) http.HandlerFunc {
 		if err != nil {
 			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
 				"Failed to list recent errored runs")
+			return
+		}
+		writeData(w, out)
+	}
+}
+
+// ListPromptBlocksHandler exposes the parsed agent prompt blocks under
+// prompts/agents/*.md to the v2 SPA. Backs the assembly-bench prompt
+// builder at /v2/prompts/build. The blocks themselves are embedded into
+// the binary at build time, so this is a read-only, side-effect-free
+// endpoint — no scope upgrade required.
+func ListPromptBlocksHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out, err := svc.ListPromptBlocks(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+				"Failed to list prompt blocks")
 			return
 		}
 		writeData(w, out)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -119,6 +119,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/agents", ListAgentDefinitionsHandler(svc))
 		r.Get("/agents/settings", GetAgentSettingsHandler(svc, a))
 		r.Get("/agents/status", AgentSubsystemStatusHandler(svc))
+		r.Get("/agents/prompt-blocks", ListPromptBlocksHandler(svc))
+		r.Get("/agents/runs", ListAllAgentRunsHandler(svc))
 		r.Get("/agents/runs/recent-errors", ListRecentErroredAgentRunsHandler(svc))
 		r.Get("/agents/runs/{shortId}", GetAgentRunHandler(svc))
 		r.Get("/agents/runs/{shortId}/transcript", GetAgentRunTranscriptHandler(svc))

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -17,6 +17,7 @@ import (
 	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
+	"breadbox/prompts"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -26,6 +27,23 @@ import (
 // claude-opus-4-7 is the latest Opus (matches the agent_definitions
 // migration default).
 const DefaultAgentModel = "claude-opus-4-7"
+
+// defaultAgentSystemPrompt is the breadbox-flavored baseline injected
+// whenever a definition's system_prompt is empty. Embedded from
+// prompts/agents/default-system-prompt.md at build time. Resolved once
+// at package init — missing file is a programming error (the prompts
+// package panics on a missing embed). The prompt deliberately does NOT
+// repeat what the MCP server's own instructions already cover (resource
+// list, amount sign convention, short_id convention); it adds the
+// autonomous-agent persona + the safety invariants we want every run to
+// honor regardless of the user-supplied prompt.
+var defaultAgentSystemPrompt = func() string {
+	data, err := prompts.Agent("default-system-prompt")
+	if err != nil {
+		panic(fmt.Sprintf("service: load default agent system prompt: %v", err))
+	}
+	return strings.TrimSpace(string(data))
+}()
 
 // DefaultAgentMaxTurns is the per-run turn cap when a definition omits one.
 const DefaultAgentMaxTurns = 10
@@ -159,6 +177,25 @@ type AgentRunListResult struct {
 	Limit   int                `json:"limit"`
 	Offset  int                `json:"offset"`
 	HasMore bool               `json:"has_more"`
+}
+
+// AgentRunWithAgentResponse is the per-row shape for ListAllAgentRuns —
+// every field on AgentRunResponse, plus the parent agent's slug + name so
+// the global /agents/runs view can label each row without an extra fetch.
+type AgentRunWithAgentResponse struct {
+	AgentRunResponse
+	AgentSlug string `json:"agent_slug"`
+	AgentName string `json:"agent_name"`
+}
+
+// AgentRunListWithAgentResult is the paginated envelope for the global
+// (cross-agent) run list. Mirrors AgentRunListResult but the per-row type
+// carries agent identity.
+type AgentRunListWithAgentResult struct {
+	Runs    []AgentRunWithAgentResponse `json:"runs"`
+	Limit   int                         `json:"limit"`
+	Offset  int                         `json:"offset"`
+	HasMore bool                        `json:"has_more"`
 }
 
 // CreateAgentDefinitionParams holds validated inputs for definition creation.
@@ -679,6 +716,150 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 	}, nil
 }
 
+// AllAgentRunListParams carries the optional filters for ListAllAgentRuns.
+// Mirrors AgentRunListParams but adds AgentSlugOrID so the caller can
+// optionally narrow to one agent (e.g. the global view with an agent
+// chip selected); empty = every agent.
+type AllAgentRunListParams struct {
+	Limit         int
+	Offset        int
+	AgentSlugOrID string // "" | slug | UUID
+	Status        string
+	Trigger       string
+	HitCap        string
+	Start         *time.Time
+	End           *time.Time
+}
+
+// ListAllAgentRuns returns offset-paginated runs across every agent,
+// joined against agent_definitions so each row carries the agent's slug
+// and name. Powers /v2/agents/runs (the cross-agent global view).
+//
+// Same hand-rolled SQL pattern as ListAgentRuns — composable WHERE
+// clauses with positional params. We don't go through sqlc because the
+// filter combinatorics balloon the generated surface and offer no
+// type-safety win over scanning a known column list.
+func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams) (*AgentRunListWithAgentResult, error) {
+	limit := p.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := p.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	args := []any{}
+	where := []string{}
+	idx := 1
+
+	if p.AgentSlugOrID != "" {
+		def, err := s.resolveAgentDefinition(ctx, p.AgentSlugOrID)
+		if err != nil {
+			return nil, err
+		}
+		where = append(where, fmt.Sprintf("r.agent_definition_id = $%d", idx))
+		args = append(args, def.ID)
+		idx++
+	}
+	if p.Status != "" {
+		where = append(where, fmt.Sprintf("r.status = $%d", idx))
+		args = append(args, p.Status)
+		idx++
+	}
+	if p.Trigger != "" {
+		where = append(where, fmt.Sprintf(`r."trigger" = $%d`, idx))
+		args = append(args, p.Trigger)
+		idx++
+	}
+	switch p.HitCap {
+	case "max_turns", "max_budget":
+		where = append(where, fmt.Sprintf("r.hit_cap = $%d", idx))
+		args = append(args, p.HitCap)
+		idx++
+	case "any":
+		where = append(where, "r.hit_cap IS NOT NULL")
+	case "":
+		// no-op
+	}
+	if p.Start != nil {
+		where = append(where, fmt.Sprintf("r.started_at >= $%d", idx))
+		args = append(args, *p.Start)
+		idx++
+	}
+	if p.End != nil {
+		where = append(where, fmt.Sprintf("r.started_at <= $%d", idx))
+		args = append(args, *p.End)
+		idx++
+	}
+
+	whereClause := ""
+	if len(where) > 0 {
+		whereClause = "WHERE " + strings.Join(where, " AND ")
+	}
+
+	// Peek for has_more by asking for limit+1.
+	args = append(args, limit+1, offset)
+	query := fmt.Sprintf(`
+		SELECT r.id, r.short_id, r.agent_definition_id, r."trigger", r.status, r.started_at, r.completed_at,
+		       r.duration_ms, r.total_cost_usd, r.input_tokens, r.output_tokens, r.cache_read_tokens,
+		       r.cache_creation_tokens, r.turn_count, r.max_turns_used, r.num_tool_calls,
+		       r.error_message, r.transcript_path, r.session_id,
+		       r.operator_note, r.prompt_prefix, r.hit_cap,
+		       d.slug, d.name
+		FROM agent_runs r
+		JOIN agent_definitions d ON d.id = r.agent_definition_id
+		%s
+		ORDER BY r.started_at DESC
+		LIMIT $%d OFFSET $%d`,
+		whereClause, idx, idx+1)
+
+	rows, err := s.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list all agent runs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []AgentRunWithAgentResponse
+	for rows.Next() {
+		var r db.AgentRun
+		var slug, name string
+		if scanErr := rows.Scan(
+			&r.ID, &r.ShortID, &r.AgentDefinitionID, &r.Trigger, &r.Status,
+			&r.StartedAt, &r.CompletedAt, &r.DurationMs, &r.TotalCostUsd,
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens,
+			&r.CacheCreationTokens, &r.TurnCount, &r.MaxTurnsUsed,
+			&r.NumToolCalls, &r.ErrorMessage, &r.TranscriptPath, &r.SessionID,
+			&r.OperatorNote, &r.PromptPrefix, &r.HitCap,
+			&slug, &name,
+		); scanErr != nil {
+			return nil, fmt.Errorf("scan agent run: %w", scanErr)
+		}
+		out = append(out, AgentRunWithAgentResponse{
+			AgentRunResponse: agentRunFromRow(r),
+			AgentSlug:        slug,
+			AgentName:        name,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate agent runs: %w", err)
+	}
+
+	hasMore := len(out) > limit
+	if hasMore {
+		out = out[:limit]
+	}
+	if out == nil {
+		out = []AgentRunWithAgentResponse{}
+	}
+	return &AgentRunListWithAgentResult{
+		Runs:    out,
+		Limit:   limit,
+		Offset:  offset,
+		HasMore: hasMore,
+	}, nil
+}
+
 // AgentRunNoteMaxLen caps the operator note size both in the SPA textarea
 // and on the server. Free-form text but bounded so we don't accidentally
 // host arbitrarily-large blobs.
@@ -899,11 +1080,20 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 		maxBudget = *def.MaxBudgetUSD
 	}
 
+	// SystemPrompt: caller-defined override wins; otherwise the breadbox
+	// baseline is injected. Without this fallback the SDK silently uses
+	// its built-in "Claude Code"-style persona, which is optimized for
+	// coding tasks rather than recurring data review.
+	systemPrompt := derefString(def.SystemPrompt)
+	if strings.TrimSpace(systemPrompt) == "" {
+		systemPrompt = defaultAgentSystemPrompt
+	}
+
 	spec := &agent.JobSpec{
 		RunID:             run.ID,
 		AgentDefinitionID: def.ID,
 		Prompt:            def.Prompt,
-		SystemPrompt:      derefString(def.SystemPrompt),
+		SystemPrompt:      systemPrompt,
 		Model:             def.Model,
 		MaxTurns:          def.MaxTurns,
 		MaxBudgetUsd:      maxBudget,

--- a/internal/service/prompt_blocks.go
+++ b/internal/service/prompt_blocks.go
@@ -124,6 +124,10 @@ func parsePromptBlock(id, body string) PromptBlock {
 		block.Content = body
 		legacyParsePromptHeader(body, &block)
 	}
+	// Markdown sources usually end with one trailing newline (some
+	// with two). Strip them so the expansion editor doesn't surface
+	// phantom blank lines and the composed prompt joins cleanly.
+	block.Content = strings.TrimRight(block.Content, " \t\r\n")
 	if block.Title == "" {
 		block.Title = humanizeBlockID(id)
 	}

--- a/internal/service/prompt_blocks.go
+++ b/internal/service/prompt_blocks.go
@@ -1,0 +1,236 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"breadbox/prompts"
+)
+
+// PromptBlock is one reusable agent-prompt building block — the parsed
+// view of a single `prompts/agents/*.md` file. The v2 SPA's prompt
+// builder composes these into agent prompts.
+//
+// On-disk format is YAML frontmatter + markdown body:
+//
+//	---
+//	title: Routine Review Strategy
+//	description: Daily or weekly review of recent transactions
+//	icon: calendar-check
+//	---
+//
+//	<body markdown — sent to the model verbatim>
+//
+// Icon names are kebab-case Lucide identifiers (matching the React
+// `DynamicIcon` resolver). Group classifies the block by its filename
+// prefix and tells the UI how to render the picker:
+//
+//	strategy    — top-level approach. One selected; mutually exclusive.
+//	depth       — review intensity modifier. Zero or one; mutually exclusive.
+//	integration — optional add-ons (gmail, sync, account-linking). Multi-select.
+//	knowledge   — domain knowledge (category-system, merchants, comments). Multi-select.
+type PromptBlock struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Icon        string `json:"icon,omitempty"`
+	Group       string `json:"group"`
+	Content     string `json:"content"`
+}
+
+// Block IDs that the builder excludes from the user-facing palette.
+// default-system-prompt is injected by AssembleJobSpec as the SDK
+// systemPrompt, not as a user-prompt building block — surfacing it in
+// the builder would be confusing (it's a different field entirely).
+var hiddenPromptBlockIDs = map[string]bool{
+	"default-system-prompt": true,
+}
+
+// ListPromptBlocks returns every block under prompts/agents/, parsed.
+// Reads from the embed.FS in `breadbox/prompts`, so the file set is
+// fixed at build time — no DB call, no I/O after init. Returned slice
+// is grouped + sorted within group for stable UI rendering.
+//
+// ctx is unused today (the embed.FS read is synchronous) but kept on
+// the signature so a future DB-backed override (user-authored custom
+// blocks) doesn't change the call sites.
+func (s *Service) ListPromptBlocks(_ context.Context) ([]PromptBlock, error) {
+	entries, err := prompts.FS.ReadDir("agents")
+	if err != nil {
+		return nil, fmt.Errorf("read prompts/agents: %w", err)
+	}
+	out := make([]PromptBlock, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".md")
+		if hiddenPromptBlockIDs[id] {
+			continue
+		}
+		data, err := prompts.FS.ReadFile("agents/" + name)
+		if err != nil {
+			return nil, fmt.Errorf("read prompts/agents/%s: %w", name, err)
+		}
+		block := parsePromptBlock(id, string(data))
+		out = append(out, block)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Group != out[j].Group {
+			return promptBlockGroupOrder(out[i].Group) < promptBlockGroupOrder(out[j].Group)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+// parsePromptBlock splits a `prompts/agents/*.md` file into frontmatter
+// metadata and body. Format:
+//
+//	---
+//	title: ...
+//	description: ...
+//	icon: ...
+//	---
+//
+//	<body>
+//
+// Frontmatter values may be quoted with single or double quotes; quotes
+// are stripped if present. Unknown keys are ignored. The body is the
+// composed-prompt content — what the model actually reads — with
+// leading whitespace trimmed so the composer concatenates cleanly.
+// If the frontmatter block is missing or malformed, falls back to the
+// legacy `# Title` / `> Description` convention so a stray un-migrated
+// file doesn't disappear from the picker.
+func parsePromptBlock(id, body string) PromptBlock {
+	block := PromptBlock{
+		ID:    id,
+		Group: promptBlockGroupFor(id),
+	}
+	if meta, content, ok := parsePromptFrontmatter(body); ok {
+		block.Title = meta["title"]
+		block.Description = meta["description"]
+		block.Icon = meta["icon"]
+		block.Content = strings.TrimLeft(content, "\n")
+	} else {
+		block.Content = body
+		legacyParsePromptHeader(body, &block)
+	}
+	if block.Title == "" {
+		block.Title = humanizeBlockID(id)
+	}
+	return block
+}
+
+// parsePromptFrontmatter extracts the leading YAML-ish frontmatter
+// block from `body`. We deliberately don't import a YAML library — the
+// shape is fixed (`key: value` per line, optional surrounding quotes)
+// and a 30-line scanner is easier to audit. Returns the parsed map,
+// the post-frontmatter content, and whether a frontmatter block was
+// actually present.
+func parsePromptFrontmatter(body string) (map[string]string, string, bool) {
+	const fence = "---"
+	lines := strings.Split(body, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != fence {
+		return nil, body, false
+	}
+	meta := map[string]string{}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == fence {
+			return meta, strings.Join(lines[i+1:], "\n"), true
+		}
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		sep := strings.IndexByte(line, ':')
+		if sep <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:sep])
+		val := strings.TrimSpace(line[sep+1:])
+		// Strip a single matching pair of wrapping quotes — single OR double.
+		if len(val) >= 2 {
+			first, last := val[0], val[len(val)-1]
+			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+		meta[key] = val
+	}
+	// Reached EOF without a closing fence — treat as no frontmatter.
+	return nil, body, false
+}
+
+// legacyParsePromptHeader keeps the pre-frontmatter `# Title` and
+// `> Description` convention working as a fallback. Removable once
+// every file under prompts/agents/ has been migrated to frontmatter.
+func legacyParsePromptHeader(body string, block *PromptBlock) {
+	for _, line := range strings.SplitN(body, "\n", 5) {
+		trimmed := strings.TrimSpace(line)
+		if block.Title == "" && strings.HasPrefix(trimmed, "# ") {
+			block.Title = strings.TrimSpace(strings.TrimPrefix(trimmed, "# "))
+			continue
+		}
+		if block.Description == "" && strings.HasPrefix(trimmed, "> ") {
+			block.Description = strings.TrimSpace(strings.TrimPrefix(trimmed, "> "))
+		}
+		if block.Title != "" && block.Description != "" {
+			return
+		}
+	}
+}
+
+// promptBlockGroupFor maps a block filename to its taxonomic group.
+// Anything that doesn't match a known prefix falls into "knowledge"
+// as the catch-all — better to surface an unknown block than hide it.
+func promptBlockGroupFor(id string) string {
+	switch {
+	case strings.HasPrefix(id, "strategy-"):
+		return "strategy"
+	case strings.HasPrefix(id, "review-depth-"):
+		return "depth"
+	case strings.HasSuffix(id, "-integration"),
+		strings.HasSuffix(id, "-linking"),
+		strings.HasSuffix(id, "-management"):
+		return "integration"
+	default:
+		return "knowledge"
+	}
+}
+
+func promptBlockGroupOrder(group string) int {
+	switch group {
+	case "strategy":
+		return 0
+	case "depth":
+		return 1
+	case "integration":
+		return 2
+	case "knowledge":
+		return 3
+	default:
+		return 4
+	}
+}
+
+// humanizeBlockID turns "strategy-routine-review" into "Strategy Routine
+// Review" for the rare case where a block file is missing a title.
+func humanizeBlockID(id string) string {
+	parts := strings.Split(id, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2578,6 +2578,52 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
+  /api/v1/agents/runs:
+    parameters:
+      - { name: limit, in: query, schema: { type: integer, default: 50, maximum: 200 } }
+      - { name: offset, in: query, schema: { type: integer, default: 0 } }
+      - { name: agent, in: query, schema: { type: string }, description: Optional slug or UUID to narrow to one definition }
+      - { name: status, in: query, schema: { type: string, enum: [success, error, in_progress, skipped, timeout] } }
+      - { name: trigger, in: query, schema: { type: string, enum: [cron, manual, webhook] } }
+      - { name: hit_cap, in: query, schema: { type: string, enum: [max_turns, max_budget, any] } }
+      - { name: start, in: query, schema: { type: string }, description: "YYYY-MM-DD or RFC3339; inclusive lower bound on started_at" }
+      - { name: end, in: query, schema: { type: string }, description: "YYYY-MM-DD or RFC3339; inclusive upper bound on started_at" }
+    get:
+      tags: [Agents]
+      summary: List runs across all agents
+      description: |
+        Cross-agent run history. Each row carries `agent_slug` + `agent_name`
+        in addition to the standard run fields, so callers can render an
+        agent column without a second fetch. Powers the v2 SPA's global
+        `/v2/agents/runs` view. Same filters as `/agents/{slug}/runs`,
+        plus the optional `agent=<slug>` narrowing filter.
+      responses:
+        "200":
+          description: Paginated runs envelope `{runs, limit, offset, has_more}` where each run includes `agent_slug` + `agent_name`.
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+  /api/v1/agents/prompt-blocks:
+    get:
+      tags: [Agents]
+      summary: List the embedded agent prompt-block library
+      description: |
+        Returns every parsed block under `prompts/agents/*.md` — id,
+        title, one-line description, taxonomic group (`strategy` /
+        `depth` / `integration` / `knowledge`), and full markdown
+        content. Backs the v2 SPA's assembly-bench prompt builder at
+        `/v2/prompts/build`. The block set is fixed at build time;
+        editing requires a redeploy. The `default-system-prompt` block
+        is excluded — it's injected by `AssembleJobSpec` as the SDK
+        system prompt, not composed into user prompts.
+      responses:
+        "200":
+          description: Bare JSON array of `{id, title, description, group, content}`.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: object, additionalProperties: true }
   /api/v1/agents/runs/recent-errors:
     parameters:
       - { name: hours, in: query, schema: { type: integer, default: 24, minimum: 1, maximum: 168 } }

--- a/prompts/agents/account-linking.md
+++ b/prompts/agents/account-linking.md
@@ -1,5 +1,8 @@
-# Account Linking
-> Deduplication for shared credit cards across family members
+---
+title: Account Linking
+description: Deduplication for shared credit cards across family members
+icon: link-2
+---
 
 WHEN TO USE:
 When two family members connect the same credit card (e.g., primary cardholder + authorized user), transactions appear in both feeds with different IDs. Account linking deduplicates them.

--- a/prompts/agents/category-system.md
+++ b/prompts/agents/category-system.md
@@ -1,5 +1,8 @@
-# Category System
-> Category hierarchy, slugs, merging, and taxonomy management
+---
+title: Category System
+description: Category hierarchy, slugs, merging, and taxonomy management
+icon: shapes
+---
 
 CATEGORIES:
 - 2-level hierarchy: primary → detailed subcategories

--- a/prompts/agents/default-system-prompt.md
+++ b/prompts/agents/default-system-prompt.md
@@ -1,0 +1,5 @@
+You are a Breadbox agent running autonomously on a schedule (cron, webhook, or manual). No interactive user is present during the run — make decisions, execute the task, and report results rather than asking questions. Breadbox is a self-hosted financial data aggregator service for households.
+
+Operating posture:
+- Ground yourself in MCP resources at the start of the run; the server's instructions enumerate what's available.
+- Stay scoped to the task in the user prompt. Don't expand into adjacent work mid-run.

--- a/prompts/agents/gmail-integration.md
+++ b/prompts/agents/gmail-integration.md
@@ -1,5 +1,10 @@
-# Gmail Integration
-> Cross-reference transactions with email receipts for better accuracy
+---
+title: Gmail Integration
+description: Cross-reference transactions with email receipts for better accuracy
+icon: mail
+---
+
+## Gmail Integration
 
 WHEN THIS HELPS:
 - Online purchases where the bank feed shows a payment processor name instead of the merchant

--- a/prompts/agents/merchant-analysis.md
+++ b/prompts/agents/merchant-analysis.md
@@ -1,5 +1,8 @@
-# Merchant Analysis
-> Identify spending patterns and recurring charges using merchant summaries
+---
+title: Merchant Analysis
+description: Identify spending patterns and recurring charges using merchant summaries
+icon: store
+---
 
 USE merchant_summary TO:
 - Get a compact index of merchants with transaction counts, totals, averages, and date ranges

--- a/prompts/agents/review-depth-efficient.md
+++ b/prompts/agents/review-depth-efficient.md
@@ -1,5 +1,8 @@
-# Review Depth: Efficient
-> Move fast — confirm clear items quickly, skip ambiguous ones
+---
+title: "Review Depth: Efficient"
+description: Move fast — confirm clear items quickly, skip ambiguous ones
+icon: rabbit
+---
 
 REVIEW APPROACH:
 - Use fields=minimal on query_transactions (name, amount, date only) when fetching the backlog

--- a/prompts/agents/review-depth-thorough.md
+++ b/prompts/agents/review-depth-thorough.md
@@ -1,5 +1,8 @@
-# Review Depth: Thorough
-> Take your time — examine each transaction carefully
+---
+title: "Review Depth: Thorough"
+description: Take your time — examine each transaction carefully
+icon: telescope
+---
 
 REVIEW APPROACH:
 - Use fields=core,category on query_transactions for full context per transaction

--- a/prompts/agents/strategy-anomaly-detection.md
+++ b/prompts/agents/strategy-anomaly-detection.md
@@ -1,5 +1,8 @@
-# Anomaly Detection Strategy
-> Monitor for unusual charges, duplicates, and spending spikes
+---
+title: Anomaly Detection Strategy
+description: Monitor for unusual charges, duplicates, and spending spikes
+icon: siren
+---
 
 You are monitoring transactions for anomalies that need human attention. Your job is to surface genuinely suspicious or unusual activity — not to cry wolf.
 

--- a/prompts/agents/strategy-bulk-review.md
+++ b/prompts/agents/strategy-bulk-review.md
@@ -1,5 +1,8 @@
-# Bulk Review Strategy
-> Thorough review of a large accumulated needs-review backlog
+---
+title: Bulk Review Strategy
+description: Thorough review of a large accumulated needs-review backlog
+icon: list-checks
+---
 
 You are reviewing a large backlog of transactions tagged needs-review that has accumulated over time. Rules from previous sessions likely cover some patterns already. Focus on what's still uncategorized.
 

--- a/prompts/agents/strategy-initial-setup.md
+++ b/prompts/agents/strategy-initial-setup.md
@@ -1,5 +1,8 @@
-# Initial Setup Strategy
-> First-time setup when no rules exist yet — establishing the category mapping foundation
+---
+title: Initial Setup Strategy
+description: First-time setup when no rules exist yet — establishing the category mapping foundation
+icon: sparkles
+---
 
 You are performing the very first categorization setup for a user who just connected their bank accounts. No rules exist yet. Your goal is to establish the mapping from raw provider categories to the user's category taxonomy, review all historical transactions, and create rules that handle future syncs.
 

--- a/prompts/agents/strategy-quick-review.md
+++ b/prompts/agents/strategy-quick-review.md
@@ -1,5 +1,8 @@
-# Quick Review Strategy
-> Rapidly clear a large needs-review backlog, prioritizing speed with reasonable accuracy
+---
+title: Quick Review Strategy
+description: Rapidly clear a large needs-review backlog, prioritizing speed with reasonable accuracy
+icon: zap
+---
 
 You are clearing a large backlog of transactions tagged needs-review efficiently. Handle the obvious patterns quickly, leave edge cases for later.
 

--- a/prompts/agents/strategy-routine-review.md
+++ b/prompts/agents/strategy-routine-review.md
@@ -1,5 +1,8 @@
-# Routine Review Strategy
-> Daily or weekly review of recent transactions
+---
+title: Routine Review Strategy
+description: Daily or weekly review of recent transactions
+icon: calendar-check
+---
 
 You are performing a routine review of recently synced transactions. The queue — transactions tagged needs-review — is typically small (5-30 items). Focus on accuracy and incremental rule coverage.
 

--- a/prompts/agents/strategy-spending-report.md
+++ b/prompts/agents/strategy-spending-report.md
@@ -1,5 +1,8 @@
-# Spending Report Strategy
-> Generate a periodic spending summary with trends and analysis
+---
+title: Spending Report Strategy
+description: Generate a periodic spending summary with trends and analysis
+icon: chart-no-axes-column
+---
 
 You are preparing a spending report for the family. Produce a clear, actionable summary — not a data dump.
 

--- a/prompts/agents/sync-management.md
+++ b/prompts/agents/sync-management.md
@@ -1,5 +1,8 @@
-# Sync Management
-> Check data freshness and trigger syncs when needed
+---
+title: Sync Management
+description: Check data freshness and trigger syncs when needed
+icon: refresh-cw
+---
 
 BEFORE STARTING WORK:
 - Call get_sync_status to check when each connection was last synced

--- a/prompts/agents/transaction-comments.md
+++ b/prompts/agents/transaction-comments.md
@@ -1,5 +1,8 @@
-# Transaction Comments & Annotations
-> Annotate transactions with reasoning and context
+---
+title: Transaction Comments & Annotations
+description: Annotate transactions with reasoning and context
+icon: message-square
+---
 
 THREE WRITE PATHS — pick the right one:
 - Compound review decision: call update_transactions with an operation that sets the category, removes the needs-review tag (with an optional note), and optionally attaches a `comment`. Everything lands in one audit-atomic batch.

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,10 @@
     "": {
       "name": "breadbox-web",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-collapsible": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -85,6 +89,16 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,10 @@
     "validate": "bun run scripts/validate.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -109,6 +109,23 @@ export interface AgentRunListResult {
   has_more: boolean;
 }
 
+// AgentRunWithAgent extends AgentRun with the parent definition's slug
+// and name. Returned by GET /api/v1/agents/runs (the cross-agent global
+// list) so the v2 SPA can render an Agent column without a per-row
+// fetch. Per-agent endpoints (/agents/{slug}/runs) still return plain
+// AgentRun — the slug is in the URL.
+export interface AgentRunWithAgent extends AgentRun {
+  agent_slug: string;
+  agent_name: string;
+}
+
+export interface AgentRunWithAgentListResult {
+  runs: AgentRunWithAgent[];
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
 export interface AgentSettings {
   auth_mode: "subscription" | "api_key";
   subscription_token?: string | null; // masked
@@ -297,6 +314,37 @@ export function useAgentRuns(
     // flips to success/error as soon as the sidecar finishes (the
     // orchestrator runs async post-iter-47 and doesn't push status into
     // the cache). Stops automatically once no in-flight runs remain.
+    refetchInterval: (q) =>
+      (q.state.data?.runs ?? []).some((r) => r.status === "in_progress")
+        ? 2000
+        : false,
+  });
+}
+
+// useAllAgentRuns powers the v2 /agents/runs global view — every run
+// across every agent, ordered by started_at DESC. Filters mirror
+// useAgentRuns plus an optional `agent` slug filter. Polls every 2s
+// while any visible row is in_progress so freshly-fired runs update
+// their status in place.
+export function useAllAgentRuns(
+  filters: AgentRunsFilters & { agent?: string } = {},
+  limit = 50,
+  offset = 0,
+) {
+  return useQuery({
+    queryKey: ["agents", "runs", "all", { limit, offset, ...filters }],
+    queryFn: () => {
+      const qs = new URLSearchParams();
+      qs.set("limit", String(limit));
+      qs.set("offset", String(offset));
+      if (filters.agent) qs.set("agent", filters.agent);
+      if (filters.status) qs.set("status", filters.status);
+      if (filters.trigger) qs.set("trigger", filters.trigger);
+      if (filters.hit_cap) qs.set("hit_cap", filters.hit_cap);
+      if (filters.start) qs.set("start", filters.start);
+      if (filters.end) qs.set("end", filters.end);
+      return api<AgentRunWithAgentListResult>(`/api/v1/agents/runs?${qs.toString()}`);
+    },
     refetchInterval: (q) =>
       (q.state.data?.runs ?? []).some((r) => r.status === "in_progress")
         ? 2000

--- a/web/src/api/queries/prompt-blocks.ts
+++ b/web/src/api/queries/prompt-blocks.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+// PromptBlockGroup mirrors the Go-side taxonomy in
+// internal/service/prompt_blocks.go::promptBlockGroupFor. Bumping this
+// requires a coordinated change on both sides.
+export type PromptBlockGroup =
+  | "strategy"
+  | "depth"
+  | "integration"
+  | "knowledge";
+
+export interface PromptBlock {
+  id: string;
+  title: string;
+  description: string;
+  /** Kebab-case Lucide icon name (e.g. "calendar-check"), or empty
+   *  when the block file omits the frontmatter `icon` field. */
+  icon?: string;
+  group: PromptBlockGroup;
+  content: string;
+}
+
+// usePromptBlocks loads the embedded library once per session. The
+// blocks ship inside the Go binary at build time so the response is
+// effectively static; staleTime is generous to suppress refetches as
+// the user navigates between the builder and other routes.
+export function usePromptBlocks() {
+  return useQuery({
+    queryKey: ["agents", "prompt-blocks"],
+    queryFn: () => api<PromptBlock[]>("/api/v1/agents/prompt-blocks"),
+    staleTime: 60 * 60 * 1000,
+  });
+}

--- a/web/src/components/floating-action-bar.tsx
+++ b/web/src/components/floating-action-bar.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+export interface FloatingActionBarProps {
+  /** Pill contents — buttons, text, separators. The bar is fully
+   *  agnostic about what goes inside; caller composes. */
+  children: React.ReactNode;
+  className?: string;
+  /** Per-instance label for assistive tech (e.g. "Bulk transaction
+   *  actions", "Prompt builder actions"). */
+  ariaLabel?: string;
+}
+
+// FloatingActionBar is the shared floating-pill chrome used by
+// surfaces that want a viewport-pinned action toolbar — bulk
+// selection on /v2/transactions, output actions on /v2/prompts/build,
+// any future "act on the page" surface. Outer wrapper is
+// `pointer-events-none` so the empty band stays click-through; only
+// the inner pill captures events. Use this for *transient or
+// contextual* actions; PageHeader.actions is still the right home for
+// persistent page-level affordances (create, settings).
+export function FloatingActionBar({
+  children,
+  className,
+  ariaLabel,
+}: FloatingActionBarProps) {
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6"
+      role={ariaLabel ? "toolbar" : undefined}
+      aria-label={ariaLabel}
+    >
+      <div
+        data-state="open"
+        className={cn(
+          "pointer-events-auto bg-popover/95 text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 shadow-xl backdrop-blur-sm",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4 data-[state=open]:duration-200",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/button-group.tsx
+++ b/web/src/components/ui/button-group.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      className={cn(
+        "flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative m-0! self-stretch bg-input data-[orientation=vertical]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+}

--- a/web/src/components/ui/empty.tsx
+++ b/web/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -1,0 +1,469 @@
+import { type ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2, PenTool } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AGENT_MODELS, TOOL_SCOPES } from "./agent-constants";
+import { CronField } from "./cron-field";
+import { RuleDslHelp } from "./rule-dsl-help";
+
+// Shared schema for the two-column agent form. Slug is always part of
+// the typed payload — in create mode it's user-editable, in edit mode
+// the field is hidden but the existing value is carried through so the
+// schema validates either way. Numerics use z.preprocess instead of
+// z.coerce to dodge the iter-4 resolver bug where coerce.number left
+// the input type as `unknown`; preprocess converts string → number
+// explicitly at submit time while defaults stay typed.
+const agentFormSchema = z.object({
+  name: z.string().min(1, "Name is required").max(120),
+  slug: z
+    .string()
+    .min(2, "Slug must be at least 2 characters")
+    .max(64)
+    .regex(
+      /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/,
+      "Use lowercase letters, digits, dashes (kebab-case)",
+    ),
+  prompt: z.string().min(1, "Prompt is required"),
+  system_prompt: z.string().optional().or(z.literal("")),
+  schedule_cron: z.string().optional().or(z.literal("")),
+  tool_scope: z.enum(["read_only", "read_write"]),
+  allowed_tools_raw: z.string().optional(),
+  model: z.string().min(1),
+  max_turns: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? undefined : Number(v)),
+    z.number().int().min(1).max(200),
+  ),
+  max_budget_usd: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
+    z.number().positive().nullable(),
+  ),
+  quiet_hours_start: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
+    .optional()
+    .or(z.literal("")),
+  quiet_hours_end: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
+    .optional()
+    .or(z.literal("")),
+  trigger_on_sync_complete: z.boolean(),
+});
+
+export type AgentFormValues = z.input<typeof agentFormSchema>;
+
+export interface AgentFormProps {
+  mode: "create" | "edit";
+  initialValues: AgentFormValues;
+  onSubmit: (values: AgentFormValues) => Promise<void> | void;
+  submitLabel: string;
+  pending: boolean;
+  cancelTo?: string;
+  // extraActions render between Cancel and Submit. Edit mode injects the
+  // "Test this prompt" dry-run button here; create mode leaves it empty
+  // (no slug exists yet, so no run endpoint to target).
+  extraActions?: (form: ReturnType<typeof useAgentForm>) => ReactNode;
+}
+
+function useAgentForm(initialValues: AgentFormValues) {
+  return useForm<AgentFormValues>({
+    resolver: zodResolver(agentFormSchema),
+    defaultValues: initialValues,
+  });
+}
+
+export function AgentForm({
+  mode,
+  initialValues,
+  onSubmit,
+  submitLabel,
+  pending,
+  cancelTo = "/agents",
+  extraActions,
+}: AgentFormProps) {
+  const form = useAgentForm(initialValues);
+  const submit = form.handleSubmit(async (values) => {
+    await onSubmit(values);
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={submit} className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div className="space-y-4 md:col-span-2">
+          <Card className="space-y-4 p-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={mode === "create" ? "Weekly transaction review" : undefined}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {mode === "create" && (
+              <FormField
+                control={form.control}
+                name="slug"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Slug</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="weekly-transaction-review"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Kebab-case identifier used in URLs and API calls. Permanent — pick carefully.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            <FormField
+              control={form.control}
+              name="prompt"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex items-center justify-between gap-2">
+                    <FormLabel>Prompt</FormLabel>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      asChild
+                    >
+                      <Link to="/prompts/build">
+                        <PenTool className="size-3.5" />
+                        Build with templates
+                      </Link>
+                    </Button>
+                  </div>
+                  <FormControl>
+                    <Textarea
+                      rows={10}
+                      placeholder={
+                        mode === "create"
+                          ? "Review last week's uncategorized transactions and apply the closest matching category…"
+                          : undefined
+                      }
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Sent to Claude on every run. Be specific about the outcome (what to categorize,
+                    what to report, what not to touch). Need a head start?{" "}
+                    <Link to="/prompts/build" className="underline">
+                      Open the prompt builder
+                    </Link>
+                    .
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <RuleDslHelp />
+            <FormField
+              control={form.control}
+              name="system_prompt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>System prompt (optional)</FormLabel>
+                  <FormControl>
+                    <Textarea rows={4} {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Optional override. Leave blank to use the breadbox baseline
+                    (autonomous-agent persona + the safety invariants every run
+                    should honor). Fill this in only when you need a fundamentally
+                    different posture — the user prompt above is the right place
+                    for per-task instructions.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <Card className="space-y-4 p-4">
+            <FormField
+              control={form.control}
+              name="model"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Model</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {AGENT_MODELS.map((m) => (
+                        <SelectItem key={m.value} value={m.value}>
+                          {m.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="schedule_cron"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Schedule</FormLabel>
+                  <FormControl>
+                    <CronField
+                      value={field.value ?? ""}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tool_scope"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tool scope</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {TOOL_SCOPES.map((s) => (
+                        <SelectItem key={s.value} value={s.value}>
+                          {s.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Controls which MCP write tools the run can call.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="allowed_tools_raw"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Allowed tools (optional)</FormLabel>
+                  <FormControl>
+                    <Textarea rows={3} placeholder="mcp__breadbox__*" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Comma-separated MCP tool names. Leave blank to allow every tool in scope.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="max_turns"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Max turns</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={200}
+                        value={
+                          field.value === undefined || field.value === null
+                            ? ""
+                            : String(field.value)
+                        }
+                        onChange={(e) => field.onChange(e.target.value)}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="max_budget_usd"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Max cost (USD)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min={0}
+                        placeholder="0.50"
+                        value={
+                          field.value === undefined || field.value === null
+                            ? ""
+                            : String(field.value)
+                        }
+                        onChange={(e) => field.onChange(e.target.value)}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="quiet_hours_start"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Quiet hours start</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="time"
+                        placeholder="22:00"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="quiet_hours_end"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Quiet hours end</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="time"
+                        placeholder="07:00"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Cron fires inside the window are silently skipped. Leave both blank
+                      to disable.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormField
+              control={form.control}
+              name="trigger_on_sync_complete"
+              render={({ field }) => (
+                <FormItem className="mt-4 flex items-start gap-3 rounded-md border p-3">
+                  <FormControl>
+                    <input
+                      type="checkbox"
+                      className="mt-1 size-4"
+                      checked={field.value}
+                      onChange={(e) => field.onChange(e.target.checked)}
+                    />
+                  </FormControl>
+                  <div className="space-y-1">
+                    <FormLabel className="font-medium">
+                      Run after every successful sync
+                    </FormLabel>
+                    <FormDescription>
+                      Fires this agent (trigger=webhook) whenever a bank sync completes.
+                      Useful for keep-up agents like "re-categorize freshly synced
+                      transactions" — pairs with cron OR replaces it.
+                    </FormDescription>
+                    <FormMessage />
+                  </div>
+                </FormItem>
+              )}
+            />
+          </Card>
+
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button type="button" variant="outline" asChild>
+              <Link to={cancelTo}>Cancel</Link>
+            </Button>
+            {extraActions?.(form)}
+            <Button type="submit" disabled={pending}>
+              {pending && <Loader2 className="size-4 animate-spin" />}
+              {submitLabel}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+// CREATE_DEFAULTS mirror the Go-side service defaults in internal/service/
+// agents.go::Create. Keep aligned — when a new field gets a server-side
+// default, mirror it here so the form shows the same starting state.
+export const CREATE_DEFAULTS: AgentFormValues = {
+  name: "",
+  slug: "",
+  prompt: "",
+  system_prompt: "",
+  schedule_cron: "",
+  tool_scope: "read_write",
+  allowed_tools_raw: "",
+  model: AGENT_MODELS[1].value, // Sonnet — balanced default
+  max_turns: 25,
+  max_budget_usd: null,
+  quiet_hours_start: "",
+  quiet_hours_end: "",
+  trigger_on_sync_complete: false,
+};

--- a/web/src/features/agents/agents-tabs.tsx
+++ b/web/src/features/agents/agents-tabs.tsx
@@ -1,0 +1,26 @@
+import { Link } from "@tanstack/react-router";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+// AgentsTabs is the sub-nav shared between /agents (definitions) and
+// /agents/runs (global run history). Each tab is a real <Link> so
+// middle-click, cmd-click, and "open in new tab" all work — the radix
+// Tabs primitive renders the trigger via Slot when `asChild` is set, and
+// the `value` prop is driven by the current route rather than internal
+// state. Keeps the two list views feeling like one surface without
+// forcing a shared route component.
+export type AgentsTabValue = "agents" | "runs";
+
+export function AgentsTabs({ value }: { value: AgentsTabValue }) {
+  return (
+    <Tabs value={value}>
+      <TabsList>
+        <TabsTrigger value="agents" asChild>
+          <Link to="/agents">Agents</Link>
+        </TabsTrigger>
+        <TabsTrigger value="runs" asChild>
+          <Link to="/agents/runs">Runs</Link>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/web/src/features/agents/transcript-sheet.tsx
+++ b/web/src/features/agents/transcript-sheet.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, Loader2, Sparkles, StickyNote } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { PageError } from "@/components/page-error";
+import { TranscriptViewer } from "@/features/agents/transcript-viewer";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  AGENT_RUN_NOTE_MAX_LEN,
+  useAgentRun,
+  useTranscript,
+  useUpdateAgentRunNote,
+} from "@/api/queries/agents";
+
+export interface TranscriptSheetProps {
+  shortId: string | null;
+  onClose: () => void;
+}
+
+// TranscriptSheet renders one run's full audit trail: prompt prefix (if
+// any), operator note editor, then the streaming transcript itself.
+// Shared between /agents/$slug/runs (per-agent) and /agents/runs (global)
+// so the deep-link behavior (?run=<shortId> opens the drawer) is
+// identical in both contexts.
+export function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
+  const open = Boolean(shortId);
+  const runDetail = useAgentRun(shortId ?? undefined);
+  const inProgress = runDetail.data?.status === "in_progress";
+  const transcript = useTranscript(shortId ?? undefined, { inProgress });
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-2xl">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle>Transcript</SheetTitle>
+          <SheetDescription>
+            {shortId ? (
+              <span className="font-mono text-xs">Run {shortId}</span>
+            ) : null}
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {runDetail.data?.prompt_prefix && (
+            <PromptPrefixBlock prefix={runDetail.data.prompt_prefix} />
+          )}
+          {shortId && (
+            <OperatorNoteEditor
+              shortId={shortId}
+              storedNote={runDetail.data?.operator_note ?? ""}
+              loading={runDetail.isLoading}
+            />
+          )}
+          {transcript.isLoading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-32 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+          ) : transcript.isError && inProgress ? (
+            <InProgressTranscriptPlaceholder />
+          ) : transcript.isError ? (
+            <PageError
+              resource="transcript"
+              error={transcript.error}
+              onRetry={() => transcript.refetch()}
+              retrying={transcript.isFetching}
+            />
+          ) : transcript.data && shortId ? (
+            <>
+              {inProgress && <InProgressBanner />}
+              <TranscriptViewer
+                events={transcript.data.events}
+                rawLength={transcript.data.rawLength}
+                truncated={transcript.data.truncated}
+                shortId={shortId}
+              />
+            </>
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+interface OperatorNoteEditorProps {
+  shortId: string;
+  storedNote: string;
+  loading: boolean;
+}
+
+function OperatorNoteEditor({
+  shortId,
+  storedNote,
+  loading,
+}: OperatorNoteEditorProps) {
+  const update = useUpdateAgentRunNote();
+  const [draft, setDraft] = useState(storedNote);
+
+  useEffect(() => {
+    setDraft(storedNote);
+  }, [storedNote, shortId]);
+
+  const dirty = draft !== storedNote;
+  const tooLong = draft.length > AGENT_RUN_NOTE_MAX_LEN;
+  const onSave = () => {
+    if (tooLong) return;
+    void withMutationToast(
+      () => update.mutateAsync({ shortId, note: draft }),
+      {
+        success:
+          storedNote === ""
+            ? "Note added"
+            : draft === ""
+              ? "Note cleared"
+              : "Note saved",
+        error: "Failed to save note",
+      },
+    );
+  };
+
+  return (
+    <div className="mb-4 rounded-md border p-3">
+      <label
+        htmlFor={`note-${shortId}`}
+        className="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs uppercase tracking-wider"
+      >
+        <StickyNote className="size-3.5" />
+        Operator note
+      </label>
+      <Textarea
+        id={`note-${shortId}`}
+        rows={2}
+        placeholder={
+          loading
+            ? "Loading…"
+            : "Add context — why this fired, what you're investigating, follow-ups…"
+        }
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={loading}
+        aria-invalid={tooLong}
+      />
+      <div className="mt-1.5 flex items-center justify-between">
+        <span
+          className={`text-xs ${tooLong ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {draft.length} / {AGENT_RUN_NOTE_MAX_LEN}
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant={dirty ? "default" : "outline"}
+          onClick={onSave}
+          disabled={!dirty || tooLong || update.isPending}
+        >
+          {update.isPending ? <Loader2 className="size-3.5 animate-spin" /> : null}
+          {draft === "" && storedNote !== "" ? "Clear note" : "Save note"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PromptPrefixBlock({ prefix }: { prefix: string }) {
+  return (
+    <div className="mb-4 rounded-md border border-dashed bg-muted/40 p-3">
+      <div className="text-muted-foreground mb-1 inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide">
+        <Sparkles className="size-3.5" />
+        Prompt prefix (this run only)
+      </div>
+      <p className="whitespace-pre-wrap text-sm leading-relaxed">{prefix}</p>
+    </div>
+  );
+}
+
+// HitCapPill flags runs that bumped into a safety ceiling. max_turns is
+// amber (clean termination but probably incomplete work — operator may
+// want to raise the cap or split the prompt); max_budget is red (mid-run
+// abort — the agent's plan exceeded what was budgeted).
+export function HitCapPill({
+  cap,
+}: {
+  cap: "max_turns" | "max_budget" | null;
+}) {
+  if (!cap) return null;
+  if (cap === "max_turns") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+        title="Run hit max_turns — work may be incomplete. Consider raising max_turns or splitting the prompt."
+      >
+        <AlertTriangle className="size-3" />
+        max turns
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-950/40 dark:text-red-300"
+      title="Run exceeded max_budget_usd — terminated mid-task. Consider raising the budget cap or narrowing the agent's scope."
+    >
+      <AlertTriangle className="size-3" />
+      over budget
+    </span>
+  );
+}
+
+function InProgressTranscriptPlaceholder() {
+  return (
+    <div className="text-muted-foreground flex flex-col items-center gap-3 py-12 text-center text-sm">
+      <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+      <div className="space-y-1">
+        <div className="text-foreground font-medium">Run starting…</div>
+        <p className="max-w-xs">
+          Transcript will appear here as the agent begins streaming events.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function InProgressBanner() {
+  return (
+    <div className="bg-muted/40 text-muted-foreground mb-4 flex items-center gap-2 rounded-md border px-3 py-2 text-xs">
+      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      <span>Run in progress — events will keep arriving below.</span>
+    </div>
+  );
+}

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -10,11 +10,11 @@ import { Kbd } from "@/components/ui/kbd";
 import { Separator } from "@/components/ui/separator";
 import { CategoryCommandList } from "@/components/category-command";
 import { TagCommandList } from "@/components/tag-command";
+import { FloatingActionBar } from "@/components/floating-action-bar";
 import { KbdTooltip } from "@/components/kbd-tooltip";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
 import { applyBulkTransactionOp } from "@/features/transactions/bulk-update";
-import { cn } from "@/lib/utils";
 
 interface SelectionActionBarProps {
   selectedIds: string[];
@@ -58,17 +58,11 @@ export function SelectionActionBar({
     totalCount > selectedIds.length;
 
   return (
-    // pointer-events-none on the outer wrapper so the empty space around the
-    // pill stays click-through, while the pill itself re-enables events.
-    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6">
-      <div
-        data-state="open"
-        className={cn(
-          "pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border bg-popover/95 p-1 pl-3 text-popover-foreground shadow-xl backdrop-blur-sm",
-          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4 data-[state=open]:duration-200",
-        )}
-      >
-        {update.isPending ? (
+    <FloatingActionBar
+      ariaLabel="Bulk transaction actions"
+      className="pl-3"
+    >
+      {update.isPending ? (
           <div className="flex items-center gap-2 px-2 py-1 text-sm">
             <Loader2 className="size-4 animate-spin" />
             <span className="font-medium">
@@ -145,8 +139,7 @@ export function SelectionActionBar({
             </KbdTooltip>
           </>
         )}
-      </div>
-    </div>
+    </FloatingActionBar>
   );
 }
 

--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -5,6 +5,7 @@ import {
   Bot,
   FileText,
   Key,
+  PenTool,
   Plug,
   Settings,
   Shapes,
@@ -74,6 +75,7 @@ export const NAV: NavGroup[] = [
     label: "System",
     items: [
       { kind: "link", title: "Agents", to: "/agents", icon: Bot },
+      { kind: "link", title: "Prompt builder", to: "/prompts/build", icon: PenTool },
       { kind: "link", title: "API keys", to: "/api-keys", icon: Key },
       { kind: "modal", title: "Settings", modalKey: "settings", icon: Settings },
     ],

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -46,8 +46,14 @@ import {
 } from "@/routes/account-detail";
 import { RulesPage, rulesSearchSchema } from "@/routes/rules";
 import { AgentsPage } from "@/routes/agents";
+import { AgentNewPage, agentsNewSearchSchema } from "@/routes/agents.new";
+import { AgentsRunsPage, agentsRunsSearchSchema } from "@/routes/agents.runs";
 import { AgentEditPage } from "@/routes/agents.$slug.edit";
 import { AgentRunsPage, agentRunsSearchSchema } from "@/routes/agents.$slug.runs";
+import {
+  PromptsBuildPage,
+  promptsBuildSearchSchema,
+} from "@/routes/prompts.build";
 import { RuleDetailPage } from "@/routes/rule-detail";
 import { RuleFormPage } from "@/routes/rule-form";
 import { NAV_LEAVES } from "@/lib/nav";
@@ -126,6 +132,10 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
   },
   "/agents": {
     component: AgentsPage,
+  },
+  "/prompts/build": {
+    component: PromptsBuildPage,
+    validateSearch: promptsBuildSearchSchema,
   },
 };
 
@@ -220,8 +230,24 @@ const ruleDetailRoute = createRoute({
   component: RuleDetailPage,
 });
 
-// /agents/$slug/edit and /agents/$slug/runs — declared before the more
-// general /agents nav-leaf route so chi-style longest-match prevails.
+// /agents/new, /agents/runs, /agents/$slug/edit and /agents/$slug/runs —
+// declared before the more general /agents nav-leaf route so chi-style
+// longest-match prevails. /agents/runs is a static path and must precede
+// the dynamic /agents/$slug/* family for the same reason.
+const agentNewRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/agents/new",
+  component: AgentNewPage,
+  validateSearch: agentsNewSearchSchema,
+});
+
+const agentsRunsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/agents/runs",
+  component: AgentsRunsPage,
+  validateSearch: agentsRunsSearchSchema,
+});
+
 const agentEditRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/agents/$slug/edit",
@@ -267,6 +293,8 @@ const routeTree = rootRoute.addChildren([
   ruleNewRoute,
   ruleEditRoute,
   ruleDetailRoute,
+  agentNewRoute,
+  agentsRunsRoute,
   agentEditRoute,
   agentRunsRoute,
   ...pageRoutes,

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -34,7 +34,9 @@ export function AgentEditPage() {
   if (agentQuery.isLoading || !agentQuery.data) {
     return (
       <>
-        <SoftBackButton to="/agents">Back to agents</SoftBackButton>
+        <SoftBackButton to="/agents" className="self-start">
+          Back to agents
+        </SoftBackButton>
         <PageHeader
           eyebrow="Agent"
           title="Edit agent"
@@ -109,7 +111,9 @@ function AgentEditFormView({
 
   return (
     <>
-      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
+      <SoftBackButton to="/agents" className="self-start">
+        Back to agents
+      </SoftBackButton>
       <PageHeader
         eyebrow="Agent"
         title={agent.name}

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -1,28 +1,6 @@
-import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { Loader2, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
@@ -35,44 +13,9 @@ import {
   type AgentDefinition,
 } from "@/api/queries/agents";
 import {
-  AGENT_MODELS,
-  TOOL_SCOPES,
-} from "@/features/agents/agent-constants";
-import { CronField } from "@/features/agents/cron-field";
-import { RuleDslHelp } from "@/features/agents/rule-dsl-help";
-
-// Use z.preprocess (not z.coerce) for numerics to dodge the iter-4 resolver
-// bug where coerce.number leaves the input type as `unknown`. Preprocess
-// converts string → number explicitly at submit time; defaults stay typed.
-const agentEditSchema = z.object({
-  name: z.string().min(1, "Name is required").max(120),
-  prompt: z.string().min(1, "Prompt is required"),
-  system_prompt: z.string().optional().or(z.literal("")),
-  schedule_cron: z.string().optional().or(z.literal("")),
-  tool_scope: z.enum(["read_only", "read_write"]),
-  allowed_tools_raw: z.string().optional(), // comma-separated; split at submit
-  model: z.string().min(1),
-  max_turns: z.preprocess(
-    (v) => (v === "" || v === null || v === undefined ? undefined : Number(v)),
-    z.number().int().min(1).max(200),
-  ),
-  max_budget_usd: z.preprocess(
-    (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
-    z.number().positive().nullable(),
-  ),
-  quiet_hours_start: z
-    .string()
-    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
-    .optional()
-    .or(z.literal("")),
-  quiet_hours_end: z
-    .string()
-    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:MM 24-hour")
-    .optional()
-    .or(z.literal("")),
-  trigger_on_sync_complete: z.boolean(),
-});
-type AgentEditForm = z.input<typeof agentEditSchema>;
+  AgentForm,
+  type AgentFormValues,
+} from "@/features/agents/agent-form";
 
 export function AgentEditPage() {
   const { slug } = useParams({ strict: false }) as { slug: string };
@@ -109,12 +52,6 @@ export function AgentEditPage() {
   return <AgentEditFormView agent={agentQuery.data} slug={slug} />;
 }
 
-// AgentEditFormView mounts useForm with the loaded agent's values as the
-// actual defaultValues — no post-mount resync, no race with shadcn's
-// controlled Select. Earlier shapes (defaultValues + useEffect form.reset,
-// or `values` prop syncing) reliably left the Model field rendering empty
-// for any agent whose stored model differed from the form's placeholder
-// default (tool_scope was lucky because "read_write" already matched).
 function AgentEditFormView({
   agent,
   slug,
@@ -124,25 +61,24 @@ function AgentEditFormView({
 }) {
   const navigate = useNavigate();
   const updateAgent = useUpdateAgent(slug);
-  const form = useForm<AgentEditForm>({
-    resolver: zodResolver(agentEditSchema),
-    defaultValues: {
-      name: agent.name,
-      prompt: agent.prompt,
-      system_prompt: agent.system_prompt ?? "",
-      schedule_cron: agent.schedule_cron ?? "",
-      tool_scope: agent.tool_scope as AgentEditForm["tool_scope"],
-      allowed_tools_raw: (agent.allowed_tools ?? []).join(", "),
-      model: agent.model,
-      max_turns: agent.max_turns,
-      max_budget_usd: agent.max_budget_usd ?? null,
-      quiet_hours_start: agent.quiet_hours_start ?? "",
-      quiet_hours_end: agent.quiet_hours_end ?? "",
-      trigger_on_sync_complete: agent.trigger_on_sync_complete,
-    },
-  });
 
-  const onSubmit = form.handleSubmit(async (values) => {
+  const initialValues: AgentFormValues = {
+    name: agent.name,
+    slug: agent.slug, // present but unused in edit mode (field hidden)
+    prompt: agent.prompt,
+    system_prompt: agent.system_prompt ?? "",
+    schedule_cron: agent.schedule_cron ?? "",
+    tool_scope: agent.tool_scope,
+    allowed_tools_raw: (agent.allowed_tools ?? []).join(", "),
+    model: agent.model,
+    max_turns: agent.max_turns,
+    max_budget_usd: agent.max_budget_usd ?? null,
+    quiet_hours_start: agent.quiet_hours_start ?? "",
+    quiet_hours_end: agent.quiet_hours_end ?? "",
+    trigger_on_sync_complete: agent.trigger_on_sync_complete,
+  };
+
+  const onSubmit = async (values: AgentFormValues) => {
     const tools = (values.allowed_tools_raw ?? "")
       .split(",")
       .map((s) => s.trim())
@@ -159,12 +95,8 @@ function AgentEditFormView({
           model: values.model,
           max_turns: values.max_turns as unknown as number,
           max_budget_usd: values.max_budget_usd as unknown as number | null,
-          quiet_hours_start: values.quiet_hours_start
-            ? values.quiet_hours_start
-            : null,
-          quiet_hours_end: values.quiet_hours_end
-            ? values.quiet_hours_end
-            : null,
+          quiet_hours_start: values.quiet_hours_start ? values.quiet_hours_start : null,
+          quiet_hours_end: values.quiet_hours_end ? values.quiet_hours_end : null,
           trigger_on_sync_complete: values.trigger_on_sync_complete,
         }),
       {
@@ -173,7 +105,7 @@ function AgentEditFormView({
       },
     );
     if (ok) navigate({ to: "/agents" });
-  });
+  };
 
   return (
     <>
@@ -183,301 +115,20 @@ function AgentEditFormView({
         title={agent.name}
         description="Update prompt, schedule, model, and safety caps. Changes take effect on the next scheduled fire or manual run."
       />
-
-      <Form {...form}>
-          <form onSubmit={onSubmit} className="grid grid-cols-1 gap-6 md:grid-cols-3">
-            <div className="space-y-4 md:col-span-2">
-              <Card className="space-y-4 p-4">
-                <FormField
-                  control={form.control}
-                  name="name"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Name</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="prompt"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Prompt</FormLabel>
-                      <FormControl>
-                        <Textarea rows={10} {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Sent to Claude on every run. Be specific about the
-                        outcome (what to categorize, what to report, what
-                        not to touch).
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <RuleDslHelp />
-                <FormField
-                  control={form.control}
-                  name="system_prompt"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>System prompt (optional)</FormLabel>
-                      <FormControl>
-                        <Textarea rows={4} {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Optional override sent as the SDK system prompt
-                        instead of the default. Leave blank for default behavior.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </Card>
-            </div>
-
-            <div className="space-y-4">
-              <Card className="space-y-4 p-4">
-                <FormField
-                  control={form.control}
-                  name="model"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Model</FormLabel>
-                      <Select onValueChange={field.onChange} value={field.value}>
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {AGENT_MODELS.map((m) => (
-                            <SelectItem key={m.value} value={m.value}>
-                              {m.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="schedule_cron"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Schedule</FormLabel>
-                      <FormControl>
-                        <CronField
-                          value={field.value ?? ""}
-                          onChange={field.onChange}
-                          onBlur={field.onBlur}
-                          name={field.name}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="tool_scope"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Tool scope</FormLabel>
-                      <Select onValueChange={field.onChange} value={field.value}>
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {TOOL_SCOPES.map((s) => (
-                            <SelectItem key={s.value} value={s.value}>
-                              {s.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormDescription>
-                        Controls which MCP write tools the run can call.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="allowed_tools_raw"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Allowed tools (optional)</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          rows={3}
-                          placeholder="mcp__breadbox__*"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormDescription>
-                        Comma-separated MCP tool names. Leave blank to allow
-                        every tool in scope.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <div className="grid grid-cols-2 gap-3">
-                  <FormField
-                    control={form.control}
-                    name="max_turns"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Max turns</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="number"
-                            min={1}
-                            max={200}
-                            value={
-                              field.value === undefined || field.value === null
-                                ? ""
-                                : String(field.value)
-                            }
-                            onChange={(e) => field.onChange(e.target.value)}
-                            onBlur={field.onBlur}
-                            name={field.name}
-                            ref={field.ref}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="max_budget_usd"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Max cost (USD)</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="number"
-                            step="0.01"
-                            min={0}
-                            placeholder="0.50"
-                            value={
-                              field.value === undefined || field.value === null
-                                ? ""
-                                : String(field.value)
-                            }
-                            onChange={(e) => field.onChange(e.target.value)}
-                            onBlur={field.onBlur}
-                            name={field.name}
-                            ref={field.ref}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <FormField
-                    control={form.control}
-                    name="quiet_hours_start"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Quiet hours start</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="time"
-                            placeholder="22:00"
-                            {...field}
-                            value={field.value ?? ""}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="quiet_hours_end"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Quiet hours end</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="time"
-                            placeholder="07:00"
-                            {...field}
-                            value={field.value ?? ""}
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          Cron fires inside the window are silently skipped.
-                          Leave both blank to disable.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <FormField
-                  control={form.control}
-                  name="trigger_on_sync_complete"
-                  render={({ field }) => (
-                    <FormItem className="mt-4 flex items-start gap-3 rounded-md border p-3">
-                      <FormControl>
-                        <input
-                          type="checkbox"
-                          className="mt-1 size-4"
-                          checked={field.value}
-                          onChange={(e) => field.onChange(e.target.checked)}
-                        />
-                      </FormControl>
-                      <div className="space-y-1">
-                        <FormLabel className="font-medium">
-                          Run after every successful sync
-                        </FormLabel>
-                        <FormDescription>
-                          Fires this agent (trigger=webhook) whenever a bank
-                          sync completes. Useful for keep-up agents like
-                          "re-categorize freshly synced transactions" — pairs
-                          with cron OR replaces it.
-                        </FormDescription>
-                        <FormMessage />
-                      </div>
-                    </FormItem>
-                  )}
-                />
-              </Card>
-
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                <Button type="button" variant="outline" asChild>
-                  <Link to="/agents">Cancel</Link>
-                </Button>
-                <TestPromptButton
-                  slug={slug}
-                  promptValue={form.watch("prompt")}
-                  disabled={updateAgent.isPending}
-                />
-                <Button type="submit" disabled={updateAgent.isPending}>
-                  {updateAgent.isPending && (
-                    <Loader2 className="size-4 animate-spin" />
-                  )}
-                  Save changes
-                </Button>
-              </div>
-            </div>
-          </form>
-        </Form>
+      <AgentForm
+        mode="edit"
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        submitLabel="Save changes"
+        pending={updateAgent.isPending}
+        extraActions={(form) => (
+          <TestPromptButton
+            slug={slug}
+            promptValue={form.watch("prompt")}
+            disabled={updateAgent.isPending}
+          />
+        )}
+      />
     </>
   );
 }
@@ -526,7 +177,6 @@ function TestPromptButton({
           "Test run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
       },
     );
-    // navigate() above triggers regardless of toast result; no-op here.
     void ok;
   };
   return (

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -126,7 +126,9 @@ export function AgentRunsPage() {
 
   return (
     <>
-      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
+      <SoftBackButton to="/agents" className="self-start">
+        Back to agents
+      </SoftBackButton>
       <PageHeader
         eyebrow="Agent runs"
         title={agentQuery.data ? `${agentQuery.data.name} — runs` : "Run history"}

--- a/web/src/routes/agents.new.tsx
+++ b/web/src/routes/agents.new.tsx
@@ -1,8 +1,7 @@
-import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/page-header";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { useCreateAgent } from "@/api/queries/agents";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
@@ -63,11 +62,9 @@ export function AgentNewPage() {
 
   return (
     <>
-      <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
-        <Link to="/agents">
-          <ArrowLeft className="size-4" /> Back to agents
-        </Link>
-      </Button>
+      <SoftBackButton to="/agents" className="self-start">
+        Back to agents
+      </SoftBackButton>
       <PageHeader
         eyebrow="Agent"
         title="New agent"

--- a/web/src/routes/agents.new.tsx
+++ b/web/src/routes/agents.new.tsx
@@ -1,0 +1,88 @@
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/page-header";
+import { useCreateAgent } from "@/api/queries/agents";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  AgentForm,
+  CREATE_DEFAULTS,
+  type AgentFormValues,
+} from "@/features/agents/agent-form";
+
+// agentsNewSearchSchema accepts an optional `?prompt=` parameter so the
+// prompt builder can deep-link into the create flow with the composed
+// text pre-loaded. Unknown keys are dropped by TanStack Router's zod
+// integration — `prompt` is the only field we read here.
+export const agentsNewSearchSchema = z.object({
+  prompt: z.string().optional(),
+});
+type AgentsNewSearch = z.infer<typeof agentsNewSearchSchema>;
+
+export function AgentNewPage() {
+  const navigate = useNavigate();
+  const createAgent = useCreateAgent();
+  const search = useSearch({ strict: false }) as AgentsNewSearch;
+
+  const onSubmit = async (values: AgentFormValues) => {
+    const tools = (values.allowed_tools_raw ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const created = await withMutationToast(
+      () =>
+        createAgent.mutateAsync({
+          name: values.name,
+          slug: values.slug ?? "",
+          prompt: values.prompt,
+          system_prompt: values.system_prompt ? values.system_prompt : null,
+          schedule_cron: values.schedule_cron ? values.schedule_cron : null,
+          tool_scope: values.tool_scope,
+          allowed_tools: tools,
+          model: values.model,
+          max_turns: values.max_turns as unknown as number,
+          max_budget_usd: values.max_budget_usd as unknown as number | null,
+          quiet_hours_start: values.quiet_hours_start
+            ? values.quiet_hours_start
+            : null,
+          quiet_hours_end: values.quiet_hours_end ? values.quiet_hours_end : null,
+          trigger_on_sync_complete: values.trigger_on_sync_complete,
+        }),
+      {
+        success: `Created agent ${values.name}`,
+        error: "Failed to create agent",
+      },
+    );
+    if (created) {
+      // Land on the agents list so the new card is visible. The user can
+      // immediately click into edit / runs / run-now from there.
+      navigate({ to: "/agents" });
+    }
+  };
+
+  return (
+    <>
+      <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+        <Link to="/agents">
+          <ArrowLeft className="size-4" /> Back to agents
+        </Link>
+      </Button>
+      <PageHeader
+        eyebrow="Agent"
+        title="New agent"
+        description="Define a recurring Claude Agent SDK run. All fields can be edited later — schedule, scope, and safety caps default to safe values."
+      />
+      <AgentForm
+        mode="create"
+        initialValues={{
+          ...CREATE_DEFAULTS,
+          prompt: search.prompt ?? CREATE_DEFAULTS.prompt,
+        }}
+        onSubmit={onSubmit}
+        submitLabel={createAgent.isPending ? "Creating…" : "Create agent"}
+        pending={createAgent.isPending}
+      />
+    </>
+  );
+}

--- a/web/src/routes/agents.runs.tsx
+++ b/web/src/routes/agents.runs.tsx
@@ -144,7 +144,7 @@ export function AgentsRunsPage() {
       />
       <AgentsTabs value="runs" />
 
-      <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Select
           value={search.agent ?? ANY_VALUE}
           onValueChange={(v) =>

--- a/web/src/routes/agents.runs.tsx
+++ b/web/src/routes/agents.runs.tsx
@@ -1,10 +1,15 @@
 import { useMemo } from "react";
-import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { type ColumnDef } from "@tanstack/react-table";
 import { z } from "zod";
-import { Clock, FilterX, Loader2 } from "lucide-react";
+import {
+  Clock,
+  FilterX,
+  Loader2,
+  Sparkles,
+  StickyNote,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { SoftBackButton } from "@/components/soft-back-button";
 import {
   Select,
   SelectContent,
@@ -20,20 +25,23 @@ import {
   DateRangeFilter,
   type DateRangeValue,
 } from "@/components/date-range-filter";
-import {
-  useAgent,
-  useAgentRuns,
-  type AgentRun,
-  type AgentRunsFilters,
-} from "@/api/queries/agents";
 import { formatDuration, formatRelativeTime } from "@/lib/format";
 import { RunStatusPill } from "@/features/agents/run-status-pill";
-import { TranscriptSheet } from "@/features/agents/transcript-sheet";
-import { RunFlagsCell } from "@/routes/agents.runs";
+import {
+  HitCapPill,
+  TranscriptSheet,
+} from "@/features/agents/transcript-sheet";
+import { AgentsTabs } from "@/features/agents/agents-tabs";
+import {
+  useAgents,
+  useAllAgentRuns,
+  type AgentRunWithAgent,
+} from "@/api/queries/agents";
 
-export const agentRunsSearchSchema = z.object({
+export const agentsRunsSearchSchema = z.object({
   run: z.string().optional(),
   page: z.number().int().positive().optional(),
+  agent: z.string().optional(),
   status: z
     .enum(["success", "error", "in_progress", "skipped", "timeout"])
     .optional(),
@@ -42,18 +50,18 @@ export const agentRunsSearchSchema = z.object({
   start: z.string().optional(),
   end: z.string().optional(),
 });
-type AgentRunsSearch = z.infer<typeof agentRunsSearchSchema>;
+type AgentsRunsSearch = z.infer<typeof agentsRunsSearchSchema>;
 
 const PAGE_SIZE = 25;
 const ANY_VALUE = "__any__";
 
-export function AgentRunsPage() {
-  const { slug } = useParams({ strict: false }) as { slug: string };
-  const search = useSearch({ strict: false }) as AgentRunsSearch;
+export function AgentsRunsPage() {
+  const search = useSearch({ strict: false }) as AgentsRunsSearch;
   const navigate = useNavigate();
   const page = search.page ?? 1;
 
-  const filters: AgentRunsFilters = {
+  const filters = {
+    agent: search.agent,
     status: search.status ?? "",
     trigger: search.trigger ?? "",
     hit_cap: search.hit_cap ?? "",
@@ -61,14 +69,18 @@ export function AgentRunsPage() {
     end: search.end,
   };
   const hasActiveFilters = Boolean(
-    search.status ||
+    search.agent ||
+      search.status ||
       search.trigger ||
       search.hit_cap ||
       search.start ||
       search.end,
   );
 
-  const setFilter = (patch: Partial<AgentRunsSearch>) => {
+  const agentsQuery = useAgents();
+  const runsQuery = useAllAgentRuns(filters, PAGE_SIZE, (page - 1) * PAGE_SIZE);
+
+  const setFilter = (patch: Partial<AgentsRunsSearch>) => {
     navigate({
       to: ".",
       search: (prev: Record<string, unknown>) => ({
@@ -83,6 +95,7 @@ export function AgentRunsPage() {
       to: ".",
       search: (prev: Record<string, unknown>) => ({
         ...prev,
+        agent: undefined,
         status: undefined,
         trigger: undefined,
         hit_cap: undefined,
@@ -92,9 +105,6 @@ export function AgentRunsPage() {
       }),
     });
   };
-
-  const agentQuery = useAgent(slug);
-  const runsQuery = useAgentRuns(slug, filters, PAGE_SIZE, (page - 1) * PAGE_SIZE);
 
   const openRunShortId = search.run ?? null;
   const openRun = (shortId: string) => {
@@ -118,28 +128,48 @@ export function AgentRunsPage() {
 
   const runs = runsQuery.data?.runs ?? [];
   const hasMore = runsQuery.data?.has_more ?? false;
+  const agents = agentsQuery.data ?? [];
 
-  const columns = useMemo<ColumnDef<AgentRun>[]>(
-    () => buildPerAgentRunsColumns(),
+  const columns = useMemo<ColumnDef<AgentRunWithAgent>[]>(
+    () => buildGlobalRunsColumns(),
     [],
   );
 
   return (
     <>
-      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
       <PageHeader
-        eyebrow="Agent runs"
-        title={agentQuery.data ? `${agentQuery.data.name} — runs` : "Run history"}
-        description="Every fire of this agent (cron, manual, or webhook). Click any row to view its transcript."
+        eyebrow="System"
+        title="Agent runs"
+        description="Every fire of every agent in this household — cron, manual, or webhook. Click any row to view its transcript."
       />
+      <AgentsTabs value="runs" />
 
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Select
+          value={search.agent ?? ANY_VALUE}
+          onValueChange={(v) =>
+            setFilter({ agent: v === ANY_VALUE ? undefined : v })
+          }
+        >
+          <SelectTrigger size="sm" className="w-52">
+            <SelectValue placeholder="All agents" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ANY_VALUE}>All agents</SelectItem>
+            {agents.map((a) => (
+              <SelectItem key={a.id} value={a.slug}>
+                {a.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
         <Select
           value={search.status ?? ANY_VALUE}
           onValueChange={(v) =>
             setFilter({
               status:
-                v === ANY_VALUE ? undefined : (v as AgentRunsSearch["status"]),
+                v === ANY_VALUE ? undefined : (v as AgentsRunsSearch["status"]),
             })
           }
         >
@@ -161,9 +191,7 @@ export function AgentRunsPage() {
           onValueChange={(v) =>
             setFilter({
               trigger:
-                v === ANY_VALUE
-                  ? undefined
-                  : (v as AgentRunsSearch["trigger"]),
+                v === ANY_VALUE ? undefined : (v as AgentsRunsSearch["trigger"]),
             })
           }
         >
@@ -183,9 +211,7 @@ export function AgentRunsPage() {
           onValueChange={(v) =>
             setFilter({
               hit_cap:
-                v === ANY_VALUE
-                  ? undefined
-                  : (v as AgentRunsSearch["hit_cap"]),
+                v === ANY_VALUE ? undefined : (v as AgentsRunsSearch["hit_cap"]),
             })
           }
         >
@@ -232,8 +258,20 @@ export function AgentRunsPage() {
           emptyState={
             <EmptyState
               icon={Clock}
-              title="No runs yet"
-              description="Trigger a run from the agents list, or wait for the next scheduled fire."
+              title={hasActiveFilters ? "No runs match these filters" : "No runs yet"}
+              description={
+                hasActiveFilters
+                  ? "Try widening the date range or clearing some filters."
+                  : "Trigger a run from the Agents tab, or wait for the next scheduled fire."
+              }
+              action={
+                hasActiveFilters ? (
+                  <Button variant="outline" size="sm" onClick={clearFilters}>
+                    <FilterX className="size-3.5" />
+                    Clear filters
+                  </Button>
+                ) : undefined
+              }
             />
           }
         />
@@ -260,13 +298,29 @@ export function AgentRunsPage() {
   );
 }
 
-function buildPerAgentRunsColumns(): ColumnDef<AgentRun>[] {
+function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
   return [
     {
       id: "status",
       header: "Status",
       meta: { className: "w-[110px]" },
       cell: ({ row }) => <RunStatusPill status={row.original.status} />,
+    },
+    {
+      id: "agent",
+      header: "Agent",
+      meta: { className: "w-[22%] min-w-[160px]" },
+      cell: ({ row }) => (
+        <Link
+          to="/agents/$slug/edit"
+          params={{ slug: row.original.agent_slug }}
+          className="hover:text-foreground truncate text-sm font-medium"
+          onClick={(e) => e.stopPropagation()}
+          title={`Edit ${row.original.agent_name}`}
+        >
+          {row.original.agent_name}
+        </Link>
+      ),
     },
     {
       id: "trigger",
@@ -281,7 +335,7 @@ function buildPerAgentRunsColumns(): ColumnDef<AgentRun>[] {
     {
       id: "started",
       header: "Started",
-      meta: { className: "w-[180px]" },
+      meta: { className: "w-[140px]" },
       cell: ({ row }) => (
         <span
           className="text-muted-foreground text-sm"
@@ -294,7 +348,7 @@ function buildPerAgentRunsColumns(): ColumnDef<AgentRun>[] {
     {
       id: "duration",
       header: "Duration",
-      meta: { className: "w-[100px] text-right tabular-nums" },
+      meta: { className: "w-[80px] text-right tabular-nums" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
           {formatDuration(row.original.duration_ms)}
@@ -304,7 +358,7 @@ function buildPerAgentRunsColumns(): ColumnDef<AgentRun>[] {
     {
       id: "cost",
       header: "Cost",
-      meta: { className: "w-[100px] text-right tabular-nums" },
+      meta: { className: "w-[90px] text-right tabular-nums" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm font-mono">
           {row.original.total_cost_usd != null
@@ -316,7 +370,7 @@ function buildPerAgentRunsColumns(): ColumnDef<AgentRun>[] {
     {
       id: "tools",
       header: "Tools",
-      meta: { className: "w-[80px] text-right tabular-nums" },
+      meta: { className: "w-[70px] text-right tabular-nums" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
           {row.original.num_tool_calls != null
@@ -332,4 +386,45 @@ function buildPerAgentRunsColumns(): ColumnDef<AgentRun>[] {
       cell: ({ row }) => <RunFlagsCell run={row.original} />,
     },
   ];
+}
+
+// RunFlagsCell collapses the per-row indicators (prefix, operator note,
+// hit_cap) into a single right-aligned cluster of icons + cap pill.
+// Title attributes carry the preview text so hover reveals context.
+export function RunFlagsCell({
+  run,
+}: {
+  run: { operator_note?: string | null; prompt_prefix?: string | null; hit_cap?: "max_turns" | "max_budget" | null };
+}) {
+  const hasNote = Boolean(run.operator_note && run.operator_note.trim() !== "");
+  const notePreview = hasNote
+    ? (run.operator_note ?? "").trim().slice(0, 120)
+    : "";
+  const hasPrefix = Boolean(
+    run.prompt_prefix && run.prompt_prefix.trim() !== "",
+  );
+  const prefixPreview = hasPrefix
+    ? (run.prompt_prefix ?? "").trim().slice(0, 120)
+    : "";
+  return (
+    <span className="inline-flex items-center justify-end gap-1.5">
+      {hasPrefix && (
+        <span
+          title={`Prompt prefix: ${prefixPreview}`}
+          aria-label="Has prompt prefix"
+        >
+          <Sparkles className="text-muted-foreground size-3.5" />
+        </span>
+      )}
+      {hasNote && (
+        <span
+          title={`Operator note: ${notePreview}`}
+          aria-label="Has operator note"
+        >
+          <StickyNote className="text-muted-foreground size-3.5" />
+        </span>
+      )}
+      <HitCapPill cap={run.hit_cap ?? null} />
+    </span>
+  );
 }

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -1,16 +1,14 @@
-import { useState } from "react";
-import { Link } from "@tanstack/react-router";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { type ColumnDef } from "@tanstack/react-table";
 import {
   AlertCircle,
   Bot,
   CheckCircle2,
   Clock,
-  Coins,
   History,
   KeyRound,
+  MoreHorizontal,
   Pencil,
   Play,
   Plus,
@@ -27,18 +25,16 @@ import { PageError } from "@/components/page-error";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Card } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { Skeleton } from "@/components/ui/skeleton";
+import { DataTable } from "@/components/data-table";
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Dialog,
   DialogContent,
@@ -48,59 +44,26 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { formatRelativeTime } from "@/lib/format";
 import {
   useAgents,
   useAgentSubsystemStatus,
-  useCreateAgent,
   useDeleteAgent,
-  useRecentErroredAgentRuns,
   useRunAgentNow,
   useToggleAgent,
   PROMPT_PREFIX_MAX_LEN,
-  type AgentCostStats,
   type AgentDefinition,
-  type AgentRecentCapStats,
-  type AgentRecentErrorStats,
-  type RecentErroredAgentRun,
 } from "@/api/queries/agents";
 import { openModal } from "@/lib/modals";
-import { useNavigate } from "@tanstack/react-router";
-
-const createAgentSchema = z.object({
-  name: z.string().min(1, "Name is required").max(120),
-  slug: z
-    .string()
-    .min(2, "Slug must be at least 2 characters")
-    .max(64)
-    .regex(
-      /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/,
-      "Use lowercase letters, digits, dashes (kebab-case)",
-    ),
-  prompt: z.string().min(1, "Prompt is required"),
-  schedule_cron: z.string().optional().or(z.literal("")),
-});
-type CreateAgentForm = z.infer<typeof createAgentSchema>;
+import { AgentsTabs } from "@/features/agents/agents-tabs";
 
 export function AgentsPage() {
   const agentsQuery = useAgents();
   const statusQuery = useAgentSubsystemStatus();
-  const createAgent = useCreateAgent();
   const deleteAgent = useDeleteAgent();
   const navigate = useNavigate();
-  const [createOpen, setCreateOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<AgentDefinition | null>(
     null,
   );
@@ -109,30 +72,10 @@ export function AgentsPage() {
   const status = statusQuery.data;
   const showOnboardingBanner = Boolean(status) && !status?.ready;
 
-  const form = useForm<CreateAgentForm>({
-    resolver: zodResolver(createAgentSchema),
-    defaultValues: { name: "", slug: "", prompt: "", schedule_cron: "" },
-  });
-
-  const onCreate = form.handleSubmit(async (values) => {
-    const ok = await withMutationToast(
-      () =>
-        createAgent.mutateAsync({
-          name: values.name,
-          slug: values.slug,
-          prompt: values.prompt,
-          schedule_cron: values.schedule_cron || null,
-        }),
-      {
-        success: `Created agent ${values.name}`,
-        error: "Failed to create agent",
-      },
-    );
-    if (ok) {
-      setCreateOpen(false);
-      form.reset();
-    }
-  });
+  const columns = useMemo<ColumnDef<AgentDefinition>[]>(
+    () => buildColumns({ onDelete: (a) => setPendingDelete(a) }),
+    [],
+  );
 
   return (
     <>
@@ -141,12 +84,16 @@ export function AgentsPage() {
         title="Agents"
         description="Recurring Claude Agent SDK runs that call breadbox MCP to enrich, categorize, and review your data."
         actions={
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="size-4" />
-            New agent
+          <Button asChild>
+            <Link to="/agents/new">
+              <Plus className="size-4" />
+              New agent
+            </Link>
           </Button>
         }
       />
+
+      <AgentsTabs value="agents" />
 
       {showOnboardingBanner && status && (
         <Alert>
@@ -154,16 +101,16 @@ export function AgentsPage() {
           <AlertTitle>Finish setting up the agent subsystem</AlertTitle>
           <AlertDescription className="space-y-2">
             <p className="text-sm">
-              The seeded starter agents below won't fire until two pieces
-              are in place. Status checked without any API call:
+              The seeded starter agents below won't fire until two pieces are in
+              place. Status checked without any API call:
             </p>
             {!status.auth_configured && (
               <p className="text-muted-foreground text-xs">
-                <strong>New here?</strong> Pick the subscription token
-                option (free under your Claude plan credits, runs{" "}
-                <code>claude setup-token</code> once on any machine).
-                Switch to an Anthropic API key later if you need
-                pay-as-you-go billing past the 2026-06-15 cutover.
+                <strong>New here?</strong> Pick the subscription token option
+                (free under your Claude plan credits, runs{" "}
+                <code>claude setup-token</code> once on any machine). Switch to
+                an Anthropic API key later if you need pay-as-you-go billing
+                past the 2026-06-15 cutover.
               </p>
             )}
             <ul className="text-sm">
@@ -218,8 +165,6 @@ export function AgentsPage() {
         </Alert>
       )}
 
-      <RecentErrorsBanner />
-
       {agentsQuery.isError ? (
         <PageError
           resource="agents"
@@ -227,136 +172,33 @@ export function AgentsPage() {
           onRetry={() => agentsQuery.refetch()}
           retrying={agentsQuery.isFetching}
         />
-      ) : agentsQuery.isLoading ? (
-        <div className="flex flex-col gap-3">
-          {[0, 1, 2].map((i) => (
-            <Skeleton key={i} className="h-24 w-full rounded-xl" />
-          ))}
-        </div>
-      ) : agents.length === 0 ? (
-        <EmptyState
-          icon={Bot}
-          title="No agents yet"
-          description="Create your first agent to schedule recurring Claude runs against your data. Each agent runs locally via the Claude Agent SDK and the breadbox MCP server."
-          action={
-            <Button onClick={() => setCreateOpen(true)}>
-              <Plus className="size-4" />
-              Create your first agent
-            </Button>
+      ) : (
+        <DataTable
+          columns={columns}
+          data={agents}
+          isLoading={agentsQuery.isLoading}
+          getRowId={(a) => a.id}
+          onRowClick={(a) =>
+            navigate({ to: "/agents/$slug/edit", params: { slug: a.slug } })
+          }
+          refinedHeader
+          emptyState={
+            <EmptyState
+              icon={Bot}
+              title="No agents yet"
+              description="Create your first agent to schedule recurring Claude runs against your data. Each agent runs locally via the Claude Agent SDK and the breadbox MCP server."
+              action={
+                <Button asChild>
+                  <Link to="/agents/new">
+                    <Plus className="size-4" />
+                    Create your first agent
+                  </Link>
+                </Button>
+              }
+            />
           }
         />
-      ) : (
-        <div className="flex flex-col gap-3">
-          {agents.map((agent) => (
-            <AgentRow
-              key={agent.id}
-              agent={agent}
-              onDelete={() => setPendingDelete(agent)}
-            />
-          ))}
-        </div>
       )}
-
-      <Sheet open={createOpen} onOpenChange={setCreateOpen}>
-        <SheetContent className="sm:max-w-lg">
-          <SheetHeader>
-            <SheetTitle>New agent</SheetTitle>
-            <SheetDescription>
-              Quick-create with prompt + schedule. The full prompt builder
-              ships in the next iteration; for now you can edit advanced
-              fields via the REST API.
-            </SheetDescription>
-          </SheetHeader>
-          <Form {...form}>
-            <form
-              onSubmit={onCreate}
-              className="mt-4 flex flex-1 flex-col gap-4"
-            >
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Name</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="Weekly transaction review"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="slug"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Slug</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="weekly-transaction-review"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      Kebab-case identifier used in URLs and API calls.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="prompt"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Prompt</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        rows={6}
-                        placeholder="Review last week's uncategorized transactions and apply the closest matching category…"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="schedule_cron"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Schedule (optional)</FormLabel>
-                    <FormControl>
-                      <Input placeholder="0 9 * * 1 — Mondays at 9 AM" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Standard 5-field cron expression. Leave blank for manual
-                      triggers only.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <SheetFooter className="mt-auto flex-row justify-end gap-2 pt-4">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setCreateOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={createAgent.isPending}>
-                  {createAgent.isPending ? "Creating…" : "Create agent"}
-                </Button>
-              </SheetFooter>
-            </form>
-          </Form>
-        </SheetContent>
-      </Sheet>
 
       <ConfirmDialog
         open={Boolean(pendingDelete)}
@@ -382,15 +224,155 @@ export function AgentsPage() {
   );
 }
 
-interface AgentRowProps {
-  agent: AgentDefinition;
-  onDelete: () => void;
+// buildColumns is a function (not a top-level constant) so the Delete
+// callback can be threaded in without spreading state into every cell.
+// Memoize at the caller site.
+function buildColumns({
+  onDelete,
+}: {
+  onDelete: (agent: AgentDefinition) => void;
+}): ColumnDef<AgentDefinition>[] {
+  return [
+    {
+      id: "name",
+      header: "Agent",
+      meta: { className: "w-[28%] min-w-[200px]" },
+      cell: ({ row }) => {
+        const a = row.original;
+        return (
+          <div className="flex items-center gap-2">
+            <span className="font-medium leading-tight">{a.name}</span>
+            {a.trigger_on_sync_complete && (
+              <span
+                className="text-blue-600 dark:text-blue-400"
+                title="Also fires after every successful bank sync"
+              >
+                <Zap className="size-3.5" />
+              </span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      id: "schedule",
+      header: "Schedule",
+      meta: { className: "w-[18%]" },
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-sm">
+          {cronToProseLabel(row.original.schedule_cron)}
+        </span>
+      ),
+    },
+    {
+      id: "last_run",
+      header: "Last run",
+      meta: { className: "w-[18%]" },
+      cell: ({ row }) => <LastRunCell run={row.original.last_run} />,
+    },
+    {
+      id: "next_run",
+      header: "Next",
+      meta: { className: "w-[10%]" },
+      cell: ({ row }) => {
+        const at = row.original.next_fire_at;
+        if (!at) return <span className="text-muted-foreground">—</span>;
+        return (
+          <span
+            className="text-muted-foreground text-sm"
+            title={new Date(at).toLocaleString()}
+          >
+            {formatRelativeTime(at)}
+          </span>
+        );
+      },
+    },
+    {
+      id: "cost",
+      header: "30d cost",
+      meta: { className: "w-[10%] text-right tabular-nums" },
+      cell: ({ row }) => {
+        const stats = row.original.cost_stats_30d;
+        if (!stats || stats.run_count === 0) {
+          return <span className="text-muted-foreground">—</span>;
+        }
+        return (
+          <span
+            className="text-sm"
+            title={`${stats.run_count} run${stats.run_count === 1 ? "" : "s"} in the last 30 days`}
+          >
+            ${stats.total_cost_usd.toFixed(2)}
+          </span>
+        );
+      },
+    },
+    {
+      id: "status",
+      header: "Enabled",
+      meta: { className: "w-[80px]" },
+      cell: ({ row }) => <EnabledSwitchCell agent={row.original} />,
+    },
+    {
+      id: "actions",
+      header: () => <span className="sr-only">Actions</span>,
+      meta: { className: "w-[120px] text-right" },
+      cell: ({ row }) => (
+        <ActionsCell
+          agent={row.original}
+          onDelete={() => onDelete(row.original)}
+        />
+      ),
+    },
+  ];
 }
 
-function AgentRow({ agent, onDelete }: AgentRowProps) {
-  const toggle = useToggleAgent();
+// LastRunCell shows the most recent run's status icon plus relative
+// time. If there are no runs yet we surface that directly so an
+// operator can tell "never fired" apart from a stale row.
+function LastRunCell({ run }: { run: AgentDefinition["last_run"] }) {
+  if (!run) {
+    return (
+      <span className="text-muted-foreground text-sm opacity-70">No runs yet</span>
+    );
+  }
+  const Icon =
+    run.status === "success"
+      ? CheckCircle2
+      : run.status === "error"
+        ? XCircle
+        : run.status === "skipped"
+          ? AlertCircle
+          : Clock;
+  const color =
+    run.status === "success"
+      ? "text-emerald-600"
+      : run.status === "error"
+        ? "text-red-600"
+        : run.status === "skipped"
+          ? "text-amber-600"
+          : "text-muted-foreground";
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-sm"
+      title={`${run.status} — ${new Date(run.started_at).toLocaleString()}`}
+    >
+      <Icon className={`size-3.5 ${color}`} />
+      <span className="text-muted-foreground">
+        {formatRelativeTime(run.started_at)}
+      </span>
+    </span>
+  );
+}
 
-  const handleToggle = (enable: boolean) => {
+// stopRowClick wraps inline interactive controls so clicking them
+// doesn't also bubble up to the row's "navigate to edit" handler.
+function stopRowClick<E extends Element>(e: React.MouseEvent<E>) {
+  e.stopPropagation();
+}
+
+function EnabledSwitchCell({ agent }: { agent: AgentDefinition }) {
+  const toggle = useToggleAgent();
+  const handleChange = (enable: boolean) => {
     void withMutationToast(
       () => toggle.mutateAsync({ slug: agent.slug, enable }),
       {
@@ -399,161 +381,61 @@ function AgentRow({ agent, onDelete }: AgentRowProps) {
       },
     );
   };
-
   return (
-    <Card className="p-4">
-      <div className="flex flex-wrap items-start gap-4">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <h3 className="text-base font-semibold leading-tight truncate">
-              {agent.name}
-            </h3>
-            <Badge variant="outline" className="font-mono text-[10px]">
-              {agent.slug}
-            </Badge>
-            <Badge
-              variant={agent.tool_scope === "read_write" ? "default" : "secondary"}
-              className="text-[10px] uppercase tracking-wide"
-            >
-              {agent.tool_scope.replace("_", " ")}
-            </Badge>
-          </div>
-          <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">
-            {agent.prompt}
-          </p>
-          <div className="text-muted-foreground mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-            <span
-              className="inline-flex items-center gap-1"
-              title={
-                agent.schedule_cron
-                  ? `Cron expression: ${agent.schedule_cron}`
-                  : undefined
-              }
-            >
-              <Clock className="size-3" />
-              {cronToProseLabel(agent.schedule_cron)}
-            </span>
-            {agent.trigger_on_sync_complete && (
-              <span
-                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 font-medium text-blue-700 dark:bg-blue-950/40 dark:text-blue-300"
-                title="Also fires after every successful bank sync (trigger=webhook)"
-              >
-                <Zap className="size-3" />
-                After sync
-              </span>
-            )}
-            <NextFirePill at={agent.next_fire_at} />
-            <QuietHoursActivePill
-              start={agent.quiet_hours_start}
-              end={agent.quiet_hours_end}
-              enabled={agent.enabled}
-            />
-            <span>Model: {agent.model}</span>
-            <span>Max turns: {agent.max_turns}</span>
-            <CostStatsPill stats={agent.cost_stats_30d} />
-            <RecentErrorPill stats={agent.recent_error_stats} />
-            <RecentCapPill stats={agent.recent_cap_stats} />
-            <LastRunPill run={agent.last_run} />
-          </div>
-        </div>
-
-        <div className="flex shrink-0 items-center gap-2">
-          <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5">
-            <Switch
-              checked={agent.enabled}
-              disabled={toggle.isPending}
-              onCheckedChange={handleToggle}
-            />
-            <span className="text-xs font-medium">
-              {agent.enabled ? "Enabled" : "Disabled"}
-            </span>
-          </div>
-          <RunNowDialog
-            slug={agent.slug}
-            name={agent.name}
-            lastPrefix={agent.last_prompt_prefix ?? null}
-          />
-          <Button asChild variant="ghost" size="icon" aria-label="Run history">
-            <Link to="/agents/$slug/runs" params={{ slug: agent.slug }}>
-              <History className="size-4" />
-            </Link>
-          </Button>
-          <Button asChild variant="ghost" size="icon" aria-label="Edit agent">
-            <Link to="/agents/$slug/edit" params={{ slug: agent.slug }}>
-              <Pencil className="size-4" />
-            </Link>
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Delete agent"
-            onClick={onDelete}
-          >
-            <Trash2 className="size-4" />
-          </Button>
-        </div>
-      </div>
-    </Card>
+    <div onClick={stopRowClick} className="inline-flex">
+      <Switch
+        checked={agent.enabled}
+        disabled={toggle.isPending}
+        onCheckedChange={handleChange}
+        aria-label={agent.enabled ? "Disable agent" : "Enable agent"}
+      />
+    </div>
   );
 }
 
-// RecentErrorsBanner surfaces errored runs from the last 24h at the top
-// of /v2/agents, with one row per recent error and a click-through to the
-// matching run's transcript drawer. Hidden when there's nothing to show.
-// 60s auto-refetch (hook-side) so a fresh failure surfaces without a
-// manual reload. Catches operators who only open the SPA every few days.
-function RecentErrorsBanner() {
-  const navigate = useNavigate();
-  const recent = useRecentErroredAgentRuns(24, 5);
-  const rows = recent.data ?? [];
-  if (rows.length === 0) return null;
-
-  const openRun = (row: RecentErroredAgentRun) => {
-    navigate({
-      to: "/agents/$slug/runs",
-      params: { slug: row.agent_slug },
-      search: { run: row.run_short_id },
-    });
-  };
-
+function ActionsCell({
+  agent,
+  onDelete,
+}: {
+  agent: AgentDefinition;
+  onDelete: () => void;
+}) {
   return (
-    <Alert variant="destructive">
-      <AlertCircle className="size-4" />
-      <AlertTitle>
-        {rows.length === 1
-          ? "1 errored agent run in the last 24h"
-          : `${rows.length} errored agent runs in the last 24h`}
-      </AlertTitle>
-      <AlertDescription className="space-y-1">
-        <ul className="space-y-1">
-          {rows.map((r) => (
-            <li
-              key={r.run_short_id}
-              className="flex flex-wrap items-baseline gap-2 text-sm"
-            >
-              <button
-                type="button"
-                className="font-medium underline-offset-2 hover:underline"
-                onClick={() => openRun(r)}
-              >
-                {r.agent_name}
-              </button>
-              <span className="text-muted-foreground text-xs">
-                {formatRelativeTime(r.started_at)}
-              </span>
-              {r.error_message && (
-                <span
-                  className="text-muted-foreground truncate text-xs"
-                  title={r.error_message}
-                >
-                  — {r.error_message}
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-      </AlertDescription>
-    </Alert>
+    <div
+      onClick={stopRowClick}
+      className="flex items-center justify-end gap-1"
+    >
+      <RunNowDialog
+        slug={agent.slug}
+        name={agent.name}
+        lastPrefix={agent.last_prompt_prefix ?? null}
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label="More actions">
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuGroup>
+            <DropdownMenuItem asChild>
+              <Link to="/agents/$slug/edit" params={{ slug: agent.slug }}>
+                <Pencil className="size-4" /> Edit agent
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/agents/$slug/runs" params={{ slug: agent.slug }}>
+                <History className="size-4" /> View runs
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+            <Trash2 className="size-4" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
@@ -591,8 +473,6 @@ function RunNowDialog({
     if (ok) {
       setOpen(false);
       setPrefix("");
-      // Land on the runs page with the freshly-kicked-off run pre-selected.
-      // The transcript drawer + 2s polling pick up events as they stream in.
       if (startedShortId) {
         navigate({
           to: "/agents/$slug/runs",
@@ -616,7 +496,7 @@ function RunNowDialog({
       <DialogTrigger asChild>
         <Button variant="secondary" size="sm" disabled={runNow.isPending}>
           <Play className="size-3.5" />
-          Run now
+          Run
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg">
@@ -680,166 +560,5 @@ function RunNowDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-// RECENT_ERROR_WARN_THRESHOLD is the number of errors in the last 5 runs
-// that triggers the warning pill. Bump if it turns out noisy.
-const RECENT_ERROR_WARN_THRESHOLD = 3;
-
-// RECENT_CAP_WARN_THRESHOLD is the number of cap-exhausted runs in the
-// last 5 that triggers the amber "caps hit" pill. Lower than the error
-// threshold because cap-hits indicate the agent's plan exceeds what was
-// budgeted for it — even occasional hits are worth noticing.
-const RECENT_CAP_WARN_THRESHOLD = 2;
-
-function RecentCapPill({
-  stats,
-}: {
-  stats?: AgentRecentCapStats | null;
-}) {
-  if (!stats || stats.cap_count < RECENT_CAP_WARN_THRESHOLD) {
-    return null;
-  }
-  return (
-    <span
-      className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
-      title={`${stats.cap_count} of last ${stats.run_count} runs hit max_turns or max_budget — consider raising the caps or splitting the prompt`}
-    >
-      <AlertCircle className="size-3" />
-      {stats.cap_count}/{stats.run_count} hit cap
-    </span>
-  );
-}
-
-function RecentErrorPill({
-  stats,
-}: {
-  stats?: AgentRecentErrorStats | null;
-}) {
-  if (!stats || stats.error_count < RECENT_ERROR_WARN_THRESHOLD) {
-    return null;
-  }
-  return (
-    <span
-      className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 font-medium text-red-700 dark:bg-red-950/40 dark:text-red-300"
-      title={`${stats.error_count} of last ${stats.run_count} runs errored — check the run history`}
-    >
-      <AlertCircle className="size-3" />
-      {stats.error_count}/{stats.run_count} errored
-    </span>
-  );
-}
-
-// QuietHoursActivePill renders an amber "Quiet now" indicator when the
-// agent has quiet hours set AND the user's current local time is inside
-// the window. Distinct from the iter-20 NextFirePill (which always shows
-// "next will fire at X" honoring quiet hours) — this is the real-time
-// "this agent is silent RIGHT NOW because of its quiet window" signal,
-// which explains why an enabled agent isn't firing even though a cron
-// slot just passed. Hidden when the agent is disabled or quiet hours
-// aren't configured.
-function QuietHoursActivePill({
-  start,
-  end,
-  enabled,
-}: {
-  start?: string | null;
-  end?: string | null;
-  enabled: boolean;
-}) {
-  if (!enabled || !start || !end || start === end) return null;
-  if (!isWithinQuietWindow(new Date(), start, end)) return null;
-  return (
-    <span
-      className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
-      title={`Quiet hours ${start}–${end} are active right now; cron fires in this window are skipped`}
-    >
-      <Clock className="size-3" />
-      Quiet now
-    </span>
-  );
-}
-
-// isWithinQuietWindow mirrors internal/service/IsWithinQuietHours on the
-// SPA side so we don't need a server round-trip for an at-a-glance check.
-// HH:MM 24-hour. Wrap-midnight windows (e.g. 22:00 → 07:00) handled.
-// Empty/equal bounds → never quiet (defensive — the caller already
-// short-circuits on those, but pin the contract here too).
-function isWithinQuietWindow(
-  now: Date,
-  startHHMM: string,
-  endHHMM: string,
-): boolean {
-  const start = parseHHMM(startHHMM);
-  const end = parseHHMM(endHHMM);
-  if (start === null || end === null || start === end) return false;
-  const cur = now.getHours() * 60 + now.getMinutes();
-  if (start < end) {
-    // Same-day window: [start, end)
-    return cur >= start && cur < end;
-  }
-  // Wrap-midnight window: [start, 24:00) ∪ [00:00, end)
-  return cur >= start || cur < end;
-}
-
-function parseHHMM(hhmm: string): number | null {
-  const m = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(hhmm);
-  if (!m) return null;
-  return Number(m[1]) * 60 + Number(m[2]);
-}
-
-function NextFirePill({ at }: { at?: string | null }) {
-  if (!at) return null;
-  return (
-    <span
-      className="inline-flex items-center gap-1"
-      title={`Next scheduled fire: ${new Date(at).toLocaleString()}`}
-    >
-      <Clock className="size-3" />
-      Next: {formatRelativeTime(at)}
-    </span>
-  );
-}
-
-function CostStatsPill({
-  stats,
-}: {
-  stats?: AgentCostStats | null;
-}) {
-  if (!stats || stats.run_count === 0) {
-    return null;
-  }
-  return (
-    <span
-      className="inline-flex items-center gap-1"
-      title={`${stats.run_count} run${stats.run_count === 1 ? "" : "s"} in the last 30 days`}
-    >
-      <Coins className="size-3" />${stats.total_cost_usd.toFixed(2)} / 30d
-    </span>
-  );
-}
-
-function LastRunPill({
-  run,
-}: {
-  run: AgentDefinition["last_run"];
-}) {
-  if (!run) {
-    return <span className="opacity-70">No runs yet</span>;
-  }
-  const Icon =
-    run.status === "success"
-      ? CheckCircle2
-      : run.status === "error"
-        ? XCircle
-        : run.status === "skipped"
-          ? AlertCircle
-          : Clock;
-  return (
-    <span className="inline-flex items-center gap-1">
-      <Icon className="size-3" />
-      {run.status} · {formatRelativeTime(run.started_at)}
-    </span>
   );
 }

--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -436,8 +436,7 @@ export function PromptsBuildPage() {
   // `customs` so it fires once per add — guard with the ref so we
   // don't re-focus on unrelated `customs` mutations (rename, delete).
   // requestAnimationFrame defers the focus past React's commit phase
-  // and any in-flight click-event focus shuffling, otherwise the
-  // textarea immediately loses focus back to <body>.
+  // so the row is laid out before scrollIntoView runs.
   useEffect(() => {
     const id = pendingFocusId.current;
     if (!id) return;
@@ -583,7 +582,17 @@ export function PromptsBuildPage() {
                         <ChevronDown className="size-3.5" />
                       </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-60">
+                    <DropdownMenuContent
+                      align="end"
+                      className="w-60"
+                      // Radix restores focus to the trigger button after
+                      // the menu closes. For this menu, "Add empty block"
+                      // moves focus to the new textarea — letting Radix
+                      // then snap focus back to the chevron immediately
+                      // overrides that. preventDefault keeps focus
+                      // wherever our handler put it.
+                      onCloseAutoFocus={(e) => e.preventDefault()}
+                    >
                       <DropdownMenuItem onSelect={() => addEmptyBlock()}>
                         <Plus className="size-4" />
                         Add empty block

--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -1,0 +1,1392 @@
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+import { toast } from "sonner";
+import {
+  ArrowLeft,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Eye,
+  GripVertical,
+  Plus,
+  RotateCcw,
+  Search,
+  Trash2,
+  Wand2,
+} from "lucide-react";
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PageHeader } from "@/components/page-header";
+import { PageError } from "@/components/page-error";
+import { FloatingActionBar } from "@/components/floating-action-bar";
+import { DynamicIcon } from "@/lib/icon";
+import {
+  usePromptBlocks,
+  type PromptBlock,
+  type PromptBlockGroup,
+} from "@/api/queries/prompt-blocks";
+import { useAgents, useUpdateAgent } from "@/api/queries/agents";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { cn } from "@/lib/utils";
+
+// URL-stateful so a configuration is shareable. Edits to individual
+// block content live in-memory only — the URL stays compact, and a
+// fresh visit re-reads from the embedded library.
+export const promptsBuildSearchSchema = z.object({
+  strategy: z.string().optional(),
+  depth: z.string().optional(),
+  integrations: z.string().optional(),
+  knowledge: z.string().optional(),
+});
+type PromptsBuildSearch = z.infer<typeof promptsBuildSearchSchema>;
+
+interface CustomBlock {
+  id: string; // `custom:<incrementing>` — stable within a session
+  content: string;
+}
+
+// deriveCustomBlockTitle picks a display label for a custom block from
+// its content. First non-empty line, with a leading `# ` stripped if
+// present (so a markdown heading reads as the title). Truncated for
+// the row header; the full content is always visible when expanded.
+function deriveCustomBlockTitle(content: string): string {
+  const firstLine = content
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return "Custom block";
+  const stripped = firstLine.startsWith("# ")
+    ? firstLine.slice(2).trim()
+    : firstLine;
+  return stripped.length > 60 ? stripped.slice(0, 60) + "…" : stripped;
+}
+
+type ComposedItem =
+  | { kind: "library"; id: string }
+  | { kind: "custom"; id: string };
+
+function parseCsv(s: string | undefined): string[] {
+  if (!s) return [];
+  return s
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+function joinCsv(parts: string[]): string | undefined {
+  return parts.length === 0 ? undefined : parts.join(",");
+}
+
+function rowKey(item: ComposedItem): string {
+  return `${item.kind}:${item.id}`;
+}
+
+
+export function PromptsBuildPage() {
+  const search = useSearch({ strict: false }) as PromptsBuildSearch;
+  const navigate = useNavigate();
+  const blocksQuery = usePromptBlocks();
+
+  const strategy = search.strategy ?? "";
+  const depth = search.depth ?? "";
+  const integrations = useMemo(() => parseCsv(search.integrations), [search.integrations]);
+  const knowledge = useMemo(() => parseCsv(search.knowledge), [search.knowledge]);
+
+  const blocks = blocksQuery.data ?? [];
+  const blocksById = useMemo(() => {
+    const map = new Map<string, PromptBlock>();
+    for (const b of blocks) map.set(b.id, b);
+    return map;
+  }, [blocks]);
+
+  const blocksByGroup = useMemo(() => {
+    const g: Record<string, PromptBlock[]> = {
+      strategy: [],
+      depth: [],
+      integration: [],
+      knowledge: [],
+    };
+    for (const b of blocks) {
+      if (!g[b.group]) g[b.group] = [];
+      g[b.group].push(b);
+    }
+    return g;
+  }, [blocks]);
+
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [customs, setCustoms] = useState<CustomBlock[]>([]);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [order, setOrder] = useState<ComposedItem[] | null>(null);
+  // Modal lives on the parent so it stays mounted across the
+  // empty-state → composer-table swap that happens after the first
+  // pick. If the dialog were nested inside whichever trigger element
+  // is visible, the first selection would unmount the trigger and
+  // dismiss the dialog with it.
+  const [addBlockOpen, setAddBlockOpen] = useState(false);
+
+  // Default order: strategy first, then depth, then integrations (URL
+  // order), then knowledge (URL order), then customs.
+  const defaultOrder: ComposedItem[] = useMemo(() => {
+    const items: ComposedItem[] = [];
+    if (strategy) items.push({ kind: "library", id: strategy });
+    if (depth) items.push({ kind: "library", id: depth });
+    for (const id of integrations) items.push({ kind: "library", id });
+    for (const id of knowledge) items.push({ kind: "library", id });
+    for (const c of customs) items.push({ kind: "custom", id: c.id });
+    return items;
+  }, [strategy, depth, integrations, knowledge, customs]);
+
+  // Resync the session order whenever the URL selection drifts.
+  // Preserve manual reordering for items that still belong; append
+  // new ones at the end.
+  useEffect(() => {
+    if (order === null) {
+      setOrder(defaultOrder);
+      return;
+    }
+    const have = new Set(order.map(rowKey));
+    const want = new Set(defaultOrder.map(rowKey));
+    if (
+      have.size !== want.size ||
+      [...have].some((k) => !want.has(k)) ||
+      [...want].some((k) => !have.has(k))
+    ) {
+      const surviving = order.filter((i) => want.has(rowKey(i)));
+      const added = defaultOrder.filter((i) => !have.has(rowKey(i)));
+      setOrder([...surviving, ...added]);
+    }
+  }, [defaultOrder, order]);
+
+  const effectiveOrder = order ?? defaultOrder;
+
+  const setFilter = (patch: Partial<PromptsBuildSearch>) => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => {
+        const next: Record<string, unknown> = { ...prev, ...patch };
+        for (const k of Object.keys(next)) {
+          if (next[k] === undefined || next[k] === "") delete next[k];
+        }
+        return next;
+      },
+    });
+  };
+
+  // pickStrategy / pickDepth are toggles: clicking the active block
+  // removes it; clicking a different one replaces the current
+  // selection (Strategy and Depth are still single-select). Toggle-off
+  // matches the multi-select Integrations/Knowledge behavior so picks
+  // always feel reversible from the modal itself.
+  const pickStrategy = (id: string) =>
+    setFilter({ strategy: strategy === id ? undefined : id });
+  const pickDepth = (id: string) =>
+    setFilter({ depth: depth === id ? undefined : id });
+
+  const toggleIntegration = (id: string) => {
+    const next = integrations.includes(id)
+      ? integrations.filter((x) => x !== id)
+      : [...integrations, id];
+    setFilter({ integrations: joinCsv(next) });
+  };
+  const toggleKnowledge = (id: string) => {
+    const next = knowledge.includes(id)
+      ? knowledge.filter((x) => x !== id)
+      : [...knowledge, id];
+    setFilter({ knowledge: joinCsv(next) });
+  };
+
+  const removeFromComposition = (item: ComposedItem) => {
+    if (item.kind === "custom") {
+      setCustoms((cs) => cs.filter((c) => c.id !== item.id));
+      return;
+    }
+    if (item.id === strategy) setFilter({ strategy: undefined });
+    else if (item.id === depth) setFilter({ depth: undefined });
+    else if (integrations.includes(item.id))
+      setFilter({ integrations: joinCsv(integrations.filter((x) => x !== item.id)) });
+    else if (knowledge.includes(item.id))
+      setFilter({ knowledge: joinCsv(knowledge.filter((x) => x !== item.id)) });
+  };
+
+  // addCustomBlock takes the initial content directly (no title field
+  // — title is derived from content at render time). The modal picker
+  // collects content in its custom-form step before calling this.
+  const addCustomBlock = (content: string) => {
+    const id = `custom:${Date.now()}`;
+    setCustoms((cs) => [...cs, { id, content }]);
+    // Expand the new block by default ONLY if it has no content yet —
+    // a content-prefilled add (the common path now) starts collapsed
+    // since the user has already seen what they wrote.
+    if (!content.trim()) {
+      setExpanded((e) => ({ ...e, [id]: true }));
+    }
+  };
+
+  const composedText = useMemo(
+    () => composePrompt(effectiveOrder, blocksById, edits, customs),
+    [effectiveOrder, blocksById, edits, customs],
+  );
+
+  const isLoading = blocksQuery.isLoading;
+
+  // Active-set helper for the dropdown — shows a ✓ next to library
+  // items already in the composition.
+  const activeLibraryIds = useMemo(() => {
+    const s = new Set<string>();
+    if (strategy) s.add(strategy);
+    if (depth) s.add(depth);
+    for (const id of integrations) s.add(id);
+    for (const id of knowledge) s.add(id);
+    return s;
+  }, [strategy, depth, integrations, knowledge]);
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="System"
+        title="Prompt builder"
+        description="Compose an agent prompt from reusable blocks. Output is plain markdown — copy it anywhere, or push it directly into a Breadbox agent. Breadbox agent runs are optional and for convenience; the prompts work with any agent tool you connect to your Breadbox server."
+      />
+
+      {blocksQuery.isError ? (
+        <PageError
+          resource="prompt blocks"
+          error={blocksQuery.error}
+          onRetry={() => blocksQuery.refetch()}
+          retrying={blocksQuery.isFetching}
+        />
+      ) : (
+        <div className="flex flex-col gap-3 pb-20">
+          {isLoading ? (
+            <Card className="p-4">
+              <Skeleton className="h-32 w-full" />
+            </Card>
+          ) : (
+            <ComposerTable
+              items={effectiveOrder}
+              onReorder={setOrder}
+              blocksById={blocksById}
+              customs={customs}
+              edits={edits}
+              expanded={expanded}
+              setExpanded={setExpanded}
+              setEdits={setEdits}
+              setCustoms={setCustoms}
+              onRemove={removeFromComposition}
+              addBlockEmptyTrigger={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isLoading}
+                  onClick={() => setAddBlockOpen(true)}
+                >
+                  <Plus className="size-4" />
+                  Add block
+                </Button>
+              }
+              addBlockGhostRow={
+                <button
+                  type="button"
+                  disabled={isLoading}
+                  onClick={() => setAddBlockOpen(true)}
+                  className="text-muted-foreground hover:bg-accent/40 hover:text-foreground flex w-full items-center justify-center gap-2 py-3 text-sm transition-colors"
+                >
+                  <Plus className="size-4" />
+                  Add block
+                </button>
+              }
+            />
+          )}
+        </div>
+      )}
+      {!isLoading && !blocksQuery.isError && (
+        <AddBlockMenu
+          open={addBlockOpen}
+          onOpenChange={setAddBlockOpen}
+          blocksByGroup={blocksByGroup}
+          activeIds={activeLibraryIds}
+          onPickStrategy={pickStrategy}
+          onPickDepth={pickDepth}
+          onToggleIntegration={toggleIntegration}
+          onToggleKnowledge={toggleKnowledge}
+          onAddCustom={addCustomBlock}
+        />
+      )}
+      {effectiveOrder.length > 0 && (
+        <FloatingActionBar
+          ariaLabel="Prompt builder actions"
+          className="pl-3"
+        >
+          <ComposedStats text={composedText} />
+          <Separator orientation="vertical" className="mx-1 h-5" />
+          <PreviewButton text={composedText} disabled={false} />
+          <OutputActions text={composedText} disabled={false} />
+        </FloatingActionBar>
+      )}
+    </>
+  );
+}
+
+interface AddBlockMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  blocksByGroup: Record<string, PromptBlock[]>;
+  activeIds: Set<string>;
+  onPickStrategy: (id: string) => void;
+  onPickDepth: (id: string) => void;
+  onToggleIntegration: (id: string) => void;
+  onToggleKnowledge: (id: string) => void;
+  onAddCustom: (content: string) => void;
+}
+
+// AddBlockMenu is the modal "block library" — left rail of category
+// filters, right pane of card grid. Controlled by the parent so the
+// dialog survives re-renders where the trigger element changes (e.g.
+// empty-state card → composer table). When the dialog mounted its own
+// trigger, the first pick caused the empty card to unmount, which
+// dismissed the dialog mid-interaction.
+function AddBlockMenu({
+  open,
+  onOpenChange,
+  blocksByGroup,
+  activeIds,
+  onPickStrategy,
+  onPickDepth,
+  onToggleIntegration,
+  onToggleKnowledge,
+  onAddCustom,
+}: AddBlockMenuProps) {
+  const [mode, setMode] = useState<"pick" | "custom">("pick");
+  const [activeGroup, setActiveGroup] = useState<PromptBlockGroup | "all">(
+    "all",
+  );
+  const [query, setQuery] = useState("");
+  const [customDraft, setCustomDraft] = useState("");
+
+  // Reset all transient state when the dialog closes so the next open
+  // starts on the picker with a clean search / draft. Open state
+  // itself lives on the parent — we only forward the change and
+  // piggyback on close events to reset.
+  const handleOpenChange = (next: boolean) => {
+    onOpenChange(next);
+    if (!next) {
+      setMode("pick");
+      setActiveGroup("all");
+      setQuery("");
+      setCustomDraft("");
+    }
+  };
+
+  const openCustomForm = () => {
+    setMode("custom");
+    setCustomDraft("");
+  };
+
+  const commitCustomBlock = () => {
+    const content = customDraft.trim();
+    if (!content) return;
+    onAddCustom(content);
+    handleOpenChange(false);
+  };
+
+  const allBlocks = useMemo(
+    () => [
+      ...(blocksByGroup.strategy ?? []),
+      ...(blocksByGroup.depth ?? []),
+      ...(blocksByGroup.integration ?? []),
+      ...(blocksByGroup.knowledge ?? []),
+    ],
+    [blocksByGroup],
+  );
+
+  const counts: Record<PromptBlockGroup | "all", number> = {
+    all: allBlocks.length,
+    strategy: (blocksByGroup.strategy ?? []).length,
+    depth: (blocksByGroup.depth ?? []).length,
+    integration: (blocksByGroup.integration ?? []).length,
+    knowledge: (blocksByGroup.knowledge ?? []).length,
+  };
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allBlocks.filter((b) => {
+      if (activeGroup !== "all" && b.group !== activeGroup) return false;
+      if (!q) return true;
+      return (
+        b.title.toLowerCase().includes(q) ||
+        b.description.toLowerCase().includes(q) ||
+        b.id.toLowerCase().includes(q)
+      );
+    });
+  }, [allBlocks, activeGroup, query]);
+
+  // When viewing "All", the right pane is split into one section per
+  // group with a sticky header — so a long list reads as a structured
+  // library rather than a flat grid. A specific-group filter keeps the
+  // flat grid (only one section would be redundant).
+  const sections: Array<{ group: PromptBlockGroup; label: string; blocks: PromptBlock[] }> =
+    useMemo(() => {
+      if (activeGroup !== "all") return [];
+      const order: Array<{ group: PromptBlockGroup; label: string }> = [
+        { group: "strategy", label: "Strategy" },
+        { group: "depth", label: "Depth" },
+        { group: "integration", label: "Integrations" },
+        { group: "knowledge", label: "Knowledge" },
+      ];
+      return order
+        .map(({ group, label }) => ({
+          group,
+          label,
+          blocks: filtered.filter((b) => b.group === group),
+        }))
+        .filter((s) => s.blocks.length > 0);
+    }, [activeGroup, filtered]);
+
+  const handlePick = (block: PromptBlock) => {
+    switch (block.group) {
+      case "strategy":
+        onPickStrategy(block.id);
+        break;
+      case "depth":
+        onPickDepth(block.id);
+        break;
+      case "integration":
+        onToggleIntegration(block.id);
+        break;
+      case "knowledge":
+        onToggleKnowledge(block.id);
+        break;
+    }
+    // Stay open: user might add several integrations / both a strategy
+    // and a depth in one sitting. They dismiss via Esc / backdrop / ×.
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="flex h-[640px] max-h-[85vh] flex-col gap-0 p-0 sm:max-w-3xl">
+        {mode === "pick" ? (
+          <>
+            <DialogHeader className="border-b p-4">
+              <DialogTitle>Add a block</DialogTitle>
+              <DialogDescription className="sr-only">
+                Pick a strategy, depth modifier, integration, or knowledge
+                block to add to the prompt composition.
+              </DialogDescription>
+              <div className="relative mt-3">
+                <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+                <Input
+                  autoFocus
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search blocks…"
+                  className="pl-9"
+                />
+              </div>
+            </DialogHeader>
+
+            <div className="grid flex-1 grid-cols-[10rem_1fr] overflow-hidden">
+              <nav className="bg-muted/30 overflow-y-auto border-r p-2">
+                <CategoryRailItem
+                  label="All"
+                  count={counts.all}
+                  active={activeGroup === "all"}
+                  onClick={() => setActiveGroup("all")}
+                />
+                <CategoryRailItem
+                  label="Strategy"
+                  count={counts.strategy}
+                  active={activeGroup === "strategy"}
+                  onClick={() => setActiveGroup("strategy")}
+                />
+                <CategoryRailItem
+                  label="Depth"
+                  count={counts.depth}
+                  active={activeGroup === "depth"}
+                  onClick={() => setActiveGroup("depth")}
+                />
+                <CategoryRailItem
+                  label="Integrations"
+                  count={counts.integration}
+                  active={activeGroup === "integration"}
+                  onClick={() => setActiveGroup("integration")}
+                />
+                <CategoryRailItem
+                  label="Knowledge"
+                  count={counts.knowledge}
+                  active={activeGroup === "knowledge"}
+                  onClick={() => setActiveGroup("knowledge")}
+                />
+                <div className="mt-2 border-t pt-2">
+                  <button
+                    type="button"
+                    onClick={openCustomForm}
+                    className="hover:bg-accent text-muted-foreground hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+                  >
+                    <Plus className="size-3.5" />
+                    Custom block
+                  </button>
+                </div>
+              </nav>
+
+              {/* Scroller has NO top padding — if it did, sticky's
+                  top:0 would pin below the padding, leaving a strip
+                  above where scrolling content shows through. Each
+                  sticky header instead bakes the top breathing room
+                  into its own padding so the bg-background fills all
+                  the way to the literal top of the scroll viewport. */}
+              <div className="overflow-y-auto px-4 pb-2">
+                {filtered.length === 0 ? (
+                  <div className="text-muted-foreground flex h-full items-center justify-center pt-4 text-sm">
+                    No blocks match {query ? `"${query}"` : "this filter"}.
+                  </div>
+                ) : activeGroup === "all" ? (
+                  // Sections are flattened (Fragment, not wrapping div) so
+                  // each sticky header anchors to the scroll container —
+                  // the next header pushes the previous one out, instead
+                  // of each header being trapped at the bottom of its
+                  // own <section>.
+                  <>
+                    {sections.map((section, i) => (
+                      <Fragment key={section.group}>
+                        <div
+                          className={cn(
+                            "bg-background sticky top-0 z-10 -mx-4 flex items-baseline justify-between gap-2 px-4 pb-2",
+                            // First header pads to the top of the scroller
+                            // (covers the missing scroller pt-4). Later
+                            // headers get extra top space + own padding to
+                            // separate sections visually.
+                            i === 0 ? "pt-4" : "pt-6",
+                          )}
+                        >
+                          <h3 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                            {section.label}
+                          </h3>
+                          <span className="text-muted-foreground/70 text-xs tabular-nums">
+                            {section.blocks.length}
+                          </span>
+                        </div>
+                        <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+                          {section.blocks.map((block) => (
+                            <BlockCard
+                              key={block.id}
+                              block={block}
+                              active={activeIds.has(block.id)}
+                              onClick={() => handlePick(block)}
+                            />
+                          ))}
+                        </div>
+                      </Fragment>
+                    ))}
+                  </>
+                ) : (
+                  <div className="grid grid-cols-2 gap-3 pt-4 lg:grid-cols-3">
+                    {filtered.map((block) => (
+                      <BlockCard
+                        key={block.id}
+                        block={block}
+                        active={activeIds.has(block.id)}
+                        onClick={() => handlePick(block)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+            <DialogFooter className="border-t p-3 sm:justify-between">
+              <span className="text-muted-foreground self-center text-xs">
+                {activeIds.size === 0
+                  ? "Tap blocks to add — pick as many as you like."
+                  : `${activeIds.size} block${activeIds.size === 1 ? "" : "s"} in composition`}
+              </span>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => handleOpenChange(false)}
+              >
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <CustomBlockForm
+            value={customDraft}
+            onChange={setCustomDraft}
+            onCancel={() => setMode("pick")}
+            onCommit={commitCustomBlock}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// CustomBlockForm is the modal's secondary view — a Textarea-only
+// editor for one-off custom blocks. Title is omitted on purpose: it's
+// derived from the first non-empty content line so authors only have
+// to think about the prompt itself.
+function CustomBlockForm({
+  value,
+  onChange,
+  onCancel,
+  onCommit,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onCancel: () => void;
+  onCommit: () => void;
+}) {
+  const ready = value.trim().length > 0;
+  return (
+    <>
+      <DialogHeader className="border-b p-4">
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onCancel}
+            aria-label="Back to picker"
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          <DialogTitle>Custom block</DialogTitle>
+        </div>
+        <DialogDescription className="sr-only">
+          Write a one-off prompt block. The first non-empty line becomes
+          the row title in the composition.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Textarea
+          autoFocus
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={
+            "Paste or write a prompt fragment here…\n\nExamples:\n— Focus on transactions from last week only\n— Skip transactions over $500 unless flagged\n— Always include a TL;DR at the top of the report"
+          }
+          className="flex-1 resize-none rounded-none border-0 px-4 py-3 font-mono text-xs leading-relaxed shadow-none focus-visible:ring-0"
+        />
+      </div>
+      <DialogFooter className="border-t p-3">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="button" onClick={onCommit} disabled={!ready}>
+          <Plus className="size-4" />
+          Add to composition
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function CategoryRailItem({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "hover:bg-accent flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+        active
+          ? "bg-accent text-foreground font-medium"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <span>{label}</span>
+      <span
+        className={cn(
+          "text-xs tabular-nums",
+          active ? "text-muted-foreground" : "text-muted-foreground/70",
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+// BlockCard renders one library block as a clickable tile. Active state
+// shows a check pill in the corner so the user can tell at a glance
+// which blocks are already in the composition (especially useful for
+// the multi-select Integrations / Knowledge groups).
+function BlockCard({
+  block,
+  active,
+  onClick,
+}: {
+  block: PromptBlock;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "group hover:border-primary/40 hover:bg-accent/40 relative flex h-full flex-col gap-2 rounded-lg border p-3 text-left transition-colors",
+        active && "border-primary/40 bg-accent/30",
+      )}
+    >
+      {active && (
+        <span className="bg-primary text-primary-foreground absolute top-2 right-2 inline-flex size-5 items-center justify-center rounded-full">
+          <Check className="size-3" />
+        </span>
+      )}
+      {block.icon && (
+        <span className="bg-muted text-muted-foreground group-hover:text-foreground inline-flex size-8 items-center justify-center rounded-md">
+          <DynamicIcon name={block.icon} className="size-4" />
+        </span>
+      )}
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium leading-tight">{block.title}</span>
+        {block.description && (
+          <span className="text-muted-foreground line-clamp-3 text-xs leading-snug">
+            {block.description}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+interface ComposerTableProps {
+  items: ComposedItem[];
+  onReorder: (next: ComposedItem[]) => void;
+  blocksById: Map<string, PromptBlock>;
+  customs: CustomBlock[];
+  edits: Record<string, string>;
+  expanded: Record<string, boolean>;
+  setExpanded: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  setEdits: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  setCustoms: React.Dispatch<React.SetStateAction<CustomBlock[]>>;
+  onRemove: (item: ComposedItem) => void;
+  // addBlockEmptyTrigger is the button rendered inside the empty-state
+  // card. Just a button — it does NOT contain the dialog, which lives
+  // at the parent so it survives the empty-state → table re-render.
+  addBlockEmptyTrigger: React.ReactNode;
+  // addBlockGhostRow is the trigger rendered as a full-width ghost row
+  // at the bottom of the table when there are blocks. Subtle styling so
+  // it reads as "another row you could add" without competing with the
+  // real block rows above it.
+  addBlockGhostRow: React.ReactNode;
+}
+
+function ComposerTable({
+  items,
+  onReorder,
+  blocksById,
+  customs,
+  edits,
+  expanded,
+  setExpanded,
+  setEdits,
+  setCustoms,
+  onRemove,
+  addBlockEmptyTrigger,
+  addBlockGhostRow,
+}: ComposerTableProps) {
+  // dnd-kit sensors: PointerSensor with a small activation distance so
+  // a quick row click doesn't accidentally start a drag (only deliberate
+  // movement past 6px does). KeyboardSensor for accessibility.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  // Collapse all expanded rows while a drag is in flight so the user
+  // is dragging compact rows of uniform height (taller expanded rows
+  // make reorder targeting jumpy). Snapshot which item ids were open
+  // so we can re-expand exactly those after the drag settles. Stored
+  // in a ref so it survives the re-render the collapse triggers.
+  const expandedBeforeDrag = useRef<string[] | null>(null);
+
+  const onDragStart = () => {
+    const openIds = Object.entries(expanded)
+      .filter(([, open]) => open)
+      .map(([id]) => id);
+    if (openIds.length === 0) return;
+    expandedBeforeDrag.current = openIds;
+    setExpanded((e) => {
+      const next = { ...e };
+      for (const id of openIds) next[id] = false;
+      return next;
+    });
+  };
+
+  const restoreExpanded = () => {
+    const ids = expandedBeforeDrag.current;
+    if (!ids || ids.length === 0) return;
+    expandedBeforeDrag.current = null;
+    setExpanded((e) => {
+      const next = { ...e };
+      for (const id of ids) next[id] = true;
+      return next;
+    });
+  };
+
+  const onDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (over && active.id !== over.id) {
+      const from = items.findIndex((i) => rowKey(i) === active.id);
+      const to = items.findIndex((i) => rowKey(i) === over.id);
+      if (from >= 0 && to >= 0) onReorder(arrayMove(items, from, to));
+    }
+    restoreExpanded();
+  };
+
+  if (items.length === 0) {
+    return (
+      <Card className="text-muted-foreground flex flex-col items-center gap-3 p-8 text-center text-sm">
+        <Wand2 className="size-6 opacity-50" />
+        <div>
+          <div className="text-foreground font-medium">No blocks yet</div>
+          <p className="max-w-xs text-xs">
+            Pick a strategy to start composing. Add depth, integrations,
+            knowledge, or a custom block as needed.
+          </p>
+        </div>
+        {addBlockEmptyTrigger}
+      </Card>
+    );
+  }
+
+  const ids = items.map(rowKey);
+
+  return (
+    <Card className="overflow-hidden p-0">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragCancel={restoreExpanded}
+        modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      >
+        <Table>
+          <TableBody>
+            <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+              {items.map((item) => (
+                <SortableRow
+                  key={rowKey(item)}
+                  item={item}
+                  blocksById={blocksById}
+                  customs={customs}
+                  edits={edits}
+                  expanded={Boolean(expanded[item.id])}
+                  setExpanded={(open) =>
+                    setExpanded((e) => ({ ...e, [item.id]: open }))
+                  }
+                  setEdits={setEdits}
+                  setCustoms={setCustoms}
+                  onRemove={() => onRemove(item)}
+                />
+              ))}
+            </SortableContext>
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={3} className="border-t border-dashed p-0">
+                {addBlockGhostRow}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </DndContext>
+    </Card>
+  );
+}
+
+interface SortableRowProps {
+  item: ComposedItem;
+  blocksById: Map<string, PromptBlock>;
+  customs: CustomBlock[];
+  edits: Record<string, string>;
+  expanded: boolean;
+  setExpanded: (open: boolean) => void;
+  setEdits: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  setCustoms: React.Dispatch<React.SetStateAction<CustomBlock[]>>;
+  onRemove: () => void;
+}
+
+function SortableRow({
+  item,
+  blocksById,
+  customs,
+  edits,
+  expanded,
+  setExpanded,
+  setEdits,
+  setCustoms,
+  onRemove,
+}: SortableRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: rowKey(item) });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const library =
+    item.kind === "library" ? blocksById.get(item.id) : undefined;
+  const custom =
+    item.kind === "custom" ? customs.find((c) => c.id === item.id) : undefined;
+
+  const title =
+    library?.title ??
+    (custom ? deriveCustomBlockTitle(custom.content) : "Unknown block");
+  const description = library?.description ?? "";
+  const icon = library?.icon ?? "";
+
+  const originalContent = library?.content ?? "";
+  const editedContent = edits[item.id];
+  const currentContent =
+    item.kind === "custom"
+      ? (custom?.content ?? "")
+      : (editedContent ?? originalContent);
+  const isEdited =
+    item.kind === "library" &&
+    editedContent !== undefined &&
+    editedContent !== originalContent;
+
+  return (
+    <>
+      <TableRow
+        ref={setNodeRef}
+        style={style}
+        data-state={isDragging ? "dragging" : undefined}
+        className={cn(isDragging && "relative z-10 bg-card shadow-md")}
+      >
+        <TableCell className="w-10 align-middle">
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground flex h-6 w-6 cursor-grab items-center justify-center active:cursor-grabbing"
+            aria-label="Drag to reorder"
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="size-4" />
+          </button>
+        </TableCell>
+        <TableCell className="align-middle">
+          <button
+            type="button"
+            className="hover:text-foreground flex w-full cursor-pointer items-center gap-2 text-left"
+            onClick={() => setExpanded(!expanded)}
+            aria-expanded={expanded}
+          >
+            <span className="text-muted-foreground shrink-0">
+              {expanded ? (
+                <ChevronDown className="size-4" />
+              ) : (
+                <ChevronRight className="size-4" />
+              )}
+            </span>
+            {icon && (
+              <DynamicIcon
+                name={icon}
+                className="text-muted-foreground shrink-0 size-4"
+              />
+            )}
+            <span className="flex min-w-0 flex-col">
+              <span className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium">{title}</span>
+                {isEdited && (
+                  <Badge variant="secondary" className="text-[10px]">
+                    edited
+                  </Badge>
+                )}
+              </span>
+              {description && (
+                <span className="text-muted-foreground truncate text-xs">
+                  {description}
+                </span>
+              )}
+            </span>
+          </button>
+        </TableCell>
+        <TableCell className="w-16 text-right align-middle">
+          <div className="flex justify-end gap-0.5">
+            {isEdited && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Reset to original"
+                title="Reset to the library version"
+                onClick={() =>
+                  setEdits((s) => {
+                    const next = { ...s };
+                    delete next[item.id];
+                    return next;
+                  })
+                }
+              >
+                <RotateCcw className="size-4" />
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Remove block"
+              onClick={onRemove}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+        </TableCell>
+      </TableRow>
+      {expanded && (
+        <TableRow
+          className="hover:bg-transparent"
+          data-expansion={rowKey(item)}
+        >
+          <TableCell colSpan={3} className="p-0">
+            <Textarea
+              id={`content-${item.id}`}
+              value={currentContent}
+              rows={Math.min(24, Math.max(8, currentContent.split("\n").length))}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (item.kind === "custom") {
+                  setCustoms((cs) =>
+                    cs.map((c) =>
+                      c.id === item.id ? { ...c, content: v } : c,
+                    ),
+                  );
+                } else {
+                  setEdits((s) => ({ ...s, [item.id]: v }));
+                }
+              }}
+              aria-label="Block content"
+              className="bg-muted/20 block w-full resize-none rounded-none border-0 px-4 py-3 font-mono text-xs leading-relaxed shadow-none focus-visible:border-0 focus-visible:ring-0 dark:bg-muted/40"
+            />
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+// ComposedStats surfaces the running size of the composed prompt in
+// the floating toolbar — same metric the Preview dialog header shows,
+// just always-on so the user can watch it grow as blocks are added or
+// edited. Tabular numerals stop the digits from twitching during live
+// updates.
+function ComposedStats({ text }: { text: string }) {
+  const lineCount = text === "" ? 0 : text.split("\n").length;
+  return (
+    <span className="text-muted-foreground text-xs whitespace-nowrap tabular-nums">
+      {text.length.toLocaleString()} chars · {lineCount} lines
+    </span>
+  );
+}
+
+function PreviewButton({
+  text,
+  disabled,
+}: {
+  text: string;
+  disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled}
+        onClick={() => setOpen(true)}
+      >
+        <Eye className="size-4" />
+        Preview
+      </Button>
+      <PreviewDialog open={open} onOpenChange={setOpen} text={text} />
+    </>
+  );
+}
+
+function PreviewDialog({
+  open,
+  onOpenChange,
+  text,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  text: string;
+}) {
+  const lineCount = text === "" ? 0 : text.split("\n").length;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-3xl">
+        <DialogHeader className="border-b px-6 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <DialogTitle>Preview</DialogTitle>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {text.length.toLocaleString()} chars · {lineCount} lines
+            </span>
+          </div>
+          <DialogDescription className="sr-only">
+            The composed agent prompt as it will be sent to the model.
+          </DialogDescription>
+        </DialogHeader>
+        <pre className="bg-muted/30 flex-1 overflow-auto px-6 py-4 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+          {text || "Add blocks to see the composed prompt."}
+        </pre>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface OutputActionsProps {
+  text: string;
+  disabled: boolean;
+}
+
+function OutputActions({ text, disabled }: OutputActionsProps) {
+  const [copied, setCopied] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      toast.success("Prompt copied to clipboard");
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Couldn't access the clipboard. Copy the preview manually.");
+    }
+  };
+
+  const onUseInNewAgent = () => {
+    navigate({
+      to: "/agents/new",
+      search: { prompt: text },
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onCopy}
+        disabled={disabled}
+      >
+        {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+        {copied ? "Copied" : "Copy"}
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="sm" disabled={disabled}>
+            <Wand2 className="size-4" />
+            Use in agent
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-72">
+          <DropdownMenuGroup>
+            <DropdownMenuItem onSelect={onUseInNewAgent}>
+              <Plus className="size-4" /> Use in new agent
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setPickerOpen(true)}>
+              <Wand2 className="size-4" /> Use in existing agent…
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-muted-foreground text-xs font-normal whitespace-normal leading-snug">
+            Tip: Breadbox agents runs are optional and for convenience — the
+            prompts work on any agent tool you connect to your Breadbox server.
+          </DropdownMenuLabel>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ExistingAgentPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        text={text}
+      />
+    </div>
+  );
+}
+
+function ExistingAgentPicker({
+  open,
+  onOpenChange,
+  text,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  text: string;
+}) {
+  const agentsQuery = useAgents();
+  const [slug, setSlug] = useState<string>("");
+  const update = useUpdateAgent(slug);
+  const agents = agentsQuery.data ?? [];
+
+  const onConfirm = async () => {
+    if (!slug) return;
+    const ok = await withMutationToast(
+      () => update.mutateAsync({ prompt: text }),
+      {
+        success: "Prompt pushed to agent",
+        error: "Failed to update agent prompt",
+      },
+    );
+    if (ok) {
+      onOpenChange(false);
+      setSlug("");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Push prompt to an existing agent</DialogTitle>
+          <DialogDescription>
+            Replaces the agent's stored prompt with the composed text. The
+            agent's other settings (model, schedule, scope) are unchanged.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="agent-picker" className="text-xs">
+            Agent
+          </Label>
+          <Select value={slug} onValueChange={setSlug}>
+            <SelectTrigger id="agent-picker">
+              <SelectValue placeholder="Pick an agent…" />
+            </SelectTrigger>
+            <SelectContent>
+              {agents.map((a) => (
+                <SelectItem key={a.id} value={a.slug}>
+                  {a.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {agents.length === 0 && (
+            <p className="text-muted-foreground text-xs">
+              No agents yet. Use "Use in new agent" instead, or create one
+              first via <Link to="/agents" className="underline">Agents</Link>.
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={!slug || update.isPending}>
+            Replace prompt
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// composePrompt concatenates the ordered blocks into a single markdown
+// document. Blocks are separated by a blank line; the library block's
+// title (`# …`) stays in the body so the resulting prompt keeps its
+// section structure when read by the model. Edits override the library
+// version when present.
+function composePrompt(
+  items: ComposedItem[],
+  blocksById: Map<string, PromptBlock>,
+  edits: Record<string, string>,
+  customs: CustomBlock[],
+): string {
+  const parts: string[] = [];
+  for (const item of items) {
+    if (item.kind === "library") {
+      const original = blocksById.get(item.id);
+      if (!original) continue;
+      const content = edits[item.id] ?? original.content;
+      const trimmed = content.trim();
+      if (trimmed) parts.push(trimmed);
+    } else {
+      const c = customs.find((x) => x.id === item.id);
+      if (!c) continue;
+      const body = c.content.trim();
+      if (!body) continue;
+      parts.push(body);
+    }
+  }
+  return parts.join("\n\n");
+}

--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -7,13 +7,15 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  ChevronsDownUp,
+  ChevronsUpDown,
   Copy,
   Eye,
   GripVertical,
   Plus,
-  RotateCcw,
   Search,
   Trash2,
+  Undo2,
   Wand2,
 } from "lucide-react";
 import {
@@ -75,10 +77,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  ButtonGroup,
+  ButtonGroupSeparator,
+} from "@/components/ui/button-group";
 import { PageHeader } from "@/components/page-header";
 import { PageError } from "@/components/page-error";
 import { FloatingActionBar } from "@/components/floating-action-bar";
 import { DynamicIcon } from "@/lib/icon";
+import { useShortcut } from "@/lib/shortcuts";
 import {
   usePromptBlocks,
   type PromptBlock,
@@ -139,6 +146,78 @@ function joinCsv(parts: string[]): string | undefined {
 function rowKey(item: ComposedItem): string {
   return `${item.kind}:${item.id}`;
 }
+
+// Preset is a curated starting-point composition — one click replaces
+// the current selection with this preset's library blocks (in order).
+// Carried over from the v1 admin agent wizard's "agent types"
+// (`internal/prompts/config.go`): same labels, same block lists. Each
+// preset is Core + Default from the v1 config; Optional blocks are
+// left out so the preset is opinionated, not maximal.
+interface Preset {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  blockIds: string[];
+}
+
+const PRESETS: Preset[] = [
+  {
+    id: "initial-setup",
+    label: "Initial Setup",
+    description:
+      "First-time bulk categorization after connecting a new account.",
+    icon: "sparkles",
+    blockIds: ["strategy-initial-setup", "review-depth-efficient"],
+  },
+  {
+    id: "bulk-review",
+    label: "Bulk Review",
+    description: "Thorough review of a large pending queue.",
+    icon: "list-checks",
+    blockIds: ["strategy-bulk-review", "review-depth-thorough"],
+  },
+  {
+    id: "quick-review",
+    label: "Quick Review",
+    description: "Rapidly clear a large queue with batch operations.",
+    icon: "zap",
+    blockIds: ["strategy-quick-review", "review-depth-efficient"],
+  },
+  {
+    id: "routine-review",
+    label: "Routine Review",
+    description: "Daily or weekly review of recent transactions.",
+    icon: "calendar-check",
+    blockIds: [
+      "strategy-routine-review",
+      "review-depth-thorough",
+      "transaction-comments",
+    ],
+  },
+  {
+    id: "spending-report",
+    label: "Spending Report",
+    description: "Weekly or monthly spending summary with trends.",
+    icon: "chart-no-axes-column",
+    blockIds: [
+      "strategy-spending-report",
+      "category-system",
+      "merchant-analysis",
+    ],
+  },
+  {
+    id: "anomaly-detection",
+    label: "Anomaly Detection",
+    description: "Monitor for unusual charges, duplicates, spending spikes.",
+    icon: "siren",
+    blockIds: [
+      "strategy-anomaly-detection",
+      "merchant-analysis",
+      "account-linking",
+    ],
+  },
+];
 
 
 export function PromptsBuildPage() {
@@ -267,6 +346,13 @@ export function PromptsBuildPage() {
       setFilter({ knowledge: joinCsv(knowledge.filter((x) => x !== item.id)) });
   };
 
+  // pendingFocusId carries the id of a freshly-created empty block
+  // across the render that materializes its DOM. The matching effect
+  // below scrolls to it and focuses its textarea, then clears the ref.
+  // Stored as a ref (not state) so the effect doesn't re-trigger on
+  // unrelated re-renders.
+  const pendingFocusId = useRef<string | null>(null);
+
   // addCustomBlock takes the initial content directly (no title field
   // — title is derived from content at render time). The modal picker
   // collects content in its custom-form step before calling this.
@@ -281,12 +367,137 @@ export function PromptsBuildPage() {
     }
   };
 
+  // clearAll wipes every block out of the composition — both the
+  // URL-tracked library selections and the in-memory custom blocks.
+  // The component-level expansion/edits maps are not touched since
+  // they're keyed by item.id and will be naturally orphaned.
+  const clearAll = () => {
+    setFilter({
+      strategy: undefined,
+      depth: undefined,
+      integrations: undefined,
+      knowledge: undefined,
+    });
+    setCustoms([]);
+  };
+
+  // applyPreset replaces the current composition with the preset's
+  // block list. Each block ID is bucketed by its `group` (resolved via
+  // the loaded library) into the matching URL filter slot. Unknown
+  // IDs — e.g. a renamed prompt file — are silently dropped so a
+  // stale preset never errors. Customs are cleared on the same beat
+  // so applying a preset is a clean reset, not an additive op.
+  const applyPreset = (preset: Preset) => {
+    const next: Partial<PromptsBuildSearch> = {
+      strategy: undefined,
+      depth: undefined,
+      integrations: undefined,
+      knowledge: undefined,
+    };
+    const ints: string[] = [];
+    const knows: string[] = [];
+    for (const id of preset.blockIds) {
+      const b = blocksById.get(id);
+      if (!b) continue;
+      switch (b.group) {
+        case "strategy":
+          next.strategy = id;
+          break;
+        case "depth":
+          next.depth = id;
+          break;
+        case "integration":
+          ints.push(id);
+          break;
+        case "knowledge":
+          knows.push(id);
+          break;
+      }
+    }
+    next.integrations = joinCsv(ints);
+    next.knowledge = joinCsv(knows);
+    setFilter(next);
+    setCustoms([]);
+    setAddBlockOpen(false);
+  };
+
+  // addEmptyBlock appends an empty custom block to the composition and
+  // hands focus to it: expanded, textarea scrolled into view, cursor
+  // ready. Triggered both by the toolbar button and the "E" shortcut.
+  const addEmptyBlock = () => {
+    const id = `custom:${Date.now()}`;
+    setCustoms((cs) => [...cs, { id, content: "" }]);
+    setExpanded((e) => ({ ...e, [id]: true }));
+    pendingFocusId.current = id;
+  };
+
+  // After a render that included a newly-added empty block, locate its
+  // textarea by id, scroll it into the viewport, and focus it. Tied to
+  // `customs` so it fires once per add — guard with the ref so we
+  // don't re-focus on unrelated `customs` mutations (rename, delete).
+  // requestAnimationFrame defers the focus past React's commit phase
+  // and any in-flight click-event focus shuffling, otherwise the
+  // textarea immediately loses focus back to <body>.
+  useEffect(() => {
+    const id = pendingFocusId.current;
+    if (!id) return;
+    // The render where the new item lands in `effectiveOrder` is one
+    // commit AFTER the render where it lands in `customs` (the order
+    // sync is itself an effect). Wait for the row to actually appear
+    // in the DOM before clearing the ref.
+    const ta = document.getElementById(`content-${id}`);
+    if (!(ta instanceof HTMLTextAreaElement)) return;
+    pendingFocusId.current = null;
+    requestAnimationFrame(() => {
+      ta.scrollIntoView({ behavior: "smooth", block: "center" });
+      ta.focus();
+    });
+  }, [effectiveOrder, customs]);
+
   const composedText = useMemo(
     () => composePrompt(effectiveOrder, blocksById, edits, customs),
     [effectiveOrder, blocksById, edits, customs],
   );
 
   const isLoading = blocksQuery.isLoading;
+
+  // Expand-all toggle: true only when every row in the composition is
+  // currently expanded. Drives the "Collapse all" / "Expand all"
+  // button label so the action is always the opposite of the current
+  // state. An empty composition reports false so the button never
+  // renders in that branch (gated by effectiveOrder.length > 0).
+  const allExpanded = useMemo(() => {
+    if (effectiveOrder.length === 0) return false;
+    return effectiveOrder.every((i) => expanded[i.id]);
+  }, [effectiveOrder, expanded]);
+
+  const toggleExpandAll = () => {
+    if (allExpanded) {
+      setExpanded((e) => {
+        const next = { ...e };
+        for (const i of effectiveOrder) next[i.id] = false;
+        return next;
+      });
+    } else {
+      setExpanded((e) => {
+        const next = { ...e };
+        for (const i of effectiveOrder) next[i.id] = true;
+        return next;
+      });
+    }
+  };
+
+  // Page-level shortcuts registered with the global shortcut registry
+  // so they show up in the ⇧? shortcut sheet alongside the rest of the
+  // app's bindings. useShortcut handles the input/dialog guard for us.
+  useShortcut(["mod", "Enter"], () => setAddBlockOpen(true), {
+    label: "Add block",
+    group: "Prompt builder",
+  });
+  useShortcut(["shift", "mod", "Enter"], () => addEmptyBlock(), {
+    label: "Add empty block",
+    group: "Prompt builder",
+  });
 
   // Active-set helper for the dropdown — shows a ✓ next to library
   // items already in the composition.
@@ -321,40 +532,90 @@ export function PromptsBuildPage() {
               <Skeleton className="h-32 w-full" />
             </Card>
           ) : (
-            <ComposerTable
-              items={effectiveOrder}
-              onReorder={setOrder}
-              blocksById={blocksById}
-              customs={customs}
-              edits={edits}
-              expanded={expanded}
-              setExpanded={setExpanded}
-              setEdits={setEdits}
-              setCustoms={setCustoms}
-              onRemove={removeFromComposition}
-              addBlockEmptyTrigger={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={isLoading}
-                  onClick={() => setAddBlockOpen(true)}
-                >
-                  <Plus className="size-4" />
-                  Add block
-                </Button>
-              }
-              addBlockGhostRow={
-                <button
-                  type="button"
-                  disabled={isLoading}
-                  onClick={() => setAddBlockOpen(true)}
-                  className="text-muted-foreground hover:bg-accent/40 hover:text-foreground flex w-full items-center justify-center gap-2 py-3 text-sm transition-colors"
-                >
-                  <Plus className="size-4" />
-                  Add block
-                </button>
-              }
-            />
+            <>
+              <div className="flex items-center justify-end gap-1">
+                {effectiveOrder.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={toggleExpandAll}
+                    className="text-muted-foreground hover:text-foreground h-8 px-2 text-xs"
+                  >
+                    {allExpanded ? (
+                      <>
+                        <ChevronsDownUp className="size-3.5" />
+                        Collapse all
+                      </>
+                    ) : (
+                      <>
+                        <ChevronsUpDown className="size-3.5" />
+                        Expand all
+                      </>
+                    )}
+                  </Button>
+                )}
+                <ButtonGroup>
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    onClick={() => setAddBlockOpen(true)}
+                    className="h-8 px-3 text-xs"
+                  >
+                    <Plus className="size-3.5" />
+                    Add block
+                  </Button>
+                  {/* Visible hairline divider between the main action and
+                      the overflow trigger — `bg-input` is too low-contrast
+                      on the filled primary surface, so we lean on the
+                      primary-foreground tone the kbd pills used. */}
+                  <ButtonGroupSeparator className="bg-primary-foreground/25" />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="default"
+                        size="sm"
+                        aria-label="More add-block options"
+                        className="h-8 px-2"
+                      >
+                        <ChevronDown className="size-3.5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-60">
+                      <DropdownMenuItem onSelect={() => addEmptyBlock()}>
+                        <Plus className="size-4" />
+                        Add empty block
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </ButtonGroup>
+              </div>
+              <ComposerTable
+                items={effectiveOrder}
+                onReorder={setOrder}
+                blocksById={blocksById}
+                customs={customs}
+                edits={edits}
+                expanded={expanded}
+                setExpanded={setExpanded}
+                setEdits={setEdits}
+                setCustoms={setCustoms}
+                onRemove={removeFromComposition}
+                addBlockEmptyTrigger={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={isLoading}
+                    onClick={() => setAddBlockOpen(true)}
+                  >
+                    <Plus className="size-4" />
+                    Add block
+                  </Button>
+                }
+              />
+            </>
           )}
         </div>
       )}
@@ -364,11 +625,14 @@ export function PromptsBuildPage() {
           onOpenChange={setAddBlockOpen}
           blocksByGroup={blocksByGroup}
           activeIds={activeLibraryIds}
+          composedCount={effectiveOrder.length}
           onPickStrategy={pickStrategy}
           onPickDepth={pickDepth}
           onToggleIntegration={toggleIntegration}
           onToggleKnowledge={toggleKnowledge}
           onAddCustom={addCustomBlock}
+          onClearAll={clearAll}
+          onApplyPreset={applyPreset}
         />
       )}
       {effectiveOrder.length > 0 && (
@@ -391,11 +655,21 @@ interface AddBlockMenuProps {
   onOpenChange: (open: boolean) => void;
   blocksByGroup: Record<string, PromptBlock[]>;
   activeIds: Set<string>;
+  // composedCount is the total number of blocks currently in the
+  // composition (library + custom). Drives the footer count text and
+  // the disabled state of the Clear all action. Distinct from
+  // activeIds.size, which only counts library picks.
+  composedCount: number;
   onPickStrategy: (id: string) => void;
   onPickDepth: (id: string) => void;
   onToggleIntegration: (id: string) => void;
   onToggleKnowledge: (id: string) => void;
   onAddCustom: (content: string) => void;
+  onClearAll: () => void;
+  // onApplyPreset replaces the current composition with the preset's
+  // ordered block IDs. The page-level handler resolves each ID to its
+  // group via blocksById to decide which URL filter slot it lands in.
+  onApplyPreset: (preset: Preset) => void;
 }
 
 // AddBlockMenu is the modal "block library" — left rail of category
@@ -409,16 +683,22 @@ function AddBlockMenu({
   onOpenChange,
   blocksByGroup,
   activeIds,
+  composedCount,
   onPickStrategy,
   onPickDepth,
   onToggleIntegration,
   onToggleKnowledge,
   onAddCustom,
+  onClearAll,
+  onApplyPreset,
 }: AddBlockMenuProps) {
   const [mode, setMode] = useState<"pick" | "custom">("pick");
-  const [activeGroup, setActiveGroup] = useState<PromptBlockGroup | "all">(
-    "all",
-  );
+  // "presets" is a virtual category — it doesn't filter the block grid,
+  // it swaps the right pane for a preset-card view. Other values still
+  // drive the block filter as before.
+  const [activeGroup, setActiveGroup] = useState<
+    PromptBlockGroup | "all" | "presets"
+  >("all");
   const [query, setQuery] = useState("");
   const [customDraft, setCustomDraft] = useState("");
 
@@ -546,6 +826,13 @@ function AddBlockMenu({
             <div className="grid flex-1 grid-cols-[10rem_1fr] overflow-hidden">
               <nav className="bg-muted/30 overflow-y-auto border-r p-2">
                 <CategoryRailItem
+                  label="Presets"
+                  count={PRESETS.length}
+                  active={activeGroup === "presets"}
+                  onClick={() => setActiveGroup("presets")}
+                />
+                <div className="my-2 border-t" />
+                <CategoryRailItem
                   label="All"
                   count={counts.all}
                   active={activeGroup === "all"}
@@ -587,36 +874,33 @@ function AddBlockMenu({
                 </div>
               </nav>
 
-              {/* Scroller has NO top padding — if it did, sticky's
-                  top:0 would pin below the padding, leaving a strip
-                  above where scrolling content shows through. Each
-                  sticky header instead bakes the top breathing room
-                  into its own padding so the bg-background fills all
-                  the way to the literal top of the scroll viewport. */}
-              <div className="overflow-y-auto px-4 pb-2">
-                {filtered.length === 0 ? (
-                  <div className="text-muted-foreground flex h-full items-center justify-center pt-4 text-sm">
+              <div className="overflow-y-auto p-4">
+                {activeGroup === "presets" ? (
+                  <div className="flex flex-col gap-3">
+                    <p className="text-muted-foreground text-xs">
+                      Picking a preset replaces the current composition with a
+                      curated set of blocks. You can edit, reorder, or remove
+                      any of them afterwards.
+                    </p>
+                    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                      {PRESETS.map((preset) => (
+                        <PresetCard
+                          key={preset.id}
+                          preset={preset}
+                          onClick={() => onApplyPreset(preset)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : filtered.length === 0 ? (
+                  <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
                     No blocks match {query ? `"${query}"` : "this filter"}.
                   </div>
                 ) : activeGroup === "all" ? (
-                  // Sections are flattened (Fragment, not wrapping div) so
-                  // each sticky header anchors to the scroll container —
-                  // the next header pushes the previous one out, instead
-                  // of each header being trapped at the bottom of its
-                  // own <section>.
-                  <>
-                    {sections.map((section, i) => (
-                      <Fragment key={section.group}>
-                        <div
-                          className={cn(
-                            "bg-background sticky top-0 z-10 -mx-4 flex items-baseline justify-between gap-2 px-4 pb-2",
-                            // First header pads to the top of the scroller
-                            // (covers the missing scroller pt-4). Later
-                            // headers get extra top space + own padding to
-                            // separate sections visually.
-                            i === 0 ? "pt-4" : "pt-6",
-                          )}
-                        >
+                  <div className="flex flex-col gap-6">
+                    {sections.map((section) => (
+                      <section key={section.group} className="flex flex-col gap-2">
+                        <div className="flex items-baseline justify-between gap-2">
                           <h3 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
                             {section.label}
                           </h3>
@@ -634,11 +918,11 @@ function AddBlockMenu({
                             />
                           ))}
                         </div>
-                      </Fragment>
+                      </section>
                     ))}
-                  </>
+                  </div>
                 ) : (
-                  <div className="grid grid-cols-2 gap-3 pt-4 lg:grid-cols-3">
+                  <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
                     {filtered.map((block) => (
                       <BlockCard
                         key={block.id}
@@ -653,17 +937,29 @@ function AddBlockMenu({
             </div>
             <DialogFooter className="border-t p-3 sm:justify-between">
               <span className="text-muted-foreground self-center text-xs">
-                {activeIds.size === 0
+                {composedCount === 0
                   ? "Tap blocks to add — pick as many as you like."
-                  : `${activeIds.size} block${activeIds.size === 1 ? "" : "s"} in composition`}
+                  : `${composedCount} block${composedCount === 1 ? "" : "s"} in composition`}
               </span>
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={() => handleOpenChange(false)}
-              >
-                Done
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={composedCount === 0}
+                  onClick={onClearAll}
+                  className="text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                >
+                  Clear all
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => handleOpenChange(false)}
+                >
+                  Done
+                </Button>
+              </div>
             </DialogFooter>
           </>
         ) : (
@@ -818,6 +1114,44 @@ function BlockCard({
   );
 }
 
+// PresetCard renders one preset as a tile. The "Includes N blocks"
+// subtitle hints at the scope without listing block names — keeps the
+// card compact and consistent with BlockCard's visual rhythm.
+function PresetCard({
+  preset,
+  onClick,
+}: {
+  preset: Preset;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group hover:border-primary/40 hover:bg-accent/40 relative flex h-full flex-col gap-2 rounded-lg border p-3 text-left transition-colors"
+    >
+      {preset.icon && (
+        <span className="bg-muted text-muted-foreground group-hover:text-foreground inline-flex size-8 items-center justify-center rounded-md">
+          <DynamicIcon name={preset.icon} className="size-4" />
+        </span>
+      )}
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium leading-tight">
+          {preset.label}
+        </span>
+        {preset.description && (
+          <span className="text-muted-foreground line-clamp-3 text-xs leading-snug">
+            {preset.description}
+          </span>
+        )}
+        <span className="text-muted-foreground/70 mt-1 text-[10px] tabular-nums uppercase tracking-wide">
+          Includes {preset.blockIds.length} blocks
+        </span>
+      </div>
+    </button>
+  );
+}
+
 interface ComposerTableProps {
   items: ComposedItem[];
   onReorder: (next: ComposedItem[]) => void;
@@ -833,11 +1167,6 @@ interface ComposerTableProps {
   // card. Just a button — it does NOT contain the dialog, which lives
   // at the parent so it survives the empty-state → table re-render.
   addBlockEmptyTrigger: React.ReactNode;
-  // addBlockGhostRow is the trigger rendered as a full-width ghost row
-  // at the bottom of the table when there are blocks. Subtle styling so
-  // it reads as "another row you could add" without competing with the
-  // real block rows above it.
-  addBlockGhostRow: React.ReactNode;
 }
 
 function ComposerTable({
@@ -852,7 +1181,6 @@ function ComposerTable({
   setCustoms,
   onRemove,
   addBlockEmptyTrigger,
-  addBlockGhostRow,
 }: ComposerTableProps) {
   // dnd-kit sensors: PointerSensor with a small activation distance so
   // a quick row click doesn't accidentally start a drag (only deliberate
@@ -951,11 +1279,6 @@ function ComposerTable({
                 />
               ))}
             </SortableContext>
-            <TableRow className="hover:bg-transparent">
-              <TableCell colSpan={3} className="border-t border-dashed p-0">
-                {addBlockGhostRow}
-              </TableCell>
-            </TableRow>
           </TableBody>
         </Table>
       </DndContext>
@@ -1009,8 +1332,12 @@ function SortableRow({
   const title =
     library?.title ??
     (custom ? deriveCustomBlockTitle(custom.content) : "Unknown block");
-  const description = library?.description ?? "";
-  const icon = library?.icon ?? "";
+  const description =
+    library?.description ?? (custom ? "Custom block" : "");
+  // Library blocks bring their own icon from frontmatter; custom
+  // blocks fall back to a generic "you wrote this" pen-on-square mark
+  // so the row stays visually aligned with library rows.
+  const icon = library?.icon ?? (custom ? "square-pen" : "");
 
   const originalContent = library?.content ?? "";
   const editedContent = edits[item.id];
@@ -1096,7 +1423,7 @@ function SortableRow({
                   })
                 }
               >
-                <RotateCcw className="size-4" />
+                <Undo2 className="size-4" />
               </Button>
             )}
             <Button
@@ -1133,8 +1460,17 @@ function SortableRow({
                   setEdits((s) => ({ ...s, [item.id]: v }));
                 }
               }}
+              onKeyDown={(e) => {
+                // Escape blurs the textarea so page-level shortcuts
+                // (P, C, ⌘+Enter, etc.) become reachable again without
+                // having to click outside the row.
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  e.currentTarget.blur();
+                }
+              }}
               aria-label="Block content"
-              className="bg-muted/20 block w-full resize-none rounded-none border-0 px-4 py-3 font-mono text-xs leading-relaxed shadow-none focus-visible:border-0 focus-visible:ring-0 dark:bg-muted/40"
+              className="bg-muted/60 border-border/60 block w-full resize-none rounded-none border-0 border-t px-4 py-3 font-mono text-xs leading-relaxed shadow-none focus-visible:border-0 focus-visible:border-t focus-visible:ring-0 dark:bg-black/30"
             />
           </TableCell>
         </TableRow>
@@ -1165,6 +1501,11 @@ function PreviewButton({
   disabled: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  useShortcut(["p"], () => setOpen((v) => !v), {
+    label: "Preview prompt",
+    group: "Prompt builder",
+    enabled: !disabled,
+  });
   return (
     <>
       <Button
@@ -1195,7 +1536,10 @@ function PreviewDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-3xl">
-        <DialogHeader className="border-b px-6 py-4">
+        <DialogHeader className="border-b py-4 pr-12 pl-6">
+          {/* pr-12 reserves room for shadcn's absolute-positioned X
+              close button on the right edge — without it the line/char
+              count sits behind the X and gets clipped. */}
           <div className="flex items-center justify-between gap-3">
             <DialogTitle>Preview</DialogTitle>
             <span className="text-muted-foreground text-xs tabular-nums">
@@ -1234,6 +1578,12 @@ function OutputActions({ text, disabled }: OutputActionsProps) {
       toast.error("Couldn't access the clipboard. Copy the preview manually.");
     }
   };
+
+  useShortcut(["c"], () => onCopy(), {
+    label: "Copy prompt",
+    group: "Prompt builder",
+    enabled: !disabled,
+  });
 
   const onUseInNewAgent = () => {
     navigate({

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -38,10 +38,12 @@ import {
   Users,
   Wallet,
   Wand2,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import {
   Popover,
   PopoverContent,
@@ -49,6 +51,7 @@ import {
 } from "@/components/ui/popover";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { FloatingActionBar } from "@/components/floating-action-bar";
 import { TimelineRail } from "@/components/timeline-rail";
 import { DataTable } from "@/components/data-table";
 import { CategoryBadge } from "@/components/category-badge";
@@ -1118,6 +1121,15 @@ export function ComponentsSection() {
       </Specimen>
 
       <Specimen
+        label="FloatingActionBar"
+        code="components/floating-action-bar"
+        description="Viewport-pinned action pill (`position: fixed`, bottom-center) with rounded chrome, border, shadow, and backdrop blur. Outer wrapper is `pointer-events-none` so the empty band stays click-through; only the inner pill captures events. Used by the bulk-selection toolbar on /v2/transactions and the output toolbar on /v2/prompts/build. Use for *transient or contextual* actions; PageHeader.actions is still the right home for persistent page-level affordances."
+        className="block"
+      >
+        <FloatingActionBarDemo />
+      </Specimen>
+
+      <Specimen
         label="EmptyState"
         code="components/empty-state"
         description="Three variants share one primitive — pick the weight that fits the surface. Same icon-tile vocabulary as the rest of v2 (square rounded-xl, not circle)."
@@ -1730,6 +1742,51 @@ function ThemeSpecimen() {
 function CronFieldDemo() {
   const [value, setValue] = useState("0 9 * * 1");
   return <CronField value={value} onChange={setValue} />;
+}
+
+// FloatingActionBar uses position:fixed → showing one inside the sandbox
+// would pin it to the viewport regardless of where the specimen sits.
+// We render a button that mounts the real bar so readers can see the
+// actual behavior (and dismiss it without leaving the sandbox).
+function FloatingActionBarDemo() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-xs">
+        The bar pins to the viewport bottom — toggle it on to see real
+        placement. Composition is freeform; the chrome is the only shared
+        piece.
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? "Hide live bar" : "Show live bar"}
+      </Button>
+      {open && (
+        <FloatingActionBar ariaLabel="Sandbox example actions" className="pl-3">
+          <span className="text-sm font-medium whitespace-nowrap">
+            3 selected
+          </span>
+          <Separator orientation="vertical" className="mx-1 h-5" />
+          <Button size="sm" className="h-8 rounded-full">
+            Apply
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 rounded-full"
+            onClick={() => setOpen(false)}
+            aria-label="Dismiss"
+          >
+            <X className="size-4" />
+          </Button>
+        </FloatingActionBar>
+      )}
+    </div>
+  );
 }
 
 // Inline visual demo of the NavUser trigger — the dropdown itself depends on


### PR DESCRIPTION
## Summary

End-to-end redesign of the v2 agents experience, plus a brand-new prompt builder under `/v2/prompts/build`.

**Agents pages**
- Agents list rendered as a `DataTable` (was cards) — dropped slug/prompt/scope from the main view; surfaces schedule, last run, cost, etc.
- Dedicated global runs page at `/v2/agents/runs` (sibling to `/agents`), unified via a small `AgentsTabs` sub-nav.
- New + edit agent forms are full pages (no more side-sheet) sharing a `AgentForm` feature component.
- Transcript inspection moved into a shared `TranscriptSheet`.

**Prompt builder (`/v2/prompts/build`)**
- Standalone tool that composes an agent prompt from reusable library blocks. Output is plain markdown — copy anywhere, or push into a Breadbox agent. Works for any agent tool, not just our SDK.
- Blocks ship inside the Go binary as `prompts/agents/*.md` with YAML frontmatter (title/description/icon), parsed by a new `internal/service/prompt_blocks.go` and served via `/api/v1/agents/prompt-blocks`.
- Composer table: drag-reorder (auto-collapse during drag, restore on drop), per-block edit with a recessed editor surface, library/custom blocks unified.
- Add-a-block modal: sidebar of categories (`Presets`, `All`, `Strategy`, `Depth`, `Integrations`, `Knowledge`, `Custom block`), section headers in the "All" view, search, and a footer with live composition count + "Clear all" + "Done".
- Presets carried over from the v1 admin wizard (Initial Setup, Bulk Review, Quick Review, Routine Review, Spending Report, Anomaly Detection) — picking one replaces the composition.
- Split-button toolbar via shadcn's button-group primitive: primary "Add block" + adjoining dropdown for "Add empty block".
- Page-level keyboard shortcuts registered with the global `useShortcut` registry (visible in `⇧?`): `⌘+Enter` Add block, `⇧+⌘+Enter` Add empty block, `P` Preview, `C` Copy. Esc blurs a focused block textarea so shortcuts work again without clicking out.
- Floating action bar (extracted from the transactions list selection bar into a shared `FloatingActionBar` primitive) shows live char/line counts + Preview + Copy + Use in agent.

**Backend / data**
- Service: new `ListPromptBlocks` (`internal/service/prompt_blocks.go`) parses frontmatter + body, trims trailing whitespace, taxonomizes by filename prefix.
- REST: `GET /api/v1/agents/runs` (all runs across agents) + `GET /api/v1/agents/prompt-blocks` wired in `internal/api/router.go`; OpenAPI updated; endpoint catalog kept in sync.
- Prompts library migrated to YAML frontmatter (`prompts/agents/*.md`).
- New `prompts/agents/default-system-prompt.md` injected as the SDK `systemPrompt` baseline when an agent's prompt is empty — keeps user prompts focused on the task while still grounding the agent.

**Compliance with main**
- Rebased onto latest main; absorbed the page-spacing contract that landed in #1296 (drop `mb-*` on direct children of `<main>`, swap inline ghost back-buttons for the shared `SoftBackButton`, use `self-start` to opt out of `align-items: stretch`).

## Test plan

- [ ] `/v2/agents` table — sorting, row click → edit, run-now, delete, onboarding banner gating
- [ ] `/v2/agents/runs` global list — filter by agent / status / trigger / cap state / date
- [ ] `/v2/agents/$slug/runs` per-agent list — same filters, back to agents
- [ ] `/v2/agents/new` and `/v2/agents/$slug/edit` — form validation, "Test prompt", save
- [ ] Transcript sheet opens for any run, renders NDJSON cleanly
- [ ] Prompt builder
  - [ ] URL-shareable selection (`?strategy=…&integrations=a,b&knowledge=c,d`)
  - [ ] Add block modal: filter rail, search, preset apply, custom-block form, Clear all, Done
  - [ ] Composer: drag reorder, expand all / collapse all, individual edit, reset-edit, remove
  - [ ] Shortcuts: `⌘+Enter`, `⇧+⌘+Enter`, `P`, `C`, Esc-to-blur
  - [ ] Preview dialog renders composed text, count matches floating bar
  - [ ] Copy + "Use in new agent" / "Use in existing agent" both reach the agent form with the prompt pre-filled
- [ ] `go test ./...` passes locally
- [ ] `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
