### PR TITLE
feat(admin): add v2_default toggle to land at /v2/ from /

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -44,6 +44,14 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			return
 		}
 
+		// Opt-in: when v2_default is set, the v1 admin root becomes a
+		// redirect to the v2 SPA. Bookmarks and deep links into other v1
+		// pages keep working — only `/` flips.
+		if appconfig.Bool(ctx, a.Queries, appconfig.KeyV2Default, false) {
+			http.Redirect(w, r, "/v2/", http.StatusSeeOther)
+			return
+		}
+
 		// Anchor every wall-clock decision (day buckets, "Today" hero
 		// counters, absolute-time tooltips) to the viewer's browser
 		// timezone via the bb_tz cookie. Falls back to server local when

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -310,6 +310,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings/help", HelpSettingsHandler(a, sm, tr))
 		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
 		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
+		r.Post("/settings/v2-default", SettingsV2DefaultPostHandler(a, sm))
 	})
 
 	// Admin API (authenticated, JSON responses).

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -50,6 +50,7 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 	retentionDays, _ := a.Service.GetSyncLogRetentionDays(ctx)
 	syncLogCount, _ := a.Service.CountSyncLogs(ctx)
 	onboardingDismissed := appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false)
+	v2Default := appconfig.Bool(ctx, a.Queries, appconfig.KeyV2Default, false)
 
 	nextSyncTime := ""
 	if a.Scheduler != nil {
@@ -68,6 +69,7 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		ProviderCount:        len(a.Providers),
 		HasEncryptionKey:     len(a.Config.EncryptionKey) > 0,
 		OnboardingDismissed:  onboardingDismissed,
+		V2Default:            v2Default,
 		NextSyncTime:         nextSyncTime,
 		ConfigSources:        a.Config.ConfigSources,
 	}
@@ -200,6 +202,35 @@ func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.Handl
 			SetFlash(ctx, sm, "success", fmt.Sprintf("Sync log retention set to %d days.", retentionDays))
 		}
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	}
+}
+
+// SettingsV2DefaultPostHandler serves POST /settings/v2-default. Toggles
+// the app_config key that flips the v1 admin root to redirect at /v2/.
+// Unchecked checkboxes don't submit, so a missing form value is treated
+// as "off".
+func SettingsV2DefaultPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		enabled := r.FormValue("v2_default") == "on"
+		value := "false"
+		if enabled {
+			value = "true"
+		}
+		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+			Key:   appconfig.KeyV2Default,
+			Value: pgconv.Text(value),
+		}); err != nil {
+			a.Logger.Error("save v2 default", "error", err)
+			FlashRedirect(w, r, sm, "error", "Failed to save default UI setting.", "/settings/system")
+			return
+		}
+		if enabled {
+			SetFlash(ctx, sm, "success", "v2 dashboard is now the default. Visiting / will land on /v2/.")
+		} else {
+			SetFlash(ctx, sm, "success", "v1 admin dashboard restored as the default landing page.")
+		}
+		http.Redirect(w, r, "/settings/system", http.StatusSeeOther)
 	}
 }
 

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -38,6 +38,12 @@ const (
 	// KeyAgentRunRetentionDays is the number of days to keep completed
 	// agent_runs rows. Default: 30. 0 disables cleanup.
 	KeyAgentRunRetentionDays = "agent.run_retention_days"
+
+	// KeyV2Default, when "true", makes the v1 admin root (`/`) redirect to
+	// `/v2/`. Transitional setting — the v1 admin UI is on track for full
+	// retirement, and this lets a household opt into v2-as-home in the
+	// meantime. Default: false (v1 feed at root). Read in admin.FeedHandler.
+	KeyV2Default = "v2_default"
 )
 
 // AuthMode values for KeyAgentAuthMode.

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -48,6 +48,7 @@ templ SettingsSystem(p SettingsProps) {
 	</div>
 	<div class="grid gap-6 bb-stagger max-w-2xl">
 		@settingsSystemCard(p)
+		@settingsDefaultUICard(p)
 	</div>
 }
 
