### PR TITLE
fix(agents): install libstdc++/libgcc in runtime, persist runner errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,11 @@ FROM alpine:3.21
 # postgresql16-client: required by the /backups page for pg_dump and psql.
 #   Must match the server major version (postgres:16-alpine in compose) —
 #   pg_dump refuses to dump a newer server.
-RUN apk --no-cache add ca-certificates tzdata postgresql16-client
+# libstdc++, libgcc: required by the Bun-compiled breadbox-agent sidecar.
+#   Even with --target=bun-linux-*-musl the resulting binary dynamically
+#   links libstdc++.so.6 and libgcc_s.so.1, which aren't in alpine base.
+#   Without these, the sidecar exits 127 and every agent run fails.
+RUN apk --no-cache add ca-certificates tzdata postgresql16-client libstdc++ libgcc
 
 WORKDIR /app
 COPY --from=builder /breadbox /app/breadbox

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -40,7 +40,8 @@ SET status                = $2,
     max_turns_used        = $10,
     num_tool_calls        = $11,
     transcript_path       = $12,
-    session_id            = $13
+    session_id            = $13,
+    error_message         = $14
 WHERE id = $1
 RETURNING *;
 

--- a/internal/service/agent_error_message_test.go
+++ b/internal/service/agent_error_message_test.go
@@ -1,0 +1,113 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/service"
+)
+
+// TestOrchestratorRunNow_PersistsErrorMessage pins the iter-34 bug: when
+// the runner returned a non-nil error (sidecar crash, scanner failure,
+// etc.), result.Err was populated but CompleteAgentRunDB didn't pass it
+// into agent_runs.error_message. The DB row showed status='error' with
+// NO error_message, leaving operators staring at a failed run with no
+// indication of *why* and forcing them to grep container logs.
+//
+// On a real Docker deploy this manifested as the breadbox-agent musl
+// binary failing to load libstdc++ — a clear "exit 127, missing library"
+// signal in stderr that never made it to the UI because the column
+// stayed NULL.
+func TestOrchestratorRunNow_PersistsErrorMessage(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+
+	def, err := svc.CreateAgentDefinition(context.Background(), service.CreateAgentDefinitionParams{
+		Name:         "orch-err-msg",
+		Slug:         "orch-err-msg",
+		Prompt:       "error message persistence regression test prompt — must exceed validation length so padding lives here.",
+		ToolScope:    "read_only",
+		AllowedTools: []string{},
+		Model:        "claude-haiku-4-5",
+		MaxTurns:     10,
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	const errText = "agent: sidecar exited non-zero: exit=exit status 127 stderr=Error loading shared library libstdc++.so.6"
+	runner := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		e := errors.New(errText)
+		return agent.RunResult{
+			Status:     agent.StatusError,
+			Err:        e,
+			DurationMs: 5,
+		}, e
+	})
+
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+	runResp, _ := orch.RunNow(context.Background(), def, "")
+	if runResp == nil {
+		t.Fatalf("RunNow returned nil run response")
+	}
+
+	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if persisted.Status != "error" {
+		t.Fatalf("Status = %q, want %q", persisted.Status, "error")
+	}
+	if persisted.ErrorMessage == nil {
+		t.Fatalf("ErrorMessage = nil, want runner error text (regression: orchestrator must persist result.Err to agent_runs.error_message)")
+	}
+	if !strings.Contains(*persisted.ErrorMessage, "libstdc++") {
+		t.Errorf("ErrorMessage = %q, want it to contain runner error text", *persisted.ErrorMessage)
+	}
+}
+
+// TestOrchestratorRunNow_SuccessLeavesErrorMessageEmpty guards the other
+// direction: a clean success must not paint error_message with stale
+// text from a prior code path.
+func TestOrchestratorRunNow_SuccessLeavesErrorMessageEmpty(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+
+	def, err := svc.CreateAgentDefinition(context.Background(), service.CreateAgentDefinitionParams{
+		Name:         "orch-err-msg-ok",
+		Slug:         "orch-err-msg-ok",
+		Prompt:       "success path error_message guard — must exceed validation length so this padding is here.",
+		ToolScope:    "read_only",
+		AllowedTools: []string{},
+		Model:        "claude-haiku-4-5",
+		MaxTurns:     10,
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	runner := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{Status: agent.StatusSuccess, TurnCount: 1, DurationMs: 5}, nil
+	})
+
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+	runResp, err := orch.RunNow(context.Background(), def, "")
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if persisted.ErrorMessage != nil {
+		t.Errorf("ErrorMessage = %q, want nil on success", *persisted.ErrorMessage)
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -961,8 +961,16 @@ func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, ca
 // turn_count, which made every run look like a max-turns hit. The cap
 // itself never changes mid-run, so the orchestrator captures it
 // from def.MaxTurns at run-start and passes it through here.
+//
+// When result.Err is non-nil (status="error" or "timeout"), its message
+// is truncated and persisted to error_message so the transcript drawer
+// can show the operator *why* the run failed without grepping logs.
+// Sidecar crashes (e.g. exit 127) attach full stderr to result.Err,
+// which can easily reach several KB — capped at runErrorMessageMax to
+// keep the column readable in the UI and bounded in size.
 func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult, maxTurnsCap int) (db.AgentRun, error) {
 	costPtr := result.TotalCostUSD
+	errMsg := truncateRunError(result.Err)
 	return s.Queries.CompleteAgentRun(ctx, db.CompleteAgentRunParams{
 		ID:                  runID,
 		Status:              result.Status,
@@ -977,7 +985,26 @@ func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, res
 		NumToolCalls:        pgtype.Int4{Int32: int32(result.NumToolCalls), Valid: true},
 		TranscriptPath:      pgtype.Text{String: result.TranscriptPath, Valid: result.TranscriptPath != ""},
 		SessionID:           pgtype.Text{String: result.SessionID, Valid: result.SessionID != ""},
+		ErrorMessage:        pgtype.Text{String: errMsg, Valid: errMsg != ""},
 	})
+}
+
+// runErrorMessageMax bounds the persisted error_message length. Sidecar
+// stderr can be very long (musl-vs-glibc relocation dumps run into the
+// thousands of lines); the UI shows this verbatim in a scrollable pre,
+// so a few KB is enough for the operator to identify the failure mode
+// and grep server logs for the rest.
+const runErrorMessageMax = 4000
+
+func truncateRunError(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	if len(s) > runErrorMessageMax {
+		return s[:runErrorMessageMax] + "\n…(truncated; see server logs)"
+	}
+	return s
 }
 
 // AgentRunFromRow is exported so the orchestrator (same package) can build

--- a/web/src/features/agents/transcript-sheet.tsx
+++ b/web/src/features/agents/transcript-sheet.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, Loader2, Sparkles, StickyNote } from "lucide-react";
+import {
+  AlertTriangle,
+  Loader2,
+  Sparkles,
+  StickyNote,
+  XCircle,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -48,6 +54,10 @@ export function TranscriptSheet({ shortId, onClose }: TranscriptSheetProps) {
           </SheetDescription>
         </SheetHeader>
         <div className="flex-1 overflow-y-auto px-6 py-4">
+          {runDetail.data?.status === "error" &&
+            runDetail.data?.error_message && (
+              <RunErrorBlock message={runDetail.data.error_message} />
+            )}
           {runDetail.data?.prompt_prefix && (
             <PromptPrefixBlock prefix={runDetail.data.prompt_prefix} />
           )}
@@ -165,6 +175,25 @@ function OperatorNoteEditor({
           {draft === "" && storedNote !== "" ? "Clear note" : "Save note"}
         </Button>
       </div>
+    </div>
+  );
+}
+
+// RunErrorBlock surfaces the orchestrator's error_message at the top of
+// the transcript sheet for failed runs. Without this, a run shows up with
+// status=error but no human-readable reason — the operator has to grep
+// container logs to find out what happened (e.g. a sidecar crash before
+// any transcript events were emitted).
+function RunErrorBlock({ message }: { message: string }) {
+  return (
+    <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+      <div className="text-destructive mb-1 inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide">
+        <XCircle className="size-3.5" />
+        Run error
+      </div>
+      <pre className="text-foreground/90 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+        {message}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Production agent runs were silently failing the moment the sidecar launched. Three stacked bugs made the failure both invisible and intermittent-looking — the operator saw a red status pill, no message, and an empty transcript drawer.

Filed after debugging run `gVDs3eIZ` on `breadbox.exe.xyz`, where the container logs revealed the underlying chain but the v2 SPA showed nothing actionable.

## Root cause — Dockerfile runtime image missing libstdc++/libgcc

Stage 1b builds the sidecar with Bun's `--target=bun-linux-*-musl`, but the resulting binary still **dynamically** links `libstdc++.so.6` and `libgcc_s.so.1`. Stage 2 (Go builder) installs them; Stage 3 (runtime, the image we actually ship) only installed `ca-certificates tzdata postgresql16-client`.

Symptom:

```
agent: sidecar exited non-zero: exit=exit status 127
stderr=Error loading shared library libstdc++.so.6: No such file or directory
Error loading shared library libgcc_s.so.1: No such file or directory
Error relocating /usr/local/bin/breadbox-agent: __cxa_guard_acquire: symbol not found
…(dozens more relocation errors)
```

Fix: add `libstdc++ libgcc` to the runtime stage's `apk add`.

## Bug #2 — orchestrator dropped `result.Err`

`Sidecar.Run` populates `result.Err` on every failure path (crash, scanner blowup, ctx cancel, budget exceeded). The orchestrator passes `result` into `CompleteAgentRunDB`, but `CompleteAgentRun` had no `error_message` parameter. So a failed run wrote `status='error'` with `error_message=NULL` — leaving the operator no breadcrumb without grepping container logs.

- `CompleteAgentRun` SQL now accepts `$14 error_message`
- `CompleteAgentRunDB` truncates `result.Err.Error()` to 4 KB (musl relocation dumps run several KB) and writes it through

## Bug #3 — UI never rendered `error_message`

The `error_message` field was typed in `web/src/api/queries/agents.ts` but no component displayed it. `TranscriptSheet` showed the status pill, the prompt prefix, the operator note, and the transcript — nothing about *why* the run failed. Added `RunErrorBlock` at the top of failed runs.

## Files changed

- `Dockerfile` — runtime apk add gains `libstdc++ libgcc` (root cause)
- `internal/db/queries/agent_runs.sql` — `CompleteAgentRun` now sets `error_message`
- `internal/service/agents.go` — pass `result.Err` through with 4 KB cap
- `internal/service/agent_error_message_test.go` — regression tests for both persist + no-bleed-on-success
- `web/src/features/agents/transcript-sheet.tsx` — surface `error_message` in the drawer

## Test plan

- [x] `go test -tags integration -count=1 -run 'Agent|Orchestrator' ./internal/service/` — all pass
- [x] `go test -tags integration -count=1 ./internal/db/` — pass
- [x] `bun run lint` + `bun run build` — pass
- [ ] After merge: redeploy `breadbox.exe.xyz` and re-fire `routine-review` manually; expect status=success with `breadbox-agent --version` resolving cleanly inside the container
- [ ] If for any reason the sidecar still fails: confirm the UI now shows the error message in the transcript drawer instead of leaving it blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)