### PR TITLE
fix(agents): attribute in-app agent annotations to the per-run agent key

### DIFF
--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"breadbox/internal/app"
@@ -75,15 +76,17 @@ func runMCPStdio(parent context.Context, version string) error {
 	}
 	defer a.DB.Close()
 
-	// Ensure a system-actor API key row exists so ContextWithAPIKey can
-	// point at a real `actor_type='system'` record. The plaintext is never
-	// exposed externally — this row is purely a DB-side anchor for the
-	// audit trail.
-	systemKey, err := ensureStdioSystemKey(ctx, a.Queries)
+	// Resolve the actor: if BREADBOX_API_KEY is set in the env and validates
+	// against a live row, use it — this is how the in-app agent orchestrator
+	// attributes annotations to the per-run agent key (actor_type='agent',
+	// actor_name=<slug>) instead of the stdio singleton. Otherwise fall back
+	// to the system-actor singleton row so Claude Desktop and other plain
+	// stdio clients still get a real `api_keys` row to point at.
+	actorKey, scope, err := resolveStdioActorKey(ctx, a.Service, a.Queries)
 	if err != nil {
-		return fmt.Errorf("ensure stdio system key: %w", err)
+		return fmt.Errorf("resolve stdio actor key: %w", err)
 	}
-	ctx = service.ContextWithAPIKey(ctx, systemKey)
+	ctx = service.ContextWithAPIKey(ctx, actorKey)
 
 	mcpServer := breadboxmcp.NewMCPServer(a.Service, version)
 
@@ -100,7 +103,7 @@ func runMCPStdio(parent context.Context, version string) error {
 		Mode:          mcpCfg.Mode,
 		DisabledTools: mcpCfg.DisabledTools,
 		Instructions:  mcpCfg.Instructions,
-		APIKeyScope:   "full_access", // stdio has no API key surface
+		APIKeyScope:   scope,
 	})
 
 	sigCh := make(chan os.Signal, 1)
@@ -112,6 +115,33 @@ func runMCPStdio(parent context.Context, version string) error {
 
 	logger.Info("starting MCP stdio server", "version", version)
 	return server.Run(ctx, &mcpsdk.StdioTransport{})
+}
+
+// resolveStdioActorKey picks the api_keys row that should be attached to
+// the stdio session's context. When BREADBOX_API_KEY is set and validates
+// (the orchestrator passes its per-run agent key here), use that row so
+// annotations and audit events are attributed to the agent. Falls back to
+// the stdio singleton (actor_type='system', actor_name='stdio') for
+// unauthenticated callers like a developer's Claude Desktop pointing at
+// the binary directly. Returns the resolved key plus the scope BuildServer
+// should advertise (so a read_only agent key narrows the exposed toolset).
+func resolveStdioActorKey(ctx context.Context, svc *service.Service, q *db.Queries) (*db.ApiKey, string, error) {
+	if token := strings.TrimSpace(os.Getenv("BREADBOX_API_KEY")); token != "" {
+		key, err := svc.ValidateAPIKey(ctx, token)
+		if err == nil {
+			return key, key.Scope, nil
+		}
+		// Fall through to the singleton on validation failure so a
+		// stale/typo'd env var doesn't break the stdio entry point.
+		// The MCP child can still serve read-only tools under the
+		// system actor; the orchestrator's mint-and-revoke contract
+		// means a valid agent key is always present for real runs.
+	}
+	key, err := ensureStdioSystemKey(ctx, q)
+	if err != nil {
+		return nil, "", err
+	}
+	return key, "full_access", nil
 }
 
 // stdioSystemKeyPrefix is the unique prefix of the singleton stdio key

