### PR TITLE
fix(v2): stack rules filter toolbar selects under search on mobile

### DIFF
--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -287,7 +287,7 @@ function RulesToolbar({
   onSortChange: (v: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
       <Input
         type="search"
         value={query}
@@ -298,30 +298,32 @@ function RulesToolbar({
         autoCapitalize="none"
         autoCorrect="off"
         spellCheck={false}
-        className="h-9 max-w-xs"
+        className="h-9 sm:max-w-xs"
       />
-      <Select value={enabled ?? "all"} onValueChange={onEnabledChange}>
-        <SelectTrigger className="h-9 w-[140px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All states</SelectItem>
-          <SelectItem value="true">Enabled</SelectItem>
-          <SelectItem value="false">Disabled</SelectItem>
-        </SelectContent>
-      </Select>
-      <Select value={sort} onValueChange={onSortChange}>
-        <SelectTrigger className="ml-auto h-9 w-[160px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="priority">Pipeline stage</SelectItem>
-          <SelectItem value="hit_count">Most hits</SelectItem>
-          <SelectItem value="last_hit_at">Recently active</SelectItem>
-          <SelectItem value="created_at">Newest first</SelectItem>
-          <SelectItem value="name">Name (A–Z)</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="flex gap-2 sm:contents">
+        <Select value={enabled ?? "all"} onValueChange={onEnabledChange}>
+          <SelectTrigger className="h-9 flex-1 sm:w-[140px] sm:flex-none">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All states</SelectItem>
+            <SelectItem value="true">Enabled</SelectItem>
+            <SelectItem value="false">Disabled</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={sort} onValueChange={onSortChange}>
+          <SelectTrigger className="h-9 flex-1 sm:ml-auto sm:w-[160px] sm:flex-none">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="priority">Pipeline stage</SelectItem>
+            <SelectItem value="hit_count">Most hits</SelectItem>
+            <SelectItem value="last_hit_at">Recently active</SelectItem>
+            <SelectItem value="created_at">Newest first</SelectItem>
+            <SelectItem value="name">Name (A–Z)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Stack the rules-list filter toolbar on mobile so the search no longer wraps awkwardly and the sort select doesn't jump to its own row via `ml-auto`.

## Summary

- **MOBILE-39**: at `<sm`, the search input takes row 1 full-width and the two selects (`All states`, `Pipeline stage`) share row 2 evenly via `flex-1`.
- At `sm+`, layout is unchanged: search-select-select inline with the sort select right-anchored via `sm:ml-auto`. The wrapping `<div className="flex gap-2 sm:contents">` uses `display: contents` to pass through at desktop so the parent flex still sees the sort select directly and `ml-auto` resolves as before.
- `h-9` retained; tap-target affordances from MOBILE-5 still apply via the trigger's `pointer-coarse:` pseudo.

## Screenshot

`/v2/rules` at desktop (1280), tablet (768), mobile (390):

<img src="https://i.img402.dev/gti4z3xay9.jpg" width="900" alt="/v2/rules — desktop, tablet, mobile">

Mobile (390): search row 1 full-width, selects row 2 side-by-side. Desktop (1280): inline with sort right-anchored. Matches the spec.

## Test plan

- [x] `bun run lint`
- [x] `bun run build`
- [x] Visual: simple-validate-ui composite at 1280 / 768 / 390
