### PR TITLE
fix(v2): unblock cmdk adaptive height and add safe-area-top to detail sheet header

### DIFF
--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -215,7 +215,7 @@ export function CommandPalette() {
       className="overflow-hidden p-0 sm:max-w-xl"
     >
       <CommandInput placeholder="Search or jump to anything…" />
-      <CommandList className="max-h-[440px] [&_[cmdk-group-heading]]:text-muted-foreground/70 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-2.5 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group]]:px-2 [&_[cmdk-input]]:h-11 [&_[cmdk-input-wrapper]_svg]:size-4 [&_[cmdk-item]]:gap-2.5 [&_[cmdk-item]]:px-2.5 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:size-4">
+      <CommandList className="max-h-[440px] [&_[cmdk-group-heading]]:text-muted-foreground/70 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-2.5 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-4 [&_[cmdk-item]]:gap-2.5 [&_[cmdk-item]]:px-2.5 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:size-4">
         <CommandEmpty>
           <div className="text-muted-foreground flex flex-col items-center gap-1 py-4 text-sm">
             <span className="font-medium">No matches</span>

--- a/web/src/components/detail-sheet-header.tsx
+++ b/web/src/components/detail-sheet-header.tsx
@@ -54,7 +54,9 @@ export function DetailSheetHeader({
     <SheetHeader
       className={cn(
         "gap-3 border-b",
-        isAccent ? "bg-muted/20 p-6" : "p-5",
+        isAccent
+          ? "bg-muted/20 px-6 pb-6 pt-[calc(1.5rem+env(safe-area-inset-top))]"
+          : "px-5 pb-5 pt-[calc(1.25rem+env(safe-area-inset-top))]",
         className,
       )}
     >


### PR DESCRIPTION
Two LOW-priority mobile polish items for the v2 SPA mobile sprint.

## MOBILE-41 — Unblock cmdk adaptive input height

`web/src/components/command-palette.tsx` carried a `[&_[cmdk-input]]:h-11` override on `<CommandList>` that forced the search input to 44px regardless of pointer type. #1317 already shipped a smarter adaptive default on the underlying `CommandInput` primitive (`h-9 pointer-coarse:h-12`) — the override masked that improvement on both ends: desktop got a wastefully tall 44px input where 36px reads better, and touch got 44px where 48px is more thumb-friendly.

Removed the single `[&_[cmdk-input]]:h-11` arbitrary variant; left the rest of the cmdk-* density tweaks (group-heading, group, input-wrapper svg, item, item svg) intact. The primitive's defaults now apply.

## MOBILE-42 — Safe-area-top on detail sheet header

`web/src/components/detail-sheet-header.tsx` used uniform `p-5` (default density) / `p-6` (accent density) on `SheetHeader`. On iPhone landscape with notch, a side-anchored Sheet's header top edge can sit under the notch.

Split the uniform padding into horizontal + vertical components and added `env(safe-area-inset-top)` to the top padding only:

- accent: `bg-muted/20 px-6 pb-6 pt-[calc(1.5rem+env(safe-area-inset-top))]`
- default: `px-5 pb-5 pt-[calc(1.25rem+env(safe-area-inset-top))]`

`env(safe-area-inset-top)` resolves to 0 on non-notched devices and in portrait, so the change is a no-op there. Only the top side is adjusted — bottom-anchored sheets already handle `safe-area-inset-bottom` via #1318, and per scope this PR doesn't touch the other sides or the underlying `ui/sheet.tsx` primitive.

## Validation

- `cd web && bun run lint && bun run build` — clean.
- Visual validation skipped intentionally; both items require a real notched iPhone in landscape to capture meaningfully.
