### PR TITLE
fix(v2): stack connect-bank and reauth sheet footer buttons on mobile

### DIFF
--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -410,16 +410,22 @@ export function ConnectBankSheet({
         </div>
 
         {stage.kind === "pick" && (
-          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <div className="bg-muted/20 flex flex-col-reverse items-stretch gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-6">
             <Button
               variant="outline"
               size="sm"
               onClick={() => handleSheetChange(false)}
               disabled={linkSession.isPending}
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
-            <Button size="sm" onClick={onContinue} disabled={continueDisabled}>
+            <Button
+              size="sm"
+              onClick={onContinue}
+              disabled={continueDisabled}
+              className="w-full sm:w-auto"
+            >
               {linkSession.isPending ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : null}

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -235,12 +235,13 @@ export function ReauthSheet({
         </div>
 
         {conn && stage.kind === "confirm" && (
-          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <div className="bg-muted/20 flex flex-col-reverse items-stretch gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-6">
             <Button
               variant="outline"
               size="sm"
               onClick={() => onOpenChange(false)}
               disabled={reauthStart.isPending}
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
@@ -248,6 +249,7 @@ export function ReauthSheet({
               size="sm"
               onClick={onReconnect}
               disabled={reauthStart.isPending}
+              className="w-full sm:w-auto"
             >
               {reauthStart.isPending ? (
                 <Loader2 className="size-4 animate-spin" />
@@ -258,11 +260,12 @@ export function ReauthSheet({
         )}
 
         {conn && stage.kind === "unsupported" && (
-          <div className="bg-muted/20 flex items-center justify-end gap-2 border-t px-6 py-3">
+          <div className="bg-muted/20 flex flex-col-reverse items-stretch gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-end sm:px-6">
             <Button
               variant="outline"
               size="sm"
               onClick={() => onOpenChange(false)}
+              className="w-full sm:w-auto"
             >
               Close
             </Button>


### PR DESCRIPTION
## Summary

Apply the mobile button-stacking pattern to two hand-rolled Sheet footers that were missed by the `FormFooter` migration:

- `connect-bank-sheet.tsx` — Cancel + Continue (pick stage)
- `reauth-sheet.tsx` — Cancel + Reconnect (confirm stage) and Close (unsupported stage)

Each footer now uses `flex flex-col-reverse items-stretch ... sm:flex-row sm:items-center sm:justify-end` with `w-full sm:w-auto` on each `<Button>`, so on narrow viewports the primary action sits on top and both buttons span full width. Desktop behavior is unchanged.

These Sheets stay hand-rolled rather than migrating to the `FormFooter` primitive (different surface — Sheets, not forms).

## Pattern precedent

- #1321 — `FormFooter` primitive that codifies the stacking pattern
- #1328 — disconnect-confirm dialog footer
- #1336 — agent prompts dialog footer

Canon: `.claude/rules/v2-frontend.md` "Mobile / iOS Safari patterns" → "Stack actions full-width, primary-on-top".

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` succeeds
- [ ] Manual smoke at narrow viewport: open connect-bank sheet, confirm Cancel/Continue stack with Continue on top, both full-width
- [ ] Manual smoke at narrow viewport: trigger reauth on a connection, confirm Cancel/Reconnect stack with Reconnect on top, both full-width
