### PR TITLE
fix(v2): mobile responsiveness sprint for iOS Safari (11 fixes)

### DIFF
--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -28,8 +28,6 @@ _(empty — both user-reported P0 bugs shipped)_
 ## Backlog (P0 — re-scout, post-fix issues)
 
 - [ ] **MOBILE-14** Agent form right card sinks below at 375px. `web/src/features/agents/agent-form.tsx` (~line 113). `grid-cols-1 md:grid-cols-3` plus `md:col-span-2` on the left card causes the right card (settings/model/budget) to fall far down at 375px. Add `sm:grid-cols-2` reflow or stack semantically until md.
-- [ ] **MOBILE-15** FormFooter buttons stack vertically on narrow mobile. `web/src/components/form-footer.tsx` (~line 56). `flex flex-wrap gap-2` lets "Cancel" + "Create category" wrap to two rows when text is long. Try `flex-nowrap` with text truncation, or short labels on mobile.
-- [ ] **MOBILE-16** PageHeader actions clip on mobile. `web/src/components/page-header.tsx` (~lines 48-66). Right-hand actions div has `shrink-0` so two buttons can overflow at 375px. Drop `shrink-0` or allow `flex-wrap` so actions can drop below the title.
 
 ## Backlog (P1 — re-scout)
 
