### PR TITLE
fix(v2): safe-area-top on detail dialog header; full-width confirm dialog buttons on mobile

### DIFF
--- a/web/src/components/confirm-dialog.tsx
+++ b/web/src/components/confirm-dialog.tsx
@@ -119,8 +119,21 @@ export function ConfirmDialog({
           {body && <div className="text-sm sm:text-left">{body}</div>}
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={pending}>{cancelLabel}</AlertDialogCancel>
+          {/* AlertDialogFooter already stacks via flex-col-reverse on mobile
+              and flex-row at sm+. The shadcn Button primitive is
+              `inline-flex shrink-0` though, so without an explicit width the
+              stacked buttons sit as narrow column-aligned pills on 375px.
+              Force full-width tap targets at mobile, restore inline at sm+ —
+              same pattern as FormFooter (#1321) and disconnect-confirmation
+              (#1328). */}
+          <AlertDialogCancel
+            className="w-full sm:w-auto"
+            disabled={pending}
+          >
+            {cancelLabel}
+          </AlertDialogCancel>
           <AlertDialogAction
+            className="w-full sm:w-auto"
             variant={actionVariant}
             disabled={pending}
             onClick={(e) => {

--- a/web/src/components/detail-dialog-header.tsx
+++ b/web/src/components/detail-dialog-header.tsx
@@ -59,7 +59,18 @@ export function DetailDialogHeader({
   className,
 }: DetailDialogHeaderProps) {
   return (
-    <DialogHeader className={cn("gap-3 sm:text-left", className)}>
+    <DialogHeader
+      className={cn(
+        "gap-3 sm:text-left",
+        // Push the header down when the device reports a safe-area-inset-top
+        // (e.g. iPad in landscape with a notch). The DialogContent surface
+        // sits under the notch otherwise. Resolves to 0 on portrait /
+        // non-notched devices — change is harmless there. Mirrors the sheet
+        // variant from #1342.
+        "mt-[env(safe-area-inset-top)]",
+        className,
+      )}
+    >
       <div className="flex items-start gap-3">
         <span
           aria-hidden


### PR DESCRIPTION
## Summary

Two iter-31 shared-components mobile fixes from the scout, paired in one PR.

**MOBILE-49 — `DetailDialogHeader` safe-area-top.** On iPad in landscape with a notch, the centered `<Dialog>` could sit under the notch because the header had no safe-area awareness. Mirror the fix from #1342 (which patched `DetailSheetHeader`): add `mt-[env(safe-area-inset-top)]` to the `<DialogHeader>` so the lockup gets nudged down when the device reports a top inset. Resolves to 0 on portrait / non-notched devices — change is harmless there.

**MOBILE-50 — `ConfirmDialog` full-width footer buttons on mobile.** `AlertDialogFooter` already stacks `flex-col-reverse` on mobile and `flex-row` at sm+, but the shadcn `Button` primitive is `inline-flex shrink-0` — so the stacked Cancel/Action buttons sat as narrow content-width pills on 375px instead of full-width tap targets. Add `w-full sm:w-auto` directly to `AlertDialogCancel` and `AlertDialogAction` (no extra wrapper needed since the parent already handles direction). Same pattern as FormFooter (#1321) and disconnect-confirmation (#1328).

## Test plan

- [ ] iPad landscape with notch — open any form-bearing centered Dialog (Add member, Create login, Share link); header text no longer overlaps the notch.
- [ ] Portrait / non-notched — Dialog header renders unchanged (safe-area inset is 0).
- [ ] iPhone SE / 375px — open any `ConfirmDialog` (disconnect, delete, regenerate, etc.); Cancel and primary buttons are full-width stacked, with the primary on top per `flex-col-reverse`.
- [ ] Desktop ≥640px — buttons render inline at content-width like before.
