### PR TITLE
chore(v2): mobile-sweep detail-page coverage (mobile-safari iter 9)

### DIFF
--- a/.claude/mobile-safari-sprint.md
+++ b/.claude/mobile-safari-sprint.md
@@ -23,7 +23,8 @@ Perfect mobile support for the v2 SPA at `web/`, prioritizing iOS Safari (26.2+ 
 - ✅ Iter 5 (PR #1359 → sprint): restore bfcache on iOS Safari swipe-back. Pulled `/v2/*` out of the session-middleware group in `internal/api/router.go` so the static SPA bundle stops carrying `Vary: Cookie` (which WebKit treats as a bfcache blocker). Tightened the `pageshow` handler in `web/src/main.tsx` to only re-validate `["me"]` instead of invalidating every cached query, eliminating the post-restore refetch storm. Verified via curl against a freshly-built binary: `Vary: Cookie` is gone from `/v2/` responses.
 - ✅ Iter 6 (PR #1360 → sprint): `bun run memory-sweep` — Playwright-based structural-leak detector. Drives list↔detail N=20 times under webkit, samples DOM node count + shadcn slot count at iter 1/5/10/15/20, reports verdict per flow. Baseline: `/v2/accounts` clean (0 growth across 20 iters); `/v2/transactions` clean iter 1-15 (1838→1742, attrition) then drops to 252 at iter 20 — likely session loss after rapid navigations; flagged for follow-up investigation. WebKit doesn't expose `performance.memory`, so this is a structural proxy; real iOS heap data needs Safari Web Inspector.
 - ✅ Iter 7 (PR #1361 → sprint): rolled `LeaveGuard` out to `tag-form`, `category-form`, `api-key-form`, and the password-change form in `account-section.tsx`. Each navigates only on success and now resets the form before navigating (so the guard doesn't intercept the post-save nav). The password form uses a custom title/description.
-- ✅ Iter 8 (PR pending → sprint): Web Vitals listener at `web/src/lib/web-vitals.ts`. Uses standard `PerformanceObserver` for `largest-contentful-paint`, `event` (INP-proxy), and `layout-shift` (CLS). Gated by `VITE_REPORT_VITALS` (defaults to on in dev, off in prod). Logs structured `[vitals] ✓ LCP=504 (good) path=/v2/sandbox`-style lines. Verified: LCP=504ms and INP=112ms captured live on `/v2/sandbox`.
+- ✅ Iter 8 (PR #1362 → sprint): Web Vitals listener at `web/src/lib/web-vitals.ts`. Uses standard `PerformanceObserver` for `largest-contentful-paint`, `event` (INP-proxy), and `layout-shift` (CLS). Gated by `VITE_REPORT_VITALS` (defaults to on in dev, off in prod). Logs structured `[vitals] ✓ LCP=504 (good) path=/v2/sandbox`-style lines. Verified: LCP=504ms and INP=112ms captured live on `/v2/sandbox`.
+- ✅ Iter 9 (PR pending → sprint): extended `mobile-sweep` to walk 7 detail/edit flows (transactions, accounts, categories, tags, connections, rules, agents-edit) after the static routes. Each flow scrapes one short_id from its list and inspects the resolved detail URL. **All 7 detail pages clean across iPhone SE 1st-gen, iPhone 13, and iPhone 15 Pro Max** — 0 overflow, no JS errors. Detail surfaces inherit the layout work from earlier iterations.
 
 ## Queue (priority order)
 
@@ -33,23 +34,21 @@ Each iteration: pick the next item, branch off `mobile-safari/sprint`, ship a su
 
 2. **View Transitions wiring** — wrap `transactions list → detail` and `agents list → detail` route transitions with `startViewTransitionIfSupported`. Helper is in `lib/navigation/feature.ts`. Test fallback path (older browsers see instant navigation).
 
-3. **Detail-page sweep** — extend `mobile-sweep.ts` to scrape one ID per list route and visit the corresponding detail/edit/new pages. The current sweep only covers parameter-less routes.
+3. **iPhone SE 1st-gen (320px) edge** — `/v2/api-keys` still shows ~55px overflow on the 320px profile. Consider `table-layout: fixed` opt-in on DataTable or other approaches. Lowest priority — 320px devices are ~8 years old.
 
-4. **iPhone SE 1st-gen (320px) edge** — `/v2/api-keys` still shows ~55px overflow on the 320px profile. Consider `table-layout: fixed` opt-in on DataTable or other approaches. Lowest priority — 320px devices are ~8 years old.
+4. **bfcache verification** — write a Playwright test that actually exercises bfcache restore (multi-page traversal + back gesture). Confirms the `pageshow` + `event.persisted` handler in `main.tsx` fires correctly.
 
-5. **bfcache verification** — write a Playwright test that actually exercises bfcache restore (multi-page traversal + back gesture). Confirms the `pageshow` + `event.persisted` handler in `main.tsx` fires correctly.
+5. **Form-field iOS keyboard audit** — verify every `<Input>` consumer passes appropriate `inputMode` / `enterKeyHint` / `autoCapitalize` defaults. `SearchInput` already does; others might not.
 
-6. **Form-field iOS keyboard audit** — verify every `<Input>` consumer passes appropriate `inputMode` / `enterKeyHint` / `autoCapitalize` defaults. `SearchInput` already does; others might not.
+6. **LeaveGuard — remaining settings sub-forms** — audit `household-section`, `backups-section`, `agents-section` for `useForm` instances that need LeaveGuard. Those files are 600+ lines each and likely contain multiple sub-forms; needs per-form judgment on whether the field is sensitive enough to warrant a guard.
 
-7. **LeaveGuard — remaining settings sub-forms** — audit `household-section`, `backups-section`, `agents-section` for `useForm` instances that need LeaveGuard. Those files are 600+ lines each and likely contain multiple sub-forms; needs per-form judgment on whether the field is sensitive enough to warrant a guard.
+7. **Memory phase — TanStack Query `gcTime` cap** — cache currently has no upper bound on retained queries. Set a sensible `gcTime` (5 min default is fine for most; consider `Infinity` for `["me"]` and shorter for paginated lists). Verify via `bun run memory-sweep`.
 
-8. **Memory phase — TanStack Query `gcTime` cap** — cache currently has no upper bound on retained queries. Set a sensible `gcTime` (5 min default is fine for most; consider `Infinity` for `["me"]` and shorter for paginated lists). Verify via `bun run memory-sweep`.
+8. **Memory phase — virtualize transactions list** — long-history households render the entire TanStack Table row tree in DOM (1800+ nodes at iter 1 of the memory sweep). Add `@tanstack/react-virtual` row windowing to DataTable when row count exceeds N. Defer if a profile shows no real iOS pain.
 
-9. **Memory phase — virtualize transactions list** — long-history households render the entire TanStack Table row tree in DOM (1800+ nodes at iter 1 of the memory sweep). Add `@tanstack/react-virtual` row windowing to DataTable when row count exceeds N. Defer if a profile shows no real iOS pain.
+9. **Memory phase — `useEffect` cleanup audit** — grep for `useEffect` returning no cleanup against patterns that hold a listener (`addEventListener`, `setInterval`, `IntersectionObserver`, `MutationObserver`, `ResizeObserver`). Trace common offenders in `features/transactions/*` and `components/data-table.tsx`.
 
-10. **Memory phase — `useEffect` cleanup audit** — grep for `useEffect` returning no cleanup against patterns that hold a listener (`addEventListener`, `setInterval`, `IntersectionObserver`, `MutationObserver`, `ResizeObserver`). Trace common offenders in `features/transactions/*` and `components/data-table.tsx`.
-
-11. **Transactions session-loss after rapid navigations** — `bun run memory-sweep` shows `/v2/transactions` dropping to 252 nodes at iter 20 (AuthSplash territory). Likely session lifetime or scs middleware behavior under hammered navs. Reproduce, then either bump session ttl on /v2 boundary or stabilize the auth gate.
+10. **Transactions session-loss after rapid navigations** — `bun run memory-sweep` shows `/v2/transactions` dropping to 252 nodes at iter 20 (AuthSplash territory). Likely session lifetime or scs middleware behavior under hammered navs. Reproduce, then either bump session ttl on /v2 boundary or stabilize the auth gate.
 
 ## Operating notes
 

--- a/web/scripts/mobile-sweep.ts
+++ b/web/scripts/mobile-sweep.ts
@@ -45,6 +45,122 @@ const STATIC_ROUTES = [
   "/v2/sandbox",
 ];
 
+// Detail-page flows. For each, walk the list to scrape one short_id, then
+// inspect the resolved detail URL. Most lists render `<Link to="/<resource>/$id">`
+// rows, so a simple href-substring selector works; transactions deliberately
+// uses programmatic `onRowClick` so we click the first row instead.
+type DetailFlow = {
+  label: string;
+  listPath: string;
+  detailPath: (id: string) => string;
+  // Picker returns the short_id string or null. Receives a page already
+  // landed on listPath with networkidle reached.
+  pickId: (page: Page) => Promise<string | null>;
+};
+
+const DETAIL_FLOWS: DetailFlow[] = [
+  {
+    label: "/v2/transactions/$id",
+    listPath: "/v2/transactions",
+    detailPath: (id) => `/v2/transactions/${id}`,
+    // DataTable rows use onRowClick, no per-row anchor. Click the first
+    // body row and read the resulting URL.
+    pickId: async (p) => {
+      const row = p.locator("tbody tr").first();
+      await row.waitFor({ state: "visible", timeout: 5_000 }).catch(() => {});
+      const before = p.url();
+      await row.click().catch(() => {});
+      await p
+        .waitForURL(
+          (u) => u !== before && /\/v2\/transactions\/[^/?#]+/.test(u),
+          { timeout: 5_000 },
+        )
+        .catch(() => {});
+      return p.url().match(/\/v2\/transactions\/([^/?#]+)/)?.[1] ?? null;
+    },
+  },
+  {
+    label: "/v2/accounts/$id",
+    listPath: "/v2/accounts",
+    detailPath: (id) => `/v2/accounts/${id}`,
+    pickId: async (p) =>
+      await p.evaluate(() => {
+        const a = document.querySelector(
+          'a[href*="/v2/accounts/"]:not([href$="/accounts"])',
+        ) as HTMLAnchorElement | null;
+        return a?.href.match(/\/v2\/accounts\/([^/?#]+)/)?.[1] ?? null;
+      }),
+  },
+  {
+    label: "/v2/categories/$id",
+    listPath: "/v2/categories",
+    detailPath: (id) => `/v2/categories/${id}`,
+    pickId: async (p) =>
+      await p.evaluate(() => {
+        const a = document.querySelector(
+          'a[href*="/v2/categories/"]:not([href$="/categories"]):not([href$="/category/new"])',
+        ) as HTMLAnchorElement | null;
+        return a?.href.match(/\/v2\/categories\/([^/?#]+)/)?.[1] ?? null;
+      }),
+  },
+  {
+    label: "/v2/tags/$slug",
+    listPath: "/v2/tags",
+    detailPath: (slug) => `/v2/tags/${slug}`,
+    pickId: async (p) =>
+      await p.evaluate(() => {
+        const a = document.querySelector(
+          'a[href*="/v2/tags/"]:not([href$="/tags"]):not([href$="/tag/new"])',
+        ) as HTMLAnchorElement | null;
+        return a?.href.match(/\/v2\/tags\/([^/?#]+)/)?.[1] ?? null;
+      }),
+  },
+  {
+    label: "/v2/connections/$id",
+    listPath: "/v2/connections",
+    detailPath: (id) => `/v2/connections/${id}`,
+    pickId: async (p) =>
+      await p.evaluate(() => {
+        const a = document.querySelector(
+          'a[href*="/v2/connections/"]:not([href$="/connections"])',
+        ) as HTMLAnchorElement | null;
+        return a?.href.match(/\/v2\/connections\/([^/?#]+)/)?.[1] ?? null;
+      }),
+  },
+  {
+    label: "/v2/rules/$id",
+    listPath: "/v2/rules",
+    detailPath: (id) => `/v2/rules/${id}`,
+    pickId: async (p) =>
+      await p.evaluate(() => {
+        const a = document.querySelector(
+          'a[href*="/v2/rules/"]:not([href$="/rules"])',
+        ) as HTMLAnchorElement | null;
+        return a?.href.match(/\/v2\/rules\/([^/?#]+)/)?.[1] ?? null;
+      }),
+  },
+  {
+    label: "/v2/agents/$slug/edit",
+    listPath: "/v2/agents",
+    detailPath: (slug) => `/v2/agents/${slug}/edit`,
+    // Agents list uses DataTable + onRowClick like transactions — no per-row
+    // anchor. Click the first body row, capture the resulting URL.
+    pickId: async (p) => {
+      const row = p.locator("tbody tr").first();
+      await row.waitFor({ state: "visible", timeout: 5_000 }).catch(() => {});
+      const before = p.url();
+      await row.click().catch(() => {});
+      await p
+        .waitForURL(
+          (u) => u !== before && /\/v2\/agents\/[^/]+\/edit/.test(u),
+          { timeout: 5_000 },
+        )
+        .catch(() => {});
+      return p.url().match(/\/v2\/agents\/([^/]+)\/edit/)?.[1] ?? null;
+    },
+  },
+];
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const portFile = join(repoRoot, ".breadbox-port");
 
@@ -335,7 +451,7 @@ async function main() {
   console.log(`base: ${baseUrl}`);
   console.log(`out:  ${outDir}`);
   console.log(`viewports: ${VIEWPORTS.map((v) => v.name).join(", ")}`);
-  console.log(`routes: ${STATIC_ROUTES.length}`);
+  console.log(`static routes: ${STATIC_ROUTES.length}, detail flows: ${DETAIL_FLOWS.length}`);
   console.log("");
 
   const browser = await webkit.launch({ headless: true });
@@ -357,6 +473,39 @@ async function main() {
           finding.ok ? null : "navfail",
         ].filter(Boolean);
         console.log(tags.length === 0 ? "ok" : tags.join(" "));
+      }
+      // Detail flows: scrape an id from each list, then inspect the resolved
+      // detail/edit page like any other route.
+      for (const flow of DETAIL_FLOWS) {
+        process.stdout.write(`  [${viewport.name}] ${flow.label} ... `);
+        try {
+          await page.goto(`${baseUrl}${flow.listPath}`, {
+            waitUntil: "domcontentloaded",
+            timeout: 10_000,
+          });
+          await page.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => {});
+          await page.waitForTimeout(300);
+          const id = await flow.pickId(page);
+          if (!id) {
+            console.log("skipped (no id found on list)");
+            continue;
+          }
+          const finding = await inspect(page, flow.detailPath(id), viewport);
+          // Mark the route label as the templated path (not the resolved
+          // one) so reports across runs are comparable.
+          finding.route = flow.label;
+          findings.push(finding);
+          const tags = [
+            finding.overflowPx > 0 ? `overflow=${finding.overflowPx}px` : null,
+            finding.smallTapTargets > 0 ? `taps=${finding.smallTapTargets}` : null,
+            finding.consoleErrors.length > 0 ? `js=${finding.consoleErrors.length}` : null,
+            finding.pageErrors.length > 0 ? `pe=${finding.pageErrors.length}` : null,
+            finding.ok ? null : "navfail",
+          ].filter(Boolean);
+          console.log(tags.length === 0 ? "ok" : tags.join(" "));
+        } catch (err) {
+          console.log(`error: ${(err as Error).message}`);
+        }
       }
       await ctx.close();
     }


### PR DESCRIPTION
## Summary

Iter 9 of the mobile-safari sprint. Extends `bun run mobile-sweep` to walk **7 detail/edit flows** in addition to the 16 parameter-less routes, closing a known gap in the regression loop.

For each flow the sweep scrapes one `short_id` from the list page and inspects the resolved detail URL like any other route. Picker strategies:

- **Anchor lookup** (`a[href*="/v2/<resource>/"]`) for accounts, categories, tags, connections, rules — those lists render per-row `<Link>` elements.
- **First-row click + URL read** for transactions and agents-edit — those lists use DataTable's `onRowClick` (no per-row anchor).

## Detail-page baseline (3 viewports × 7 flows)

| flow | iPhone SE 1st-gen | iPhone 13 | iPhone 15 PM |
|---|:---:|:---:|:---:|
| `/v2/transactions/$id` | clean | clean | clean |
| `/v2/accounts/$id` | clean | clean | clean |
| `/v2/categories/$id` | clean | clean | clean |
| `/v2/tags/$slug` | clean | clean | clean |
| `/v2/connections/$id` | clean | clean | clean |
| `/v2/rules/$id` | clean | clean | clean |
| `/v2/agents/$slug/edit` | clean | clean | clean |

**0 horizontal overflow on every detail page, every viewport** — including the 320px iPhone SE 1st-gen profile. 0 JS errors. The earlier per-route layout work on list pages carries through to detail pages — no new findings to file.

(Tap-target counts: 7-13 per page. Same `pointer-coarse:before` recipe calibration question already on the queue.)

## Test plan

- [ ] `cd web && bun run lint` ✅
- [ ] `make dev` + `make web-dev`, then `BASE_URL=http://localhost:6080 bun run mobile-sweep`
- [ ] Output should now include `/v2/transactions/$id`, `/v2/accounts/$id`, etc. lines per viewport
- [ ] `tmp/mobile-sweep-<stamp>/findings.md` has the per-flow per-viewport trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
