### PR TITLE
fix(v2): show scroll affordance on horizontally-clipped tables

### DIFF
--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -10,7 +10,16 @@ function Table({
   return (
     <div
       data-slot="table-container"
-      className={cn("relative w-full overflow-x-auto", containerClassName)}
+      className={cn(
+        // `scroll-shadow-x` (globals.css) layers a CSS-only gradient fade
+        // on each edge so a clipped table signals its scrollability on
+        // narrow viewports — without it iOS users see a flat right edge
+        // and assume the table is broken. `-webkit-overflow-scrolling:touch`
+        // is the implicit default on iOS 13+ but explicit beats implicit
+        // when this wrapper sits inside several nested scroll contexts.
+        "relative w-full overflow-x-auto scroll-shadow-x [-webkit-overflow-scrolling:touch]",
+        containerClassName,
+      )}
     >
       <table
         data-slot="table"

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -153,3 +153,28 @@
 [data-slot="button"] {
   cursor: default;
 }
+
+/* Scroll-shadow indicator for horizontally-scrolling containers (used by
+   the Table primitive). Four layered backgrounds: two solid "cover" fades
+   that mask the shadow at the start/end (anchored to the local content
+   with `background-attachment: local` so they shrink as you scroll into
+   them), and two shadow gradients pinned to the viewport edges with
+   `scroll` so they fade in once the cover has scrolled away. Pure CSS,
+   no JS listener. Color uses --card so the cover blends with the
+   surrounding card surface; shadow color is themed for both modes so it
+   remains visible against the dark card. */
+.scroll-shadow-x {
+  --scroll-shadow-cover: var(--card);
+  --scroll-shadow-color: rgb(0 0 0 / 0.1);
+  background:
+    linear-gradient(to right, var(--scroll-shadow-cover) 30%, transparent),
+    linear-gradient(to right, transparent, var(--scroll-shadow-cover) 70%) 100% 0,
+    linear-gradient(to right, var(--scroll-shadow-color), transparent),
+    linear-gradient(to left, var(--scroll-shadow-color), transparent) 100% 0;
+  background-repeat: no-repeat;
+  background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+.dark .scroll-shadow-x {
+  --scroll-shadow-color: rgb(0 0 0 / 0.35);
+}


### PR DESCRIPTION
## Why

Mobile users see clipped tables and assume they're broken — the v2 SPA wraps `<table>` in `overflow-x-auto` but renders no affordance signaling "more content scrolls offscreen." On iOS Safari specifically the right edge sits flat against the card border with no fade.

This PR adds the canonical CSS-only scroll-shadow pattern to the `Table` primitive's wrapper, plus an explicit `-webkit-overflow-scrolling:touch` belt for nested-scroller momentum on iOS (the default on iOS 13+, but belt-and-suspenders given the wrapper sits inside several other scroll contexts).

## Approach

Two layered backgrounds per side:

- **Cover gradient** (40px, anchored to local content via `background-attachment: local`) — solid `--card` that masks the shadow when there's nothing to scroll into. As you scroll into it, it scrolls with the content and uncovers the shadow.
- **Shadow gradient** (14px, anchored to viewport via `background-attachment: scroll`) — subtle dark-to-transparent that signals "more content this way." Themed via `--scroll-shadow-color` so it stays visible in both light (`rgb(0 0 0 / 0.10)`) and dark (`rgb(0 0 0 / 0.35)`) modes against the card surface.

No JS scroll listener, no `IntersectionObserver`, no re-render. Pure CSS.

## Changes

- `web/src/globals.css` — add `.scroll-shadow-x` utility (15 lines of CSS + 10 lines of comment) and dark-mode override.
- `web/src/components/ui/table.tsx` — apply `scroll-shadow-x` and `[-webkit-overflow-scrolling:touch]` to the container div.

## Touching `components/ui/*`

Same justification path as #1316, #1317, #1318 — scroll affordance is a semantic UX-correctness concern, not styling. The shadcn `Table` primitive ships the `overflow-x-auto` wrapper but no edge indication; we can't compose-over-the-primitive without re-implementing the wrapper. This is the right spot.

## Scope

MOBILE-11 only. The brief mentioned bundling MOBILE-10 (`100vw` → `100dvw`) and MOBILE-13 (`h-svh` → `h-dvh`) if the diff stays ≤30 LOC — the CSS utility alone is 25 lines, so kept this scoped per the brief's explicit fallback.

## Test plan

- [ ] `/v2/transactions` on mobile 375×812 — right edge of the table card shows a subtle fade indicating scrollability.
- [ ] Same page after scrolling right — fade now appears on the left edge instead.
- [ ] `/v2/transactions` on desktop — table fits, no fade visible (cover gradient masks it).
- [ ] DataTable consumers (`/v2/tags`, `/v2/api-keys`) inherit the affordance automatically via the underlying `Table` primitive.
- [ ] Dark mode — shadow remains visible against the dark card.
- [ ] iOS Safari momentum scroll feels native (subjective, real-device check).

Visual validation skipped this iteration — worktree dev server wasn't configured and per the sprint brief, push + PR is the required exit. Orchestrator can pick up screenshots in the next loop.

---

Refs MOBILE-11 in `.claude/mobile-sprint-state.md`. Related PRs: #1312, #1316, #1317, #1318.
