### PR TITLE
fix(v2): iOS web-app shell polish — meta tags, cold-load splash, tap-highlight

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,31 @@
     <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
     <meta name="color-scheme" content="light dark" />
 
+    <!-- iOS web-app metadata.
+
+         `apple-mobile-web-app-capable=yes` lets the page run in
+         standalone mode (no Safari chrome) when "Add to Home Screen"
+         is used — the navbar / sticky header take over the top of
+         the screen as if it were a native app.
+
+         `apple-mobile-web-app-status-bar-style=black-translucent`
+         extends the app content under the iOS status bar; combined
+         with the `viewport-fit=cover` + safe-area padding we ship
+         in #1318, the content reads edge-to-edge.
+
+         `apple-mobile-web-app-title` is the icon label on the home
+         screen (defaults to the page title if missing).
+
+         `apple-touch-icon` is the home-screen icon. Reuse favicon.svg
+         for now — vector scales to any home-screen icon size iOS
+         wants. PNG variants at 180×180 (and 192/512 for Android) are
+         the canonical follow-up; defer to a future asset-generation
+         PR. -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Breadbox" />
+    <link rel="apple-touch-icon" href="./favicon.svg" />
+
     <!-- Open Graph — Slack / Discord / iMessage / Linear link previews. -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Breadbox" />
@@ -84,7 +109,36 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- Cold-load splash: shown until the Vite bundle hydrates the SPA
+           (~200-500ms on cold mobile cache). React's createRoot replaces
+           the contents on first render, so this disappears automatically.
+           Uses raw hex values + media query (Tailwind isn't loaded yet)
+           and respects the `<html class="dark">` set by the no-flash
+           bootstrap script above. -->
+      <style>
+        .app-splash {
+          position: fixed;
+          inset: 0;
+          display: grid;
+          place-items: center;
+          background: #fafafa;
+          color: #1a1a1a;
+        }
+        @media (prefers-color-scheme: dark) {
+          .app-splash { background: #1a1a1a; color: #fafafa; }
+        }
+        html.dark .app-splash { background: #1a1a1a; color: #fafafa; }
+        .app-splash svg { width: 32px; height: 32px; opacity: 0.4; animation: app-splash-spin 1s linear infinite; }
+        @keyframes app-splash-spin { to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) { .app-splash svg { animation: none; opacity: 0.6; } }
+      </style>
+      <div class="app-splash" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+        </svg>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -123,6 +123,14 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* iOS Safari tap highlight — disabled globally because our shadcn primitives
+     ship their own intentional focus / active states. The default
+     `rgba(0,0,0,0.4)` overlay on `<button>` / `<a>` / `[role=button]` was
+     layering on top of our pressed treatments and reading as a glitch on
+     touch. Keep `cursor: pointer` and `:focus-visible` for keyboard. */
+  html {
+    -webkit-tap-highlight-color: transparent;
+  }
 }
 
 /* shadcn's CardHeader is designed for title + description (stacked) with


### PR DESCRIPTION
## Summary

iOS Safari shell polish for the v2 SPA — three small changes that improve the cold-load and home-screen-install experience on mobile. Builds on #1318 (which added `viewport-fit=cover` + safe-area padding) for the standalone-app case.

## Changes

### 1. iOS web-app meta tags (`web/index.html`)

Added the four `apple-*` metas required for a real "Add to Home Screen" install to render edge-to-edge:

- `apple-mobile-web-app-capable=yes` — runs in standalone mode (no Safari chrome) so the app's own header takes over the top of the screen.
- `apple-mobile-web-app-status-bar-style=black-translucent` — extends content under the status bar; pairs with the `viewport-fit=cover` + safe-area padding from #1318 for true edge-to-edge.
- `apple-mobile-web-app-title=Breadbox` — home-screen icon label.
- `apple-touch-icon` pointing at `favicon.svg` — SVG scales to whatever icon size iOS picks.

### 2. Cold-load splash (`web/index.html`)

Inline splash inside `<div id="root">` that renders synchronously with the HTML, so the user sees something on slow mobile networks during the 200–500ms before the Vite bundle hydrates. Key constraints baked in:

- Raw hex + `@media (prefers-color-scheme: dark)` — Tailwind isn't loaded yet.
- Respects `html.dark` set by the no-flash bootstrap script above.
- Reduced-motion users get a static dim icon instead of spin.
- `aria-hidden="true"` keeps it out of screen readers.
- React's `createRoot` replaces `#root` contents on first render — no cleanup needed.

### 3. Tap-highlight override (`web/src/globals.css`)

`-webkit-tap-highlight-color: transparent` on `html` (inside `@layer base`). The default iOS Safari blue overlay was layering on top of the intentional `:active`/`focus-visible` states our shadcn primitives already ship, reading as a glitch on touch.

## Out of scope (deferred follow-ups)

- `manifest.json` (Web App Manifest) — needs proper PNG icons at 192/512. Future asset-generation PR.
- PNG `apple-touch-icon` variants at 180×180 — same future PR.
- Service worker / offline shell — separate decision.
- `overscroll-behavior: contain` — needs per-surface targeting.
- `inputmode` on numeric inputs — needs an input-by-input audit.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [ ] Verify cold-load splash appears on slow 3G throttling, then is replaced (not blended) on hydration
- [ ] Verify "Add to Home Screen" on iOS produces a standalone-mode launch
- [ ] Verify tap on a button no longer shows the blue overlay on iOS Safari
