### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/agent/sidecar/events.ts
+++ b/agent/sidecar/events.ts
@@ -17,13 +17,10 @@ export interface SidecarEvent {
 
 // Switch stdout to blocking mode at module load. Without this, writeSync on
 // a pipe whose kernel buffer is full throws EAGAIN (Bun pipes stdout in
-// O_NONBLOCK by default). We hit this in iter-47 dogfooding: an MCP tool
-// returned ~64 KB of JSON (list_categories), writeSync wrote up to the
-// pipe boundary and then threw EAGAIN on the next call — the line got
-// truncated at byte 65538 and the subsequent error event's bytes were
-// concatenated onto the tail with no newline, producing one corrupted
-// line that dropped the tool_result and made the viewer show the call
-// as "pending" forever.
+// O_NONBLOCK by default). A ~64 KB MCP tool result (e.g. list_categories)
+// hits the pipe boundary mid-write, the next writeSync throws EAGAIN, and
+// the NDJSON line gets truncated — concatenating the next event's bytes
+// onto the tail with no newline and dropping the tool_result.
 //
 // setBlocking(true) makes writeSync block until the kernel accepts every
 // byte — the natural single-writer behavior we want for an NDJSON stream

--- a/agent/sidecar/index.ts
+++ b/agent/sidecar/index.ts
@@ -108,12 +108,10 @@ async function main() {
 
       // Normalize SDK type names to the breadbox-side contract documented in
       // internal/agent/event.go and consumed by web/src/features/agents/
-      // transcript-viewer.tsx. The SDK currently emits "assistant" /
-      // "user" for content events; iter-1's spec named these "assistant_message"
-      // / "user_message" assuming an earlier SDK shape. Tool_use blocks
-      // arrive as content blocks INSIDE the assistant event, not as their
-      // own top-level events — counting them is handled below by inspecting
-      // the nested message content.
+      // transcript-viewer.tsx. The SDK emits "assistant" / "user" for content
+      // events; the breadbox contract uses "assistant_message" / "user_message".
+      // Tool_use blocks arrive as content blocks INSIDE the assistant event,
+      // not as top-level events — counted below by inspecting nested content.
       let type = rawType;
       if (rawType === "assistant") type = "assistant_message";
       else if (rawType === "user") type = "user_message";

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -81,8 +81,8 @@ Exit codes (full reference):
 
 - **Per-agent caps**: `max_turns` and `max_budget_usd` on every definition.
 - **Global ceiling**: `agent.global_max_budget_usd` in Settings → Agents.
-- **Concurrency**: `agent.max_concurrent` (default 3 since iter-29; was 1 in iter-1 as a v1 safety net, lifted after the orchestrator's mint-and-revoke proved out under contention). Excess cron fires log as `skipped` rows; manual runs return 503 `CONCURRENCY_LOCKED`. Raise (or drop back to 1) in Settings → Agents.
-- **Triggers**: `cron` (schedule_cron), `manual` (Run now / API /run), and `webhook` (iter-30 — opt-in per agent via `trigger_on_sync_complete`, fires after every successful bank sync). The orchestrator surfaces the trigger on every run row so the history shows which path fired it.
+- **Concurrency**: `agent.max_concurrent` (default 3). Excess cron fires log as `skipped` rows; manual runs return 503 `CONCURRENCY_LOCKED`. Raise (or drop back to 1) in Settings → Agents.
+- **Triggers**: `cron` (schedule_cron), `manual` (Run now / API /run), and `webhook` (opt-in per agent via `trigger_on_sync_complete`, fires after every successful bank sync). The orchestrator surfaces the trigger on every run row so the history shows which path fired it.
 - **Scope**: per-agent `tool_scope` is `read_only` or `read_write`. Read-only agents mint a read-only API key that the MCP server rejects writes on.
 - **Mint-and-revoke**: every run gets a fresh, scoped API key named `agent:<slug>:<runShortID>`. It's revoked the instant the run completes (or errors).
 - **Encrypted at rest**: subscription tokens and API keys are AES-256-GCM encrypted in `app_config`. The full value never leaves the server after you save it — `GET /api/v1/agents/settings` returns a masked display string.

--- a/internal/agent/seed_test.go
+++ b/internal/agent/seed_test.go
@@ -67,10 +67,9 @@ func TestSeedDefaults_PopulatesEmptyTable(t *testing.T) {
 		}
 	}
 
-	// iter-46: per-agent model tuning. The seed-row Model field must
-	// reach the DB unchanged; the defensive default-to-Opus path in
-	// SeedDefaults must NOT kick in when the seed entry sets Model
-	// explicitly (which all canonical seeds do as of iter-46).
+	// Per-agent model tuning. The seed-row Model field must reach the DB
+	// unchanged; the defensive default-to-Opus path in SeedDefaults must
+	// NOT kick in when the seed entry sets Model explicitly.
 	bySlug := make(map[string]string, len(defs))
 	for _, d := range defs {
 		bySlug[d.Slug] = d.Model

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -5,6 +5,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -153,8 +154,6 @@ func UpdateAgentDefinitionHandler(svc *service.Service) http.HandlerFunc {
 		if err != nil {
 			// Try not-found / validation first, then mutation-shaped errors
 			// (duplicate slug from a rename → 409 CONFLICT, otherwise 500).
-			// Before iter-35 the dup-slug branch only existed on Create;
-			// Update fell through to a generic 500.
 			if errors.Is(err, service.ErrNotFound) {
 				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "agent not found")
 				return
@@ -443,19 +442,7 @@ func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusOK)
-		// Best-effort copy; partial reads are OK for a viewer.
-		buf := make([]byte, 32*1024)
-		for {
-			n, rerr := f.Read(buf)
-			if n > 0 {
-				if _, werr := w.Write(buf[:n]); werr != nil {
-					return
-				}
-			}
-			if rerr != nil {
-				return
-			}
-		}
+		_, _ = io.Copy(w, f)
 	}
 }
 
@@ -518,10 +505,10 @@ func UpdateAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFu
 type runAgentNowRequest struct {
 	PromptPrefix string `json:"prompt_prefix,omitempty"`
 	// PromptOverride replaces def.Prompt entirely for this fire. Powers
-	// the iter-45 "Test this prompt" button on the agent edit page so an
-	// operator can dry-fire an unsaved prompt without round-tripping
-	// through Save. Mutually exclusive with PromptPrefix at apply time
-	// (override wins) per Orchestrator.RunNowWith.
+	// the "Test this prompt" button on the agent edit page so an operator
+	// can dry-fire an unsaved prompt without round-tripping through Save.
+	// Mutually exclusive with PromptPrefix at apply time (override wins)
+	// per Orchestrator.RunNowWith.
 	PromptOverride string `json:"prompt,omitempty"`
 }
 
@@ -531,10 +518,10 @@ type runAgentNowRequest struct {
 // related from the operator's POV.
 const PromptPrefixMaxLen = 2000
 
-// PromptOverrideMaxLen caps the iter-45 full-prompt override. 20× the
-// prefix cap because real agent prompts are long-form markdown (the
-// seeded starters run 1000-2500 chars each). 40 KB is well under any
-// model's effective context but blocks pathological pastes.
+// PromptOverrideMaxLen caps the full-prompt override. 20× the prefix cap
+// because real agent prompts are long-form markdown (the seeded starters
+// run 1000-2500 chars each). 40 KB is well under any model's effective
+// context but blocks pathological pastes.
 const PromptOverrideMaxLen = 40_000
 
 // RunAgentNowHandler triggers an immediate synchronous run of the named agent.

--- a/internal/api/agents_mutation_error_test.go
+++ b/internal/api/agents_mutation_error_test.go
@@ -12,15 +12,10 @@ import (
 	"breadbox/internal/service"
 )
 
-// TestWriteAgentDefinitionMutationError pins the iter-35 fix for audit
-// HIGH #4: before iter-35 only CreateAgentDefinitionHandler mapped the
-// Postgres unique-constraint failure to 409 CONFLICT — the Update path
-// fell through to a generic 500. The shared helper now serves both
-// handlers, so a slug-rename collision returns 409 consistently.
-//
-// Tests run against the helper directly (no router setup needed), which
-// also makes the validation-error and generic-error branches cheap to
-// pin.
+// TestWriteAgentDefinitionMutationError pins the shared helper that maps
+// Postgres unique-constraint failures (slug collision) to 409 CONFLICT for
+// both Create and Update paths. Tests run against the helper directly so
+// the validation-error and generic-error branches are cheap to pin too.
 func TestWriteAgentDefinitionMutationError(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"breadbox/internal/agent"
 	"breadbox/internal/app"
@@ -329,7 +330,7 @@ func runAgentList(parent context.Context, jsonOut bool) error {
 	fmt.Fprintf(os.Stdout, "  %-*s  %-*s  %-9s  %-22s  %-21s  %s\n",
 		slugW, "slug", nameW, "name", "enabled", "model", "schedule", "next fire")
 	fmt.Fprintf(os.Stdout, "  %s\n",
-		dashes(slugW+nameW+9+22+21+25+12))
+		strings.Repeat("-", slugW+nameW+9+22+21+25+12))
 	for _, d := range defs {
 		schedule := "manual"
 		if d.ScheduleCron != nil && *d.ScheduleCron != "" {
@@ -350,10 +351,3 @@ func runAgentList(parent context.Context, jsonOut bool) error {
 	return nil
 }
 
-func dashes(n int) string {
-	out := make([]byte, n)
-	for i := range out {
-		out[i] = '-'
-	}
-	return string(out)
-}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -126,19 +126,14 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	} else if n := cleanupResult.RowsAffected(); n > 0 {
 		logger.Info("cleaned up orphaned agent runs", "count", n)
 	}
-	// Default was 1 in iter-1 as a v1 safety net. Lifted to 3 in iter-29 after
-	// 28 iterations of dogfood proved the semaphore + mint-and-revoke survive
-	// concurrent contention. Operators can raise (or lower back to 1) in
-	// Settings → Agents.
+	// Operators can raise (or lower) in Settings → Agents. The orchestrator's
+	// mint-and-revoke + semaphore handle concurrent contention safely.
 	agentMaxConcurrent := appconfig.Int(ctx, a.Queries, appconfig.KeyAgentMaxConcurrent, 3)
 	agentRuntimePath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
 	// Default transcripts to ./transcripts/agents (relative to the cwd
-	// `breadbox serve` was launched from). Iter-1 left this empty, which
-	// silently dropped transcripts — every run row had transcript_path=""
-	// and the v2 SPA's "open transcript" hit 404. Operators can override
-	// via Settings → Agents → "breadbox-agent transcripts dir" if they
-	// want them elsewhere. Daily cleanup (iter-25) still prunes whatever
-	// path is in effect.
+	// `breadbox serve` was launched from). An empty value silently drops
+	// transcripts — run rows end up with transcript_path="" and the v2 SPA's
+	// "open transcript" 404s. Operators can override via Settings → Agents.
 	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
 	agentSidecar := &agent.Sidecar{
 		BinaryPath:    agentRuntimePath,

--- a/internal/service/agent_error_message_test.go
+++ b/internal/service/agent_error_message_test.go
@@ -13,17 +13,10 @@ import (
 	"breadbox/internal/service"
 )
 
-// TestOrchestratorRunNow_PersistsErrorMessage pins the iter-34 bug: when
-// the runner returned a non-nil error (sidecar crash, scanner failure,
-// etc.), result.Err was populated but CompleteAgentRunDB didn't pass it
-// into agent_runs.error_message. The DB row showed status='error' with
-// NO error_message, leaving operators staring at a failed run with no
-// indication of *why* and forcing them to grep container logs.
-//
-// On a real Docker deploy this manifested as the breadbox-agent musl
-// binary failing to load libstdc++ — a clear "exit 127, missing library"
-// signal in stderr that never made it to the UI because the column
-// stayed NULL.
+// TestOrchestratorRunNow_PersistsErrorMessage pins that a runner error
+// (sidecar crash, scanner failure) reaches agent_runs.error_message via
+// CompleteAgentRunDB — without it, the row shows status='error' but no
+// reason, and operators have to grep container logs.
 func TestOrchestratorRunNow_PersistsErrorMessage(t *testing.T) {
 	svc, _, _ := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)

--- a/internal/service/agent_max_turns_used_test.go
+++ b/internal/service/agent_max_turns_used_test.go
@@ -11,15 +11,13 @@ import (
 	"breadbox/internal/service"
 )
 
-// TestOrchestratorRunNow_MaxTurnsUsed_RecordsCapNotTurnCount is the
-// iter-33 regression test. Before iter-33, max_turns_used was set to
-// result.TurnCount instead of def.MaxTurns, which meant the column
-// was useless: every run looked like it hit the cap (e.g. "7/7" for
-// a clean 7-turn run with a cap of 10). The fix passes def.MaxTurns
-// through CompleteAgentRunDB. This test pins both:
+// TestOrchestratorRunNow_MaxTurnsUsed_RecordsCapNotTurnCount pins:
 //   - max_turns_used == def.MaxTurns (the cap snapshot)
 //   - turn_count == result.TurnCount (the actual turns used)
-// so the SPA can render "actual / cap" correctly.
+//
+// so the SPA can render "actual / cap" correctly. The two columns are easy
+// to mix up — using result.TurnCount for max_turns_used makes every run
+// look like it hit the cap (e.g. "7/7" for a clean 7-turn run with cap 10).
 func TestOrchestratorRunNow_MaxTurnsUsed_RecordsCapNotTurnCount(t *testing.T) {
 	svc, _, _ := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -97,12 +97,12 @@ func (o *Orchestrator) SmokeTest(ctx context.Context) (*agent.SmokeResult, error
 // apply to a manual run. Both fields default to "use the def value"; set
 // them sparingly:
 //
-//   - PromptPrefix prepends to def.Prompt for this fire only (iter-23).
-//   - PromptOverride replaces def.Prompt entirely for this fire (iter-45),
-//     enabling the "Test this prompt" flow on the edit form. Takes
-//     precedence over PromptPrefix when both are set — the override is
-//     the full prompt the operator wants to test, and prepending a prefix
-//     wouldn't match the typed value any longer.
+//   - PromptPrefix prepends to def.Prompt for this fire only.
+//   - PromptOverride replaces def.Prompt entirely for this fire, enabling
+//     the "Test this prompt" flow on the edit form. Takes precedence over
+//     PromptPrefix when both are set — the override is the full prompt the
+//     operator wants to test, and prepending a prefix wouldn't match the
+//     typed value any longer.
 //
 // Cron + webhook paths always pass the zero value; only manual runs from
 // the v2 SPA / CLI / HTTP API construct non-empty overrides.
@@ -119,15 +119,15 @@ type RunOverrides struct {
 // promptPrefix is the operator-supplied per-run prefix that gets prepended to
 // the agent's stored prompt for this fire only. Empty string disables the
 // prefix; cron callers always pass "". For a full prompt override (the
-// iter-45 "Test this prompt" flow), use RunNowWith instead.
+// "Test this prompt" flow), use RunNowWith instead.
 func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse, promptPrefix string) (*AgentRunResponse, error) {
 	return o.RunNowWith(ctx, def, RunOverrides{PromptPrefix: promptPrefix})
 }
 
 // RunNowWith is the full-shape variant of RunNow that accepts the operator's
-// RunOverrides struct. Used by the iter-45 "Test this prompt" button on
-// the agent edit page to dry-fire an unsaved prompt without mutating the
-// stored definition.
+// RunOverrides struct. Used by the "Test this prompt" button on the agent
+// edit page to dry-fire an unsaved prompt without mutating the stored
+// definition.
 func (o *Orchestrator) RunNowWith(ctx context.Context, def *AgentDefinitionResponse, ov RunOverrides) (*AgentRunResponse, error) {
 	if err := o.sem.Acquire(ctx); err != nil {
 		return nil, err
@@ -144,14 +144,13 @@ func (o *Orchestrator) RunNowWith(ctx context.Context, def *AgentDefinitionRespo
 //
 // Runs each agent in its own goroutine so the sync engine returns
 // immediately. Concurrency is bounded by the orchestrator's existing
-// semaphore (iter-29 default: 3) — excess fires roll into skipped rows.
+// semaphore — excess fires roll into skipped rows.
 func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
 	// Use a fresh context for the lookup — the incoming ctx is the sync
 	// engine's, and a cancelled webhook request or timed-out sync would
-	// silently no-op the entire webhook trigger here (audit HIGH #3 from
-	// iter-32). Per-dispatched goroutine below ALSO uses a fresh ctx for
-	// the same reason. 30s is plenty for the unindexed-by-default lookup
-	// even with a few dozen agents.
+	// silently no-op the entire webhook trigger here. Per-dispatched
+	// goroutine below ALSO uses a fresh ctx for the same reason. 30s is
+	// plenty for the unindexed-by-default lookup even with a few dozen agents.
 	lookupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	defs, err := o.svc.ListAgentDefinitionsForSyncWebhook(lookupCtx)
@@ -322,19 +321,17 @@ func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionRespo
 		}
 		result, runErr := o.runner.Run(runCtx, *spec, handler)
 
-		completedRow, completeErr := o.svc.CompleteAgentRunDB(runCtx, runRow.ID, result, def.MaxTurns)
-		if completeErr != nil {
+		if _, completeErr := o.svc.CompleteAgentRunDB(runCtx, runRow.ID, result, def.MaxTurns); completeErr != nil {
 			o.logger.Error("orchestrator: persist completed run failed",
 				"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)
 			return
 		}
-		if cap := capFromRunErr(runErr); cap != "" {
-			if _, err := o.svc.SetAgentRunHitCapDB(runCtx, runRow.ID, cap); err != nil {
+		if hitCap := capFromRunErr(runErr); hitCap != "" {
+			if _, err := o.svc.SetAgentRunHitCapDB(runCtx, runRow.ID, hitCap); err != nil {
 				o.logger.Warn("orchestrator: persist hit_cap failed",
-					"agent", def.Slug, "run", runResp.ShortID, "cap", cap, "error", err)
+					"agent", def.Slug, "run", runResp.ShortID, "cap", hitCap, "error", err)
 			}
 		}
-		_ = completedRow
 		if runErr != nil {
 			o.logger.Warn("orchestrator: run finished with error",
 				"agent", def.Slug, "run", runResp.ShortID,
@@ -394,7 +391,7 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	if err == nil {
 		// Override semantics: a full PromptOverride wins outright (the
 		// operator is testing a freshly-typed prompt, not annotating the
-		// stored one). Otherwise fall through to the iter-23 prefix prepend.
+		// stored one). Otherwise fall through to the prefix prepend.
 		switch {
 		case ov.PromptOverride != "":
 			spec.Prompt = ov.PromptOverride
@@ -436,12 +433,12 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	// having already classified status (max_turns → success, budget → error),
 	// so we record the cap separately for the audit trail without rewriting
 	// status.
-	if cap := capFromRunErr(runErr); cap != "" {
-		if capRow, err := o.svc.SetAgentRunHitCapDB(ctx, runRow.ID, cap); err == nil {
+	if hitCap := capFromRunErr(runErr); hitCap != "" {
+		if capRow, err := o.svc.SetAgentRunHitCapDB(ctx, runRow.ID, hitCap); err == nil {
 			completedRow = capRow
 		} else {
 			o.logger.Warn("orchestrator: persist hit_cap failed",
-				"agent", def.Slug, "run", runResp.ShortID, "cap", cap, "error", err)
+				"agent", def.Slug, "run", runResp.ShortID, "cap", hitCap, "error", err)
 		}
 	}
 

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -402,12 +402,12 @@ func TestOrchestratorRunNow_CleanSuccess_LeavesHitCapNil(t *testing.T) {
 	}
 }
 
-// TestOrchestratorRunNow_TripleConcurrency exercises the iter-29 default
-// (max_concurrent=3). Fires 3 RunNow calls concurrently; all should
-// complete cleanly with no semaphore lockout. Verifies mint-and-revoke,
-// per-run row creation, and end-state run count all behave under
-// contention. The 4th concurrent attempt should still lock — the cap is
-// a real ceiling, not a no-op.
+// TestOrchestratorRunNow_TripleConcurrency exercises the default
+// max_concurrent=3. Fires 3 RunNow calls concurrently; all should complete
+// cleanly with no semaphore lockout. Verifies mint-and-revoke, per-run row
+// creation, and end-state run count all behave under contention. The 4th
+// concurrent attempt should still lock — the cap is a real ceiling, not a
+// no-op.
 func TestOrchestratorRunNow_TripleConcurrency(t *testing.T) {
 	svc, _, _ := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)
@@ -484,10 +484,10 @@ func TestOrchestratorRunNow_TripleConcurrency(t *testing.T) {
 }
 
 // TestOrchestratorRunNowWith_PromptOverride_ReplacesDefPrompt pins the
-// iter-45 "Test this prompt" flow: when an operator passes
-// RunOverrides.PromptOverride, the sidecar receives THAT text as
-// spec.Prompt instead of def.Prompt. Operator can dry-fire an unsaved
-// edit-form prompt without round-tripping through Save.
+// "Test this prompt" flow: when an operator passes RunOverrides.PromptOverride,
+// the sidecar receives THAT text as spec.Prompt instead of def.Prompt.
+// Operator can dry-fire an unsaved edit-form prompt without round-tripping
+// through Save.
 func TestOrchestratorRunNowWith_PromptOverride_ReplacesDefPrompt(t *testing.T) {
 	svc, _, _ := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)

--- a/internal/service/agent_recent_cap_test.go
+++ b/internal/service/agent_recent_cap_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// TestListAgentDefinitions_PopulatesRecentCapStats pins the iter-32
-// aggregate rollup: the list response carries recent_cap_stats based on
-// the last 5 non-skipped runs, with skipped rows excluded. Seeds a mix
-// of clean, capped, and skipped runs and verifies the totals.
+// TestListAgentDefinitions_PopulatesRecentCapStats pins the aggregate
+// rollup: the list response carries recent_cap_stats based on the last 5
+// non-skipped runs, with skipped rows excluded. Seeds a mix of clean,
+// capped, and skipped runs and verifies the totals.
 func TestListAgentDefinitions_PopulatesRecentCapStats(t *testing.T) {
 	svc, q, _ := newService(t)
 	ctx := context.Background()

--- a/internal/service/agent_recent_errors_test.go
+++ b/internal/service/agent_recent_errors_test.go
@@ -13,10 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// TestListRecentErroredAgentRuns_OnlyRecentErrors verifies the iter-38
-// surface: errored runs from the last `windowHours` show up; older
-// errors and non-error runs don't. Limit is respected; ordering is
-// most-recent-first by started_at.
+// TestListRecentErroredAgentRuns_OnlyRecentErrors verifies that errored
+// runs from the last `windowHours` show up; older errors and non-error
+// runs don't. Limit is respected; ordering is most-recent-first by started_at.
 func TestListRecentErroredAgentRuns_OnlyRecentErrors(t *testing.T) {
 	svc, q, pool := newService(t)
 	ctx := context.Background()

--- a/internal/service/agent_runs_filter_test.go
+++ b/internal/service/agent_runs_filter_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// TestListAgentRuns_ScansNewColumns is a regression test for an iter-22
-// through iter-27 bug: ListAgentRuns' hand-rolled SELECT was missing
-// operator_note, prompt_prefix, and hit_cap, so the v2 SPA run history
-// never showed those pills even when the underlying row had them. The
-// fix landed in iter-31 (this iteration); this test pins it.
+// TestListAgentRuns_ScansNewColumns pins that ListAgentRuns' hand-rolled
+// SELECT includes operator_note, prompt_prefix, and hit_cap — the v2 SPA
+// run history relies on all three being on the list payload.
 func TestListAgentRuns_ScansNewColumns(t *testing.T) {
 	svc, q, _ := newService(t)
 	ctx := context.Background()
@@ -33,13 +31,13 @@ func TestListAgentRuns_ScansNewColumns(t *testing.T) {
 	}
 	if err := q.SetAgentRunPromptPrefix(ctx, db.SetAgentRunPromptPrefixParams{
 		ID:           row.ID,
-		PromptPrefix: pgtype.Text{String: "iter-23 prefix payload", Valid: true},
+		PromptPrefix: pgtype.Text{String: "prefix payload", Valid: true},
 	}); err != nil {
 		t.Fatalf("set prefix: %v", err)
 	}
 	if _, err := q.SetAgentRunNote(ctx, db.SetAgentRunNoteParams{
 		ID:           row.ID,
-		OperatorNote: pgtype.Text{String: "iter-22 note payload", Valid: true},
+		OperatorNote: pgtype.Text{String: "note payload", Valid: true},
 	}); err != nil {
 		t.Fatalf("set note: %v", err)
 	}
@@ -58,11 +56,11 @@ func TestListAgentRuns_ScansNewColumns(t *testing.T) {
 		t.Fatalf("expected 1 run, got %d", len(list.Runs))
 	}
 	got := list.Runs[0]
-	if got.PromptPrefix == nil || *got.PromptPrefix != "iter-23 prefix payload" {
-		t.Errorf("PromptPrefix from list = %v, want \"iter-23 prefix payload\"", got.PromptPrefix)
+	if got.PromptPrefix == nil || *got.PromptPrefix != "prefix payload" {
+		t.Errorf("PromptPrefix from list = %v, want \"prefix payload\"", got.PromptPrefix)
 	}
-	if got.OperatorNote == nil || *got.OperatorNote != "iter-22 note payload" {
-		t.Errorf("OperatorNote from list = %v, want \"iter-22 note payload\"", got.OperatorNote)
+	if got.OperatorNote == nil || *got.OperatorNote != "note payload" {
+		t.Errorf("OperatorNote from list = %v, want \"note payload\"", got.OperatorNote)
 	}
 	if got.HitCap == nil || *got.HitCap != "max_turns" {
 		t.Errorf("HitCap from list = %v, want \"max_turns\"", got.HitCap)

--- a/internal/service/agent_scheduler.go
+++ b/internal/service/agent_scheduler.go
@@ -128,9 +128,9 @@ func (s *AgentScheduler) logCleanupResult(r AgentCleanupResult, source string) {
 
 // EntryCountForTest returns the live count of cron entries — agent
 // registrations PLUS the singleton cleanup tick added in Start. Exposed
-// for the iter-34 concurrent-Reload regression test; the cron library
-// has no other way to verify "no duplicate entries leaked." Do not call
-// from production code.
+// for the concurrent-Reload regression test; the cron library has no
+// other way to verify "no duplicate entries leaked." Do not call from
+// production code.
 func (s *AgentScheduler) EntryCountForTest() int {
 	return len(s.cron.Entries())
 }
@@ -148,7 +148,7 @@ func (s *AgentScheduler) Stop() {
 // Holds reloadMu for the entire span so two concurrent CRUD-triggered
 // reloads can't both pass the "remove all" phase and then both call
 // AddFunc, producing duplicate cron entries whose EntryIDs are leaked
-// (entryIDs[slug] can only store one ID). Cf. iter-32 audit BLOCKER #2.
+// (entryIDs[slug] can only store one ID).
 func (s *AgentScheduler) Reload(ctx context.Context) {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
@@ -333,7 +333,7 @@ func (s *AgentScheduler) cleanupAgentRuns(ctx context.Context) int64 {
 	retentionDays := appconfig.Int(ctx, s.svc.Queries, appconfig.KeyAgentRunRetentionDays, 30)
 	cutoff := time.Now().AddDate(0, 0, -retentionDays)
 	result, err := s.svc.Queries.DeleteAgentRunsOlderThan(ctx,
-		pgtype.Timestamptz{Time: cutoff, Valid: true})
+		pgconv.Timestamptz(cutoff))
 	if err != nil {
 		s.logger.Error("agent run cleanup failed", "error", err)
 		return 0

--- a/internal/service/agent_scheduler_reload_race_test.go
+++ b/internal/service/agent_scheduler_reload_race_test.go
@@ -12,19 +12,14 @@ import (
 	"breadbox/internal/service"
 )
 
-// TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries pins the
-// iter-34 fix for audit BLOCKER #2. Before iter-34, two concurrent
-// Reload() calls could interleave their "remove all + re-register"
-// phases such that AddFunc ran twice per slug, producing duplicate
-// cron entries whose EntryIDs were silently leaked (entryIDs[slug]
-// could only store the last one — the others fired forever, no way to
-// cancel them).
-//
-// The fix serializes the whole Reload critical section with reloadMu.
-// This test fires N concurrent Reloads against the live scheduler +
-// service and asserts the underlying cron.Cron has exactly the same
-// number of per-agent entries it would have after one sequential
-// Reload — no duplicates, no leaks.
+// TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries pins that
+// concurrent Reload() calls can't interleave their "remove all +
+// re-register" phases such that AddFunc runs twice per slug — which would
+// leak duplicate cron entries whose EntryIDs aren't recoverable
+// (entryIDs[slug] only stores the last one; the rest fire forever).
+// reloadMu serializes the full critical section; this test fires N
+// concurrent Reloads and asserts the per-agent entry count matches a
+// sequential Reload.
 func TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries(t *testing.T) {
 	svc, _, _ := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)
@@ -63,8 +58,8 @@ func TestAgentScheduler_Reload_ConcurrentCRUD_NoDuplicateEntries(t *testing.T) {
 	const cleanupEntries = 1
 
 	// Fire 8 concurrent Reload calls — simulates a burst of CRUD
-	// mutations all triggering OnDefinitionChanged at once. Before
-	// iter-34 this routinely produced duplicate cron entries.
+	// mutations all triggering OnDefinitionChanged at once. Without
+	// reloadMu this routinely produces duplicate cron entries.
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -61,7 +61,6 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSe
 		return nil, fmt.Errorf("read anthropic api key: %w", err)
 	}
 
-	// Default lifted from 1 → 3 in iter-29; see serve.go for the rationale.
 	maxConcurrent := appconfig.Int(ctx, s.Queries, appconfig.KeyAgentMaxConcurrent, 3)
 	runtimePath := appconfig.String(ctx, s.Queries, appconfig.KeyAgentRuntimePath, "")
 	// Default matches serve.go fallback — keeps the Settings → Agents

--- a/internal/service/agent_webhook_trigger_test.go
+++ b/internal/service/agent_webhook_trigger_test.go
@@ -40,9 +40,8 @@ func TestFireSyncCompleteAgents_OnlyFiresEligible(t *testing.T) {
 	// Deterministic wait: we expect exactly 1 fire (only the eligible
 	// agent qualifies). Block until it lands or fail after a generous
 	// timeout. Then sweep the channel briefly to catch any unexpected
-	// extra fires the bug-this-test-pins might produce. Replaces the
-	// iter-30 time.After polling pattern flagged as LOW #6 in iter-32
-	// audit — the previous shape was timing-sensitive under CI load.
+	// extra fires. A polling-based wait would be timing-sensitive under
+	// CI load.
 	var got []string
 	select {
 	case agentID := <-fired:

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -155,9 +155,9 @@ type AgentRunResponse struct {
 	TurnCount           *int     `json:"turn_count,omitempty"`
 	// MaxTurnsUsed is the per-run snapshot of the agent's max_turns cap
 	// at the time the run started. Named for historical reasons; "max
-	// turns at run-start" would be clearer. Pair with turn_count to
-	// render "actual / cap". Until iter-33 this column erroneously
-	// mirrored turn_count, making every run look like it hit the cap.
+	// turns at run-start" would be clearer. Pair with turn_count to render
+	// "actual / cap" — these are easy to mix up: setting MaxTurnsUsed to
+	// result.TurnCount makes every run look like it hit the cap.
 	MaxTurnsUsed        *int     `json:"max_turns_used,omitempty"`
 	NumToolCalls        *int     `json:"num_tool_calls,omitempty"`
 	ErrorMessage        *string  `json:"error_message,omitempty"`
@@ -957,10 +957,9 @@ func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, ca
 //
 // maxTurnsCap is the per-run snapshot of the agent's max_turns at the
 // time the run started. Stored separately from turn_count so the SPA
-// can render "turns / cap" — until iter-33 this column mirrored
-// turn_count, which made every run look like a max-turns hit. The cap
-// itself never changes mid-run, so the orchestrator captures it
-// from def.MaxTurns at run-start and passes it through here.
+// can render "turns / cap". The cap itself never changes mid-run, so the
+// orchestrator captures it from def.MaxTurns at run-start and passes it
+// through here.
 //
 // When result.Err is non-nil (status="error" or "timeout"), its message
 // is truncated and persisted to error_message so the transcript drawer
@@ -1014,8 +1013,8 @@ func AgentRunFromRow(row db.AgentRun) AgentRunResponse {
 }
 
 // MintRunAPIKey mints a scoped API key for one agent run.
-// Returns the plaintext + the created record. The orchestrator (iter 3)
-// is responsible for revocation via RevokeAPIKey on completion.
+// Returns the plaintext + the created record. The orchestrator is
+// responsible for revocation via RevokeAPIKey on completion.
 func (s *Service) MintRunAPIKey(ctx context.Context, def *AgentDefinitionResponse, runShortID string) (*CreateAPIKeyResult, error) {
 	scope := "full_access"
 	if def.ToolScope == "read_only" {
@@ -1031,7 +1030,7 @@ func (s *Service) MintRunAPIKey(ctx context.Context, def *AgentDefinitionRespons
 
 // AssembleJobSpec builds the agent.JobSpec the runner needs.
 // Reads encrypted auth tokens from app_config and assembles MCP config.
-// Does NOT start the run — the orchestrator (iter 3) calls Runner.Run.
+// Does NOT start the run — the orchestrator calls Runner.Run.
 func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionResponse, run *AgentRunResponse, apiKeyPlaintext string, encKey []byte) (*agent.JobSpec, error) {
 	authMode := appconfig.String(ctx, s.Queries, appconfig.KeyAgentAuthMode, appconfig.AuthModeSubscription)
 
@@ -1060,7 +1059,7 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 	}
 
 	// (transcript_dir is read by the Sidecar layer; see Sidecar.Run for
-	// the authoritative path assembly — iter-36 audit HIGH #5 cleanup.)
+	// the authoritative path assembly.)
 
 	// Resolve to the currently-running breadbox binary so the SDK's MCP
 	// child spawn works regardless of $PATH. The TS SDK calls
@@ -1137,11 +1136,9 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 	}
 	// Note: transcript path is set by Sidecar.Run from (TranscriptDir,
 	// spec.RunID) and overwrites whatever's here on the spec. Don't try
-	// to control it from this side — keeping the assignment authority
-	// in one place avoids the iter-36 audit HIGH #5 inconsistency where
-	// AssembleJobSpec set `<dir>/<short_id>.ndjson` and Sidecar.Run
-	// then opened `<dir>/<RunID>.ndjson`, leaving the spec field briefly
-	// inconsistent before marshal.
+	// to control it from this side — keeping the assignment authority in
+	// one place avoids drift where AssembleJobSpec and Sidecar.Run use
+	// different identifiers (short_id vs RunID) for the same file.
 	return spec, nil
 }
 
@@ -1225,9 +1222,7 @@ func validateAgentDefinitionFields(name, slug, prompt, toolScope, model string, 
 	if model != "" && strings.TrimSpace(model) == "" {
 		return fmt.Errorf("%w: model cannot be blank", ErrInvalidParameter)
 	}
-	// 0 is accepted and falls back to DefaultAgentMaxTurns in the caller —
-	// the docstring used to say "1-100" but the actual behavior allowed
-	// 0 silently. iter-36 audit LOW #7 reworded for accuracy.
+	// 0 is accepted and falls back to DefaultAgentMaxTurns in the caller.
 	if maxTurns < 0 || maxTurns > 100 {
 		return fmt.Errorf("%w: max_turns must be 0-100 (0 falls back to the default)", ErrInvalidParameter)
 	}

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -232,7 +232,6 @@ func TestGetAgentSettings_DefaultsWhenUnset(t *testing.T) {
 	if s.SubscriptionToken != nil {
 		t.Errorf("SubscriptionToken should be nil when unset, got %v", *s.SubscriptionToken)
 	}
-	// Default lifted from 1 → 3 in iter-29. See serve.go for rationale.
 	if s.MaxConcurrent != 3 {
 		t.Errorf("MaxConcurrent default = %d, want 3", s.MaxConcurrent)
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2388,7 +2388,7 @@ paths:
       description: |
         Creates a Claude Agent SDK definition. Body includes the usual
         `name`, `slug`, `prompt`, `model`, `max_turns`, `max_budget_usd`,
-        `tool_scope`, `allowed_tools`, `schedule_cron`, and the iter-30
+        `tool_scope`, `allowed_tools`, `schedule_cron`, and the
         `trigger_on_sync_complete` flag (fire after every successful
         sync, in addition to any cron schedule). **Requires `full_access` scope.**
       requestBody:
@@ -2690,8 +2690,8 @@ paths:
         row. Status may be `success`, `error`, or `timeout`. Optional body
         accepts `prompt_prefix` (prepends operator context to the saved
         prompt for this fire only) and `prompt` (replaces the saved prompt
-        entirely for this fire — powers the iter-45 "Test this prompt"
-        button on the edit page). When both are set, `prompt` wins.
+        entirely for this fire — powers the "Test this prompt" button on
+        the edit page). When both are set, `prompt` wins.
         **Requires `full_access` scope.**
       requestBody:
         required: false

--- a/web/src/api/queries/agents.ts
+++ b/web/src/api/queries/agents.ts
@@ -255,7 +255,7 @@ export interface RunAgentNowParams {
   slug: string;
   promptPrefix?: string; // operator-supplied per-run prefix; max 2000 chars
   // promptOverride replaces def.Prompt entirely for this fire; max 40000 chars.
-  // Powers the iter-45 "Test this prompt" button on the edit page. When both
+  // Powers the "Test this prompt" button on the edit page. When both
   // promptPrefix and promptOverride are set, override wins on the server.
   promptOverride?: string;
 }
@@ -312,8 +312,8 @@ export function useAgentRuns(
     enabled: Boolean(slug),
     // Poll while ANY visible run is in_progress so the row's status pill
     // flips to success/error as soon as the sidecar finishes (the
-    // orchestrator runs async post-iter-47 and doesn't push status into
-    // the cache). Stops automatically once no in-flight runs remain.
+    // orchestrator runs async and doesn't push status into the cache).
+    // Stops automatically once no in-flight runs remain.
     refetchInterval: (q) =>
       (q.state.data?.runs ?? []).some((r) => r.status === "in_progress")
         ? 2000

--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -32,9 +32,9 @@ import { RuleDslHelp } from "./rule-dsl-help";
 // the typed payload — in create mode it's user-editable, in edit mode
 // the field is hidden but the existing value is carried through so the
 // schema validates either way. Numerics use z.preprocess instead of
-// z.coerce to dodge the iter-4 resolver bug where coerce.number left
-// the input type as `unknown`; preprocess converts string → number
-// explicitly at submit time while defaults stay typed.
+// z.coerce because coerce.number leaves the input type as `unknown` for
+// the RHF resolver; preprocess converts string → number explicitly at
+// submit time while defaults stay typed.
 const agentFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(120),
   slug: z

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -63,9 +63,8 @@ function turnHasContent(t: TurnGroup): boolean {
 }
 
 // extractToolUses pulls tool_use content blocks out of an assistant message.
-// The SDK nests them inside `message.content[]`; earlier viewer iterations
-// expected standalone top-level "tool_use" events that never actually
-// appeared on the wire (iter-46 finding, fixed in iter-48).
+// The SDK nests them inside `message.content[]`; there are no standalone
+// top-level "tool_use" events on the wire.
 function extractToolUses(
   data: AssistantMessageData,
   ts: number,
@@ -445,7 +444,7 @@ interface ToolCallPairProps {
   toolResult?: ToolResultData & { ts: number };
 }
 
-// FilterChip is a small toggle button used for the iter-43 "Tools only" /
+// FilterChip is a small toggle button used for the "Tools only" /
 // "Errors only" quick filters above the transcript event stream. Active
 // state inverts the visual (filled badge) so the chip reads as "currently
 // applied" without a separate state indicator.

--- a/web/src/routes/agents.$slug.edit.tsx
+++ b/web/src/routes/agents.$slug.edit.tsx
@@ -133,12 +133,11 @@ function AgentEditFormView({
   );
 }
 
-// TestPromptButton dry-fires the in-edit-form prompt via the iter-45
-// prompt_override path on POST /api/v1/agents/:slug/run. Lets operators
-// iterate on prompts without round-tripping through Save (which would
-// mutate the stored definition + fire every cron from that point onward
-// with the new prompt). Disabled when the form is mid-save or the prompt
-// field is empty.
+// TestPromptButton dry-fires the in-edit-form prompt via the prompt_override
+// path on POST /api/v1/agents/:slug/run. Lets operators iterate on prompts
+// without round-tripping through Save (which would mutate the stored
+// definition + fire every cron from that point onward with the new prompt).
+// Disabled when the form is mid-save or the prompt field is empty.
 //
 // On success, navigates to the agent's run history with the new run's
 // transcript drawer pre-opened, so operators can immediately read the

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -379,12 +379,6 @@ function LastRunCell({ run }: { run: AgentDefinition["last_run"] }) {
   );
 }
 
-// stopRowClick wraps inline interactive controls so clicking them
-// doesn't also bubble up to the row's "navigate to edit" handler.
-function stopRowClick<E extends Element>(e: React.MouseEvent<E>) {
-  e.stopPropagation();
-}
-
 function EnabledSwitchCell({ agent }: { agent: AgentDefinition }) {
   const toggle = useToggleAgent();
   const handleChange = (enable: boolean) => {
@@ -397,7 +391,7 @@ function EnabledSwitchCell({ agent }: { agent: AgentDefinition }) {
     );
   };
   return (
-    <div onClick={stopRowClick} className="inline-flex">
+    <div onClick={(e) => e.stopPropagation()} className="inline-flex">
       <Switch
         checked={agent.enabled}
         disabled={toggle.isPending}
@@ -417,7 +411,7 @@ function ActionsCell({
 }) {
   return (
     <div
-      onClick={stopRowClick}
+      onClick={(e) => e.stopPropagation()}
       className="flex items-center justify-end gap-1"
     >
       <RunNowDialog


### PR DESCRIPTION
## Summary

Daily simplify-drift review of the 19 PRs merged into `main` in the last 24 hours. Net `-71` lines across 27 files. No behavior change; no new abstractions; no schema or migration touches.

The dominant cleanup is removing **53 "iter-N" sprint-history comments** from the agents-subsystem files that landed via #1276, #1301, and the iteration follow-ups (#1297, #1303–#1311, #1315). Per `CLAUDE.md` ("Don't reference the current task, fix, or callers, since those belong in the PR description and rot as the codebase evolves"). WHY content kept; sprint-iteration provenance dropped.

## PRs reviewed

- #1274 — fix(v2): make settings modal sub-pages scrollable
- #1276 — feat(agents): Claude Agent SDK integration — recurring AI runs that call breadbox MCP
- #1296 — design(v2): unify page-spacing contract on `<main>`
- #1297 — fix(v2): stop duplicating comment body in transaction activity timeline
- #1298 — fix(v2): make Shift+? toggle the keyboard shortcut sheet
- #1299 — design(v2): redesign error surfaces — ErrorPage hero + PageError card
- #1300 — v2 polish sprint: roll up #1277-#1294 (CategoryPicker, sandbox, tx-row, DataTable)
- #1301 — feat(v2): agents redesign + prompt builder + presets
- #1302 — fix(v2): let PageHeader subtitle expand to page width
- #1303 — fix(v2): family-member filter on accounts and connections
- #1304 — cleanup(v2/prompts): simplify prompt-builder code
- #1305 — fix(v2): preventDefault on Enter to stop tx-list flash-back
- #1306 — chore(v2): drop institution/type group toggle on accounts page
- #1307 — fix(v2): stop SoftBackButton from stretching to full width
- #1308 — design(v2): redesign Settings → Agents pane
- #1309 — feat(agents): ship breadbox-agent sidecar via release CI + Docker
- #1310 — design(v2): grow settings modal for more content breathing room
- #1311 — feat(admin): add v2_default toggle to land at /v2/ from /
- #1315 — fix(agents): install libstdc++/libgcc in runtime, persist runner errors

## Changes

**Sprint-history scaffolding (53 occurrences)**

- `internal/service/agent_*.go`, `internal/api/agents.go`, `internal/cli/serve.go`, `internal/agent/seed_test.go`, `agent/sidecar/{events,index}.ts`, `openapi.yaml`, `docs/agents.md`, `web/src/api/queries/agents.ts`, `web/src/features/agents/{agent-form,transcript-viewer}.tsx`, `web/src/routes/agents.$slug.edit.tsx` — drop "iter-N" provenance from comments and doc bodies; preserve substantive WHY content. Two test-data string literals (`"iter-23 prefix payload"`, `"iter-22 note payload"` in `agent_runs_filter_test.go`) renamed to neutral payloads.

**Mechanical reuse / quality wins**

- `internal/service/agent_orchestrator.go:325-337` — delete dead `_ = completedRow` line; `completedRow` was never read in the async `prepareRun` closure (only the synchronous `runLocked` path uses it for the cap-update return value).
- `internal/service/agent_orchestrator.go:331, 439` — rename `cap` → `hitCap` to stop shadowing Go's `cap` builtin (flagged HIGH by the quality reviewer).
- `internal/cli/agent.go:332-359` — replace the 7-line local `dashes(n)` helper with `strings.Repeat("-", n)` (already used by the sibling table renderer in `doctor_local_full.go`).
- `internal/service/agent_scheduler.go:336` — use `pgconv.Timestamptz(cutoff)` instead of inline `pgtype.Timestamptz{Time: cutoff, Valid: true}` (pgconv exists for exactly this).
- `internal/api/agents.go:447-458` — replace the hand-rolled 32 KB read loop in the transcript streamer with `io.Copy(w, f)`.
- `web/src/routes/agents.tsx:382-386, 400, 420` — inline the one-line `stopRowClick` helper at its two call sites.

## Reviewer findings intentionally NOT addressed

- **`internal/api/agents.go` `writeAgentError` → `writeServiceError`** (Reuse HIGH #1): the canonical helper returns `"INVALID_PARAMETER"` while the local one returns `"VALIDATION_ERROR"`. Error codes are a stable contract per `.claude/rules/api.md` — needs explicit Ricardo call.
- **`internal/agent/sidecar.go` mutex** (Efficiency MEDIUM #7): removing the process-wide lock to let the orchestrator's semaphore actually parallelize sidecar runs is a real perf win, but the existing mutex was added as an explicit safety net — defer to a focused PR.
- **Orchestrator `prepareRun` / `runLocked` extraction** (Quality HIGH #1): genuine 90% duplication, but extracting a shared body crosses the "no new abstractions" guardrail for this PR.
- **N+1 in `ListAgentDefinitions.lastRunSummary`** (Efficiency MEDIUM #1): needs a new `GetLatestAgentRunsForAllDefinitions` sqlc query — out of scope.
- **`.claude/sprint-state.md`** (Quality HIGH #6): 850-line sprint-workflow file that landed on `main` via #1276; per `.claude/rules/agents.md` it's documented as living on the `agents/claude-agent-sdk-sprint` branch. Flagging here so you can decide whether to delete it separately — felt too big a call for a simplify-drift sweep.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make test-integration` (full matrix, all packages green)
- [x] `cd web && bun run lint` (TypeScript type-check)

https://claude.ai/code/session_01VkGDoJmdn818N3HD1Hv8c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkGDoJmdn818N3HD1Hv8c6)_