### PR TITLE
fix(v2): close iter 28 transaction-detail polish followups

### DIFF
--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -44,11 +44,16 @@ export function TagChip({
       {tag.icon && <DynamicIcon name={tag.icon} style={tint} />}
       <span style={tint}>{tag.display_name}</span>
       {onRemove && (
+        // The visible × stays small (10–12px) to fit inside the chip; on
+        // touch devices a centered 44pt invisible pseudo-element extends the
+        // hit area so the tap target meets Apple HIG. Same TAP_TARGET recipe
+        // as `Button`'s icon sizes — see `web/src/components/ui/button.tsx`
+        // and the iter-28 followup.
         <button
           type="button"
           onClick={onRemove}
           aria-label={`Remove ${tag.display_name}`}
-          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 -mr-0.5 ml-0.5 rounded-full focus-visible:ring-[3px] focus-visible:outline-none"
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 -mr-0.5 ml-0.5 relative rounded-full focus-visible:ring-[3px] focus-visible:outline-none pointer-coarse:before:absolute pointer-coarse:before:left-1/2 pointer-coarse:before:top-1/2 pointer-coarse:before:size-11 pointer-coarse:before:-translate-x-1/2 pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']"
         >
           <X className={size === "sm" ? "size-2.5" : "size-3"} />
         </button>

--- a/web/src/features/transactions/comment-composer.tsx
+++ b/web/src/features/transactions/comment-composer.tsx
@@ -42,6 +42,11 @@ export function CommentComposer({ transactionId }: CommentComposerProps) {
         onKeyDown={onKeyDown}
         placeholder="Add a note…"
         rows={2}
+        // `enterKeyHint="send"` paints the iOS keyboard return key as "send"
+        // so mobile users get a visible affordance for posting — the desktop
+        // `⌘ Enter` hint is hidden at <sm. The actual submit still requires
+        // the Post button or ⌘/Ctrl+Enter; the hint is purely cosmetic.
+        enterKeyHint="send"
         className="resize-none text-sm"
         disabled={update.isPending}
       />


### PR DESCRIPTION
Closes the 5 deferred items from iter 28's transaction-detail scout. Two genuine fixes ship here; three are non-issues per verification.

## Verdict per candidate

### (a) Comment composer keyboard hints — **FIX**

`web/src/features/transactions/comment-composer.tsx`

The `⌘ Enter` hint is hidden on `sm:` (line 49: `hidden text-xs sm:block`), which is fine on mobile because the explicit "Post note" Button label sits right next to it as the actual submit affordance. Mobile users do *not* need ⌘ Enter to post — they can tap the button. Still, adding `enterKeyHint="send"` paints the iOS keyboard return key as "send", which is a free polish that aligns the keyboard glyph with the user's intent (sending a note). Submit still requires the Button or ⌘/Ctrl+Enter; the hint is purely cosmetic and uses zero JS.

### (b) ActivityTimeline max-height — **NON-ISSUE**

`web/src/routes/transaction-detail.tsx` (~lines 90-98)

The page wrapper is `mx-auto flex max-w-5xl flex-col gap-5` — a standard scrolling detail page, no Sheet or fixed-height container. The activity feed sits inside `<SectionCard>` and the page itself scrolls naturally on mobile. Constraining the timeline to `max-h-[60vh] overflow-y-auto` would create a nested scroll surface that is strictly worse for iOS Safari (rubber-banding, conflicting touch handlers, lost momentum). Per the brief: "Skip if the page naturally scrolls and the long feed is FINE (most users would WANT to scroll the page to reach new comments)" — this applies cleanly. No change.

### (c) Pagination button tap targets — **NON-ISSUE**

`web/src/components/pagination-bar.tsx` (~lines 100-108) + `web/src/components/ui/pagination.tsx`

The numbered links go through `<PaginationLink>` which renders `buttonVariants({ variant, size })` with `size="icon"` as the default. The `icon`, `icon-xs`, `icon-sm`, and `icon-lg` Button sizes include the `TAP_TARGET` recipe at `web/src/components/ui/button.tsx:12-13` (`pointer-coarse:before:size-11` invisible 44pt pseudo-element). So PR #1317 already covers these. No change.

(Aside: `PaginationPrevious`/`PaginationNext` use `size="default"` which has h-9 (36px) + horizontal padding + text, so the visible hit area is already wide enough on mobile — only the 36px height is slightly under spec, but that's a separate concern from the scout's stated claim about page-number links.)

### (d) CommentComposer label visibility on mobile — **NON-ISSUE**

`web/src/features/transactions/comment-composer.tsx` (~lines 52-61)

Verified the rendered Button — `{update.isPending ? "Posting…" : "Post note"}` always emits text. The `<Loader2>` spinner is only an *additional* leading icon while `update.isPending`; the label remains visible at every breakpoint. The scout's "only a spinner shows" claim doesn't match the source. No change.

### (e) Tag chip × button size — **FIX**

`web/src/components/tag-chip.tsx` (~lines 47-55)

This is the genuine gap of the five. The remove × is a raw `<button>` (not a shadcn `<Button>`), so it doesn't inherit the `TAP_TARGET` pseudo from #1317. The visible X icon is `size-2.5` (10px) or `size-3` (12px) — well below Apple's 44pt minimum. Applied the same `pointer-coarse:before:size-11` recipe used by Button's icon sizes: invisible centered pseudo-element extends the hit area without changing visual size. Preserves the chip density.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run build` clean
- [ ] (optional) tap a tag chip's × on iOS Safari at 375px — confirms the hit area is forgiving
- [ ] (optional) focus the comment composer on iOS — keyboard return key reads "send" / "go" depending on locale
