### PR TITLE
fix(v2): finish viewport-unit polish across auth, sidebar, popover/select/dropdown

### DIFF
--- a/web/src/components/auth-shell.tsx
+++ b/web/src/components/auth-shell.tsx
@@ -37,8 +37,8 @@ export function AuthShell({
   topRight,
 }: AuthShellProps) {
   return (
-    <div className="bg-background min-h-screen">
-      <div className="grid min-h-screen lg:grid-cols-2">
+    <div className="bg-background min-h-dvh">
+      <div className="grid min-h-dvh lg:grid-cols-2">
         <BrandPane />
         <div className="relative flex flex-col">
           <header className="flex items-center justify-between px-6 pt-6 sm:px-10 lg:hidden">

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 max-h-[min(60vh,var(--radix-dropdown-menu-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-[min(60vh,var(--radix-dropdown-menu-content-available-height))] min-w-[8rem] max-w-[calc(100dvw-1rem)] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-72 max-w-[calc(100vw-1rem)] origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 w-72 max-w-[calc(100dvw-1rem)] origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -67,7 +67,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-[min(60vh,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-[min(60vh,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100dvw-1rem)] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -137,7 +137,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            "group/sidebar-wrapper flex min-h-dvh w-full has-data-[variant=inset]:bg-sidebar",
             className
           )}
           {...props}


### PR DESCRIPTION
## Summary

T4 polish for the viewport-unit cleanup. Five stragglers across four files were missed by earlier sprint PRs (#1318, #1320, and the pre-#1326 dvw sweep). All share the same iOS Safari root cause: static viewport units (`vh`/`vw`/`svh`) measure the wrong viewport state for full-page wrappers and popover/select chrome clamps, causing visible layout shifts across iOS chrome (address bar) transitions.

## The 5 edits

- **`web/src/components/auth-shell.tsx`** (lines 40–41): `min-h-screen` → `min-h-dvh` on the outer wrapper AND inner grid. With static `100vh`, the auth pages render with content that requires scrolling DOWN to reach when the iOS address bar is visible, and shift again as the bar collapses.
- **`web/src/components/ui/sidebar.tsx`** (line 140): `min-h-svh` → `min-h-dvh` on the outer sidebar wrapper. `svh` is the worst-case minimum (chrome fully expanded). `dvh` tracks the actual visible area. (PR #1320 already swapped a different `h-svh` → `h-full` on the desktop sidebar INNER column at line 240 — this targets the outer wrapper.)
- **`web/src/components/ui/popover.tsx`** (line 33): `max-w-[calc(100vw-1rem)]` → `max-w-[calc(100dvw-1rem)]`
- **`web/src/components/ui/dropdown-menu.tsx`** (line 45): same swap
- **`web/src/components/ui/select.tsx`** (line 70): same swap

The popover/dropdown/select max-w values were shipped in PR #1316 with `vw`. The vw values include the chrome-collapsed-maximum width on iOS, so during transitions the clamped popover/select can briefly exceed the visible viewport. Same fix philosophy as PR #1320 used for `selection-action-bar.tsx`.

## `ui/*` justification

Three of the five edits are in `web/src/components/ui/*`. Same precedent applies as PRs #1316, #1317, #1318, #1320: viewport-unit semantic correctness is a defaults concern (not styling), narrowly scoped, well-documented. Not worth extracting a wrapper for a 1-char swap.

## Out of scope

- `web/src/routes/sandbox.tsx:274` has `h-[calc(100vh-6rem)]` on the sandbox sidebar, but it's gated to `lg:block` (desktop only) where iOS chrome doesn't apply. Skipped intentionally.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [ ] iOS Safari verification — pixel-perfect-invisible until iOS chrome transitions; covered by the same precedent as earlier dvh/dvw sweeps in this sprint.
