### PR TITLE
fix(v2): contain overscroll on table and transcript pre to block iOS gesture leaks

### DIFF
--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -17,7 +17,7 @@ function Table({
         // and assume the table is broken. `-webkit-overflow-scrolling:touch`
         // is the implicit default on iOS 13+ but explicit beats implicit
         // when this wrapper sits inside several nested scroll contexts.
-        "relative w-full overflow-x-auto scroll-shadow-x [-webkit-overflow-scrolling:touch]",
+        "relative w-full overflow-x-auto scroll-shadow-x overscroll-contain [-webkit-overflow-scrolling:touch]",
         containerClassName,
       )}
     >

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -561,7 +561,7 @@ function CodeJson({ value }: { value: unknown }) {
     }
   }, [value]);
   return (
-    <pre className="bg-muted max-h-48 overflow-auto rounded p-2 text-[11px] leading-tight">
+    <pre className="bg-muted max-h-48 overflow-auto overscroll-contain rounded p-2 text-[11px] leading-tight">
       {text}
     </pre>
   );


### PR DESCRIPTION
## Summary

Adds `overscroll-contain` to two nested-scroll containers in the v2 SPA so iOS Safari pull-to-refresh and back-swipe gestures stop leaking through when the user means to scroll inside an inner container.

`overscroll-behavior: contain` keeps scroll momentum inside the container at its bounds — no bounce/refresh propagates to the parent or the browser chrome.

## Changes

- **`web/src/components/ui/table.tsx`** (MOBILE-34): horizontally-scrolling table wrapper. Inside a vertically-scrolling page, starting a touch scroll at the top of the table could trigger iOS pull-to-refresh; vertical bounce inside a constrained-height table could also leak to the parent. Adds `overscroll-contain` alongside the existing `overflow-x-auto` / `scroll-shadow-x` / `[-webkit-overflow-scrolling:touch]` semantics — same justification path as PR #1319 for this primitive (semantic scroll-container behavior, narrowly scoped).
- **`web/src/features/agents/transcript-viewer.tsx`** (MOBILE-40): the `<pre>` rendering structured tool payloads. It sits inside a Sheet body that itself scrolls — two scroll contexts in series. Without containment, swiping inside the `<pre>` at its bounds could either scroll the sheet or trigger the browser back gesture. Adds `overscroll-contain` so the pre owns its scroll; users scroll the sheet by touching outside the pre. The other `<pre>` in this file (~line 436) has no `overflow-auto`, so it doesn't need the fix.

## Out of scope

A codebase-wide audit of `overflow-auto` containers is a separate PR.

## Test plan

- [ ] iOS Safari: scroll a wide table on `/v2/transactions` — pull-to-refresh should NOT trigger when touch starts at the top of the table wrapper.
- [ ] iOS Safari: open an agent run transcript, expand a tool call with large JSON payload, scroll inside the `<pre>` — the sheet behind it should NOT scroll, and the browser back-swipe should NOT fire.
- [ ] Desktop: regression check — table horizontal scroll and pre vertical scroll behave identically (overscroll-behavior is a no-op when there's nothing to rubber-band into).
