### PR TITLE
fix(v2): let PageHeader subtitle expand to page width

### DIFF
--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -57,7 +57,7 @@ export function PageHeader({
         )}
         <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
         {description && (
-          <p className="text-muted-foreground max-w-prose text-sm">
+          <p className="text-muted-foreground text-sm">
             {description}
           </p>
         )}


### PR DESCRIPTION
## Summary

`PageHeader` capped its description at `max-w-prose` (~65ch), which on wide / unbounded routes — most visibly `/v2/prompts/build` — wrapped the framing copy at roughly half the page width even at 1440px. The width cap belongs on the page wrapper, not the shared header (form pages already use `max-w-2xl`, list pages already use `max-w-5xl`, full-width pages opt into being full-width on purpose).

Dropped the `max-w-prose` class so the description fills the container its page actually defines.

## Screenshot

After (1440×900, `/v2/prompts/build`):

<img src="https://i.img402.dev/kcq1dalyna.jpg" width="800" alt="prompt builder — subtitle now spans full page">

## Test plan

- [x] `bun run lint` (tsc) passes
- [x] Visual check on `/v2/prompts/build` — subtitle now spans the page
- [ ] Spot-check that narrow form pages (`/v2/tags/new`, `/v2/rules/new`) still look fine — their wrapper already constrains width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
