### PR TITLE
fix(v2): stack and full-width critical-surface buttons on mobile

### DIFF
--- a/web/src/routes/api-key-created.tsx
+++ b/web/src/routes/api-key-created.tsx
@@ -99,7 +99,7 @@ export function APIKeyCreatedPage() {
               <Button
                 type="button"
                 onClick={onCopy}
-                className="shrink-0"
+                className="w-full shrink-0 sm:w-auto"
                 variant={copied ? "secondary" : "default"}
               >
                 {copied ? (

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -377,10 +377,11 @@ function DetailBody({
               Disconnecting wipes credentials and soft-deletes related
               transactions. This can&apos;t be undone.
             </p>
-            <div className="flex gap-2">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
               <Button
                 size="sm"
                 variant="ghost"
+                className="w-full sm:w-auto"
                 onClick={() => setConfirmingDisconnect(false)}
                 disabled={disconnect.isPending}
               >
@@ -389,6 +390,7 @@ function DetailBody({
               <Button
                 size="sm"
                 variant="destructive"
+                className="w-full sm:w-auto"
                 onClick={onDisconnect}
                 disabled={disconnect.isPending}
               >


### PR DESCRIPTION
## Summary

Phase 2 mobile polish — two button-stacking fixes on critical surfaces that mis-render on narrow widths.

- **API key copy (`api-key-created.tsx`)** — on mobile the input wraps to its own row, but the Copy button stayed at its natural ~80px width and gave a tiny tap target on a one-time-only critical surface. Adds `w-full sm:w-auto` so the button spans full width when stacked and restores its inline width at `sm+`.
- **Disconnect confirmation (`connection-detail.tsx`)** — both buttons sat side-by-side at 375px on a destructive action where mis-taps are bad. Switches the wrapper to `flex flex-col-reverse gap-2 sm:flex-row` (mirroring the FormFooter pattern from #1321) so on mobile the destructive primary "Disconnect" sits on top and "Cancel" below, both full-width; at `sm+` they go back to inline `[Cancel, Disconnect]`.

5 LOC total.

## Evidence

**API key created — Copy button full-width on mobile, inline on desktop/tablet:**

<img src="https://i.img402.dev/157e06swhn.jpg" width="900" alt="api-key-created page across desktop / tablet / mobile">

**Disconnect confirm — Disconnect on top, Cancel below, both full-width on mobile; inline on desktop/tablet:**

<img src="https://i.img402.dev/05ye1bcpte.jpg" width="900" alt="connection disconnect confirm across desktop / tablet / mobile">

## Test plan

- [x] `cd web && bun run lint` clean
- [x] `cd web && bun run build` clean
- [x] Mobile 390 — API key Copy button full-width, sits under the input
- [x] Mobile 390 — Disconnect (destructive, red) sits on top of Cancel, both full-width
- [x] Desktop 1280 / tablet 768 — both rows render inline as before
