### PR TITLE
fix(v2): surface agent settings above prompt body on mobile

### DIFF
--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -111,7 +111,7 @@ export function AgentForm({
   return (
     <Form {...form}>
       <form onSubmit={submit} className="grid grid-cols-1 gap-6 md:grid-cols-3">
-        <div className="space-y-4 md:col-span-2">
+        <div className="space-y-4 md:col-span-2 md:order-none">
           <Card className="space-y-4 p-4">
             <FormField
               control={form.control}
@@ -220,7 +220,16 @@ export function AgentForm({
           </Card>
         </div>
 
-        <div className="space-y-4">
+        {/*
+          Mobile reorder (MOBILE-14): the operational knobs card (Model,
+          Schedule, Tool scope, Allowed tools, Max turns, Budget) sits FIRST
+          on mobile so users don't scroll past the long prompt textarea to
+          reach the controls they tweak most. `order-first` only re-shuffles
+          visual position — DOM order and keyboard tab order are unchanged
+          (still Name → Slug → Prompt → … → Model → Schedule …). At md+ both
+          cards revert to source order via `md:order-none`.
+        */}
+        <div className="order-first space-y-4 md:order-none">
           <Card className="space-y-4 p-4">
             <FormField
               control={form.control}


### PR DESCRIPTION
## Summary

MOBILE-14: On screens narrower than `md` (768px) the agent edit form stacks
both cards into one column. The left card (Name, Slug, Prompt, System prompt)
holds a long-form textarea that can run to hundreds of lines, so users had to
scroll past the entire prompt body to reach the operational knobs in the
right card (Model, Schedule, Tool scope, Allowed tools, Max turns, Budget) —
exactly the controls a user is most likely to tweak.

Fix: add `order-first` to the right card and `md:order-none` to both cards
so the right (operational) card renders **first on mobile** and source order
is restored at `md+`. No DOM changes, no field reordering, no behavior
changes for create vs edit.

## Tab order

CSS `order` only changes visual position. Keyboard tab order and
screen-reader reading order still follow DOM order (Name -> Slug -> Prompt
-> ... -> Model -> Schedule -> ...). This is intentional: SR users hear the
form's logical order; only the visual layout is reshuffled for the mobile
viewport. A brief comment documents this above the right card.

## Files

- `web/src/features/agents/agent-form.tsx`

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [ ] `/v2/agents/<slug>/edit` at 375px - settings card (Model/Schedule/...) visible above basics card (Name/Prompt/...)
- [ ] Same route at >=1280px - basics card on left, settings card on right (unchanged)
- [ ] Tab order on mobile still walks Name -> Prompt -> ... -> Model -> Schedule (verify with Tab key)
