### PR TITLE
fix(v2): tighten empty-state width and add iOS momentum to error pre

### DIFF
--- a/web/src/components/empty-state.tsx
+++ b/web/src/components/empty-state.tsx
@@ -70,7 +70,7 @@ export function EmptyState({
       )}
       <h3 className="text-sm font-medium">{title}</h3>
       {description && (
-        <p className="text-muted-foreground max-w-sm text-sm">{description}</p>
+        <p className="text-muted-foreground max-w-xs text-sm">{description}</p>
       )}
       {action && <div className="mt-3">{action}</div>}
     </div>

--- a/web/src/routes/error.tsx
+++ b/web/src/routes/error.tsx
@@ -149,7 +149,7 @@ export function ErrorPage({ error, reset }: ErrorPageProps) {
               </CollapsibleTrigger>
               <CollapsibleContent>
                 <div className="px-6 pb-6 sm:px-10">
-                  <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed">
+                  <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed [-webkit-overflow-scrolling:touch]">
                     {stack}
                   </pre>
                 </div>


### PR DESCRIPTION
## Summary

Two micro-fixes for the mobile sprint:

- **MOBILE-17**: `EmptyState` description capped at `max-w-xs` (320px) instead of `max-w-sm` (384px) so it never exceeds the 375px iPhone SE viewport, even when rendered into a parent with zero horizontal padding. Reads identically on tablet+ since the cap is already narrower than the typical card.
- **MOBILE-18**: Added `[-webkit-overflow-scrolling:touch]` to the collapsible stack-trace `<pre>` on the error page. iOS 13+ defaults to momentum scrolling but explicit beats implicit, matching the `Table` pattern shipped in #1319.

No-op on Chromium/desktop; both fixes target iOS Safari edge cases.