--- a/internal/cli/mcp_integration_test.go
+++ b/internal/cli/mcp_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration && !lite
+
+package cli
+
+import (
+	"log/slog"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+func TestResolveStdioActorKey_UsesBreadboxAPIKeyEnv(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+	ctx := t.Context()
+
+	created, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+		Name:      "agent:reviewer:abc123de",
+		Scope:     "full_access",
+		ActorType: "agent",
+		ActorName: "reviewer",
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	t.Setenv("BREADBOX_API_KEY", created.PlaintextKey)
+
+	got, scope, err := resolveStdioActorKey(ctx, svc, queries)
+	if err != nil {
+		t.Fatalf("resolveStdioActorKey: %v", err)
+	}
+	if got.ActorType != "agent" {
+		t.Errorf("ActorType = %q, want %q", got.ActorType, "agent")
+	}
+	if !got.ActorName.Valid || got.ActorName.String != "reviewer" {
+		t.Errorf("ActorName = %+v, want valid=true string=%q", got.ActorName, "reviewer")
+	}
+	if scope != "full_access" {
+		t.Errorf("scope = %q, want %q", scope, "full_access")
+	}
+}
+
+func TestResolveStdioActorKey_PropagatesReadOnlyScope(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+	ctx := t.Context()
+
+	created, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+		Name:      "agent:viewer:def45678",
+		Scope:     "read_only",
+		ActorType: "agent",
+		ActorName: "viewer",
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	t.Setenv("BREADBOX_API_KEY", created.PlaintextKey)
+
+	_, scope, err := resolveStdioActorKey(ctx, svc, queries)
+	if err != nil {
+		t.Fatalf("resolveStdioActorKey: %v", err)
+	}
+	if scope != "read_only" {
+		t.Errorf("scope = %q, want %q", scope, "read_only")
+	}
+}
+
+func TestResolveStdioActorKey_FallsBackToStdioSingleton(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+	ctx := t.Context()
+
+	t.Setenv("BREADBOX_API_KEY", "")
+
+	got, scope, err := resolveStdioActorKey(ctx, svc, queries)
+	if err != nil {
+		t.Fatalf("resolveStdioActorKey: %v", err)
+	}
+	if got.ActorType != "system" {
+		t.Errorf("ActorType = %q, want %q", got.ActorType, "system")
+	}
+	if !got.ActorName.Valid || got.ActorName.String != "stdio" {
+		t.Errorf("ActorName = %+v, want valid=true string=%q", got.ActorName, "stdio")
+	}
+	if scope != "full_access" {
+		t.Errorf("scope = %q, want %q", scope, "full_access")
+	}
+}
+
+func TestResolveStdioActorKey_InvalidKeyFallsBack(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+	ctx := t.Context()
+
+	t.Setenv("BREADBOX_API_KEY", "bb_not_a_real_key_12345")
+
+	got, _, err := resolveStdioActorKey(ctx, svc, queries)
+	if err != nil {
+		t.Fatalf("resolveStdioActorKey: %v", err)
+	}
+	if got.ActorType != "system" {
+		t.Errorf("ActorType = %q, want %q (stdio singleton fallback)", got.ActorType, "system")
+	}
+}


### PR DESCRIPTION
## Summary

In-app agent edits were all showing up as **"stdio"** in the activity timeline instead of referencing the agent that made them.

**Root cause:** the agent orchestrator already mints a scoped `actor_type='agent'` API key per run (name `agent:<slug>:<runID>`, `actor_name=<slug>`) and passes it as `BREADBOX_API_KEY` to the spawned `breadbox mcp` subprocess (`internal/service/agents.go`). But `runMCPStdio` ignored that env var and unconditionally attached the system/stdio singleton row (`actor_type='system'`, `actor_name='stdio'`) to the context — so every annotation the agent wrote was attributed to "stdio".

**Fix:** `runMCPStdio` now resolves the actor via a new `resolveStdioActorKey` helper:
- If `BREADBOX_API_KEY` is set and validates against a live row, use it — and propagate its scope to `BuildServer` so a `read_only` agent key still narrows the exposed toolset.
- Otherwise fall back to the stdio singleton, so plain stdio clients (Claude Desktop pointing at the binary directly) keep working. A stale/typo'd env var also falls back rather than breaking the entry point.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean (default, `-tags=lite`, `-tags=headless`)
- [x] New integration tests in `internal/cli/mcp_integration_test.go`:
  - agent key wins over the singleton
  - `read_only` scope propagates
  - missing env → stdio singleton fallback
  - invalid env → stdio singleton fallback
- [x] Existing integration suites for `cli`/`service`/`mcp`/`agent` pass
- [ ] Manual: trigger an in-app agent run that tags/comments a transaction, confirm the timeline shows the agent slug rather than "stdio"

🤖 Generated with [Claude Code](https://claude.com/claude-code)