### PR TITLE
feat(agents): ship breadbox-agent sidecar via release CI + Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,11 +356,32 @@ jobs:
             -o breadbox-${{ matrix.goos }}-${{ matrix.goarch }} \
             ./cmd/breadbox
 
+      - name: Build sidecar (bun cross-compile)
+        # The Claude Agent SDK is TypeScript-only, so the sidecar ships as a
+        # standalone Bun-compiled binary alongside the Go binary. Bun supports
+        # cross-compilation from any host, so we map goos/goarch to the
+        # matching bun --target and emit one sidecar per release matrix cell.
+        run: |
+          cd agent/sidecar
+          bun install --frozen-lockfile
+          case "${{ matrix.goos }}-${{ matrix.goarch }}" in
+            linux-amd64)  TARGET=bun-linux-x64    ;;
+            linux-arm64)  TARGET=bun-linux-arm64  ;;
+            darwin-amd64) TARGET=bun-darwin-x64   ;;
+            darwin-arm64) TARGET=bun-darwin-arm64 ;;
+            *) echo "unsupported matrix cell: ${{ matrix.goos }}-${{ matrix.goarch }}"; exit 1 ;;
+          esac
+          bun build --compile --minify --target=$TARGET \
+            --outfile ../../breadbox-agent-${{ matrix.goos }}-${{ matrix.goarch }} \
+            index.ts
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: breadbox-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: breadbox-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            breadbox-${{ matrix.goos }}-${{ matrix.goarch }}
+            breadbox-agent-${{ matrix.goos }}-${{ matrix.goarch }}
 
   publish-release:
     name: Publish Release
@@ -375,6 +396,8 @@ jobs:
           merge-multiple: true
 
       - name: Generate SHA256 checksums
+        # `breadbox-*` matches both the Go binary (`breadbox-<os>-<arch>`)
+        # and the sidecar (`breadbox-agent-<os>-<arch>`) per matrix cell.
         run: |
           cd artifacts
           sha256sum breadbox-* > SHA256SUMS

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,25 @@ RUN bun install --frozen-lockfile
 COPY web/ ./
 RUN bun run build
 
+# Stage 1b: Compile the Claude Agent SDK sidecar to a standalone binary.
+# Bun cross-compiles to $TARGETARCH from $BUILDPLATFORM, so this runs
+# natively (no QEMU). We pick the musl variant because the runtime stage
+# below is Alpine (musl libc) — the glibc-targeted Bun binary would not
+# load there without gcompat shims.
+FROM --platform=$BUILDPLATFORM oven/bun:1 AS sidecar-builder
+ARG TARGETARCH
+WORKDIR /sidecar
+COPY agent/sidecar/package.json agent/sidecar/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY agent/sidecar/ ./
+RUN case "$TARGETARCH" in \
+        amd64) TARGET=bun-linux-x64-musl   ;; \
+        arm64) TARGET=bun-linux-arm64-musl ;; \
+        *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && bun build --compile --minify --target=$TARGET \
+        --outfile /breadbox-agent index.ts
+
 # Stage 2: Build Go binary (runs natively on the build host, cross-compiles Go)
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
@@ -58,6 +77,9 @@ RUN apk --no-cache add ca-certificates tzdata postgresql16-client
 
 WORKDIR /app
 COPY --from=builder /breadbox /app/breadbox
+# Sidecar lands on PATH so internal/agent.LocateBinary picks it up via the
+# `breadbox-agent` lookup without any extra config.
+COPY --from=sidecar-builder /breadbox-agent /usr/local/bin/breadbox-agent
 
 EXPOSE 8080
 ENTRYPOINT []

--- a/agent/sidecar/bun.lock
+++ b/agent/sidecar/bun.lock
@@ -1,0 +1,62 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "breadbox-agent-sidecar",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.5.0",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.1.77", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.33.5", "@img/sharp-darwin-x64": "^0.33.5", "@img/sharp-linux-arm": "^0.33.5", "@img/sharp-linux-arm64": "^0.33.5", "@img/sharp-linux-x64": "^0.33.5", "@img/sharp-linuxmusl-arm64": "^0.33.5", "@img/sharp-linuxmusl-x64": "^0.33.5", "@img/sharp-win32-x64": "^0.33.5" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,17 +7,21 @@ Recurring AI-powered workflows that run via the Claude Agent SDK and call breadb
 1. **Authenticate**: Settings → Agents → pick auth mode.
    - **Subscription token (recommended for hobbyists)**: run `claude setup-token` on any machine, paste the resulting `sk-ant-oat01-…` token. Free under your Claude plan's monthly Agent SDK credit (until 2026-06-15; details: https://support.claude.com/en/articles/15036540).
    - **Anthropic API key**: paste an `sk-ant-…` key from console.anthropic.com. Billed per API call; durable past the 2026-06-15 cutover.
