### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/web/src/features/agents/agent-form.tsx
+++ b/web/src/features/agents/agent-form.tsx
@@ -124,11 +124,6 @@ export function AgentForm({
           iPad portrait (768) with the sidebar visible the right column
           collapses to ~155px and the inputs become unreadable. Defer the
           3-col layout to `lg` (1024px) so iPad portrait gets the same
-          stacked layout as phones. */}
-      {/* `md` breakpoint at 768px tries to split into a 2:1 grid, but on
-          iPad portrait (768) with the sidebar visible the right column
-          collapses to ~155px and the inputs become unreadable. Defer the
-          3-col layout to `lg` (1024px) so iPad portrait gets the same
           stacked layout as phones.
 
           `min-w-0` on each grid item: CSS Grid items default to


### PR DESCRIPTION
## Summary

Daily simplify-drift review of PRs merged in the last 24 hours.

## PRs reviewed

- #1397 — feat(v2): mobile Safari support sprint for the v2 SPA
- #1380 — fix(mcp): wrap list_annotations in {"annotations": [...]} envelope

## Changes

- `web/src/features/agents/agent-form.tsx:123` — removed a duplicated JSDoc comment block. The standalone shorter copy was fully contained in the longer block that immediately follows it (which adds the `min-w-0` rationale), so it was pure redundancy.

Both PRs otherwise reviewed clean across reuse, quality, and efficiency:
- #1380's `decodeAnnotations` test helper correctly composes existing `decodeToolResult`/`requireKeys`/`asArray` helpers; the envelope comment is genuine WHY.
- #1397's substantive new code (`LeaveGuard`, `web-vitals`, the `selection-action-bar` migration to the shared `FloatingActionBar`, `embed.go` MIME registration, `router.go`) reuses existing helpers/stdlib and contains efficiency *fixes* (scoped bfcache `invalidateQueries`, lazy routes, vendor chunking) rather than regressions. The remaining diff is CSS/attribute additions, Playwright specs, docs, and dev tooling.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `bun run lint` (tsc, web)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpNgzAhCyCFQXMQ5GT6K8N)_