### PR TITLE
fix(v2): restore iOS Safari bfcache on swipe-back (mobile-safari iter 5)

### DIFF
--- a/.claude/mobile-safari-sprint.md
+++ b/.claude/mobile-safari-sprint.md
@@ -19,7 +19,8 @@ Perfect mobile support for the v2 SPA at `web/`, prioritizing iOS Safari (26.2+ 
 - ✅ Phase 1.5: Mobile sweep tool (`bun run mobile-sweep`) + `docs/mobile-sweep-findings.md`.
 - ✅ Phase 2 (PR #1356 → sprint): overflow fixes on `/v2/tags`, `/v2/api-keys`, `/v2/agents`, `/v2/categories`. All at 0px overflow on iPhone 13 / 15 Pro Max.
 - ✅ Iter 3 (PR #1357 → sprint): `LeaveGuard` component + wired to `agent-form.tsx` and `rule-form.tsx`.
-- ✅ Iter 4 (PR pending → sprint): PWA assets — 180/192/512 PNG icons rasterized from favicon.svg via `bun run generate-icons`, `manifest.webmanifest` with maskable variant, sized apple-touch-icon. 404 + error pages confirmed to have back-to-home links (no Safari chrome in standalone mode).
+- ✅ Iter 4 (PR #1358 → sprint): PWA assets — 180/192/512 PNG icons rasterized from favicon.svg via `bun run generate-icons`, `manifest.webmanifest` with maskable variant, sized apple-touch-icon. 404 + error pages confirmed to have back-to-home links (no Safari chrome in standalone mode).
+- ✅ Iter 5 (PR pending → sprint): restore bfcache on iOS Safari swipe-back. Pulled `/v2/*` out of the session-middleware group in `internal/api/router.go` so the static SPA bundle stops carrying `Vary: Cookie` (which WebKit treats as a bfcache blocker). Tightened the `pageshow` handler in `web/src/main.tsx` to only re-validate `["me"]` instead of invalidating every cached query, eliminating the post-restore refetch storm. Verified via curl against a freshly-built binary: `Vary: Cookie` is gone from `/v2/` responses.
 
 ## Queue (priority order)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -306,12 +306,20 @@ func NewRouter(a *app.App, version string) http.Handler {
 					webui.MountBackupRoutes(r, a, sm)
 				})
 			})
-			// /v2/* — embedded SPA static bundle. The session middleware lets
-			// the SPA shell load on /login, but the SPA's own queries
-			// (/web/v1/me) gate the authenticated content.
-			r.Handle("/v2", http.RedirectHandler("/v2/", http.StatusMovedPermanently))
-			r.Handle("/v2/*", webui.Handler())
 		})
