### PR TITLE
fix(v2): respect iOS safe-area insets on viewport, sticky header, and sheets

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover activates env(safe-area-inset-*) on edge-to-edge
+         iOS devices (notch / Dynamic Island / home indicator). Without it,
+         the insets resolve to 0 and the browser chrome eats into content.
+         We deliberately do NOT set user-scalable=no or maximum-scale=1 —
+         both block accessibility zoom on iOS. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <title>Breadbox — Self-hosted finance for households</title>
     <meta

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -60,15 +60,22 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
+          // Each side pads its edge-touching axes from env(safe-area-inset-*)
+          // so the sheet never sits under the iPhone notch / Dynamic Island /
+          // home indicator on edge-to-edge devices. Left/right sheets always
+          // touch top + bottom edges, so they also need pt/pb insets. Browsers
+          // that don't expose safe-area resolve env(...) to 0 — graceful
+          // degradation, no fallback needed. Justification (semantic
+          // correctness, not styling): safe-area is a viewport-edge concern.
           "fixed z-50 flex flex-col gap-4 bg-background shadow-lg duration-200 transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in",
           side === "right" &&
-            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            "inset-y-0 right-0 h-full w-3/4 border-l pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&
-            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+            "inset-y-0 left-0 h-full w-3/4 border-r pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
           side === "top" &&
-            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+            "inset-x-0 top-0 h-auto border-b pt-[env(safe-area-inset-top)] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&
-            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            "inset-x-0 bottom-0 h-auto border-t pb-[env(safe-area-inset-bottom)] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
           className
         )}
         {...props}

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -197,7 +197,17 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          {/* Safe-area: SheetContent has `p-0` here (sidebar needs a flush
+              layout) which would otherwise clobber the sheet primitive's own
+              env(safe-area-inset-*) padding. Re-apply the insets on the inner
+              column so the BrandHeader clears the notch and NavUser clears
+              the home indicator on edge-to-edge iPhones. Values resolve to 0
+              elsewhere — non-iPhone layouts unchanged. Semantic correctness
+              concern (viewport-edge), not styling — same justification as
+              the sheet.tsx edit shipping in the same PR. */}
+          <div className="flex h-full w-full flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+            {children}
+          </div>
         </SheetContent>
       </Sheet>
     )

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -136,7 +136,15 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
           horizontally-scrolling table) grows the inset past the viewport
           instead of letting the page's own overflow container scroll. */}
       <SidebarInset className="min-w-0">
-        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex h-14 shrink-0 items-center gap-2 border-b backdrop-blur">
+        {/* pt-[env(safe-area-inset-top)] pairs with viewport-fit=cover in
+            web/index.html so the sticky header clears the iPhone notch /
+            Dynamic Island instead of letting the status bar overlap its
+            contents. Switching the fixed `h-14` to `min-h-14` lets the
+            header grow by the inset on edge-to-edge iPhones (otherwise
+            border-box squeezes the 56px interactive area). The inset
+            resolves to 0 elsewhere (desktop, Android, older iOS), so
+            non-iPhone layouts are unchanged. */}
+        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex min-h-14 shrink-0 items-center gap-2 border-b pt-[env(safe-area-inset-top)] backdrop-blur">
           <div className="flex w-full items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-1 h-4" />


### PR DESCRIPTION
## Summary

Bundles MOBILE-7 and MOBILE-9: makes the v2 SPA safe-area-aware on edge-to-edge iOS devices (iPhone 14 Pro / 15 / 16). These two are coherent — enabling `viewport-fit=cover` without padding for it creates new ugliness (content under the notch); padding for safe-area without enabling `viewport-fit=cover` is a no-op (insets resolve to 0). Shipping them together.

### Files changed
- **`web/index.html`** — add `viewport-fit=cover` to the viewport meta. This is the gate that activates `env(safe-area-inset-*)` on iOS. Deliberately did NOT add `user-scalable=no` / `maximum-scale=1` (both block accessibility zoom).
- **`web/src/routes/__root.tsx`** — sticky header gets `pt-[env(safe-area-inset-top)]`. Switched the fixed `h-14` to `min-h-14` so the inset adds to the header instead of squeezing its 56px interactive area (border-box).
- **`web/src/components/ui/sheet.tsx`** — `SheetContent` pads each viewport-touching edge with its matching `env(safe-area-inset-*)`. Left/right sheets always touch top + bottom too, so they get `pt` + `pb` insets as well.
- **`web/src/components/ui/sidebar.tsx`** — re-apply top/bottom insets on the mobile sheet's inner column. The mobile sidebar passes `p-0` to `SheetContent` (it needs a flush layout), which clobbers the sheet primitive's own safe-area padding via `tailwind-merge`. Applying the insets on the inner `<div>` survives the `p-0` override so `BrandHeader` clears the notch and `NavUser` clears the home indicator.

### `ui/*` edit justification
Same path as #1316 / #1317: `ui/*` edits are acceptable when they're a semantic correctness concern, not styling. Safe-area is a viewport-edge concern, not a visual one — `env(safe-area-inset-*)` resolves to 0 on every browser that doesn't expose it (desktop, Android, older iOS, dev Chromium), so non-iPhone layouts are byte-for-byte unchanged.

### Out of scope
- **MOBILE-10** (`selection-action-bar` `100vw`) — separate PR per sprint plan.
- Sheet `SheetPrimitive.Close` (X button) — uses absolute positioning relative to the padding box, so it sits under the notch on top/right sheets. The mobile sidebar hides this button (`[&>button]:hidden`), so it's not an immediate practical issue. Left for a follow-up.

## Evidence

Captured against a Chromium iPhone-15-Pro context with a CSS shim that overrides `env(safe-area-inset-*)` to the device's real inset values (top=59, bottom=34) and overlays the inset zones in red so the safe-area effect is visible in the screenshot. On real iOS the values come from the OS — same mechanism.

### iPhone 15 Pro — home page (sticky header below notch)

`SidebarTrigger`, breadcrumb, and search pill all sit cleanly below the red notch zone. The page content scrolls under the bottom red zone (expected — only the sticky header needs an inset; scroll content goes edge-to-edge by design).

<img src="https://i.img402.dev/nmjrc8so9w.jpg" width="320" alt="iPhone 15 Pro — sticky header below simulated notch">

### iPhone 15 Pro — mobile sidebar Sheet open

`BrandHeader` sits below the notch, `NavUser` (admin row) sits above the home indicator. Before this PR, the brand mark was under the notch and the user row was hidden behind the home indicator.

<img src="https://i.img402.dev/0gvmnovj4y.jpg" width="320" alt="iPhone 15 Pro — mobile sidebar Sheet with BrandHeader below notch and NavUser above home indicator">

### Desktop / tablet / mobile-Chromium — no regression

Standard `simple-validate-ui` composite. No browser here exposes safe-area insets, so the layout is byte-for-byte identical to `sprint/mobile-ios-safari` HEAD.

<img src="https://i.img402.dev/b9kzeg89vd.jpg" width="800" alt="Desktop 1280x800 / tablet 768x1024 / mobile 390x844 — non-iPhone layouts unchanged">

## Test plan

- [x] `cd web && bun run lint` — clean
- [x] `cd web && bun run build` — clean
- [x] Chromium iPhone-15-Pro emulation with safe-area shim: sticky header clears notch, sheet `BrandHeader` clears notch, sheet `NavUser` clears home indicator
- [x] Non-iPhone composite (desktop/tablet/mobile): unchanged
- [ ] Real iPhone smoke test (notch + home indicator) — recommend before merge if reviewer has device handy
