### PR TITLE
fix(v2): keep popovers/menus/dropdowns onscreen on mobile

### DIFF
--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -32,6 +32,7 @@ function DropdownMenuTrigger({
 function DropdownMenuContent({
   className,
   sideOffset = 4,
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
@@ -39,8 +40,9 @@ function DropdownMenuContent({
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-[min(60vh,var(--radix-dropdown-menu-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -19,6 +19,7 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -27,8 +28,9 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 w-72 max-w-[calc(100vw-1rem)] origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -59,6 +59,7 @@ function SelectContent({
   children,
   position = "item-aligned",
   align = "center",
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -66,13 +67,14 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-[min(60vh,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
         )}
         position={position}
         align={align}
+        collisionPadding={collisionPadding}
         {...props}
       >
         <SelectScrollUpButton />


### PR DESCRIPTION
## Summary

Fixes the family of "menus render offscreen on mobile" bugs (MOBILE-2/3/4) by adding viewport-aware defaults to the three Radix `Content` primitives that float over the page: `Popover`, `Select`, and `DropdownMenu`. All three now ship with:

- `collisionPadding={8}` so Radix keeps the panel >= 8px from every viewport edge.
- `max-w-[calc(100vw-1rem)]` so the panel never exceeds the viewport width on a 375px iPhone.
- `max-h-[min(60vh,var(--radix-*-content-available-height))]` on `SelectContent` and `DropdownMenuContent` so long menus cap at 60vh on mobile instead of running off the bottom.

`PopoverContent` keeps its `w-72` default; the new `max-w` clamps the rendered width on narrow viewports without touching the desktop sizing.

## Fix path: ui/* tweak (over wrapper sweep)

The brief allows either wrapping each primitive (preferred) or making narrow tweaks to `web/src/components/ui/*` (alternative). I went with the ui/* tweak based on the size + nature of the change:

- **Sweep would touch 34 files.** `grep -rln "PopoverContent\|SelectContent\|DropdownMenuContent" web/src/ | wc -l` returns 34 — well above the 15-site threshold the brief sets for "do the wrapper sweep". A wrapper sweep across 34 call sites would dwarf the actual bug fix.
- **The change is semantic-behavior, not styling.** `collisionPadding` is a Radix-native viewport-collision concern (positioning, not appearance), and `max-w-[calc(100vw-1rem)]` is a viewport-safety hard stop (the design never wanted a popover wider than the screen). This matches upstream shadcn intent for mobile and is the kind of "fix the wrong default" change that's appropriate in `ui/*` — not a custom style fork.
- **Per-primitive props remain overridable.** All three Content components accept the new props as defaults via destructuring (e.g. `collisionPadding = 8`), so any call site that needs different padding/clamp still wins.

No sandbox specimen change — the new defaults are already exercised by the existing `Popover`/`Select`/`Dropdown`/`RowActionsMenu` specimens in `web/src/sandbox/sections/primitives.tsx` and `components.tsx` (see right-edge proof below).

## Mobile evidence (375x812 iPhone SE)

All shots captured against the embedded SPA via Playwright (Vite dev proxying to the Go backend on :8082). The opened menus stay inside the viewport with a visible gap to the edge.

### Sandbox primitives — Popover, Select, Dropdown all open at 375px

<table>
  <tr>
    <th>Popover</th><th>Select</th><th>Dropdown</th>
  </tr>
  <tr>
    <td><img src="https://i.img402.dev/9ni9uufajg.jpg" width="260" alt="popover open mobile"></td>
    <td><img src="https://i.img402.dev/6im8q0s5pn.jpg" width="260" alt="select open mobile"></td>
    <td><img src="https://i.img402.dev/wa76ia17uu.jpg" width="260" alt="dropdown open mobile"></td>
  </tr>
</table>

### Right-edge proof — RowActionsMenu kebab triggered from the rightmost edge of the card

The kebab triggers in the `RowActionsMenu` specimen sit flush against the right edge of their parent cards inside the 375px viewport. Before the fix, the dropdown clipped the right edge or wrapped weirdly; after the fix it flips left and respects the 8px collision padding.

<img src="https://i.img402.dev/mk0ylhefmh.jpg" width="320" alt="row-actions dropdown opened from right edge of a card at 375px — stays onscreen with 8px collision padding">

### Real /v2/transactions — toolbar filter Popover + Sort DropdownMenu

<table>
  <tr>
    <th>Status filter (popover)</th><th>Sort (dropdown)</th>
  </tr>
  <tr>
    <td><img src="https://i.img402.dev/jpb7p66rri.jpg" width="320" alt="status filter popover open on transactions page mobile"></td>
    <td><img src="https://i.img402.dev/a5o31a1ac2.jpg" width="320" alt="sort dropdown open on transactions page mobile"></td>
  </tr>
</table>

### Tablet (768x1024) + Desktop (1280x800) reference — no regression

<table>
  <tr><th>Tablet</th><th>Desktop</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/nxykhyl9aq.jpg" width="400" alt="popover open tablet"></td>
    <td><img src="https://i.img402.dev/yahapgr5vf.jpg" width="400" alt="popover open desktop"></td>
  </tr>
</table>

## Test plan

- [x] `cd web && bun run lint` clean (`tsc -b --noEmit`).
- [x] `cd web && bun run build` clean (TypeScript build + Vite production bundle).
- [x] Visual: Popover, Select, DropdownMenu open at 375x812 and stay inside the viewport with >= 8px gap to every edge.
- [x] Visual: RowActionsMenu kebab opened from the right edge of a card flips/clamps to stay onscreen.
- [x] Visual: `/v2/transactions` filter Popover + Sort DropdownMenu open onscreen at 375x812.
- [x] Visual: Tablet (768x1024) and desktop (1280x800) renders unchanged — `max-w-[calc(100vw-1rem)]` is a clamp, not a target size.
- [ ] Reviewer to spot-check on a real iOS Safari device (the dvh viewport quirks the sprint references).

## Scope

Three files only: `web/src/components/ui/popover.tsx`, `select.tsx`, `dropdown-menu.tsx`. No call sites touched; no v1 admin code touched; no unrelated styling tweaks.
