### PR TITLE
design(v2): grow settings modal for more content breathing room

### DIFF
--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -57,7 +57,7 @@ export function SettingsShell() {
   if (isDesktop) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="flex h-[600px] max-w-3xl flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogContent className="flex h-[min(720px,85vh)] max-w-4xl flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl">
           <DialogHeader className="sr-only">
             <DialogTitle>Settings</DialogTitle>
             <DialogDescription>Manage your account and app preferences.</DialogDescription>


### PR DESCRIPTION
## Summary

- Grows the desktop settings dialog from `h-[600px] max-w-3xl` (768×600) to `h-[min(720px,85vh)] max-w-4xl` (896×720, capped at 85vh on shorter laptops).
- Mobile sheet (`Sheet side="bottom" h-[92dvh]`) untouched.
- Account and Agents sections were the obvious cramps — both feel a lot more at-home with the extra width.

## Before / After

<table>
  <tr><th>Before (h-[600px] max-w-3xl)</th><th>After (h-[min(720px,85vh)] max-w-4xl)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/jtdd62h461.jpg" width="420" alt="settings modal — before"></td>
    <td><img src="https://i.img402.dev/nnt7hksg5t.jpg" width="420" alt="settings modal — after"></td>
  </tr>
</table>

Each composite shows desktop 1280×800, tablet 768×1024, mobile 390×844 (mobile is the bottom-sheet variant — visually identical between before/after).

## Test plan

- [x] `bun run lint` (tsc -b --noEmit) clean
- [x] Captured at three viewports via `web/scripts/validate.ts`
- [ ] Eyeball at `/v2/?m=settings` after merge
