### PR TITLE
fix(v2): mobile sprint Phase 2 — splash, navbar, dvh polish, 401 visibility-gate

### DIFF
--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -79,7 +79,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — `CLEAN` status; now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — `CLEAN` status; now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338 (state-doc merge included).
+- **fix/mobile-prompts-builder-layout** (subagent `aa905e04`) — **MOBILE-38 (T2 HIGH)**. Stack prompts builder nav above content on mobile via `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]`; nav becomes horizontal scroll rail using `scroll-shadow-x` (same pattern as #1324). PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -61,8 +61,7 @@ Each iteration:
 
 ## In-flight PRs
 
-- **fix/mobile-navbar-no-blur** (subagent `ad2dc3ef`) — MOBILE-27 (T1, user-reported). Drops `backdrop-blur` + translucent bg on `<header>` at <640px; keeps the desktop glassy look. PR # TBD.
-- **fix/mobile-viewport-units-polish** (subagent `af498752`) — **MOBILE-28 (T4 polish)**. Finishes the viewport-unit cleanup: `min-h-screen` → `min-h-dvh` in `auth-shell.tsx` (×2), `min-h-svh` → `min-h-dvh` in `sidebar.tsx` wrapper, `100vw` → `100dvw` in popover/select/dropdown `max-w` clamps. Same family as PR #1320. PR # TBD.
+_(none)_
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -71,6 +70,8 @@ Each iteration:
 ## Completed (Phase 2)
 
 - ✅ **MOBILE-22/23** Button stacking polish — PR #1328 merged into sprint branch (`543599c8`). API-key Copy button gains `w-full sm:w-auto`; disconnect confirmation rewrapped as `flex-col-reverse sm:flex-row` with destructive Disconnect button on top + full-width-when-stacked. Follows the FormFooter pattern from #1321.
+- ✅ **MOBILE-27** Mobile navbar blur — PR #1330 merged into sprint branch (`70f8518d`). `<header>` now uses solid `bg-background` at <640px (no `backdrop-blur`, no translucency), restoring the glassy look at sm+ via `sm:backdrop-blur` / `sm:bg-background/95`. Eliminates the visible seam between solid safe-area zone and previously-blurred header on iOS.
+- ✅ **MOBILE-28** Viewport-unit polish (T4) — PR #1331 merged into sprint branch (`84bdb932`). 5 viewport-unit straggler swaps: `min-h-screen` → `min-h-dvh` on auth-shell wrapper + grid; `min-h-svh` → `min-h-dvh` on sidebar outer wrapper; `max-w-[calc(100vw-1rem)]` → `max-w-[calc(100dvw-1rem)]` in popover/select/dropdown content clamps. Finishes the dvh/dvw family.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 22 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348 + state-doc merges).
+- **fix/mobile-iter28-followups** (subagent `a3a715a9`) — **T4 pattern polish**. Verify-and-fix the 5 deferred findings from iter 28's transaction-detail scout (comment-composer hints, ActivityTimeline max-h, pagination tap targets, comment-composer label visibility, tag-chip × size). Subagent decides FIX / NON-ISSUE / DEFERRED per item and PRs whatever's real. PR # TBD (or state-doc commit if all are non-issues).
 
 ## Closed scouts (iter 29)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342 (state-doc merge included).
+- **fix/mobile-agent-runs-columns** (subagent `aaa7e078`) — **MOBILE-37 (T2 HIGH, last meaningful HIGH)**. Hide Trigger / Duration / Cost / Tools columns on `<sm` via `max-sm:hidden` in column meta.className; keep Status / Agent / Started / Flags. Mobile users tap the row to open the full run detail. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -49,7 +49,6 @@ Each iteration:
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
 
 - [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
-- [ ] **MOBILE-38 (HIGH)** Prompts builder modal `grid-cols-[10rem_1fr]` doesn't reflow on iPhone landscape. `web/src/routes/prompts.build.tsx` (~line 825). Switch to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]` so the nav rail stacks on small screens.
 - [ ] **MOBILE-39 (MEDIUM)** Rules filter toolbar three fixed-width selects wrap awkwardly. `web/src/routes/rules.tsx` (~line 290). Apply chip-rail pattern from #1324 (`max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto`).
 - [ ] **MOBILE-40 (MEDIUM)** Transcript sheet nested scroll trap. `web/src/features/agents/transcript-viewer.tsx`. Inner `<pre max-h-48 overflow-auto>` inside sheet body creates two scroll contexts; iOS swipe-up in the pre triggers back-gesture instead of scrolling sheet. Fix: `overscroll-behavior-y: contain` on the pre + expand `max-h` so it doesn't compete with the sheet scroll.
 - [ ] **MOBILE-41 (LOW)** Command palette input `h-11` vs `h-12` threshold from #1317. `web/src/components/command-palette.tsx` (~line 218). Debatable; bumping to `h-12` for consistency.
@@ -80,7 +79,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — `CLEAN` status; now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338 (state-doc merge included).
-- **fix/mobile-prompts-builder-layout** (subagent `aa905e04`) — **MOBILE-38 (T2 HIGH)**. Stack prompts builder nav above content on mobile via `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]`; nav becomes horizontal scroll rail using `scroll-shadow-x` (same pattern as #1324). PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -97,6 +95,7 @@ Each iteration:
 - ✅ **MOBILE-36** Prompts add-block dialog footer stacking — PR #1336 merged into sprint branch (`943dec09`). Inner action wrapper rewrapped as `flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center` so "Done" (affirmative) sits on top on mobile per the #1321 convention.
 - ✅ **MOBILE-31** Global `prefers-reduced-motion` (T2 HIGH a11y) — PR #1337 merged into sprint branch (`46323665`). Adds one `@media (prefers-reduced-motion: reduce)` block to `globals.css` using the CSS-tricks pattern (compress animation/transition to 0.01ms so `animationend` handlers still fire). Covers ~51 `animate-spin` usages + all shadcn primitive transitions without touching call sites. Cold-load splash (#1332) retains its own per-element `animation: none` override.
 - ✅ **MOBILE-32/33** iOS form ergonomics (T2 HIGH/MEDIUM) — PR #1338 merged into sprint branch (`d00c6305`). `SearchInput` gets defaults (`inputMode="search"`, `enterKeyHint="search"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`) so every search consumer benefits. Numeric inputs (agent `max_turns`, `budget_usd_cents`, link-account tolerance, rule values) get `inputMode="numeric|decimal"`. Identifier fields (API key name/prefix, rule values) get autocorrect/autocapitalize off.
+- ✅ **MOBILE-38** Prompts builder mobile layout (T2 HIGH) — PR #1339 merged into sprint branch (`d6ada115`). `grid grid-cols-[10rem_1fr]` swapped to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]`; nav becomes a horizontal scroll-shadow chip rail on `<sm` with dividers flipped from horizontal rules to vertical separators between pills. Pattern matches #1324 (transactions filter) / MOBILE-21 (settings tabs).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -61,7 +61,8 @@ Each iteration:
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-ios-shell-polish** (subagent `ad462135`) — **MOBILE-29 (T1 — user-authorized SPA pitfalls sweep)**. iOS web-app meta tags (`apple-mobile-web-app-capable`, `status-bar-style`, `title`, `apple-touch-icon`) + cold-load splash inside `<div id="root">` (vanishes when React mounts) + global `-webkit-tap-highlight-color: transparent` in globals.css. PR # TBD.
+- **Deep SPA-pitfall audit** (Explore agent `a11a115d`) — read-only scout across 10 categories: touch interactions, form ergonomics, scroll behavior, auth redirect races beyond #1329, loading/perf, memory/lifecycle, offline/connectivity, cookie durability, standalone-mode edge cases, a11y + reduced-motion. Will fold findings into backlog for follow-up PRs.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345 (state-doc merge included).
+- **T3 categories+tags scout** (Explore agent `ac9a04c6`) — auditing `routes/categor*`, `routes/tag*`, `features/categories/*`, `features/tags/*`, and the picker components for iOS issues. Findings will fold into backlog (or report clean).
 
 ## Closed scouts (iter 25)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,11 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343 (state-doc merge included).
-- **T3 accounts scout** (Explore agent `a4c578a0`) — auditing `routes/accounts.tsx`, `routes/account-detail.tsx`, `features/accounts/*` for iOS issues. Will fold findings into backlog when done.
+- **docs/mobile-patterns-canon** (subagent `ab283dd3`) — **T7 documentation drift**. Adds a "Mobile / iOS Safari patterns" section to `.claude/rules/v2-frontend.md` codifying everything Phase 1 + Phase 2 established (viewport units, safe-area, tap targets, scroll-shadow, mobile reflow, form ergonomics, bfcache, reduced-motion, iOS web-app metadata). Pure docs, no runtime change. PR # TBD.
+
+## Closed scouts (iter 25)
+
+- ✅ **T3 accounts scout** — `routes/accounts.tsx`, `routes/account-detail.tsx`, `features/accounts/*` reported CLEAN. Phase 1 + Phase 2 patterns already cover the surfaces present here. No new backlog items.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,11 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345 (state-doc merge included).
-- **T3 categories+tags scout** (Explore agent `ac9a04c6`) — auditing `routes/categor*`, `routes/tag*`, `features/categories/*`, `features/tags/*`, and the picker components for iOS issues. Findings will fold into backlog (or report clean).
+- **fix/mobile-picker-popover-widths** (subagent `a812ec23`) — **MOBILE-43 + MOBILE-44 (T3 scout-found)**. Widen icon-picker (`w-72`) and color-picker (`w-64`) popovers on mobile via `w-[calc(100dvw-2rem)] sm:w-72`. Same pattern as #1320 dvw + #1316 popover clamp. PR # TBD.
+
+## Closed scouts (iter 27)
+
+- ✅ **T3 categories+tags scout** — most surfaces (category-list rows, category-detail hero, tags table column hides, category-form layout) REPORTED CLEAN. Only the 2 picker popovers above had mobile width issues. Tags table already had `md:table-cell` column hides matching #1343 pattern.
 
 ## Closed scouts (iter 25)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -47,7 +47,6 @@ Each iteration:
 
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
 
-- [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
 
 ## Deferred / low-value (won't fix without evidence)
 
@@ -74,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342 (state-doc merge included).
-- **fix/mobile-agent-runs-columns** (subagent `aaa7e078`) — **MOBILE-37 (T2 HIGH, last meaningful HIGH)**. Hide Trigger / Duration / Cost / Tools columns on `<sm` via `max-sm:hidden` in column meta.className; keep Status / Agent / Started / Flags. Mobile users tap the row to open the full run detail. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -95,6 +93,7 @@ Each iteration:
 - ✅ **MOBILE-34/40** iOS overscroll hygiene (T2 MEDIUM) — PR #1340 merged into sprint branch (`ba76a4f3`). Adds `overscroll-contain` to the Table primitive's scroll-shadow wrapper (blocks pull-to-refresh and parent rubber-band when scrolling tables) and to the transcript-viewer's `<pre>` code blocks (blocks back-swipe leakage from inner scroll).
 - ✅ **MOBILE-39** Rules filter toolbar mobile stack (T2 MEDIUM) — PR #1341 merged into sprint branch (`7e56b5ba`). At `<sm`, search takes full width on row 1, the two selects share row 2 via `flex-1`. At `sm+`, `display: contents` wrapper transparently passes through so `ml-auto` on the sort select keeps right-anchoring as before.
 - ✅ **MOBILE-41/42** LOW polish bundle — PR #1342 merged into sprint branch (`54b566eb`). Removed `[&_[cmdk-input]]:h-11` override from `command-palette.tsx` so the primitive's `h-9 pointer-coarse:h-12` adaptive defaults apply (#1317). Added `pt-[calc(*+env(safe-area-inset-top))]` to `detail-sheet-header.tsx` for iPhone landscape with notch (harmless on devices without one — env resolves to 0).
+- ✅ **MOBILE-37** Agent runs table mobile column collapse (T2 HIGH) — PR #1343 merged into sprint branch (`aa40ebc7`). Trigger / Duration / Cost / Tools columns gain `max-sm:hidden`; Agent column widens to `max-sm:w-[40%] max-sm:min-w-[140px]` so it dominates the remaining mobile view. DataTable already propagates `column.meta.className` to both TableHead and TableCell (no DataTable change needed). Power-user metrics remain accessible via row-tap → run detail sheet.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 23 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349 + state-doc merges).
-- **fix/mobile-detail-dialog-and-confirm** (subagent `a8ba22b7`) — **MOBILE-49 + MOBILE-50 (T3 scout-found)**. detail-dialog-header gets safe-area-top (mirror of #1342); confirm-dialog buttons get full-width-when-stacked (mirror of #1328). PR # TBD.
 
 ## Closed scouts (iter 31)
 
@@ -131,6 +130,7 @@ Each iteration:
 - ✅ **MOBILE-45/46** FloatingActionBar safe-area-bottom + CommandList max-h adaptive — PR #1347 merged into sprint branch (`4ef34cd7`). FAB clears iPhone home indicator via `bottom-[max(1rem,env(safe-area-inset-bottom))]`; CommandList caps at `max-h-[min(300px,50dvh)]` so dropdowns adapt to shorter viewports (iOS keyboard open, landscape).
 - ✅ **MOBILE-47/48** connect/reauth sheet footers — PR #1348 merged into sprint branch (`8d37e803`). `connect-bank-sheet.tsx` (pick stage) and `reauth-sheet.tsx` (confirm stage) hand-rolled footers now follow the canonical `flex-col-reverse sm:flex-row` + `w-full sm:w-auto` pattern (matches #1321/#1328/#1336).
 - ✅ **T4 iter-28 followups** — PR #1349 merged into sprint branch (`ed1dbc5d`). Verified all 5 deferred items from iter 28: **fixed 2** (comment-composer textarea gets `enterKeyHint="send"` → iOS keyboard tints the return key; tag-chip × button gets the `pointer-coarse:` 44pt pseudo from #1317 since the raw `<button>` didn't inherit Button's TAP_TARGET); **closed 3 as non-issues** (ActivityTimeline page-scrolls naturally, PaginationLink already uses `buttonVariants({size:"icon"})` which inherits TAP_TARGET, CommentComposer button label is additive — spinner doesn't replace it).
+- ✅ **MOBILE-49/50** detail-dialog-header safe-area-top + confirm-dialog button widths — PR #1350 merged into sprint branch (`84b66052`). DialogHeader gets `mt-[env(safe-area-inset-top)]` (clean margin-shift approach; iPad-landscape notched device clearance). `AlertDialogCancel` + `AlertDialogAction` get `w-full sm:w-auto` so stacked buttons reach full tap width on 375px (AlertDialogFooter already had `flex-col-reverse` semantic — only the button widths were the gap).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 22 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348 + state-doc merges).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 23 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349 + state-doc merges).
+- **T3 shared-components scout** (Explore agent `a4e586be`) — auditing detail-list, list-card, status-panel, timeline-rail, soft-back-button, id-pill, kbd-tooltip, eyebrow, brand-header, hero-grid, coming-soon-pill, color-rail-card, **confirm-dialog (button stacking?)**, **detail-dialog-header (safe-area-top?)**. Findings or clean.
 
 ## Closed scouts (iter 29)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -49,6 +49,16 @@ Each iteration:
 - [ ] **MOBILE-33 (MEDIUM)** Identifier-field autocapitalize/autocorrect — slug/API-key/agent-slug inputs need `autoCorrect="off" autoCapitalize="off"` so iOS doesn't mangle them. Files: `web/src/features/agents/agent-form.tsx` (slug field at create time), `web/src/routes/api-key-new.tsx` (key name).
 - [ ] **MOBILE-34 (MEDIUM)** `overscroll-behavior: contain` on tables/lists — prevents iOS pull-to-refresh and parent rubber-band when scrolling inside `data-table.tsx`. Tailwind: `overscroll-contain`. One-line addition to the existing Table wrapper.
 
+## Backlog (T3 scout — rules / agents / prompts, iter ~17)
+
+- [ ] **MOBILE-36 (HIGH)** Prompts add-block `DialogFooter` doesn't use `flex-col-reverse` — secondary appears above primary on mobile. `web/src/routes/prompts.build.tsx` (~line 948). Apply same pattern as PR #1321 FormFooter.
+- [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
+- [ ] **MOBILE-38 (HIGH)** Prompts builder modal `grid-cols-[10rem_1fr]` doesn't reflow on iPhone landscape. `web/src/routes/prompts.build.tsx` (~line 825). Switch to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]` so the nav rail stacks on small screens.
+- [ ] **MOBILE-39 (MEDIUM)** Rules filter toolbar three fixed-width selects wrap awkwardly. `web/src/routes/rules.tsx` (~line 290). Apply chip-rail pattern from #1324 (`max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto`).
+- [ ] **MOBILE-40 (MEDIUM)** Transcript sheet nested scroll trap. `web/src/features/agents/transcript-viewer.tsx`. Inner `<pre max-h-48 overflow-auto>` inside sheet body creates two scroll contexts; iOS swipe-up in the pre triggers back-gesture instead of scrolling sheet. Fix: `overscroll-behavior-y: contain` on the pre + expand `max-h` so it doesn't compete with the sheet scroll.
+- [ ] **MOBILE-41 (LOW)** Command palette input `h-11` vs `h-12` threshold from #1317. `web/src/components/command-palette.tsx` (~line 218). Debatable; bumping to `h-12` for consistency.
+- [ ] **MOBILE-42 (LOW)** `detail-sheet-header.tsx` missing safe-area-top in iPhone landscape with notch. `web/src/components/detail-sheet-header.tsx` (~lines 54-59). `pt-5` → `pt-[calc(1.25rem+env(safe-area-inset-top))]`.
+
 ## Deferred / low-value (won't fix without evidence)
 
 - **scroll-padding-top for anchor links** — niche, no anchor-link UX in the app today.
@@ -73,8 +83,9 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. Ships #1328+#1330+#1331+#1332+#1333 (button stacking, navbar blur, dvh polish, iOS shell + cold-load splash, 401 visibility-gate). **Awaiting user merge** — splash is the highest-impact item for the user's "blank pages 1-2s" complaint on transactions list.
-- **fix/mobile-tx-lazy-category-picker** (subagent `a40a0938`) — **MOBILE-35 (perf)**. Defer per-row CategoryPicker content (or hoist its data hook) to reduce per-page memory ~250 KB. Improves iOS Safari bfcache eligibility on the transactions list. PR # TBD.
+- **PR #1334** sprint→main Phase 2 bundle. Ships #1328+#1330+#1331+#1332+#1333. **Awaiting user merge** — splash is the highest-impact item for the user's "blank pages 1-2s" complaint on transactions list.
+- **fix/mobile-tx-lazy-category-picker** (subagent `a40a0938`) — **MOBILE-35 (perf)**. Defer per-row CategoryPicker content. PR # TBD.
+- **fix/mobile-prompts-dialog-footer** (subagent `ae93b950`) — **MOBILE-36 (T3 scout)**. Verify and fix the prompts add-block DialogFooter to use the `flex-col-reverse` pattern from #1321 if the audit's claim holds; otherwise close as non-issue. PR # TBD or no-op state commit.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -71,7 +71,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 24 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350 + state-doc merges).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 25 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350, #1351 + state-doc merges).
+- **docs/mobile-patterns-canon-refresh** (subagent `a0aa29f8`) — **T7 documentation drift**. Refresh `.claude/rules/v2-frontend.md` "Mobile / iOS Safari patterns" with 6 additions covering #1346 (picker dvw widths), #1347 (FAB safe-area-bottom + CommandList max-h-dvh), #1348 (sheet footer stacking), #1349 (raw-button tap-zone recipe + textarea enterKeyHint), #1350 (Dialog header mt-env + AlertDialog buttons), #1351 (skip link + FormMessage alert). Pure docs. PR # TBD.
 
 ## Closed scouts (iter 32)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344 (state-doc merge included).
+- **docs/sandbox-mobile-pattern-specimens** (subagent `a1ed71e0`) — **T6 sandbox completeness**. Adds sandbox demos for `scroll-shadow-x` utility, mobile reflow patterns (button stack, CSS order, chip-rail). Closes the gap where #1344's canon documented patterns but the sandbox had no specimens. PR # TBD.
 
 ## Closed scouts (iter 25)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 22 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348 + state-doc merges).
-- **fix/mobile-iter28-followups** (subagent `a3a715a9`) — **T4 pattern polish**. Verify-and-fix the 5 deferred findings from iter 28's transaction-detail scout (comment-composer hints, ActivityTimeline max-h, pagination tap targets, comment-composer label visibility, tag-chip × size). Subagent decides FIX / NON-ISSUE / DEFERRED per item and PRs whatever's real. PR # TBD (or state-doc commit if all are non-issues).
 
 ## Closed scouts (iter 29)
 
@@ -126,6 +125,7 @@ Each iteration:
 - ✅ **MOBILE-43/44** Picker popover mobile widths — PR #1346 merged into sprint branch (`0aa00e0a`). Icon-picker (`w-72`) and color-picker (`w-64`) PopoverContents now use `w-[calc(100dvw-2rem)] sm:w-{72|64}` — full visible width minus 16px margin on mobile, locked to design size at sm+.
 - ✅ **MOBILE-45/46** FloatingActionBar safe-area-bottom + CommandList max-h adaptive — PR #1347 merged into sprint branch (`4ef34cd7`). FAB clears iPhone home indicator via `bottom-[max(1rem,env(safe-area-inset-bottom))]`; CommandList caps at `max-h-[min(300px,50dvh)]` so dropdowns adapt to shorter viewports (iOS keyboard open, landscape).
 - ✅ **MOBILE-47/48** connect/reauth sheet footers — PR #1348 merged into sprint branch (`8d37e803`). `connect-bank-sheet.tsx` (pick stage) and `reauth-sheet.tsx` (confirm stage) hand-rolled footers now follow the canonical `flex-col-reverse sm:flex-row` + `w-full sm:w-auto` pattern (matches #1321/#1328/#1336).
+- ✅ **T4 iter-28 followups** — PR #1349 merged into sprint branch (`ed1dbc5d`). Verified all 5 deferred items from iter 28: **fixed 2** (comment-composer textarea gets `enterKeyHint="send"` → iOS keyboard tints the return key; tag-chip × button gets the `pointer-coarse:` 44pt pseudo from #1317 since the raw `<button>` didn't inherit Button's TAP_TARGET); **closed 3 as non-issues** (ActivityTimeline page-scrolls naturally, PaginationLink already uses `buttonVariants({size:"icon"})` which inherits TAP_TARGET, CommentComposer button label is additive — spinner doesn't replace it).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,8 @@ Each iteration:
 
 ## In-flight PRs
 
-_(none)_
+- **PR #1334** sprint→main Phase 2 bundle. Ships #1328+#1330+#1331+#1332+#1333 (button stacking, navbar blur, dvh polish, iOS shell + cold-load splash, 401 visibility-gate). **Awaiting user merge** — splash is the highest-impact item for the user's "blank pages 1-2s" complaint on transactions list.
+- **fix/mobile-tx-lazy-category-picker** (subagent `a40a0938`) — **MOBILE-35 (perf)**. Defer per-row CategoryPicker content (or hoist its data hook) to reduce per-page memory ~250 KB. Improves iOS Safari bfcache eligibility on the transactions list. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -71,7 +71,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 25 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350, #1351 + state-doc merges).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 26 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350, #1351, #1352 + state-doc merges).
+- **T3 per-agent routes scout** (Explore agent `ae03f6ba`) — auditing agents.$slug.edit, agents.$slug.runs, agents.tsx (list), agents.new. Verifying whether they inherited #1322 (form order) + #1343 (runs columns) or have their own layouts that skipped the fixes.
 
 ## Closed scouts (iter 32)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -11,13 +11,25 @@
 Phase 1 shipped fixes (now in main):
 - Sidebar close-on-tap, popover/select/dropdown collision + width clamps, 44pt tap targets via `pointer-coarse:` pseudo, `viewport-fit=cover` + safe-area, table scroll-shadow + iOS momentum, dvw/dvh viewport units, PageHeader wrap + FormFooter stacking, agent-form CSS-order reshuffle, empty-state width + error pre momentum, transactions filter chip rail, settings tab scroll.
 
-## Workflow (unchanged)
+## Workflow — PROACTIVE MODE
 
-1. Loop wakes → sync branch → merge ready PRs → pick next backlog item.
-2. Spawn ONE subagent in worktree isolation. Brief includes file paths + iOS quirks.
-3. Subagent opens PR against this branch with `img402.dev` screenshots at 375×812 / 768×1024 / 1280×800.
-4. Orchestrator reviews next iteration. Merges when green. Never merge to `main` directly without explicit auth.
-5. When backlog is meaningfully accumulated (3+ merged), open a fresh `sprint → main` bundle PR.
+The loop NEVER reports idle. Every iteration must produce a merge, a dispatch, or a scout-then-dispatch chain.
+
+Priority ladder — try each tier until something dispatches:
+- **T1 User-reported bugs** (highest)
+- **T2 Backlog items in state doc** (P0/P1/P2 including deferred)
+- **T3 Fresh scout on a previously-unaudited surface** (rotate; don't repeat within 5 iterations)
+- **T4 Polish on existing patterns** — extend `scroll-shadow-x`, hunt straggler `100vh`/`100vw`, verify `pointer-coarse:` on icon-button consumers, safe-area on dialogs, FormFooter pattern on forms
+- **T5 Mobile a11y** — ARIA, focus traps, reduced-motion, contrast, screen-reader labels
+- **T6 Sandbox completeness** — every component+variant exercised in `web/src/sandbox/sections/*`
+- **T7 Documentation drift** — `.claude/rules/v2-frontend.md` codifies new patterns
+
+Each iteration:
+1. Sync sprint branch, merge ready PRs.
+2. Pick from priority ladder.
+3. Spawn ONE subagent in worktree isolation. Brief includes file paths + iOS quirks + visual evidence requirement via img402.dev.
+4. Record which tier the work came from in state doc.
+5. When backlog → main accumulates 3+ merged PRs, open a fresh `sprint → main` bundle PR.
 
 ## iOS Safari quirks reference
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,16 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346 (state-doc merge included).
-- **T3 transaction-detail+features scout** (Explore agent `af710cb7`) — auditing transaction-detail, activity-timeline, comment-composer, tag-manager, category-editor, pagination, selection-action-bar buttons, row skeleton. Findings will fold into backlog (or report clean).
+- **fix/mobile-fab-and-commandlist** (subagent `a3c78774`) — **MOBILE-45 + MOBILE-46 (T3 scout-found, HIGH + MEDIUM)**. FloatingActionBar gains `bottom-[max(1rem,env(safe-area-inset-bottom))]` so it clears the iPhone home indicator. CommandList `max-h-[300px]` → `max-h-[min(300px,50dvh)]` so dropdowns don't push offscreen with iOS keyboard open. PR # TBD.
+
+## Closed scouts (iter 28)
+
+- ✅ **T3 transaction-detail+features scout** — 7 findings, 2 actionable (above), 5 deferred:
+  - Comment composer keyboard hints (minor UX polish)
+  - ActivityTimeline max-height (design question, no clear bug)
+  - Pagination button sizes (likely already covered by `pointer-coarse:` tap zone from #1317 — verify before changing)
+  - CommentComposer label visibility on mobile (minor polish)
+  - Tag chip × button size (likely already covered by `pointer-coarse:` tap zone — verify before changing)
 
 ## Closed scouts (iter 27)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -83,6 +83,7 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge.** Original scope was #1328+#1330+#1331+#1332+#1333; after the state-doc conflict was resolved (`858a75e1`) and #1335 + #1336 merged into sprint, the bundle now also includes the lazy-CategoryPicker perf fix and the prompts dialog-footer stacking fix.
+- **fix/mobile-prefers-reduced-motion** (subagent `a10d7f50`) — **MOBILE-31 (T2 HIGH from audit)**. Adds one global `@media (prefers-reduced-motion: reduce)` block to `globals.css` (CSS-tricks pattern — compress to 0.01ms so `animationend` still fires). Single-file ≤15 LOC. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -51,7 +51,6 @@ Each iteration:
 
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
 
-- [ ] **MOBILE-36 (HIGH)** Prompts add-block `DialogFooter` doesn't use `flex-col-reverse` — secondary appears above primary on mobile. `web/src/routes/prompts.build.tsx` (~line 948). Apply same pattern as PR #1321 FormFooter.
 - [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
 - [ ] **MOBILE-38 (HIGH)** Prompts builder modal `grid-cols-[10rem_1fr]` doesn't reflow on iPhone landscape. `web/src/routes/prompts.build.tsx` (~line 825). Switch to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]` so the nav rail stacks on small screens.
 - [ ] **MOBILE-39 (MEDIUM)** Rules filter toolbar three fixed-width selects wrap awkwardly. `web/src/routes/rules.tsx` (~line 290). Apply chip-rail pattern from #1324 (`max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto`).
@@ -83,9 +82,7 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. Ships #1328+#1330+#1331+#1332+#1333. **Awaiting user merge** — splash is the highest-impact item for the user's "blank pages 1-2s" complaint on transactions list.
-- **fix/mobile-tx-lazy-category-picker** (subagent `a40a0938`) — **MOBILE-35 (perf)**. Defer per-row CategoryPicker content. PR # TBD.
-- **fix/mobile-prompts-dialog-footer** (subagent `ae93b950`) — **MOBILE-36 (T3 scout)**. Verify and fix the prompts add-block DialogFooter to use the `flex-col-reverse` pattern from #1321 if the audit's claim holds; otherwise close as non-issue. PR # TBD or no-op state commit.
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge.** Original scope was #1328+#1330+#1331+#1332+#1333; after the state-doc conflict was resolved (`858a75e1`) and #1335 + #1336 merged into sprint, the bundle now also includes the lazy-CategoryPicker perf fix and the prompts dialog-footer stacking fix.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -98,6 +95,8 @@ Each iteration:
 - ✅ **MOBILE-28** Viewport-unit polish (T4) — PR #1331 merged into sprint branch (`84bdb932`). 5 viewport-unit straggler swaps: `min-h-screen` → `min-h-dvh` on auth-shell wrapper + grid; `min-h-svh` → `min-h-dvh` on sidebar outer wrapper; `max-w-[calc(100vw-1rem)]` → `max-w-[calc(100dvw-1rem)]` in popover/select/dropdown content clamps. Finishes the dvh/dvw family.
 - ✅ **MOBILE-29** iOS web-app shell polish — PR #1332 merged into sprint branch (`658e69f6`). Adds iOS PWA meta tags (`apple-mobile-web-app-capable=yes`, `status-bar-style=black-translucent`, `apple-mobile-web-app-title=Breadbox`, `apple-touch-icon` → favicon.svg), inline cold-load splash in `<div id="root">` (auto-vanishes when React hydrates, respects `prefers-reduced-motion` and `prefers-color-scheme`), and global `-webkit-tap-highlight-color: transparent`.
 - ✅ **MOBILE-30** 401 visibility-gate — PR #1333 merged into sprint branch (`73e53940`). `AuthenticatedGate` in `__root.tsx` now defers the redirect-to-login while `document.visibilityState !== "visible"`, attaching a `visibilitychange` listener that fires the redirect when the user re-engages. Closes the residual bfcache-restore race left by PR #1329; cleanup-on-unmount included.
+- ✅ **MOBILE-35** Per-row CategoryPicker lazy body — PR #1335 merged into sprint branch (`fb8439c3`). Splits `CategoryPicker` into a lightweight always-mounted shell (just `useState(open)` + trigger) and a `PickerBody` that mounts only when `open === true` and owns `useCategoryEditor` (the mutation hook). Audit's actual finding: 50× `useMutation` observers per page (not popover content) were the leak. Reduces transactions-list React memory, improving iOS Safari bfcache eligibility.
+- ✅ **MOBILE-36** Prompts add-block dialog footer stacking — PR #1336 merged into sprint branch (`943dec09`). Inner action wrapper rewrapped as `flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center` so "Done" (affirmative) sits on top on mobile per the #1321 convention.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -71,7 +71,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 23 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349 + state-doc merges).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 24 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350 + state-doc merges).
+- **T5 mobile-a11y audit** (Explore agent `aeb7dcd0`) — auditing ARIA landmarks, skip-to-content, icon-button aria-labels, focus traps, reduced-motion edge cases, VoiceOver flows. Findings or clean.
 
 ## Closed scouts (iter 31)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -48,8 +48,11 @@ Each iteration:
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard. `web/src/routes/__root.tsx`. Requires real-device validation; no simulator fully reproduces keyboard occlusion.
 - [ ] **MOBILE-19** HeroGrid 20px padding feels cramped on 375px. `web/src/components/hero-grid.tsx`. Subjective — defer until visual evidence shows a clear problem.
 
-**New:**
-- _(empty — backlog drained, awaiting user reports or future scout)_
+**New (T1 — user-reported):**
+- [ ] **MOBILE-26** iOS Safari swipe-back gesture freezes / shows blank page. Tap-back works fine. _(in flight)_
+  - Likely cause: bfcache restore with no `pageshow` handler — TanStack Query refetches on focus, a stale-session 401 fires `navigate({ to: "/login" })` mid-swipe-animation. SPA is bfcache-eligible (no `unload`/WS/etc.) but doesn't react when restored.
+  - Files: `web/src/main.tsx`, `web/src/routes/__root.tsx` (401 handler).
+  - Fix: `pageshow` listener with `event.persisted` check that calls `router.invalidate()` + `queryClient.invalidateQueries()`; optionally gate the 401 redirect on `document.visibilityState === "visible"`.
 
 **Closed by audit:**
 - ✅ **MOBILE-API-COPY (closed as already-handled)** Scout flagged that API key copy on iOS might silently fail. Verified: `onCopy` at `api-key-created.tsx:47` already has try/catch with a clear error toast ("Couldn't access the clipboard. Select the value and copy manually.") and the readonly Input has `onFocus={e => e.currentTarget.select()}` for manual-copy ergonomics. No code change required.
@@ -58,7 +61,7 @@ Each iteration:
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-ios-swipe-back-bfcache** (subagent `af43354e`) — MOBILE-26 (T1). Adds `pageshow` handler that calls `router.invalidate()` + `queryClient.invalidateQueries()` on bfcache restore. Optional belt-and-suspenders to gate 401 redirect on `document.visibilityState`. PR # TBD.
 
 ## Completed (Phase 2)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -36,12 +36,18 @@ Phase 1 shipped fixes (now in main):
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard. `web/src/routes/__root.tsx`. Requires real-device validation; no simulator fully reproduces keyboard occlusion.
 - [ ] **MOBILE-19** HeroGrid 20px padding feels cramped on 375px. `web/src/components/hero-grid.tsx`. Subjective — defer until visual evidence shows a clear problem.
 
-**New (to be seeded by future scouts or user reports):**
-- _(empty — Phase 2 is reactive; new items added as users report bugs or scouts find issues)_
+**New (Phase 2 scout, iter 12):**
+- [ ] **MOBILE-22** API key copy button isn't full-width when stacked — `web/src/routes/api-key-created.tsx` (~lines 91-112). _(in flight, see below)_
+- [ ] **MOBILE-23** Disconnect confirmation buttons cramped on mobile — `web/src/routes/connection-detail.tsx` (~lines 379-401). _(in flight, see below)_
+- [ ] **MOBILE-24** CSV column-mapping label wraps aggressively on narrow viewports — `web/src/features/connections/csv-import-form.tsx` (~lines 422-478). Needs visual evidence before fix.
+- [ ] **MOBILE-25** CSV drag-drop file input may not open picker reliably on iOS — `web/src/features/connections/csv-import-form.tsx` (~lines 166-190). Needs simulator verification.
+
+**Closed by audit:**
+- ✅ **MOBILE-API-COPY (closed as already-handled)** Scout flagged that API key copy on iOS might silently fail. Verified: `onCopy` at `api-key-created.tsx:47` already has try/catch with a clear error toast ("Couldn't access the clipboard. Select the value and copy manually.") and the readonly Input has `onFocus={e => e.currentTarget.select()}` for manual-copy ergonomics. No code change required.
 
 ## In-flight PRs
 
-_(none)_
+- **fix/mobile-button-stacking-polish** (subagent `a0ad94fa`) — bundles MOBILE-22 + MOBILE-23. Adds `w-full sm:w-auto` to api-key Copy button; rewraps disconnect confirmation as `flex-col-reverse sm:flex-row` (destructive on top) with full-width-when-stacked buttons. Follows the FormFooter pattern from PR #1321. PR # TBD.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -42,7 +42,20 @@ Each iteration:
 - Mobile sheet is shadcn Sidebar's built-in behavior (`useSidebar().openMobile`).
 - Reuse `scroll-shadow-x` @utility from globals.css for any horizontal-scroll container.
 
-## Backlog (Phase 2)
+## Backlog (Phase 2 — SPA-pitfall audit, iter ~14)
+
+- [ ] **MOBILE-30 (HIGH)** Visibility-gate 401 redirect — `web/src/routes/__root.tsx` (~line 60-64). `AuthenticatedGate` redirects to `/login` on any 401 without checking `document.hidden`. On bfcache restore where the page is briefly not visible, the redirect can fire before user re-engagement. Gate with `if (is401 && !document.hidden)`. Complements PR #1329 (bfcache fix).
+- [ ] **MOBILE-31 (HIGH)** Reduced-motion bundle — wrap `animate-spin`, sidebar `transition-[left,right,width]`, and other animations with `motion-safe:` variants OR add global `@media (prefers-reduced-motion: reduce)` override in `globals.css`. Affects spinners across the app + `web/src/components/ui/sidebar.tsx` line ~165.
+- [ ] **MOBILE-32 (HIGH)** iOS keyboard hints — add `inputmode="email|numeric|decimal"` to typed inputs and `enterkeyhint="go|search|done"` on form submit fields. Audit: `web/src/routes/login.tsx`, `web/src/features/settings/*`, any amount/number inputs.
+- [ ] **MOBILE-33 (MEDIUM)** Identifier-field autocapitalize/autocorrect — slug/API-key/agent-slug inputs need `autoCorrect="off" autoCapitalize="off"` so iOS doesn't mangle them. Files: `web/src/features/agents/agent-form.tsx` (slug field at create time), `web/src/routes/api-key-new.tsx` (key name).
+- [ ] **MOBILE-34 (MEDIUM)** `overscroll-behavior: contain` on tables/lists — prevents iOS pull-to-refresh and parent rubber-band when scrolling inside `data-table.tsx`. Tailwind: `overscroll-contain`. One-line addition to the existing Table wrapper.
+
+## Deferred / low-value (won't fix without evidence)
+
+- **scroll-padding-top for anchor links** — niche, no anchor-link UX in the app today.
+- **Icon-only button aria-label audit** — already mostly correct; only outliers in `calendar.tsx` day grid (low impact, Radix handles).
+- **`role="alert"` on FormMessage** — Sonner toasts already announce form errors.
+- **`gcTime` tuning** — speculative; current 5min default is fine.
 
 **Carried over from Phase 1 (deferred):**
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard. `web/src/routes/__root.tsx`. Requires real-device validation; no simulator fully reproduces keyboard occlusion.
@@ -61,8 +74,7 @@ Each iteration:
 
 ## In-flight PRs
 
-- **fix/mobile-ios-shell-polish** (subagent `ad462135`) — **MOBILE-29 (T1 — user-authorized SPA pitfalls sweep)**. iOS web-app meta tags (`apple-mobile-web-app-capable`, `status-bar-style`, `title`, `apple-touch-icon`) + cold-load splash inside `<div id="root">` (vanishes when React mounts) + global `-webkit-tap-highlight-color: transparent` in globals.css. PR # TBD.
-- **Deep SPA-pitfall audit** (Explore agent `a11a115d`) — read-only scout across 10 categories: touch interactions, form ergonomics, scroll behavior, auth redirect races beyond #1329, loading/perf, memory/lifecycle, offline/connectivity, cookie durability, standalone-mode edge cases, a11y + reduced-motion. Will fold findings into backlog for follow-up PRs.
+- **fix/mobile-401-visibility-gate** (subagent `a6a0df8b`) — MOBILE-30 (HIGH from audit). Gates the `__root.tsx` 401 redirect on `document.visibilityState === "visible"` so it doesn't fire during bfcache restore. Direct complement to PR #1329. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -73,6 +85,7 @@ Each iteration:
 - ✅ **MOBILE-22/23** Button stacking polish — PR #1328 merged into sprint branch (`543599c8`). API-key Copy button gains `w-full sm:w-auto`; disconnect confirmation rewrapped as `flex-col-reverse sm:flex-row` with destructive Disconnect button on top + full-width-when-stacked. Follows the FormFooter pattern from #1321.
 - ✅ **MOBILE-27** Mobile navbar blur — PR #1330 merged into sprint branch (`70f8518d`). `<header>` now uses solid `bg-background` at <640px (no `backdrop-blur`, no translucency), restoring the glassy look at sm+ via `sm:backdrop-blur` / `sm:bg-background/95`. Eliminates the visible seam between solid safe-area zone and previously-blurred header on iOS.
 - ✅ **MOBILE-28** Viewport-unit polish (T4) — PR #1331 merged into sprint branch (`84bdb932`). 5 viewport-unit straggler swaps: `min-h-screen` → `min-h-dvh` on auth-shell wrapper + grid; `min-h-svh` → `min-h-dvh` on sidebar outer wrapper; `max-w-[calc(100vw-1rem)]` → `max-w-[calc(100dvw-1rem)]` in popover/select/dropdown content clamps. Finishes the dvh/dvw family.
+- ✅ **MOBILE-29** iOS web-app shell polish — PR #1332 merged into sprint branch (`658e69f6`). Adds iOS PWA meta tags (`apple-mobile-web-app-capable=yes`, `status-bar-style=black-translucent`, `apple-mobile-web-app-title=Breadbox`, `apple-touch-icon` → favicon.svg), inline cold-load splash in `<div id="root">` (auto-vanishes when React hydrates, respects `prefers-reduced-motion` and `prefers-color-scheme`), and global `-webkit-tap-highlight-color: transparent`.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -44,8 +44,6 @@ Each iteration:
 
 ## Backlog (Phase 2 — SPA-pitfall audit, iter ~14)
 
-- [ ] **MOBILE-32 (HIGH)** iOS keyboard hints — add `inputmode="email|numeric|decimal"` to typed inputs and `enterkeyhint="go|search|done"` on form submit fields. Audit: `web/src/routes/login.tsx`, `web/src/features/settings/*`, any amount/number inputs.
-- [ ] **MOBILE-33 (MEDIUM)** Identifier-field autocapitalize/autocorrect — slug/API-key/agent-slug inputs need `autoCorrect="off" autoCapitalize="off"` so iOS doesn't mangle them. Files: `web/src/features/agents/agent-form.tsx` (slug field at create time), `web/src/routes/api-key-new.tsx` (key name).
 - [ ] **MOBILE-34 (MEDIUM)** `overscroll-behavior: contain` on tables/lists — prevents iOS pull-to-refresh and parent rubber-band when scrolling inside `data-table.tsx`. Tailwind: `overscroll-contain`. One-line addition to the existing Table wrapper.
 
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
@@ -82,7 +80,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — `CLEAN` status; now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337 (state-doc merge included).
-- **fix/mobile-form-ergonomics** (subagent `a8a6bc0f`) — **MOBILE-32 + MOBILE-33 (T2 HIGH/MEDIUM)**. iOS keyboard hints (`inputmode`, `enterkeyhint`) across typed inputs + `autoCorrect="off" autoCapitalize="off" spellCheck={false}` on identifier fields (slugs, API key names). Prefer setting defaults on `SearchInput` so every search box benefits. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -98,6 +95,7 @@ Each iteration:
 - ✅ **MOBILE-35** Per-row CategoryPicker lazy body — PR #1335 merged into sprint branch (`fb8439c3`). Splits `CategoryPicker` into a lightweight always-mounted shell (just `useState(open)` + trigger) and a `PickerBody` that mounts only when `open === true` and owns `useCategoryEditor` (the mutation hook). Audit's actual finding: 50× `useMutation` observers per page (not popover content) were the leak. Reduces transactions-list React memory, improving iOS Safari bfcache eligibility.
 - ✅ **MOBILE-36** Prompts add-block dialog footer stacking — PR #1336 merged into sprint branch (`943dec09`). Inner action wrapper rewrapped as `flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center` so "Done" (affirmative) sits on top on mobile per the #1321 convention.
 - ✅ **MOBILE-31** Global `prefers-reduced-motion` (T2 HIGH a11y) — PR #1337 merged into sprint branch (`46323665`). Adds one `@media (prefers-reduced-motion: reduce)` block to `globals.css` using the CSS-tricks pattern (compress animation/transition to 0.01ms so `animationend` handlers still fire). Covers ~51 `animate-spin` usages + all shadcn primitive transitions without touching call sites. Cold-load splash (#1332) retains its own per-element `animation: none` override.
+- ✅ **MOBILE-32/33** iOS form ergonomics (T2 HIGH/MEDIUM) — PR #1338 merged into sprint branch (`d00c6305`). `SearchInput` gets defaults (`inputMode="search"`, `enterKeyHint="search"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`) so every search consumer benefits. Numeric inputs (agent `max_turns`, `budget_usd_cents`, link-account tolerance, rule values) get `inputMode="numeric|decimal"`. Identifier fields (API key name/prefix, rule values) get autocorrect/autocapitalize off.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -1,69 +1,50 @@
-# Mobile Responsiveness Sprint — v2 SPA / iOS Safari
+# Mobile Responsiveness Sprint — v2 SPA / iOS Safari (Phase 2)
 
 **Branch:** `sprint/mobile-ios-safari`
 **Goal:** v2 SPA works excellently in iOS mobile Safari (reference: iPhone 14 Pro, 393×852, dvh-aware).
-**Cadence:** Autonomous /loop iteration every 30 min. One subagent PR per iteration.
+**Cadence:** Autonomous /loop iteration every 20 min. One subagent PR per iteration.
 
-## Workflow
+## Phase status
+
+**Phase 1: SHIPPED.** PR [#1326](https://github.com/canalesb93/breadbox/pull/1326) merged into main with 12 fixes (MOBILE-1..MOBILE-21). Sprint branch was deleted on origin, then recreated from main for continued Phase 2 work.
+
+Phase 1 shipped fixes (now in main):
+- Sidebar close-on-tap, popover/select/dropdown collision + width clamps, 44pt tap targets via `pointer-coarse:` pseudo, `viewport-fit=cover` + safe-area, table scroll-shadow + iOS momentum, dvw/dvh viewport units, PageHeader wrap + FormFooter stacking, agent-form CSS-order reshuffle, empty-state width + error pre momentum, transactions filter chip rail, settings tab scroll.
+
+## Workflow (unchanged)
 
 1. Loop wakes → sync branch → merge ready PRs → pick next backlog item.
 2. Spawn ONE subagent in worktree isolation. Brief includes file paths + iOS quirks.
 3. Subagent opens PR against this branch with `img402.dev` screenshots at 375×812 / 768×1024 / 1280×800.
-4. Orchestrator reviews next iteration. Merges when green. Never merge to `main`.
+4. Orchestrator reviews next iteration. Merges when green. Never merge to `main` directly without explicit auth.
+5. When backlog is meaningfully accumulated (3+ merged), open a fresh `sprint → main` bundle PR.
 
-## iOS Safari quirks to keep in mind
+## iOS Safari quirks reference
 
-- `100vh` is broken (counts the address bar). Prefer `100dvh` / `100svh`.
-- Inputs with `font-size < 16px` auto-zoom on focus. Always ≥16px on inputs/textareas/selects.
-- Tap targets < 44×44pt are rejected by Apple HIG.
-- `env(safe-area-inset-*)` for notch/home indicator.
-- Sticky elements behave oddly with the keyboard — test forms.
+- `100vh` is broken; prefer `100dvh` / `100svh`. `100vw` similarly; prefer `100dvw` for floating containers.
+- Inputs with `font-size < 16px` auto-zoom on focus. Always ≥16px on inputs.
+- Tap targets < 44×44pt fail Apple HIG. Use `@media (pointer: coarse)` for touch-only rules (NOT viewport queries).
+- `env(safe-area-inset-*)` requires `viewport-fit=cover` in `<meta viewport>`.
+- Sticky elements interact poorly with the keyboard — test forms.
 - Popovers/dropdowns must respect viewport bounds (Radix `collisionPadding`).
-- Sheet on mobile is shadcn Sidebar's built-in behavior (`useSidebar().openMobile`).
+- Mobile sheet is shadcn Sidebar's built-in behavior (`useSidebar().openMobile`).
+- Reuse `scroll-shadow-x` @utility from globals.css for any horizontal-scroll container.
 
-## Backlog (P0)
+## Backlog (Phase 2)
 
-_(empty — both user-reported P0 bugs shipped)_
+**Carried over from Phase 1 (deferred):**
+- [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard. `web/src/routes/__root.tsx`. Requires real-device validation; no simulator fully reproduces keyboard occlusion.
+- [ ] **MOBILE-19** HeroGrid 20px padding feels cramped on 375px. `web/src/components/hero-grid.tsx`. Subjective — defer until visual evidence shows a clear problem.
 
-## Backlog (P1 — re-scout)
-
-- [ ] **MOBILE-19** HeroGrid tight 20px padding on 375px. `web/src/components/hero-grid.tsx` (~lines 43-45). `px-5 sm:px-7` is fine but feels a touch cramped per scout. Subjective — defer until visual evidence shows a clear problem. May close as won't-fix.
-
-## Backlog (P1-P2 — scout-seeded)
-
-- [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard / backdrop-blur glitches. `web/src/routes/__root.tsx` (`sticky top-0`). Validate in real device. (Header safe-area top inset handled in MOBILE-7 PR; keyboard-overlap concern still open.)
-
-> Items touching `web/src/components/ui/*` should be solved by composing over the primitive (wrap, prop-pass) — only edit `ui/*` if there is no other path. Use `/shadcn` skill to verify if a primitive can be upgraded via prop instead.
+**New (to be seeded by future scouts or user reports):**
+- _(empty — Phase 2 is reactive; new items added as users report bugs or scouts find issues)_
 
 ## In-flight PRs
 
-- **Final scout** (Explore agent `af9b31eb`) — confirming no remaining mobile issues across untouched surfaces (setup/login/api-key-created, auth-shell, timeline-rail, floating-action-bar, connection/account detail, CSV flow). Will fold any genuine finds into the backlog; if empty, sprint is ready for sprint → main PR.
-
-## Sprint status
-
-**SPRINT WRAP-UP PR OPEN: [#1326](https://github.com/canalesb93/breadbox/pull/1326)** (sprint/mobile-ios-safari → main). 12 fixes shipped (10 PRs merged into sprint branch + 2 follow-ups committed directly: dvw cleanup on sibling components, then settings-tab strip scroll). Awaiting user review + merge.
-
-## Completed (additions since wrap-up PR opened)
-
-- ✅ **MOBILE-21** Mobile settings tabs not h-scrollable — pushed directly to sprint branch (`6cb17938`). The `<ul>` had `w-max` so it grew past its parent `<nav>` (which has no overflow), making the `overflow-x-auto` on the ul itself a no-op. Removing `w-max` constrains the ul to parent width; the `shrink-0` pills inside then push horizontally as intended.
-
-## Completed
-
-- ✅ **MOBILE-1** Sidebar close-on-tap — PR #1312 merged (`ab6dd40a`). `useSidebar().setOpenMobile(false)` wired into `NavMain` (link + modal) and `NavUser` (logout). Desktop unaffected.
-- ✅ **MOBILE-2/3/4** Popover/Select/DropdownMenu onscreen — PR #1316 merged (`cfd98db9`). Added `collisionPadding={8}` (overridable default), `max-w-[calc(100vw-1rem)]`, and `max-h-[min(60vh, available-height)]` to all three primitive Content components.
-- ✅ **MOBILE-5/12** 44pt tap targets — PR #1317 merged (`3b2f91f5`). Tailwind v4 `pointer-coarse:` variant adds invisible 44×44 tap zone via `::before` pseudo to all icon Button sizes; CommandInput bumps to `h-12` on touch. Desktop visuals unchanged (verified via mouse `pointer: fine`).
-- ✅ **MOBILE-6 (verified non-issue, closed)** Input font-size auto-zoom — `web/src/components/ui/input.tsx` and `textarea.tsx` already use `text-base` (16px) on mobile and `md:text-sm` (14px) at desktop ≥768px. iOS auto-zoom only fires on inputs <16px on mobile viewports; both meet the threshold. No code change required.
-- ✅ **MOBILE-7/9** iOS safe-area pass — PR #1318 merged (`78c814d9`). Added `viewport-fit=cover` to `web/index.html` (activates `env(safe-area-inset-*)`), per-side safe-area padding to `SheetContent`, mobile sidebar inner content respects bottom inset, and `pt-[env(safe-area-inset-top)]` on the sticky `<main>` header so it sits below the notch/Dynamic Island.
-- ✅ **MOBILE-11** Table scroll affordance — PR #1319 merged (`66d7d8d2`). Added `scroll-shadow-x` utility (4-layer CSS-only gradient, dark-mode aware) + `[-webkit-overflow-scrolling:touch]` to the `Table` primitive's container. Clipped tables now show a fade indicating scrollability; flat right edge confusion resolved.
-- ✅ **MOBILE-10/13** Dynamic viewport units — PR #1320 merged (`b3411af3`). Selection action bar swapped `100vw` → `100dvw` so it stays within the dynamic viewport as iOS chrome collapses; desktop sidebar swapped `h-svh` → `h-full` (parent-relative) so it fills exactly its container instead of the worst-case small-viewport height.
-- ✅ **MOBILE-15/16** Header + footer mobile stacking — PR #1321 merged (`669cfed6`). `PageHeader` actions cluster now wraps on mobile (`flex-wrap` + `sm:flex-nowrap sm:shrink-0`) so pages with multiple action buttons no longer overflow horizontally. `FormFooter` action cluster goes full-width column with primary on top (`flex-col-reverse w-full`) at <640px, restoring inline row on ≥640px — affirmative-on-top matches iOS / Material.
-- ✅ **MOBILE-14** Agent form mobile order — PR #1322 merged (`1bad8159`). CSS `order-first` / `md:order-none` reorders the agent-form cards so the operational knobs card (Model, Schedule, Tool scope, Allowed tools, Max turns, Budget) appears ABOVE the long prompt body on <768px. DOM and tab order unchanged.
-- ✅ **MOBILE-17/18** Small polish — PR #1323 merged (`d053acaa`). Empty-state description `max-w-sm` → `max-w-xs` (no longer exceeds 375px viewport in worst-case parents); error page `<pre>` gains explicit `[-webkit-overflow-scrolling:touch]` for parity with the table primitive.
-- ✅ **MOBILE-20** Transactions filter rail — PR #1324 merged (`b169174b`). Filter pills become a horizontal-scroll chip rail on <640px (using the same `scroll-shadow-x` fade as the Table primitive); at sm+ they revert to wrap. Subagent also promoted `scroll-shadow-x` to a Tailwind `@utility` so variants (`max-sm:`, `dark:`) compile to real rules, and added a `--scroll-shadow-cover` CSS variable so consumers on the page surface (vs inside a Card) can override via `[--scroll-shadow-cover:var(--background)]`.
+_(none)_
 
 ## Notes for next iteration
 
-- Always `git fetch && git pull` before starting.
-- Run `gh pr list --base sprint/mobile-ios-safari --state open` to see in-flight work.
-- Run `gh pr list --base sprint/mobile-ios-safari --state merged` to track velocity.
-- If a subagent PR has failing CI, comment summary, skip merging, mark as blocked here.
+- Backlog is intentionally thin. If nothing actionable on a fire, do a focused scout on a previously-unaudited flow (auth/setup-account/CSV import/connection creation) rather than dispatching a pointless PR.
+- New user-reported bugs ALWAYS take priority over deferred / scout items.
+- The `sprint/mobile-ios-safari` branch tip and `main` should diverge only by in-flight PRs; if it gets stale by >24h with no PRs, hard-reset it to `origin/main` to keep the diff base honest.

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -76,7 +76,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340 (state-doc merge included).
+- **fix/mobile-rules-toolbar-stack** (subagent `ac4da836`) — **MOBILE-39 (T2 MEDIUM)**. Stack rules filter toolbar at <sm (search row 1 full-width, two selects share row 2 via `flex-1`); restore inline + `ml-auto` at sm+ using `display: contents` wrapper trick. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,12 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 24 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350 + state-doc merges).
-- **T5 mobile-a11y audit** (Explore agent `aeb7dcd0`) — auditing ARIA landmarks, skip-to-content, icon-button aria-labels, focus traps, reduced-motion edge cases, VoiceOver flows. Findings or clean.
+- **fix/mobile-a11y-form-alert-and-skip-link** (subagent `abfb57bb`) — **MOBILE-51 + MOBILE-52 (T5 a11y bundle)**. FormMessage gains `role="alert" aria-live="polite"` so VoiceOver announces form errors proactively; `__root.tsx` gains a `sr-only focus-visible:not-sr-only` skip-to-main-content link that becomes visible on keyboard focus. PR # TBD.
+
+## Closed scouts (iter 32)
+
+- ✅ **T5 mobile-a11y audit** — most categories CLEAN: ARIA landmarks (header / main / nav semantically correct), icon-button aria-labels (row-actions / tag-chip / sidebar trigger / data-table / pagination all good), focus traps (Radix defaults retained), contrast on `pointer-coarse:` (AA passes light + dark), prefers-reduced-motion (PR #1337 rule confirmed at globals.css:202 — scout's HIGH finding here was a FALSE POSITIVE).
+- 2 actionable (above). 1 deferred LOW (sonner aria-live verification — speculative, can't verify from code).
 
 ## Closed scouts (iter 31)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -36,12 +36,13 @@ Phase 1 shipped fixes (now in main):
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard. `web/src/routes/__root.tsx`. Requires real-device validation; no simulator fully reproduces keyboard occlusion.
 - [ ] **MOBILE-19** HeroGrid 20px padding feels cramped on 375px. `web/src/components/hero-grid.tsx`. Subjective — defer until visual evidence shows a clear problem.
 
-**New (Phase 2 scout, iter 12):**
-- [ ] **MOBILE-24** CSV column-mapping label wraps aggressively on narrow viewports — `web/src/features/connections/csv-import-form.tsx` (~lines 422-478). Needs visual evidence before fix.
-- [ ] **MOBILE-25** CSV drag-drop file input may not open picker reliably on iOS — `web/src/features/connections/csv-import-form.tsx` (~lines 166-190). Needs simulator verification.
+**New:**
+- _(empty — backlog drained, awaiting user reports or future scout)_
 
 **Closed by audit:**
 - ✅ **MOBILE-API-COPY (closed as already-handled)** Scout flagged that API key copy on iOS might silently fail. Verified: `onCopy` at `api-key-created.tsx:47` already has try/catch with a clear error toast ("Couldn't access the clipboard. Select the value and copy manually.") and the readonly Input has `onFocus={e => e.currentTarget.select()}` for manual-copy ergonomics. No code change required.
+- ✅ **MOBILE-24 (closed as non-issue)** Scout flagged CSV column-mapping labels as wrapping aggressively on narrow viewports. Verified: `grid-cols-1 sm:grid-cols-2` means mobile gets ONE column per row — each ColumnSelect has the full 375px row width and the `text-xs` label easily fits "Separate Debit and Credit" in one line. Two-column wrap is a tablet+ concern where verticality is cheap. No code change.
+- ✅ **MOBILE-25 (closed as non-issue)** Scout flagged file input with `className="hidden"` as potentially not opening picker on iOS. Verified: `<label htmlFor="csv-file">` + `<input type="file" className="hidden">` IS the canonical React/Tailwind pattern and iOS Safari opens the picker correctly when you tap the associated label. `display:none` removes from layout but preserves label-association interactivity. No code change.
 
 ## In-flight PRs
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343 (state-doc merge included).
-- **docs/mobile-patterns-canon** (subagent `ab283dd3`) — **T7 documentation drift**. Adds a "Mobile / iOS Safari patterns" section to `.claude/rules/v2-frontend.md` codifying everything Phase 1 + Phase 2 established (viewport units, safe-area, tap targets, scroll-shadow, mobile reflow, form ergonomics, bfcache, reduced-motion, iOS web-app metadata). Pure docs, no runtime change. PR # TBD.
 
 ## Closed scouts (iter 25)
 
@@ -99,6 +98,7 @@ Each iteration:
 - ✅ **MOBILE-39** Rules filter toolbar mobile stack (T2 MEDIUM) — PR #1341 merged into sprint branch (`7e56b5ba`). At `<sm`, search takes full width on row 1, the two selects share row 2 via `flex-1`. At `sm+`, `display: contents` wrapper transparently passes through so `ml-auto` on the sort select keeps right-anchoring as before.
 - ✅ **MOBILE-41/42** LOW polish bundle — PR #1342 merged into sprint branch (`54b566eb`). Removed `[&_[cmdk-input]]:h-11` override from `command-palette.tsx` so the primitive's `h-9 pointer-coarse:h-12` adaptive defaults apply (#1317). Added `pt-[calc(*+env(safe-area-inset-top))]` to `detail-sheet-header.tsx` for iPhone landscape with notch (harmless on devices without one — env resolves to 0).
 - ✅ **MOBILE-37** Agent runs table mobile column collapse (T2 HIGH) — PR #1343 merged into sprint branch (`aa40ebc7`). Trigger / Duration / Cost / Tools columns gain `max-sm:hidden`; Agent column widens to `max-sm:w-[40%] max-sm:min-w-[140px]` so it dominates the remaining mobile view. DataTable already propagates `column.meta.className` to both TableHead and TableCell (no DataTable change needed). Power-user metrics remain accessible via row-tap → run detail sheet.
+- ✅ **T7 mobile-patterns canon** — PR #1344 merged into sprint branch (`eef5255a`). Adds a "Mobile / iOS Safari patterns" section to `.claude/rules/v2-frontend.md` codifying 9 pattern families (viewport units, safe-area, tap targets, scroll-shadow, mobile reflow, form ergonomics, bfcache/lifecycle, reduced-motion + tap-highlight, iOS web-app metadata) with PR citations. Future agents have the canon.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -37,8 +37,6 @@ Phase 1 shipped fixes (now in main):
 - [ ] **MOBILE-19** HeroGrid 20px padding feels cramped on 375px. `web/src/components/hero-grid.tsx`. Subjective — defer until visual evidence shows a clear problem.
 
 **New (Phase 2 scout, iter 12):**
-- [ ] **MOBILE-22** API key copy button isn't full-width when stacked — `web/src/routes/api-key-created.tsx` (~lines 91-112). _(in flight, see below)_
-- [ ] **MOBILE-23** Disconnect confirmation buttons cramped on mobile — `web/src/routes/connection-detail.tsx` (~lines 379-401). _(in flight, see below)_
 - [ ] **MOBILE-24** CSV column-mapping label wraps aggressively on narrow viewports — `web/src/features/connections/csv-import-form.tsx` (~lines 422-478). Needs visual evidence before fix.
 - [ ] **MOBILE-25** CSV drag-drop file input may not open picker reliably on iOS — `web/src/features/connections/csv-import-form.tsx` (~lines 166-190). Needs simulator verification.
 
@@ -47,7 +45,11 @@ Phase 1 shipped fixes (now in main):
 
 ## In-flight PRs
 
-- **fix/mobile-button-stacking-polish** (subagent `a0ad94fa`) — bundles MOBILE-22 + MOBILE-23. Adds `w-full sm:w-auto` to api-key Copy button; rewraps disconnect confirmation as `flex-col-reverse sm:flex-row` (destructive on top) with full-width-when-stacked buttons. Follows the FormFooter pattern from PR #1321. PR # TBD.
+_(none)_
+
+## Completed (Phase 2)
+
+- ✅ **MOBILE-22/23** Button stacking polish — PR #1328 merged into sprint branch (`543599c8`). API-key Copy button gains `w-full sm:w-auto`; disconnect confirmation rewrapped as `flex-col-reverse sm:flex-row` with destructive Disconnect button on top + full-width-when-stacked. Follows the FormFooter pattern from #1321.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -44,7 +44,6 @@ Each iteration:
 
 ## Backlog (Phase 2 — SPA-pitfall audit, iter ~14)
 
-- [ ] **MOBILE-31 (HIGH)** Reduced-motion bundle — wrap `animate-spin`, sidebar `transition-[left,right,width]`, and other animations with `motion-safe:` variants OR add global `@media (prefers-reduced-motion: reduce)` override in `globals.css`. Affects spinners across the app + `web/src/components/ui/sidebar.tsx` line ~165.
 - [ ] **MOBILE-32 (HIGH)** iOS keyboard hints — add `inputmode="email|numeric|decimal"` to typed inputs and `enterkeyhint="go|search|done"` on form submit fields. Audit: `web/src/routes/login.tsx`, `web/src/features/settings/*`, any amount/number inputs.
 - [ ] **MOBILE-33 (MEDIUM)** Identifier-field autocapitalize/autocorrect — slug/API-key/agent-slug inputs need `autoCorrect="off" autoCapitalize="off"` so iOS doesn't mangle them. Files: `web/src/features/agents/agent-form.tsx` (slug field at create time), `web/src/routes/api-key-new.tsx` (key name).
 - [ ] **MOBILE-34 (MEDIUM)** `overscroll-behavior: contain` on tables/lists — prevents iOS pull-to-refresh and parent rubber-band when scrolling inside `data-table.tsx`. Tailwind: `overscroll-contain`. One-line addition to the existing Table wrapper.
@@ -83,7 +82,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge.** Original scope was #1328+#1330+#1331+#1332+#1333; after the state-doc conflict was resolved (`858a75e1`) and #1335 + #1336 merged into sprint, the bundle now also includes the lazy-CategoryPicker perf fix and the prompts dialog-footer stacking fix.
-- **fix/mobile-prefers-reduced-motion** (subagent `a10d7f50`) — **MOBILE-31 (T2 HIGH from audit)**. Adds one global `@media (prefers-reduced-motion: reduce)` block to `globals.css` (CSS-tricks pattern — compress to 0.01ms so `animationend` still fires). Single-file ≤15 LOC. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -98,6 +96,7 @@ Each iteration:
 - ✅ **MOBILE-30** 401 visibility-gate — PR #1333 merged into sprint branch (`73e53940`). `AuthenticatedGate` in `__root.tsx` now defers the redirect-to-login while `document.visibilityState !== "visible"`, attaching a `visibilitychange` listener that fires the redirect when the user re-engages. Closes the residual bfcache-restore race left by PR #1329; cleanup-on-unmount included.
 - ✅ **MOBILE-35** Per-row CategoryPicker lazy body — PR #1335 merged into sprint branch (`fb8439c3`). Splits `CategoryPicker` into a lightweight always-mounted shell (just `useState(open)` + trigger) and a `PickerBody` that mounts only when `open === true` and owns `useCategoryEditor` (the mutation hook). Audit's actual finding: 50× `useMutation` observers per page (not popover content) were the leak. Reduces transactions-list React memory, improving iOS Safari bfcache eligibility.
 - ✅ **MOBILE-36** Prompts add-block dialog footer stacking — PR #1336 merged into sprint branch (`943dec09`). Inner action wrapper rewrapped as `flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center` so "Done" (affirmative) sits on top on mobile per the #1321 convention.
+- ✅ **MOBILE-31** Global `prefers-reduced-motion` (T2 HIGH a11y) — PR #1337 merged into sprint branch (`46323665`). Adds one `@media (prefers-reduced-motion: reduce)` block to `globals.css` using the CSS-tricks pattern (compress animation/transition to 0.01ms so `animationend` handlers still fire). Covers ~51 `animate-spin` usages + all shadcn primitive transitions without touching call sites. Cold-load splash (#1332) retains its own per-element `animation: none` override.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,16 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347 (state-doc merge included).
-- **T3 providers+connections scout** (Explore agent `a50e7ae4`) — auditing `routes/providers.tsx`, `features/providers/*`, `features/connections/*` (plaid-link-button, teller-connect-button, connect-bank-sheet, reauth-sheet, sync-activity-bars, sync-history-list, family-tabs, etc.). Particularly Plaid/Teller SDK launch interactions on iOS. Findings will fold into backlog (or report clean).
+- **fix/mobile-connect-reauth-sheet-footers** (subagent `ac020f11`) — **MOBILE-47 + MOBILE-48 (T3 scout-found, HIGH bundle)**. Stack `connect-bank-sheet.tsx` and `reauth-sheet.tsx` footer buttons on mobile via the established `flex-col-reverse sm:flex-row` + `w-full sm:w-auto` pattern (#1321/#1328/#1336). PR # TBD.
+
+## Closed scouts (iter 29)
+
+- ✅ **T3 providers+connections scout** — 20 files audited, 2 actionable (above), most CLEAN:
+  - family-tabs.tsx — already has the iter-24 horizontal-scroll fix
+  - plaid-link-button + teller-connect-button — render `null`, SDK launches in browser-native modals (no SPA-side mobile concern)
+  - sync-history-list, connection-row, connection-status-badge, connections-summary, env-locked-notice, provider-status, csv-card, plaid-card, teller-card — all good at 375px
+  - sync-activity-bars — acceptable as-is (fixed-height bar chart, 7+ bars fit)
+  - No Plaid/Teller SDK launch issues on iOS detected
 
 ## Closed scouts (iter 28)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347 (state-doc merge included).
+- **T3 providers+connections scout** (Explore agent `a50e7ae4`) — auditing `routes/providers.tsx`, `features/providers/*`, `features/connections/*` (plaid-link-button, teller-connect-button, connect-bank-sheet, reauth-sheet, sync-activity-bars, sync-history-list, family-tabs, etc.). Particularly Plaid/Teller SDK launch interactions on iOS. Findings will fold into backlog (or report clean).
 
 ## Closed scouts (iter 28)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347 (state-doc merge included).
-- **fix/mobile-connect-reauth-sheet-footers** (subagent `ac020f11`) — **MOBILE-47 + MOBILE-48 (T3 scout-found, HIGH bundle)**. Stack `connect-bank-sheet.tsx` and `reauth-sheet.tsx` footer buttons on mobile via the established `flex-col-reverse sm:flex-row` + `w-full sm:w-auto` pattern (#1321/#1328/#1336). PR # TBD.
 
 ## Closed scouts (iter 29)
 
@@ -125,6 +124,7 @@ Each iteration:
 - ✅ **T6 sandbox specimens** — PR #1345 merged into sprint branch (`97807c42`). Adds two specimens to `web/src/sandbox/sections/patterns.tsx`: `scroll-shadow-x utility` (card surface + page-surface cover override) and `Mobile reflow patterns` (button stack with primary-on-top, CSS `order` reshuffle, horizontal scroll-rail filter pills). Each cites the originating PR in code comments.
 - ✅ **MOBILE-43/44** Picker popover mobile widths — PR #1346 merged into sprint branch (`0aa00e0a`). Icon-picker (`w-72`) and color-picker (`w-64`) PopoverContents now use `w-[calc(100dvw-2rem)] sm:w-{72|64}` — full visible width minus 16px margin on mobile, locked to design size at sm+.
 - ✅ **MOBILE-45/46** FloatingActionBar safe-area-bottom + CommandList max-h adaptive — PR #1347 merged into sprint branch (`4ef34cd7`). FAB clears iPhone home indicator via `bottom-[max(1rem,env(safe-area-inset-bottom))]`; CommandList caps at `max-h-[min(300px,50dvh)]` so dropdowns adapt to shorter viewports (iOS keyboard open, landscape).
+- ✅ **MOBILE-47/48** connect/reauth sheet footers — PR #1348 merged into sprint branch (`8d37e803`). `connect-bank-sheet.tsx` (pick stage) and `reauth-sheet.tsx` (confirm stage) hand-rolled footers now follow the canonical `flex-col-reverse sm:flex-row` + `w-full sm:w-auto` pattern (matches #1321/#1328/#1336).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -61,7 +61,13 @@ Each iteration:
 
 ## In-flight PRs
 
-- **fix/mobile-ios-swipe-back-bfcache** (subagent `af43354e`) — MOBILE-26 (T1). Adds `pageshow` handler that calls `router.invalidate()` + `queryClient.invalidateQueries()` on bfcache restore. Optional belt-and-suspenders to gate 401 redirect on `document.visibilityState`. PR # TBD.
+- **PR #1329** MOBILE-26 (T1) iOS swipe-back bfcache fix — retargeted to `main` per user auth, CI running, will merge when green.
+- **fix/mobile-navbar-no-blur** (subagent `ad2dc3ef`) — MOBILE-27 (T1, user-reported). Drops `backdrop-blur` + translucent bg on `<header>` at <640px; keeps the desktop glassy look. Eliminates the visible seam between solid safe-area zone and blurred header. PR # TBD.
+
+## Backlog additions
+
+- [x] **MOBILE-26** iOS swipe-back blank/freeze — fix in flight (#1329).
+- [x] **MOBILE-27** Mobile navbar glassy effect looks bad against safe-area gap — fix in flight.
 
 ## Completed (Phase 2)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 24 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350 + state-doc merges).
-- **fix/mobile-a11y-form-alert-and-skip-link** (subagent `abfb57bb`) — **MOBILE-51 + MOBILE-52 (T5 a11y bundle)**. FormMessage gains `role="alert" aria-live="polite"` so VoiceOver announces form errors proactively; `__root.tsx` gains a `sr-only focus-visible:not-sr-only` skip-to-main-content link that becomes visible on keyboard focus. PR # TBD.
 
 ## Closed scouts (iter 32)
 
@@ -137,6 +136,7 @@ Each iteration:
 - ✅ **MOBILE-47/48** connect/reauth sheet footers — PR #1348 merged into sprint branch (`8d37e803`). `connect-bank-sheet.tsx` (pick stage) and `reauth-sheet.tsx` (confirm stage) hand-rolled footers now follow the canonical `flex-col-reverse sm:flex-row` + `w-full sm:w-auto` pattern (matches #1321/#1328/#1336).
 - ✅ **T4 iter-28 followups** — PR #1349 merged into sprint branch (`ed1dbc5d`). Verified all 5 deferred items from iter 28: **fixed 2** (comment-composer textarea gets `enterKeyHint="send"` → iOS keyboard tints the return key; tag-chip × button gets the `pointer-coarse:` 44pt pseudo from #1317 since the raw `<button>` didn't inherit Button's TAP_TARGET); **closed 3 as non-issues** (ActivityTimeline page-scrolls naturally, PaginationLink already uses `buttonVariants({size:"icon"})` which inherits TAP_TARGET, CommentComposer button label is additive — spinner doesn't replace it).
 - ✅ **MOBILE-49/50** detail-dialog-header safe-area-top + confirm-dialog button widths — PR #1350 merged into sprint branch (`84b66052`). DialogHeader gets `mt-[env(safe-area-inset-top)]` (clean margin-shift approach; iPad-landscape notched device clearance). `AlertDialogCancel` + `AlertDialogAction` get `w-full sm:w-auto` so stacked buttons reach full tap width on 375px (AlertDialogFooter already had `flex-col-reverse` semantic — only the button widths were the gap).
+- ✅ **MOBILE-51/52** a11y form-alert + skip-link (T5 bundle) — PR #1351 merged into sprint branch (`cf94529a`). FormMessage gains `role="alert" aria-live="polite"` (conditional on error state) — VoiceOver / NVDA now announce form validation errors as they appear (WCAG 3.3.1). `__root.tsx` gains a `sr-only focus-visible:not-sr-only` skip-to-main-content link + `<main id="main" tabIndex={-1}>` so keyboard / VoiceOver users can bypass the sidebar (WCAG 2.4.1).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -57,7 +57,6 @@ Each iteration:
 
 **Carried over from Phase 1 (deferred):**
 - [ ] **MOBILE-8** Sticky `<main>` header may overlap iOS keyboard. `web/src/routes/__root.tsx`. Requires real-device validation; no simulator fully reproduces keyboard occlusion.
-- [ ] **MOBILE-19** HeroGrid 20px padding feels cramped on 375px. `web/src/components/hero-grid.tsx`. Subjective — defer until visual evidence shows a clear problem.
 
 **New (T1 — user-reported):**
 - [ ] **MOBILE-26** iOS Safari swipe-back gesture freezes / shows blank page. Tap-back works fine. _(in flight)_
@@ -73,7 +72,12 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 23 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349 + state-doc merges).
-- **T3 shared-components scout** (Explore agent `a4e586be`) — auditing detail-list, list-card, status-panel, timeline-rail, soft-back-button, id-pill, kbd-tooltip, eyebrow, brand-header, hero-grid, coming-soon-pill, color-rail-card, **confirm-dialog (button stacking?)**, **detail-dialog-header (safe-area-top?)**. Findings or clean.
+- **fix/mobile-detail-dialog-and-confirm** (subagent `a8ba22b7`) — **MOBILE-49 + MOBILE-50 (T3 scout-found)**. detail-dialog-header gets safe-area-top (mirror of #1342); confirm-dialog buttons get full-width-when-stacked (mirror of #1328). PR # TBD.
+
+## Closed scouts (iter 31)
+
+- ✅ **T3 shared-components scout** — 14 files audited. 2 actionable above. 1 deferred (kbd-tooltip showing on touch — LOW polish, defer). 11 CLEAN (detail-list, list-card, status-panel, timeline-rail, soft-back-button, id-pill, eyebrow, brand-header, coming-soon-pill, color-rail-card, **hero-grid**).
+- ✅ **MOBILE-19** Hero-grid padding (deferred from Phase 1) — verified non-issue by scout. `px-5 sm:px-7` reads correctly at 375px; "feels cramped" was subjective and no visual evidence surfaced.
 
 ## Closed scouts (iter 29)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -48,7 +48,6 @@ Each iteration:
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
 
 - [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
-- [ ] **MOBILE-39 (MEDIUM)** Rules filter toolbar three fixed-width selects wrap awkwardly. `web/src/routes/rules.tsx` (~line 290). Apply chip-rail pattern from #1324 (`max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto`).
 - [ ] **MOBILE-41 (LOW)** Command palette input `h-11` vs `h-12` threshold from #1317. `web/src/components/command-palette.tsx` (~line 218). Debatable; bumping to `h-12` for consistency.
 - [ ] **MOBILE-42 (LOW)** `detail-sheet-header.tsx` missing safe-area-top in iPhone landscape with notch. `web/src/components/detail-sheet-header.tsx` (~lines 54-59). `pt-5` → `pt-[calc(1.25rem+env(safe-area-inset-top))]`.
 
@@ -77,7 +76,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340 (state-doc merge included).
-- **fix/mobile-rules-toolbar-stack** (subagent `ac4da836`) — **MOBILE-39 (T2 MEDIUM)**. Stack rules filter toolbar at <sm (search row 1 full-width, two selects share row 2 via `flex-1`); restore inline + `ml-auto` at sm+ using `display: contents` wrapper trick. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -96,6 +94,7 @@ Each iteration:
 - ✅ **MOBILE-32/33** iOS form ergonomics (T2 HIGH/MEDIUM) — PR #1338 merged into sprint branch (`d00c6305`). `SearchInput` gets defaults (`inputMode="search"`, `enterKeyHint="search"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`) so every search consumer benefits. Numeric inputs (agent `max_turns`, `budget_usd_cents`, link-account tolerance, rule values) get `inputMode="numeric|decimal"`. Identifier fields (API key name/prefix, rule values) get autocorrect/autocapitalize off.
 - ✅ **MOBILE-38** Prompts builder mobile layout (T2 HIGH) — PR #1339 merged into sprint branch (`d6ada115`). `grid grid-cols-[10rem_1fr]` swapped to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]`; nav becomes a horizontal scroll-shadow chip rail on `<sm` with dividers flipped from horizontal rules to vertical separators between pills. Pattern matches #1324 (transactions filter) / MOBILE-21 (settings tabs).
 - ✅ **MOBILE-34/40** iOS overscroll hygiene (T2 MEDIUM) — PR #1340 merged into sprint branch (`ba76a4f3`). Adds `overscroll-contain` to the Table primitive's scroll-shadow wrapper (blocks pull-to-refresh and parent rubber-band when scrolling tables) and to the transcript-viewer's `<pre>` code blocks (blocks back-swipe leakage from inner scroll).
+- ✅ **MOBILE-39** Rules filter toolbar mobile stack (T2 MEDIUM) — PR #1341 merged into sprint branch (`7e56b5ba`). At `<sm`, search takes full width on row 1, the two selects share row 2 via `flex-1`. At `sm+`, `display: contents` wrapper transparently passes through so `ml-auto` on the sort select keeps right-anchoring as before.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -77,7 +77,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339 (state-doc merge included).
-- **fix/mobile-overscroll-contain** (subagent `a9ce28c0`) — **MOBILE-34 + MOBILE-40 (T2 MEDIUM bundle)**. Adds `overscroll-contain` to the Table primitive wrapper and the transcript-viewer `<pre>` to block iOS pull-to-refresh / back-swipe leaks from inner scroll containers. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -95,6 +94,7 @@ Each iteration:
 - ✅ **MOBILE-31** Global `prefers-reduced-motion` (T2 HIGH a11y) — PR #1337 merged into sprint branch (`46323665`). Adds one `@media (prefers-reduced-motion: reduce)` block to `globals.css` using the CSS-tricks pattern (compress animation/transition to 0.01ms so `animationend` handlers still fire). Covers ~51 `animate-spin` usages + all shadcn primitive transitions without touching call sites. Cold-load splash (#1332) retains its own per-element `animation: none` override.
 - ✅ **MOBILE-32/33** iOS form ergonomics (T2 HIGH/MEDIUM) — PR #1338 merged into sprint branch (`d00c6305`). `SearchInput` gets defaults (`inputMode="search"`, `enterKeyHint="search"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`) so every search consumer benefits. Numeric inputs (agent `max_turns`, `budget_usd_cents`, link-account tolerance, rule values) get `inputMode="numeric|decimal"`. Identifier fields (API key name/prefix, rule values) get autocorrect/autocapitalize off.
 - ✅ **MOBILE-38** Prompts builder mobile layout (T2 HIGH) — PR #1339 merged into sprint branch (`d6ada115`). `grid grid-cols-[10rem_1fr]` swapped to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]`; nav becomes a horizontal scroll-shadow chip rail on `<sm` with dividers flipped from horizontal rules to vertical separators between pills. Pattern matches #1324 (transactions filter) / MOBILE-21 (settings tabs).
+- ✅ **MOBILE-34/40** iOS overscroll hygiene (T2 MEDIUM) — PR #1340 merged into sprint branch (`ba76a4f3`). Adds `overscroll-contain` to the Table primitive's scroll-shadow wrapper (blocks pull-to-refresh and parent rubber-band when scrolling tables) and to the transcript-viewer's `<pre>` code blocks (blocks back-swipe leakage from inner scroll).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 25 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350, #1351 + state-doc merges).
-- **docs/mobile-patterns-canon-refresh** (subagent `a0aa29f8`) — **T7 documentation drift**. Refresh `.claude/rules/v2-frontend.md` "Mobile / iOS Safari patterns" with 6 additions covering #1346 (picker dvw widths), #1347 (FAB safe-area-bottom + CommandList max-h-dvh), #1348 (sheet footer stacking), #1349 (raw-button tap-zone recipe + textarea enterKeyHint), #1350 (Dialog header mt-env + AlertDialog buttons), #1351 (skip link + FormMessage alert). Pure docs. PR # TBD.
 
 ## Closed scouts (iter 32)
 
@@ -138,6 +137,7 @@ Each iteration:
 - ✅ **T4 iter-28 followups** — PR #1349 merged into sprint branch (`ed1dbc5d`). Verified all 5 deferred items from iter 28: **fixed 2** (comment-composer textarea gets `enterKeyHint="send"` → iOS keyboard tints the return key; tag-chip × button gets the `pointer-coarse:` 44pt pseudo from #1317 since the raw `<button>` didn't inherit Button's TAP_TARGET); **closed 3 as non-issues** (ActivityTimeline page-scrolls naturally, PaginationLink already uses `buttonVariants({size:"icon"})` which inherits TAP_TARGET, CommentComposer button label is additive — spinner doesn't replace it).
 - ✅ **MOBILE-49/50** detail-dialog-header safe-area-top + confirm-dialog button widths — PR #1350 merged into sprint branch (`84b66052`). DialogHeader gets `mt-[env(safe-area-inset-top)]` (clean margin-shift approach; iPad-landscape notched device clearance). `AlertDialogCancel` + `AlertDialogAction` get `w-full sm:w-auto` so stacked buttons reach full tap width on 375px (AlertDialogFooter already had `flex-col-reverse` semantic — only the button widths were the gap).
 - ✅ **MOBILE-51/52** a11y form-alert + skip-link (T5 bundle) — PR #1351 merged into sprint branch (`cf94529a`). FormMessage gains `role="alert" aria-live="polite"` (conditional on error state) — VoiceOver / NVDA now announce form validation errors as they appear (WCAG 3.3.1). `__root.tsx` gains a `sr-only focus-visible:not-sr-only` skip-to-main-content link + `<main id="main" tabIndex={-1}>` so keyboard / VoiceOver users can bypass the sidebar (WCAG 2.4.1).
+- ✅ **T7 canon refresh** — PR #1352 merged into sprint branch (`ba87c056`). 6 additions to the "Mobile / iOS Safari patterns" section in `.claude/rules/v2-frontend.md` covering everything from PRs #1346 through #1351 (picker dvw widths, CommandList max-h-dvh, FAB safe-area-bottom, DialogHeader mt-env, AlertDialog button width, raw-button tap-zone recipe, textarea enterKeyHint, skip link, FormMessage alert). Canon is current.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -44,7 +44,6 @@ Each iteration:
 
 ## Backlog (Phase 2 — SPA-pitfall audit, iter ~14)
 
-- [ ] **MOBILE-30 (HIGH)** Visibility-gate 401 redirect — `web/src/routes/__root.tsx` (~line 60-64). `AuthenticatedGate` redirects to `/login` on any 401 without checking `document.hidden`. On bfcache restore where the page is briefly not visible, the redirect can fire before user re-engagement. Gate with `if (is401 && !document.hidden)`. Complements PR #1329 (bfcache fix).
 - [ ] **MOBILE-31 (HIGH)** Reduced-motion bundle — wrap `animate-spin`, sidebar `transition-[left,right,width]`, and other animations with `motion-safe:` variants OR add global `@media (prefers-reduced-motion: reduce)` override in `globals.css`. Affects spinners across the app + `web/src/components/ui/sidebar.tsx` line ~165.
 - [ ] **MOBILE-32 (HIGH)** iOS keyboard hints — add `inputmode="email|numeric|decimal"` to typed inputs and `enterkeyhint="go|search|done"` on form submit fields. Audit: `web/src/routes/login.tsx`, `web/src/features/settings/*`, any amount/number inputs.
 - [ ] **MOBILE-33 (MEDIUM)** Identifier-field autocapitalize/autocorrect — slug/API-key/agent-slug inputs need `autoCorrect="off" autoCapitalize="off"` so iOS doesn't mangle them. Files: `web/src/features/agents/agent-form.tsx` (slug field at create time), `web/src/routes/api-key-new.tsx` (key name).
@@ -74,7 +73,7 @@ Each iteration:
 
 ## In-flight PRs
 
-- **fix/mobile-401-visibility-gate** (subagent `a6a0df8b`) — MOBILE-30 (HIGH from audit). Gates the `__root.tsx` 401 redirect on `document.visibilityState === "visible"` so it doesn't fire during bfcache restore. Direct complement to PR #1329. PR # TBD.
+_(none)_
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -86,6 +85,7 @@ Each iteration:
 - ✅ **MOBILE-27** Mobile navbar blur — PR #1330 merged into sprint branch (`70f8518d`). `<header>` now uses solid `bg-background` at <640px (no `backdrop-blur`, no translucency), restoring the glassy look at sm+ via `sm:backdrop-blur` / `sm:bg-background/95`. Eliminates the visible seam between solid safe-area zone and previously-blurred header on iOS.
 - ✅ **MOBILE-28** Viewport-unit polish (T4) — PR #1331 merged into sprint branch (`84bdb932`). 5 viewport-unit straggler swaps: `min-h-screen` → `min-h-dvh` on auth-shell wrapper + grid; `min-h-svh` → `min-h-dvh` on sidebar outer wrapper; `max-w-[calc(100vw-1rem)]` → `max-w-[calc(100dvw-1rem)]` in popover/select/dropdown content clamps. Finishes the dvh/dvw family.
 - ✅ **MOBILE-29** iOS web-app shell polish — PR #1332 merged into sprint branch (`658e69f6`). Adds iOS PWA meta tags (`apple-mobile-web-app-capable=yes`, `status-bar-style=black-translucent`, `apple-mobile-web-app-title=Breadbox`, `apple-touch-icon` → favicon.svg), inline cold-load splash in `<div id="root">` (auto-vanishes when React hydrates, respects `prefers-reduced-motion` and `prefers-color-scheme`), and global `-webkit-tap-highlight-color: transparent`.
+- ✅ **MOBILE-30** 401 visibility-gate — PR #1333 merged into sprint branch (`73e53940`). `AuthenticatedGate` in `__root.tsx` now defers the redirect-to-login while `document.visibilityState !== "visible"`, attaching a `visibilitychange` listener that fires the redirect when the user re-engages. Closes the residual bfcache-restore race left by PR #1329; cleanup-on-unmount included.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344 (state-doc merge included).
-- **docs/sandbox-mobile-pattern-specimens** (subagent `a1ed71e0`) — **T6 sandbox completeness**. Adds sandbox demos for `scroll-shadow-x` utility, mobile reflow patterns (button stack, CSS order, chip-rail). Closes the gap where #1344's canon documented patterns but the sandbox had no specimens. PR # TBD.
 
 ## Closed scouts (iter 25)
 
@@ -100,6 +99,7 @@ Each iteration:
 - ✅ **MOBILE-41/42** LOW polish bundle — PR #1342 merged into sprint branch (`54b566eb`). Removed `[&_[cmdk-input]]:h-11` override from `command-palette.tsx` so the primitive's `h-9 pointer-coarse:h-12` adaptive defaults apply (#1317). Added `pt-[calc(*+env(safe-area-inset-top))]` to `detail-sheet-header.tsx` for iPhone landscape with notch (harmless on devices without one — env resolves to 0).
 - ✅ **MOBILE-37** Agent runs table mobile column collapse (T2 HIGH) — PR #1343 merged into sprint branch (`aa40ebc7`). Trigger / Duration / Cost / Tools columns gain `max-sm:hidden`; Agent column widens to `max-sm:w-[40%] max-sm:min-w-[140px]` so it dominates the remaining mobile view. DataTable already propagates `column.meta.className` to both TableHead and TableCell (no DataTable change needed). Power-user metrics remain accessible via row-tap → run detail sheet.
 - ✅ **T7 mobile-patterns canon** — PR #1344 merged into sprint branch (`eef5255a`). Adds a "Mobile / iOS Safari patterns" section to `.claude/rules/v2-frontend.md` codifying 9 pattern families (viewport units, safe-area, tap targets, scroll-shadow, mobile reflow, form ergonomics, bfcache/lifecycle, reduced-motion + tap-highlight, iOS web-app metadata) with PR citations. Future agents have the canon.
+- ✅ **T6 sandbox specimens** — PR #1345 merged into sprint branch (`97807c42`). Adds two specimens to `web/src/sandbox/sections/patterns.tsx`: `scroll-shadow-x utility` (card surface + page-surface cover override) and `Mobile reflow patterns` (button stack with primary-on-top, CSS `order` reshuffle, horizontal scroll-rail filter pills). Each cites the originating PR in code comments.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -75,7 +75,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341 (state-doc merge included).
+- **fix/mobile-palette-and-sheet-header-polish** (subagent `a62c8837`) — **MOBILE-41 + MOBILE-42 (T2 LOW bundle)**. Remove `[&_[cmdk-input]]:h-11` override in `command-palette.tsx` so the primitive's `h-9 pointer-coarse:h-12` adaptive defaults apply (#1317). Add `pt-[calc(*+env(safe-area-inset-top))]` to `detail-sheet-header.tsx` for iPhone landscape with notch. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346 (state-doc merge included).
+- **T3 transaction-detail+features scout** (Explore agent `af710cb7`) — auditing transaction-detail, activity-timeline, comment-composer, tag-manager, category-editor, pagination, selection-action-bar buttons, row skeleton. Findings will fold into backlog (or report clean).
 
 ## Closed scouts (iter 27)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345 (state-doc merge included).
-- **fix/mobile-picker-popover-widths** (subagent `a812ec23`) — **MOBILE-43 + MOBILE-44 (T3 scout-found)**. Widen icon-picker (`w-72`) and color-picker (`w-64`) popovers on mobile via `w-[calc(100dvw-2rem)] sm:w-72`. Same pattern as #1320 dvw + #1316 popover clamp. PR # TBD.
 
 ## Closed scouts (iter 27)
 
@@ -105,6 +104,7 @@ Each iteration:
 - ✅ **MOBILE-37** Agent runs table mobile column collapse (T2 HIGH) — PR #1343 merged into sprint branch (`aa40ebc7`). Trigger / Duration / Cost / Tools columns gain `max-sm:hidden`; Agent column widens to `max-sm:w-[40%] max-sm:min-w-[140px]` so it dominates the remaining mobile view. DataTable already propagates `column.meta.className` to both TableHead and TableCell (no DataTable change needed). Power-user metrics remain accessible via row-tap → run detail sheet.
 - ✅ **T7 mobile-patterns canon** — PR #1344 merged into sprint branch (`eef5255a`). Adds a "Mobile / iOS Safari patterns" section to `.claude/rules/v2-frontend.md` codifying 9 pattern families (viewport units, safe-area, tap targets, scroll-shadow, mobile reflow, form ergonomics, bfcache/lifecycle, reduced-motion + tap-highlight, iOS web-app metadata) with PR citations. Future agents have the canon.
 - ✅ **T6 sandbox specimens** — PR #1345 merged into sprint branch (`97807c42`). Adds two specimens to `web/src/sandbox/sections/patterns.tsx`: `scroll-shadow-x utility` (card surface + page-surface cover override) and `Mobile reflow patterns` (button stack with primary-on-top, CSS `order` reshuffle, horizontal scroll-rail filter pills). Each cites the originating PR in code comments.
+- ✅ **MOBILE-43/44** Picker popover mobile widths — PR #1346 merged into sprint branch (`0aa00e0a`). Icon-picker (`w-72`) and color-picker (`w-64`) PopoverContents now use `w-[calc(100dvw-2rem)] sm:w-{72|64}` — full visible width minus 16px margin on mobile, locked to design size at sm+.
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -48,8 +48,6 @@ Each iteration:
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
 
 - [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
-- [ ] **MOBILE-41 (LOW)** Command palette input `h-11` vs `h-12` threshold from #1317. `web/src/components/command-palette.tsx` (~line 218). Debatable; bumping to `h-12` for consistency.
-- [ ] **MOBILE-42 (LOW)** `detail-sheet-header.tsx` missing safe-area-top in iPhone landscape with notch. `web/src/components/detail-sheet-header.tsx` (~lines 54-59). `pt-5` → `pt-[calc(1.25rem+env(safe-area-inset-top))]`.
 
 ## Deferred / low-value (won't fix without evidence)
 
@@ -76,7 +74,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341 (state-doc merge included).
-- **fix/mobile-palette-and-sheet-header-polish** (subagent `a62c8837`) — **MOBILE-41 + MOBILE-42 (T2 LOW bundle)**. Remove `[&_[cmdk-input]]:h-11` override in `command-palette.tsx` so the primitive's `h-9 pointer-coarse:h-12` adaptive defaults apply (#1317). Add `pt-[calc(*+env(safe-area-inset-top))]` to `detail-sheet-header.tsx` for iPhone landscape with notch. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 
@@ -96,6 +93,7 @@ Each iteration:
 - ✅ **MOBILE-38** Prompts builder mobile layout (T2 HIGH) — PR #1339 merged into sprint branch (`d6ada115`). `grid grid-cols-[10rem_1fr]` swapped to `flex flex-col sm:grid sm:grid-cols-[10rem_1fr]`; nav becomes a horizontal scroll-shadow chip rail on `<sm` with dividers flipped from horizontal rules to vertical separators between pills. Pattern matches #1324 (transactions filter) / MOBILE-21 (settings tabs).
 - ✅ **MOBILE-34/40** iOS overscroll hygiene (T2 MEDIUM) — PR #1340 merged into sprint branch (`ba76a4f3`). Adds `overscroll-contain` to the Table primitive's scroll-shadow wrapper (blocks pull-to-refresh and parent rubber-band when scrolling tables) and to the transcript-viewer's `<pre>` code blocks (blocks back-swipe leakage from inner scroll).
 - ✅ **MOBILE-39** Rules filter toolbar mobile stack (T2 MEDIUM) — PR #1341 merged into sprint branch (`7e56b5ba`). At `<sm`, search takes full width on row 1, the two selects share row 2 via `flex-1`. At `sm+`, `display: contents` wrapper transparently passes through so `ml-auto` on the sort select keeps right-anchoring as before.
+- ✅ **MOBILE-41/42** LOW polish bundle — PR #1342 merged into sprint branch (`54b566eb`). Removed `[&_[cmdk-input]]:h-11` override from `command-palette.tsx` so the primitive's `h-9 pointer-coarse:h-12` adaptive defaults apply (#1317). Added `pt-[calc(*+env(safe-area-inset-top))]` to `detail-sheet-header.tsx` for iPhone landscape with notch (harmless on devices without one — env resolves to 0).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -61,13 +61,11 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1329** MOBILE-26 (T1) iOS swipe-back bfcache fix — retargeted to `main` per user auth, CI running, will merge when green.
-- **fix/mobile-navbar-no-blur** (subagent `ad2dc3ef`) — MOBILE-27 (T1, user-reported). Drops `backdrop-blur` + translucent bg on `<header>` at <640px; keeps the desktop glassy look. Eliminates the visible seam between solid safe-area zone and blurred header. PR # TBD.
+- **fix/mobile-navbar-no-blur** (subagent `ad2dc3ef`) — MOBILE-27 (T1, user-reported). Drops `backdrop-blur` + translucent bg on `<header>` at <640px; keeps the desktop glassy look. PR # TBD.
 
-## Backlog additions
+## Completed (Phase 2 — direct-to-main)
 
-- [x] **MOBILE-26** iOS swipe-back blank/freeze — fix in flight (#1329).
-- [x] **MOBILE-27** Mobile navbar glassy effect looks bad against safe-area gap — fix in flight.
+- ✅ **MOBILE-26** iOS swipe-back bfcache fix — PR #1329 merged into MAIN per user auth (`34dee658`). Adds `pageshow` listener that calls `router.invalidate()` + `queryClient.invalidateQueries()` on `event.persisted === true`, eliminating the freeze/blank-page race between bfcache restore and stale-query 401 redirect.
 
 ## Completed (Phase 2)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -44,13 +44,11 @@ Each iteration:
 
 ## Backlog (Phase 2 — SPA-pitfall audit, iter ~14)
 
-- [ ] **MOBILE-34 (MEDIUM)** `overscroll-behavior: contain` on tables/lists — prevents iOS pull-to-refresh and parent rubber-band when scrolling inside `data-table.tsx`. Tailwind: `overscroll-contain`. One-line addition to the existing Table wrapper.
 
 ## Backlog (T3 scout — rules / agents / prompts, iter ~17)
 
 - [ ] **MOBILE-37 (HIGH)** Agent runs table column widths explode beyond viewport on iOS. `web/src/routes/agents.runs.tsx` (~lines 303-388). Rigid `w-[22%] min-w-[160px]` + 8 fixed columns ⇒ horizontal scroll required. Verify whether the existing `scroll-shadow-x` from Table primitive helps; if not, hide-on-mobile or collapse columns into a Metrics expander.
 - [ ] **MOBILE-39 (MEDIUM)** Rules filter toolbar three fixed-width selects wrap awkwardly. `web/src/routes/rules.tsx` (~line 290). Apply chip-rail pattern from #1324 (`max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto`).
-- [ ] **MOBILE-40 (MEDIUM)** Transcript sheet nested scroll trap. `web/src/features/agents/transcript-viewer.tsx`. Inner `<pre max-h-48 overflow-auto>` inside sheet body creates two scroll contexts; iOS swipe-up in the pre triggers back-gesture instead of scrolling sheet. Fix: `overscroll-behavior-y: contain` on the pre + expand `max-h` so it doesn't compete with the sheet scroll.
 - [ ] **MOBILE-41 (LOW)** Command palette input `h-11` vs `h-12` threshold from #1317. `web/src/components/command-palette.tsx` (~line 218). Debatable; bumping to `h-12` for consistency.
 - [ ] **MOBILE-42 (LOW)** `detail-sheet-header.tsx` missing safe-area-top in iPhone landscape with notch. `web/src/components/detail-sheet-header.tsx` (~lines 54-59). `pt-5` → `pt-[calc(1.25rem+env(safe-area-inset-top))]`.
 
@@ -78,7 +76,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — `CLEAN` status; now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339 (state-doc merge included).
+- **fix/mobile-overscroll-contain** (subagent `a9ce28c0`) — **MOBILE-34 + MOBILE-40 (T2 MEDIUM bundle)**. Adds `overscroll-contain` to the Table primitive wrapper and the transcript-viewer `<pre>` to block iOS pull-to-refresh / back-swipe leaks from inner scroll containers. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -73,7 +73,6 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346 (state-doc merge included).
-- **fix/mobile-fab-and-commandlist** (subagent `a3c78774`) — **MOBILE-45 + MOBILE-46 (T3 scout-found, HIGH + MEDIUM)**. FloatingActionBar gains `bottom-[max(1rem,env(safe-area-inset-bottom))]` so it clears the iPhone home indicator. CommandList `max-h-[300px]` → `max-h-[min(300px,50dvh)]` so dropdowns don't push offscreen with iOS keyboard open. PR # TBD.
 
 ## Closed scouts (iter 28)
 
@@ -115,6 +114,7 @@ Each iteration:
 - ✅ **T7 mobile-patterns canon** — PR #1344 merged into sprint branch (`eef5255a`). Adds a "Mobile / iOS Safari patterns" section to `.claude/rules/v2-frontend.md` codifying 9 pattern families (viewport units, safe-area, tap targets, scroll-shadow, mobile reflow, form ergonomics, bfcache/lifecycle, reduced-motion + tap-highlight, iOS web-app metadata) with PR citations. Future agents have the canon.
 - ✅ **T6 sandbox specimens** — PR #1345 merged into sprint branch (`97807c42`). Adds two specimens to `web/src/sandbox/sections/patterns.tsx`: `scroll-shadow-x utility` (card surface + page-surface cover override) and `Mobile reflow patterns` (button stack with primary-on-top, CSS `order` reshuffle, horizontal scroll-rail filter pills). Each cites the originating PR in code comments.
 - ✅ **MOBILE-43/44** Picker popover mobile widths — PR #1346 merged into sprint branch (`0aa00e0a`). Icon-picker (`w-72`) and color-picker (`w-64`) PopoverContents now use `w-[calc(100dvw-2rem)] sm:w-{72|64}` — full visible width minus 16px margin on mobile, locked to design size at sm+.
+- ✅ **MOBILE-45/46** FloatingActionBar safe-area-bottom + CommandList max-h adaptive — PR #1347 merged into sprint branch (`4ef34cd7`). FAB clears iPhone home indicator via `bottom-[max(1rem,env(safe-area-inset-bottom))]`; CommandList caps at `max-h-[min(300px,50dvh)]` so dropdowns adapt to shorter viewports (iOS keyboard open, landscape).
 
 ## Notes for next iteration
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -81,7 +81,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge.** Original scope was #1328+#1330+#1331+#1332+#1333; after the state-doc conflict was resolved (`858a75e1`) and #1335 + #1336 merged into sprint, the bundle now also includes the lazy-CategoryPicker perf fix and the prompts dialog-footer stacking fix.
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — `CLEAN` status; now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337 (state-doc merge included).
+- **fix/mobile-form-ergonomics** (subagent `a8a6bc0f`) — **MOBILE-32 + MOBILE-33 (T2 HIGH/MEDIUM)**. iOS keyboard hints (`inputmode`, `enterkeyhint`) across typed inputs + `autoCorrect="off" autoCapitalize="off" spellCheck={false}` on identifier fields (slugs, API key names). Prefer setting defaults on `SearchInput` so every search box benefits. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,8 @@ Each iteration:
 
 ## In-flight PRs
 
-- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342 (state-doc merge included).
+- **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes #1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343 (state-doc merge included).
+- **T3 accounts scout** (Explore agent `a4c578a0`) — auditing `routes/accounts.tsx`, `routes/account-detail.tsx`, `features/accounts/*` for iOS issues. Will fold findings into backlog when done.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -62,6 +62,7 @@ Each iteration:
 ## In-flight PRs
 
 - **fix/mobile-navbar-no-blur** (subagent `ad2dc3ef`) — MOBILE-27 (T1, user-reported). Drops `backdrop-blur` + translucent bg on `<header>` at <640px; keeps the desktop glassy look. PR # TBD.
+- **fix/mobile-viewport-units-polish** (subagent `af498752`) — **MOBILE-28 (T4 polish)**. Finishes the viewport-unit cleanup: `min-h-screen` → `min-h-dvh` in `auth-shell.tsx` (×2), `min-h-svh` → `min-h-dvh` in `sidebar.tsx` wrapper, `100vw` → `100dvw` in popover/select/dropdown `max-w` clamps. Same family as PR #1320. PR # TBD.
 
 ## Completed (Phase 2 — direct-to-main)
 

--- a/.claude/mobile-sprint-state.md
+++ b/.claude/mobile-sprint-state.md
@@ -72,7 +72,11 @@ Each iteration:
 ## In-flight PRs
 
 - **PR #1334** sprint→main Phase 2 bundle. **Awaiting user merge** — now includes 26 PRs (#1328, #1330, #1331, #1332, #1333, #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1345, #1346, #1347, #1348, #1349, #1350, #1351, #1352 + state-doc merges).
-- **T3 per-agent routes scout** (Explore agent `ae03f6ba`) — auditing agents.$slug.edit, agents.$slug.runs, agents.tsx (list), agents.new. Verifying whether they inherited #1322 (form order) + #1343 (runs columns) or have their own layouts that skipped the fixes.
+- **fix/mobile-per-agent-routes** (subagent `a91963f2`) — **MOBILE-53/54/55 (T3 scout-found, HIGH/MEDIUM/MEDIUM bundle)**. per-agent runs columns get `max-sm:hidden` (#1343 pattern applied to local `buildPerAgentRunsColumns`); agents list agent-name column gets `max-sm:w-full max-sm:min-w-[140px]`; agent-form quiet-hours time grid gets `grid-cols-1 sm:grid-cols-2`. PR # TBD.
+
+## Closed scouts (iter 34)
+
+- ✅ **T3 per-agent routes scout** — 4 files audited. 3 actionable (above) + 1 CLEAN (agents.new.tsx — thin wrapper around AgentForm which inherits #1322 fix). agents.$slug.edit.tsx also clean (same wrapper).
 
 ## Closed scouts (iter 32)
 

--- a/.claude/rules/v2-frontend.md
+++ b/.claude/rules/v2-frontend.md
@@ -82,6 +82,50 @@ There's a living component gallery at `/v2/sandbox` (`web/src/sandbox/`, route i
 - **Never import `static/css/styles.css`** or any v1 stylesheet. The v2 design system is shadcn theme tokens + Tailwind utilities. v1 grew unboundedly — we're not paying that cost again.
 - **Do not commit changes to `web/src/components/ui/*` styling.** If a primitive looks wrong, theme tokens in `globals.css` are the lever.
 
+### Mobile / iOS Safari patterns
+
+The v2 SPA is browsed from iOS Safari as a first-class target (Add-to-Home-Screen workflow, swipe-back gestures, dynamic chrome). These patterns are already codified in `globals.css`, the `ui/*` primitives, and the call sites listed below — apply them consistently rather than reinventing each one.
+
+#### Viewport units — prefer dynamic
+
+iOS Safari's `100vh` / `100vw` refer to the *largest* viewport (URL bar collapsed), so layouts sized that way overflow when the chrome is visible. Use `100dvh` / `100dvw` (Tailwind: `min-h-dvh`, `max-w-[calc(100dvw-1rem)]`, etc.) for any full-page shell, sticky/sheet container, or floating-edge element. `svh` only when you specifically want the worst-case-anchored size (rare). Precedent: (#1320), (#1331).
+
+#### Safe-area insets
+
+The viewport meta in `web/index.html` ships `viewport-fit=cover`, which activates `env(safe-area-inset-*)`. Any sticky or fixed element that sits at a viewport edge needs explicit padding for the home-indicator / notch — e.g. `pt-[env(safe-area-inset-top)]`, `pb-[env(safe-area-inset-bottom)]`, or combined with existing spacing via `pt-[calc(1.25rem+env(safe-area-inset-top))]`. The Sheet primitive (`ui/sheet.tsx`) already wires side-aware safe-area padding internally — consumers don't add it for Sheet content. Precedent: (#1318), (#1342).
+
+#### Tap targets — 44pt minimum via `pointer-coarse:`
+
+The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-element that extends icon-only buttons to a 44×44pt hit area on `(pointer: coarse)` (touch) devices, leaving visual size untouched on `pointer: fine` (mouse). Use `@media (pointer: coarse)` or Tailwind's `pointer-coarse:` variant for touch-only rules — **not** viewport-width queries, which both catch desktop windows resized small and miss iPads in landscape. Precedent: (#1317).
+
+#### Horizontal-scroll affordance — `scroll-shadow-x` utility
+
+`globals.css` defines a Tailwind `@utility scroll-shadow-x` that paints a fading gradient at the clipped edges of a horizontally-scrolling container. Apply via `className="scroll-shadow-x overflow-x-auto"` on any horizontal-scroll region so users see scrollability without a visible scrollbar. Override the cover color for non-card surfaces with `[--scroll-shadow-cover:var(--background)]`. Always pair with `[-webkit-overflow-scrolling:touch]` (default on iOS 13+, kept defensively) and `overscroll-contain` to block parent rubber-band / pull-to-refresh. Precedent: (#1319), (#1324), (#1340).
+
+#### Mobile reflow patterns
+
+- **Stack actions full-width, primary-on-top.** Action clusters with destructive or affirmative buttons use `flex flex-col-reverse w-full gap-2 sm:flex-row sm:w-auto sm:items-center` so the primary action ends up on top of the stack on mobile (matches iOS / Material guidance). Precedent: (#1321) FormFooter, (#1328) disconnect, (#1336) prompts dialog, (#1339) prompts builder.
+- **CSS `order` to reshuffle for mobile-first content.** When source order needs to differ from visual order on mobile (e.g. operational knobs above a long prompt body), use `order-first md:order-none`. Tab/keyboard order continues to follow the DOM, so accessibility is preserved. Precedent: (#1322).
+- **Horizontal scroll-rail for filter pills.** Chip-style filter sets that wrap awkwardly switch to a single-row scroll rail on mobile via `max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:scroll-shadow-x`. Precedent: (#1324) transactions, (#1339) prompts builder.
+- **Stack-then-inline for narrow toolbars.** Toolbars with search + a couple of selects use `flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center`; if a wrapper would otherwise break a child's `ml-auto`, give the wrapper `display: contents` instead of a new flex context. Precedent: (#1341).
+- **Hide-on-mobile data table columns.** For wide tables, add `max-sm:hidden` to non-essential column `meta.className`. Keep 3–4 essential columns visible; row-tap opens detail. Precedent: (#1343).
+
+#### Form ergonomics — iOS keyboard hints
+
+Typed inputs surface the right iOS keyboard via `inputmode="email|numeric|decimal|search"`, and submit fields tint the return key via `enterkeyhint="go|search|send|done"`. Identifier fields (slugs, API key names, regex values) need `autoCorrect="off" autoCapitalize="none" spellCheck={false}` so iOS doesn't autocorrect technical strings. `SearchInput` ships these defaults so every consumer benefits without per-call-site work. Precedent: (#1338).
+
+#### bfcache & lifecycle
+
+A `pageshow` listener with `event.persisted === true` (lives in `main.tsx`, don't duplicate) invalidates router + queries on iOS Safari swipe-back restore. The 401-redirect in `__root.tsx` is visibility-gated (`document.visibilityState === "visible"`) so a stale 401 from a backgrounded tab doesn't fire mid-restore and bounce the user to login. Never add `beforeunload` / `unload` handlers — they disable bfcache entirely. Precedent: (#1329), (#1333).
+
+#### Reduced motion + tap highlight
+
+`globals.css` carries a global `@media (prefers-reduced-motion: reduce)` block that compresses all animations and transitions to 0.01ms — long enough for `animationend` to still fire, short enough to feel instant — so per-call-site `motion-safe:` variants aren't needed. The same file sets `-webkit-tap-highlight-color: transparent` on `html` so the default iOS blue tap overlay doesn't layer on top of shadcn focus/active states. Precedent: (#1337) motion, (#1332) tap-highlight.
+
+#### iOS web-app metadata
+
+`web/index.html` sets `apple-mobile-web-app-capable=yes`, `apple-mobile-web-app-status-bar-style=black-translucent`, `apple-mobile-web-app-title`, and `apple-touch-icon` so "Add to Home Screen" launches the SPA standalone (no Safari chrome). A cold-load splash lives inside `<div id="root">` as synchronous HTML + inline CSS — it respects `prefers-color-scheme` and `prefers-reduced-motion`, and React's `createRoot` replaces it on first render, covering the JS-hydration gap. Precedent: (#1332).
+
 ### State
 
 - **Server state** → TanStack Query exclusively. Cache keys: `["resource", filter1, filter2, ...]`. One hook per resource in `api/queries/<resource>.ts`.

--- a/.claude/rules/v2-frontend.md
+++ b/.claude/rules/v2-frontend.md
@@ -90,13 +90,29 @@ The v2 SPA is browsed from iOS Safari as a first-class target (Add-to-Home-Scree
 
 iOS Safari's `100vh` / `100vw` refer to the *largest* viewport (URL bar collapsed), so layouts sized that way overflow when the chrome is visible. Use `100dvh` / `100dvw` (Tailwind: `min-h-dvh`, `max-w-[calc(100dvw-1rem)]`, etc.) for any full-page shell, sticky/sheet container, or floating-edge element. `svh` only when you specifically want the worst-case-anchored size (rare). Precedent: (#1320), (#1331).
 
+Picker / popover contents adopt the same pattern at narrow viewports — clamp the floating panel width with `w-[calc(100dvw-2rem)] sm:w-72` (or similar) so it doesn't overflow on phones but locks to a comfortable size at `sm`. Precedent: (#1346) icon-picker + color-picker.
+
+`CommandList` and other dropdown bodies cap their max-height against the dynamic viewport: `max-h-[min(300px,50dvh)]` keeps the list onscreen when the iOS keyboard is open and the available height collapses. Precedent: (#1347).
+
 #### Safe-area insets
 
 The viewport meta in `web/index.html` ships `viewport-fit=cover`, which activates `env(safe-area-inset-*)`. Any sticky or fixed element that sits at a viewport edge needs explicit padding for the home-indicator / notch — e.g. `pt-[env(safe-area-inset-top)]`, `pb-[env(safe-area-inset-bottom)]`, or combined with existing spacing via `pt-[calc(1.25rem+env(safe-area-inset-top))]`. The Sheet primitive (`ui/sheet.tsx`) already wires side-aware safe-area padding internally — consumers don't add it for Sheet content. Precedent: (#1318), (#1342).
 
+Floating bottom elements (FloatingActionBar primitive, similar absolutely-positioned bars) use `max()` so the offset never collapses below the existing rhythm on devices without a home indicator: `bottom-[max(1rem,env(safe-area-inset-bottom))]`. Precedent: (#1347).
+
+`DialogHeader` (the AlertDialog / Dialog sibling to SheetHeader) gets `mt-[env(safe-area-inset-top)]` to clear the notch on iPad-landscape full-screen dialogs. The Sheet variant uses padding-based safe-area (#1342); the Dialog variant uses margin-based — both are valid for their context (Sheet content scrolls under the inset; Dialog headers shift the entire chrome). Precedent: (#1350).
+
 #### Tap targets — 44pt minimum via `pointer-coarse:`
 
 The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-element that extends icon-only buttons to a 44×44pt hit area on `(pointer: coarse)` (touch) devices, leaving visual size untouched on `pointer: fine` (mouse). Use `@media (pointer: coarse)` or Tailwind's `pointer-coarse:` variant for touch-only rules — **not** viewport-width queries, which both catch desktop windows resized small and miss iPads in landscape. Precedent: (#1317).
+
+For **raw `<button>` elements** that don't go through Button (e.g. the tag-chip × close button), apply the same recipe inline — the element must be `position: relative`:
+
+```tsx
+"... relative pointer-coarse:before:absolute pointer-coarse:before:left-1/2 pointer-coarse:before:top-1/2 pointer-coarse:before:size-11 pointer-coarse:before:-translate-x-1/2 pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']"
+```
+
+Precedent: (#1349) tag-chip × button.
 
 #### Horizontal-scroll affordance — `scroll-shadow-x` utility
 
@@ -104,7 +120,7 @@ The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-e
 
 #### Mobile reflow patterns
 
-- **Stack actions full-width, primary-on-top.** Action clusters with destructive or affirmative buttons use `flex flex-col-reverse w-full gap-2 sm:flex-row sm:w-auto sm:items-center` so the primary action ends up on top of the stack on mobile (matches iOS / Material guidance). Precedent: (#1321) FormFooter, (#1328) disconnect, (#1336) prompts dialog, (#1339) prompts builder.
+- **Stack actions full-width, primary-on-top.** Action clusters with destructive or affirmative buttons use `flex flex-col-reverse w-full gap-2 sm:flex-row sm:w-auto sm:items-center` so the primary action ends up on top of the stack on mobile (matches iOS / Material guidance). Precedent: (#1321) FormFooter, (#1328) disconnect, (#1336) prompts dialog, (#1339) prompts builder. **AlertDialogFooter** already handles `flex-col-reverse` semantically — apply `w-full sm:w-auto` directly to `AlertDialogCancel` / `AlertDialogAction` instead of wrapping them. Precedent: (#1350) confirm dialogs, (#1348) connect-bank-sheet + reauth-sheet footers.
 - **CSS `order` to reshuffle for mobile-first content.** When source order needs to differ from visual order on mobile (e.g. operational knobs above a long prompt body), use `order-first md:order-none`. Tab/keyboard order continues to follow the DOM, so accessibility is preserved. Precedent: (#1322).
 - **Horizontal scroll-rail for filter pills.** Chip-style filter sets that wrap awkwardly switch to a single-row scroll rail on mobile via `max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:scroll-shadow-x`. Precedent: (#1324) transactions, (#1339) prompts builder.
 - **Stack-then-inline for narrow toolbars.** Toolbars with search + a couple of selects use `flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center`; if a wrapper would otherwise break a child's `ml-auto`, give the wrapper `display: contents` instead of a new flex context. Precedent: (#1341).
@@ -113,6 +129,8 @@ The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-e
 #### Form ergonomics — iOS keyboard hints
 
 Typed inputs surface the right iOS keyboard via `inputmode="email|numeric|decimal|search"`, and submit fields tint the return key via `enterkeyhint="go|search|send|done"`. Identifier fields (slugs, API key names, regex values) need `autoCorrect="off" autoCapitalize="none" spellCheck={false}` so iOS doesn't autocorrect technical strings. `SearchInput` ships these defaults so every consumer benefits without per-call-site work. Precedent: (#1338).
+
+Textareas wrapping a submit action (comment composer, etc.) get `enterKeyHint="send"` even though the textarea itself doesn't submit — it paints the iOS return key glyph as "send", making the affordance discoverable. Precedent: (#1349) comment-composer.
 
 #### bfcache & lifecycle
 
@@ -125,6 +143,12 @@ A `pageshow` listener with `event.persisted === true` (lives in `main.tsx`, don'
 #### iOS web-app metadata
 
 `web/index.html` sets `apple-mobile-web-app-capable=yes`, `apple-mobile-web-app-status-bar-style=black-translucent`, `apple-mobile-web-app-title`, and `apple-touch-icon` so "Add to Home Screen" launches the SPA standalone (no Safari chrome). A cold-load splash lives inside `<div id="root">` as synchronous HTML + inline CSS — it respects `prefers-color-scheme` and `prefers-reduced-motion`, and React's `createRoot` replaces it on first render, covering the JS-hydration gap. Precedent: (#1332).
+
+#### Accessibility patterns
+
+- **Skip-to-content link.** Every authenticated shell renders `<a href="#main" className="sr-only focus-visible:not-sr-only ...">Skip to main content</a>` at the top of the layout, paired with `<main id="main" tabIndex={-1}>`. Required for WCAG 2.4.1 (bypass blocks); also speeds up keyboard navigation past the sidebar. Precedent: (#1351).
+- **Form error announcements.** `FormMessage` (`ui/form.tsx`) conditionally applies `role="alert" aria-live="polite"` when an error is present, so VoiceOver / NVDA announce form validation errors as they appear. Required for WCAG 3.3.1. Don't re-implement per-field announcements — the primitive handles it. Precedent: (#1351).
+- **iOS keyboard `enterKeyHint` on textareas.** Textareas that submit on a keyboard action benefit from `enterKeyHint="send"` so the iOS return key glyph signals the affordance — already present on `SearchInput` via #1338, extended to `comment-composer` in (#1349).
 
 ### State
 

--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,31 @@
     <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
     <meta name="color-scheme" content="light dark" />
 
+    <!-- iOS web-app metadata.
+
+         `apple-mobile-web-app-capable=yes` lets the page run in
+         standalone mode (no Safari chrome) when "Add to Home Screen"
+         is used — the navbar / sticky header take over the top of
+         the screen as if it were a native app.
+
+         `apple-mobile-web-app-status-bar-style=black-translucent`
+         extends the app content under the iOS status bar; combined
+         with the `viewport-fit=cover` + safe-area padding we ship
+         in #1318, the content reads edge-to-edge.
+
+         `apple-mobile-web-app-title` is the icon label on the home
+         screen (defaults to the page title if missing).
+
+         `apple-touch-icon` is the home-screen icon. Reuse favicon.svg
+         for now — vector scales to any home-screen icon size iOS
+         wants. PNG variants at 180×180 (and 192/512 for Android) are
+         the canonical follow-up; defer to a future asset-generation
+         PR. -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Breadbox" />
+    <link rel="apple-touch-icon" href="./favicon.svg" />
+
     <!-- Open Graph — Slack / Discord / iMessage / Linear link previews. -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Breadbox" />
@@ -84,7 +109,36 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- Cold-load splash: shown until the Vite bundle hydrates the SPA
+           (~200-500ms on cold mobile cache). React's createRoot replaces
+           the contents on first render, so this disappears automatically.
+           Uses raw hex values + media query (Tailwind isn't loaded yet)
+           and respects the `<html class="dark">` set by the no-flash
+           bootstrap script above. -->
+      <style>
+        .app-splash {
+          position: fixed;
+          inset: 0;
+          display: grid;
+          place-items: center;
+          background: #fafafa;
+          color: #1a1a1a;
+        }
+        @media (prefers-color-scheme: dark) {
+          .app-splash { background: #1a1a1a; color: #fafafa; }
+        }
+        html.dark .app-splash { background: #1a1a1a; color: #fafafa; }
+        .app-splash svg { width: 32px; height: 32px; opacity: 0.4; animation: app-splash-spin 1s linear infinite; }
+        @keyframes app-splash-spin { to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) { .app-splash svg { animation: none; opacity: 0.6; } }
+      </style>
+      <div class="app-splash" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+        </svg>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/components/auth-shell.tsx
+++ b/web/src/components/auth-shell.tsx
@@ -37,8 +37,8 @@ export function AuthShell({
   topRight,
 }: AuthShellProps) {
   return (
-    <div className="bg-background min-h-screen">
-      <div className="grid min-h-screen lg:grid-cols-2">
+    <div className="bg-background min-h-dvh">
+      <div className="grid min-h-dvh lg:grid-cols-2">
         <BrandPane />
         <div className="relative flex flex-col">
           <header className="flex items-center justify-between px-6 pt-6 sm:px-10 lg:hidden">

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -42,6 +42,14 @@ interface CategoryPickerProps {
 // rows — a rounded-rect trigger showing the current category (or an "add"
 // affordance when uncategorized) over a searchable popover. stopPropagation
 // keeps a click from also firing the row's navigate handler.
+//
+// Memory note: this component renders 50× on the transactions list. The
+// always-mounted shell deliberately holds nothing heavier than a single
+// useState — the mutation observer (useCategoryEditor → useUpdateTransactions)
+// and the category list query (useCategories) live in PickerBody, which only
+// mounts while the popover is open. Eagerly mounting them per row was a
+// significant chunk of per-page React memory and contributed to iOS Safari
+// evicting the list from bfcache.
 export function CategoryPicker({
   transactionId,
   category,
@@ -51,12 +59,6 @@ export function CategoryPicker({
   className,
 }: CategoryPickerProps) {
   const [open, setOpen] = useState(false);
-  const { apply, isPending } = useCategoryEditor(transactionId);
-
-  const onPick = async (pick: CategoryPick) => {
-    setOpen(false);
-    await (onPickOverride ?? apply)(pick);
-  };
 
   const iconClass = CATEGORY_BADGE_ICON[size];
   // Width tuned to end at the badge's text edge — wider eats into the
@@ -69,7 +71,6 @@ export function CategoryPicker({
       <PopoverTrigger asChild>
         <button
           type="button"
-          disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
             "group/picker focus-visible:ring-ring relative inline-flex items-center rounded-md transition-shadow focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
@@ -113,12 +114,46 @@ export function CategoryPicker({
         align="start"
         onClick={(e) => e.stopPropagation()}
       >
-        <CategoryCommandList
-          currentSlug={category?.slug}
-          showReset={overridden}
-          onPick={onPick}
-        />
+        {open ? (
+          <PickerBody
+            transactionId={transactionId}
+            currentSlug={category?.slug}
+            showReset={overridden}
+            onPickOverride={onPickOverride}
+            close={() => setOpen(false)}
+          />
+        ) : null}
       </PopoverContent>
     </Popover>
+  );
+}
+
+// PickerBody is the heavy half of CategoryPicker — the editor mutation hook
+// and the category-list query mount only while this is rendered. The `open`
+// gate in CategoryPicker keeps that work off the per-row hot path.
+function PickerBody({
+  transactionId,
+  currentSlug,
+  showReset,
+  onPickOverride,
+  close,
+}: {
+  transactionId: string;
+  currentSlug: string | null | undefined;
+  showReset: boolean | undefined;
+  onPickOverride: ((pick: CategoryPick) => void | Promise<void>) | undefined;
+  close: () => void;
+}) {
+  const { apply } = useCategoryEditor(transactionId);
+  const onPick = async (pick: CategoryPick) => {
+    close();
+    await (onPickOverride ?? apply)(pick);
+  };
+  return (
+    <CategoryCommandList
+      currentSlug={currentSlug}
+      showReset={showReset}
+      onPick={onPick}
+    />
   );
 }

--- a/web/src/components/color-picker.tsx
+++ b/web/src/components/color-picker.tsx
@@ -67,7 +67,7 @@ export function ColorPicker({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 space-y-3 p-3" align="start">
+      <PopoverContent className="w-[calc(100dvw-2rem)] space-y-3 p-3 sm:w-64" align="start">
         <div className="grid grid-cols-6 gap-1.5">
           {PRESET_COLORS.map((color) => {
             const selected = color === value;

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -215,7 +215,7 @@ export function CommandPalette() {
       className="overflow-hidden p-0 sm:max-w-xl"
     >
       <CommandInput placeholder="Search or jump to anything…" />
-      <CommandList className="max-h-[440px] [&_[cmdk-group-heading]]:text-muted-foreground/70 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-2.5 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group]]:px-2 [&_[cmdk-input]]:h-11 [&_[cmdk-input-wrapper]_svg]:size-4 [&_[cmdk-item]]:gap-2.5 [&_[cmdk-item]]:px-2.5 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:size-4">
+      <CommandList className="max-h-[440px] [&_[cmdk-group-heading]]:text-muted-foreground/70 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-2.5 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-4 [&_[cmdk-item]]:gap-2.5 [&_[cmdk-item]]:px-2.5 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:size-4">
         <CommandEmpty>
           <div className="text-muted-foreground flex flex-col items-center gap-1 py-4 text-sm">
             <span className="font-medium">No matches</span>

--- a/web/src/components/confirm-dialog.tsx
+++ b/web/src/components/confirm-dialog.tsx
@@ -119,8 +119,21 @@ export function ConfirmDialog({
           {body && <div className="text-sm sm:text-left">{body}</div>}
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={pending}>{cancelLabel}</AlertDialogCancel>
+          {/* AlertDialogFooter already stacks via flex-col-reverse on mobile
+              and flex-row at sm+. The shadcn Button primitive is
+              `inline-flex shrink-0` though, so without an explicit width the
+              stacked buttons sit as narrow column-aligned pills on 375px.
+              Force full-width tap targets at mobile, restore inline at sm+ —
+              same pattern as FormFooter (#1321) and disconnect-confirmation
+              (#1328). */}
+          <AlertDialogCancel
+            className="w-full sm:w-auto"
+            disabled={pending}
+          >
+            {cancelLabel}
+          </AlertDialogCancel>
           <AlertDialogAction
+            className="w-full sm:w-auto"
             variant={actionVariant}
             disabled={pending}
             onClick={(e) => {

--- a/web/src/components/detail-dialog-header.tsx
+++ b/web/src/components/detail-dialog-header.tsx
@@ -59,7 +59,18 @@ export function DetailDialogHeader({
   className,
 }: DetailDialogHeaderProps) {
   return (
-    <DialogHeader className={cn("gap-3 sm:text-left", className)}>
+    <DialogHeader
+      className={cn(
+        "gap-3 sm:text-left",
+        // Push the header down when the device reports a safe-area-inset-top
+        // (e.g. iPad in landscape with a notch). The DialogContent surface
+        // sits under the notch otherwise. Resolves to 0 on portrait /
+        // non-notched devices — change is harmless there. Mirrors the sheet
+        // variant from #1342.
+        "mt-[env(safe-area-inset-top)]",
+        className,
+      )}
+    >
       <div className="flex items-start gap-3">
         <span
           aria-hidden

--- a/web/src/components/detail-sheet-header.tsx
+++ b/web/src/components/detail-sheet-header.tsx
@@ -54,7 +54,9 @@ export function DetailSheetHeader({
     <SheetHeader
       className={cn(
         "gap-3 border-b",
-        isAccent ? "bg-muted/20 p-6" : "p-5",
+        isAccent
+          ? "bg-muted/20 px-6 pb-6 pt-[calc(1.5rem+env(safe-area-inset-top))]"
+          : "px-5 pb-5 pt-[calc(1.25rem+env(safe-area-inset-top))]",
         className,
       )}
     >

--- a/web/src/components/floating-action-bar.tsx
+++ b/web/src/components/floating-action-bar.tsx
@@ -25,7 +25,7 @@ export function FloatingActionBar({
 }: FloatingActionBarProps) {
   return (
     <div
-      className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6"
+      className="pointer-events-none fixed inset-x-0 bottom-[max(1rem,env(safe-area-inset-bottom))] z-40 flex justify-center px-4 sm:bottom-[max(1.5rem,env(safe-area-inset-bottom))]"
       role={ariaLabel ? "toolbar" : undefined}
       aria-label={ariaLabel}
     >

--- a/web/src/components/icon-picker.tsx
+++ b/web/src/components/icon-picker.tsx
@@ -122,7 +122,7 @@ export function IconPicker({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start">
+      <PopoverContent className="w-[calc(100dvw-2rem)] p-0 sm:w-72" align="start">
         <Command shouldFilter={false}>
           <CommandInput
             placeholder="Search icons…"

--- a/web/src/components/search-input.tsx
+++ b/web/src/components/search-input.tsx
@@ -39,6 +39,16 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
         <Input
           ref={ref}
           type="search"
+          // iOS form-ergonomics defaults — every consumer of SearchInput
+          // gets the search-tinted keyboard (magnifying-glass return key)
+          // for free, with no autocapitalize/autocorrect interfering with
+          // merchant slugs, IDs, and other technical query terms. Consumers
+          // can still override any of these via props.
+          inputMode="search"
+          enterKeyHint="search"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           className={cn("pl-8", className)}
           {...props}
         />

--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -44,11 +44,16 @@ export function TagChip({
       {tag.icon && <DynamicIcon name={tag.icon} style={tint} />}
       <span style={tint}>{tag.display_name}</span>
       {onRemove && (
+        // The visible × stays small (10–12px) to fit inside the chip; on
+        // touch devices a centered 44pt invisible pseudo-element extends the
+        // hit area so the tap target meets Apple HIG. Same TAP_TARGET recipe
+        // as `Button`'s icon sizes — see `web/src/components/ui/button.tsx`
+        // and the iter-28 followup.
         <button
           type="button"
           onClick={onRemove}
           aria-label={`Remove ${tag.display_name}`}
-          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 -mr-0.5 ml-0.5 rounded-full focus-visible:ring-[3px] focus-visible:outline-none"
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 -mr-0.5 ml-0.5 relative rounded-full focus-visible:ring-[3px] focus-visible:outline-none pointer-coarse:before:absolute pointer-coarse:before:left-1/2 pointer-coarse:before:top-1/2 pointer-coarse:before:size-11 pointer-coarse:before:-translate-x-1/2 pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']"
         >
           <X className={size === "sm" ? "size-2.5" : "size-3"} />
         </button>

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -95,7 +95,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        "max-h-[min(300px,50dvh)] scroll-py-1 overflow-x-hidden overflow-y-auto",
         className
       )}
       {...props}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 max-h-[min(60vh,var(--radix-dropdown-menu-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-[min(60vh,var(--radix-dropdown-menu-content-available-height))] min-w-[8rem] max-w-[calc(100dvw-1rem)] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -147,6 +147,10 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   // Errored messages get a leading AlertCircle so validation reads
   // as a status signal, not as ordinary copy. Plain messages (passed
   // as children without an underlying field error) stay clean.
+  // role="alert" + aria-live="polite" make VoiceOver / NVDA announce
+  // validation errors when they appear (WCAG 3.3.1). Conditional so
+  // success/empty states don't claim to be alerts; polite queues the
+  // announcement instead of interrupting.
   return (
     <p
       data-slot="form-message"
@@ -156,6 +160,8 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
         error ? "text-destructive" : "text-muted-foreground",
         className
       )}
+      role={error ? "alert" : undefined}
+      aria-live={error ? "polite" : undefined}
       {...props}
     >
       {error ? (

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-72 max-w-[calc(100vw-1rem)] origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 w-72 max-w-[calc(100dvw-1rem)] origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -67,7 +67,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-[min(60vh,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100vw-1rem)] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-[min(60vh,var(--radix-select-content-available-height))] min-w-[8rem] max-w-[calc(100dvw-1rem)] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -137,7 +137,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            "group/sidebar-wrapper flex min-h-dvh w-full has-data-[variant=inset]:bg-sidebar",
             className
           )}
           {...props}

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -17,7 +17,7 @@ function Table({
         // and assume the table is broken. `-webkit-overflow-scrolling:touch`
         // is the implicit default on iOS 13+ but explicit beats implicit
         // when this wrapper sits inside several nested scroll contexts.
-        "relative w-full overflow-x-auto scroll-shadow-x [-webkit-overflow-scrolling:touch]",
+        "relative w-full overflow-x-auto scroll-shadow-x overscroll-contain [-webkit-overflow-scrolling:touch]",
         containerClassName,
       )}
     >

--- a/web/src/features/accounts/link-account-sheet.tsx
+++ b/web/src/features/accounts/link-account-sheet.tsx
@@ -159,6 +159,7 @@ export function LinkAccountSheet({
             <Input
               id="tolerance"
               type="number"
+              inputMode="numeric"
               min={0}
               max={30}
               value={toleranceDays}

--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -326,6 +326,7 @@ export function AgentForm({
                     <FormControl>
                       <Input
                         type="number"
+                        inputMode="numeric"
                         min={1}
                         max={200}
                         value={
@@ -352,6 +353,7 @@ export function AgentForm({
                     <FormControl>
                       <Input
                         type="number"
+                        inputMode="decimal"
                         step="0.01"
                         min={0}
                         placeholder="0.50"

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -561,7 +561,7 @@ function CodeJson({ value }: { value: unknown }) {
     }
   }, [value]);
   return (
-    <pre className="bg-muted max-h-48 overflow-auto rounded p-2 text-[11px] leading-tight">
+    <pre className="bg-muted max-h-48 overflow-auto overscroll-contain rounded p-2 text-[11px] leading-tight">
       {text}
     </pre>
   );

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -144,6 +144,8 @@ export function APIKeyForm() {
                 <Input
                   placeholder="e.g. Claude MCP, Mobile CLI"
                   autoFocus
+                  autoCorrect="off"
+                  spellCheck={false}
                   {...field}
                 />
               </FormControl>
@@ -235,6 +237,8 @@ export function APIKeyForm() {
               <FormControl>
                 <Input
                   placeholder="Defaults to the key name"
+                  autoCorrect="off"
+                  spellCheck={false}
                   {...field}
                 />
               </FormControl>

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -410,16 +410,22 @@ export function ConnectBankSheet({
         </div>
 
         {stage.kind === "pick" && (
-          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <div className="bg-muted/20 flex flex-col-reverse items-stretch gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-6">
             <Button
               variant="outline"
               size="sm"
               onClick={() => handleSheetChange(false)}
               disabled={linkSession.isPending}
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
-            <Button size="sm" onClick={onContinue} disabled={continueDisabled}>
+            <Button
+              size="sm"
+              onClick={onContinue}
+              disabled={continueDisabled}
+              className="w-full sm:w-auto"
+            >
               {linkSession.isPending ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : null}

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -235,12 +235,13 @@ export function ReauthSheet({
         </div>
 
         {conn && stage.kind === "confirm" && (
-          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <div className="bg-muted/20 flex flex-col-reverse items-stretch gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-6">
             <Button
               variant="outline"
               size="sm"
               onClick={() => onOpenChange(false)}
               disabled={reauthStart.isPending}
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
@@ -248,6 +249,7 @@ export function ReauthSheet({
               size="sm"
               onClick={onReconnect}
               disabled={reauthStart.isPending}
+              className="w-full sm:w-auto"
             >
               {reauthStart.isPending ? (
                 <Loader2 className="size-4 animate-spin" />
@@ -258,11 +260,12 @@ export function ReauthSheet({
         )}
 
         {conn && stage.kind === "unsupported" && (
-          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <div className="bg-muted/20 flex flex-col-reverse items-stretch gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-6">
             <Button
               variant="outline"
               size="sm"
               onClick={() => onOpenChange(false)}
+              className="w-full sm:w-auto"
             >
               Close
             </Button>

--- a/web/src/features/rules/condition-row.tsx
+++ b/web/src/features/rules/condition-row.tsx
@@ -197,6 +197,7 @@ function ValueInput({
     return (
       <Input
         type="number"
+        inputMode="decimal"
         step="0.01"
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -231,9 +232,15 @@ function ValueInput({
         onChange={(e) => onChange(e.target.value)}
         className="bg-background h-8 min-w-0 flex-1"
         placeholder={op === "in" ? "slug1, slug2, …" : "tag-slug"}
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
       />
     );
   }
+  // Rule values are technical: merchant fragments, regex patterns, CSV ID
+  // lists. Skip iOS autocorrect/autocapitalize so 'uber' doesn't become
+  // 'Uber' and a regex like `^[a-z]+` isn't mangled into smart quotes.
   return (
     <Input
       value={value}
@@ -242,6 +249,9 @@ function ValueInput({
       placeholder={
         op === "in" ? "value1, value2, …" : op === "matches" ? "regex…" : "value…"
       }
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
     />
   );
 }

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -400,6 +400,7 @@ export function RuleForm({
                         </p>
                         <Input
                           type="number"
+                          inputMode="numeric"
                           min={0}
                           max={1000}
                           value={field.value}

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -277,6 +277,7 @@ export function AgentsSection() {
                       <FormControl>
                         <Input
                           type="number"
+                          inputMode="numeric"
                           min={1}
                           max={50}
                           {...field}
@@ -303,6 +304,7 @@ export function AgentsSection() {
                       <FormControl>
                         <Input
                           type="number"
+                          inputMode="decimal"
                           step="0.01"
                           placeholder="No global cap"
                           {...field}
@@ -332,6 +334,9 @@ export function AgentsSection() {
                       <Input
                         placeholder="auto: $BREADBOX_AGENT_BIN, ./bin/breadbox-agent, or PATH"
                         className="font-mono text-xs"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
                         {...field}
                       />
                     </FormControl>

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -401,6 +401,10 @@ function AddMemberDialog({ onDone }: { onDone: () => void }) {
                 <FormControl>
                   <Input
                     type="email"
+                    inputMode="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
                     placeholder="e.g. alex@example.com"
                     {...field}
                   />
@@ -540,7 +544,15 @@ function CreateLoginDialog({
               <FormItem>
                 <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input type="email" autoFocus {...field} />
+                  <Input
+                    type="email"
+                    inputMode="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    autoFocus
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/web/src/features/tags/tag-form.tsx
+++ b/web/src/features/tags/tag-form.tsx
@@ -121,6 +121,8 @@ export function TagForm({ mode, tag }: TagFormProps) {
                   <Input
                     placeholder="needs-review"
                     autoFocus
+                    autoCapitalize="none"
+                    autoCorrect="off"
                     spellCheck={false}
                     className="font-mono text-sm"
                     {...field}

--- a/web/src/features/transactions/comment-composer.tsx
+++ b/web/src/features/transactions/comment-composer.tsx
@@ -42,6 +42,11 @@ export function CommentComposer({ transactionId }: CommentComposerProps) {
         onKeyDown={onKeyDown}
         placeholder="Add a note…"
         rows={2}
+        // `enterKeyHint="send"` paints the iOS keyboard return key as "send"
+        // so mobile users get a visible affordance for posting — the desktop
+        // `⌘ Enter` hint is hidden at <sm. The actual submit still requires
+        // the Post button or ⌘/Ctrl+Enter; the hint is purely cosmetic.
+        enterKeyHint="send"
         className="resize-none text-sm"
         disabled={update.isPending}
       />

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -189,3 +189,23 @@
 .dark .scroll-shadow-x {
   --scroll-shadow-color: rgb(0 0 0 / 0.35);
 }
+
+/* Respect the user's motion preferences globally — Apple HIG requirement and
+   a common reason iOS users disable our drawer/spinner/sheet animations via
+   Settings → Accessibility → Motion → Reduce Motion. Per the CSS-tricks
+   accessible-animation pattern, animations technically run but compress to
+   ~0ms, so JS code waiting on `animationend` / `transitionend` still fires
+   instead of hanging. `!important` is bounded by the media query, and the
+   pseudo-element selectors catch overlays like the #1317 tap-target zone.
+   The cold-load splash in `web/index.html` (#1332) has its own per-element
+   `animation: none` override that wins over this rule — no conflict. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -123,6 +123,14 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* iOS Safari tap highlight — disabled globally because our shadcn primitives
+     ship their own intentional focus / active states. The default
+     `rgba(0,0,0,0.4)` overlay on `<button>` / `<a>` / `[role=button]` was
+     layering on top of our pressed treatments and reading as a glitch on
+     touch. Keep `cursor: pointer` and `:focus-visible` for keyboard. */
+  html {
+    -webkit-tap-highlight-color: transparent;
+  }
 }
 
 /* shadcn's CardHeader is designed for title + description (stacked) with

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -144,7 +144,7 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             border-box squeezes the 56px interactive area). The inset
             resolves to 0 elsewhere (desktop, Android, older iOS), so
             non-iPhone layouts are unchanged. */}
-        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex min-h-14 shrink-0 items-center gap-2 border-b pt-[env(safe-area-inset-top)] backdrop-blur">
+        <header className="bg-background sticky top-0 z-30 flex min-h-14 shrink-0 items-center gap-2 border-b pt-[env(safe-area-inset-top)] sm:bg-background/95 sm:supports-[backdrop-filter]:bg-background/80 sm:backdrop-blur">
           <div className="flex w-full items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-1 h-4" />

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -58,9 +58,22 @@ function AuthenticatedGate({ pathname }: { pathname: string }) {
   const is401 = me.error instanceof ApiError && me.error.status === 401;
 
   useEffect(() => {
-    if (is401) {
-      navigate({ to: "/login", search: { redirect: pathname } });
+    if (!is401) return;
+    // Don't redirect while the page is hidden — bfcache restore briefly
+    // marks document.hidden=true; firing navigate here completes before
+    // the user re-engages and undoes the snapshot they were swiping back
+    // to. Pair with the pageshow handler in main.tsx (PR #1329).
+    if (document.visibilityState !== "visible") {
+      const onVisible = () => {
+        if (document.visibilityState === "visible") {
+          document.removeEventListener("visibilitychange", onVisible);
+          navigate({ to: "/login", search: { redirect: pathname } });
+        }
+      };
+      document.addEventListener("visibilitychange", onVisible);
+      return () => document.removeEventListener("visibilitychange", onVisible);
     }
+    navigate({ to: "/login", search: { redirect: pathname } });
   }, [is401, navigate, pathname]);
 
   // Gate: never render the authenticated shell until /me has resolved

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -144,6 +144,16 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
 
   return (
     <SidebarProvider>
+      {/* Skip link — invisible until keyboard-focused, then jumps to <main>
+          so VoiceOver / keyboard users can bypass the sidebar nav
+          (WCAG 2.4.1 Bypass Blocks). The target <main> needs id="main" and
+          tabIndex={-1} to receive programmatic focus from the anchor. */}
+      <a
+        href="#main"
+        className="sr-only focus-visible:not-sr-only focus-visible:bg-background focus-visible:text-foreground focus-visible:ring-ring focus-visible:fixed focus-visible:top-2 focus-visible:left-2 focus-visible:z-50 focus-visible:rounded-md focus-visible:px-3 focus-visible:py-2 focus-visible:text-sm focus-visible:font-medium focus-visible:shadow-md focus-visible:ring-2"
+      >
+        Skip to main content
+      </a>
       <AppSidebar />
       {/* min-w-0: the inset is a flex child — without it, a wide page (e.g. a
           horizontally-scrolling table) grows the inset past the viewport
@@ -190,7 +200,11 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             fragment (`<>`) so children sit directly under <main>. Pages that
             need a width constraint (`mx-auto max-w-2xl|5xl`) wrap once and
             apply `flex flex-col gap-5` on that wrapper themselves. */}
-        <main className="flex min-w-0 flex-1 flex-col gap-5 p-3 sm:p-6">
+        <main
+          id="main"
+          tabIndex={-1}
+          className="flex min-w-0 flex-1 flex-col gap-5 p-3 sm:p-6"
+        >
           <Outlet />
         </main>
       </SidebarInset>

--- a/web/src/routes/agents.runs.tsx
+++ b/web/src/routes/agents.runs.tsx
@@ -309,7 +309,10 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "agent",
       header: "Agent",
-      meta: { className: "w-[22%] min-w-[160px]" },
+      meta: {
+        className:
+          "w-[22%] min-w-[160px] max-sm:w-[40%] max-sm:min-w-[140px]",
+      },
       cell: ({ row }) => (
         <Link
           to="/agents/$slug/edit"
@@ -325,7 +328,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "trigger",
       header: "Trigger",
-      meta: { className: "w-[90px]" },
+      meta: { className: "w-[90px] max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-xs uppercase tracking-wide">
           {row.original.trigger}
@@ -348,7 +351,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "duration",
       header: "Duration",
-      meta: { className: "w-[80px] text-right tabular-nums" },
+      meta: { className: "w-[80px] text-right tabular-nums max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
           {formatDuration(row.original.duration_ms)}
@@ -358,7 +361,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "cost",
       header: "Cost",
-      meta: { className: "w-[90px] text-right tabular-nums" },
+      meta: { className: "w-[90px] text-right tabular-nums max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm font-mono">
           {row.original.total_cost_usd != null
@@ -370,7 +373,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "tools",
       header: "Tools",
-      meta: { className: "w-[70px] text-right tabular-nums" },
+      meta: { className: "w-[70px] text-right tabular-nums max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
           {row.original.num_tool_calls != null

--- a/web/src/routes/api-key-created.tsx
+++ b/web/src/routes/api-key-created.tsx
@@ -99,7 +99,7 @@ export function APIKeyCreatedPage() {
               <Button
                 type="button"
                 onClick={onCopy}
-                className="shrink-0"
+                className="w-full shrink-0 sm:w-auto"
                 variant={copied ? "secondary" : "default"}
               >
                 {copied ? (

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -377,10 +377,11 @@ function DetailBody({
               Disconnecting wipes credentials and soft-deletes related
               transactions. This can&apos;t be undone.
             </p>
-            <div className="flex gap-2">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
               <Button
                 size="sm"
                 variant="ghost"
+                className="w-full sm:w-auto"
                 onClick={() => setConfirmingDisconnect(false)}
                 disabled={disconnect.isPending}
               >
@@ -389,6 +390,7 @@ function DetailBody({
               <Button
                 size="sm"
                 variant="destructive"
+                className="w-full sm:w-auto"
                 onClick={onDisconnect}
                 disabled={disconnect.isPending}
               >

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -87,6 +87,11 @@ export function LoginPage() {
                     type="email"
                     placeholder="you@example.com"
                     autoComplete="username"
+                    inputMode="email"
+                    enterKeyHint="next"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
                     autoFocus
                     {...field}
                   />
@@ -106,6 +111,7 @@ export function LoginPage() {
                     type="password"
                     placeholder="••••••••"
                     autoComplete="current-password"
+                    enterKeyHint="go"
                     {...field}
                   />
                 </FormControl>

--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -822,15 +822,21 @@ function AddBlockMenu({
               </div>
             </DialogHeader>
 
-            <div className="grid flex-1 grid-cols-[10rem_1fr] overflow-hidden">
-              <nav className="bg-muted/30 overflow-y-auto border-r p-2">
+            {/* On mobile the 160px sidebar would eat ~43% of a 375px viewport,
+                leaving the block grid cramped. Stack the nav above the content
+                as a horizontal-scroll chip rail at <sm (same pattern as the
+                transactions filter rail in #1324 / settings tabs in MOBILE-21).
+                Dividers flip from horizontal rules to vertical separators so
+                the visual grouping survives the rotation. */}
+            <div className="flex flex-1 flex-col overflow-hidden sm:grid sm:grid-cols-[10rem_1fr]">
+              <nav className="bg-muted/30 border-b p-2 max-sm:flex max-sm:items-center max-sm:gap-1 max-sm:overflow-x-auto max-sm:scroll-shadow-x max-sm:[--scroll-shadow-cover:var(--muted)] max-sm:[-webkit-overflow-scrolling:touch] sm:overflow-y-auto sm:border-r sm:border-b-0">
                 <CategoryRailItem
                   label="Presets"
                   count={PRESETS.length}
                   active={activeGroup === "presets"}
                   onClick={() => setActiveGroup("presets")}
                 />
-                <div className="my-2 border-t" />
+                <div className="max-sm:mx-1 max-sm:h-5 max-sm:shrink-0 max-sm:border-l sm:my-2 sm:border-t" />
                 <CategoryRailItem
                   label="All"
                   count={counts.all}
@@ -861,11 +867,11 @@ function AddBlockMenu({
                   active={activeGroup === "knowledge"}
                   onClick={() => setActiveGroup("knowledge")}
                 />
-                <div className="mt-2 border-t pt-2">
+                <div className="max-sm:mx-1 max-sm:h-5 max-sm:shrink-0 max-sm:border-l sm:mt-2 sm:border-t sm:pt-2">
                   <button
                     type="button"
                     onClick={openCustomForm}
-                    className="hover:bg-accent text-muted-foreground hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+                    className="hover:bg-accent text-muted-foreground hover:text-foreground flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors max-sm:shrink-0 max-sm:whitespace-nowrap sm:w-full"
                   >
                     <Plus className="size-3.5" />
                     Custom block
@@ -1061,7 +1067,10 @@ function CategoryRailItem({
       type="button"
       onClick={onClick}
       className={cn(
-        "hover:bg-accent flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+        // On mobile the rail flows horizontally — pills must not shrink or
+        // wrap, and they don't span the full row. sm+ restores the original
+        // full-width vertical list layout (label left, count right).
+        "hover:bg-accent flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors max-sm:shrink-0 max-sm:whitespace-nowrap sm:w-full sm:justify-between",
         active
           ? "bg-accent text-foreground font-medium"
           : "text-muted-foreground hover:text-foreground",

--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -951,7 +951,7 @@ function AddBlockMenu({
                   ? "Tap blocks to add — pick as many as you like."
                   : `${composedCount} block${composedCount === 1 ? "" : "s"} in composition`}
               </span>
-              <div className="flex items-center gap-2">
+              <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center">
                 <Button
                   type="button"
                   variant="ghost"

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -287,7 +287,7 @@ function RulesToolbar({
   onSortChange: (v: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
       <Input
         type="search"
         value={query}
@@ -298,30 +298,32 @@ function RulesToolbar({
         autoCapitalize="none"
         autoCorrect="off"
         spellCheck={false}
-        className="h-9 max-w-xs"
+        className="h-9 sm:max-w-xs"
       />
-      <Select value={enabled ?? "all"} onValueChange={onEnabledChange}>
-        <SelectTrigger className="h-9 w-[140px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All states</SelectItem>
-          <SelectItem value="true">Enabled</SelectItem>
-          <SelectItem value="false">Disabled</SelectItem>
-        </SelectContent>
-      </Select>
-      <Select value={sort} onValueChange={onSortChange}>
-        <SelectTrigger className="ml-auto h-9 w-[160px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="priority">Pipeline stage</SelectItem>
-          <SelectItem value="hit_count">Most hits</SelectItem>
-          <SelectItem value="last_hit_at">Recently active</SelectItem>
-          <SelectItem value="created_at">Newest first</SelectItem>
-          <SelectItem value="name">Name (A–Z)</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="flex gap-2 sm:contents">
+        <Select value={enabled ?? "all"} onValueChange={onEnabledChange}>
+          <SelectTrigger className="h-9 flex-1 sm:w-[140px] sm:flex-none">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All states</SelectItem>
+            <SelectItem value="true">Enabled</SelectItem>
+            <SelectItem value="false">Disabled</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={sort} onValueChange={onSortChange}>
+          <SelectTrigger className="h-9 flex-1 sm:ml-auto sm:w-[160px] sm:flex-none">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="priority">Pipeline stage</SelectItem>
+            <SelectItem value="hit_count">Most hits</SelectItem>
+            <SelectItem value="last_hit_at">Recently active</SelectItem>
+            <SelectItem value="created_at">Newest first</SelectItem>
+            <SelectItem value="name">Name (A–Z)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -293,6 +293,11 @@ function RulesToolbar({
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         placeholder="Search rules…"
+        inputMode="search"
+        enterKeyHint="search"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
         className="h-9 max-w-xs"
       />
       <Select value={enabled ?? "all"} onValueChange={onEnabledChange}>

--- a/web/src/routes/setup-account.tsx
+++ b/web/src/routes/setup-account.tsx
@@ -187,6 +187,7 @@ export function SetupAccountPage() {
                     type="password"
                     placeholder="Re-enter your password"
                     autoComplete="new-password"
+                    enterKeyHint="go"
                     {...field}
                   />
                 </FormControl>

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Card } from "@/components/ui/card";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useShortcut } from "@/lib/shortcuts";
 import { displayKey } from "@/lib/kbd-display";
@@ -70,6 +71,22 @@ const FORMATTERS: { code: string; input: string; output: string }[] = [
 ];
 
 const KEY_TOKENS = ["mod", "shift", "alt", "ctrl", "enter", "esc", "k", "/"];
+
+// A long-enough chip list to force horizontal overflow inside a typical
+// list-page column so the scroll-shadow gradient is visible without
+// resizing the viewport.
+const SCROLL_RAIL_PILLS = [
+  "All",
+  "Inbox",
+  "Uncategorised",
+  "Food & Drink",
+  "Transport",
+  "Subscriptions",
+  "Housing",
+  "Travel",
+  "Health",
+  "Income",
+];
 
 export function PatternsSection() {
   const [debounceInput, setDebounceInput] = useState("");
@@ -253,6 +270,171 @@ export function PatternsSection() {
             useMediaQuery(min-width:1024px):{" "}
             <code className="text-foreground font-mono">{String(isWide)}</code>
           </span>
+        </div>
+      </Specimen>
+
+      {/*
+        Mobile / iOS Safari patterns — canon lives in
+        `.claude/rules/v2-frontend.md` ("Mobile / iOS Safari patterns",
+        #1344). These specimens demo the per-component techniques so future
+        contributors can see them in isolation. Globals (reduced-motion,
+        tap-highlight, web-app metadata, cold-load splash) intentionally
+        omitted — the rules doc is the canonical reference for those.
+      */}
+
+      <Specimen
+        label="scroll-shadow-x utility"
+        code="globals.css · @utility scroll-shadow-x"
+        description="A CSS-only gradient fade painted at the clipped edges of a horizontally-scrolling container so scrollability is visible without a scrollbar. Scroll the row below — the right edge fades; after scrolling, the left edge fades in. Default cover is `var(--card)` (matches the Table primitive); on non-card surfaces override with `[--scroll-shadow-cover:var(--background)]`. Pair with `[-webkit-overflow-scrolling:touch]` + `overscroll-contain` on iOS."
+        className="block"
+      >
+        {/* Card surface — default --scroll-shadow-cover (var(--card)) blends. */}
+        <div className="space-y-1">
+          <p className="text-muted-foreground text-xs">
+            On a <code className="font-mono">bg-card</code> surface — default
+            cover.
+          </p>
+          <Card className="p-2">
+            <div className="scroll-shadow-x flex gap-2 overflow-x-auto overscroll-contain [-webkit-overflow-scrolling:touch]">
+              {SCROLL_RAIL_PILLS.map((p) => (
+                <Button
+                  key={`card-${p}`}
+                  size="sm"
+                  variant="outline"
+                  className="shrink-0"
+                >
+                  {p}
+                </Button>
+              ))}
+            </div>
+          </Card>
+        </div>
+
+        {/* Page surface — override --scroll-shadow-cover to var(--background). */}
+        <div className="mt-4 space-y-1">
+          <p className="text-muted-foreground text-xs">
+            On a <code className="font-mono">bg-background</code> surface —
+            override via{" "}
+            <code className="font-mono">
+              [--scroll-shadow-cover:var(--background)]
+            </code>
+            .
+          </p>
+          <div className="scroll-shadow-x flex gap-2 overflow-x-auto overscroll-contain [-webkit-overflow-scrolling:touch] [--scroll-shadow-cover:var(--background)]">
+            {SCROLL_RAIL_PILLS.map((p) => (
+              <Button
+                key={`bg-${p}`}
+                size="sm"
+                variant="outline"
+                className="shrink-0"
+              >
+                {p}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Mobile reflow patterns"
+        code="flex-col-reverse · order-first · max-sm:scroll-shadow-x"
+        description="Three canonical techniques for reshaping desktop layouts on narrow viewports without forking the component. Each demo is wrapped in a deliberately narrow container so the mobile state is visible without resizing the window."
+        className="block"
+      >
+        {/* 1. Button stack with primary on top.
+            Canon: see PR #1321 (FormFooter) / #1328 (disconnect) / #1336 +
+            #1339 (prompts). The wrapper toggles `flex-col-reverse w-full`
+            (primary above secondary, full-width) to `sm:flex-row sm:w-auto`
+            (primary right-aligned). The DOM order stays {secondary, primary}
+            so tab order is preserved; `flex-col-reverse` only inverts the
+            visual axis. */}
+        <div className="w-full space-y-1">
+          <p className="text-muted-foreground text-xs">
+            <strong className="text-foreground">Button stack, primary on top.</strong>{" "}
+            Narrow widths get a full-width column with primary above
+            secondary; sm+ reverts to an inline row. DOM order preserved for
+            keyboard tab order.
+          </p>
+          <div className="bg-muted/30 max-w-[280px] rounded-md border p-3">
+            <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
+              <Button variant="outline" size="sm">
+                Cancel
+              </Button>
+              <Button size="sm">Save changes</Button>
+            </div>
+          </div>
+        </div>
+
+        {/* 2. CSS `order` for mobile-first content.
+            Canon: see PR #1322 (agent-form mobile reorder). DOM order is
+            {Prompt, Controls} so keyboard tab order surfaces the long
+            textarea first; visual order on mobile flips so the operational
+            knobs sit above the prompt. `md:order-none` reverts both cards
+            to source order at md+. */}
+        <div className="mt-5 w-full space-y-1">
+          <p className="text-muted-foreground text-xs">
+            <strong className="text-foreground">CSS `order` to reshuffle visual order.</strong>{" "}
+            DOM is {`{Prompt, Controls}`}; visual order on mobile is{" "}
+            {`{Controls, Prompt}`} via{" "}
+            <code className="font-mono">order-first md:order-none</code>.
+            Tab/keyboard order still follows the DOM.
+          </p>
+          <div className="bg-muted/30 max-w-[420px] rounded-md border p-3">
+            <div className="grid gap-2 md:grid-cols-2">
+              <Card className="p-3 text-sm">
+                <div className="text-muted-foreground text-xs uppercase tracking-wider">
+                  Prompt (DOM 1)
+                </div>
+                <p className="text-foreground/80 mt-1 text-xs">
+                  Long body content — wants to live first in source order so
+                  screen readers and tab navigation reach it without a
+                  detour.
+                </p>
+              </Card>
+              <Card className="order-first p-3 text-sm md:order-none">
+                <div className="text-muted-foreground text-xs uppercase tracking-wider">
+                  Controls (DOM 2)
+                </div>
+                <p className="text-foreground/80 mt-1 text-xs">
+                  Operational knobs — visually first on mobile so users
+                  don't scroll past the long body to reach them.
+                </p>
+              </Card>
+            </div>
+          </div>
+        </div>
+
+        {/* 3. Horizontal scroll-rail for filter pills.
+            Canon: see PR #1324 (transactions toolbar) / #1339 (prompts).
+            At sm+ the pills wrap normally; below sm they switch to a
+            single-row scroll rail with the scroll-shadow-x fade affordance.
+            Override the cover to --background because the rail sits on the
+            page surface, not on a card. */}
+        <div className="mt-5 w-full space-y-1">
+          <p className="text-muted-foreground text-xs">
+            <strong className="text-foreground">Horizontal scroll-rail for filter pills.</strong>{" "}
+            At sm+ the chips wrap; below sm they become a single-row scroll
+            rail via{" "}
+            <code className="font-mono">
+              max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:scroll-shadow-x
+            </code>
+            . Page surface, so cover is overridden to{" "}
+            <code className="font-mono">--background</code>.
+          </p>
+          <div className="bg-background max-w-[360px] rounded-md border p-3">
+            <div className="flex items-center gap-2 max-sm:scroll-shadow-x max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:overscroll-contain max-sm:[--scroll-shadow-cover:var(--background)] max-sm:[-webkit-overflow-scrolling:touch] sm:flex-wrap">
+              {SCROLL_RAIL_PILLS.map((p) => (
+                <Button
+                  key={`rail-${p}`}
+                  size="sm"
+                  variant="outline"
+                  className="shrink-0"
+                >
+                  {p}
+                </Button>
+              ))}
+            </div>
+          </div>
         </div>
       </Specimen>
     </SandboxSection>


### PR DESCRIPTION
## Summary

Phase 2 of the v2 mobile sprint. Bundles 5 fixes that landed on `sprint/mobile-ios-safari` after PR #1326 (Phase 1) merged.

Opening this now because of a real user-visible reason: the user reports the iOS swipe-back fix from #1329 isn't fully resolving the blank-page problem on the transactions list. Hypothesis is **bfcache eviction under iOS Safari's per-page memory budget** — the heavy transactions list exceeds the budget, gets evicted from the back-forward cache, and the SPA cold-reloads on swipe-back. The `pageshow` handler from #1329 can't help when bfcache restore never happens.

The most impactful fix already sitting on the sprint branch is the **cold-load splash from #1332** — even when the SPA cold-reloads, the user sees branded content instead of blank white. That fix needs to be in main to help.

A separate investigation for the actual bfcache eviction (likely needs row virtualization on the transactions table) will follow.

## What's in this bundle

- **#1328** Critical-surface button stacking — api-key Copy goes full-width when stacked; disconnect confirmation rewraps as `flex-col-reverse sm:flex-row` with destructive Disconnect on top. Same pattern as the FormFooter in #1321.
- **#1330** Mobile navbar drops `backdrop-blur` at `<640px` so the safe-area zone (solid `bg-background`) doesn't seam against a previously-translucent header. Desktop glassy look preserved via `sm:backdrop-blur`.
- **#1331** Viewport-unit polish — 5 stragglers swapped to dynamic units: `min-h-screen` → `min-h-dvh` (auth-shell wrapper + grid), `min-h-svh` → `min-h-dvh` (sidebar wrapper), `max-w-[calc(100vw-1rem)]` → `max-w-[calc(100dvw-1rem)]` (popover / select / dropdown content). Finishes the dvh/dvw family.
- **#1332** iOS web-app shell polish — iOS PWA meta tags (`apple-mobile-web-app-capable`, `status-bar-style=black-translucent`, `apple-mobile-web-app-title`, `apple-touch-icon`), inline cold-load splash inside `<div id="root">` (renders synchronously, auto-vanishes when React mounts, respects `prefers-reduced-motion` + `prefers-color-scheme`), and global `-webkit-tap-highlight-color: transparent`.
- **#1333** 401 redirect deferred until `document.visibilityState === "visible"` — closes the residual race where #1329's `pageshow` handler fires but a queued 401 navigates to /login before the user re-engages. Complements #1329.

## Test plan

- [ ] CI green (this PR triggers the full matrix; constituent PRs only ran lint locally because `sprint/**` isn't in the CI trigger allowlist).
- [ ] Pull locally, `make web && make build`, smoke at `http://localhost:8080/v2/`.
- [ ] Cold-load on mobile (375×812) — splash visible instantly, vanishes when React mounts.
- [ ] On iOS Safari real device: swipe back from `/v2/transactions/:id` to `/v2/transactions`. If bfcache restore works, instant. If bfcache evicted, the splash now masks the cold reload instead of showing blank white.
- [ ] Disconnect confirmation on mobile shows Disconnect on top + full-width stacked.
- [ ] API key created page has full-width Copy button at <640px.
- [ ] Sticky nav header has solid background at <640px (no blur seam).
- [ ] Sidebar fills full viewport, no gap at the bottom.

## Notes

The cold-load splash specifically addresses the user's "blank pages for 1-2 seconds" report. The deeper fix (preventing bfcache eviction by reducing the transactions list's memory footprint via row virtualization) will be a follow-up.

🤖 Phase 2 of the mobile-iOS-safari sprint loop.