+		// /v2/* — embedded SPA static bundle. Deliberately NOT inside the
+		// session-middleware group above: `sm.LoadAndSave` appends
+		// `Vary: Cookie` to every response, and `Vary: Cookie` is one of
+		// the canonical reasons WebKit (and Chrome) refuse to bfcache a
+		// page. With bfcache disabled, iOS Safari swipe-back triggers a
+		// full SPA cold-reload (blank page + ~1-2s freeze) instead of
+		// instantly restoring the previous DOM from memory. The SPA's
+		// authenticated content is gated by its own /web/v1/me query, which
+		// loads the session through scs separately — so dropping middleware
+		// here just affects the static asset response, never the auth
+		// boundary.
+		r.Handle("/v2", http.RedirectHandler("/v2/", http.StatusMovedPermanently))
+		r.Handle("/v2/*", webui.Handler())
 
 		tr, err := admin.NewTemplateRenderer(sm)
 		if err != nil {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -329,16 +329,31 @@ const queryClient = new QueryClient({
 // iOS Safari restores the SPA from bfcache on swipe-back: the DOM snapshot is
 // reconstituted and JS resumes mid-state. Without intervention the stale React
 // + React-Query state can trigger a 401-refetch → /login redirect race during
-// Safari's restore animation, presenting as a frozen / blank page. Invalidate
-// the router (re-runs loaders + search validation) and mark queries stale (so
-// they refetch fresh data without flashing skeletons) on `pageshow.persisted`.
+// Safari's restore animation, presenting as a frozen / blank page. The fix
+// has two parts:
+//
+//  1. Re-validate the session (`["me"]`) so a 401 fires from a cold loader
+//     state instead of mid-restore animation; the auth gate in `__root.tsx`
+//     waits for `document.visibilityState === "visible"` before redirecting.
+//
+//  2. Invalidate the router so route loaders + search-param validation re-run
+//     against the now-restored DOM.
+//
+// We deliberately do NOT call `queryClient.invalidateQueries()` (no args) —
+// that fires a refetch storm against every cached query on the visible page
+// (transactions list alone has 10+), producing a measurable 1-2s freeze
+// after the restore. TanStack Query's 30s staleTime already handles freshness
+// for normal data; the bfcache restore window is usually shorter than that.
+// Routes that need stricter freshness can opt into their own `pageshow`
+// handler or use a shorter staleTime.
+//
 // Don't `queryClient.clear()` — that drops cached data instantly. Don't add a
 // `beforeunload`/`unload` handler — that would disable bfcache entirely.
 if (typeof window !== "undefined") {
   window.addEventListener("pageshow", (event) => {
     if (event.persisted) {
       router.invalidate();
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ["me"] });
     }
   });
 }


### PR DESCRIPTION
## Summary

Iter 5 of the mobile-safari sprint. Fixes the reported "blank page + 1-2s freeze on iOS Safari swipe-back" by restoring bfcache eligibility and eliminating a refetch storm in the bfcache-restore handler.

## Root causes

### 1. `Vary: Cookie` was disabling bfcache

`internal/api/router.go` had `/v2/*` (the embedded SPA bundle) inside the same `chi.Router` group as `/web/v1/*`, which uses `sm.LoadAndSave` (the scs session middleware). `sm.LoadAndSave` appends `Vary: Cookie` to every response. Per WebKit + Chrome bfcache rules, `Vary: Cookie` is one of the canonical reasons the browser **refuses to bfcache** a page — so iOS swipe-back was triggering a full SPA cold-reload (blank page + JS re-bootstrap) instead of restoring the previous DOM from memory.

**Fix**: moved `/v2/*` outside the session-middleware group. The static SPA bundle never needed session loading anyway — the SPA's queries to `/web/v1/me` still run through scs separately, so the auth boundary is unchanged.

Verified via curl on a freshly-built binary:

```diff
- Vary: Cookie       (before)
+ (no Vary header)   (after)
```

### 2. `pageshow` handler was a refetch storm

`main.tsx`'s `pageshow.persisted` handler called `queryClient.invalidateQueries()` with **no args** — invalidating every cached query in one go. On a page like `/v2/transactions` (10+ queries) that fires a parallel refetch storm right after the restore, producing the 1-2s freeze even when bfcache itself was working.

**Fix**: invalidate only `["me"]` (auth state, the only thing we genuinely need fresh after a possible signout-from-another-tab). The 30s `staleTime` handles freshness for normal data; bfcache restore windows are usually shorter than that anyway.

## Why this isn't a Navigation API thing

The earlier Phase 1 research confirmed (and MDN agrees): the Navigation API `navigate` event does **not** fire on bfcache restore — bfcache pages are paused, not navigated. So adopting Navigation API wouldn't have helped here. The browser owns the swipe-back gesture; we can only control whether the cached page is eligible to be restored, and what runs when it resumes.

## Test plan

- [ ] `make build && ./breadbox serve` — confirm `curl -I http://localhost:8080/v2/` has no `Vary: Cookie` header
- [ ] On real iOS Safari: tap a transaction → external link / new tab → swipe back. Page should restore instantly (no white flash, no skeleton, no refetch storm)
- [ ] WebKit Web Inspector → Network → reload → back: should show "Restored from page cache" for the navigation entry
- [ ] Existing CI: `go build ./...`, `go vet ./...`, integration tests
- [ ] Mobile sweep no regressions: `BASE_URL=http://localhost:6080 bun run mobile-sweep` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
