### PR TITLE
feat(v2): LeaveGuard rollout — tag, category, api-key, password (mobile-safari iter 7)

### DIFF
--- a/.claude/mobile-safari-sprint.md
+++ b/.claude/mobile-safari-sprint.md
@@ -21,7 +21,8 @@ Perfect mobile support for the v2 SPA at `web/`, prioritizing iOS Safari (26.2+ 
 - ✅ Iter 3 (PR #1357 → sprint): `LeaveGuard` component + wired to `agent-form.tsx` and `rule-form.tsx`.
 - ✅ Iter 4 (PR #1358 → sprint): PWA assets — 180/192/512 PNG icons rasterized from favicon.svg via `bun run generate-icons`, `manifest.webmanifest` with maskable variant, sized apple-touch-icon. 404 + error pages confirmed to have back-to-home links (no Safari chrome in standalone mode).
 - ✅ Iter 5 (PR #1359 → sprint): restore bfcache on iOS Safari swipe-back. Pulled `/v2/*` out of the session-middleware group in `internal/api/router.go` so the static SPA bundle stops carrying `Vary: Cookie` (which WebKit treats as a bfcache blocker). Tightened the `pageshow` handler in `web/src/main.tsx` to only re-validate `["me"]` instead of invalidating every cached query, eliminating the post-restore refetch storm. Verified via curl against a freshly-built binary: `Vary: Cookie` is gone from `/v2/` responses.
-- ✅ Iter 6 (PR pending → sprint): `bun run memory-sweep` — Playwright-based structural-leak detector. Drives list↔detail N=20 times under webkit, samples DOM node count + shadcn slot count at iter 1/5/10/15/20, reports verdict per flow. Baseline: `/v2/accounts` clean (0 growth across 20 iters); `/v2/transactions` clean iter 1-15 (1838→1742, attrition) then drops to 252 at iter 20 — likely session loss after rapid navigations; flagged for follow-up investigation. WebKit doesn't expose `performance.memory`, so this is a structural proxy; real iOS heap data needs Safari Web Inspector.
+- ✅ Iter 6 (PR #1360 → sprint): `bun run memory-sweep` — Playwright-based structural-leak detector. Drives list↔detail N=20 times under webkit, samples DOM node count + shadcn slot count at iter 1/5/10/15/20, reports verdict per flow. Baseline: `/v2/accounts` clean (0 growth across 20 iters); `/v2/transactions` clean iter 1-15 (1838→1742, attrition) then drops to 252 at iter 20 — likely session loss after rapid navigations; flagged for follow-up investigation. WebKit doesn't expose `performance.memory`, so this is a structural proxy; real iOS heap data needs Safari Web Inspector.
+- ✅ Iter 7 (PR pending → sprint): rolled `LeaveGuard` out to `tag-form`, `category-form`, `api-key-form`, and the password-change form in `account-section.tsx`. Each navigates only on success and now resets the form before navigating (so the guard doesn't intercept the post-save nav). The password form uses a custom title/description.
 
 ## Queue (priority order)
 
@@ -41,7 +42,7 @@ Each iteration: pick the next item, branch off `mobile-safari/sprint`, ship a su
 
 7. **Form-field iOS keyboard audit** — verify every `<Input>` consumer passes appropriate `inputMode` / `enterKeyHint` / `autoCapitalize` defaults. `SearchInput` already does; others might not.
 
-8. **LeaveGuard for other forms** — apply LeaveGuard to remaining dirty-state forms: category-form, tag-form, settings forms, API key new form.
+8. **LeaveGuard — remaining settings sub-forms** — audit `household-section`, `backups-section`, `agents-section` for `useForm` instances that need LeaveGuard. Those files are 600+ lines each and likely contain multiple sub-forms; needs per-form judgment on whether the field is sensitive enough to warrant a guard.
 
 9. **Memory phase — TanStack Query `gcTime` cap** — cache currently has no upper bound on retained queries. Set a sensible `gcTime` (5 min default is fine for most; consider `Infinity` for `["me"]` and shorter for paginated lists). Verify via `bun run memory-sweep`.
 

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -25,6 +25,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { FormFooter } from "@/components/form-footer";
+import { LeaveGuard } from "@/components/leave-guard";
 import { cn } from "@/lib/utils";
 import { useCreateAPIKey } from "@/api/queries/api-keys";
 import { storePendingPlaintextKey } from "@/features/api-keys/plaintext-store";
@@ -123,6 +124,9 @@ export function APIKeyForm() {
         plaintext: created.plaintext_key,
       });
       toast.success(`Created "${values.name}".`);
+      // Reset before navigating so LeaveGuard doesn't intercept the
+      // post-save nav to /api-keys/created. Only on success.
+      form.reset(values);
       navigate({ to: "/api-keys/created" });
     } catch (err) {
       const msg =
@@ -133,6 +137,9 @@ export function APIKeyForm() {
 
   return (
     <Form {...form}>
+      <LeaveGuard
+        when={form.formState.isDirty && !form.formState.isSubmitting}
+      />
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
         <FormField
           control={form.control}

--- a/web/src/features/categories/category-form.tsx
+++ b/web/src/features/categories/category-form.tsx
@@ -36,6 +36,7 @@ import {
 import { FormFooter } from "@/components/form-footer";
 import { IconPicker } from "@/components/icon-picker";
 import { ColorPicker } from "@/components/color-picker";
+import { LeaveGuard } from "@/components/leave-guard";
 import { DynamicIcon } from "@/lib/icon";
 import {
   useCategories,
@@ -99,7 +100,12 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
           }),
         { success: "Category created." },
       );
-      if (ok) navigate({ to: "/categories" });
+      if (ok) {
+        // Reset before navigating so LeaveGuard doesn't intercept the
+        // parent's post-save nav. Reset only on success.
+        form.reset(values);
+        navigate({ to: "/categories" });
+      }
     } else if (category) {
       const ok = await withMutationToast(
         () =>
@@ -115,7 +121,10 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
           }),
         { success: "Category updated." },
       );
-      if (ok) navigate({ to: "/categories" });
+      if (ok) {
+        form.reset(values);
+        navigate({ to: "/categories" });
+      }
     }
   };
 
@@ -124,6 +133,9 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
 
   return (
     <Form {...form}>
+      <LeaveGuard
+        when={form.formState.isDirty && !form.formState.isSubmitting}
+      />
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         <FormField
           control={form.control}

--- a/web/src/features/settings/account-section.tsx
+++ b/web/src/features/settings/account-section.tsx
@@ -16,6 +16,7 @@ import { useMe } from "@/api/queries/me";
 import { useChangePassword } from "@/api/queries/account";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { SettingsSectionHeader } from "@/components/settings-section-header";
+import { LeaveGuard } from "@/components/leave-guard";
 
 const schema = z
   .object({
@@ -66,6 +67,12 @@ export function AccountSection() {
           description="At least 8 characters. You'll stay signed in."
         />
         <Form {...form}>
+          <LeaveGuard
+            when={form.formState.isDirty && !form.formState.isSubmitting}
+            title="Discard your password change?"
+            description="You've started typing a new password but haven't saved it. Leaving will lose what you typed."
+            confirmLabel="Discard"
+          />
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField
               control={form.control}

--- a/web/src/features/tags/tag-form.tsx
+++ b/web/src/features/tags/tag-form.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { FormFooter } from "@/components/form-footer";
 import { IconPicker } from "@/components/icon-picker";
 import { ColorPicker } from "@/components/color-picker";
+import { LeaveGuard } from "@/components/leave-guard";
 import { useCreateTag, useUpdateTag } from "@/api/queries/tags";
 import { withMutationToast } from "@/lib/mutation-toast";
 import type { Tag } from "@/api/types";
@@ -85,7 +86,13 @@ export function TagForm({ mode, tag }: TagFormProps) {
           }),
         { success: "Tag created." },
       );
-      if (ok) navigate({ to: "/tags" });
+      if (ok) {
+        // Reset before navigating so LeaveGuard doesn't intercept the
+        // parent's post-save nav. Reset only on success — failed saves
+        // should keep the form dirty so the user's edits are protected.
+        form.reset(values);
+        navigate({ to: "/tags" });
+      }
     } else if (tag) {
       const ok = await withMutationToast(
         () =>
@@ -100,7 +107,10 @@ export function TagForm({ mode, tag }: TagFormProps) {
           }),
         { success: "Tag updated." },
       );
-      if (ok) navigate({ to: "/tags" });
+      if (ok) {
+        form.reset(values);
+        navigate({ to: "/tags" });
+      }
     }
   };
 
@@ -109,6 +119,9 @@ export function TagForm({ mode, tag }: TagFormProps) {
 
   return (
     <Form {...form}>
+      <LeaveGuard
+        when={form.formState.isDirty && !form.formState.isSubmitting}
+      />
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         {mode === "create" ? (
           <FormField


### PR DESCRIPTION
## Summary

Iter 7 of the mobile-safari sprint. Repeats the iter-3 LeaveGuard pattern across more dirty-state surfaces so users can't accidentally lose typed-but-unsaved input.

**Forms now protected:**

- `tag-form` (create + edit)
- `category-form` (create + edit)
- `api-key-form` (create — keys are immutable, no edit)
- `account-section.tsx` password-change form (with custom copy: "Discard your password change?")

Already protected from iter 3: `agent-form` (create + edit), `rule-form`.

## Pattern

Each form already navigates only on mutation success. Added `form.reset(values)` on the success branch so the LeaveGuard doesn't intercept the parent's post-save navigation. On failure the form stays dirty so the user's edits are still protected.

```tsx
const onSubmit = async (values) => {
  const ok = await withMutationToast(...);
  if (ok) {
    form.reset(values);              // ← clears dirty so LeaveGuard skips the nav
    navigate({ to: "/tags" });
  }
};

return (
  <Form {...form}>
    <LeaveGuard when={form.formState.isDirty && !form.formState.isSubmitting} />
    <form onSubmit={form.handleSubmit(onSubmit)}>...
```

## Out of scope

Settings sub-forms in `household-section.tsx` / `backups-section.tsx` / `agents-section.tsx` deferred — those files are 600+ lines each and likely contain multiple sub-forms; needs per-form judgment on which fields are sensitive enough to warrant a guard. Filed as queue item #8.

## Test plan

- [ ] `cd web && bun run lint` ✅
- [ ] Open `/v2/tags/<slug>`, edit, try to navigate away → confirm dialog
- [ ] Same on `/v2/categories/<id>`, `/v2/api-keys/new`
- [ ] Open settings → Account, type into "New password" field, try to navigate away → confirm dialog ("Discard your password change?")
- [ ] Successful save → no dialog on the auto-nav
- [ ] Failed save → form stays dirty, dialog still fires on subsequent nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