@@ -257,6 +258,42 @@ templ settingsSystemCard(p SettingsProps) {
 			<div><span class="text-base-content/40">Uptime</span> <span class="font-medium">{ p.Uptime }</span></div>
 			<div><span class="text-base-content/40">Providers</span> <span class="font-medium">{ fmt.Sprintf("%d configured", p.ProviderCount) }</span></div>
 		</div>
+	</div>
+}
+
+// settingsDefaultUICard renders the "Default landing UI" toggle on the
+// System tab. Transitional — the v1 admin is on track for retirement and
+// this lets a household flip `/` to the v2 SPA in the meantime.
+templ settingsDefaultUICard(p SettingsProps) {
+	<div class="bb-card p-5">
+		<div class="bb-icon-header">
+			<div class="bb-icon-header__tile bg-base-200/60">
+				<i data-lucide="layout-dashboard" class="w-4 h-4 text-base-content/60"></i>
+			</div>
+			<div class="bb-icon-header__text">
+				<h2 class="text-sm font-semibold">Default landing UI</h2>
+				<p class="text-xs text-base-content/45">Where signing in (or visiting <code>/</code>) lands you</p>
+			</div>
+		</div>
+		<form method="POST" action="/settings/v2-default" class="mt-1">
+			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+			<label class="flex items-start gap-3 p-3 rounded-xl bg-base-200/40 cursor-pointer">
+				if p.V2Default {
+					<input type="checkbox" name="v2_default" class="toggle toggle-sm toggle-primary mt-0.5" checked/>
+				} else {
+					<input type="checkbox" name="v2_default" class="toggle toggle-sm toggle-primary mt-0.5"/>
+				}
+				<div class="flex-1 min-w-0">
+					<div class="text-sm font-medium">Use the v2 dashboard at <code>/</code></div>
+					<p class="text-xs text-base-content/50 mt-0.5">
+						When on, visiting the root redirects to <code>/v2/</code>. The v1 admin pages remain reachable at their existing paths during the transition.
+					</p>
+				</div>
+			</label>
+			<div class="mt-4">
+				<button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Default UI</button>
+			</div>
+		</form>
 	</div>
 }
 

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -16,6 +16,7 @@ type SettingsProps struct {
 	ProviderCount        int
 	HasEncryptionKey     bool
 	OnboardingDismissed  bool
+	V2Default            bool
 	NextSyncTime         string
 	// ConfigSources maps config keys to their source: "env", "db", or "default".
 	ConfigSources map[string]string


### PR DESCRIPTION
## Summary

Adds an opt-in app-config toggle so a household can land at the v2 SPA from the v1 admin root (`/`) ahead of the broader v1 retirement. Default behaviour is unchanged.

- **New `v2_default` `app_config` key** — `appconfig.KeyV2Default`. Off by default; when `"true"`, `admin.FeedHandler` returns a 303 to `/v2/` after the existing onboarding gate.
- **Settings → System tab** gains a "Default landing UI" card with a `toggle` checkbox posting to `POST /settings/v2-default` (CSRF-guarded, admin-only, registered alongside `/settings/sync` and `/settings/retention`).
- Onboarding still wins — if `onboarding_dismissed` is false, `/` keeps redirecting to `/getting-started` regardless of `v2_default`, so first-run is untouched.
- Every other v1 admin path (`/transactions`, `/connections`, `/settings/*`, etc.) keeps working; only `/` flips. This is deliberate — v2 doesn't cover every surface yet, and we still want deep links to resolve.

Tracked under #1313 (full v1 admin retirement).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/admin/... ./internal/appconfig/... ./internal/templates/...`
- [ ] **Browser screenshot of the new toggle is not attached** — this worktree didn't have a dev server set up (no ENCRYPTION_KEY accessible from the sandbox) and the change is small + additive (reuses the `bb-card` / `bb-icon-header` / form pattern from the adjacent `settingsSystemCard`). Reviewer should sanity-check the toggle on the System tab after pulling.
- [ ] Manual: toggle on → visit `/` → land on `/v2/`. Toggle off → `/` renders v1 feed again. First-run (`onboarding_dismissed=false`) still routes to `/getting-started` either way.