### PR TITLE
fix(v2): stack prompts add-block dialog footer with primary on top on mobile

### DIFF
--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -951,7 +951,7 @@ function AddBlockMenu({
                   ? "Tap blocks to add — pick as many as you like."
                   : `${composedCount} block${composedCount === 1 ? "" : "s"} in composition`}
               </span>
-              <div className="flex items-center gap-2">
+              <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center">
                 <Button
                   type="button"
                   variant="ghost"


### PR DESCRIPTION
## Summary

- `prompts.build.tsx`'s picker `DialogFooter` (line ~948) groups its two buttons in an inner `<div className="flex items-center gap-2">`. The shadcn `DialogFooter` primitive already flips to `flex-col-reverse` on mobile (so the action cluster floats above the helper-text span — correct), but the inner cluster itself stayed `flex-row`, leaving "Clear all" + "Done" cramped side-by-side on narrow screens and — if they ever wrap — putting the secondary "Clear all" above the primary "Done".
- Apply the same wrapper pattern PR #1321 established for `FormFooter`: `flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center`. On mobile each button is full-width with the primary "Done" on top; on `sm+` they collapse back to the right-aligned row.
- No change to the shadcn `DialogFooter` primitive (`web/src/components/ui/dialog.tsx`) — this is a one-spot override because the picker footer is the only `DialogFooter` in the file that nests its actions in an extra inline wrapper. The other two `DialogFooter`s (line 1035, 1688) put their `<Button>`s as direct children and already inherit the primitive's correct mobile order.

## Test plan

- [x] `bun run lint` — clean.
- [x] `bun run build` — clean.
- [ ] On mobile (≤640px), open Agents → New / edit → Prompt builder → "Add block": footer shows "Done" full-width on top, "Clear all" full-width below, hint text below that.
- [ ] On desktop (≥640px), same dialog: hint on left, "Clear all" + "Done" as a right-aligned row, no visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)