@@ -46,7 +44,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-- **fix/mobile-header-and-footer-stack** (subagent `a6623977`) — bundles MOBILE-15 + MOBILE-16. PageHeader actions wrap on mobile (`flex-wrap`, `sm:flex-nowrap`); FormFooter stacks buttons full-width with primary on top via `flex-col-reverse sm:flex-row`. Composed-layer components (no ui/* edit). PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -57,6 +55,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-7/9** iOS safe-area pass — PR #1318 merged (`78c814d9`). Added `viewport-fit=cover` to `web/index.html` (activates `env(safe-area-inset-*)`), per-side safe-area padding to `SheetContent`, mobile sidebar inner content respects bottom inset, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header so it sits below the notch/Dynamic Island.
 - ✅ **MOBILE-11** Table scroll affordance — PR #1319 merged (`66d7d8d2`). Added `scroll-shadow-x` utility (4-layer CSS-only gradient, dark-mode aware) + `[-webkit-overflow-scrolling:touch]` to the `Table` primitive's container. Clipped tables now show a fade indicating scrollability; flat right edge confusion resolved.
 - ✅ **MOBILE-10/13** Dynamic viewport units — PR #1320 merged (`b3411af3`). Selection action bar swapped `100vw` → `100dvw` so it stays within the dynamic viewport as iOS chrome collapses; desktop sidebar swapped `h-svh` → `h-full` (parent-relative) so it fills exactly its container instead of the worst-case small-viewport height.
+- ✅ **MOBILE-15/16** Header + footer mobile stacking — PR #1321 merged (`669cfed6`). `PageHeader` actions cluster now wraps on mobile (`flex-wrap` + `sm:flex-nowrap sm:shrink-0`) so pages with multiple action buttons no longer overflow horizontally. `FormFooter` action cluster goes full-width column with primary on top (`flex-col-reverse w-full`) at <640px, restoring inline row on ≥640px — affirmative-on-top matches iOS / Material.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -27,9 +27,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## Backlog (P1 — re-scout)
 
-- [ ] **MOBILE-17** Empty state `max-w-sm` (384px) exceeds 375px viewport. `web/src/components/empty-state.tsx` (~line 73). Bump to `max-w-xs` or rely on viewport padding.
-- [ ] **MOBILE-18** Error page `<pre>` block lacks iOS momentum. `web/src/routes/error.tsx` (~line 152). Add `[-webkit-overflow-scrolling:touch]` (same pattern as #1319 table fix).
-- [ ] **MOBILE-19** HeroGrid tight 10px padding on 375px. `web/src/components/hero-grid.tsx` (~lines 43-45). `px-5 sm:px-7` feels cramped. Consider `px-4 sm:px-5` (more breathing room actually means less mobile padding) — verify against design intent.
+- [ ] **MOBILE-19** HeroGrid tight 20px padding on 375px. `web/src/components/hero-grid.tsx` (~lines 43-45). `px-5 sm:px-7` is fine but feels a touch cramped per scout. Subjective — defer until visual evidence shows a clear problem. May close as won't-fix.
 - [ ] **MOBILE-20** Transactions toolbar wraps pills above sort/select buttons. `web/src/features/transactions/transactions-toolbar.tsx` (~line 202). `flex flex-wrap` pushes sort/select to a third row when there are several filter chips. Consider horizontal-scroll chip rail on mobile or fixed positioning.
 
 ## Backlog (P1-P2 — scout-seeded)
@@ -40,7 +38,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-- **fix/mobile-empty-state-and-error-pre** (subagent `aaf9e92d`) — MOBILE-17 + MOBILE-18. `max-w-sm` → `max-w-xs` on empty-state description; `[-webkit-overflow-scrolling:touch]` added to error page `<pre>`. PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -53,6 +51,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-10/13** Dynamic viewport units — PR #1320 merged (`b3411af3`). Selection action bar swapped `100vw` → `100dvw` so it stays within the dynamic viewport as iOS chrome collapses; desktop sidebar swapped `h-svh` → `h-full` (parent-relative) so it fills exactly its container instead of the worst-case small-viewport height.
 - ✅ **MOBILE-15/16** Header + footer mobile stacking — PR #1321 merged (`669cfed6`). `PageHeader` actions cluster now wraps on mobile (`flex-wrap` + `sm:flex-nowrap sm:shrink-0`) so pages with multiple action buttons no longer overflow horizontally. `FormFooter` action cluster goes full-width column with primary on top (`flex-col-reverse w-full`) at <640px, restoring inline row on ≥640px — affirmative-on-top matches iOS / Material.
 - ✅ **MOBILE-14** Agent form mobile order — PR #1322 merged (`1bad8159`). CSS `order-first` / `md:order-none` reorders the agent-form cards so the operational knobs card (Model, Schedule, Tool scope, Allowed tools, Max turns, Budget) appears ABOVE the long prompt body on <768px. DOM and tab order unchanged.
+- ✅ **MOBILE-17/18** Small polish — PR #1323 merged (`d053acaa`). Empty-state description `max-w-sm` → `max-w-xs` (no longer exceeds 375px viewport in worst-case parents); error page `<pre>` gains explicit `[-webkit-overflow-scrolling:touch]` for parity with the table primitive.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -41,7 +41,11 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## Sprint status
 
-**SPRINT WRAP-UP PR OPEN: [#1326](https://github.com/canalesb93/breadbox/pull/1326)** (sprint/mobile-ios-safari → main). 11 fixes shipped (10 PRs merged into sprint branch + 1 follow-up dvw cleanup committed directly). Awaiting user review + merge.
+**SPRINT WRAP-UP PR OPEN: [#1326](https://github.com/canalesb93/breadbox/pull/1326)** (sprint/mobile-ios-safari → main). 12 fixes shipped (10 PRs merged into sprint branch + 2 follow-ups committed directly: dvw cleanup on sibling components, then settings-tab strip scroll). Awaiting user review + merge.
+
+## Completed (additions since wrap-up PR opened)
+
+- ✅ **MOBILE-21** Mobile settings tabs not h-scrollable — pushed directly to sprint branch (`6cb17938`). The `<ul>` had `w-max` so it grew past its parent `<nav>` (which has no overflow), making the `overflow-x-auto` on the ul itself a no-op. Removing `w-max` constrains the ul to parent width; the `shrink-0` pills inside then push horizontally as intended.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -27,26 +27,25 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## Backlog (P1-P2 — scout-seeded)
 
-- [ ] **MOBILE-5** Icon-only buttons below 44pt tap target. `web/src/components/ui/button.tsx` (`icon-xs` size-6 = 24px, `icon-sm` size-8 = 32px) and `row-actions-menu.tsx` (kebab triggers). Goal: ≥44px on touch viewports.
 - [ ] **MOBILE-6** Input font-size triggers Safari auto-zoom. `web/src/components/ui/input.tsx` (`text-base` then `md:text-sm`). Keep ≥16px on mobile viewports.
 - [ ] **MOBILE-7** Viewport meta missing safe-area + zoom intent. `web/index.html`. Add `viewport-fit=cover`, leave `user-scalable=yes` (accessibility).
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device.
 - [ ] **MOBILE-9** Sheet content not safe-area aware. `web/src/components/ui/sheet.tsx` (lines 62-71). Add `env(safe-area-inset-*)` padding (compose, don't edit ui/*).
 - [ ] **MOBILE-10** `100vw` math in `selection-action-bar.tsx` causes occasional horizontal scroll on iOS. `web/src/features/connections/selection-action-bar.tsx` (line 121). Replace with `w-full` + parent constraint.
 - [ ] **MOBILE-11** Table horizontal scroll lacks touch affordance. `web/src/components/ui/table.tsx`, `web/src/components/data-table.tsx`. Add scroll-shadow indicator + `-webkit-overflow-scrolling: touch`.
-- [ ] **MOBILE-12** Command palette input below tap target. `web/src/components/ui/command.tsx` (`h-9` = 36px). Need `h-12 md:h-9`.
 - [ ] **MOBILE-13** Sidebar uses `h-svh` instead of `h-full`. `web/src/components/ui/sidebar.tsx` (line 230). Switch to `h-full` with parent height constraint.
 
 > Items touching `web/src/components/ui/*` should be solved by composing over the primitive (wrap, prop-pass) — only edit `ui/*` if there is no other path. Use `/shadcn` skill to verify if a primitive can be upgraded via prop instead.
 
 ## In-flight PRs
 
-- **fix/mobile-tap-targets** (subagent `a0c32b09`) — bundles MOBILE-5 + MOBILE-12. Adds `(pointer: coarse)` pseudo-element tap-zone to icon-only Button variants + bumps CommandInput height on touch. Visual size unchanged on desktop. PR # TBD.
+_(none)_
 
 ## Completed
 
 - ✅ **MOBILE-1** Sidebar close-on-tap — PR #1312 merged (`ab6dd40a`). `useSidebar().setOpenMobile(false)` wired into `NavMain` (link + modal) and `NavUser` (logout). Desktop unaffected.
-- ✅ **MOBILE-2/3/4** Popover/Select/DropdownMenu onscreen — PR #1316 merged (`cfd98db9`). Added `collisionPadding={8}` (overridable default), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` to all three primitive Content components. ui/* tweak path chosen over wrapper sweep (34 call sites > 15 threshold).
+- ✅ **MOBILE-2/3/4** Popover/Select/DropdownMenu onscreen — PR #1316 merged (`cfd98db9`). Added `collisionPadding={8}` (overridable default), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` to all three primitive Content components.
+- ✅ **MOBILE-5/12** 44pt tap targets — PR #1317 merged (`3b2f91f5`). Tailwind v4 `pointer-coarse:` variant adds invisible 44×44 tap zone via `::before` pseudo to all icon Button sizes; CommandInput bumps to `h-12` on touch. Desktop visuals unchanged (verified via mouse `pointer: fine`).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -40,7 +40,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-empty-state-and-error-pre** (subagent `aaf9e92d`) — MOBILE-17 + MOBILE-18. `max-w-sm` → `max-w-xs` on empty-state description; `[-webkit-overflow-scrolling:touch]` added to error page `<pre>`. PR # TBD.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -41,7 +41,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## Sprint status
 
-**10 PRs merged on `sprint/mobile-ios-safari`.** Awaiting user authorization to open a final `sprint/mobile-ios-safari → main` PR — explicit permission needed per memory `feedback_no_auto_merge.md` (auth to merge subagent PRs INTO the sprint branch ≠ auth to merge sprint INTO main).
+**SPRINT WRAP-UP PR OPEN: [#1326](https://github.com/canalesb93/breadbox/pull/1326)** (sprint/mobile-ios-safari → main). 11 fixes shipped (10 PRs merged into sprint branch + 1 follow-up dvw cleanup committed directly). Awaiting user review + merge.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -35,7 +35,8 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-viewport-units** (subagent) — bundles MOBILE-10 + MOBILE-13. Swaps `100vw` → `100dvw` in selection-action-bar; `h-svh` → `h-full`/`h-dvh` in sidebar. PR # TBD.
+- **Re-scout** (Explore agent) — auditing v2 SPA post-fixes for NEW mobile issues (forms, detail heroes, dialogs, toolbars, table columns, empty states). Will fold findings into backlog when done.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -38,7 +38,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-transactions-toolbar-rail** (subagent `a858ae15`) — MOBILE-20. Converts transactions filter-pills container to horizontal-scroll chip rail on mobile (`max-sm:scroll-shadow-x max-sm:overflow-x-auto max-sm:flex-nowrap`); restores `flex-wrap` on sm+. Reuses `scroll-shadow-x` utility from PR #1319. PR # TBD.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -25,6 +25,19 @@
 
 _(empty — both user-reported P0 bugs shipped)_
 
+## Backlog (P0 — re-scout, post-fix issues)
+
+- [ ] **MOBILE-14** Agent form right card sinks below at 375px. `web/src/features/agents/agent-form.tsx` (~line 113). `grid-cols-1 md:grid-cols-3` plus `md:col-span-2` on the left card causes the right card (settings/model/budget) to fall far down at 375px. Add `sm:grid-cols-2` reflow or stack semantically until md.
+- [ ] **MOBILE-15** FormFooter buttons stack vertically on narrow mobile. `web/src/components/form-footer.tsx` (~line 56). `flex flex-wrap gap-2` lets "Cancel" + "Create category" wrap to two rows when text is long. Try `flex-nowrap` with text truncation, or short labels on mobile.
+- [ ] **MOBILE-16** PageHeader actions clip on mobile. `web/src/components/page-header.tsx` (~lines 48-66). Right-hand actions div has `shrink-0` so two buttons can overflow at 375px. Drop `shrink-0` or allow `flex-wrap` so actions can drop below the title.
+
+## Backlog (P1 — re-scout)
+
+- [ ] **MOBILE-17** Empty state `max-w-sm` (384px) exceeds 375px viewport. `web/src/components/empty-state.tsx` (~line 73). Bump to `max-w-xs` or rely on viewport padding.
+- [ ] **MOBILE-18** Error page `<pre>` block lacks iOS momentum. `web/src/routes/error.tsx` (~line 152). Add `[-webkit-overflow-scrolling:touch]` (same pattern as #1319 table fix).
+- [ ] **MOBILE-19** HeroGrid tight 10px padding on 375px. `web/src/components/hero-grid.tsx` (~lines 43-45). `px-5 sm:px-7` feels cramped. Consider `px-4 sm:px-5` (more breathing room actually means less mobile padding) — verify against design intent.
+- [ ] **MOBILE-20** Transactions toolbar wraps pills above sort/select buttons. `web/src/features/transactions/transactions-toolbar.tsx` (~line 202). `flex flex-wrap` pushes sort/select to a third row when there are several filter chips. Consider horizontal-scroll chip rail on mobile or fixed positioning.
+
 ## Backlog (P1-P2 — scout-seeded)
 
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device. (Header safe-area top inset handled in MOBILE-7 PR; keyboard-overlap concern still open.)
@@ -36,7 +49,6 @@ _(empty — both user-reported P0 bugs shipped)_
 ## In-flight PRs
 
 - **fix/mobile-viewport-units** (subagent) — bundles MOBILE-10 + MOBILE-13. Swaps `100vw` → `100dvw` in selection-action-bar; `h-svh` → `h-full`/`h-dvh` in sidebar. PR # TBD.
-- **Re-scout** (Explore agent) — auditing v2 SPA post-fixes for NEW mobile issues (forms, detail heroes, dialogs, toolbars, table columns, empty states). Will fold findings into backlog when done.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -41,14 +41,12 @@ _(empty — both user-reported P0 bugs shipped)_
 ## Backlog (P1-P2 — scout-seeded)
 
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device. (Header safe-area top inset handled in MOBILE-7 PR; keyboard-overlap concern still open.)
-- [ ] **MOBILE-10** `100vw` math in `selection-action-bar.tsx` causes occasional horizontal scroll on iOS. `web/src/features/connections/selection-action-bar.tsx` (line 121). Replace with `w-full` + parent constraint.
-- [ ] **MOBILE-13** Sidebar uses `h-svh` instead of `h-full`. `web/src/components/ui/sidebar.tsx` (line 230). Switch to `h-full` with parent height constraint.
 
 > Items touching `web/src/components/ui/*` should be solved by composing over the primitive (wrap, prop-pass) — only edit `ui/*` if there is no other path. Use `/shadcn` skill to verify if a primitive can be upgraded via prop instead.
 
 ## In-flight PRs
 
-- **fix/mobile-viewport-units** (subagent) — bundles MOBILE-10 + MOBILE-13. Swaps `100vw` → `100dvw` in selection-action-bar; `h-svh` → `h-full`/`h-dvh` in sidebar. PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -58,6 +56,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-6 (verified non-issue, closed)** Input font-size auto-zoom — `web/src/components/ui/input.tsx` and `textarea.tsx` already use `text-base` (16px) on mobile and `md:text-sm` (14px) at desktop ≥768px. iOS auto-zoom only fires on inputs <16px on mobile viewports; both meet the threshold. No code change required.
 - ✅ **MOBILE-7/9** iOS safe-area pass — PR #1318 merged (`78c814d9`). Added `viewport-fit=cover` to `web/index.html` (activates `env(safe-area-inset-*)`), per-side safe-area padding to `SheetContent`, mobile sidebar inner content respects bottom inset, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header so it sits below the notch/Dynamic Island.
 - ✅ **MOBILE-11** Table scroll affordance — PR #1319 merged (`66d7d8d2`). Added `scroll-shadow-x` utility (4-layer CSS-only gradient, dark-mode aware) + `[-webkit-overflow-scrolling:touch]` to the `Table` primitive's container. Clipped tables now show a fade indicating scrollability; flat right edge confusion resolved.
+- ✅ **MOBILE-10/13** Dynamic viewport units — PR #1320 merged (`b3411af3`). Selection action bar swapped `100vw` → `100dvw` so it stays within the dynamic viewport as iOS chrome collapses; desktop sidebar swapped `h-svh` → `h-full` (parent-relative) so it fills exactly its container instead of the worst-case small-viewport height.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -41,7 +41,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-tap-targets** (subagent `a0c32b09`) — bundles MOBILE-5 + MOBILE-12. Adds `(pointer: coarse)` pseudo-element tap-zone to icon-only Button variants + bumps CommandInput height on touch. Visual size unchanged on desktop. PR # TBD.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -21,21 +21,9 @@
 - Popovers/dropdowns must respect viewport bounds (Radix `collisionPadding`).
 - Sheet on mobile is shadcn Sidebar's built-in behavior (`useSidebar().openMobile`).
 
-## Backlog (P0 — broken / user-reported)
+## Backlog (P0)
 
-- [ ] **MOBILE-2** Menus / popovers / pickers render offscreen on mobile.
-  - Files: audit `Popover`, `DropdownMenu`, `Command`, `Combobox`, `Select` usages across `web/src/`.
-  - Cause: missing `collisionPadding`, fixed `side`/`align` that overflow viewport, or content wider than `100vw - 2 * padding`.
-  - Fix: tighten Radix props (`collisionPadding`, `sideOffset`), constrain widths with `max-w-[calc(100vw-2rem)]`, prefer `Sheet` on mobile for category-picker-class pickers.
-
-## Backlog (P0 — additional from scout)
-
-- [ ] **MOBILE-3** Popover content overflows narrow viewports.
-  - File: `web/src/components/ui/popover.tsx` (`w-72` ≈ 18rem with no max-width).
-  - Fix: `w-72 max-w-[calc(100vw-1rem)]`, or wrap via composed component if `ui/*` is off-limits. Validate Radix collisionPadding for selects/dropdowns too.
-- [ ] **MOBILE-4** Select / DropdownMenu render offscreen.
-  - Files: `web/src/components/ui/select.tsx` (lines ~66-76), `web/src/components/ui/dropdown-menu.tsx` (lines ~32-50).
-  - Fix: `max-h-[50vh]`, `collisionPadding`, and viewport-aware width clamp.
+_(empty — both user-reported P0 bugs shipped)_
 
 ## Backlog (P1-P2 — scout-seeded)
 
@@ -53,11 +41,12 @@
 
 ## In-flight PRs
 
-- **fix/mobile-menus-onscreen** (subagent `a9a0c0ce`) — bundles MOBILE-2 + MOBILE-3 + MOBILE-4. Adds `collisionPadding`, `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh,var(--radix-popper-available-height))]` to Popover / Select / DropdownMenu primitives (wrapper sweep or ui/* tweak, subagent picks the right path based on call-site count). PR # TBD on subagent return.
+_(none)_
 
 ## Completed
 
-- ✅ **MOBILE-1** Sidebar close-on-tap — PR #1312 merged into sprint branch (commit `ab6dd40a`). `useSidebar().setOpenMobile(false)` wired into both `NavMain` (link + modal branches) and `NavUser` (logout path). Desktop unaffected (gated on `isMobile`).
+- ✅ **MOBILE-1** Sidebar close-on-tap — PR #1312 merged (`ab6dd40a`). `useSidebar().setOpenMobile(false)` wired into `NavMain` (link + modal) and `NavUser` (logout). Desktop unaffected.
+- ✅ **MOBILE-2/3/4** Popover/Select/DropdownMenu onscreen — PR #1316 merged (`cfd98db9`). Added `collisionPadding={8}` (overridable default), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` to all three primitive Content components. ui/* tweak path chosen over wrapper sweep (34 call sites > 15 threshold).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -44,7 +44,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-agent-form-order** (subagent `a84bd45e`) — MOBILE-14. Reorders agent-form cards on mobile via CSS `order-first` / `md:order-none` so model/schedule/scope settings appear above the long prompt body on narrow viewports. Tab order unchanged (DOM order preserved). PR # TBD.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -25,10 +25,6 @@
 
 _(empty — both user-reported P0 bugs shipped)_
 
-## Backlog (P0 — re-scout, post-fix issues)
-
-- [ ] **MOBILE-14** Agent form right card sinks below at 375px. `web/src/features/agents/agent-form.tsx` (~line 113). `grid-cols-1 md:grid-cols-3` plus `md:col-span-2` on the left card causes the right card (settings/model/budget) to fall far down at 375px. Add `sm:grid-cols-2` reflow or stack semantically until md.
-
 ## Backlog (P1 — re-scout)
 
 - [ ] **MOBILE-17** Empty state `max-w-sm` (384px) exceeds 375px viewport. `web/src/components/empty-state.tsx` (~line 73). Bump to `max-w-xs` or rely on viewport padding.
@@ -44,7 +40,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-- **fix/mobile-agent-form-order** (subagent `a84bd45e`) — MOBILE-14. Reorders agent-form cards on mobile via CSS `order-first` / `md:order-none` so model/schedule/scope settings appear above the long prompt body on narrow viewports. Tab order unchanged (DOM order preserved). PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -56,6 +52,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-11** Table scroll affordance — PR #1319 merged (`66d7d8d2`). Added `scroll-shadow-x` utility (4-layer CSS-only gradient, dark-mode aware) + `[-webkit-overflow-scrolling:touch]` to the `Table` primitive's container. Clipped tables now show a fade indicating scrollability; flat right edge confusion resolved.
 - ✅ **MOBILE-10/13** Dynamic viewport units — PR #1320 merged (`b3411af3`). Selection action bar swapped `100vw` → `100dvw` so it stays within the dynamic viewport as iOS chrome collapses; desktop sidebar swapped `h-svh` → `h-full` (parent-relative) so it fills exactly its container instead of the worst-case small-viewport height.
 - ✅ **MOBILE-15/16** Header + footer mobile stacking — PR #1321 merged (`669cfed6`). `PageHeader` actions cluster now wraps on mobile (`flex-wrap` + `sm:flex-nowrap sm:shrink-0`) so pages with multiple action buttons no longer overflow horizontally. `FormFooter` action cluster goes full-width column with primary on top (`flex-col-reverse w-full`) at <640px, restoring inline row on ≥640px — affirmative-on-top matches iOS / Material.
+- ✅ **MOBILE-14** Agent form mobile order — PR #1322 merged (`1bad8159`). CSS `order-first` / `md:order-none` reorders the agent-form cards so the operational knobs card (Model, Schedule, Tool scope, Allowed tools, Max turns, Budget) appears ABOVE the long prompt body on <768px. DOM and tab order unchanged.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -34,9 +34,28 @@
   - Cause: missing `collisionPadding`, fixed `side`/`align` that overflow viewport, or content wider than `100vw - 2 * padding`.
   - Fix: tighten Radix props (`collisionPadding`, `sideOffset`), constrain widths with `max-w-[calc(100vw-2rem)]`, prefer `Sheet` on mobile for category-picker-class pickers.
 
-## Backlog (P1-P2 — to be seeded by scout)
+## Backlog (P0 — additional from scout)
 
-_Pending: Explore agent is scouting routes for additional issues. Will be folded in next iteration._
+- [ ] **MOBILE-3** Popover content overflows narrow viewports.
+  - File: `web/src/components/ui/popover.tsx` (`w-72` ≈ 18rem with no max-width).
+  - Fix: `w-72 max-w-[calc(100vw-1rem)]`, or wrap via composed component if `ui/*` is off-limits. Validate Radix collisionPadding for selects/dropdowns too.
+- [ ] **MOBILE-4** Select / DropdownMenu render offscreen.
+  - Files: `web/src/components/ui/select.tsx` (lines ~66-76), `web/src/components/ui/dropdown-menu.tsx` (lines ~32-50).
+  - Fix: `max-h-[50vh]`, `collisionPadding`, and viewport-aware width clamp.
+
+## Backlog (P1-P2 — scout-seeded)
+
+- [ ] **MOBILE-5** Icon-only buttons below 44pt tap target. `web/src/components/ui/button.tsx` (`icon-xs` size-6 = 24px, `icon-sm` size-8 = 32px) and `row-actions-menu.tsx` (kebab triggers). Goal: ≥44px on touch viewports.
+- [ ] **MOBILE-6** Input font-size triggers Safari auto-zoom. `web/src/components/ui/input.tsx` (`text-base` then `md:text-sm`). Keep ≥16px on mobile viewports.
+- [ ] **MOBILE-7** Viewport meta missing safe-area + zoom intent. `web/index.html`. Add `viewport-fit=cover`, leave `user-scalable=yes` (accessibility).
+- [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device.
+- [ ] **MOBILE-9** Sheet content not safe-area aware. `web/src/components/ui/sheet.tsx` (lines 62-71). Add `env(safe-area-inset-*)` padding (compose, don't edit ui/*).
+- [ ] **MOBILE-10** `100vw` math in `selection-action-bar.tsx` causes occasional horizontal scroll on iOS. `web/src/features/connections/selection-action-bar.tsx` (line 121). Replace with `w-full` + parent constraint.
+- [ ] **MOBILE-11** Table horizontal scroll lacks touch affordance. `web/src/components/ui/table.tsx`, `web/src/components/data-table.tsx`. Add scroll-shadow indicator + `-webkit-overflow-scrolling: touch`.
+- [ ] **MOBILE-12** Command palette input below tap target. `web/src/components/ui/command.tsx` (`h-9` = 36px). Need `h-12 md:h-9`.
+- [ ] **MOBILE-13** Sidebar uses `h-svh` instead of `h-full`. `web/src/components/ui/sidebar.tsx` (line 230). Switch to `h-full` with parent height constraint.
+
+> Items touching `web/src/components/ui/*` should be solved by composing over the primitive (wrap, prop-pass) — only edit `ui/*` if there is no other path. Use `/shadcn` skill to verify if a primitive can be upgraded via prop instead.
 
 ## In-flight PRs
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -36,7 +36,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-table-scroll** (subagent `ae5b5b90`) — MOBILE-11 primary. Adds scroll-shadow gradient + iOS momentum to `Table` wrapper. May fold in MOBILE-10 (`100vw` → `100dvw`) and MOBILE-13 (`h-svh` → `h-full`/`h-dvh`) if diff stays ≤30 LOC. PR # TBD.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -27,10 +27,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## Backlog (P1-P2 — scout-seeded)
 
-- [ ] **MOBILE-6** Input font-size triggers Safari auto-zoom. `web/src/components/ui/input.tsx` (`text-base` then `md:text-sm`). Keep ≥16px on mobile viewports.
-- [ ] **MOBILE-7** Viewport meta missing safe-area + zoom intent. `web/index.html`. Add `viewport-fit=cover`, leave `user-scalable=yes` (accessibility).
-- [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device.
-- [ ] **MOBILE-9** Sheet content not safe-area aware. `web/src/components/ui/sheet.tsx` (lines 62-71). Add `env(safe-area-inset-*)` padding (compose, don't edit ui/*).
+- [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device. (Header safe-area top inset handled in MOBILE-7 PR; keyboard-overlap concern still open.)
 - [ ] **MOBILE-10** `100vw` math in `selection-action-bar.tsx` causes occasional horizontal scroll on iOS. `web/src/features/connections/selection-action-bar.tsx` (line 121). Replace with `w-full` + parent constraint.
 - [ ] **MOBILE-11** Table horizontal scroll lacks touch affordance. `web/src/components/ui/table.tsx`, `web/src/components/data-table.tsx`. Add scroll-shadow indicator + `-webkit-overflow-scrolling: touch`.
 - [ ] **MOBILE-13** Sidebar uses `h-svh` instead of `h-full`. `web/src/components/ui/sidebar.tsx` (line 230). Switch to `h-full` with parent height constraint.
@@ -39,13 +36,14 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-safe-area** (subagent `a36a66a9`) — bundles MOBILE-7 + MOBILE-9 (+ sticky header top-inset). Adds `viewport-fit=cover`, safe-area padding to Sheet content per side, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header. PR # TBD.
 
 ## Completed
 
 - ✅ **MOBILE-1** Sidebar close-on-tap — PR #1312 merged (`ab6dd40a`). `useSidebar().setOpenMobile(false)` wired into `NavMain` (link + modal) and `NavUser` (logout). Desktop unaffected.
 - ✅ **MOBILE-2/3/4** Popover/Select/DropdownMenu onscreen — PR #1316 merged (`cfd98db9`). Added `collisionPadding={8}` (overridable default), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` to all three primitive Content components.
 - ✅ **MOBILE-5/12** 44pt tap targets — PR #1317 merged (`3b2f91f5`). Tailwind v4 `pointer-coarse:` variant adds invisible 44×44 tap zone via `::before` pseudo to all icon Button sizes; CommandInput bumps to `h-12` on touch. Desktop visuals unchanged (verified via mouse `pointer: fine`).
+- ✅ **MOBILE-6 (verified non-issue, closed)** Input font-size auto-zoom — `web/src/components/ui/input.tsx` and `textarea.tsx` already use `text-base` (16px) on mobile and `md:text-sm` (14px) at desktop ≥768px. iOS auto-zoom only fires on inputs <16px on mobile viewports; both meet the threshold. No code change required.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -37,7 +37,11 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **Final scout** (Explore agent `af9b31eb`) — confirming no remaining mobile issues across untouched surfaces (setup/login/api-key-created, auth-shell, timeline-rail, floating-action-bar, connection/account detail, CSV flow). Will fold any genuine finds into the backlog; if empty, sprint is ready for sprint → main PR.
+
+## Sprint status
+
+**10 PRs merged on `sprint/mobile-ios-safari`.** Awaiting user authorization to open a final `sprint/mobile-ios-safari → main` PR — explicit permission needed per memory `feedback_no_auto_merge.md` (auth to merge subagent PRs INTO the sprint branch ≠ auth to merge sprint INTO main).
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -28,7 +28,6 @@ _(empty — both user-reported P0 bugs shipped)_
 ## Backlog (P1 — re-scout)
 
 - [ ] **MOBILE-19** HeroGrid tight 20px padding on 375px. `web/src/components/hero-grid.tsx` (~lines 43-45). `px-5 sm:px-7` is fine but feels a touch cramped per scout. Subjective — defer until visual evidence shows a clear problem. May close as won't-fix.
-- [ ] **MOBILE-20** Transactions toolbar wraps pills above sort/select buttons. `web/src/features/transactions/transactions-toolbar.tsx` (~line 202). `flex flex-wrap` pushes sort/select to a third row when there are several filter chips. Consider horizontal-scroll chip rail on mobile or fixed positioning.
 
 ## Backlog (P1-P2 — scout-seeded)
 
@@ -38,7 +37,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-- **fix/mobile-transactions-toolbar-rail** (subagent `a858ae15`) — MOBILE-20. Converts transactions filter-pills container to horizontal-scroll chip rail on mobile (`max-sm:scroll-shadow-x max-sm:overflow-x-auto max-sm:flex-nowrap`); restores `flex-wrap` on sm+. Reuses `scroll-shadow-x` utility from PR #1319. PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -52,6 +51,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-15/16** Header + footer mobile stacking — PR #1321 merged (`669cfed6`). `PageHeader` actions cluster now wraps on mobile (`flex-wrap` + `sm:flex-nowrap sm:shrink-0`) so pages with multiple action buttons no longer overflow horizontally. `FormFooter` action cluster goes full-width column with primary on top (`flex-col-reverse w-full`) at <640px, restoring inline row on ≥640px — affirmative-on-top matches iOS / Material.
 - ✅ **MOBILE-14** Agent form mobile order — PR #1322 merged (`1bad8159`). CSS `order-first` / `md:order-none` reorders the agent-form cards so the operational knobs card (Model, Schedule, Tool scope, Allowed tools, Max turns, Budget) appears ABOVE the long prompt body on <768px. DOM and tab order unchanged.
 - ✅ **MOBILE-17/18** Small polish — PR #1323 merged (`d053acaa`). Empty-state description `max-w-sm` → `max-w-xs` (no longer exceeds 375px viewport in worst-case parents); error page `<pre>` gains explicit `[-webkit-overflow-scrolling:touch]` for parity with the table primitive.
+- ✅ **MOBILE-20** Transactions filter rail — PR #1324 merged (`b169174b`). Filter pills become a horizontal-scroll chip rail on <640px (using the same `scroll-shadow-x` fade as the Table primitive); at sm+ they revert to wrap. Subagent also promoted `scroll-shadow-x` to a Tailwind `@utility` so variants (`max-sm:`, `dark:`) compile to real rules, and added a `--scroll-shadow-cover` CSS variable so consumers on the page surface (vs inside a Card) can override via `[--scroll-shadow-cover:var(--background)]`.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -36,7 +36,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-- **fix/mobile-safe-area** (subagent `a36a66a9`) — bundles MOBILE-7 + MOBILE-9 (+ sticky header top-inset). Adds `viewport-fit=cover`, safe-area padding to Sheet content per side, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header. PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -44,6 +44,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-2/3/4** Popover/Select/DropdownMenu onscreen — PR #1316 merged (`cfd98db9`). Added `collisionPadding={8}` (overridable default), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` to all three primitive Content components.
 - ✅ **MOBILE-5/12** 44pt tap targets — PR #1317 merged (`3b2f91f5`). Tailwind v4 `pointer-coarse:` variant adds invisible 44×44 tap zone via `::before` pseudo to all icon Button sizes; CommandInput bumps to `h-12` on touch. Desktop visuals unchanged (verified via mouse `pointer: fine`).
 - ✅ **MOBILE-6 (verified non-issue, closed)** Input font-size auto-zoom — `web/src/components/ui/input.tsx` and `textarea.tsx` already use `text-base` (16px) on mobile and `md:text-sm` (14px) at desktop ≥768px. iOS auto-zoom only fires on inputs <16px on mobile viewports; both meet the threshold. No code change required.
+- ✅ **MOBILE-7/9** iOS safe-area pass — PR #1318 merged (`78c814d9`). Added `viewport-fit=cover` to `web/index.html` (activates `env(safe-area-inset-*)`), per-side safe-area padding to `SheetContent`, mobile sidebar inner content respects bottom inset, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header so it sits below the notch/Dynamic Island.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -1,0 +1,54 @@
+# Mobile Responsiveness Sprint — v2 SPA / iOS Safari
+
+**Branch:** `sprint/mobile-ios-safari`
+**Goal:** v2 SPA works excellently in iOS mobile Safari (reference: iPhone 14 Pro, 393×852, dvh-aware).
+**Cadence:** Autonomous /loop iteration every 30 min. One subagent PR per iteration.
+
+## Workflow
+
+1. Loop wakes → sync branch → merge ready PRs → pick next backlog item.
+2. Spawn ONE subagent in worktree isolation. Brief includes file paths + iOS quirks.
+3. Subagent opens PR against this branch with `img402.dev` screenshots at 375×812 / 768×1024 / 1280×800.
+4. Orchestrator reviews next iteration. Merges when green. Never merge to `main`.
+
+## iOS Safari quirks to keep in mind
+
+- `100vh` is broken (counts the address bar). Prefer `100dvh` / `100svh`.
+- Inputs with `font-size < 16px` auto-zoom on focus. Always ≥16px on inputs/textareas/selects.
+- Tap targets < 44×44pt are rejected by Apple HIG.
+- `env(safe-area-inset-*)` for notch/home indicator.
+- Sticky elements behave oddly with the keyboard — test forms.
+- Popovers/dropdowns must respect viewport bounds (Radix `collisionPadding`).
+- Sheet on mobile is shadcn Sidebar's built-in behavior (`useSidebar().openMobile`).
+
+## Backlog (P0 — broken / user-reported)
+
+- [ ] **MOBILE-1** Sidebar stays open after tapping a nav item on mobile.
+  - Files: `web/src/components/nav-main.tsx`, `web/src/components/app-sidebar.tsx`, `web/src/components/ui/sidebar.tsx`
+  - Cause: `NavRow` for `kind: "link"` renders `<Link>` directly inside `SidebarMenuButton asChild` — no `setOpenMobile(false)` on tap. Modal items also miss this.
+  - Fix: call `useSidebar().setOpenMobile(false)` on nav-link tap on mobile.
+  - Status: PR not yet opened.
+
+- [ ] **MOBILE-2** Menus / popovers / pickers render offscreen on mobile.
+  - Files: audit `Popover`, `DropdownMenu`, `Command`, `Combobox`, `Select` usages across `web/src/`.
+  - Cause: missing `collisionPadding`, fixed `side`/`align` that overflow viewport, or content wider than `100vw - 2 * padding`.
+  - Fix: tighten Radix props (`collisionPadding`, `sideOffset`), constrain widths with `max-w-[calc(100vw-2rem)]`, prefer `Sheet` on mobile for category-picker-class pickers.
+
+## Backlog (P1-P2 — to be seeded by scout)
+
+_Pending: Explore agent is scouting routes for additional issues. Will be folded in next iteration._
+
+## In-flight PRs
+
+_(none yet)_
+
+## Completed
+
+_(none yet)_
+
+## Notes for next iteration
+
+- Always `git fetch && git pull` before starting.
+- Run `gh pr list --base sprint/mobile-ios-safari --state open` to see in-flight work.
+- Run `gh pr list --base sprint/mobile-ios-safari --state merged` to track velocity.
+- If a subagent PR has failing CI, comment summary, skip merging, mark as blocked here.

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -46,7 +46,7 @@ _(empty — both user-reported P0 bugs shipped)_
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-header-and-footer-stack** (subagent `a6623977`) — bundles MOBILE-15 + MOBILE-16. PageHeader actions wrap on mobile (`flex-wrap`, `sm:flex-nowrap`); FormFooter stacks buttons full-width with primary on top via `flex-col-reverse sm:flex-row`. Composed-layer components (no ui/* edit). PR # TBD.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -53,7 +53,7 @@
 
 ## In-flight PRs
 
-_(none yet)_
+- **fix/mobile-menus-onscreen** (subagent `a9a0c0ce`) — bundles MOBILE-2 + MOBILE-3 + MOBILE-4. Adds `collisionPadding`, `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh,var(--radix-popper-available-height))]` to Popover / Select / DropdownMenu primitives (wrapper sweep or ui/* tweak, subagent picks the right path based on call-site count). PR # TBD on subagent return.
 
 ## Completed
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -29,14 +29,13 @@ _(empty — both user-reported P0 bugs shipped)_
 
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device. (Header safe-area top inset handled in MOBILE-7 PR; keyboard-overlap concern still open.)
 - [ ] **MOBILE-10** `100vw` math in `selection-action-bar.tsx` causes occasional horizontal scroll on iOS. `web/src/features/connections/selection-action-bar.tsx` (line 121). Replace with `w-full` + parent constraint.
-- [ ] **MOBILE-11** Table horizontal scroll lacks touch affordance. `web/src/components/ui/table.tsx`, `web/src/components/data-table.tsx`. Add scroll-shadow indicator + `-webkit-overflow-scrolling: touch`.
 - [ ] **MOBILE-13** Sidebar uses `h-svh` instead of `h-full`. `web/src/components/ui/sidebar.tsx` (line 230). Switch to `h-full` with parent height constraint.
 
 > Items touching `web/src/components/ui/*` should be solved by composing over the primitive (wrap, prop-pass) — only edit `ui/*` if there is no other path. Use `/shadcn` skill to verify if a primitive can be upgraded via prop instead.
 
 ## In-flight PRs
 
-- **fix/mobile-table-scroll** (subagent `ae5b5b90`) — MOBILE-11 primary. Adds scroll-shadow gradient + iOS momentum to `Table` wrapper. May fold in MOBILE-10 (`100vw` → `100dvw`) and MOBILE-13 (`h-svh` → `h-full`/`h-dvh`) if diff stays ≤30 LOC. PR # TBD.
+_(none)_
 
 ## Completed
 
@@ -45,6 +44,7 @@ _(empty — both user-reported P0 bugs shipped)_
 - ✅ **MOBILE-5/12** 44pt tap targets — PR #1317 merged (`3b2f91f5`). Tailwind v4 `pointer-coarse:` variant adds invisible 44×44 tap zone via `::before` pseudo to all icon Button sizes; CommandInput bumps to `h-12` on touch. Desktop visuals unchanged (verified via mouse `pointer: fine`).
 - ✅ **MOBILE-6 (verified non-issue, closed)** Input font-size auto-zoom — `web/src/components/ui/input.tsx` and `textarea.tsx` already use `text-base` (16px) on mobile and `md:text-sm` (14px) at desktop ≥768px. iOS auto-zoom only fires on inputs <16px on mobile viewports; both meet the threshold. No code change required.
 - ✅ **MOBILE-7/9** iOS safe-area pass — PR #1318 merged (`78c814d9`). Added `viewport-fit=cover` to `web/index.html` (activates `env(safe-area-inset-*)`), per-side safe-area padding to `SheetContent`, mobile sidebar inner content respects bottom inset, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header so it sits below the notch/Dynamic Island.
+- ✅ **MOBILE-11** Table scroll affordance — PR #1319 merged (`66d7d8d2`). Added `scroll-shadow-x` utility (4-layer CSS-only gradient, dark-mode aware) + `[-webkit-overflow-scrolling:touch]` to the `Table` primitive's container. Clipped tables now show a fade indicating scrollability; flat right edge confusion resolved.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -23,12 +23,6 @@
 
 ## Backlog (P0 — broken / user-reported)
 
-- [ ] **MOBILE-1** Sidebar stays open after tapping a nav item on mobile.
-  - Files: `web/src/components/nav-main.tsx`, `web/src/components/app-sidebar.tsx`, `web/src/components/ui/sidebar.tsx`
-  - Cause: `NavRow` for `kind: "link"` renders `<Link>` directly inside `SidebarMenuButton asChild` — no `setOpenMobile(false)` on tap. Modal items also miss this.
-  - Fix: call `useSidebar().setOpenMobile(false)` on nav-link tap on mobile.
-  - Status: PR not yet opened.
-
 - [ ] **MOBILE-2** Menus / popovers / pickers render offscreen on mobile.
   - Files: audit `Popover`, `DropdownMenu`, `Command`, `Combobox`, `Select` usages across `web/src/`.
   - Cause: missing `collisionPadding`, fixed `side`/`align` that overflow viewport, or content wider than `100vw - 2 * padding`.
@@ -63,7 +57,7 @@ _(none yet)_
 
 ## Completed
 
-_(none yet)_
+- ✅ **MOBILE-1** Sidebar close-on-tap — PR #1312 merged into sprint branch (commit `ab6dd40a`). `useSidebar().setOpenMobile(false)` wired into both `NavMain` (link + modal branches) and `NavUser` (logout path). Desktop unaffected (gated on `isMobile`).
 
 ## Notes for next iteration
 

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover activates env(safe-area-inset-*) on edge-to-edge
+         iOS devices (notch / Dynamic Island / home indicator). Without it,
+         the insets resolve to 0 and the browser chrome eats into content.
+         We deliberately do NOT set user-scalable=no or maximum-scale=1 —
+         both block accessibility zoom on iOS. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <title>Breadbox — Self-hosted finance for households</title>
     <meta

--- a/web/src/components/date-range-filter.tsx
+++ b/web/src/components/date-range-filter.tsx
@@ -166,7 +166,7 @@ export function DateRangeFilter({
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        className="flex w-auto max-w-[calc(100vw-2rem)] flex-col p-0 sm:flex-row"
+        className="flex w-auto max-w-[calc(100dvw-2rem)] flex-col p-0 sm:flex-row"
       >
         <ul className="flex flex-wrap gap-1 p-2 sm:w-36 sm:flex-col sm:gap-0.5 sm:border-r sm:p-2">
           {PRESETS.map((preset) => (

--- a/web/src/components/empty-state.tsx
+++ b/web/src/components/empty-state.tsx
@@ -70,7 +70,7 @@ export function EmptyState({
       )}
       <h3 className="text-sm font-medium">{title}</h3>
       {description && (
-        <p className="text-muted-foreground max-w-sm text-sm">{description}</p>
+        <p className="text-muted-foreground max-w-xs text-sm">{description}</p>
       )}
       {action && <div className="mt-3">{action}</div>}
     </div>

--- a/web/src/components/floating-action-bar.tsx
+++ b/web/src/components/floating-action-bar.tsx
@@ -32,7 +32,7 @@ export function FloatingActionBar({
       <div
         data-state="open"
         className={cn(
-          "pointer-events-auto bg-popover/95 text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 shadow-xl backdrop-blur-sm",
+          "pointer-events-auto bg-popover/95 text-popover-foreground flex max-w-[calc(100dvw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 shadow-xl backdrop-blur-sm",
           "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4 data-[state=open]:duration-200",
           className,
         )}

--- a/web/src/components/form-footer.tsx
+++ b/web/src/components/form-footer.tsx
@@ -67,7 +67,7 @@ export function FormFooter({
           {hint}
         </div>
       )}
-      <div className="ml-auto flex items-center gap-2">
+      <div className="ml-auto flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center">
         {secondary}
         {primary}
       </div>

--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -5,6 +5,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { Eyebrow } from "@/components/eyebrow";
 import { isNavMatch, navKey, type NavGroup, type NavLeaf } from "@/lib/nav";
@@ -15,6 +16,13 @@ export function NavMain({ group }: { group: NavGroup }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const navigate = useNavigate();
   const { key: activeModal } = useActiveModal();
+  // Close the mobile sheet on tap so the destination is visible — matches the
+  // behaviour of every native iOS app where a nav tap dismisses the drawer.
+  // Desktop is unaffected because we only touch the mobile-only open state.
+  const { isMobile, setOpenMobile } = useSidebar();
+  const closeMobileSheet = () => {
+    if (isMobile) setOpenMobile(false);
+  };
 
   return (
     <SidebarGroup>
@@ -30,9 +38,11 @@ export function NavMain({ group }: { group: NavGroup }) {
             item={item}
             pathname={pathname}
             activeModal={activeModal}
-            onOpenModal={(modalKey) =>
-              navigate({ to: ".", search: openModal(modalKey) })
-            }
+            onOpenModal={(modalKey) => {
+              closeMobileSheet();
+              navigate({ to: ".", search: openModal(modalKey) });
+            }}
+            onNavigate={closeMobileSheet}
           />
         ))}
       </SidebarMenu>
@@ -68,9 +78,16 @@ interface NavRowProps {
   pathname: string;
   activeModal: string | null;
   onOpenModal: (modalKey: string) => void;
+  onNavigate: () => void;
 }
 
-function NavRow({ item, pathname, activeModal, onOpenModal }: NavRowProps) {
+function NavRow({
+  item,
+  pathname,
+  activeModal,
+  onOpenModal,
+  onNavigate,
+}: NavRowProps) {
   const Icon = item.icon;
 
   if (item.kind === "modal") {
@@ -97,7 +114,11 @@ function NavRow({ item, pathname, activeModal, onOpenModal }: NavRowProps) {
         tooltip={item.title}
         className={NAV_ROW_CLS}
       >
-        <Link to={item.to}>
+        {/* onClick lives on the <Link> directly: asChild forwards props via
+            Radix Slot, but attaching here is the unambiguous, easy-to-audit
+            shape and also fires when the user middle/cmd-clicks. The handler
+            is a no-op on desktop — it only closes the mobile sheet. */}
+        <Link to={item.to} onClick={onNavigate}>
           <Icon />
           <span>{item.title}</span>
         </Link>

