### PR TITLE
a11y(v2): announce form errors via role=alert; add skip-to-main-content link

### DIFF
--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -147,6 +147,10 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   // Errored messages get a leading AlertCircle so validation reads
   // as a status signal, not as ordinary copy. Plain messages (passed
   // as children without an underlying field error) stay clean.
+  // role="alert" + aria-live="polite" make VoiceOver / NVDA announce
+  // validation errors when they appear (WCAG 3.3.1). Conditional so
+  // success/empty states don't claim to be alerts; polite queues the
+  // announcement instead of interrupting.
   return (
     <p
       data-slot="form-message"
@@ -156,6 +160,8 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
         error ? "text-destructive" : "text-muted-foreground",
         className
       )}
+      role={error ? "alert" : undefined}
+      aria-live={error ? "polite" : undefined}
       {...props}
     >
       {error ? (

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -144,6 +144,16 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
 
   return (
     <SidebarProvider>
+      {/* Skip link — invisible until keyboard-focused, then jumps to <main>
+          so VoiceOver / keyboard users can bypass the sidebar nav
+          (WCAG 2.4.1 Bypass Blocks). The target <main> needs id="main" and
+          tabIndex={-1} to receive programmatic focus from the anchor. */}
+      <a
+        href="#main"
+        className="sr-only focus-visible:not-sr-only focus-visible:bg-background focus-visible:text-foreground focus-visible:ring-ring focus-visible:fixed focus-visible:top-2 focus-visible:left-2 focus-visible:z-50 focus-visible:rounded-md focus-visible:px-3 focus-visible:py-2 focus-visible:text-sm focus-visible:font-medium focus-visible:shadow-md focus-visible:ring-2"
+      >
+        Skip to main content
+      </a>
       <AppSidebar />
       {/* min-w-0: the inset is a flex child — without it, a wide page (e.g. a
           horizontally-scrolling table) grows the inset past the viewport
@@ -190,7 +200,11 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             fragment (`<>`) so children sit directly under <main>. Pages that
             need a width constraint (`mx-auto max-w-2xl|5xl`) wrap once and
             apply `flex flex-col gap-5` on that wrapper themselves. */}
-        <main className="flex min-w-0 flex-1 flex-col gap-5 p-3 sm:p-6">
+        <main
+          id="main"
+          tabIndex={-1}
+          className="flex min-w-0 flex-1 flex-col gap-5 p-3 sm:p-6"
+        >
           <Outlet />
         </main>
       </SidebarInset>


### PR DESCRIPTION
## Summary

Two small, screen-reader-focused a11y fixes from the iter-32 mobile audit. Both are narrowly scoped and well-documented.

### MOBILE-51 — FormMessage missing `role="alert"` (MEDIUM)

`web/src/components/ui/form.tsx`

When validation fails, `FormMessage` rendered the error in a plain `<p>`. The input already had `aria-invalid` and `aria-describedby` linking to the message, so a screen reader could navigate to it — but VoiceOver/NVDA did not **announce** the error proactively when it appeared.

Fix: when `error` is truthy, set `role="alert" aria-live="polite"` on the message `<p>`. Conditional so success/empty states don't claim to be alerts. `polite` queues the announcement (matches how sonner handles toasts) instead of interrupting.

Maps to **WCAG 2.1 SC 3.3.1 — Error Identification** (announce the error, not just attach it).

### MOBILE-52 — No skip-to-main-content link (MEDIUM)

`web/src/routes/__root.tsx`

VoiceOver and keyboard-only users had to tab through the entire sidebar nav to reach page content. Added a visually-hidden skip link at the top of the `AuthenticatedShell` that becomes visible on keyboard focus and jumps to `<main>`. Gave `<main>` `id="main"` and `tabIndex={-1}` so it can receive programmatic focus from the anchor. Background / text / ring colors are theme tokens, so it works in dark mode.

Maps to **WCAG 2.1 SC 2.4.1 — Bypass Blocks** (provide a way to skip repeated content).

## Out of scope

The audit's reduced-motion HIGH was a false positive — PR #1337 already added the `prefers-reduced-motion` rule in `globals.css:202`. The sonner `aria-live` verification was speculative; sonner handles it internally.

## Why these belong in `web/src/components/ui/*`

Same justification path as the recent `ui/*` PRs (#1316 onward): semantic correctness, narrowly scoped, no behavior change for sighted users, well-documented inline.

## Test plan

- [ ] Tab through a page on desktop — skip link appears in top-left corner on first Tab, jumps to main content on Enter.
- [ ] VoiceOver (macOS, ⌘F5): submit an invalid form (e.g. blank required field). The validation message should be announced automatically, not require navigation.
- [ ] Visual check: success/empty FormMessage states still render without `role="alert"` (no implicit assistive-tech announcement when nothing is wrong).
- [ ] Dark mode: skip-link contrast on focus.
