### PR TITLE
fix(v2): family-member filter on accounts and connections

### DIFF
--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -46,36 +46,26 @@ export function AccountsPage() {
   const accountsQuery = useAccounts();
   const usersQuery = useUsers();
 
-  // Counts per user, shared by the FamilyTabs labels and by the filter
-  // resolution below. We key on user short_id to match the tab's value.
+  // Counts per user, shared by the FamilyTabs labels and the filter below.
+  // AccountResponse.user_id is the owner's short_id (see service/accounts.go
+  // — `textPtr(r.UserShortID)`), so we can key directly on it.
   const countsByUserShortId = useMemo(() => {
     const out = new Map<string, number>();
-    const idToShortId = new Map<string, string>();
     for (const u of usersQuery.data ?? []) {
-      idToShortId.set(u.id, u.short_id);
       out.set(u.short_id, 0);
     }
     for (const a of accountsQuery.data ?? []) {
       if (!a.user_id) continue;
-      const sid = idToShortId.get(a.user_id);
-      if (!sid) continue;
-      out.set(sid, (out.get(sid) ?? 0) + 1);
+      out.set(a.user_id, (out.get(a.user_id) ?? 0) + 1);
     }
     return out;
   }, [accountsQuery.data, usersQuery.data]);
 
-  // Resolve the selected short_id back to a UUID so we can filter the
-  // accounts (which carry the user's UUID, not short_id).
-  const filterUserId = useMemo(() => {
-    if (userFilter === "all") return null;
-    return usersQuery.data?.find((u) => u.short_id === userFilter)?.id ?? null;
-  }, [userFilter, usersQuery.data]);
-
   const visible = useMemo(() => {
     const all = accountsQuery.data ?? [];
-    if (filterUserId == null) return all;
-    return all.filter((a) => a.user_id === filterUserId);
-  }, [accountsQuery.data, filterUserId]);
+    if (userFilter === "all") return all;
+    return all.filter((a) => a.user_id === userFilter);
+  }, [accountsQuery.data, userFilter]);
 
   const groups = useMemo(() => groupAccounts(visible, groupBy), [visible, groupBy]);
 

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -56,39 +56,26 @@ export function ConnectionsPage() {
   );
 
   // Connection counts per user, used as a tab-label superscript and as the
-  // basis for the visible-after-filtering list below.
-  const countsByUser = useMemo(() => {
-    const m = new Map<string, number>();
-    for (const c of connectionsQuery.data ?? []) {
-      // The connection carries the user's UUID; the FamilyTabs key on
-      // short_id, which we get by joining against the users list.
-      if (!c.user_id) continue;
-      m.set(c.user_id, (m.get(c.user_id) ?? 0) + 1);
-    }
-    return m;
-  }, [connectionsQuery.data]);
-
-  // Map UUID counts → short_id counts so the FamilyTabs can render them by
-  // the same key it uses for the trigger value.
+  // basis for the visible-after-filtering list below. ConnectionResponse.
+  // user_id is the owner's short_id (see service/connections.go —
+  // `textPtr(r.UserShortID)`), matching the FamilyTabs trigger key.
   const countsByUserShortId = useMemo(() => {
     const out = new Map<string, number>();
     for (const u of usersQuery.data ?? []) {
-      out.set(u.short_id, countsByUser.get(u.id) ?? 0);
+      out.set(u.short_id, 0);
+    }
+    for (const c of connectionsQuery.data ?? []) {
+      if (!c.user_id) continue;
+      out.set(c.user_id, (out.get(c.user_id) ?? 0) + 1);
     }
     return out;
-  }, [countsByUser, usersQuery.data]);
-
-  // Resolve the selected short_id back to a UUID for the row filter.
-  const filterUserId = useMemo(() => {
-    if (userFilter === "all") return null;
-    return usersQuery.data?.find((u) => u.short_id === userFilter)?.id ?? null;
-  }, [userFilter, usersQuery.data]);
+  }, [connectionsQuery.data, usersQuery.data]);
 
   const visible = useMemo(() => {
     const all = connectionsQuery.data ?? [];
-    if (filterUserId == null) return all;
-    return all.filter((c) => c.user_id === filterUserId);
-  }, [connectionsQuery.data, filterUserId]);
+    if (userFilter === "all") return all;
+    return all.filter((c) => c.user_id === userFilter);
+  }, [connectionsQuery.data, userFilter]);
 
   const attentionCount = useMemo(
     () => (connectionsQuery.data ?? []).filter(needsAttention).length,


### PR DESCRIPTION
## Summary

The Accounts and Connections pages' family-member filter was completely broken: every per-user tab showed `0` accounts/connections, and selecting any tab other than **All** yielded an empty list.

**Cause:** the resolution logic walked `users.find((u) => u.short_id === filter)?.id` to map the selected short_id back to a UUID, then compared it against `account.user_id` / `connection.user_id`. But [#989 (`mcp(short_id): user_id on AccountResponse and ConnectionResponse`)](https://github.com/canalesb93/breadbox/pull/989) — back in October — changed those API fields to return the owner's **short_id**, not the UUID. The UUID compare never matched, so:

- count badges next to each tab showed `0`
- selecting any tab showed the "no accounts for this filter" empty state

**Fix:** drop the UUID-resolution detour and compare `user_id` (short_id) directly. Reword the comments so the next reader doesn't repeat the mistake.

## Evidence — accounts page

Ricardo tab (8 accounts, was: empty state with badge `0`):

<img src="https://i.img402.dev/im6engkzoa.jpg" width="800" alt="accounts page — Ricardo filter shows 8 accounts">

Admin tab (correctly empty — that user owns no accounts):

<img src="https://i.img402.dev/yji1jrf771.jpg" width="800" alt="accounts page — Admin filter correctly empty">

Connections page has identical bug + identical fix.

## Test plan

- [x] `bun run lint` (tsc -b --noEmit) clean
- [x] Headless-chromium walk through every family tab on `/v2/accounts` and `/v2/connections`: badges match the per-user account/connection distribution; the row count on the **All** tab equals the sum of rows shown across per-user tabs
- [x] Admin user (owns no accounts/connections) hits the empty state with eyebrow "Showing 0 of N"
- [ ] Smoke-check on production-embedded build after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
