### PR TITLE
fix(v2): widen icon and color pickers on mobile, lock at sm

### DIFF
--- a/web/src/components/color-picker.tsx
+++ b/web/src/components/color-picker.tsx
@@ -67,7 +67,7 @@ export function ColorPicker({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 space-y-3 p-3" align="start">
+      <PopoverContent className="w-[calc(100dvw-2rem)] space-y-3 p-3 sm:w-64" align="start">
         <div className="grid grid-cols-6 gap-1.5">
           {PRESET_COLORS.map((color) => {
             const selected = color === value;

--- a/web/src/components/icon-picker.tsx
+++ b/web/src/components/icon-picker.tsx
@@ -122,7 +122,7 @@ export function IconPicker({
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start">
+      <PopoverContent className="w-[calc(100dvw-2rem)] p-0 sm:w-72" align="start">
         <Command shouldFilter={false}>
           <CommandInput
             placeholder="Search icons…"


### PR DESCRIPTION
## Summary

Widens the icon-picker and color-picker popovers on mobile so the icon/color grid isn't cramped on 375px viewports, while preserving the original desktop widths.

- `icon-picker.tsx` — `w-72` → `w-[calc(100dvw-2rem)] sm:w-72`. At <sm the picker takes the full visible width minus 16px per side; at sm+ it locks back to 288px.
- `color-picker.tsx` — same swap with `sm:w-64`.

T3 scout filed this as MOBILE-43 (icon) + MOBILE-44 (color): the fixed `w-72` resolved to 288px on iOS 375px, leaving ~87px of unused space and a tight 8-col tap target.

## Why `100dvw`

Phase 1 (#1320) established dynamic viewport units across the v2 SPA so iOS Safari's address-bar collapse doesn't push popovers slightly offscreen mid-transition.

## Why this stays inside the shadcn clamps

The shadcn `PopoverContent` primitive (#1316 -> #1331) already applies a `max-w-[calc(100dvw-1rem)]` collision clamp and uses Radix's `collisionPadding` for positioning. `w-[calc(100dvw-2rem)]` is strictly smaller than the clamp, so the picker's width controls on mobile and the existing collision logic keeps it on-screen regardless of `align="start"`.

## Out of scope

No changes to the icon grid, color swatches, search, or grid-cols-8 layout — purely a popover width tweak.

## Test plan

- [ ] iOS Safari 375px — both popovers expand to viewport width minus 16px margin per side; no overflow past either edge.
- [ ] Desktop >=640px — both popovers render at original `w-72` / `w-64`.
- [ ] `align="start"` positioning still respects collision padding.
