### PR TITLE
chore(v2): drop institution/type group toggle on accounts page

### DIFF
--- a/web/src/features/accounts/account-utils.ts
+++ b/web/src/features/accounts/account-utils.ts
@@ -106,11 +106,8 @@ export function totalsByCurrency(accounts: Account[]): CurrencyTotal[] {
   return [...m.values()].sort((a, b) => b.count - a.count);
 }
 
-// Group accounts by a chosen dimension. We render the page grouped by
-// connection (institution) by default since that's how users think about
-// their money; "type" gives a depository-vs-credit overview.
-export type AccountGroupBy = "institution" | "type";
-
+// Accounts on the list page are always grouped by connection (institution)
+// — that's how users think about their money.
 export interface AccountGroup {
   key: string;
   label: string;
@@ -164,21 +161,11 @@ export function groupNetTotal(accounts: Account[]): GroupTotal {
   return { currency: primary, total, excluded };
 }
 
-export function groupAccounts(
-  accounts: Account[],
-  by: AccountGroupBy,
-): AccountGroup[] {
+export function groupAccounts(accounts: Account[]): AccountGroup[] {
   const m = new Map<string, AccountGroup>();
   for (const a of accounts) {
-    let key: string;
-    let label: string;
-    if (by === "institution") {
-      key = a.connection_id ?? "_unlinked";
-      label = a.institution_name ?? "Manual / CSV";
-    } else {
-      key = a.type;
-      label = TYPE_LABEL[a.type] ?? a.type;
-    }
+    const key = a.connection_id ?? "_unlinked";
+    const label = a.institution_name ?? "Manual / CSV";
     let g = m.get(key);
     if (!g) {
       g = { key, label, accounts: [] };

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -1,38 +1,28 @@
 import { useMemo } from "react";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { Banknote, Building2, Layers, Plus } from "lucide-react";
+import { Banknote, Plus } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { ListCard } from "@/components/list-card";
 import { Button } from "@/components/ui/button";
 import { ListRowSkeleton } from "@/components/list-row-skeleton";
 import { PageError } from "@/components/page-error";
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from "@/components/ui/toggle-group";
 import { useAccounts } from "@/api/queries/accounts";
 import { useUsers } from "@/api/queries/users";
 import { FamilyTabs } from "@/features/connections/family-tabs";
 import { AccountRow } from "@/features/accounts/account-row";
 import { AccountsSummary } from "@/features/accounts/accounts-summary";
-import {
-  groupAccounts,
-  groupNetTotal,
-  type AccountGroupBy,
-} from "@/features/accounts/account-utils";
+import { groupAccounts, groupNetTotal } from "@/features/accounts/account-utils";
 import { formatBalance } from "@/lib/format";
 
 // Search-param schema.
 //   user → "all" or a user short_id  (family-member filter)
-//   group → "institution" (default) or "type" (grouping dimension)
 //   action → "connect" (passthrough into the connect-bank flow on
 //            /connections; sending users here would be confusing since this
 //            page never opens its own sheet, so we just navigate.)
 export const accountsSearchSchema = z.object({
   user: z.string().optional(),
-  group: z.enum(["institution", "type"]).optional(),
 });
 
 type AccountsSearch = z.infer<typeof accountsSearchSchema>;
@@ -41,7 +31,6 @@ export function AccountsPage() {
   const search = useSearch({ strict: false }) as AccountsSearch;
   const navigate = useNavigate();
   const userFilter = search.user ?? "all";
-  const groupBy: AccountGroupBy = search.group ?? "institution";
 
   const accountsQuery = useAccounts();
   const usersQuery = useUsers();
@@ -77,7 +66,7 @@ export function AccountsPage() {
     return all.filter((a) => a.user_id === filterUserId);
   }, [accountsQuery.data, filterUserId]);
 
-  const groups = useMemo(() => groupAccounts(visible, groupBy), [visible, groupBy]);
+  const groups = useMemo(() => groupAccounts(visible), [visible]);
 
   function setUserFilter(next: string) {
     navigate({
@@ -85,17 +74,6 @@ export function AccountsPage() {
       search: (prev: AccountsSearch) => ({
         ...prev,
         user: next === "all" ? undefined : next,
-      }),
-      replace: true,
-    });
-  }
-
-  function setGroupBy(next: AccountGroupBy) {
-    navigate({
-      to: "/accounts",
-      search: (prev: AccountsSearch) => ({
-        ...prev,
-        group: next === "institution" ? undefined : next,
       }),
       replace: true,
     });
@@ -147,25 +125,6 @@ export function AccountsPage() {
           counts={countsByUserShortId}
           totalCount={totalCount}
         />
-      )}
-
-      {accounts.length > 0 && (
-        <div className="flex items-center justify-end">
-          <ToggleGroup
-            type="single"
-            size="sm"
-            value={groupBy}
-            onValueChange={(v) => v && setGroupBy(v as AccountGroupBy)}
-            variant="outline"
-          >
-            <ToggleGroupItem value="institution" aria-label="Group by institution">
-              <Building2 className="size-3.5" /> Institution
-            </ToggleGroupItem>
-            <ToggleGroupItem value="type" aria-label="Group by type">
-              <Layers className="size-3.5" /> Type
-            </ToggleGroupItem>
-          </ToggleGroup>
-        </div>
       )}
 
       {isLoading ? (


### PR DESCRIPTION
## Summary

Drop the institution / type group toggle on the accounts list page. Institution was already the default and is the way users think about accounts; "type" was a hedge that never paid off. Removes the toggle UI, the `group` search param, and the `type` branch in `groupAccounts`.

## Screenshot

<img src="https://i.img402.dev/0cthdyft7r.jpg" width="800" alt="accounts page — no group toggle, grouped by institution">

## Test plan

- [x] `bun run lint` clean
- [x] Headless-chromium smoke at `/v2/accounts`: no toggle rendered, page is still grouped by institution (American Express, CapitalOne, …)
- [ ] Smoke-check on production-embedded build after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
