### PR TITLE
docs(v2): refresh mobile-patterns canon with #1346-1351 additions

### DIFF
--- a/.claude/rules/v2-frontend.md
+++ b/.claude/rules/v2-frontend.md
@@ -90,13 +90,29 @@ The v2 SPA is browsed from iOS Safari as a first-class target (Add-to-Home-Scree
 
 iOS Safari's `100vh` / `100vw` refer to the *largest* viewport (URL bar collapsed), so layouts sized that way overflow when the chrome is visible. Use `100dvh` / `100dvw` (Tailwind: `min-h-dvh`, `max-w-[calc(100dvw-1rem)]`, etc.) for any full-page shell, sticky/sheet container, or floating-edge element. `svh` only when you specifically want the worst-case-anchored size (rare). Precedent: (#1320), (#1331).
 
+Picker / popover contents adopt the same pattern at narrow viewports — clamp the floating panel width with `w-[calc(100dvw-2rem)] sm:w-72` (or similar) so it doesn't overflow on phones but locks to a comfortable size at `sm`. Precedent: (#1346) icon-picker + color-picker.
+
+`CommandList` and other dropdown bodies cap their max-height against the dynamic viewport: `max-h-[min(300px,50dvh)]` keeps the list onscreen when the iOS keyboard is open and the available height collapses. Precedent: (#1347).
+
 #### Safe-area insets
 
 The viewport meta in `web/index.html` ships `viewport-fit=cover`, which activates `env(safe-area-inset-*)`. Any sticky or fixed element that sits at a viewport edge needs explicit padding for the home-indicator / notch — e.g. `pt-[env(safe-area-inset-top)]`, `pb-[env(safe-area-inset-bottom)]`, or combined with existing spacing via `pt-[calc(1.25rem+env(safe-area-inset-top))]`. The Sheet primitive (`ui/sheet.tsx`) already wires side-aware safe-area padding internally — consumers don't add it for Sheet content. Precedent: (#1318), (#1342).
 
+Floating bottom elements (FloatingActionBar primitive, similar absolutely-positioned bars) use `max()` so the offset never collapses below the existing rhythm on devices without a home indicator: `bottom-[max(1rem,env(safe-area-inset-bottom))]`. Precedent: (#1347).
+
+`DialogHeader` (the AlertDialog / Dialog sibling to SheetHeader) gets `mt-[env(safe-area-inset-top)]` to clear the notch on iPad-landscape full-screen dialogs. The Sheet variant uses padding-based safe-area (#1342); the Dialog variant uses margin-based — both are valid for their context (Sheet content scrolls under the inset; Dialog headers shift the entire chrome). Precedent: (#1350).
+
 #### Tap targets — 44pt minimum via `pointer-coarse:`
 
 The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-element that extends icon-only buttons to a 44×44pt hit area on `(pointer: coarse)` (touch) devices, leaving visual size untouched on `pointer: fine` (mouse). Use `@media (pointer: coarse)` or Tailwind's `pointer-coarse:` variant for touch-only rules — **not** viewport-width queries, which both catch desktop windows resized small and miss iPads in landscape. Precedent: (#1317).
+
+For **raw `<button>` elements** that don't go through Button (e.g. the tag-chip × close button), apply the same recipe inline — the element must be `position: relative`:
+
+```tsx
+"... relative pointer-coarse:before:absolute pointer-coarse:before:left-1/2 pointer-coarse:before:top-1/2 pointer-coarse:before:size-11 pointer-coarse:before:-translate-x-1/2 pointer-coarse:before:-translate-y-1/2 pointer-coarse:before:content-['']"
+```
+
+Precedent: (#1349) tag-chip × button.
 
 #### Horizontal-scroll affordance — `scroll-shadow-x` utility
 
@@ -104,7 +120,7 @@ The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-e
 
 #### Mobile reflow patterns
 
-- **Stack actions full-width, primary-on-top.** Action clusters with destructive or affirmative buttons use `flex flex-col-reverse w-full gap-2 sm:flex-row sm:w-auto sm:items-center` so the primary action ends up on top of the stack on mobile (matches iOS / Material guidance). Precedent: (#1321) FormFooter, (#1328) disconnect, (#1336) prompts dialog, (#1339) prompts builder.
+- **Stack actions full-width, primary-on-top.** Action clusters with destructive or affirmative buttons use `flex flex-col-reverse w-full gap-2 sm:flex-row sm:w-auto sm:items-center` so the primary action ends up on top of the stack on mobile (matches iOS / Material guidance). Precedent: (#1321) FormFooter, (#1328) disconnect, (#1336) prompts dialog, (#1339) prompts builder. **AlertDialogFooter** already handles `flex-col-reverse` semantically — apply `w-full sm:w-auto` directly to `AlertDialogCancel` / `AlertDialogAction` instead of wrapping them. Precedent: (#1350) confirm dialogs, (#1348) connect-bank-sheet + reauth-sheet footers.
 - **CSS `order` to reshuffle for mobile-first content.** When source order needs to differ from visual order on mobile (e.g. operational knobs above a long prompt body), use `order-first md:order-none`. Tab/keyboard order continues to follow the DOM, so accessibility is preserved. Precedent: (#1322).
 - **Horizontal scroll-rail for filter pills.** Chip-style filter sets that wrap awkwardly switch to a single-row scroll rail on mobile via `max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:scroll-shadow-x`. Precedent: (#1324) transactions, (#1339) prompts builder.
 - **Stack-then-inline for narrow toolbars.** Toolbars with search + a couple of selects use `flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center`; if a wrapper would otherwise break a child's `ml-auto`, give the wrapper `display: contents` instead of a new flex context. Precedent: (#1341).
@@ -113,6 +129,8 @@ The Button primitive (`ui/button.tsx`) attaches an invisible `::before` pseudo-e
 #### Form ergonomics — iOS keyboard hints
 
 Typed inputs surface the right iOS keyboard via `inputmode="email|numeric|decimal|search"`, and submit fields tint the return key via `enterkeyhint="go|search|send|done"`. Identifier fields (slugs, API key names, regex values) need `autoCorrect="off" autoCapitalize="none" spellCheck={false}` so iOS doesn't autocorrect technical strings. `SearchInput` ships these defaults so every consumer benefits without per-call-site work. Precedent: (#1338).
+
+Textareas wrapping a submit action (comment composer, etc.) get `enterKeyHint="send"` even though the textarea itself doesn't submit — it paints the iOS return key glyph as "send", making the affordance discoverable. Precedent: (#1349) comment-composer.
 
 #### bfcache & lifecycle
 
@@ -125,6 +143,12 @@ A `pageshow` listener with `event.persisted === true` (lives in `main.tsx`, don'
 #### iOS web-app metadata
 
 `web/index.html` sets `apple-mobile-web-app-capable=yes`, `apple-mobile-web-app-status-bar-style=black-translucent`, `apple-mobile-web-app-title`, and `apple-touch-icon` so "Add to Home Screen" launches the SPA standalone (no Safari chrome). A cold-load splash lives inside `<div id="root">` as synchronous HTML + inline CSS — it respects `prefers-color-scheme` and `prefers-reduced-motion`, and React's `createRoot` replaces it on first render, covering the JS-hydration gap. Precedent: (#1332).
+
+#### Accessibility patterns
+
+- **Skip-to-content link.** Every authenticated shell renders `<a href="#main" className="sr-only focus-visible:not-sr-only ...">Skip to main content</a>` at the top of the layout, paired with `<main id="main" tabIndex={-1}>`. Required for WCAG 2.4.1 (bypass blocks); also speeds up keyboard navigation past the sidebar. Precedent: (#1351).
+- **Form error announcements.** `FormMessage` (`ui/form.tsx`) conditionally applies `role="alert" aria-live="polite"` when an error is present, so VoiceOver / NVDA announce form validation errors as they appear. Required for WCAG 3.3.1. Don't re-implement per-field announcements — the primitive handles it. Precedent: (#1351).
+- **iOS keyboard `enterKeyHint` on textareas.** Textareas that submit on a keyboard action benefit from `enterKeyHint="send"` so the iOS return key glyph signals the affordance — already present on `SearchInput` via #1338, extended to `comment-composer` in (#1349).
 
 ### State
 


### PR DESCRIPTION
## Summary

Refreshes the "Mobile / iOS Safari patterns" section in `.claude/rules/v2-frontend.md` to cover six PRs that landed after the original canon PR (#1344). Closes the drift between the docs and the patterns now established in `ui/*`, `globals.css`, and feature call sites.

## Additions

- **Viewport units** — picker / popover width pattern (`w-[calc(100dvw-2rem)] sm:w-72`) from #1346, and `CommandList` `max-h-[min(300px,50dvh)]` from #1347.
- **Safe-area insets** — `bottom-[max(1rem,env(safe-area-inset-bottom))]` for floating bottom elements (#1347), and `mt-[env(safe-area-inset-top)]` for `DialogHeader` (#1350) — contrasted with the existing padding-based `SheetHeader` (#1342).
- **Mobile reflow / Stack actions** — extended with the `AlertDialogFooter` precedent: apply `w-full sm:w-auto` directly to `AlertDialogCancel` / `AlertDialogAction` (#1350) and to connect-bank / reauth sheet footers (#1348).
- **Tap targets** — new "raw `<button>`" snippet for the inline `pointer-coarse:before:*` recipe (#1349) so consumers off the Button primitive can replicate the 44pt hit area.
- **Form ergonomics** — `enterKeyHint="send"` on textareas wrapping a submit action (#1349 comment-composer).
- **Accessibility patterns** — new subsection covering skip-to-content link + `<main id="main" tabIndex={-1}>` (#1351), `FormMessage` `role="alert" aria-live="polite"` (#1351), and the textarea `enterKeyHint` reminder (#1338 → #1349).

## Test plan

- [x] Docs-only — no build or lint required.
- [x] Section structure preserved; no existing subsections restructured.
