### PR TITLE
fix(v2): defer 401 redirect until document is visible

### DIFF
--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -58,9 +58,22 @@ function AuthenticatedGate({ pathname }: { pathname: string }) {
   const is401 = me.error instanceof ApiError && me.error.status === 401;
 
   useEffect(() => {
-    if (is401) {
-      navigate({ to: "/login", search: { redirect: pathname } });
+    if (!is401) return;
+    // Don't redirect while the page is hidden — bfcache restore briefly
+    // marks document.hidden=true; firing navigate here completes before
+    // the user re-engages and undoes the snapshot they were swiping back
+    // to. Pair with the pageshow handler in main.tsx (PR #1329).
+    if (document.visibilityState !== "visible") {
+      const onVisible = () => {
+        if (document.visibilityState === "visible") {
+          document.removeEventListener("visibilitychange", onVisible);
+          navigate({ to: "/login", search: { redirect: pathname } });
+        }
+      };
+      document.addEventListener("visibilitychange", onVisible);
+      return () => document.removeEventListener("visibilitychange", onVisible);
     }
+    navigate({ to: "/login", search: { redirect: pathname } });
   }, [is401, navigate, pathname]);
 
   // Gate: never render the authenticated shell until /me has resolved


### PR DESCRIPTION
## Summary

Defers the 401-to-`/login` redirect in `AuthenticatedGate` until `document.visibilityState === "visible"`. Pairs with PR #1329's `pageshow` bfcache handler.

## Cause (MOBILE-30)

PR #1329 fixed the freeze/blank-page race during iOS Safari swipe-back from bfcache by invalidating the router + queries in a `pageshow` handler. There's a residual edge: while the page is being restored from bfcache, `document.hidden === true` for a brief window. If a stale `/me` query resolves with 401 during that window, the SPA navigates to `/login` — which can complete before the user re-engages, undoing the snapshot they were swiping back to.

The defensive fix is to gate the 401 redirect on visibility. If the page is hidden (bfcache restore in progress, tab in background, app backgrounded), we register a one-shot `visibilitychange` listener and defer the navigate until the user is actually looking at the page.

The inline comment documents the bfcache coupling so a future reader doesn't simplify it back.

## Scope

- Single `useEffect` in `web/src/routes/__root.tsx::AuthenticatedGate` — the only 401-redirect site in `__root.tsx`.
- No change to the `is401` source-of-truth, query keys, or splash/error rendering.
- No change to MOBILE-31..34.

## Manual test plan

- [ ] iOS Safari: log in, navigate to any v2 page, expire the session server-side (or wait it out), navigate away to another origin, swipe-back. Page should restore from bfcache and not flash-redirect to `/login` before the snapshot paints.
- [ ] iOS Safari, foreground tab: expire session, refresh — should redirect to `/login` immediately (visibility is `visible` so the gate falls through to the existing path).
- [ ] Desktop, backgrounded tab: expire session, switch back — redirect should fire when the tab regains focus.

## Related

- #1329 — the bfcache `pageshow` handler this complements.
