### PR TITLE
cleanup(v2/prompts): simplify prompt-builder code

### DIFF
--- a/internal/service/prompt_blocks.go
+++ b/internal/service/prompt_blocks.go
@@ -7,8 +7,26 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
+	"breadbox/internal/slugs"
 	"breadbox/prompts"
+)
+
+// PromptBlockGroup is the taxonomy classification used by the v2 SPA's
+// prompt-builder picker. The string union on the client mirrors these
+// constants — keep both sides in sync.
+type PromptBlockGroup string
+
+const (
+	// strategy — top-level approach. One selected; mutually exclusive.
+	GroupStrategy PromptBlockGroup = "strategy"
+	// depth — review intensity modifier. Zero or one; mutually exclusive.
+	GroupDepth PromptBlockGroup = "depth"
+	// integration — optional add-ons (gmail, sync, account-linking). Multi-select.
+	GroupIntegration PromptBlockGroup = "integration"
+	// knowledge — domain knowledge (categories, merchants, comments). Multi-select.
+	GroupKnowledge PromptBlockGroup = "knowledge"
 )
 
 // PromptBlock is one reusable agent-prompt building block — the parsed
@@ -26,20 +44,14 @@ import (
 //	<body markdown — sent to the model verbatim>
 //
 // Icon names are kebab-case Lucide identifiers (matching the React
-// `DynamicIcon` resolver). Group classifies the block by its filename
-// prefix and tells the UI how to render the picker:
-//
-//	strategy    — top-level approach. One selected; mutually exclusive.
-//	depth       — review intensity modifier. Zero or one; mutually exclusive.
-//	integration — optional add-ons (gmail, sync, account-linking). Multi-select.
-//	knowledge   — domain knowledge (category-system, merchants, comments). Multi-select.
+// `DynamicIcon` resolver).
 type PromptBlock struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Icon        string `json:"icon,omitempty"`
-	Group       string `json:"group"`
-	Content     string `json:"content"`
+	ID          string           `json:"id"`
+	Title       string           `json:"title"`
+	Description string           `json:"description"`
+	Icon        string           `json:"icon,omitempty"`
+	Group       PromptBlockGroup `json:"group"`
+	Content     string           `json:"content"`
 }
 
 // Block IDs that the builder excludes from the user-facing palette.
@@ -50,15 +62,11 @@ var hiddenPromptBlockIDs = map[string]bool{
 	"default-system-prompt": true,
 }
 
