### PR TITLE
fix(v2): stack prompts builder nav above content on mobile

### DIFF
--- a/web/src/routes/prompts.build.tsx
+++ b/web/src/routes/prompts.build.tsx
@@ -822,15 +822,21 @@ function AddBlockMenu({
               </div>
             </DialogHeader>
 
-            <div className="grid flex-1 grid-cols-[10rem_1fr] overflow-hidden">
-              <nav className="bg-muted/30 overflow-y-auto border-r p-2">
+            {/* On mobile the 160px sidebar would eat ~43% of a 375px viewport,
+                leaving the block grid cramped. Stack the nav above the content
+                as a horizontal-scroll chip rail at <sm (same pattern as the
+                transactions filter rail in #1324 / settings tabs in MOBILE-21).
+                Dividers flip from horizontal rules to vertical separators so
+                the visual grouping survives the rotation. */}
+            <div className="flex flex-1 flex-col overflow-hidden sm:grid sm:grid-cols-[10rem_1fr]">
+              <nav className="bg-muted/30 border-b p-2 max-sm:flex max-sm:items-center max-sm:gap-1 max-sm:overflow-x-auto max-sm:scroll-shadow-x max-sm:[--scroll-shadow-cover:var(--muted)] max-sm:[-webkit-overflow-scrolling:touch] sm:overflow-y-auto sm:border-r sm:border-b-0">
                 <CategoryRailItem
                   label="Presets"
                   count={PRESETS.length}
                   active={activeGroup === "presets"}
                   onClick={() => setActiveGroup("presets")}
                 />
-                <div className="my-2 border-t" />
+                <div className="max-sm:mx-1 max-sm:h-5 max-sm:shrink-0 max-sm:border-l sm:my-2 sm:border-t" />
                 <CategoryRailItem
                   label="All"
                   count={counts.all}
@@ -861,11 +867,11 @@ function AddBlockMenu({
                   active={activeGroup === "knowledge"}
                   onClick={() => setActiveGroup("knowledge")}
                 />
-                <div className="mt-2 border-t pt-2">
+                <div className="max-sm:mx-1 max-sm:h-5 max-sm:shrink-0 max-sm:border-l sm:mt-2 sm:border-t sm:pt-2">
                   <button
                     type="button"
                     onClick={openCustomForm}
-                    className="hover:bg-accent text-muted-foreground hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+                    className="hover:bg-accent text-muted-foreground hover:text-foreground flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors max-sm:shrink-0 max-sm:whitespace-nowrap sm:w-full"
                   >
                     <Plus className="size-3.5" />
                     Custom block
@@ -1061,7 +1067,10 @@ function CategoryRailItem({
       type="button"
       onClick={onClick}
       className={cn(
-        "hover:bg-accent flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+        // On mobile the rail flows horizontally — pills must not shrink or
+        // wrap, and they don't span the full row. sm+ restores the original
+        // full-width vertical list layout (label left, count right).
+        "hover:bg-accent flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors max-sm:shrink-0 max-sm:whitespace-nowrap sm:w-full sm:justify-between",
         active
           ? "bg-accent text-foreground font-medium"
           : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## MOBILE-38 — prompts builder modal layout (T2 HIGH)

The "Add a block" modal at `/v2/prompts/build` used a hard-coded `grid-cols-[10rem_1fr]` for its category nav + content split. On iPhone portrait (375px) the 160px sidebar consumed ~43% of the viewport, leaving only ~215px for the 2-column block tile grid — too cramped — and the labels (`Strategy`, `Integrations`, etc.) still felt tight against the 10rem box.

## Fix — Option A (horizontal scroll rail on mobile)

Matches the precedent set by the transactions filter rail (#1324) and the settings tabs scroll fix (MOBILE-21):

- Outer container flips from `grid grid-cols-[10rem_1fr]` to `flex flex-col` at `<sm`, restoring the 2-column grid at `sm+`.
- `<nav>` becomes a horizontal-scroll chip rail at `<sm`: `flex` + `overflow-x-auto` + `scroll-shadow-x` + `[-webkit-overflow-scrolling:touch]`, with `--scroll-shadow-cover` overridden to `var(--muted)` to match the nav's `bg-muted/30` background. At `sm+` it reverts to its original vertical column with a right border.
- The two dividers (`border-t` separators) rotate to vertical separators (`border-l` + fixed height) at `<sm` so the visual grouping survives the layout flip.
- `CategoryRailItem` gets `max-sm:shrink-0 max-sm:whitespace-nowrap` so pills don't squeeze, and the original `w-full justify-between` is gated behind `sm:` so the count sits inline with the label on mobile instead of being pushed to a 100%-wide row's right edge.

Net result on iPhone portrait: full 375px width for the block grid, nav becomes a thumb-friendly horizontal swipe row at the top of the modal.

No changes to the block grid (content side), the category list, or shared dialog primitives.

## Test plan

- [ ] iPhone portrait (~375px): nav renders as a single horizontal-scroll row at the top; pills do not wrap or squeeze; block grid below uses the full viewport width.
- [ ] iPhone landscape (~668-744px usable): same horizontal-rail behavior (still `<sm`).
- [ ] sm+ (≥640px) and desktop: layout unchanged — vertical 160px sidebar + content grid.
- [ ] Active state, hover, and the trailing "Custom block" button all render correctly in both layouts.

## Validation note

Tried to capture a 3-viewport composite via `simple-validate-ui`, but the worktree's harness env (no `ENCRYPTION_KEY`, locked-down server boot) wouldn't let me spin up a backend wired to my freshly-built v2 bundle. The CSS-only diff is small (~15 LOC, no logic changes) and `bun run lint` + `bun run build` both pass — visual evidence to follow post-merge or via the reviewer's local dev environment.

## Precedent

- PR #1324 — transactions toolbar filter pills as horizontal rail (`scroll-shadow-x` fade affordance, `[--scroll-shadow-cover]` arbitrary-property override).
- MOBILE-21 — settings tabs horizontal scroll fix on mobile.
- `web/src/globals.css` — `scroll-shadow-x` utility definition.
