### PR TITLE
fix(v2): remove View Transitions that blank iOS Safari back-swipe preview

### DIFF
--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -147,10 +147,11 @@ export function TagsTable({
         isError={isError}
         getRowId={(t) => t.id}
         onRowClick={(t) =>
+          // No `viewTransition` — it blanks iOS Safari's back-swipe preview
+          // on scrolled list→detail navs (see transactions.tsx / csswg#8333).
           navigate({
             to: "/tags/$slug",
             params: { slug: t.slug },
-            viewTransition: true,
           })
         }
         emptyState={emptyState}

--- a/web/src/routes/agents.tsx
+++ b/web/src/routes/agents.tsx
@@ -194,10 +194,11 @@ export function AgentsPage() {
           isLoading={agentsQuery.isLoading}
           getRowId={(a) => a.id}
           onRowClick={(a) =>
+            // No `viewTransition` — it blanks iOS Safari's back-swipe preview
+            // on scrolled list→detail navs (see transactions.tsx / csswg#8333).
             navigate({
               to: "/agents/$slug/edit",
               params: { slug: a.slug },
-              viewTransition: true,
             })
           }
           refinedHeader

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -164,14 +164,17 @@ export function TransactionsPage() {
 
   const openTransaction = useCallback(
     (t: Transaction) =>
-      // `viewTransition: true` opts into the browser's View Transitions API
-      // on Safari 26.2+, Chrome, and Firefox — list → detail gets a
-      // cross-fade instead of an instant swap. TanStack Router gates on
-      // `document.startViewTransition` so older browsers see plain nav.
+      // NOTE: deliberately NO `viewTransition: true`. Running a same-document
+      // View Transition on a scrolled list→detail nav corrupts iOS Safari's
+      // back-swipe preview snapshot — the gesture reveals a blank page while
+      // swiping back. Safari captures its preview mid-transition and there's
+      // no way to opt out of that capture (csswg-drafts#8333, "incorrect
+      // capture"); the `hasUAVisualTransition` coordination that mitigates it
+      // isn't present on the Safari versions we target. A cross-fade isn't
+      // worth a broken back gesture. Same applies on /tags and /agents.
       navigate({
         to: "/transactions/$id",
         params: { id: t.short_id },
-        viewTransition: true,
       }),
     [navigate],
   );


### PR DESCRIPTION
## Summary

On iOS Safari, scrolling a list, opening a row's detail page, then swiping back showed a **blank page during the back-swipe gesture**. Root cause: the View Transition we run on list→detail navigations (added iter-14) corrupts Safari's back/forward swipe-preview snapshot.

## Root cause

`viewTransition: true` was set on three list→detail navigations — transactions, tags, agents. When the user taps a row, TanStack runs `document.startViewTransition()` for a cross-fade. iOS Safari independently captures a back-swipe **preview snapshot** at navigation time, and per the CSS WG's analysis of this exact interaction ([csswg-drafts#8333](https://github.com/w3c/csswg-drafts/issues/8333), "incorrect capture"), it captures *during* the transition — producing a blank/inconsistent frame that's then shown while swiping back. Scroll position is the trigger: at scroll 0 the captured frame happens to match a fresh render, so it looks fine; once scrolled it no longer matches and renders blank.

The platform's mitigation (`hasUAVisualTransition`, which lets a page skip its own transition when the UA is doing its back-preview) isn't present on the Safari versions we actually target, and even where present it addresses the *double-transition* case, not the *incorrect-capture* case that bites us here.

## Fix

Remove `viewTransition: true` from the three navs. The cross-fade was iter-14 polish; a broken back-swipe gesture is a far worse trade. Navigation still works exactly as before — it's just an instant swap. Each call site keeps a comment so the flag isn't re-added without understanding the conflict.

(The `startViewTransitionIfSupported` helper in `lib/navigation/feature.ts` is left in place — it's unused util code now, not part of this bug.)

## Verification

- `bun run lint` clean.
- Chrome: row-click on `/transactions` still navigates to the detail route (no regression; transition just no longer runs).
- ⚠️ **Needs on-device confirmation**: the iOS back-swipe gesture can't be driven from a headless/desktop environment, so the actual "blank preview is gone" check has to happen on a real iPhone against this build.

## Out of scope

The separate "every page swipe-back is blank in macOS Safari" behavior is a general Safari-on-SPAs limitation (reproduces across many sites, version 18.x), not introduced by us — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
