### PR TITLE
fix(v2): iOS form ergonomics — keyboard hints and autocorrect-off on identifiers

### DIFF
--- a/web/src/components/search-input.tsx
+++ b/web/src/components/search-input.tsx
@@ -39,6 +39,16 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
         <Input
           ref={ref}
           type="search"
+          // iOS form-ergonomics defaults — every consumer of SearchInput
+          // gets the search-tinted keyboard (magnifying-glass return key)
+          // for free, with no autocapitalize/autocorrect interfering with
+          // merchant slugs, IDs, and other technical query terms. Consumers
+          // can still override any of these via props.
+          inputMode="search"
+          enterKeyHint="search"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           className={cn("pl-8", className)}
           {...props}
         />

--- a/web/src/features/accounts/link-account-sheet.tsx
+++ b/web/src/features/accounts/link-account-sheet.tsx
@@ -159,6 +159,7 @@ export function LinkAccountSheet({
             <Input
               id="tolerance"
               type="number"
+              inputMode="numeric"
               min={0}
               max={30}
               value={toleranceDays}

--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -326,6 +326,7 @@ export function AgentForm({
                     <FormControl>
                       <Input
                         type="number"
+                        inputMode="numeric"
                         min={1}
                         max={200}
                         value={
@@ -352,6 +353,7 @@ export function AgentForm({
                     <FormControl>
                       <Input
                         type="number"
+                        inputMode="decimal"
                         step="0.01"
                         min={0}
                         placeholder="0.50"

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -144,6 +144,8 @@ export function APIKeyForm() {
                 <Input
                   placeholder="e.g. Claude MCP, Mobile CLI"
                   autoFocus
+                  autoCorrect="off"
+                  spellCheck={false}
                   {...field}
                 />
               </FormControl>
@@ -235,6 +237,8 @@ export function APIKeyForm() {
               <FormControl>
                 <Input
                   placeholder="Defaults to the key name"
+                  autoCorrect="off"
+                  spellCheck={false}
                   {...field}
                 />
               </FormControl>

--- a/web/src/features/rules/condition-row.tsx
+++ b/web/src/features/rules/condition-row.tsx
@@ -197,6 +197,7 @@ function ValueInput({
     return (
       <Input
         type="number"
+        inputMode="decimal"
         step="0.01"
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -231,9 +232,15 @@ function ValueInput({
         onChange={(e) => onChange(e.target.value)}
         className="bg-background h-8 min-w-0 flex-1"
         placeholder={op === "in" ? "slug1, slug2, …" : "tag-slug"}
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
       />
     );
   }
+  // Rule values are technical: merchant fragments, regex patterns, CSV ID
+  // lists. Skip iOS autocorrect/autocapitalize so 'uber' doesn't become
+  // 'Uber' and a regex like `^[a-z]+` isn't mangled into smart quotes.
   return (
     <Input
       value={value}
@@ -242,6 +249,9 @@ function ValueInput({
       placeholder={
         op === "in" ? "value1, value2, …" : op === "matches" ? "regex…" : "value…"
       }
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
     />
   );
 }

--- a/web/src/features/rules/rule-form.tsx
+++ b/web/src/features/rules/rule-form.tsx
@@ -400,6 +400,7 @@ export function RuleForm({
                         </p>
                         <Input
                           type="number"
+                          inputMode="numeric"
                           min={0}
                           max={1000}
                           value={field.value}

--- a/web/src/features/settings/agents-section.tsx
+++ b/web/src/features/settings/agents-section.tsx
@@ -277,6 +277,7 @@ export function AgentsSection() {
                       <FormControl>
                         <Input
                           type="number"
+                          inputMode="numeric"
                           min={1}
                           max={50}
                           {...field}
@@ -303,6 +304,7 @@ export function AgentsSection() {
                       <FormControl>
                         <Input
                           type="number"
+                          inputMode="decimal"
                           step="0.01"
                           placeholder="No global cap"
                           {...field}
@@ -332,6 +334,9 @@ export function AgentsSection() {
                       <Input
                         placeholder="auto: $BREADBOX_AGENT_BIN, ./bin/breadbox-agent, or PATH"
                         className="font-mono text-xs"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
                         {...field}
                       />
                     </FormControl>

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -401,6 +401,10 @@ function AddMemberDialog({ onDone }: { onDone: () => void }) {
                 <FormControl>
                   <Input
                     type="email"
+                    inputMode="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
                     placeholder="e.g. alex@example.com"
                     {...field}
                   />
@@ -540,7 +544,15 @@ function CreateLoginDialog({
               <FormItem>
                 <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input type="email" autoFocus {...field} />
+                  <Input
+                    type="email"
+                    inputMode="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    autoFocus
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/web/src/features/tags/tag-form.tsx
+++ b/web/src/features/tags/tag-form.tsx
@@ -121,6 +121,8 @@ export function TagForm({ mode, tag }: TagFormProps) {
                   <Input
                     placeholder="needs-review"
                     autoFocus
+                    autoCapitalize="none"
+                    autoCorrect="off"
                     spellCheck={false}
                     className="font-mono text-sm"
                     {...field}

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -87,6 +87,11 @@ export function LoginPage() {
                     type="email"
                     placeholder="you@example.com"
                     autoComplete="username"
+                    inputMode="email"
+                    enterKeyHint="next"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
                     autoFocus
                     {...field}
                   />
@@ -106,6 +111,7 @@ export function LoginPage() {
                     type="password"
                     placeholder="••••••••"
                     autoComplete="current-password"
+                    enterKeyHint="go"
                     {...field}
                   />
                 </FormControl>

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -293,6 +293,11 @@ function RulesToolbar({
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         placeholder="Search rules…"
+        inputMode="search"
+        enterKeyHint="search"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
         className="h-9 max-w-xs"
       />
       <Select value={enabled ?? "all"} onValueChange={onEnabledChange}>

--- a/web/src/routes/setup-account.tsx
+++ b/web/src/routes/setup-account.tsx
@@ -187,6 +187,7 @@ export function SetupAccountPage() {
                     type="password"
                     placeholder="Re-enter your password"
                     autoComplete="new-password"
+                    enterKeyHint="go"
                     {...field}
                   />
                 </FormControl>


### PR DESCRIPTION
Bundles MOBILE-32 (iOS keyboard hints) and MOBILE-33 (autocorrect/autocapitalize off on identifier fields) because both are the same-shape input-attribute audit and complement each other in form ergonomics on iOS.

## What changed

`inputmode` and `enterkeyhint` tell iOS Safari which on-screen keyboard to surface. `autoCorrect="off" autoCapitalize="none" spellCheck={false}` stops iOS from helpfully turning `breadbox-sync-agent` into "Breadbox sync agent" or mangling regex patterns into smart quotes.

The shadcn `<Input>` primitive is left untouched (per project rules) — attrs go on each call site. The one exception is `SearchInput`, which is shared across the SPA: setting `inputMode="search"` + `enterKeyHint="search"` + identifier-style autocorrect defaults there means every consumer (Tags, Categories, API keys, Transactions toolbar) inherits the right behavior for free.

## Field-by-field audit

| File | Field | Attrs added | Why |
|---|---|---|---|
| `web/src/components/search-input.tsx` | search box (shared) | `inputMode="search"`, `enterKeyHint="search"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Every SearchInput consumer (Tags, Categories, API keys, Transactions) gets the magnifying-glass return key + no autocapitalize on merchant fragments. Highest-leverage change. |
| `web/src/routes/login.tsx` | `username` | `inputMode="email"`, `enterKeyHint="next"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Email/username login; `@` + `.com` keys on iOS keyboard, no autocapitalize on the first char. |
| `web/src/routes/login.tsx` | `password` | `enterKeyHint="go"` | Submit the login form straight from the keyboard. |
| `web/src/routes/setup-account.tsx` | `confirm_password` | `enterKeyHint="go"` | Submit from the second password field. |
| `web/src/features/agents/agent-form.tsx` | `max_turns` | `inputMode="numeric"` | Integer-only field; surfaces the iOS numeric keypad. |
| `web/src/features/agents/agent-form.tsx` | `max_budget_usd` | `inputMode="decimal"` | Allows `0.50` — needs the decimal keypad on iOS. |
| `web/src/features/settings/agents-section.tsx` | `max_concurrent` | `inputMode="numeric"` | Integer; numeric keypad. |
| `web/src/features/settings/agents-section.tsx` | `global_max_budget_usd` | `inputMode="decimal"` | Decimal USD amount. |
| `web/src/features/settings/agents-section.tsx` | `runtime_path` | `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Filesystem path (`./bin/breadbox-agent`) — identifier-style, never a sentence. |
| `web/src/features/settings/household-section.tsx` | `email` (Add member dialog) | `inputMode="email"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Email input; same treatment as login username. |
| `web/src/features/settings/household-section.tsx` | `username` (Create login dialog) | same | Same. |
| `web/src/features/rules/rule-form.tsx` | priority | `inputMode="numeric"` | Integer 0–1000. |
| `web/src/features/rules/condition-row.tsx` | numeric value input | `inputMode="decimal"` | Money/numeric comparison value, allows decimals. |
| `web/src/features/rules/condition-row.tsx` | tags value input | `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Tag slugs (kebab-case identifiers). |
| `web/src/features/rules/condition-row.tsx` | string value input | `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Holds merchant fragments, regex patterns, CSV ID lists — all technical. |
| `web/src/routes/rules.tsx` | rule search input | `inputMode="search"`, `enterKeyHint="search"`, `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` | Raw `<Input type="search">` rather than `SearchInput`; matched the SearchInput defaults manually for consistency. |
| `web/src/features/accounts/link-account-sheet.tsx` | `tolerance` | `inputMode="numeric"` | Integer 0–30 days. |
| `web/src/features/api-keys/api-key-form.tsx` | `name` | `autoCorrect="off"`, `spellCheck={false}` | Examples "Claude MCP", "Mobile CLI" — iOS would otherwise autocorrect acronyms. Autocapitalize left ON since these are display labels. |
| `web/src/features/api-keys/api-key-form.tsx` | `actor_name` | `autoCorrect="off"`, `spellCheck={false}` | Same reasoning. |
| `web/src/features/tags/tag-form.tsx` | `slug` | `autoCapitalize="none"`, `autoCorrect="off"` (already had `spellCheck={false}`) | Was partially set; brought it in line with `agent-form.tsx`'s create-mode slug. |

## Deliberately not touched

- `web/src/components/ui/input.tsx` — shadcn primitive stays generic per project rules.
- `web/src/features/categories/category-form.tsx` `sort_order` — already has `inputMode="numeric"`.
- `web/src/features/agents/agent-form.tsx` `slug` (create mode) — already had `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`.
- `web/src/features/transactions/transactions-toolbar.tsx` Min/Max amount inputs — already have `inputMode="decimal"`.
- `web/src/features/settings/backups-section.tsx` `retention_days` — already has `inputMode="numeric"`.
- Display-name fields, descriptions, rule names ("Uber Eats → Food Delivery") — sentence-shaped labels where autocapitalize/autocorrect is appropriate.
- `CommandInput` instances inside Popovers (e.g. category picker, account filter) — opened by tapping a button, not surfaced as primary keyboard entry.

## Out of scope (per task)

- No changes to form validation, field order, or names.
- No `pattern` attributes.
- MOBILE-34 (`overscroll-contain`) intentionally not bundled.

## Validation

- `cd web && bun run lint` — passes.
- `cd web && bun run build` — passes.
- No screenshot: these are keyboard-attribute changes that only manifest on iOS Safari (Chromium ignores `inputmode` for keyboard surfacing). The diff is the evidence.
