### PR TITLE
fix(v2): drop sticky navbar blur on mobile so it merges with safe-area

### DIFF
--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -144,7 +144,7 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             border-box squeezes the 56px interactive area). The inset
             resolves to 0 elsewhere (desktop, Android, older iOS), so
             non-iPhone layouts are unchanged. */}
-        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex min-h-14 shrink-0 items-center gap-2 border-b pt-[env(safe-area-inset-top)] backdrop-blur">
+        <header className="bg-background sticky top-0 z-30 flex min-h-14 shrink-0 items-center gap-2 border-b pt-[env(safe-area-inset-top)] sm:bg-background/95 sm:supports-[backdrop-filter]:bg-background/80 sm:backdrop-blur">
           <div className="flex w-full items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-1 h-4" />


### PR DESCRIPTION
## Cause

The sticky `<header>` in `web/src/routes/__root.tsx` used a translucent background plus `backdrop-blur`. On iOS the `pt-[env(safe-area-inset-top)]` (shipped in #1318) reserves the notch zone, but that zone is filled by the body's solid `bg-background`, not the header. The result on mobile: a SOLID strip above a BLURRED/translucent header — a visible seam under the notch.

Quote from user: "on mobile let's make the navbar not be a glassy/blur effect. Doesn't look great in iOS since the safe area space isn't glassy blue. Ok to keep on desktop tho."

## Fix

Flip both the translucency and the blur on the `sm:` breakpoint (640px) — solid on mobile, glassy on desktop.

Before:
```tsx
<header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 ... backdrop-blur">
```

After:
```tsx
<header className="bg-background sticky top-0 z-30 ... sm:bg-background/95 sm:supports-[backdrop-filter]:bg-background/80 sm:backdrop-blur">
```

- Mobile (`<sm:`): solid `bg-background`, no `backdrop-blur` → header merges seamlessly with the safe-area gap above it (both solid `bg-background`).
- Desktop (`sm:+`): `sm:bg-background/95` + `sm:supports-[backdrop-filter]:bg-background/80` + `sm:backdrop-blur` reproduce today's translucent/blurred look exactly.

The `pt-[env(safe-area-inset-top)]` from #1318 is untouched — that's still what pushes the header below the notch.

## Test plan

- [ ] iOS Safari (notched iPhone): scroll a long list — verify the strip above the header and the header itself are visually one continuous `bg-background`, no seam.
- [ ] Desktop ≥640px: header still feels translucent/blurred over scrolled content (visually unchanged from today).
- [ ] Android Chrome / older iOS: `env(safe-area-inset-top)` resolves to 0, so the header sits flush at top with solid bg — also fine.