--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -141,9 +141,14 @@ function ThemeSubmenu() {
 }
 
 export function NavUser({ me }: { me: Me | null }) {
-  const { isMobile } = useSidebar();
+  const { isMobile, setOpenMobile } = useSidebar();
   const navigate = useNavigate();
   const logout = useLogout();
+  // Mirrors NavMain: tapping a nav target on mobile should dismiss the sheet so
+  // the destination is visible. Desktop is untouched.
+  const closeMobileSheet = () => {
+    if (isMobile) setOpenMobile(false);
+  };
 
   const onLogout = async () => {
     try {
@@ -153,6 +158,7 @@ export function NavUser({ me }: { me: Me | null }) {
       // gone client-side; surface a toast but don't block navigation.
       toast.error("Couldn't reach the server — signing out anyway.");
     }
+    closeMobileSheet();
     navigate({ to: "/login" });
   };
 
@@ -255,7 +261,7 @@ export function NavUser({ me }: { me: Me | null }) {
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem asChild className="gap-2">
-                <Link to="/sandbox">
+                <Link to="/sandbox" onClick={closeMobileSheet}>
                   <Palette className="text-muted-foreground" />
                   Design system
                 </Link>

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -63,7 +63,7 @@ export function PageHeader({
         )}
       </div>
       {actions && (
-        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+        <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:flex-nowrap">{actions}</div>
       )}
     </div>
   );

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -157,7 +157,16 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
         className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-10 -mx-px border-b px-2 backdrop-blur"
       >
         <ul
-          className="-mx-2 flex w-max flex-nowrap items-center gap-1 overflow-x-auto px-2 py-2 whitespace-nowrap [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          // No `w-max`: the ul is parent-width so its `overflow-x-auto` actually
+          // has a scroll context. With `w-max` the ul itself overflowed its
+          // parent `<nav>` (which has no overflow), so the pill strip rendered
+          // past the viewport edge but couldn't be scrolled. Now the
+          // `shrink-0` pills inside push horizontally, and `overflow-x-auto`
+          // routes the gesture correctly. Scrollbar is hidden per the existing
+          // `scrollbar-width:none` / webkit-scrollbar rules — affordance comes
+          // from the always-truncated rightmost pill, matching the rest of the
+          // mobile chip rails.
+          className="-mx-2 flex flex-nowrap items-center gap-1 overflow-x-auto px-2 py-2 whitespace-nowrap [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         >
           {SETTINGS_SECTIONS.map((s) => {
             const Icon = s.icon;

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -4,6 +4,14 @@ import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
+// Icon-only sizes share an invisible 44×44pt tap-zone on touch devices
+// (Apple HIG minimum). The visible square stays small; a centered
+// pseudo-element extends the hit area without affecting layout. Scoped
+// to `pointer-coarse:` so desktop mice (`pointer: fine`) are unaffected.
+// See MOBILE-5 + the `Buttons — tap target` specimen in the sandbox.
+const TAP_TARGET =
+  "relative pointer-coarse:before:absolute pointer-coarse:before:left-1/2 pointer-coarse:before:top-1/2 pointer-coarse:before:size-11 pointer-coarse:before:-translate-x-1/2 pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']"
+
 const buttonVariants = cva(
   // Disabled treatment: filled variants (default/destructive) override
   // `disabled:opacity-50` with a `bg-muted text-muted-foreground` swap below
@@ -32,10 +40,10 @@ const buttonVariants = cva(
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        icon: `size-9 ${TAP_TARGET}`,
+        "icon-xs": `size-6 rounded-md [&_svg:not([class*='size-'])]:size-3 ${TAP_TARGET}`,
+        "icon-sm": `size-8 ${TAP_TARGET}`,
+        "icon-lg": `size-10 ${TAP_TARGET}`,
       },
     },
     defaultVariants: {

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -67,13 +67,18 @@ function CommandInput({
   return (
     <div
       data-slot="command-input-wrapper"
-      className="flex h-9 items-center gap-2 border-b px-3"
+      // h-12 on touch (≥44pt tap target per Apple HIG, MOBILE-12); h-9
+      // on `pointer: fine` keeps desktop density unchanged. CommandDialog
+      // overrides this via `**:data-[slot=command-input-wrapper]:h-12`
+      // when rendered inside the palette, so the touch bump only changes
+      // standalone usage.
+      className="flex h-9 items-center gap-2 border-b px-3 pointer-coarse:h-12"
     >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:h-12",
           className
         )}
         {...props}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -32,6 +32,7 @@ function DropdownMenuTrigger({
 function DropdownMenuContent({
   className,
   sideOffset = 4,
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
@@ -39,8 +40,9 @@ function DropdownMenuContent({
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-[min(60vh,var(--radix-dropdown-menu-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -19,6 +19,7 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
@@ -27,8 +28,9 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 w-72 max-w-[calc(100vw-1rem)] origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -59,6 +59,7 @@ function SelectContent({
   children,
   position = "item-aligned",
   align = "center",
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -66,13 +67,14 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-[min(60vh,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
         )}
         position={position}
         align={align}
+        collisionPadding={collisionPadding}
         {...props}
       >
         <SelectScrollUpButton />

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -60,15 +60,22 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
+          // Each side pads its edge-touching axes from env(safe-area-inset-*)
+          // so the sheet never sits under the iPhone notch / Dynamic Island /
+          // home indicator on edge-to-edge devices. Left/right sheets always
+          // touch top + bottom edges, so they also need pt/pb insets. Browsers
+          // that don't expose safe-area resolve env(...) to 0 — graceful
+          // degradation, no fallback needed. Justification (semantic
+          // correctness, not styling): safe-area is a viewport-edge concern.
           "fixed z-50 flex flex-col gap-4 bg-background shadow-lg duration-200 transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in",
           side === "right" &&
-            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            "inset-y-0 right-0 h-full w-3/4 border-l pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&
-            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+            "inset-y-0 left-0 h-full w-3/4 border-r pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
           side === "top" &&
-            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+            "inset-x-0 top-0 h-auto border-b pt-[env(safe-area-inset-top)] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&
-            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            "inset-x-0 bottom-0 h-auto border-t pb-[env(safe-area-inset-bottom)] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
           className
         )}
         {...props}

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -197,7 +197,17 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          {/* Safe-area: SheetContent has `p-0` here (sidebar needs a flush
+              layout) which would otherwise clobber the sheet primitive's own
+              env(safe-area-inset-*) padding. Re-apply the insets on the inner
+              column so the BrandHeader clears the notch and NavUser clears
+              the home indicator on edge-to-edge iPhones. Values resolve to 0
+              elsewhere — non-iPhone layouts unchanged. Semantic correctness
+              concern (viewport-edge), not styling — same justification as
+              the sheet.tsx edit shipping in the same PR. */}
+          <div className="flex h-full w-full flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+            {children}
+          </div>
         </SheetContent>
       </Sheet>
     )

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -237,7 +237,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-full w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -10,7 +10,16 @@ function Table({
   return (
     <div
       data-slot="table-container"
-      className={cn("relative w-full overflow-x-auto", containerClassName)}
+      className={cn(
+        // `scroll-shadow-x` (globals.css) layers a CSS-only gradient fade
+        // on each edge so a clipped table signals its scrollability on
+        // narrow viewports — without it iOS users see a flat right edge
+        // and assume the table is broken. `-webkit-overflow-scrolling:touch`
+        // is the implicit default on iOS 13+ but explicit beats implicit
+        // when this wrapper sits inside several nested scroll contexts.
+        "relative w-full overflow-x-auto scroll-shadow-x [-webkit-overflow-scrolling:touch]",
+        containerClassName,
+      )}
     >
       <table
         data-slot="table"

--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -111,7 +111,7 @@ export function AgentForm({
   return (
     <Form {...form}>
       <form onSubmit={submit} className="grid grid-cols-1 gap-6 md:grid-cols-3">
-        <div className="space-y-4 md:col-span-2">
+        <div className="space-y-4 md:col-span-2 md:order-none">
           <Card className="space-y-4 p-4">
             <FormField
               control={form.control}
@@ -220,7 +220,16 @@ export function AgentForm({
           </Card>
         </div>
 
-        <div className="space-y-4">
+        {/*
+          Mobile reorder (MOBILE-14): the operational knobs card (Model,
+          Schedule, Tool scope, Allowed tools, Max turns, Budget) sits FIRST
+          on mobile so users don't scroll past the long prompt textarea to
+          reach the controls they tweak most. `order-first` only re-shuffles
+          visual position — DOM order and keyboard tab order are unchanged
+          (still Name → Slug → Prompt → … → Model → Schedule …). At md+ both
+          cards revert to source order via `md:order-none`.
+        */}
+        <div className="order-first space-y-4 md:order-none">
           <Card className="space-y-4 p-4">
             <FormField
               control={form.control}

--- a/web/src/features/connections/selection-action-bar.tsx
+++ b/web/src/features/connections/selection-action-bar.tsx
@@ -118,7 +118,7 @@ export function SelectionActionBar({
   return (
     <>
       <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
-        <div className="bg-popover text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
+        <div className="bg-popover text-popover-foreground flex max-w-[calc(100dvw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
           <span className="text-sm font-medium whitespace-nowrap">
             {selected.length} selected
           </span>

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -215,8 +215,16 @@ export function TransactionsToolbar({
         />
 
         {/* Filter pills — grouped so they wrap as a unit, independent of
-            the sort/select controls. */}
-        <div className="flex flex-wrap items-center gap-2">
+            the sort/select controls. On <640px the row becomes a horizontal-
+            scroll rail (with the `scroll-shadow-x` fade affordance from
+            globals.css) so the toolbar stays a single row instead of
+            consuming 4+ rows on a 375px viewport. At sm+ it reverts to the
+            original `flex-wrap` behavior — at desktop widths the pills fit
+            on one row, and on intermediate widths they wrap as before.
+            The toolbar lives on the page surface, so override the
+            scroll-shadow cover from --card (the Table default) to
+            --background so the fade blends with the page. */}
+        <div className="flex items-center gap-2 max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:[--scroll-shadow-cover:var(--background)] max-sm:[-webkit-overflow-scrolling:touch] sm:flex-wrap">
           <FilterPill
             icon={Banknote}
             label="Account"

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -155,15 +155,18 @@
 }
 
 /* Scroll-shadow indicator for horizontally-scrolling containers (used by
-   the Table primitive). Four layered backgrounds: two solid "cover" fades
-   that mask the shadow at the start/end (anchored to the local content
-   with `background-attachment: local` so they shrink as you scroll into
-   them), and two shadow gradients pinned to the viewport edges with
-   `scroll` so they fade in once the cover has scrolled away. Pure CSS,
-   no JS listener. Color uses --card so the cover blends with the
-   surrounding card surface; shadow color is themed for both modes so it
-   remains visible against the dark card. */
-.scroll-shadow-x {
+   the Table primitive and the mobile transactions-toolbar filter rail).
+   Four layered backgrounds: two solid "cover" fades that mask the shadow
+   at the start/end (anchored to the local content with
+   `background-attachment: local` so they shrink as you scroll into them),
+   and two shadow gradients pinned to the viewport edges with `scroll` so
+   they fade in once the cover has scrolled away. Pure CSS, no JS listener.
+   Cover defaults to `--card` (matches the Table primitive, which sits
+   inside a Card); consumers on the page surface override via Tailwind's
+   arbitrary-property syntax — e.g. `[--scroll-shadow-cover:var(--background)]`.
+   Declared as `@utility` so Tailwind variants
+   (`max-sm:scroll-shadow-x`, `dark:scroll-shadow-x`) compile to real rules. */
+@utility scroll-shadow-x {
   --scroll-shadow-cover: var(--card);
   --scroll-shadow-color: rgb(0 0 0 / 0.1);
   background:

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -153,3 +153,28 @@
 [data-slot="button"] {
   cursor: default;
 }
+
+/* Scroll-shadow indicator for horizontally-scrolling containers (used by
+   the Table primitive). Four layered backgrounds: two solid "cover" fades
+   that mask the shadow at the start/end (anchored to the local content
+   with `background-attachment: local` so they shrink as you scroll into
+   them), and two shadow gradients pinned to the viewport edges with
+   `scroll` so they fade in once the cover has scrolled away. Pure CSS,
+   no JS listener. Color uses --card so the cover blends with the
+   surrounding card surface; shadow color is themed for both modes so it
+   remains visible against the dark card. */
+.scroll-shadow-x {
+  --scroll-shadow-cover: var(--card);
+  --scroll-shadow-color: rgb(0 0 0 / 0.1);
+  background:
+    linear-gradient(to right, var(--scroll-shadow-cover) 30%, transparent),
+    linear-gradient(to right, transparent, var(--scroll-shadow-cover) 70%) 100% 0,
+    linear-gradient(to right, var(--scroll-shadow-color), transparent),
+    linear-gradient(to left, var(--scroll-shadow-color), transparent) 100% 0;
+  background-repeat: no-repeat;
+  background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+.dark .scroll-shadow-x {
+  --scroll-shadow-color: rgb(0 0 0 / 0.35);
+}

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -136,7 +136,15 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
           horizontally-scrolling table) grows the inset past the viewport
           instead of letting the page's own overflow container scroll. */}
       <SidebarInset className="min-w-0">
-        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex h-14 shrink-0 items-center gap-2 border-b backdrop-blur">
+        {/* pt-[env(safe-area-inset-top)] pairs with viewport-fit=cover in
+            web/index.html so the sticky header clears the iPhone notch /
+            Dynamic Island instead of letting the status bar overlap its
+            contents. Switching the fixed `h-14` to `min-h-14` lets the
+            header grow by the inset on edge-to-edge iPhones (otherwise
+            border-box squeezes the 56px interactive area). The inset
+            resolves to 0 elsewhere (desktop, Android, older iOS), so
+            non-iPhone layouts are unchanged. */}
+        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex min-h-14 shrink-0 items-center gap-2 border-b pt-[env(safe-area-inset-top)] backdrop-blur">
           <div className="flex w-full items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-1 h-4" />

--- a/web/src/routes/error.tsx
+++ b/web/src/routes/error.tsx
@@ -149,7 +149,7 @@ export function ErrorPage({ error, reset }: ErrorPageProps) {
               </CollapsibleTrigger>
               <CollapsibleContent>
                 <div className="px-6 pb-6 sm:px-10">
-                  <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed">
+                  <pre className="bg-muted/40 text-muted-foreground max-h-[440px] overflow-auto rounded-md border p-3 text-[11px] leading-relaxed [-webkit-overflow-scrolling:touch]">
                     {stack}
                   </pre>
                 </div>

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -137,6 +137,25 @@ export function PrimitivesSection() {
       </Specimen>
 
       <Specimen
+        label="Button — icon tap target"
+        code="size=icon* @ pointer: coarse"
+        description="Icon-only sizes (icon-xs/sm/icon/icon-lg = 24–40px visible) stay visually small on desktop but get a centered 44×44pt invisible tap-zone via a `pointer-coarse:before:size-11` pseudo-element. Apple HIG minimum without inflating the layout. Resize-emulate a touch viewport in DevTools to see the hit area expand (the box is invisible — toggle ::before in DevTools or temporarily add `before:bg-destructive/20` to confirm)."
+      >
+        <Button size="icon-xs" variant="ghost" aria-label="Add (icon-xs)">
+          <Plus />
+        </Button>
+        <Button size="icon-sm" variant="ghost" aria-label="Add (icon-sm)">
+          <Plus />
+        </Button>
+        <Button size="icon" variant="ghost" aria-label="Add (icon)">
+          <Plus />
+        </Button>
+        <Button size="icon-lg" variant="ghost" aria-label="Add (icon-lg)">
+          <Plus />
+        </Button>
+      </Specimen>
+
+      <Specimen
         label="Button — disabled across variants"
         code="disabled"
         description="Filled variants (default + destructive) swap to bg-muted text-muted-foreground instead of opacity-50 so dark mode doesn't render the near-white primary token as a bright tile. Outline/ghost/secondary/link keep the inherited opacity dim."


### PR DESCRIPTION
## Summary

Autonomous mobile-responsiveness sprint targeting **iOS Safari** on the v2 SPA. Eleven small PRs landed on `sprint/mobile-ios-safari` over a single afternoon; this PR bundles them for review against `main`.

The sprint started from two user-reported bugs ("sidebar stays open after tapping" and "menus render offscreen") and expanded into a full mobile audit. The 11 changes are individually small (most diffs are ≤30 LOC); the rationale for stacking them onto a sprint branch instead of going straight to `main` was to gather visual evidence across multiple surfaces in one place and to land the cumulative work as one reviewable unit.

## Shipped fixes

**Interaction**
- #1312 Sidebar closes on nav tap (`useSidebar().setOpenMobile(false)`, gated on `isMobile`, applied to both nav-main link/modal branches and nav-user logout path).
- #1317 Icon-only buttons + command input meet Apple HIG 44pt tap target via a Tailwind v4 `pointer-coarse:` invisible `::before` pseudo-element. Desktop visuals identical.

**Layout & overflow**
- #1316 Popover / Select / DropdownMenu gain `collisionPadding={8}` (overridable), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` so menus stay onscreen on 375px viewports.
- #1320 Selection-action-bar and sidebar swapped to dynamic viewport units (`100dvw`, `h-full`) so iOS chrome transitions don't push UI offscreen.
- #1321 PageHeader actions wrap on mobile (`flex-wrap` + `sm:flex-nowrap sm:shrink-0`); FormFooter buttons stack full-width column with the affirmative action on TOP (`flex-col-reverse w-full` then `sm:flex-row`) — matches iOS / Material guidance.
- #1322 Agent form cards use CSS `order` to surface the operational knobs (Model, Schedule, Tool scope, Allowed tools, Budget) above the long prompt textarea on mobile. DOM and tab order unchanged.
- #1323 Empty-state description `max-w-sm` → `max-w-xs`; error page `<pre>` gains explicit `[-webkit-overflow-scrolling:touch]`.
- #1324 Transactions filter pills become a horizontal-scroll chip rail on `<640px` (single row instead of 4+); promoted `scroll-shadow-x` to a Tailwind `@utility` (so `max-sm:` and `dark:` variants compile) and added `--scroll-shadow-cover` so consumers off the `--card` surface can override.
- (head of this PR) Same `100vw → 100dvw` cleanup applied to `date-range-filter.tsx` and `floating-action-bar.tsx` — sibling components that #1320 missed.

**iOS edge-to-edge**
- #1318 `viewport-fit=cover` on `<meta name="viewport">` (activates `env(safe-area-inset-*)`), per-side safe-area padding on `SheetContent`, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header so the title sits below the notch / Dynamic Island.

**Affordance**
- #1319 Tables get `scroll-shadow-x` (CSS-only 4-layer gradient, dark-mode-aware) + `[-webkit-overflow-scrolling:touch]` on the wrapper. Clipped tables now signal scrollability instead of looking broken.

## Patterns introduced

- **`@media (pointer: coarse)`** for tap-target rules — correctly catches touch (iPad, iPhone) without false-positives on desktop windows resized small.
- **`@utility scroll-shadow-x`** in `globals.css` — pure-CSS gradient fade that signals horizontal scroll. Used by Table primitive + transactions filter rail. Theme-token-aware via `--scroll-shadow-cover` variable.
- **CSS `order` for mobile reflow** — preserves DOM (and screen-reader / keyboard tab) order while reshuffling visual position on narrow viewports. See agent-form.
- **`max-sm:` + `sm:`** breakpoint pairs — preferred over single-side queries because they make the breakpoint behavior explicit on both sides.

## Validation

Each constituent PR includes mobile (375×812), tablet (768×1024), and desktop (1280×800) screenshots from the `simple-validate-ui` skill, uploaded to img402.dev. The screenshots verify visual parity on desktop (no regressions) and the fix on mobile.

Bun lint (`tsc --noEmit`) and bun build (`tsc -b && vite build`) clean on every constituent PR. Sprint branch tip CI will run via this PR.

## Test plan

- [ ] CI green (full matrix runs on this PR — sprint/* doesn't trigger per-PR CI).
- [ ] Pull the branch locally; `make web && make build` smoke-test the production embed at `http://localhost:8080/v2/`.
- [ ] Open in iOS Safari (real device or `Develop → Responsive` simulator). Sanity-check: home, transactions, categories, account-detail, agent-edit. Look for any regression vs. main.
- [ ] Tap any sidebar item on a narrow viewport — drawer closes.
- [ ] Open a kebab menu (`row-actions-menu`) near the right edge — menu stays onscreen.
- [ ] On `/v2/transactions` mobile: filter pills scroll horizontally with a fading right edge; table also scrolls horizontally with the same fade.
- [ ] On an edge-to-edge device: header sits below the notch, sheet content respects the home indicator.

## Notes on deferred items

- **MOBILE-8** (sticky header + iOS keyboard overlap) — needs real-device verification; no simulator fully reproduces the keyboard-occlusion case. Skipped this sprint.
- **MOBILE-6** (input auto-zoom on focus) — verified non-issue; inputs already `text-base` (16px) on mobile.
- **MOBILE-19** (HeroGrid padding) — scout flagged it as "feels cramped" but the current `px-5` reads fine in practice; deferred as subjective polish.

🤖 Orchestrated by Claude Code via autonomous 20-min `/loop` over `sprint/mobile-ios-safari`.
