### PR TITLE
chore(v2): memory-sweep tool + memory phase queue (mobile-safari iter 6)

### DIFF
--- a/.claude/mobile-safari-sprint.md
+++ b/.claude/mobile-safari-sprint.md
@@ -20,7 +20,8 @@ Perfect mobile support for the v2 SPA at `web/`, prioritizing iOS Safari (26.2+ 
 - ✅ Phase 2 (PR #1356 → sprint): overflow fixes on `/v2/tags`, `/v2/api-keys`, `/v2/agents`, `/v2/categories`. All at 0px overflow on iPhone 13 / 15 Pro Max.
 - ✅ Iter 3 (PR #1357 → sprint): `LeaveGuard` component + wired to `agent-form.tsx` and `rule-form.tsx`.
 - ✅ Iter 4 (PR #1358 → sprint): PWA assets — 180/192/512 PNG icons rasterized from favicon.svg via `bun run generate-icons`, `manifest.webmanifest` with maskable variant, sized apple-touch-icon. 404 + error pages confirmed to have back-to-home links (no Safari chrome in standalone mode).
-- ✅ Iter 5 (PR pending → sprint): restore bfcache on iOS Safari swipe-back. Pulled `/v2/*` out of the session-middleware group in `internal/api/router.go` so the static SPA bundle stops carrying `Vary: Cookie` (which WebKit treats as a bfcache blocker). Tightened the `pageshow` handler in `web/src/main.tsx` to only re-validate `["me"]` instead of invalidating every cached query, eliminating the post-restore refetch storm. Verified via curl against a freshly-built binary: `Vary: Cookie` is gone from `/v2/` responses.
+- ✅ Iter 5 (PR #1359 → sprint): restore bfcache on iOS Safari swipe-back. Pulled `/v2/*` out of the session-middleware group in `internal/api/router.go` so the static SPA bundle stops carrying `Vary: Cookie` (which WebKit treats as a bfcache blocker). Tightened the `pageshow` handler in `web/src/main.tsx` to only re-validate `["me"]` instead of invalidating every cached query, eliminating the post-restore refetch storm. Verified via curl against a freshly-built binary: `Vary: Cookie` is gone from `/v2/` responses.
+- ✅ Iter 6 (PR pending → sprint): `bun run memory-sweep` — Playwright-based structural-leak detector. Drives list↔detail N=20 times under webkit, samples DOM node count + shadcn slot count at iter 1/5/10/15/20, reports verdict per flow. Baseline: `/v2/accounts` clean (0 growth across 20 iters); `/v2/transactions` clean iter 1-15 (1838→1742, attrition) then drops to 252 at iter 20 — likely session loss after rapid navigations; flagged for follow-up investigation. WebKit doesn't expose `performance.memory`, so this is a structural proxy; real iOS heap data needs Safari Web Inspector.
 
 ## Queue (priority order)
 
@@ -41,6 +42,14 @@ Each iteration: pick the next item, branch off `mobile-safari/sprint`, ship a su
 7. **Form-field iOS keyboard audit** — verify every `<Input>` consumer passes appropriate `inputMode` / `enterKeyHint` / `autoCapitalize` defaults. `SearchInput` already does; others might not.
 
 8. **LeaveGuard for other forms** — apply LeaveGuard to remaining dirty-state forms: category-form, tag-form, settings forms, API key new form.
+
+9. **Memory phase — TanStack Query `gcTime` cap** — cache currently has no upper bound on retained queries. Set a sensible `gcTime` (5 min default is fine for most; consider `Infinity` for `["me"]` and shorter for paginated lists). Verify via `bun run memory-sweep`.
+
+10. **Memory phase — virtualize transactions list** — long-history households render the entire TanStack Table row tree in DOM (1800+ nodes at iter 1 of the memory sweep). Add `@tanstack/react-virtual` row windowing to DataTable when row count exceeds N. Defer if a profile shows no real iOS pain.
+
+11. **Memory phase — `useEffect` cleanup audit** — grep for `useEffect` returning no cleanup against patterns that hold a listener (`addEventListener`, `setInterval`, `IntersectionObserver`, `MutationObserver`, `ResizeObserver`). Trace common offenders in `features/transactions/*` and `components/data-table.tsx`.
+
+12. **Transactions session-loss after rapid navigations** — `bun run memory-sweep` shows `/v2/transactions` dropping to 252 nodes at iter 20 (AuthSplash territory). Likely session lifetime or scs middleware behavior under hammered navs. Reproduce, then either bump session ttl on /v2 boundary or stabilize the auth gate.
 
 ## Operating notes
 

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "lint": "tsc -b --noEmit",
     "validate": "bun run scripts/validate.ts",
     "mobile-sweep": "bun run scripts/mobile-sweep.ts",
+    "memory-sweep": "bun run scripts/memory-sweep.ts",
     "generate-icons": "bun run scripts/generate-icons.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",

--- a/web/scripts/memory-sweep.ts
+++ b/web/scripts/memory-sweep.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+// Memory-leak detector for the v2 SPA. Drives a list ↔ detail navigation
+// loop N times under webkit and reports DOM-growth deltas — a structural
+// proxy for real memory pressure that we CAN measure on Playwright's
+// webkit (real heap bytes via `performance.memory` are Chrome-only).
+//
+// What it catches:
+//   - Component trees that don't unmount when their route exits
+//   - Detached DOM kept alive by event listeners closed over old props
+//   - Portals (dialogs, popovers) that leak after navigation
+//   - Stacked Sheets / DialogStacks where each open leaves orphans
+//
+// What it does NOT catch:
+//   - Actual byte heap usage (needs Web Inspector against a real iPhone)
+//   - JS closure leaks not tied to DOM nodes
+//   - WeakMap/WeakSet over-retention
+//
+// Usage:
+//   make dev (backend) + make web-dev (vite at :6080) — or use the
+//   embedded build on :8080.
+//   BASE_URL=http://localhost:6080 bun run memory-sweep
+//
+// Output: tmp/memory-sweep-<stamp>.md with per-iteration metrics + a
+// verdict on each route's structural-leak score.
+
+import { webkit, devices, type Page, type BrowserContext } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ITERATIONS = Number(process.env.MEMORY_SWEEP_ITERATIONS ?? 20);
+const SAMPLE_AT = [1, 5, 10, 15, 20];
+const VIEWPORT = "iPhone 13";
+
+const baseUrl = process.env.BASE_URL ?? `http://localhost:${process.env.PORT ?? 8080}`;
+const user = process.env.BB_USER ?? "admin@example.com";
+const pass = process.env.BB_PASS ?? "password";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tmpDir = resolve(here, "..", "..", "tmp");
+const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+const outPath = join(tmpDir, `memory-sweep-${stamp}.md`);
+
+type Snapshot = {
+  iteration: number;
+  domNodes: number;
+  shadcnSlots: number;
+  detachedTriggers: number;
+};
+
+type FlowReport = {
+  name: string;
+  description: string;
+  snapshots: Snapshot[];
+  verdict: string;
+};
+
+async function signIn(ctx: BrowserContext): Promise<void> {
+  const page = await ctx.newPage();
+  await page.goto(`${baseUrl}/v2/login`, { waitUntil: "domcontentloaded", timeout: 15_000 });
+  if (page.url().endsWith("/login")) {
+    await page.fill('input[name="username"], input[type="email"]', user);
+    await page.fill('input[name="password"]', pass);
+    await Promise.all([
+      page.waitForURL((u) => !new URL(u).pathname.endsWith("/login"), { timeout: 10_000 }).catch(() => {}),
+      page.click('form button[type="submit"]'),
+    ]);
+  }
+  await page.close();
+}
+
+async function snapshot(page: Page, iteration: number): Promise<Snapshot> {
+  return await page.evaluate((i) => {
+    return {
+      iteration: i,
+      domNodes: document.getElementsByTagName("*").length,
+      // shadcn primitives all carry `data-slot=`. Tracking this subset
+      // catches portal-mounted dialogs/popovers/sheets that don't unmount.
+      shadcnSlots: document.querySelectorAll("[data-slot]").length,
+      // Buttons / triggers that are still attached but should have unmounted
+      // when the previous route exited. Use a heuristic: ARIA closed-but-
+      // still-mounted state pollutes this count.
+      detachedTriggers: document.querySelectorAll('[data-state="closed"]').length,
+    };
+  }, iteration);
+}
+
+async function runFlow(
+  page: Page,
+  flow: {
+    name: string;
+    description: string;
+    listUrl: string;
+    pickDetailId: (page: Page) => Promise<string | null>;
+    detailUrl: (id: string) => string;
+  },
+): Promise<FlowReport> {
+  console.log(`\n=== ${flow.name} ===`);
+  await page.goto(`${baseUrl}${flow.listUrl}`, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {});
+  await page.waitForTimeout(500);
+
+  const detailId = await flow.pickDetailId(page);
+  if (!detailId) {
+    return {
+      name: flow.name,
+      description: flow.description,
+      snapshots: [],
+      verdict: "SKIP: could not find a detail target on the list page",
+    };
+  }
+  console.log(`  detail target: ${detailId}`);
+
+  const snapshots: Snapshot[] = [];
+  // Baseline (iteration 0) after first list load.
+  snapshots.push({ ...(await snapshot(page, 0)) });
+
+  for (let i = 1; i <= ITERATIONS; i++) {
+    await page.goto(`${baseUrl}${flow.detailUrl(detailId)}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 10_000,
+    });
+    await page.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => {});
+
+    await page.goto(`${baseUrl}${flow.listUrl}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 10_000,
+    });
+    await page.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => {});
+    // Wait until the list has actually rendered rows (not the empty/loading
+    // skeleton). Without this, fast navigations on a slow query-cache
+    // refetch catch the page mid-render and we'd report misleading drops.
+    await page.locator("tbody tr").first().waitFor({ state: "visible", timeout: 5_000 }).catch(() => {});
+    await page.waitForTimeout(150);
+
+    if (SAMPLE_AT.includes(i)) {
+      const snap = await snapshot(page, i);
+      snapshots.push(snap);
+      console.log(
+        `  iter ${i}: dom=${snap.domNodes} slots=${snap.shadcnSlots} closed=${snap.detachedTriggers}`,
+      );
+    }
+  }
+
+  // Verdict: compare iter 1 → iter 20. >25% growth on DOM nodes is a real
+  // leak signal; >10% is suspicious; <10% is noise from query-cache warm-up.
+  const first = snapshots[1];
+  const last = snapshots[snapshots.length - 1];
+  let verdict = "no growth — clean";
+  if (first && last && last.iteration > 1) {
+    const delta = last.domNodes - first.domNodes;
+    const pct = (delta / first.domNodes) * 100;
+    const sign = delta >= 0 ? "+" : "";
+    const fmt = `${sign}${delta} DOM nodes (${sign}${pct.toFixed(1)}%)`;
+    if (pct > 25) verdict = `LEAK: ${fmt}`;
+    else if (pct > 10) verdict = `SUSPICIOUS: ${fmt}`;
+    else if (pct < -10)
+      verdict = `unstable: ${fmt} — query-cache eviction or loading-state race`;
+    else verdict = `clean: ${fmt}`;
+  }
+  return { name: flow.name, description: flow.description, snapshots, verdict };
+}
+
+function renderReport(reports: FlowReport[]): string {
+  const lines: string[] = [];
+  lines.push(`# Memory sweep — ${stamp}`);
+  lines.push("");
+  lines.push(`Base URL: \`${baseUrl}\``);
+  lines.push(`Viewport: \`${VIEWPORT}\` (390×664)`);
+  lines.push(`Iterations per flow: ${ITERATIONS}`);
+  lines.push("");
+  lines.push("**What this measures**: structural DOM growth across N list↔detail navigations. WebKit doesn't expose `performance.memory`, so this is a proxy — useful for catching components that leak portals, listeners, or detached subtrees, but does not reflect actual heap byte usage. For real iOS heap data, tether an iPhone to Safari Web Inspector.");
+  lines.push("");
+  lines.push("**Verdict thresholds** (iter 1 → iter 20 DOM delta):");
+  lines.push("- `< 10%`: clean — noise from query-cache warm-up");
+  lines.push("- `10-25%`: suspicious — worth investigating");
+  lines.push("- `> 25%`: LEAK — real structural retention");
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| flow | verdict |");
+  lines.push("|---|---|");
+  for (const r of reports) lines.push(`| ${r.name} | ${r.verdict} |`);
+  lines.push("");
+  lines.push("## Per-flow trace");
+  lines.push("");
+  for (const r of reports) {
+    lines.push(`### ${r.name}`);
+    lines.push("");
+    lines.push(`> ${r.description}`);
+    lines.push("");
+    if (r.snapshots.length === 0) {
+      lines.push(`${r.verdict}`);
+      lines.push("");
+      continue;
+    }
+    lines.push("| iter | domNodes | shadcnSlots | data-state=closed |");
+    lines.push("|---:|---:|---:|---:|");
+    for (const s of r.snapshots) {
+      lines.push(`| ${s.iteration} | ${s.domNodes} | ${s.shadcnSlots} | ${s.detachedTriggers} |`);
+    }
+    lines.push("");
+    lines.push(`**Verdict**: ${r.verdict}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  if (!existsSync(tmpDir)) await mkdir(tmpDir, { recursive: true });
+
+  console.log(`base: ${baseUrl}`);
+  console.log(`out:  ${outPath}`);
+  console.log(`iterations: ${ITERATIONS}, viewport: ${VIEWPORT}`);
+
+  const browser = await webkit.launch({ headless: true });
+  const ctx = await browser.newContext({ ...devices[VIEWPORT] });
+  try {
+    await signIn(ctx);
+    const page = await ctx.newPage();
+
+    const reports = await Promise.resolve()
+      .then(() =>
+        runFlow(page, {
+          name: "transactions list ↔ detail",
+          description:
+            "Walks /v2/transactions → /v2/transactions/<id> → back, repeatedly. Heaviest list in the app; if anything leaks, this catches it.",
+          listUrl: "/v2/transactions",
+          detailUrl: (id) => `/v2/transactions/${id}`,
+          pickDetailId: async (p) => {
+            // DataTable rows use programmatic navigation (`onRowClick`)
+            // rather than per-row anchors, so we can't grep an href. Click
+            // the first row, read the resulting URL, then come back.
+            const row = p.locator("tbody tr").first();
+            await row.waitFor({ state: "visible", timeout: 5_000 }).catch(() => {});
+            const before = p.url();
+            await row.click().catch(() => {});
+            await p
+              .waitForURL(
+                (u) => u !== before && /\/v2\/transactions\/[^/?#]+/.test(u),
+                { timeout: 5_000 },
+              )
+              .catch(() => {});
+            const m = p.url().match(/\/v2\/transactions\/([^/?#]+)/);
+            return m?.[1] ?? null;
+          },
+        }),
+      )
+      .then(async (first) => {
+        const second = await runFlow(page, {
+          name: "accounts list ↔ detail",
+          description:
+            "Walks /v2/accounts → /v2/accounts/<id> → back. Smaller list, exercises a different detail surface (no large data tables).",
+          listUrl: "/v2/accounts",
+          detailUrl: (id) => `/v2/accounts/${id}`,
+          pickDetailId: async (p) =>
+            await p.evaluate(() => {
+              const link = document.querySelector(
+                'a[href*="/v2/accounts/"]:not([href$="/accounts"])',
+              ) as HTMLAnchorElement | null;
+              if (!link) return null;
+              const m = link.href.match(/\/v2\/accounts\/([^/?#]+)/);
+              return m?.[1] ?? null;
+            }),
+        });
+        return [first, second];
+      });
+
+    const md = renderReport(reports);
+    await writeFile(outPath, md, "utf8");
+    console.log(`\n✓ ${outPath}`);
+  } finally {
+    await ctx.close();
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Iter 6 of the mobile-safari sprint. Closes the loop on the memory question Ricardo raised — adds a structural-leak detector we can run from Playwright, plus three concrete Memory-phase items to the queue.

## `bun run memory-sweep`

Drives list ↔ detail navigation N=20 times under webkit (iPhone 13 viewport) and samples DOM node count + shadcn-slot count + `data-state="closed"` count at iter 1/5/10/15/20. Writes `tmp/memory-sweep-<stamp>.md` with per-flow trace + verdict.

**What it catches:**
- Components that don't unmount when their route exits
- Portals (dialogs, popovers, sheets) that leak after navigation
- Stacked overlays where each open leaves orphans
- React Query cache state that holds DOM via subscriptions

**What it does NOT catch** (and why):
- Actual heap byte usage — `performance.memory` is Chrome-only; WebKit doesn't expose it. Real iOS heap data needs Safari Web Inspector tethered to an iPhone, manual.
- JS closure leaks not tied to DOM nodes
- WeakMap / WeakSet over-retention

## Baseline at sprint head

| flow | iter 1 | iter 20 | verdict |
|---|---:|---:|---|
| `/v2/accounts` ↔ detail | 311 | 311 | **clean** (0 DOM growth) |
| `/v2/transactions` ↔ detail | 1838 | 252 | **unstable** — drop at iter 20, looks like session loss after rapid navs (AuthSplash territory). Accounts stays flat through same loop → not a leak, but worth investigating |

The transactions iter-20 anomaly is filed as Memory-phase item #4 — likely scs session ttl behavior under hammered navigation, not a real-user pattern but worth understanding before we land virtualization on top.

## Queue updates

New Memory phase added (queue items 9-12):
- **9** — TanStack Query `gcTime` cap (cache currently unbounded)
- **10** — Virtualize transactions list (`@tanstack/react-virtual`)
- **11** — `useEffect` cleanup audit on listener-heavy features
- **12** — Reproduce + diagnose the transactions iter-20 session loss

## Test plan

- [ ] `cd web && bun run lint` ✅
- [ ] `cd web && BASE_URL=http://localhost:6080 bun run memory-sweep` — verify the report renders + matches baseline above
- [ ] Open the report markdown; confirm summary table + per-flow trace
- [ ] Existing CI: build + vet + integration tests
- [ ] Mobile sweep no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
