### PR TITLE
fix(v2): stop SoftBackButton from stretching to full width

### DIFF
--- a/web/src/components/soft-back-button.tsx
+++ b/web/src/components/soft-back-button.tsx
@@ -28,6 +28,13 @@ interface SoftBackButtonProps {
 // No bottom margin — the page layout (<main> or a constrained-width wrapper)
 // is a flex column with gap-5 that owns the rhythm between the back-link and
 // the PageHeader below it. Don't fork the look — change this primitive instead.
+//
+// `self-start` is baked in because every consumer renders this inside a
+// `flex flex-col` parent (the app `<main>` or a `mx-auto flex max-w-* flex-col`
+// wrapper). Without it the flex default `align-items: stretch` blows the
+// inline-flex button out to full width — content stays centered but the
+// hover/focus surface and visual weight read as a banner instead of a link.
+// In non-flex parents `self-start` is a harmless no-op.
 export function SoftBackButton({
   to,
   children,
@@ -40,7 +47,7 @@ export function SoftBackButton({
       size="sm"
       asChild
       className={cn(
-        "text-muted-foreground hover:text-foreground -ml-2 h-7 px-2 text-xs",
+        "text-muted-foreground hover:text-foreground -ml-2 h-7 self-start px-2 text-xs",
         className,
       )}
     >

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -34,9 +34,7 @@ export function AgentEditPage() {
   if (agentQuery.isLoading || !agentQuery.data) {
     return (
       <>
-        <SoftBackButton to="/agents" className="self-start">
-          Back to agents
-        </SoftBackButton>
+        <SoftBackButton to="/agents">Back to agents</SoftBackButton>
         <PageHeader
           eyebrow="Agent"
           title="Edit agent"
@@ -111,9 +109,7 @@ function AgentEditFormView({
 
   return (
     <>
-      <SoftBackButton to="/agents" className="self-start">
-        Back to agents
-      </SoftBackButton>
+      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
       <PageHeader
         eyebrow="Agent"
         title={agent.name}

--- a/web/src/routes/agents.$slug.runs.tsx
+++ b/web/src/routes/agents.$slug.runs.tsx
@@ -126,9 +126,7 @@ export function AgentRunsPage() {
 
   return (
     <>
-      <SoftBackButton to="/agents" className="self-start">
-        Back to agents
-      </SoftBackButton>
+      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
       <PageHeader
         eyebrow="Agent runs"
         title={agentQuery.data ? `${agentQuery.data.name} — runs` : "Run history"}

--- a/web/src/routes/agents.new.tsx
+++ b/web/src/routes/agents.new.tsx
@@ -62,9 +62,7 @@ export function AgentNewPage() {
 
   return (
     <>
-      <SoftBackButton to="/agents" className="self-start">
-        Back to agents
-      </SoftBackButton>
+      <SoftBackButton to="/agents">Back to agents</SoftBackButton>
       <PageHeader
         eyebrow="Agent"
         title="New agent"


### PR DESCRIPTION
## Summary

- `SoftBackButton` is an `inline-flex` ghost link, but every consumer renders it inside a `flex flex-col` parent (the app `<main>` shell or a `mx-auto flex max-w-{2xl,5xl} flex-col` wrapper around detail/form pages). With the flex default `align-items: stretch`, the link gets blown out to full width — content stays centered (because the button is `justify-center`), so the back-link visually drifts to the middle of the page instead of sitting on the left edge.
- Visible on tag detail, transaction detail, account detail, category detail, connection detail, and the corresponding `*-new` routes. The agents pages worked around it by passing `className="self-start"` per call site — a hint that the primitive itself was wrong.
- Fix at the primitive level: bake `self-start` into `SoftBackButton`'s base classes so every caller is correct by default, and drop the now-redundant overrides from the three agents routes. `self-start` is a no-op in non-flex parents, so this is safe everywhere it currently renders.

<img src="https://i.img402.dev/hg9ujpl49t.jpg" width="900" alt="back button — before vs after on /v2/tags/:slug">

The before frame on the left simulates the pre-fix state by overriding `align-self: stretch` on the rendered link at runtime; the after frame is the page as it ships in this PR.

## Test plan

- [x] `bun run lint` clean
- [x] Visual check at `/v2/tags/meaningless-tag` — link sits at content width (~112px), `align-self: flex-start`, hover surface no longer spans the full 672px container
- [x] Visual check at `/v2/agents/new` — formerly relying on the per-call-site `self-start` override; identical render after dropping the override
- [ ] Spot-check `/v2/transactions/:id`, `/v2/accounts/:id`, `/v2/categories/:id`, `/v2/connections/:id`, `/v2/tags/new`, `/v2/categories/new`, `/v2/api-keys/new`, `/v2/rules/new` on review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
