### PR TITLE
fix(v2): iOS keyboard hints on identifier inputs (mobile-safari iter 10)

### DIFF
--- a/.claude/mobile-safari-sprint.md
+++ b/.claude/mobile-safari-sprint.md
@@ -24,7 +24,8 @@ Perfect mobile support for the v2 SPA at `web/`, prioritizing iOS Safari (26.2+ 
 - ✅ Iter 6 (PR #1360 → sprint): `bun run memory-sweep` — Playwright-based structural-leak detector. Drives list↔detail N=20 times under webkit, samples DOM node count + shadcn slot count at iter 1/5/10/15/20, reports verdict per flow. Baseline: `/v2/accounts` clean (0 growth across 20 iters); `/v2/transactions` clean iter 1-15 (1838→1742, attrition) then drops to 252 at iter 20 — likely session loss after rapid navigations; flagged for follow-up investigation. WebKit doesn't expose `performance.memory`, so this is a structural proxy; real iOS heap data needs Safari Web Inspector.
 - ✅ Iter 7 (PR #1361 → sprint): rolled `LeaveGuard` out to `tag-form`, `category-form`, `api-key-form`, and the password-change form in `account-section.tsx`. Each navigates only on success and now resets the form before navigating (so the guard doesn't intercept the post-save nav). The password form uses a custom title/description.
 - ✅ Iter 8 (PR #1362 → sprint): Web Vitals listener at `web/src/lib/web-vitals.ts`. Uses standard `PerformanceObserver` for `largest-contentful-paint`, `event` (INP-proxy), and `layout-shift` (CLS). Gated by `VITE_REPORT_VITALS` (defaults to on in dev, off in prod). Logs structured `[vitals] ✓ LCP=504 (good) path=/v2/sandbox`-style lines. Verified: LCP=504ms and INP=112ms captured live on `/v2/sandbox`.
-- ✅ Iter 9 (PR pending → sprint): extended `mobile-sweep` to walk 7 detail/edit flows (transactions, accounts, categories, tags, connections, rules, agents-edit) after the static routes. Each flow scrapes one short_id from its list and inspects the resolved detail URL. **All 7 detail pages clean across iPhone SE 1st-gen, iPhone 13, and iPhone 15 Pro Max** — 0 overflow, no JS errors. Detail surfaces inherit the layout work from earlier iterations.
+- ✅ Iter 9 (PR #1363 → sprint): extended `mobile-sweep` to walk 7 detail/edit flows (transactions, accounts, categories, tags, connections, rules, agents-edit) after the static routes. Each flow scrapes one short_id from its list and inspects the resolved detail URL. **All 7 detail pages clean across iPhone SE 1st-gen, iPhone 13, and iPhone 15 Pro Max** — 0 overflow, no JS errors. Detail surfaces inherit the layout work from earlier iterations.
+- ✅ Iter 10 (PR pending → sprint): iOS keyboard-hint audit + targeted fixes. Added `autoCapitalize="none"` / `autoCorrect="off"` / `spellCheck={false}` to: `action-row.tsx` tag-slug input, `cron-field.tsx` cron-expression input, `account-section.tsx` 3 password fields. Added `type="search"` + `inputMode="search"` + `enterKeyHint="search"` + same anti-correction set to `transcript-viewer.tsx` search box. Audit cleared all other identifier-style inputs as already-handled.
 
 ## Queue (priority order)
 
@@ -38,17 +39,15 @@ Each iteration: pick the next item, branch off `mobile-safari/sprint`, ship a su
 
 4. **bfcache verification** — write a Playwright test that actually exercises bfcache restore (multi-page traversal + back gesture). Confirms the `pageshow` + `event.persisted` handler in `main.tsx` fires correctly.
 
-5. **Form-field iOS keyboard audit** — verify every `<Input>` consumer passes appropriate `inputMode` / `enterKeyHint` / `autoCapitalize` defaults. `SearchInput` already does; others might not.
+5. **LeaveGuard — remaining settings sub-forms** — audit `household-section`, `backups-section`, `agents-section` for `useForm` instances that need LeaveGuard. Those files are 600+ lines each and likely contain multiple sub-forms; needs per-form judgment on whether the field is sensitive enough to warrant a guard.
 
-6. **LeaveGuard — remaining settings sub-forms** — audit `household-section`, `backups-section`, `agents-section` for `useForm` instances that need LeaveGuard. Those files are 600+ lines each and likely contain multiple sub-forms; needs per-form judgment on whether the field is sensitive enough to warrant a guard.
+6. **Memory phase — TanStack Query `gcTime` cap** — cache currently has no upper bound on retained queries. Set a sensible `gcTime` (5 min default is fine for most; consider `Infinity` for `["me"]` and shorter for paginated lists). Verify via `bun run memory-sweep`.
 
-7. **Memory phase — TanStack Query `gcTime` cap** — cache currently has no upper bound on retained queries. Set a sensible `gcTime` (5 min default is fine for most; consider `Infinity` for `["me"]` and shorter for paginated lists). Verify via `bun run memory-sweep`.
+7. **Memory phase — virtualize transactions list** — long-history households render the entire TanStack Table row tree in DOM (1800+ nodes at iter 1 of the memory sweep). Add `@tanstack/react-virtual` row windowing to DataTable when row count exceeds N. Defer if a profile shows no real iOS pain.
 
-8. **Memory phase — virtualize transactions list** — long-history households render the entire TanStack Table row tree in DOM (1800+ nodes at iter 1 of the memory sweep). Add `@tanstack/react-virtual` row windowing to DataTable when row count exceeds N. Defer if a profile shows no real iOS pain.
+8. **Memory phase — `useEffect` cleanup audit** — grep for `useEffect` returning no cleanup against patterns that hold a listener (`addEventListener`, `setInterval`, `IntersectionObserver`, `MutationObserver`, `ResizeObserver`). Trace common offenders in `features/transactions/*` and `components/data-table.tsx`.
 
-9. **Memory phase — `useEffect` cleanup audit** — grep for `useEffect` returning no cleanup against patterns that hold a listener (`addEventListener`, `setInterval`, `IntersectionObserver`, `MutationObserver`, `ResizeObserver`). Trace common offenders in `features/transactions/*` and `components/data-table.tsx`.
-
-10. **Transactions session-loss after rapid navigations** — `bun run memory-sweep` shows `/v2/transactions` dropping to 252 nodes at iter 20 (AuthSplash territory). Likely session lifetime or scs middleware behavior under hammered navs. Reproduce, then either bump session ttl on /v2 boundary or stabilize the auth gate.
+9. **Transactions session-loss after rapid navigations** — `bun run memory-sweep` shows `/v2/transactions` dropping to 252 nodes at iter 20 (AuthSplash territory). Likely session lifetime or scs middleware behavior under hammered navs. Reproduce, then either bump session ttl on /v2 boundary or stabilize the auth gate.
 
 ## Operating notes
 

--- a/web/src/features/agents/cron-field.tsx
+++ b/web/src/features/agents/cron-field.tsx
@@ -58,6 +58,9 @@ export function CronField({
           onBlur={onBlur}
           className="pr-10 font-mono text-sm"
           aria-invalid={!valid}
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
         />
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>

--- a/web/src/features/agents/transcript-viewer.tsx
+++ b/web/src/features/agents/transcript-viewer.tsx
@@ -317,6 +317,12 @@ export function TranscriptViewer({
       <div className="relative">
         <Search className="text-muted-foreground pointer-events-none absolute left-2 top-1/2 size-4 -translate-y-1/2" />
         <Input
+          type="search"
+          inputMode="search"
+          enterKeyHint="search"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           placeholder="Search transcript (assistant text, tool names, args, results)…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}

--- a/web/src/features/rules/action-row.tsx
+++ b/web/src/features/rules/action-row.tsx
@@ -144,6 +144,9 @@ export function ActionRowFields({
             className="bg-background h-8"
             placeholder="needs-review, subscription:monthly, …"
             pattern="^[a-z0-9][a-z0-9\-:]*[a-z0-9]$"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             aria-invalid={tagInvalid}
             aria-describedby={`action-${index}-hint`}
           />

--- a/web/src/features/settings/account-section.tsx
+++ b/web/src/features/settings/account-section.tsx
@@ -81,7 +81,14 @@ export function AccountSection() {
                 <FormItem>
                   <FormLabel>Current password</FormLabel>
                   <FormControl>
-                    <Input type="password" autoComplete="current-password" {...field} />
+                    <Input
+                      type="password"
+                      autoComplete="current-password"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -94,7 +101,14 @@ export function AccountSection() {
                 <FormItem>
                   <FormLabel>New password</FormLabel>
                   <FormControl>
-                    <Input type="password" autoComplete="new-password" {...field} />
+                    <Input
+                      type="password"
+                      autoComplete="new-password"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -107,7 +121,14 @@ export function AccountSection() {
                 <FormItem>
                   <FormLabel>Confirm new password</FormLabel>
                   <FormControl>
-                    <Input type="password" autoComplete="new-password" {...field} />
+                    <Input
+                      type="password"
+                      autoComplete="new-password"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## Summary

Iter 10 of the mobile-safari sprint. Audited every `<Input>` consumer across the v2 SPA for iOS keyboard hints per `.claude/rules/v2-frontend.md` § "Form ergonomics — iOS keyboard hints" and patched the gaps.

## Fixes

- **`action-row.tsx` tag-slug input** — added `autoCapitalize="none"` / `autoCorrect="off"` / `spellCheck={false}` so iOS doesn't autocap `needs-review` to `Needs-review` or autocorrect colon-separated namespaces like `subscription:monthly`.
- **`cron-field.tsx` cron-expression input** — same triad so `0 9 * * *` doesn't get mangled.
- **`account-section.tsx` three password fields** — added the triad on top of existing `autoComplete`. Passwords like `Tr0ub4dor&3` shouldn't trigger autocorrect or first-letter capitalization.
- **`transcript-viewer.tsx` search input** — added `type="search"` + `inputMode="search"` + `enterKeyHint="search"` + the triad. Surfaces the magnifier return-key glyph and stops iOS from autocorrecting tool names + assistant phrases. Kept the bespoke wrapper (it has its own clear + highlight chrome) instead of migrating to `SearchInput`.

## Cleared (already compliant — no change needed)

- agent slug input
- tag slug input
- rule numeric priority (`inputMode="numeric"`)
- `condition-row` ValueInput (numeric, tags, generic-text all properly handled)
- `SearchInput` consumers everywhere
- comment-composer (`enterKeyHint="send"`)
- `link-account-sheet` tolerance numeric
- agent-form numeric fields (max_turns / max_budget)
- color-picker hex input
- `account-settings-card` display name (correct as-is — names should autocapitalize)

## Test plan

- [ ] `cd web && bun run lint` ✅
- [ ] `cd web && BASE_URL=http://localhost:6080 bun run mobile-sweep` — no regressions
- [ ] On a real iPhone: type into the tag-slug field (rule actions, "add tag" row) — Apple shouldn't auto-cap the first letter
- [ ] Type into the cron field — no autocorrect mangling
- [ ] Open transcript drawer search — search return-key glyph appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
