### PR TITLE
fix(v2): close mobile sidebar on nav tap

### DIFF
--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -5,6 +5,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { Eyebrow } from "@/components/eyebrow";
 import { isNavMatch, navKey, type NavGroup, type NavLeaf } from "@/lib/nav";
@@ -15,6 +16,13 @@ export function NavMain({ group }: { group: NavGroup }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const navigate = useNavigate();
   const { key: activeModal } = useActiveModal();
+  // Close the mobile sheet on tap so the destination is visible — matches the
+  // behaviour of every native iOS app where a nav tap dismisses the drawer.
+  // Desktop is unaffected because we only touch the mobile-only open state.
+  const { isMobile, setOpenMobile } = useSidebar();
+  const closeMobileSheet = () => {
+    if (isMobile) setOpenMobile(false);
+  };
 
   return (
     <SidebarGroup>
@@ -30,9 +38,11 @@ export function NavMain({ group }: { group: NavGroup }) {
             item={item}
             pathname={pathname}
             activeModal={activeModal}
-            onOpenModal={(modalKey) =>
-              navigate({ to: ".", search: openModal(modalKey) })
-            }
+            onOpenModal={(modalKey) => {
+              closeMobileSheet();
+              navigate({ to: ".", search: openModal(modalKey) });
+            }}
+            onNavigate={closeMobileSheet}
           />
         ))}
       </SidebarMenu>
@@ -68,9 +78,16 @@ interface NavRowProps {
   pathname: string;
   activeModal: string | null;
   onOpenModal: (modalKey: string) => void;
+  onNavigate: () => void;
 }
 
-function NavRow({ item, pathname, activeModal, onOpenModal }: NavRowProps) {
+function NavRow({
+  item,
+  pathname,
+  activeModal,
+  onOpenModal,
+  onNavigate,
+}: NavRowProps) {
   const Icon = item.icon;
 
   if (item.kind === "modal") {
@@ -97,7 +114,11 @@ function NavRow({ item, pathname, activeModal, onOpenModal }: NavRowProps) {
         tooltip={item.title}
         className={NAV_ROW_CLS}
       >
-        <Link to={item.to}>
+        {/* onClick lives on the <Link> directly: asChild forwards props via
+            Radix Slot, but attaching here is the unambiguous, easy-to-audit
+            shape and also fires when the user middle/cmd-clicks. The handler
+            is a no-op on desktop — it only closes the mobile sheet. */}
+        <Link to={item.to} onClick={onNavigate}>
           <Icon />
           <span>{item.title}</span>
         </Link>

--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -141,9 +141,14 @@ function ThemeSubmenu() {
 }
 
 export function NavUser({ me }: { me: Me | null }) {
-  const { isMobile } = useSidebar();
+  const { isMobile, setOpenMobile } = useSidebar();
   const navigate = useNavigate();
   const logout = useLogout();
+  // Mirrors NavMain: tapping a nav target on mobile should dismiss the sheet so
+  // the destination is visible. Desktop is untouched.
+  const closeMobileSheet = () => {
+    if (isMobile) setOpenMobile(false);
+  };
 
   const onLogout = async () => {
     try {
@@ -153,6 +158,7 @@ export function NavUser({ me }: { me: Me | null }) {
       // gone client-side; surface a toast but don't block navigation.
       toast.error("Couldn't reach the server — signing out anyway.");
     }
+    closeMobileSheet();
     navigate({ to: "/login" });
   };
 
@@ -255,7 +261,7 @@ export function NavUser({ me }: { me: Me | null }) {
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem asChild className="gap-2">
-                <Link to="/sandbox">
+                <Link to="/sandbox" onClick={closeMobileSheet}>
                   <Palette className="text-muted-foreground" />
                   Design system
                 </Link>


### PR DESCRIPTION
## Summary

Closes MOBILE-1. Tapping a sidebar nav item on a narrow viewport now closes the mobile sheet, exposing the destination page — matches native iOS behaviour. Desktop sidebar collapse/expand is untouched.

Implementation: `NavMain` and `NavUser` consume `useSidebar()` and call `setOpenMobile(false)` (gated on `isMobile`) inside the click handler. The link branch attaches `onClick` directly to `<Link>` instead of relying on `asChild` prop forwarding through `SidebarMenuButton` — unambiguous and easier to audit. The shadcn primitive in `components/ui/sidebar.tsx` is untouched.

## Mobile evidence

Composite shows desktop / tablet / mobile at the same instant. Mobile frame is captured **right after tapping "Transactions" inside the open sheet at /v2/home** — destination is visible and the sheet has dismissed.

<img src="https://i.img402.dev/5hsuh9k38r.jpg" width="900" alt="mobile sidebar closes on nav tap — after">

## Test plan

- [x] `cd web && bun run lint` clean
- [x] Mobile (390×844): opened sidebar at /v2/home, tapped Transactions → sheet closed, /v2/transactions visible
- [x] Desktop (1280×800): sidebar persistently shown; collapse/expand state unchanged by the new hook (only `setOpenMobile` fires, gated on `isMobile`)
- [x] Tablet (768×1024): sidebar persistently shown
- [ ] Real iOS Safari smoke (Ricardo to verify on device)
