### PR TITLE
a11y(v2): globally respect prefers-reduced-motion

### DIFF
--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -189,3 +189,23 @@
 .dark .scroll-shadow-x {
   --scroll-shadow-color: rgb(0 0 0 / 0.35);
 }
+
+/* Respect the user's motion preferences globally — Apple HIG requirement and
+   a common reason iOS users disable our drawer/spinner/sheet animations via
+   Settings → Accessibility → Motion → Reduce Motion. Per the CSS-tricks
+   accessible-animation pattern, animations technically run but compress to
+   ~0ms, so JS code waiting on `animationend` / `transitionend` still fires
+   instead of hanging. `!important` is bounded by the media query, and the
+   pseudo-element selectors catch overlays like the #1317 tap-target zone.
+   The cold-load splash in `web/index.html` (#1332) has its own per-element
+   `animation: none` override that wins over this rule — no conflict. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a global `@media (prefers-reduced-motion: reduce)` block to `web/src/globals.css` so the v2 SPA honors the user's OS-level motion preference (iOS Settings → Accessibility → Motion → Reduce Motion, macOS System Settings → Accessibility → Display → Reduce Motion). MOBILE-31 (HIGH) from the mobile sprint audit.

Before this PR, ~51 files used `animate-spin` (Loader2 spinners) and shadcn primitives applied `transition-*` on sidebar collapse, sheet enter/exit, dialog fade/zoom, dropdown slide animations — none respected the OS preference. Users with vestibular disorders still saw continuous spinner rotations and slide-in transitions even with Reduce Motion on, contrary to Apple HIG.

## Approach — CSS-tricks accessible-animation pattern

Used the [CSS-tricks pattern](https://css-tricks.com/introduction-reduced-motion-media-query/) of REPLACING (not disabling) animations with a 0.01ms instant-completion:

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

Why this shape:

- **Animations technically still "run"** — JS code that waits for `animationend` / `transitionend` events still fires, instead of hanging forever (a `display: none` / `animation: none` approach silently breaks any animation-tied JS).
- **`!important` is bounded by the media query** — it only takes effect when the user has Reduce Motion enabled, so it doesn't compete with normal Tailwind utility specificity outside that case.
- **`*::before, *::after`** catches pseudo-element-based UI (e.g. the tap-target zone from #1317).
- **`scroll-behavior: auto`** cancels any smooth scroll (defensive; we don't currently use `scroll-behavior: smooth`).

Per the recommended path, this is a single global rule rather than 51+ `motion-safe:` Tailwind prefixes — surgical opt-in per call site is too easy to forget for new code.

## Cold-load splash (PR #1332)

The splash inside `<div id="root">` in `web/index.html` already has:

```css
@media (prefers-reduced-motion: reduce) { .app-splash svg { animation: none; opacity: 0.6; } }
```

The new global rule WILL cascade onto it (compressing the spin to 0.01ms), but the splash's per-element `animation: none` wins by specificity. No conflict — both rules cooperate.

## Out of scope

- No `motion-safe:` variants on individual `animate-spin` / `transition-*` call sites — the global rule covers them.
- No explicit sidebar-collapse changes — global rule handles it.
- No user-facing "Reduce Motion" toggle in the app (that's separate from honoring the OS preference).

## Test plan

- [ ] `bun run lint` — clean
- [ ] `bun run build` — clean
- [ ] Toggle macOS System Settings → Accessibility → Display → Reduce Motion (or iOS Settings → Accessibility → Motion → Reduce Motion). Spinners should freeze. Sheet / dialog / dropdown enter/exit transitions should snap instead of slide. Sidebar collapse should be instant.
- [ ] Toggle Reduce Motion OFF — animations restore to normal.
- [ ] Cold-load splash still shows the fallback (svg dimmed, no spin) with Reduce Motion ON.
