### PR TITLE
fix(v2): collapse transactions filter pills into a scroll rail on mobile

### DIFF
--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -215,8 +215,13 @@ export function TransactionsToolbar({
         />
 
         {/* Filter pills — grouped so they wrap as a unit, independent of
-            the sort/select controls. */}
-        <div className="flex flex-wrap items-center gap-2">
+            the sort/select controls. On <640px the row becomes a horizontal-
+            scroll rail (with the `scroll-shadow-x` fade affordance from
+            globals.css) so the toolbar stays a single row instead of
+            consuming 4+ rows on a 375px viewport. At sm+ it reverts to the
+            original `flex-wrap` behavior — at desktop widths the pills fit
+            on one row, and on intermediate widths they wrap as before. */}
+        <div className="flex items-center gap-2 max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:[-webkit-overflow-scrolling:touch] sm:flex-wrap">
           <FilterPill
             icon={Banknote}
             label="Account"

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -220,8 +220,11 @@ export function TransactionsToolbar({
             globals.css) so the toolbar stays a single row instead of
             consuming 4+ rows on a 375px viewport. At sm+ it reverts to the
             original `flex-wrap` behavior — at desktop widths the pills fit
-            on one row, and on intermediate widths they wrap as before. */}
-        <div className="flex items-center gap-2 max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:[-webkit-overflow-scrolling:touch] sm:flex-wrap">
+            on one row, and on intermediate widths they wrap as before.
+            The toolbar lives on the page surface, so override the
+            scroll-shadow cover from --card (the Table default) to
+            --background so the fade blends with the page. */}
+        <div className="flex items-center gap-2 max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:[--scroll-shadow-cover:var(--background)] max-sm:[-webkit-overflow-scrolling:touch] sm:flex-wrap">
           <FilterPill
             icon={Banknote}
             label="Account"

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -155,15 +155,18 @@
 }
 
 /* Scroll-shadow indicator for horizontally-scrolling containers (used by
-   the Table primitive). Four layered backgrounds: two solid "cover" fades
-   that mask the shadow at the start/end (anchored to the local content
-   with `background-attachment: local` so they shrink as you scroll into
-   them), and two shadow gradients pinned to the viewport edges with
-   `scroll` so they fade in once the cover has scrolled away. Pure CSS,
-   no JS listener. Color uses --card so the cover blends with the
-   surrounding card surface; shadow color is themed for both modes so it
-   remains visible against the dark card. */
-.scroll-shadow-x {
+   the Table primitive and the mobile transactions-toolbar filter rail).
+   Four layered backgrounds: two solid "cover" fades that mask the shadow
+   at the start/end (anchored to the local content with
+   `background-attachment: local` so they shrink as you scroll into them),
+   and two shadow gradients pinned to the viewport edges with `scroll` so
+   they fade in once the cover has scrolled away. Pure CSS, no JS listener.
+   Cover defaults to `--card` (matches the Table primitive, which sits
+   inside a Card); consumers on the page surface override via Tailwind's
+   arbitrary-property syntax — e.g. `[--scroll-shadow-cover:var(--background)]`.
+   Declared as `@utility` so Tailwind variants
+   (`max-sm:scroll-shadow-x`, `dark:scroll-shadow-x`) compile to real rules. */
+@utility scroll-shadow-x {
   --scroll-shadow-cover: var(--card);
   --scroll-shadow-color: rgb(0 0 0 / 0.1);
   background:


### PR DESCRIPTION
## Summary

MOBILE-20: On a 375px viewport, the transactions toolbar's filter pills wrap to 3+ rows (Account, Category, Date, Amount, Status), pushing the toolbar to 5+ rows tall and eating roughly half the viewport before the user sees a single transaction.

This change collapses the filter-pill row into a single-row horizontal-scroll rail at `<640px`, using the existing `scroll-shadow-x` utility (from #1319) for the fade affordance. At `≥640px` the row reverts to the current `flex-wrap` behavior, so tablet/desktop are visually unchanged.

- `max-sm:flex-nowrap` keeps every pill on one row at mobile widths.
- `max-sm:overflow-x-auto` lets the user swipe to reach clipped pills.
- `max-sm:scroll-shadow-x` reuses the gradient-fade utility — same affordance pattern, same theme tokens.
- `max-sm:[--scroll-shadow-cover:var(--background)]` overrides the cover from `--card` (Table primitive default) to `--background` so the fade blends with the page surface.
- `max-sm:[-webkit-overflow-scrolling:touch]` keeps iOS momentum scrolling (defensive; default on iOS 13+).
- `sm:flex-wrap` restores the previous wrap behavior at tablet/desktop.

The shadcn `<Button>` primitive already ships with `whitespace-nowrap`, so each pill's label stays on a single line by default. The Sort + Select group is intentionally outside the rail (separate concern), and the bottom "active filter chips" row (descriptive badges with an X to clear) is unchanged.

### Why globals.css changed

`.scroll-shadow-x` was a plain CSS class, which means Tailwind doesn't compile variants like `max-sm:scroll-shadow-x` for it. Converted it to `@utility scroll-shadow-x { ... }` so the variant compiles — the Table primitive's unconditional usage continues to work identically (the rule body is unchanged), and consumers on non-card surfaces can override `--scroll-shadow-cover` via arbitrary-property syntax.

## Files

- `web/src/features/transactions/transactions-toolbar.tsx`
- `web/src/globals.css`

## Evidence

**Mobile 390×844 — filter pills on a single row; "Amount" clipped on the right indicates the rail is scrollable. Sort + Select sit on their own row, unchanged.**

<img src="https://i.img402.dev/cheuoadeok.jpg" width="320" alt="transactions — mobile 390 after">

**Desktop 1280×800 — pills fit on a single row alongside Sort + Select. No regression.**

<img src="https://i.img402.dev/hziba7ds96.jpg" width="800" alt="transactions — desktop 1280 after">

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [x] `/v2/transactions` at 390px — filter pills in one row, last pill clipped to signal scrollability
- [x] `/v2/transactions` at 1280px — pills wrap as before; no visual regression
- [ ] Activate filters (Account, Category, Pending) and confirm the bottom chips row still wraps and clears as before
- [ ] iOS Safari momentum scrolling on the rail
