### PR TITLE
fix(v2): respect safe-area-bottom on floating action bar; cap CommandList at 50dvh

### DIFF
--- a/web/src/components/floating-action-bar.tsx
+++ b/web/src/components/floating-action-bar.tsx
@@ -25,7 +25,7 @@ export function FloatingActionBar({
 }: FloatingActionBarProps) {
   return (
     <div
-      className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6"
+      className="pointer-events-none fixed inset-x-0 bottom-[max(1rem,env(safe-area-inset-bottom))] z-40 flex justify-center px-4 sm:bottom-[max(1.5rem,env(safe-area-inset-bottom))]"
       role={ariaLabel ? "toolbar" : undefined}
       aria-label={ariaLabel}
     >

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -95,7 +95,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        "max-h-[min(300px,50dvh)] scroll-py-1 overflow-x-hidden overflow-y-auto",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Two iOS Safari fixes left over from the previous mobile sprint PRs.

### MOBILE-45 — `FloatingActionBar` misses `safe-area-inset-bottom` (HIGH)

`web/src/components/floating-action-bar.tsx` sat at a fixed `bottom-4` / `sm:bottom-6`. On iPhones with a home indicator (no notch, but `env(safe-area-inset-bottom) > 0`), the bar lands inside the home-indicator gesture zone — visually clipped and tap-hostile.

```tsx
"pointer-events-none fixed inset-x-0 bottom-[max(1rem,env(safe-area-inset-bottom))] z-40 flex justify-center px-4 sm:bottom-[max(1.5rem,env(safe-area-inset-bottom))]"
```

`max(1rem, env(safe-area-inset-bottom))` returns whichever is greater — the existing 16px on devices without a home indicator (env = 0), or the actual inset on iPhone X-style devices. Mirrors the pattern #1318 used for `safe-area-inset-bottom` on Sheet bottom-anchored content (and the sticky-header `safe-area-inset-top` precedent).

### MOBILE-46 — `CommandList` fixed `max-h-[300px]` ignores viewport (MEDIUM)

`web/src/components/ui/command.tsx` capped at a static 300px. On a 375x667 device, or any iPhone with the soft keyboard open, the visible viewport can be ~400-450px tall — the dropdown gets pushed past the bottom edge and forces a page scroll to see options.

```tsx
"max-h-[min(300px,50dvh)] scroll-py-1 overflow-x-hidden overflow-y-auto"
```

`min(300px, 50dvh)` keeps the 300px cap on tall viewports (desktop, iPad landscape) and adapts to 50% of the dynamic viewport on shorter ones. Uses `dvh` (established by Phase 1 #1320).

## Why this is the right shape

- Both changes are single-className edits to existing primitives — same surgical-scope justification as the previous `ui/*` PRs in this sprint (#1316 onward).
- Both reuse patterns already canonized in `.claude/rules/v2-frontend.md` "Mobile / iOS Safari patterns" (#1344): safe-area insets via `max(static, env(...))`, viewport sizing via `dvh`.
- Five other scout findings (comment composer hints, ActivityTimeline max-height, pagination/tag-chip tap zones, label visibility) are deferred — most likely already covered by `pointer-coarse:` tap zones from #1317 and need verification before changing.

## Test plan

- [ ] Diff is two single-line changes; no behavior regressions on desktop (env values resolve to 0; `min(300px, 50dvh)` is 300px on tall viewports).
- [ ] Spot-check the FloatingActionBar on an iPhone simulator with a home indicator — bar sits above the gesture zone.
- [ ] Spot-check Command popovers (e.g. category/tag pickers) on a 375x667 viewport with on-screen keyboard — dropdown stays within the visible area.

Generated with [Claude Code](https://claude.com/claude-code)