-// ListPromptBlocks returns every block under prompts/agents/, parsed.
-// Reads from the embed.FS in `breadbox/prompts`, so the file set is
-// fixed at build time — no DB call, no I/O after init. Returned slice
-// is grouped + sorted within group for stable UI rendering.
-//
-// ctx is unused today (the embed.FS read is synchronous) but kept on
-// the signature so a future DB-backed override (user-authored custom
-// blocks) doesn't change the call sites.
-func (s *Service) ListPromptBlocks(_ context.Context) ([]PromptBlock, error) {
+// loadPromptBlocks reads + parses every file under prompts/agents/
+// once. The embed.FS contents are immutable at runtime, so the result
+// is cached forever via sync.OnceValues — the v2 SPA hits this on
+// every page mount, no reason to re-walk the FS each time.
+var loadPromptBlocks = sync.OnceValues(func() ([]PromptBlock, error) {
 	entries, err := prompts.FS.ReadDir("agents")
 	if err != nil {
 		return nil, fmt.Errorf("read prompts/agents: %w", err)
@@ -80,8 +88,7 @@ func (s *Service) ListPromptBlocks(_ context.Context) ([]PromptBlock, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read prompts/agents/%s: %w", name, err)
 		}
-		block := parsePromptBlock(id, string(data))
-		out = append(out, block)
+		out = append(out, parsePromptBlock(id, string(data)))
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Group != out[j].Group {
@@ -90,26 +97,18 @@ func (s *Service) ListPromptBlocks(_ context.Context) ([]PromptBlock, error) {
 		return out[i].ID < out[j].ID
 	})
 	return out, nil
+})
+
+// ListPromptBlocks returns the parsed library. ctx is unused today
+// (the embed.FS read is synchronous and cached) but kept on the
+// signature so a future DB-backed override (user-authored custom
+// blocks) doesn't change call sites.
+func (s *Service) ListPromptBlocks(_ context.Context) ([]PromptBlock, error) {
+	return loadPromptBlocks()
 }
 
 // parsePromptBlock splits a `prompts/agents/*.md` file into frontmatter
-// metadata and body. Format:
-//
-//	---
-//	title: ...
-//	description: ...
-//	icon: ...
-//	---
-//
-//	<body>
-//
-// Frontmatter values may be quoted with single or double quotes; quotes
-// are stripped if present. Unknown keys are ignored. The body is the
-// composed-prompt content — what the model actually reads — with
-// leading whitespace trimmed so the composer concatenates cleanly.
-// If the frontmatter block is missing or malformed, falls back to the
-// legacy `# Title` / `> Description` convention so a stray un-migrated
-// file doesn't disappear from the picker.
+// metadata and body. Format is documented on PromptBlock.
 func parsePromptBlock(id, body string) PromptBlock {
 	block := PromptBlock{
 		ID:    id,
@@ -120,16 +119,13 @@ func parsePromptBlock(id, body string) PromptBlock {
 		block.Description = meta["description"]
 		block.Icon = meta["icon"]
 		block.Content = strings.TrimLeft(content, "\n")
-	} else {
-		block.Content = body
-		legacyParsePromptHeader(body, &block)
 	}
 	// Markdown sources usually end with one trailing newline (some
 	// with two). Strip them so the expansion editor doesn't surface
 	// phantom blank lines and the composed prompt joins cleanly.
 	block.Content = strings.TrimRight(block.Content, " \t\r\n")
 	if block.Title == "" {
-		block.Title = humanizeBlockID(id)
+		block.Title = slugs.TitleCase(id)
 	}
 	return block
 }
@@ -170,71 +166,38 @@ func parsePromptFrontmatter(body string) (map[string]string, string, bool) {
 		}
 		meta[key] = val
 	}
-	// Reached EOF without a closing fence — treat as no frontmatter.
 	return nil, body, false
 }
 
-// legacyParsePromptHeader keeps the pre-frontmatter `# Title` and
-// `> Description` convention working as a fallback. Removable once
-// every file under prompts/agents/ has been migrated to frontmatter.
-func legacyParsePromptHeader(body string, block *PromptBlock) {
-	for _, line := range strings.SplitN(body, "\n", 5) {
-		trimmed := strings.TrimSpace(line)
-		if block.Title == "" && strings.HasPrefix(trimmed, "# ") {
-			block.Title = strings.TrimSpace(strings.TrimPrefix(trimmed, "# "))
-			continue
-		}
-		if block.Description == "" && strings.HasPrefix(trimmed, "> ") {
-			block.Description = strings.TrimSpace(strings.TrimPrefix(trimmed, "> "))
-		}
-		if block.Title != "" && block.Description != "" {
-			return
-		}
-	}
-}
-
-// promptBlockGroupFor maps a block filename to its taxonomic group.
-// Anything that doesn't match a known prefix falls into "knowledge"
-// as the catch-all — better to surface an unknown block than hide it.
-func promptBlockGroupFor(id string) string {
+// promptBlockGroupFor infers the group from the block's filename. A
+// future migration could move this into frontmatter, but today every
+// block file follows one of these prefix/suffix conventions.
+func promptBlockGroupFor(id string) PromptBlockGroup {
 	switch {
 	case strings.HasPrefix(id, "strategy-"):
-		return "strategy"
+		return GroupStrategy
 	case strings.HasPrefix(id, "review-depth-"):
-		return "depth"
+		return GroupDepth
 	case strings.HasSuffix(id, "-integration"),
 		strings.HasSuffix(id, "-linking"),
 		strings.HasSuffix(id, "-management"):
-		return "integration"
+		return GroupIntegration
 	default:
-		return "knowledge"
+		return GroupKnowledge
 	}
 }
 
-func promptBlockGroupOrder(group string) int {
+func promptBlockGroupOrder(group PromptBlockGroup) int {
 	switch group {
-	case "strategy":
+	case GroupStrategy:
 		return 0
-	case "depth":
+	case GroupDepth:
 		return 1
-	case "integration":
+	case GroupIntegration:
 		return 2
-	case "knowledge":
+	case GroupKnowledge:
 		return 3
 	default:
 		return 4
 	}
-}
-
-// humanizeBlockID turns "strategy-routine-review" into "Strategy Routine
-// Review" for the rare case where a block file is missing a title.
-func humanizeBlockID(id string) string {
-	parts := strings.Split(id, "-")
-	for i, p := range parts {
-		if p == "" {
-			continue
-		}
-		parts[i] = strings.ToUpper(p[:1]) + p[1:]
-	}
-	return strings.Join(parts, " ")
 }

--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -254,7 +254,6 @@ export function PromptsBuildPage() {
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [customs, setCustoms] = useState<CustomBlock[]>([]);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
-  const [order, setOrder] = useState<ComposedItem[] | null>(null);
   // Modal lives on the parent so it stays mounted across the
   // empty-state → composer-table swap that happens after the first
   // pick. If the dialog were nested inside whichever trigger element
@@ -274,14 +273,12 @@ export function PromptsBuildPage() {
     return items;
   }, [strategy, depth, integrations, knowledge, customs]);
 
+  const [order, setOrder] = useState<ComposedItem[]>(defaultOrder);
+
   // Resync the session order whenever the URL selection drifts.
   // Preserve manual reordering for items that still belong; append
   // new ones at the end.
   useEffect(() => {
-    if (order === null) {
-      setOrder(defaultOrder);
-      return;
-    }
     const have = new Set(order.map(rowKey));
     const want = new Set(defaultOrder.map(rowKey));
     if (
@@ -295,7 +292,7 @@ export function PromptsBuildPage() {
     }
   }, [defaultOrder, order]);
 
-  const effectiveOrder = order ?? defaultOrder;
+  const effectiveOrder = order;
 
   const setFilter = (patch: Partial<PromptsBuildSearch>) => {
     navigate({
@@ -310,30 +307,51 @@ export function PromptsBuildPage() {
     });
   };
 
-  // pickStrategy / pickDepth are toggles: clicking the active block
-  // removes it; clicking a different one replaces the current
-  // selection (Strategy and Depth are still single-select). Toggle-off
-  // matches the multi-select Integrations/Knowledge behavior so picks
-  // always feel reversible from the modal itself.
-  const pickStrategy = (id: string) =>
-    setFilter({ strategy: strategy === id ? undefined : id });
-  const pickDepth = (id: string) =>
-    setFilter({ depth: depth === id ? undefined : id });
-
-  const toggleIntegration = (id: string) => {
-    const next = integrations.includes(id)
-      ? integrations.filter((x) => x !== id)
-      : [...integrations, id];
-    setFilter({ integrations: joinCsv(next) });
-  };
-  const toggleKnowledge = (id: string) => {
-    const next = knowledge.includes(id)
-      ? knowledge.filter((x) => x !== id)
-      : [...knowledge, id];
-    setFilter({ knowledge: joinCsv(next) });
+  // pickBlock toggles a block into or out of the composition. Strategy
+  // and Depth are single-select (re-picking removes); Integrations and
+  // Knowledge are multi-select. Toggle-off everywhere keeps modal picks
+  // reversible without needing the row's trash button.
+  const pickBlock = (block: PromptBlock) => {
+    const id = block.id;
+    switch (block.group) {
+      case "strategy":
+        setFilter({ strategy: strategy === id ? undefined : id });
+        return;
+      case "depth":
+        setFilter({ depth: depth === id ? undefined : id });
+        return;
+      case "integration": {
+        const next = integrations.includes(id)
+          ? integrations.filter((x) => x !== id)
+          : [...integrations, id];
+        setFilter({ integrations: joinCsv(next) });
+        return;
+      }
+      case "knowledge": {
+        const next = knowledge.includes(id)
+          ? knowledge.filter((x) => x !== id)
+          : [...knowledge, id];
+        setFilter({ knowledge: joinCsv(next) });
+        return;
+      }
+    }
   };
 
   const removeFromComposition = (item: ComposedItem) => {
+    // Prune any expansion/edit entries the row left behind so the maps
+    // don't grow unbounded across add/remove churn in a session.
+    setExpanded((e) => {
+      if (!(item.id in e)) return e;
+      const next = { ...e };
+      delete next[item.id];
+      return next;
+    });
+    setEdits((s) => {
+      if (!(item.id in s)) return s;
+      const next = { ...s };
+      delete next[item.id];
+      return next;
+    });
     if (item.kind === "custom") {
       setCustoms((cs) => cs.filter((c) => c.id !== item.id));
       return;
@@ -368,10 +386,11 @@ export function PromptsBuildPage() {
   };
 
   // clearAll wipes every block out of the composition — both the
-  // URL-tracked library selections and the in-memory custom blocks.
-  // The component-level expansion/edits maps are not touched since
-  // they're keyed by item.id and will be naturally orphaned.
+  // URL-tracked library selections and the in-memory custom blocks
+  // plus their orphaned expansion/edit entries.
   const clearAll = () => {
+    setExpanded({});
+    setEdits({});
     setFilter({
       strategy: undefined,
       depth: undefined,
@@ -524,109 +543,101 @@ export function PromptsBuildPage() {
           onRetry={() => blocksQuery.refetch()}
           retrying={blocksQuery.isFetching}
         />
+      ) : isLoading ? (
+        <Card className="p-4">
+          <Skeleton className="h-32 w-full" />
+        </Card>
       ) : (
-        <div className="flex flex-col gap-3 pb-20">
-          {isLoading ? (
-            <Card className="p-4">
-              <Skeleton className="h-32 w-full" />
-            </Card>
-          ) : (
-            <>
-              <div className="flex items-center justify-end gap-1">
-                {effectiveOrder.length > 0 && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={toggleExpandAll}
-                    className="text-muted-foreground hover:text-foreground h-8 px-2 text-xs"
-                  >
-                    {allExpanded ? (
-                      <>
-                        <ChevronsDownUp className="size-3.5" />
-                        Collapse all
-                      </>
-                    ) : (
-                      <>
-                        <ChevronsUpDown className="size-3.5" />
-                        Expand all
-                      </>
-                    )}
-                  </Button>
+        <>
+          <div className="flex items-center justify-end gap-1">
+            {effectiveOrder.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={toggleExpandAll}
+                className="text-muted-foreground hover:text-foreground h-8 px-2 text-xs"
+              >
+                {allExpanded ? (
+                  <>
+                    <ChevronsDownUp className="size-3.5" />
+                    Collapse all
+                  </>
+                ) : (
+                  <>
+                    <ChevronsUpDown className="size-3.5" />
+                    Expand all
+                  </>
                 )}
-                <ButtonGroup>
+              </Button>
+            )}
+            <ButtonGroup>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                onClick={() => setAddBlockOpen(true)}
+                className="h-8 px-3 text-xs"
+              >
+                <Plus className="size-3.5" />
+                Add block
+              </Button>
+              {/* Visible hairline divider between the main action and
+                  the overflow trigger — `bg-input` is too low-contrast
+                  on the filled primary surface. */}
+              <ButtonGroupSeparator className="bg-primary-foreground/25" />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
                   <Button
                     type="button"
                     variant="default"
                     size="sm"
-                    onClick={() => setAddBlockOpen(true)}
-                    className="h-8 px-3 text-xs"
+                    aria-label="More add-block options"
+                    className="h-8 px-2"
                   >
-                    <Plus className="size-3.5" />
-                    Add block
+                    <ChevronDown className="size-3.5" />
                   </Button>
-                  {/* Visible hairline divider between the main action and
-                      the overflow trigger — `bg-input` is too low-contrast
-                      on the filled primary surface, so we lean on the
-                      primary-foreground tone the kbd pills used. */}
-                  <ButtonGroupSeparator className="bg-primary-foreground/25" />
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="default"
-                        size="sm"
-                        aria-label="More add-block options"
-                        className="h-8 px-2"
-                      >
-                        <ChevronDown className="size-3.5" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      className="w-60"
-                      // Radix restores focus to the trigger button after
-                      // the menu closes. For this menu, "Add empty block"
-                      // moves focus to the new textarea — letting Radix
-                      // then snap focus back to the chevron immediately
-                      // overrides that. preventDefault keeps focus
-                      // wherever our handler put it.
-                      onCloseAutoFocus={(e) => e.preventDefault()}
-                    >
-                      <DropdownMenuItem onSelect={() => addEmptyBlock()}>
-                        <Plus className="size-4" />
-                        Add empty block
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </ButtonGroup>
-              </div>
-              <ComposerTable
-                items={effectiveOrder}
-                onReorder={setOrder}
-                blocksById={blocksById}
-                customs={customs}
-                edits={edits}
-                expanded={expanded}
-                setExpanded={setExpanded}
-                setEdits={setEdits}
-                setCustoms={setCustoms}
-                onRemove={removeFromComposition}
-                addBlockEmptyTrigger={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={isLoading}
-                    onClick={() => setAddBlockOpen(true)}
-                  >
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  className="w-60"
+                  // Radix would snap focus back to the chevron after
+                  // close; preventDefault keeps focus on the new
+                  // textarea our handler just focused.
+                  onCloseAutoFocus={(e) => e.preventDefault()}
+                >
+                  <DropdownMenuItem onSelect={() => addEmptyBlock()}>
                     <Plus className="size-4" />
-                    Add block
-                  </Button>
-                }
-              />
-            </>
-          )}
-        </div>
+                    Add empty block
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </ButtonGroup>
+          </div>
+          <ComposerTable
+            items={effectiveOrder}
+            onReorder={setOrder}
+            blocksById={blocksById}
+            customs={customs}
+            edits={edits}
+            expanded={expanded}
+            setExpanded={setExpanded}
+            setEdits={setEdits}
+            setCustoms={setCustoms}
+            onRemove={removeFromComposition}
+            addBlockEmptyTrigger={
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isLoading}
+                onClick={() => setAddBlockOpen(true)}
+              >
+                <Plus className="size-4" />
+                Add block
+              </Button>
+            }
+          />
+        </>
       )}
       {!isLoading && !blocksQuery.isError && (
         <AddBlockMenu
@@ -635,10 +646,7 @@ export function PromptsBuildPage() {
           blocksByGroup={blocksByGroup}
           activeIds={activeLibraryIds}
           composedCount={effectiveOrder.length}
-          onPickStrategy={pickStrategy}
-          onPickDepth={pickDepth}
-          onToggleIntegration={toggleIntegration}
-          onToggleKnowledge={toggleKnowledge}
+          onPick={pickBlock}
           onAddCustom={addCustomBlock}
           onClearAll={clearAll}
           onApplyPreset={applyPreset}
@@ -669,10 +677,10 @@ interface AddBlockMenuProps {
   // the disabled state of the Clear all action. Distinct from
   // activeIds.size, which only counts library picks.
   composedCount: number;
-  onPickStrategy: (id: string) => void;
-  onPickDepth: (id: string) => void;
-  onToggleIntegration: (id: string) => void;
-  onToggleKnowledge: (id: string) => void;
+  // onPick handles selection. Parent dispatches by group to the right
+  // URL slot (single-select for strategy/depth, multi-select for
+  // integrations/knowledge), so the modal stays group-agnostic.
+  onPick: (block: PromptBlock) => void;
   onAddCustom: (content: string) => void;
   onClearAll: () => void;
   // onApplyPreset replaces the current composition with the preset's
@@ -693,10 +701,7 @@ function AddBlockMenu({
   blocksByGroup,
   activeIds,
   composedCount,
-  onPickStrategy,
-  onPickDepth,
-  onToggleIntegration,
-  onToggleKnowledge,
+  onPick,
   onAddCustom,
   onClearAll,
   onApplyPreset,
@@ -790,24 +795,9 @@ function AddBlockMenu({
         .filter((s) => s.blocks.length > 0);
     }, [activeGroup, filtered]);
 
-  const handlePick = (block: PromptBlock) => {
-    switch (block.group) {
-      case "strategy":
-        onPickStrategy(block.id);
-        break;
-      case "depth":
-        onPickDepth(block.id);
-        break;
-      case "integration":
-        onToggleIntegration(block.id);
-        break;
-      case "knowledge":
-        onToggleKnowledge(block.id);
-        break;
-    }
-    // Stay open: user might add several integrations / both a strategy
-    // and a depth in one sitting. They dismiss via Esc / backdrop / ×.
-  };
+  // Stay open after a pick: user might add several integrations / both
+  // a strategy and a depth in one sitting. They dismiss via Esc /
+  // backdrop / ×.
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -893,9 +883,16 @@ function AddBlockMenu({
                     </p>
                     <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
                       {PRESETS.map((preset) => (
-                        <PresetCard
+                        <LibraryTile
                           key={preset.id}
-                          preset={preset}
+                          icon={preset.icon}
+                          title={preset.label}
+                          description={preset.description}
+                          footer={
+                            <span className="text-muted-foreground/70 mt-1 text-[10px] tabular-nums uppercase tracking-wide">
+                              Includes {preset.blockIds.length} blocks
+                            </span>
+                          }
                           onClick={() => onApplyPreset(preset)}
                         />
                       ))}
@@ -919,11 +916,13 @@ function AddBlockMenu({
                         </div>
                         <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
                           {section.blocks.map((block) => (
-                            <BlockCard
+                            <LibraryTile
                               key={block.id}
-                              block={block}
+                              icon={block.icon}
+                              title={block.title}
+                              description={block.description}
                               active={activeIds.has(block.id)}
-                              onClick={() => handlePick(block)}
+                              onClick={() => onPick(block)}
                             />
                           ))}
                         </div>
@@ -933,11 +932,13 @@ function AddBlockMenu({
                 ) : (
                   <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
                     {filtered.map((block) => (
-                      <BlockCard
+                      <LibraryTile
                         key={block.id}
-                        block={block}
+                        icon={block.icon}
+                        title={block.title}
+                        description={block.description}
                         active={activeIds.has(block.id)}
-                        onClick={() => handlePick(block)}
+                        onClick={() => onPick(block)}
                       />
                     ))}
                   </div>
@@ -1079,17 +1080,23 @@ function CategoryRailItem({
   );
 }
 
-// BlockCard renders one library block as a clickable tile. Active state
-// shows a check pill in the corner so the user can tell at a glance
-// which blocks are already in the composition (especially useful for
-// the multi-select Integrations / Knowledge groups).
-function BlockCard({
-  block,
+// LibraryTile is the shared card visual used by both BlockCard (one
+// library block) and PresetCard (one preset). Active shows a check
+// pill in the top-right; footer is an optional bottom line (e.g.
+// "Includes 3 blocks" for presets).
+function LibraryTile({
+  icon,
+  title,
+  description,
   active,
+  footer,
   onClick,
 }: {
-  block: PromptBlock;
-  active: boolean;
+  icon?: string;
+  title: string;
+  description?: string;
+  active?: boolean;
+  footer?: React.ReactNode;
   onClick: () => void;
 }) {
   return (
@@ -1106,56 +1113,19 @@ function BlockCard({
           <Check className="size-3" />
         </span>
       )}
-      {block.icon && (
+      {icon && (
         <span className="bg-muted text-muted-foreground group-hover:text-foreground inline-flex size-8 items-center justify-center rounded-md">
-          <DynamicIcon name={block.icon} className="size-4" />
+          <DynamicIcon name={icon} className="size-4" />
         </span>
       )}
       <div className="flex flex-col gap-1">
-        <span className="text-sm font-medium leading-tight">{block.title}</span>
-        {block.description && (
+        <span className="text-sm font-medium leading-tight">{title}</span>
+        {description && (
           <span className="text-muted-foreground line-clamp-3 text-xs leading-snug">
-            {block.description}
+            {description}
           </span>
         )}
-      </div>
-    </button>
-  );
-}
-
-// PresetCard renders one preset as a tile. The "Includes N blocks"
-// subtitle hints at the scope without listing block names — keeps the
-// card compact and consistent with BlockCard's visual rhythm.
-function PresetCard({
-  preset,
-  onClick,
-}: {
-  preset: Preset;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group hover:border-primary/40 hover:bg-accent/40 relative flex h-full flex-col gap-2 rounded-lg border p-3 text-left transition-colors"
-    >
-      {preset.icon && (
-        <span className="bg-muted text-muted-foreground group-hover:text-foreground inline-flex size-8 items-center justify-center rounded-md">
-          <DynamicIcon name={preset.icon} className="size-4" />
-        </span>
-      )}
-      <div className="flex flex-col gap-1">
-        <span className="text-sm font-medium leading-tight">
-          {preset.label}
-        </span>
-        {preset.description && (
-          <span className="text-muted-foreground line-clamp-3 text-xs leading-snug">
-            {preset.description}
-          </span>
-        )}
-        <span className="text-muted-foreground/70 mt-1 text-[10px] tabular-nums uppercase tracking-wide">
-          Includes {preset.blockIds.length} blocks
-        </span>
+        {footer}
       </div>
     </button>
   );
@@ -1191,6 +1161,14 @@ function ComposerTable({
   onRemove,
   addBlockEmptyTrigger,
 }: ComposerTableProps) {
+  // Pre-index customs by id so SortableRow lookups are O(1) instead of
+  // O(customs) per row per render.
+  const customsById = useMemo(() => {
+    const m = new Map<string, CustomBlock>();
+    for (const c of customs) m.set(c.id, c);
+    return m;
+  }, [customs]);
+
   // dnd-kit sensors: PointerSensor with a small activation distance so
   // a quick row click doesn't accidentally start a drag (only deliberate
   // movement past 6px does). KeyboardSensor for accessibility.
@@ -1276,7 +1254,7 @@ function ComposerTable({
                   key={rowKey(item)}
                   item={item}
                   blocksById={blocksById}
-                  customs={customs}
+                  customsById={customsById}
                   edits={edits}
                   expanded={Boolean(expanded[item.id])}
                   setExpanded={(open) =>
@@ -1298,7 +1276,7 @@ function ComposerTable({
 interface SortableRowProps {
   item: ComposedItem;
   blocksById: Map<string, PromptBlock>;
-  customs: CustomBlock[];
+  customsById: Map<string, CustomBlock>;
   edits: Record<string, string>;
   expanded: boolean;
   setExpanded: (open: boolean) => void;
@@ -1310,7 +1288,7 @@ interface SortableRowProps {
 function SortableRow({
   item,
   blocksById,
-  customs,
+  customsById,
   edits,
   expanded,
   setExpanded,
@@ -1336,7 +1314,7 @@ function SortableRow({
   const library =
     item.kind === "library" ? blocksById.get(item.id) : undefined;
   const custom =
-    item.kind === "custom" ? customs.find((c) => c.id === item.id) : undefined;
+    item.kind === "custom" ? customsById.get(item.id) : undefined;
 
   const title =
     library?.title ??


### PR DESCRIPTION
## Summary

Code-simplifier pass over the prompt-builder files (`web/src/routes/prompts.build.tsx` + `internal/service/prompt_blocks.go`) that landed in #1301. Applied the high-impact, low-risk findings from a three-pass review (reuse / quality / efficiency); skipped the bigger refactors.

**Backend**
- `humanizeBlockID` → `slugs.TitleCase` (identical logic, shared with tag auto-create).
- Cache `ListPromptBlocks` with `sync.OnceValues` — embed.FS is immutable; SPA hits this on every page mount.
- Delete `legacyParsePromptHeader` (every prompt file uses frontmatter now; `default-system-prompt.md` is excluded).
- Promote `Group string` → typed `PromptBlockGroup` union with named constants.

**Frontend**
- Collapse four `onPickStrategy`/`onPickDepth`/`onToggleIntegration`/`onToggleKnowledge` modal props into a single `onPick(block)`. Parent's `pickBlock` does group dispatch once; modal's `handlePick` switch goes away.
- Merge `BlockCard` + `PresetCard` (~90% identical) into a shared `LibraryTile` with optional `active` + `footer` props.
- Initialize `order` from `defaultOrder` directly instead of `null` + first-render sync branch.
- Build `customsById` Map once in `ComposerTable` — SortableRow lookups become O(1).
- Prune `expanded` and `edits` entries on remove + clear-all so the maps don't grow unbounded.
- Drop the outer `<div className="flex flex-col gap-3 pb-20">` wrapper — direct violation of #1296's page-spacing contract.

Net: -59 lines, tighter prop surfaces, embed-cache win on the backend.

## Test plan

- [ ] `/v2/prompts/build` — table renders, drag/expand/edit still work
- [ ] Add block modal: `⌘+Enter` opens, `B` opens (no — that one moved); pick a block toggles into the right URL slot (single-select for strategy/depth, multi for integration/knowledge)
- [ ] Preset apply replaces composition + closes modal
- [ ] Clear all wipes everything (incl. orphan expansion/edit entries)
- [ ] Add empty block via dropdown + `⇧+⌘+Enter` both focus the new textarea
- [ ] `P` opens preview, `C` copies, Esc blurs a focused block textarea
- [ ] Page-spacing matches the rest of the v2 admin (20px rhythm under `<main>`)
- [ ] `go build ./...`, `go vet ./...`, `bun run build` clean
- [ ] Per-file `go test ./internal/service/ ./internal/slugs/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
