### PR TITLE
fix(v2): wrap header actions and stack form footer on narrow mobile

### DIFF
--- a/web/src/components/form-footer.tsx
+++ b/web/src/components/form-footer.tsx
@@ -67,7 +67,7 @@ export function FormFooter({
           {hint}
         </div>
       )}
-      <div className="ml-auto flex items-center gap-2">
+      <div className="ml-auto flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center">
         {secondary}
         {primary}
       </div>

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -63,7 +63,7 @@ export function PageHeader({
         )}
       </div>
       {actions && (
-        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+        <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:flex-nowrap">{actions}</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Two shared-component mobile layout fixes for the v2 SPA mobile sprint.

- **MOBILE-16 — `PageHeader` actions overflow on mobile.** At 375px wide, pages like Categories that pass 3+ action buttons (Filter, Sort, New) produced a single non-wrapping flex row that overflowed and forced the whole page to horizontal-scroll. Switched the actions container to wrap on mobile (`flex flex-wrap`), and restored the strict one-row behavior at `≥sm` (`sm:shrink-0 sm:flex-nowrap`).

- **MOBILE-15 — `FormFooter` buttons stack awkwardly on narrow mobile.** At 375px with `Cancel` + a verbose primary like `Create category`, the buttons wrapped to two right-aligned rows, leaving a visible step. Replaced the right-side action cluster with a column layout that goes full-width and stacks primary on top of secondary at narrow widths, and restores the inline `flex-row` at `≥sm`. `flex-col-reverse` keeps the JSX order (`secondary` first, `primary` second) while putting the affirmative action visually on top — matching iOS / Material guidance. The default `align-items: stretch` on the column container makes the inline-flex Buttons fill the full container width, so tap targets become unambiguous on mobile. The `sm:justify-between` behavior with `hint` is preserved (the hint container keeps its `order-last sm:order-first` rule).

## Files

- `web/src/components/page-header.tsx`
- `web/src/components/form-footer.tsx`

Both files are in the composed-layer (`web/src/components/*`), not `web/src/components/ui/*` — no shadcn-primitive justification needed.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [ ] `/v2/categories` at mobile 375 — PageHeader actions wrap to a second line, page does not horizontal-scroll
- [ ] `/v2/category-new` (and `/v2/tag-new`) at mobile 375 — primary action sits on TOP, full-width; secondary below, full-width
- [ ] Same routes at desktop ≥1280 — header actions stay in a single row beside the title; FormFooter is inline row at the right
- [ ] A form with `hint` (e.g. CSV import) at mobile 375 — hint above the stacked button column; at desktop ≥640 the hint is left-aligned and the buttons are right-aligned
