### PR TITLE
ci(webapp): build v3 /app assets in CI, release & Docker

### DIFF
--- a/.claude/v3-sprint-state.md
+++ b/.claude/v3-sprint-state.md
@@ -32,12 +32,14 @@ subagents, validate every surface with Chrome DevTools, merge PRs into this spri
       login gate, Node-free build, app-mpa.md rule. Validated desktop+mobile+dark, no console errors.
 - [x] Phase 2 — Read surfaces **DONE** (transactions, connections, providers, categories, tags, rules,
       api-keys, agents+runs, placeholders). Built via 4 fanned-out subagents, integrated, Chrome-validated.
-- [ ] Phase 3 — Write surfaces/forms + settings
+- [x] Phase 3 — Write surfaces/forms + settings **DONE & MERGED** (PR #1404). Forms for category/tag/
+      api-key/rule/agent + agent settings + real /app/settings + setup-account. Validated (creates persist).
 - [ ] Phase 4 — Islands (⌘K, dnd)
 - [ ] Phase 5 — Streaming (Datastar+SSE)
 - [ ] Phase 6 — Cutover + parity audit
 
 ## Progress log (newest first)
+- 2026-05-21 01:4x — Phase 3 MERGED (PR #1404). Core CRUD app complete (read+write+settings+auth). 3 PRs merged into sprint branch. NEXT: (#14) CI/deploy wiring — CRITICAL gotcha: CI runs `templ generate` directly and only injects the !headless&&!lite build tag into internal/templates/components; it MUST also inject into internal/webapp generated files or headless/lite CI cells break. Delegated #14 to a subagent. After that: Phase 4 (esbuild-via-Go islands: ⌘K palette, drag-drop rule builder), Phase 5 (Datastar+SSE streaming: sync progress, agent transcripts, activity timeline), Phase 6 cutover (302 /v2→/app, retire SPA), then loop end-state (deprecate v1+SPA, Playwright polish/mobile).
 - 2026-05-21 01:2x — Phase 3 form pattern PROVEN: Category create/edit validated in Chrome (create→303→detail, slug auto-gen, persisted). Reusable components/forms.templ established. Created a "V3 Test Category" in dev DB (harmless test data; no delete UI yet). Fanned out 4 more form agents: (A) tags+api-keys, (B) rules, (C) agents+settings-tokens, (D) settings routes+setup-account. INTEGRATION TODO when they return: wire `h.registerSettings(r)` into AUTHED group + `h.registerSetup(r)` into PUBLIC group in handler.go, and REMOVE `/settings` from registerPlaceholders (settings replaces it). Then templ generate, build, fix collisions, rebuild binary, restart :8088, Chrome-validate, PR. Watch: secrets must stay masked (agents tokens, api-key plaintext only on create page); category_override sacred.
 - 2026-05-21 01:1x — Phase 2 MERGED (PR #1403). Starting Phase 3 forms: launched 1 subagent to establish the reusable form-component pattern + Category create/edit exemplar. When it returns: validate, then fan out tags/api-keys/rules/agents/settings/setup-account forms following that pattern.
 - 2026-05-21 01:0x — Phase 2 read surfaces DONE & validated (no console errors). 9 surfaces live under /app. Fixed missing </div> in categories/tags templ from subagents. templ+build+vet green. Opening Phase 2 PR. Next: Phase 3 write surfaces/forms (+ real settings).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,12 @@ jobs:
         run: |
           templ generate
           # Prepend //go:build !headless && !lite to every generated templ
-          # file in internal/templates/components. Mirrors `make templ`.
-          find internal/templates/components -name '*_templ.go' -print0 | while IFS= read -r -d '' f; do
+          # file in internal/templates/components AND internal/webapp (the v3
+          # MPA). Mirrors `make templ` (which globs both dirs). Without the
+          # webapp glob, its *_templ.go would be untagged in CI and would
+          # compile under -tags=headless/-tags=lite, dragging in excluded
+          # packages and reddening those matrix cells.
+          find internal/templates/components internal/webapp -name '*_templ.go' -print0 | while IFS= read -r -d '' f; do
             if ! head -1 "$f" | grep -q '^//go:build'; then
               printf '//go:build !headless && !lite\n\n' | cat - "$f" > "$f.tmp" && mv "$f.tmp" "$f"
             fi
@@ -116,7 +120,13 @@ jobs:
           fi
 
       - name: Build CSS
-        run: make css
+        # webapp-css builds internal/webapp/static/css/app.css, embedded via
+        # //go:embed all:static in the v3 MPA. It is committed, so the default
+        # build compiles without it — but rebuilding keeps the embed in sync
+        # with assets/css/input.css for the jobs that compile internal/webapp.
+        run: |
+          make css
+          make webapp-css
 
       # The v2 SPA bundle is intentionally NOT built here: //go:embed
       # all:dist is satisfied by the committed web/dist/.gitkeep, and
@@ -193,7 +203,10 @@ jobs:
         run: |
           go install github.com/a-h/templ/cmd/templ@latest
           templ generate
-          find internal/templates/components -name '*_templ.go' -print0 | while IFS= read -r -d '' f; do
+          # Tag both internal/templates/components AND internal/webapp. Under
+          # -tags=headless the webapp *_templ.go MUST carry !headless or they
+          # compile here and pull in dashboard-only deps, reddening this job.
+          find internal/templates/components internal/webapp -name '*_templ.go' -print0 | while IFS= read -r -d '' f; do
             if ! head -1 "$f" | grep -q '^//go:build'; then
               printf '//go:build !headless && !lite\n\n' | cat - "$f" > "$f.tmp" && mv "$f.tmp" "$f"
             fi
@@ -204,7 +217,9 @@ jobs:
         # favicon) still needs static/css/styles.css to exist for the
         # `//go:embed all:css` directive to resolve. Headless builds don't
         # serve the CSS at runtime — but the file has to be present to
-        # compile.
+        # compile. The v3 webapp's app.css is not needed here: every webapp
+        # .go (incl. the //go:embed file) is excluded by !headless, so it is
+        # not in the headless build graph (stubs_headless.go embeds nothing).
         run: make css
 
       - name: go build -tags=headless
@@ -333,6 +348,15 @@ jobs:
         run: |
           go install github.com/a-h/templ/cmd/templ@latest
           templ generate
+
+      - name: Build CSS (v1 admin + v3 webapp)
+        # The released default binary embeds both static/css/styles.css
+        # (//go:embed all:css, gitignored) and internal/webapp/static/css/app.css
+        # (//go:embed all:static). Build both from source via the standalone
+        # Tailwind CLI (mirrors `make css` + `make webapp-css`).
+        run: |
+          make css
+          make webapp-css
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,17 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
 RUN go install github.com/a-h/templ/cmd/templ@latest \
     && /go/bin/templ generate
 
-# Build CSS: download tailwindcss-extra (musl variant for Alpine) and compile input.css
+# Build CSS: download tailwindcss-extra (musl variant for Alpine) and compile
+# both the v1 admin stylesheet (input.css → static/css/styles.css) and the v3
+# webapp stylesheet (internal/webapp/assets/css/input.css → .../static/css/app.css).
+# app.css is committed, but rebuilding here guarantees the deployed image embeds
+# CSS freshly compiled from the source input.css.
 RUN apk add --no-cache libstdc++ libgcc \
     && ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/x64/') \
     && wget -qO tailwindcss-extra "https://github.com/dobicinaitis/tailwind-cli-extra/releases/latest/download/tailwindcss-extra-linux-${ARCH}-musl" \
     && chmod +x tailwindcss-extra \
-    && ./tailwindcss-extra -i input.css -o static/css/styles.css --minify
+    && ./tailwindcss-extra -i input.css -o static/css/styles.css --minify \
+    && ./tailwindcss-extra -i internal/webapp/assets/css/input.css -o internal/webapp/static/css/app.css --minify
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION}" \


### PR DESCRIPTION
Ship the v3 MPA gracefully on eventual merge to main.

- **Critical:** CI `templ generate` steps (test-shards, test-headless) now inject `//go:build !headless && !lite` into `internal/webapp/*_templ.go` too (was `internal/templates/components` only). Without this, webapp generated files are untagged in CI and break the headless/lite matrix now that webapp is in the build graph. Mirrors the Makefile `templ` target.
- Build webapp CSS (`make webapp-css`) alongside v1 css in test-shards + a new release CSS step.
- Dockerfile compiles `internal/webapp/assets/css/input.css` → `app.css` so the deployed image embeds fresh CSS.
- Confirmed `deploy/Caddyfile` passes `/app/*` through (no path allowlist).

Surgical, additive; YAML validated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)