-2. **Build the sidecar binary** (one-time):
-   ```sh
-   make agent-sidecar
-   ```
-   Outputs `bin/breadbox-agent`. Set `agent.runtime_path` in Settings → Agents if you put it elsewhere.
+2. **Install the sidecar binary**. The Claude Agent SDK is TypeScript-only, so the runner ships as a separate standalone binary (`breadbox-agent`) that the Go server exec's per run. Pick whichever install path matches how you're running breadbox:
 
-   **Prerequisite: `bun`.** The sidecar is a TypeScript binary compiled via `bun build --compile`. If you don't have `bun` installed, the Makefile prints the install command — paste it into your shell:
-   ```sh
-   curl -fsSL https://bun.sh/install | bash
-   ```
-   No other Node/npm setup is required.
+   - **From a GitHub release** (recommended for binary installs): grab the matching artifact from [the latest release](https://github.com/canalesb93/breadbox/releases/latest), make it executable, and drop it on your PATH or at `~/.breadbox/agent-bin/breadbox-agent`:
+     ```sh
+     curl -L -o ~/.breadbox/agent-bin/breadbox-agent \
+       https://github.com/canalesb93/breadbox/releases/latest/download/breadbox-agent-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+     chmod +x ~/.breadbox/agent-bin/breadbox-agent
+     ```
+   - **Docker image**: nothing to do — the published image bundles `breadbox-agent` at `/usr/local/bin/breadbox-agent`.
+   - **From source** (dev / contributors): `make agent-sidecar` writes `bin/breadbox-agent` next to your repo checkout. Requires `bun`:
+     ```sh
+     curl -fsSL https://bun.sh/install | bash
+     ```
+
+   Discovery order is: `agent.runtime_path` (Settings → Agents) → `$BREADBOX_AGENT_BIN` → `./bin/breadbox-agent` (cwd) → `~/.breadbox/agent-bin/breadbox-agent` → `$PATH` lookup. The v2 SPA onboarding banner shows which one resolved.
 3. **Pick a starter agent** from the v2 SPA at `/v2/agents`. Five defaults are seeded on fresh installs (disabled):
    - **Initial Setup** — broad rule + category mapping after first sync.
    - **Bulk Review** — thorough categorization pass over a large queue.
@@ -58,7 +62,7 @@ Exit codes (full reference):
 | ---- | -------------------------------------------------------- | --------------------------------------------------------------------------- |
 | 0    | Test succeeded — agent subsystem is ready                | None                                                                        |
 | 3    | No Anthropic credential configured                       | Paste a token in Settings → Agents (subscription or API key)                |
-| 5    | Sidecar binary not found                                 | Run `make agent-sidecar`, or set `agent.runtime_path` if it's already built |
+| 5    | Sidecar binary not found                                 | Download `breadbox-agent-<os>-<arch>` from [the latest release](https://github.com/canalesb93/breadbox/releases/latest) into `~/.breadbox/agent-bin/` (or your PATH), use the Docker image, or `make agent-sidecar` from source |
 | 1    | Test ran but the sidecar crashed or the model errored    | Re-run with `--verbose` (planned) or check server logs for the sidecar stderr |
 
 ## Architecture (one-line view per layer)

--- a/internal/agent/sidecar.go
+++ b/internal/agent/sidecar.go
@@ -43,8 +43,9 @@ func (s *Sidecar) resolveBinary() (string, error) {
 //
 //	1. explicit path (e.g. app_config.agent.runtime_path)
 //	2. $BREADBOX_AGENT_BIN
-//	3. ./bin/breadbox-agent (process cwd)
-//	4. PATH lookup (`breadbox-agent`)
+//	3. ./bin/breadbox-agent (process cwd; dev `make agent-sidecar` output)
+//	4. ~/.breadbox/agent-bin/breadbox-agent (per-user release install)
+//	5. PATH lookup (`breadbox-agent`; Docker image + install scripts)
 //
 // Returns ErrBinaryNotFound when none of the above hit.
 func LocateBinary(explicitPath string) (string, error) {
@@ -61,6 +62,12 @@ func LocateBinary(explicitPath string) (string, error) {
 			return abs, nil
 		}
 		return local, nil
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		userInstall := filepath.Join(home, ".breadbox", "agent-bin", "breadbox-agent")
+		if _, err := os.Stat(userInstall); err == nil {
+			return userInstall, nil
+		}
 	}
 	p, err := exec.LookPath("breadbox-agent")
 	if err != nil {

--- a/internal/agent/sidecar_test.go
+++ b/internal/agent/sidecar_test.go
@@ -117,6 +117,46 @@ func TestSidecarRun_BinaryNotFound(t *testing.T) {
 	}
 }
 
+// TestLocateBinary_UserInstallDir covers step 4 of the lookup order:
+// ~/.breadbox/agent-bin/breadbox-agent. The release artifacts land here for
+// users coming from a tarball install, so this path must resolve without
+// any explicit config — it's the difference between binary_present=true
+// and an onboarding-banner nag for a fresh install.
+func TestLocateBinary_UserInstallDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	binDir := filepath.Join(tmpHome, ".breadbox", "agent-bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	binPath := filepath.Join(binDir, "breadbox-agent")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+
+	// Shadow $HOME so os.UserHomeDir() points at our temp tree. Also clear
+	// $BREADBOX_AGENT_BIN so step 2 doesn't shortcut, and point PATH at a
+	// nonexistent dir so step 5 (LookPath) doesn't accidentally win.
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("BREADBOX_AGENT_BIN", "")
+	t.Setenv("PATH", "/nonexistent-for-test")
+
+	// And cd into a directory without a ./bin/breadbox-agent so step 3
+	// doesn't shortcut either.
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	if err := os.Chdir(tmpHome); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	got, err := LocateBinary("")
+	if err != nil {
+		t.Fatalf("LocateBinary: unexpected error: %v", err)
+	}
+	if got != binPath {
+		t.Errorf("LocateBinary = %q, want %q", got, binPath)
+	}
+}
+
 func TestSidecarRun_NonZeroExit(t *testing.T) {
 	tmp := t.TempDir()
 	body := `{"type":"error","ts":1,"data":{"code":"X","message":"sidecar said no"}}`

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -596,7 +596,7 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 		if errors.Is(runErr, agent.ErrBinaryNotFound) {
 			mw.WriteError(w, http.StatusUnprocessableEntity,
 				"AGENT_BINARY_NOT_FOUND",
-				"breadbox-agent binary not found. Run `make agent-sidecar` or set agent.runtime_path.")
+				"breadbox-agent binary not found. Download the matching `breadbox-agent-<os>-<arch>` from the latest GitHub release and place it on your PATH or at ~/.breadbox/agent-bin/, set agent.runtime_path, or build from source with `make agent-sidecar`.")
 			return
 		}
 		// runResp may be non-nil even when runErr is set (mint succeeded but
@@ -671,7 +671,7 @@ func SmokeTestAgentHandler(orch *service.Orchestrator) http.HandlerFunc {
 			case errors.Is(err, agent.ErrBinaryNotFound):
 				mw.WriteError(w, http.StatusUnprocessableEntity,
 					"AGENT_BINARY_NOT_FOUND",
-					"breadbox-agent binary not found. Run `make agent-sidecar` or set agent.runtime_path.")
+					"breadbox-agent binary not found. Download the matching `breadbox-agent-<os>-<arch>` from the latest GitHub release and place it on your PATH or at ~/.breadbox/agent-bin/, set agent.runtime_path, or build from source with `make agent-sidecar`.")
 			default:
 				mw.WriteError(w, http.StatusInternalServerError,
 					"AGENT_TEST_FAILED", err.Error())

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -164,7 +164,7 @@ func runAgentRun(parent context.Context, slug string, jsonOut bool, promptPrefix
 			fmt.Fprintln(os.Stderr, "auth not configured — paste a token in Settings → Agents or run `breadbox agent test` for diagnostic detail")
 			return silentlyFail(runErr)
 		case errors.Is(runErr, agent.ErrBinaryNotFound):
-			fmt.Fprintln(os.Stderr, "breadbox-agent binary not found — run `make agent-sidecar` or set agent.runtime_path")
+			fmt.Fprintln(os.Stderr, "breadbox-agent binary not found — download breadbox-agent-<os>-<arch> from the latest GitHub release and place it on your PATH or at ~/.breadbox/agent-bin/, set agent.runtime_path, or build from source via `make agent-sidecar`")
 			return silentlyFail(runErr)
 		case errors.Is(runErr, agent.ErrConcurrencyLocked):
 			// Shouldn't happen with a fresh per-CLI orchestrator, but
@@ -253,7 +253,10 @@ func runAgentTest(parent context.Context) error {
 		case errors.Is(err, agent.ErrBinaryNotFound):
 			fmt.Fprintln(os.Stdout, "  ✗ binary        not found")
 			fmt.Fprintln(os.Stdout, "")
-			fmt.Fprintln(os.Stdout, "Build the sidecar: `make agent-sidecar` (writes ./bin/breadbox-agent).")
+			fmt.Fprintln(os.Stdout, "From a release: download `breadbox-agent-<os>-<arch>` from https://github.com/canalesb93/breadbox/releases/latest")
+			fmt.Fprintln(os.Stdout, "  and place it on your PATH or at ~/.breadbox/agent-bin/breadbox-agent.")
+			fmt.Fprintln(os.Stdout, "Docker users: the published image already includes it.")
+			fmt.Fprintln(os.Stdout, "From source: `make agent-sidecar` (writes ./bin/breadbox-agent).")
 			fmt.Fprintln(os.Stdout, "Or set an explicit path: `breadbox config set agent.runtime_path /path/to/breadbox-agent`.")
 			return silentlyFail(err)
 		default:
@@ -265,7 +268,7 @@ func runAgentTest(parent context.Context) error {
 
 	fmt.Fprintf(os.Stdout, "  ✓ auth          %s\n", result.AuthMode)
 	if result.BinaryPath == "" {
-		fmt.Fprintln(os.Stdout, "  ✓ binary        auto-discovered (./bin/breadbox-agent or $PATH)")
+		fmt.Fprintln(os.Stdout, "  ✓ binary        auto-discovered (./bin/breadbox-agent, ~/.breadbox/agent-bin/, or $PATH)")
 	} else {
 		fmt.Fprintf(os.Stdout, "  ✓ binary        %s\n", result.BinaryPath)
 	}

--- a/internal/cli/doctor_local_full.go
+++ b/internal/cli/doctor_local_full.go
@@ -150,7 +150,7 @@ func runAgentSmokeCheck(ctx context.Context, pool *pgxpool.Pool, cfg *bbconfig.C
 			Name:        "agent smoke test",
 			Status:      doctorStatusFail,
 			Message:     "binary lookup failed: " + err.Error(),
-			Remediation: "build with `make agent-sidecar` or set agent.runtime_path in Settings → Agents",
+			Remediation: "download breadbox-agent-<os>-<arch> from the latest GitHub release (or use the Docker image), or build from source with `make agent-sidecar`",
 		}
 	}
 	runCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -177,7 +177,7 @@ func liveSmokeCheck(result *agent.SmokeResult, err error) doctorCheck {
 				Name:        "agent smoke test",
 				Status:      doctorStatusFail,
 				Message:     "binary not found: " + err.Error(),
-				Remediation: "build with `make agent-sidecar` or set agent.runtime_path",
+				Remediation: "download breadbox-agent-<os>-<arch> from the latest GitHub release, set agent.runtime_path, or build from source with `make agent-sidecar`",
 			}
 		default:
 			return doctorCheck{
@@ -221,7 +221,7 @@ func agentSubsystemCheck(authMode string, authPresent bool, binaryPath string, b
 			Name:        "agent subsystem",
 			Status:      doctorStatusWarn,
 			Message:     "auth configured but breadbox-agent binary not found",
-			Remediation: "build with `make agent-sidecar` or set `agent.runtime_path` in Settings → Agents",
+			Remediation: "download breadbox-agent-<os>-<arch> from the latest GitHub release into ~/.breadbox/agent-bin/ (or use the Docker image), or build from source with `make agent-sidecar`",
 		}
 	case !authPresent && binaryReady:
 		return doctorCheck{

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -174,7 +174,7 @@ function TestPromptButton({
       {
         success: "Test run dispatched — opening transcript…",
         error:
-          "Test run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
+          "Test run failed — check Settings → Agents for auth, or install the breadbox-agent binary (see onboarding banner)",
       },
     );
     void ok;

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -154,9 +154,24 @@ export function AgentsPage() {
                       — {status.binary_path}
                     </span>
                   ) : (
-                    <code className="bg-muted rounded px-1">
-                      make agent-sidecar
-                    </code>
+                    <span className="text-muted-foreground">
+                      — download <code className="bg-muted rounded px-1">
+                        breadbox-agent-&lt;os&gt;-&lt;arch&gt;
+                      </code>{" "}
+                      from the latest{" "}
+                      <a
+                        href="https://github.com/canalesb93/breadbox/releases/latest"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="text-primary underline-offset-4 hover:underline"
+                      >
+                        GitHub release
+                      </a>{" "}
+                      and place it on your PATH or at{" "}
+                      <code className="bg-muted rounded px-1">
+                        ~/.breadbox/agent-bin/breadbox-agent
+                      </code>. The Docker image already includes it.
+                    </span>
                   )}
                 </span>
               </li>
@@ -467,7 +482,7 @@ function RunNowDialog({
           ? `Run started for ${name} (with prefix) — opening transcript`
           : `Run started for ${name} — opening transcript`,
         error:
-          "Run failed — check Settings → Agents for auth, or `make agent-sidecar` for the binary",
+          "Run failed — check Settings → Agents for auth, or install the breadbox-agent binary (see onboarding banner)",
       },
     );
     if (ok) {


### PR DESCRIPTION
## Summary

Closes #1295. Ships the `breadbox-agent` sidecar binary through the same release channels as the main `breadbox` binary so self-hosters never have to run `make agent-sidecar` themselves.

- **Release CI**: the existing `release` matrix job now also runs `bun build --compile` per cell and uploads `breadbox-agent-<os>-<arch>` (linux/darwin × amd64/arm64) alongside the Go binary. SHA256SUMS picks them up via the existing `breadbox-*` glob.
- **Docker image**: new `sidecar-builder` stage (musl variants, to match the Alpine runtime) drops the binary at `/usr/local/bin/breadbox-agent` so the `LookPath` discovery in `LocateBinary` finds it automatically.
- **LocateBinary**: new lookup step for `~/.breadbox/agent-bin/breadbox-agent` between the dev `./bin/` shortcut and the PATH fallback — the canonical install location for users coming from a release tarball.
- **Onboarding + error messaging**: the v2 SPA banner on `/v2/agents`, both run-failure toasts, `breadbox agent test`, and three doctor remediations now lead with the release-download / Docker path; `make agent-sidecar` is retained as the from-source fallback. `docs/agents.md` rewrites the install step to cover all three paths.
- **Lockfile**: `agent/sidecar/bun.lock` is now committed so `bun install --frozen-lockfile` works in CI and in the Docker build.

A fresh self-hoster who downloads `breadbox-<os>-<arch>` + `breadbox-agent-<os>-<arch>` from a release (or runs the Docker image) now sees `binary_present=true` in `/api/v1/agents/status` without touching the repo — both acceptance criteria met.

Local validation:
- `go build ./...`, `go vet ./...`, `go build -tags=headless/lite ./...`, `go vet -tags=headless/lite ./...` — all clean.
- `go test ./internal/agent/... -tags=integration` — passes, including the new `TestLocateBinary_UserInstallDir`.
- `go test ./internal/cli/...` — passes; doctor test still finds `make agent-sidecar` in remediations.
- `cd web && bun run lint` — clean.
- `bun build --compile --target=bun-linux-x64-musl ...` — produces a 103 MB ELF (musl) successfully, mirrors the CI step.

Note: `cd agent/sidecar && bun run typecheck` surfaces two pre-existing TS errors from the SDK bump (the lockfile pins `0.1.77`, code was written against `^0.1.0`). CI doesn't run typecheck today and this PR doesn't either, so it's not a regression — worth a follow-up sweep.

## Test plan

- [ ] CI release matrix produces both `breadbox-*` and `breadbox-agent-*` artifacts for all 4 OS/arch cells when a `v*` tag is pushed.
- [ ] `SHA256SUMS` includes 8 rows (4 binaries + 4 sidecars) on a release.
- [ ] Docker image `ghcr.io/canalesb93/breadbox:latest` contains `/usr/local/bin/breadbox-agent` and runs end-to-end.
- [ ] On a fresh install, dropping `breadbox-agent-<os>-<arch>` at `~/.breadbox/agent-bin/breadbox-agent` flips the onboarding banner's binary row green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
