### PR TITLE
design(v2): redesign Settings → Agents pane

### DIFF
--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -2,7 +2,20 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Bot, CheckCircle2, KeyRound, Loader2, Stethoscope, Trash2, XCircle } from "lucide-react";
+import {
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  Cpu,
+  Gauge,
+  KeyRound,
+  Loader2,
+  Plug,
+  Sparkles,
+  Stethoscope,
+  Terminal,
+  Trash2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -14,24 +27,21 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
+import { SectionCard } from "@/components/section-card";
+import { Eyebrow } from "@/components/eyebrow";
 import { withMutationToast } from "@/lib/mutation-toast";
+import { cn } from "@/lib/utils";
 import {
   useAgentSettings,
+  useAgentSubsystemStatus,
   useRunAgentCleanup,
   useSmokeTestAgent,
   useUpdateAgentSettings,
-  type AgentTestResult,
 } from "@/api/queries/agents";
 import { ApiError } from "@/api/client";
 import { toast } from "sonner";
@@ -47,25 +57,13 @@ const settingsSchema = z.object({
 
 export function AgentsSection() {
   const settingsQuery = useAgentSettings();
+  const statusQuery = useAgentSubsystemStatus();
   const updateSettings = useUpdateAgentSettings();
   const smokeTest = useSmokeTestAgent();
   const cleanup = useRunAgentCleanup();
 
-  const runCleanup = async () => {
-    try {
-      const r = await cleanup.mutateAsync();
-      toast.success(
-        `Cleanup: ${r.runs_deleted} run(s), ${r.transcripts_deleted}/${r.transcripts_scanned} transcript(s) removed (retention ${r.retention_days}d).`,
-      );
-    } catch (err) {
-      const msg = err instanceof ApiError ? err.message : String(err);
-      toast.error(`Cleanup failed — ${msg}`);
-    }
-  };
   const [tokenDraft, setTokenDraft] = useState("");
   const [apiKeyDraft, setApiKeyDraft] = useState("");
-  const [testResult, setTestResult] = useState<AgentTestResult | null>(null);
-  const [testError, setTestError] = useState<{ code: string; message: string } | null>(null);
 
   const form = useForm({
     resolver: zodResolver(settingsSchema),
@@ -135,235 +133,275 @@ export function AgentsSection() {
   };
 
   const runSmokeTest = async () => {
-    setTestResult(null);
-    setTestError(null);
     try {
       const r = await smokeTest.mutateAsync();
-      setTestResult(r);
+      toast.success("Agent connection OK", {
+        description: `${r.auth_mode} · ${r.model} · ${r.duration_ms}ms · $${r.total_cost_usd.toFixed(6)} (${r.input_tokens.toLocaleString()} in / ${r.output_tokens.toLocaleString()} out)`,
+      });
     } catch (err) {
-      if (err instanceof ApiError) {
-        setTestError({ code: err.code, message: err.message });
-      } else {
-        setTestError({ code: "UNKNOWN", message: String(err) });
-      }
+      const code = err instanceof ApiError ? err.code : "UNKNOWN";
+      const message =
+        err instanceof ApiError ? err.message : String(err);
+      toast.error(`Test failed — ${code}`, {
+        description: message,
+      });
+    }
+  };
+
+  const runCleanup = async () => {
+    try {
+      const r = await cleanup.mutateAsync();
+      toast.success(
+        `Cleanup: ${r.runs_deleted} run(s), ${r.transcripts_deleted}/${r.transcripts_scanned} transcript(s) removed (retention ${r.retention_days}d).`,
+      );
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : String(err);
+      toast.error(`Cleanup failed — ${msg}`);
     }
   };
 
   const settings = settingsQuery.data;
+  const status = statusQuery.data;
 
   return (
     <div className="space-y-6">
       <SettingsSectionHeader
         title="Agents"
-        description="Authentication and global caps for the Claude Agent SDK runner. Tokens are encrypted at rest; the full value never leaves the server after you save it."
+        description="Authentication, runtime, and global caps for the Claude Agent SDK runner. Tokens are encrypted at rest; the full value never leaves the server after you save it."
+        action={
+          settings ? (
+            <ReadinessPill
+              authConfigured={Boolean(status?.auth_configured)}
+              binaryPresent={Boolean(status?.binary_present)}
+            />
+          ) : null
+        }
       />
 
       {settingsQuery.isLoading ? (
-        <div className="space-y-3">
-          <Skeleton className="h-9 w-full" />
-          <Skeleton className="h-9 w-full" />
-          <Skeleton className="h-9 w-1/2" />
-        </div>
+        <LoadingSkeleton />
       ) : settings ? (
         <Form {...form}>
-          <form onSubmit={onSubmit} className="space-y-6">
-            <FormField
-              control={form.control}
-              name="auth_mode"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Authentication mode</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
+          <form onSubmit={onSubmit} className="space-y-5">
+            <SectionCard
+              title="Connection"
+              icon={<Plug className="text-muted-foreground size-4" />}
+            >
+              <div className="space-y-5">
+                <FormField
+                  control={form.control}
+                  name="auth_mode"
+                  render={({ field }) => (
+                    <FormItem className="space-y-3">
+                      <FormLabel>Authentication mode</FormLabel>
+                      <FormControl>
+                        <RadioGroup
+                          value={field.value}
+                          onValueChange={field.onChange}
+                          className="grid gap-3 sm:grid-cols-2"
+                        >
+                          <AuthOptionCard
+                            value="subscription"
+                            selected={field.value === "subscription"}
+                            label="Subscription token"
+                            description="Free under your Claude plan credits. Generated by `claude setup-token` — one token, one year."
+                            Icon={Sparkles}
+                          />
+                          <AuthOptionCard
+                            value="api_key"
+                            selected={field.value === "api_key"}
+                            label="Anthropic API key"
+                            description="Pay-as-you-go. Durable past 2026-06-15 when subscription auth sunsets."
+                            Icon={KeyRound}
+                          />
+                        </RadioGroup>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {authMode === "subscription" ? (
+                  <CredentialField
+                    label="Subscription token"
+                    placeholder="sk-ant-oat01-…"
+                    helper={
+                      <>
+                        Run <code className="font-mono">claude setup-token</code>{" "}
+                        on any machine, paste the resulting one-year token here.
+                      </>
+                    }
+                    stored={settings.subscription_token}
+                    draft={tokenDraft}
+                    onDraftChange={setTokenDraft}
+                    onClear={() => clearToken("subscription_token")}
+                  />
+                ) : (
+                  <CredentialField
+                    label="Anthropic API key"
+                    placeholder="sk-ant-…"
+                    helper={
+                      <>
+                        From{" "}
+                        <a
+                          href="https://console.anthropic.com"
+                          target="_blank"
+                          rel="noreferrer"
+                          className="underline-offset-2 hover:underline"
+                        >
+                          console.anthropic.com
+                        </a>
+                        . Billed per API call.
+                      </>
+                    }
+                    stored={settings.anthropic_api_key}
+                    draft={apiKeyDraft}
+                    onDraftChange={setApiKeyDraft}
+                    onClear={() => clearToken("anthropic_api_key")}
+                  />
+                )}
+              </div>
+            </SectionCard>
+
+            <SectionCard
+              title="Limits"
+              icon={<Gauge className="text-muted-foreground size-4" />}
+            >
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="max_concurrent"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Max concurrent runs</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={1}
+                          max={50}
+                          {...field}
+                          onChange={(e) =>
+                            field.onChange(Number(e.target.value))
+                          }
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        v1 default is 1. Extra triggers either skip (cron) or
+                        503 (manual).
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="global_max_budget_usd"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Max cost per run (USD)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          step="0.01"
+                          placeholder="No global cap"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Hard ceiling across all agents. Leave blank for none.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </SectionCard>
+
+            <SectionCard
+              title="Runtime"
+              icon={<Cpu className="text-muted-foreground size-4" />}
+            >
+              <FormField
+                control={form.control}
+                name="runtime_path"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>breadbox-agent binary path</FormLabel>
                     <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Pick auth mode" />
-                      </SelectTrigger>
+                      <Input
+                        placeholder="auto: $BREADBOX_AGENT_BIN, ./bin/breadbox-agent, or PATH"
+                        className="font-mono text-xs"
+                        {...field}
+                      />
                     </FormControl>
-                    <SelectContent>
-                      <SelectItem value="subscription">
-                        Claude subscription token
-                      </SelectItem>
-                      <SelectItem value="api_key">
-                        Anthropic API key
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    Subscription tokens come from <code>claude setup-token</code>{" "}
-                    and apply Claude plan credits (free under monthly limits).
-                    API keys bill per usage; durable past 2026-06-15.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {authMode === "subscription" ? (
-              <CredentialField
-                kind="subscription_token"
-                label="Subscription token"
-                placeholder="sk-ant-oat01-…"
-                helper="Run `claude setup-token` on any machine, paste the resulting one-year token here."
-                stored={settings.subscription_token}
-                draft={tokenDraft}
-                onDraftChange={setTokenDraft}
-                onClear={() => clearToken("subscription_token")}
+                    <FormDescription>
+                      Absolute path to the sidecar binary. Leave blank to use{" "}
+                      <code className="font-mono">$BREADBOX_AGENT_BIN</code>,{" "}
+                      <code className="font-mono">./bin/breadbox-agent</code>,
+                      or PATH discovery.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-            ) : (
-              <CredentialField
-                kind="anthropic_api_key"
-                label="Anthropic API key"
-                placeholder="sk-ant-…"
-                helper="From console.anthropic.com. Billed per API call."
-                stored={settings.anthropic_api_key}
-                draft={apiKeyDraft}
-                onDraftChange={setApiKeyDraft}
-                onClear={() => clearToken("anthropic_api_key")}
-              />
-            )}
-
-            <FormField
-              control={form.control}
-              name="max_concurrent"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Max concurrent runs</FormLabel>
-                  <FormControl>
-                    <Input type="number" min={1} max={50} {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Server-wide cap on agent runs in flight at once. v1 default
-                    is 1 — additional triggers either skip (cron) or 503 (manual).
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
+              {status?.binary_path && (
+                <div className="text-muted-foreground mt-3 flex items-start gap-2 text-xs">
+                  <Terminal className="mt-0.5 size-3.5 shrink-0" />
+                  <span>
+                    Resolved to{" "}
+                    <code className="bg-muted rounded px-1 font-mono">
+                      {status.binary_path}
+                    </code>
+                  </span>
+                </div>
               )}
-            />
+            </SectionCard>
 
-            <FormField
-              control={form.control}
-              name="global_max_budget_usd"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Global max cost per run (USD)</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="number"
-                      step="0.01"
-                      placeholder="No global cap"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Hard ceiling across all agents, regardless of per-agent
-                    settings. Leave blank for none.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="runtime_path"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>breadbox-agent binary path</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="auto: $BREADBOX_AGENT_BIN, ./bin/breadbox-agent, or PATH"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Absolute path to the sidecar binary. Leave blank to use{" "}
-                    <code>$BREADBOX_AGENT_BIN</code>, <code>./bin/breadbox-agent</code>,
-                    or PATH discovery.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="border-border bg-muted/30 -mx-1 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
               <div className="flex flex-wrap items-center gap-2">
                 <Button
                   type="button"
                   variant="outline"
+                  size="sm"
                   onClick={runSmokeTest}
                   disabled={smokeTest.isPending}
                 >
                   {smokeTest.isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
+                    <Loader2 className="size-3.5 animate-spin" />
                   ) : (
-                    <Stethoscope className="size-4" />
+                    <Stethoscope className="size-3.5" />
                   )}
                   Test connection
                 </Button>
                 <Button
                   type="button"
                   variant="outline"
+                  size="sm"
                   onClick={runCleanup}
                   disabled={cleanup.isPending}
-                  title="Runs the same daily prune pass on demand — useful after lowering retention so you don't have to wait for 3:15 AM."
+                  title="Runs the daily prune pass on demand — useful after lowering retention so you don't have to wait for 3:15 AM."
                 >
                   {cleanup.isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
+                    <Loader2 className="size-3.5 animate-spin" />
                   ) : (
-                    <Trash2 className="size-4" />
+                    <Trash2 className="size-3.5" />
                   )}
-                  Run cleanup now
+                  Run cleanup
                 </Button>
               </div>
-              <Button type="submit" disabled={updateSettings.isPending}>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={updateSettings.isPending}
+              >
                 {updateSettings.isPending && (
-                  <Loader2 className="size-4 animate-spin" />
+                  <Loader2 className="size-3.5 animate-spin" />
                 )}
                 Save settings
               </Button>
             </div>
 
-            {testResult && (
-              <Alert>
-                <CheckCircle2 className="size-4" />
-                <AlertTitle>Test passed</AlertTitle>
-                <AlertDescription className="space-y-1">
-                  <p>
-                    Auth ✓ {testResult.auth_mode} · Model {testResult.model}
-                    {" · "}
-                    {testResult.duration_ms}ms · $
-                    {testResult.total_cost_usd.toFixed(6)} (
-                    {testResult.input_tokens} in / {testResult.output_tokens} out)
-                  </p>
-                  {testResult.response && (
-                    <p className="text-muted-foreground">
-                      Response:{" "}
-                      <code className="bg-muted rounded px-1">
-                        {testResult.response}
-                      </code>
-                    </p>
-                  )}
-                </AlertDescription>
-              </Alert>
-            )}
-            {testError && (
-              <Alert variant="destructive">
-                <XCircle className="size-4" />
-                <AlertTitle>Test failed — {testError.code}</AlertTitle>
-                <AlertDescription className="space-y-1">
-                  <p>{testError.message}</p>
-                  <p className="text-xs">
-                    For deeper diagnostics run{" "}
-                    <code className="rounded bg-background/40 px-1 py-0.5 font-mono">
-                      breadbox agent test
-                    </code>{" "}
-                    in a shell (exit codes 3 / 5 / 1 distinguish auth /
-                    binary / runtime failures) or check the server logs
-                    for the sidecar stderr.
-                  </p>
-                </AlertDescription>
-              </Alert>
-            )}
           </form>
         </Form>
       ) : (
@@ -379,11 +417,58 @@ export function AgentsSection() {
   );
 }
 
+// ReadinessPill — at-a-glance ready/setup signal that anchors the section
+// header. Both auth and binary green → "Ready"; either missing → "Setup
+// needed" in amber. Source-of-truth is `/agents/status`, the cheap probe
+// that doesn't burn an Anthropic call.
+function ReadinessPill({
+  authConfigured,
+  binaryPresent,
+}: {
+  authConfigured: boolean;
+  binaryPresent: boolean;
+}) {
+  const ready = authConfigured && binaryPresent;
+  if (ready) {
+    return (
+      <Badge
+        variant="outline"
+        className="border-success/30 bg-success/10 text-success gap-1.5 font-medium"
+      >
+        <CheckCircle2 className="size-3" />
+        Ready
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1.5 border-amber-500/30 bg-amber-500/10 font-medium text-amber-700 dark:text-amber-400"
+    >
+      <AlertTriangle className="size-3" />
+      Setup needed
+    </Badge>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-5">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="border-border rounded-lg border p-5">
+          <Skeleton className="mb-4 h-4 w-32" />
+          <Skeleton className="mb-2 h-9 w-full" />
+          <Skeleton className="h-3 w-2/3" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 interface CredentialFieldProps {
-  kind: string;
   label: string;
   placeholder: string;
-  helper: string;
+  helper: React.ReactNode;
   stored?: string | null;
   draft: string;
   onDraftChange: (v: string) => void;
@@ -400,24 +485,36 @@ function CredentialField({
   onClear,
 }: CredentialFieldProps) {
   return (
-    <FormItem>
-      <FormLabel>{label}</FormLabel>
-      {stored ? (
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="outline" className="font-mono">
-            <KeyRound className="mr-1 size-3" /> {stored}
+    <FormItem className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <FormLabel>{label}</FormLabel>
+        {stored ? (
+          <Badge
+            variant="outline"
+            className="border-success/30 bg-success/10 text-success gap-1 font-normal"
+          >
+            <CheckCircle2 className="size-3" />
+            Connected
           </Badge>
+        ) : (
+          <Eyebrow className="text-muted-foreground/80">Not configured</Eyebrow>
+        )}
+      </div>
+      {stored && (
+        <div className="bg-muted/40 border-border flex items-center justify-between gap-2 rounded-md border px-3 py-2">
+          <code className="text-foreground/80 truncate font-mono text-xs">
+            {stored}
+          </code>
           <Button
             type="button"
             variant="ghost"
             size="sm"
+            className="text-muted-foreground hover:text-destructive h-7 px-2 text-xs"
             onClick={onClear}
           >
-            Clear stored credential
+            Remove
           </Button>
         </div>
-      ) : (
-        <p className="text-muted-foreground text-xs">No credential stored.</p>
       )}
       <FormControl>
         <Input
@@ -428,9 +525,60 @@ function CredentialField({
           value={draft}
           onChange={(e) => onDraftChange(e.target.value)}
           autoComplete="off"
+          className="font-mono text-xs"
         />
       </FormControl>
       <FormDescription>{helper}</FormDescription>
     </FormItem>
   );
 }
+
+interface AuthOptionCardProps {
+  value: string;
+  selected: boolean;
+  label: string;
+  description: string;
+  Icon: React.ComponentType<{ className?: string }>;
+}
+
+// AuthOptionCard mirrors the OptionCard pattern from api-key-form — a
+// RadioGroupItem styled as a tappable tile. Kept local because the
+// description ("free under Claude plan credits…") is settings-specific.
+function AuthOptionCard({
+  value,
+  selected,
+  label,
+  description,
+  Icon,
+}: AuthOptionCardProps) {
+  const id = `auth-mode-${value}`;
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "group relative flex cursor-pointer flex-col gap-2 rounded-lg border p-4 transition-colors",
+        "hover:border-foreground/30",
+        selected
+          ? "border-primary bg-primary/[0.04] ring-primary/30 ring-1"
+          : "border-border bg-card",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <Icon
+          className={cn(
+            "size-4 transition-colors",
+            selected ? "text-primary" : "text-muted-foreground",
+          )}
+        />
+        <RadioGroupItem id={id} value={value} className="mt-0.5" />
+      </div>
+      <div className="space-y-1">
+        <div className="text-sm font-medium">{label}</div>
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          {description}
+        </p>
+      </div>
+    </label>
+  );
+}
+


### PR DESCRIPTION
## Summary

Redesigns the Settings → Agents pane in the v2 SPA. Same data + endpoints, more legible surface.

- Splits the long single-column form into three `SectionCard`s — **Connection**, **Limits**, **Runtime** — plus a flush actions bar.
- Auth mode is now a 2-up `RadioGroup` of `OptionCard`s (Subscription token vs Anthropic API key) instead of a `Select`. Mirrors the api-key-form pattern already used elsewhere.
- Stored credential renders as a `Connected` badge + muted pill with a `Remove` action; "Paste a new value to replace…" input sits below.
- Header carries a **Ready / Setup needed** badge sourced from `/api/v1/agents/status` (the cheap probe, no Anthropic call).
- Limits split into a 2-col grid; Runtime surfaces the resolved binary path under the input when available.
- **Test connection** now fires a sonner toast (success + error variants) — the inline `TestResultPanel` / `TestErrorPanel` components are removed.

All existing functionality preserved: auth-mode toggle, credential save/clear, max concurrent, global budget cap, runtime path, smoke test, cleanup.

## Screenshots

<table>
  <tr><th>Top — Connection card</th><th>Bottom — Limits / Runtime / actions</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/pkcawk9odq.jpg" width="420" alt="agents settings — top"></td>
    <td><img src="https://i.img402.dev/85zok66l16.jpg" width="420" alt="agents settings — bottom"></td>
  </tr>
</table>

<img src="https://i.img402.dev/xc0vrsp112.jpg" width="800" alt="Test connection toast — error path">

## Test plan

- [ ] Open Settings → Agents from the v2 sidebar (or `?m=settings&ms=agents`)
- [ ] Toggle between Subscription token and Anthropic API key — the credential field swaps and "Connected" badge reflects stored state
- [ ] Edit Max concurrent and Max cost, hit Save — settings persist + toast confirms
- [ ] Click **Test connection** — success toast shows auth/model/latency/cost/tokens; failure toast shows `Test failed — <CODE>` with the API error message
- [ ] Click **Run cleanup** — toast reports counts (unchanged behavior)
- [ ] Header badge flips **Ready ↔ Setup needed** based on auth + binary state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
