### PR TITLE
fix(v2): switch to dynamic viewport units on mobile-sensitive layouts

### DIFF
--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -237,7 +237,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-full w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/web/src/features/connections/selection-action-bar.tsx
+++ b/web/src/features/connections/selection-action-bar.tsx
@@ -118,7 +118,7 @@ export function SelectionActionBar({
   return (
     <>
       <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
-        <div className="bg-popover text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
+        <div className="bg-popover text-popover-foreground flex max-w-[calc(100dvw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
           <span className="text-sm font-medium whitespace-nowrap">
             {selected.length} selected
           </span>


### PR DESCRIPTION
## Summary

iOS Safari's address bar and toolbars change the actually-visible viewport over the lifetime of a single page view. Static `vw`/`vh` units measure the *largest* viewport (UI chrome collapsed), while `svh`/`svw` measure the *smallest* (chrome fully expanded). Neither matches what the user actually sees during chrome transitions — `dvw`/`dvh` and parent-relative sizing do.

Two narrow fixes:

- **MOBILE-10 — `selection-action-bar.tsx`**: `max-w-[calc(100vw-2rem)]` -> `max-w-[calc(100dvw-2rem)]`. On iOS Safari the static `100vw` exceeds the visible width while the address bar is collapsing, briefly forcing the bar past the viewport and triggering horizontal scroll. `dvw` follows the dynamic viewport.
- **MOBILE-13 — `ui/sidebar.tsx`**: desktop `sidebar-container` was `h-svh` on a `fixed inset-y-0` element. `h-svh` clamps to the *worst-case* small viewport, leaving a visible gap at the bottom when iOS chrome retracts. Since the element is already constrained by `inset-y-0` (top:0/bottom:0), `h-full` fills its container exactly — no gap, no `svh` worst-case sizing.

## ui/* justification

Same path as #1316, #1317, #1318, #1319: a `web/src/components/ui/*` edit is acceptable when narrow and semantic. Viewport-unit selection is a correctness concern, not styling — `svh` vs `full` materially changes layout behavior on iOS, and there's no theme-token lever for it.

## Validation

Captured with `simple-validate-ui` at desktop 1280×800, tablet 768×1024, mobile 390×844. The selection action bar's `dvw` vs `vw` delta only manifests during real iOS Safari address-bar transitions — at rest in headless Chromium the two are visually identical, so the connections capture below shows the page (without rows selected) confirming no regressions. The desktop sidebar capture confirms it fills full container height with no gap at the bottom.

**/v2/connections** (action bar requires selection — visual baseline only; the `dvw` math is semantically correct per MDN):

<img src="https://i.img402.dev/x9iwryqw3b.jpg" width="900" alt="/v2/connections — three viewports">

**/v2/** (sidebar fills full height at desktop, no gap at bottom):

<img src="https://i.img402.dev/h6d33yojgk.jpg" width="900" alt="/v2/ — three viewports">

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [x] Visual baseline at three viewports captured
- [ ] Real iOS Safari: address-bar collapse during scroll on connections page with rows selected — action bar stays in viewport, no horizontal scroll
- [ ] Real iOS Safari: desktop sidebar with chrome transitions — no gap at bottom
