### PR TITLE
fix(v2): hide non-essential agent-runs columns on mobile

### DIFF
--- a/web/src/routes/agents.runs.tsx
+++ b/web/src/routes/agents.runs.tsx
@@ -309,7 +309,10 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "agent",
       header: "Agent",
-      meta: { className: "w-[22%] min-w-[160px]" },
+      meta: {
+        className:
+          "w-[22%] min-w-[160px] max-sm:w-[40%] max-sm:min-w-[140px]",
+      },
       cell: ({ row }) => (
         <Link
           to="/agents/$slug/edit"
@@ -325,7 +328,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "trigger",
       header: "Trigger",
-      meta: { className: "w-[90px]" },
+      meta: { className: "w-[90px] max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-xs uppercase tracking-wide">
           {row.original.trigger}
@@ -348,7 +351,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "duration",
       header: "Duration",
-      meta: { className: "w-[80px] text-right tabular-nums" },
+      meta: { className: "w-[80px] text-right tabular-nums max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
           {formatDuration(row.original.duration_ms)}
@@ -358,7 +361,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "cost",
       header: "Cost",
-      meta: { className: "w-[90px] text-right tabular-nums" },
+      meta: { className: "w-[90px] text-right tabular-nums max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm font-mono">
           {row.original.total_cost_usd != null
@@ -370,7 +373,7 @@ function buildGlobalRunsColumns(): ColumnDef<AgentRunWithAgent>[] {
     {
       id: "tools",
       header: "Tools",
-      meta: { className: "w-[70px] text-right tabular-nums" },
+      meta: { className: "w-[70px] text-right tabular-nums max-sm:hidden" },
       cell: ({ row }) => (
         <span className="text-muted-foreground text-sm">
           {row.original.num_tool_calls != null


### PR DESCRIPTION
## Summary

MOBILE-37 — the agent-runs table on `/v2/agents/runs` has 8 columns totaling ~800px natural width. At 375px iOS, the user has to horizontal-scroll just to learn whether a run succeeded — most columns are power-user info.

Collapse the table on `<sm` by hiding 4 non-essential columns via `meta.className: "max-sm:hidden"`, and let the Agent column take more horizontal share on mobile.

## Kept on mobile (essential at-a-glance — who ran, when, did it succeed)

- **Status** (110px — compact)
- **Agent** — now `w-[40%] min-w-[140px]` on mobile (was `w-[22%] min-w-[160px]` desktop-only); takes more share when only 4 columns are visible
- **Started** (140px)
- **Flags** (110px — already collapses to icons; the row's right-edge indicator)

## Hidden on `<sm` (power-user info — visible by tapping the row to open the run detail sheet)

- **Trigger** — one of {cron, manual, sync}, inferable from context most of the time
- **Duration**, **Cost**, **Tools** — operational metrics, used when actively debugging from the run detail page

`DataTable` (`web/src/components/data-table.tsx`) already applies `meta.className` to both `TableHead` (line 231) and `TableCell` (line 313) — no changes needed there. Horizontal scroll fallback (#1319, #1340) stays available for the remaining 4 columns if a viewport ever exceeds.

## Out of scope

- Card-stack mobile view (bigger change; bounded to column hiding here)
- Per-agent runs view (`agents.$slug.runs.tsx`) — separate PR if same issue
- Column order / colors / typography / spacing

## Validation

- `cd web && bun run lint && bun run build` — clean.
- Visual validation skipped: harness backend on :8080 serves the main repo's bundle (not this worktree's), and no worktree port was provisioned. Per task spec: "push first, polish never".

## Test plan

- [ ] Mobile 375: only Status, Agent, Started, Flags visible — no horizontal scroll
- [ ] Desktop 1280: all 8 columns render as before
- [ ] Tapping a row still opens the run detail sheet (unchanged)
