### PR TITLE
fix(v2): preventDefault on Enter to stop tx-list flash-back

### DIFF
--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -251,10 +251,18 @@ export function TransactionsPage() {
   );
   useShortcut(
     ["enter"],
-    () => {
+    (e) => {
       if (focusedIndex == null) return;
       const t = rows[focusedIndex];
-      if (t) openTransaction(t);
+      if (!t) return;
+      // Without preventDefault, the browser ALSO fires the default
+      // Enter-on-button/link action against whatever currently holds DOM
+      // focus (e.g. the sidebar's Transactions nav link the user just
+      // clicked, or the Connect bank header button). That click navigates
+      // away — often right back to the list — so the detail URL flashes
+      // in and out and the j/k focus ring vanishes with the unmount.
+      e.preventDefault();
+      openTransaction(t);
     },
     { label: "Open focused transaction", group: "Transactions" },
   );


### PR DESCRIPTION
## Summary

Tapping **Enter** on a j/k-focused row in the v2 transactions list sometimes navigated to the transaction detail page and then immediately flashed back to the list — losing the j/k focus ring with the unmount. The failure was consistent across attempts when it happened, and that's the clue: it depended on which element held real DOM focus.

The Enter shortcut handler in `web/src/routes/transactions.tsx` calls `navigate()` but doesn't `preventDefault()`. So when DOM focus happened to sit on a `<button>` / `<a>` (e.g. the sidebar's **Transactions** nav link the user had just clicked, or the **Connect bank** header button), pressing Enter did two things in parallel:

1. The custom shortcut fired → `navigate({ to: "/transactions/$id" })` — URL briefly became the detail URL.
2. The browser's default Enter-on-focused-button action fired → clicked that button → navigated right back to the list.

The result: detail URL flashes in, list URL flashes back, page unmounts/remounts, `focusedIndex` resets to `null` so the focus ring disappears.

The fix: call `e.preventDefault()` in the Enter handler when the row is opened. j/k focus is the authoritative target whenever it's set — Enter should always open that row and never double-fire on whatever DOM-focused button happens to be sitting around. When `focusedIndex` is `null`, the shortcut still no-ops and normal button-click behavior is preserved.

Confirmed with `bun run lint` (`tsc -b --noEmit`).

## Test plan

- [ ] Open `/v2/transactions`
- [ ] Click the sidebar's "Transactions" nav link (so DOM focus sits on the link)
- [ ] Press `j` to focus a row
- [ ] Press `Enter` — URL should land on `/v2/transactions/<short_id>` and stay there
- [ ] Repeat with focus on the **Connect bank** header button — same result
- [ ] Press `Escape` back to list; j/k navigation still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)