### PR TITLE
feat(admin): design-system sandbox foundation

### DIFF
--- a/internal/admin/design.go
+++ b/internal/admin/design.go
@@ -1,0 +1,51 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"net/http"
+
+	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/pages"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// DesignGalleryHandler serves GET /design — the design-system gallery.
+// Hosts every component family on one anchored scroll for quick visual
+// QA. Wired in the editor+ scope alongside other admin tooling.
+func DesignGalleryHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := BaseTemplateData(r, sm, "design", "Design system")
+		tr.RenderWithTempl(w, r, data, pages.DesignGallery(pages.DesignGalleryProps{
+			Sections: pages.DesignSections(),
+			Breadcrumbs: []components.Breadcrumb{
+				{Label: "Design system"},
+			},
+		}))
+	}
+}
+
+// DesignComponentHandler serves GET /design/c/{slug} — a single
+// component family rendered in isolation. Same admin shell as the
+// gallery (one-click back), but the main column hosts just one
+// section so screenshots focus on the component under test.
+func DesignComponentHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		section, ok := pages.FindDesignSection(slug)
+		if !ok {
+			tr.RenderNotFound(w, r)
+			return
+		}
+		data := BaseTemplateData(r, sm, "design", section.Title)
+		tr.RenderWithTempl(w, r, data, pages.DesignComponent(pages.DesignComponentProps{
+			Section: section,
+			Breadcrumbs: []components.Breadcrumb{
+				{Label: "Design system", Href: "/design"},
+				{Label: section.Title},
+			},
+		}))
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -129,6 +129,12 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Get("/tags", TagsPageHandler(svc, sm, tr))
 
+		// Design-system sandbox. /design is the full gallery; /design/c/{slug}
+		// renders a single component family in isolation for focused screenshots.
+		// Editor scope: developer tooling, not user-facing.
+		r.Get("/design", DesignGalleryHandler(sm, tr))
+		r.Get("/design/c/{slug}", DesignComponentHandler(sm, tr))
+
 		// API Keys + OAuth Clients page (Settings → API Keys tab).
 		// Editors can view and create.
 		r.Get("/settings/api-keys", AccessPageHandler(svc, sm, tr))

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -1,0 +1,28 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// DesignComponent renders /design/c/{slug} — a single component family
+// rendered in isolation on the page. Same admin shell as the gallery
+// (so navigation back is one click), but the main column hosts just one
+// section so screenshots focus on the component being tested.
+templ DesignComponent(p DesignComponentProps) {
+	@components.BreadcrumbNav(p.Breadcrumbs)
+	<div class="bb-page-header">
+		<div>
+			<h1 class="bb-page-title">{ p.Section.Title }</h1>
+			if p.Section.Description != "" {
+				<p class="text-sm text-base-content/50 mt-1">{ p.Section.Description }</p>
+			}
+		</div>
+		<div class="flex items-center gap-2">
+			<a href="/design" class="btn btn-ghost btn-sm rounded-xl gap-1.5">
+				<i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
+				Gallery
+			</a>
+		</div>
+	</div>
+	<div class="bb-card p-6">
+		@p.Section.Render()
+	</div>
+}

--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -1,0 +1,67 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// DesignGallery renders the /design page — a long, anchored scroll of
+// every component family in the system. The table of contents sticks
+// to the top of the content column so reviewers can jump between
+// sections without losing place.
+//
+// Per-section markup lives in design_sections.templ (one
+// `templ SectionX()` per entry in DesignSections). When you add a new
+// family, write the section component, then append the entry in
+// design_types.go::DesignSections().
+templ DesignGallery(p DesignGalleryProps) {
+	@components.BreadcrumbNav(p.Breadcrumbs)
+	<div class="bb-page-header">
+		<div>
+			<h1 class="bb-page-title">Design system</h1>
+			<p class="text-sm text-base-content/50 mt-1">
+				Reference gallery for every shared admin-UI component. Click a section to deep-link, or open the standalone viewer for focused screenshots.
+			</p>
+		</div>
+		<div class="flex items-center gap-2">
+			<a href="/design" class="btn btn-ghost btn-sm rounded-xl gap-1.5">
+				<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+				Reload
+			</a>
+		</div>
+	</div>
+	<div class="grid grid-cols-1 lg:grid-cols-[14rem_minmax(0,1fr)] gap-6">
+		<aside class="hidden lg:block">
+			<nav class="sticky top-6 flex flex-col gap-1 text-sm border-l border-base-300/60 pl-4">
+				for _, sec := range p.Sections {
+					<a href={ templ.SafeURL("#" + sec.Slug) } class="text-base-content/60 hover:text-base-content transition-colors">
+						{ sec.Title }
+					</a>
+				}
+			</nav>
+		</aside>
+		<div class="flex flex-col gap-10 min-w-0">
+			for _, sec := range p.Sections {
+				@designSectionBlock(sec)
+			}
+		</div>
+	</div>
+}
+
+// designSectionBlock wraps one DesignSection in the standard gallery
+// frame: anchor, title row with "Open standalone" link, description, then
+// the rendered demo inside a bordered card surface.
+templ designSectionBlock(sec DesignSection) {
+	<section id={ sec.Slug } class="scroll-mt-6">
+		<div class="flex items-baseline justify-between gap-3 mb-2">
+			<h2 class="text-lg font-semibold tracking-tight">{ sec.Title }</h2>
+			<a href={ templ.SafeURL("/design/c/" + sec.Slug) } class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1">
+				<i data-lucide="external-link" class="w-3 h-3"></i>
+				Open standalone
+			</a>
+		</div>
+		if sec.Description != "" {
+			<p class="text-sm text-base-content/50 mb-4">{ sec.Description }</p>
+		}
+		<div class="bb-card p-6">
+			@sec.Render()
+		</div>
+	</section>
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1,0 +1,641 @@
+package pages
+
+// design_sections.templ holds one `templ SectionX()` per entry in
+// DesignSections() (design_types.go). Each section demonstrates the
+// representative variants of one component family using a small grid
+// of `designExample` blocks (title + caption + the live markup).
+//
+// Layout helpers (designExample, designSwatch, designToken) live at the
+// bottom of this file so individual sections stay focused on markup.
+
+// ─── Foundations ───────────────────────────────────────────────────────
+
+templ SectionFoundations() {
+	<div class="flex flex-col gap-6">
+		@designExample("Color tokens", "DaisyUI semantic surfaces — adapt automatically across light/dark.") {
+			<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+				@designSwatch("base-100", "bg-base-100 border border-base-300")
+				@designSwatch("base-200", "bg-base-200")
+				@designSwatch("base-300", "bg-base-300")
+				@designSwatch("primary", "bg-primary text-primary-content")
+				@designSwatch("secondary", "bg-secondary text-secondary-content")
+				@designSwatch("accent", "bg-accent text-accent-content")
+				@designSwatch("info", "bg-info text-info-content")
+				@designSwatch("success", "bg-success text-success-content")
+				@designSwatch("warning", "bg-warning text-warning-content")
+				@designSwatch("error", "bg-error text-error-content")
+			</div>
+		}
+		@designExample("Typography", "Page title, section header, body, label, meta — the only sizes a page should use.") {
+			<div class="space-y-3">
+				<div class="text-2xl font-semibold tracking-tight">Page title (text-2xl semibold)</div>
+				<div class="text-xl font-semibold tracking-tight">bb-page-title (text-xl semibold)</div>
+				<div class="text-lg font-semibold">Section header (text-lg semibold)</div>
+				<div class="text-base">Body text (text-base default)</div>
+				<div class="text-sm text-base-content/70">Secondary body (text-sm @ 70%)</div>
+				<div class="text-xs text-base-content/50">Meta / caption (text-xs @ 50%)</div>
+				<div class="text-xs font-medium text-base-content/50">Form label (text-xs font-medium @ 50%)</div>
+				<div class="font-mono text-sm">Mono — bb_live_xxxxxxxxxx</div>
+			</div>
+		}
+		@designExample("Radius scale", "rounded-lg → field, rounded-xl → selector + cards, rounded-full → pills.") {
+			<div class="flex flex-wrap gap-3">
+				<div class="w-16 h-16 bg-base-200 border border-base-300 rounded-md flex items-center justify-center text-xs">md</div>
+				<div class="w-16 h-16 bg-base-200 border border-base-300 rounded-lg flex items-center justify-center text-xs">lg</div>
+				<div class="w-16 h-16 bg-base-200 border border-base-300 rounded-xl flex items-center justify-center text-xs">xl</div>
+				<div class="w-16 h-16 bg-base-200 border border-base-300 rounded-2xl flex items-center justify-center text-xs">2xl</div>
+				<div class="w-16 h-16 bg-base-200 border border-base-300 rounded-full flex items-center justify-center text-xs">full</div>
+			</div>
+		}
+	</div>
+}
+
+// ─── Buttons ───────────────────────────────────────────────────────────
+
+templ SectionButtons() {
+	<div class="flex flex-col gap-6">
+		@designExample("Sizes (sm + xs)", "Two sizes only. sm uses rounded-xl, xs uses rounded-lg.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button class="btn btn-primary btn-sm rounded-xl">Primary sm</button>
+				<button class="btn btn-primary btn-xs rounded-lg">Primary xs</button>
+			</div>
+		}
+		@designExample("Variants", "Pick by intent: primary for the page CTA, ghost for secondary, outline for selectors, soft for danger.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button class="btn btn-primary btn-sm rounded-xl">Primary</button>
+				<button class="btn btn-ghost btn-sm rounded-xl">Ghost</button>
+				<button class="btn btn-outline btn-sm rounded-xl">Outline</button>
+				<button class="btn btn-secondary btn-sm rounded-xl">Secondary</button>
+				<button class="btn btn-error btn-soft btn-sm rounded-xl">Destructive (soft)</button>
+				<button class="btn btn-error btn-sm rounded-xl">Destructive</button>
+				<button class="btn btn-sm rounded-xl" disabled>Disabled</button>
+			</div>
+		}
+		@designExample("With icons", "Icon size: w-4 h-4 for btn-sm, w-3.5 h-3.5 for btn-xs. Gap: gap-2 / gap-1.5.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button class="btn btn-primary btn-sm rounded-xl gap-2">
+					<i data-lucide="plus" class="w-4 h-4"></i>
+					New connection
+				</button>
+				<button class="btn btn-ghost btn-sm rounded-xl gap-2">
+					<i data-lucide="refresh-cw" class="w-4 h-4"></i>
+					Sync
+				</button>
+				<button class="btn btn-ghost btn-xs rounded-lg gap-1.5">
+					<i data-lucide="pencil" class="w-3.5 h-3.5"></i>
+					Edit
+				</button>
+			</div>
+		}
+		@designExample("Icon-only (square)", "btn-square keeps it 1:1. Use rounded-xl / rounded-lg matching the size.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button class="btn btn-ghost btn-sm btn-square rounded-xl" aria-label="Edit">
+					<i data-lucide="pencil" class="w-4 h-4"></i>
+				</button>
+				<button class="btn btn-ghost btn-xs btn-square rounded-lg" aria-label="Edit">
+					<i data-lucide="pencil" class="w-3.5 h-3.5"></i>
+				</button>
+				<button class="btn btn-ghost btn-sm btn-square rounded-xl" aria-label="More">
+					<i data-lucide="ellipsis-vertical" class="w-5 h-5"></i>
+				</button>
+			</div>
+		}
+		@designExample("Loading state", "Swap the label for a spinner. min-w-32 stops the button from jittering between states.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button class="btn btn-primary btn-sm rounded-xl min-w-32">
+					<span class="loading loading-spinner loading-xs"></span>
+				</button>
+				<button class="btn btn-primary btn-sm rounded-xl gap-2 min-w-32" disabled>
+					<i data-lucide="save" class="w-4 h-4"></i>
+					Save
+				</button>
+			</div>
+		}
+	</div>
+}
+
+// ─── Badges ────────────────────────────────────────────────────────────
+
+templ SectionBadges() {
+	<div class="flex flex-col gap-6">
+		@designExample("Status (badge-soft)", "Use statusBadge() / syncBadge() helpers — emits the canonical shape with badge-soft + badge-sm.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="badge badge-soft badge-success badge-sm">Active</span>
+				<span class="badge badge-soft badge-warning badge-sm">Pending</span>
+				<span class="badge badge-soft badge-error badge-sm">Error</span>
+				<span class="badge badge-soft badge-info badge-sm">Syncing</span>
+				<span class="badge badge-soft badge-neutral badge-sm">Disconnected</span>
+			</div>
+		}
+		@designExample("Metadata (badge-ghost)", "Scope, source, type, env — quiet labels with no semantic color.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="badge badge-ghost badge-xs">from env</span>
+				<span class="badge badge-ghost badge-xs">read-only</span>
+				<span class="badge badge-ghost badge-xs">plaid</span>
+				<span class="badge badge-ghost badge-xs">teller</span>
+				<span class="badge badge-ghost badge-xs">csv</span>
+			</div>
+		}
+		@designExample("Solid (counts)", "For numeric indicators / unread counts.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="badge badge-primary badge-xs">12</span>
+				<span class="badge badge-success badge-xs">+3</span>
+				<span class="badge badge-warning badge-xs">2</span>
+				<span class="badge badge-error badge-xs">!</span>
+			</div>
+		}
+		@designExample("Outline", "Less common — when soft is too loud and ghost too quiet.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="badge badge-outline badge-success badge-sm">Verified</span>
+				<span class="badge badge-outline badge-warning badge-sm">Beta</span>
+				<span class="badge badge-outline badge-info badge-sm">New</span>
+			</div>
+		}
+	</div>
+}
+
+// ─── Alerts ────────────────────────────────────────────────────────────
+
+templ SectionAlerts() {
+	<div class="flex flex-col gap-6">
+		@designExample("Page-level alerts", "role=\"alert\" + rounded-xl + mb-6. Use the matching alert-{type} color.") {
+			<div class="flex flex-col gap-3">
+				<div role="alert" class="alert alert-success rounded-xl">
+					<i data-lucide="check-circle" class="w-5 h-5"></i>
+					<span>Backup created successfully.</span>
+				</div>
+				<div role="alert" class="alert alert-info rounded-xl">
+					<i data-lucide="info" class="w-5 h-5"></i>
+					<span>Sync starts in 5 minutes.</span>
+				</div>
+				<div role="alert" class="alert alert-warning rounded-xl">
+					<i data-lucide="alert-triangle" class="w-5 h-5"></i>
+					<span>2 connections need reauth.</span>
+				</div>
+				<div role="alert" class="alert alert-error rounded-xl">
+					<i data-lucide="x-circle" class="w-5 h-5"></i>
+					<span>Failed to revoke API key.</span>
+				</div>
+			</div>
+		}
+		@designExample("Soft variant", "Less prominent — embed inside content rather than over page chrome.") {
+			<div role="alert" class="alert alert-warning alert-soft rounded-xl">
+				<i data-lucide="alert-triangle" class="w-5 h-5"></i>
+				<span>Read-only keys cannot trigger syncs.</span>
+			</div>
+		}
+		@designExample("Inline form error (bb-form-error)", "Tighter than alert; sits flush inside a form card.") {
+			<div role="alert" class="bb-form-error">
+				<i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+				<span>Password must be at least 8 characters.</span>
+			</div>
+		}
+	</div>
+}
+
+// ─── Cards ─────────────────────────────────────────────────────────────
+
+templ SectionCards() {
+	<div class="flex flex-col gap-6">
+		@designExample("Simple (bb-card p-5)", "Direct content, no internal sections.") {
+			<div class="bb-card p-5 max-w-md">
+				<h3 class="text-sm font-semibold mb-1">Connection summary</h3>
+				<p class="text-sm text-base-content/60">3 accounts, last synced 4 minutes ago.</p>
+			</div>
+		}
+		@designExample("Sectioned (bb-card p-0 overflow-hidden)", "p-0 + overflow-hidden to keep dividers flush with the rounded edge.") {
+			<div class="bb-card p-0 overflow-hidden max-w-md">
+				<div class="px-4 sm:px-5 py-3 border-b border-base-300/50">
+					<h3 class="text-sm font-semibold">Connection</h3>
+				</div>
+				<div class="px-4 sm:px-5 py-4 text-sm text-base-content/70">
+					Chase · 3 accounts
+				</div>
+				<div class="px-4 sm:px-5 py-3 border-t border-base-300/50 bg-base-200/20 flex justify-end gap-2">
+					<button class="btn btn-ghost btn-sm rounded-xl">Cancel</button>
+					<button class="btn btn-primary btn-sm rounded-xl">Save</button>
+				</div>
+			</div>
+		}
+		@designExample("Interactive (bb-card--interactive)", "Hover lift + cursor.") {
+			<a href="#" class="bb-card bb-card--interactive p-5 max-w-md block">
+				<h3 class="text-sm font-semibold mb-1">Open transaction history</h3>
+				<p class="text-sm text-base-content/60">View the full list of imported transactions.</p>
+			</a>
+		}
+		@designExample("Danger zone (bb-danger-card)", "Pair with bb-card. Use for destructive actions placed below the primary card.") {
+			<div class="bb-card bb-danger-card p-5 sm:p-6 max-w-md">
+				<div class="flex items-start justify-between gap-4 flex-col sm:flex-row sm:items-center">
+					<div>
+						<h3 class="text-sm font-semibold text-error/80">Delete connection</h3>
+						<p class="text-xs text-base-content/50 mt-0.5">All transactions and accounts will be removed. This cannot be undone.</p>
+					</div>
+					<button class="btn btn-error btn-soft btn-sm rounded-xl shrink-0 gap-2">
+						<i data-lucide="trash-2" class="w-4 h-4"></i>
+						Delete
+					</button>
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// ─── Form controls ─────────────────────────────────────────────────────
+
+templ SectionFormControls() {
+	<div class="flex flex-col gap-6">
+		@designExample("Text input", "input-bordered + rounded-xl. Pair with the text-xs label.") {
+			<div class="max-w-sm">
+				<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="ds-input-1">Email</label>
+				<input id="ds-input-1" type="email" class="input input-bordered w-full rounded-xl" placeholder="alex@example.com"/>
+			</div>
+		}
+		@designExample("Select", "Same shape as input. WARNING: never apply bg-base-200/50 — browsers render the alpha as fully transparent on selects.") {
+			<div class="max-w-sm">
+				<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="ds-select-1">Scope</label>
+				<select id="ds-select-1" class="select select-bordered w-full rounded-xl">
+					<option>Full access</option>
+					<option>Read only</option>
+				</select>
+			</div>
+		}
+		@designExample("Textarea", "textarea-bordered + rounded-xl.") {
+			<div class="max-w-sm">
+				<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="ds-textarea-1">Note</label>
+				<textarea id="ds-textarea-1" class="textarea textarea-bordered w-full rounded-xl" rows="3" placeholder="What's this transaction for?"></textarea>
+			</div>
+		}
+		@designExample("Compact (filter bar)", "input-sm / select-sm for filter bars. Styled by bb-filter-bar.") {
+			<div class="bb-filter-bar mb-0">
+				<label>
+					<span>Start date</span>
+					<input type="date" class="input input-sm input-bordered" value="2026-05-01"/>
+				</label>
+				<label>
+					<span>Status</span>
+					<select class="select select-sm select-bordered">
+						<option>All</option>
+						<option>Active</option>
+						<option>Error</option>
+					</select>
+				</label>
+				<button type="button" class="btn btn-sm btn-primary rounded-xl self-end">Filter</button>
+			</div>
+		}
+		@designExample("Checkbox / toggle / radio", "DaisyUI primitives.") {
+			<div class="flex flex-wrap items-center gap-6">
+				<label class="label cursor-pointer gap-2">
+					<input type="checkbox" class="checkbox" checked/>
+					<span class="label-text">Send daily digest</span>
+				</label>
+				<label class="label cursor-pointer gap-2">
+					<input type="checkbox" class="toggle" checked/>
+					<span class="label-text">Auto-sync</span>
+				</label>
+				<label class="label cursor-pointer gap-2">
+					<input type="radio" name="ds-radio-1" class="radio" checked/>
+					<span class="label-text">Daily</span>
+				</label>
+				<label class="label cursor-pointer gap-2">
+					<input type="radio" name="ds-radio-1" class="radio"/>
+					<span class="label-text">Weekly</span>
+				</label>
+			</div>
+		}
+	</div>
+}
+
+// ─── Tables ────────────────────────────────────────────────────────────
+
+templ SectionTables() {
+	<div class="flex flex-col gap-6">
+		@designExample("Standard (table-sm table-zebra)", "Default for most list pages. Use hover:bg-base-200 on <tr>.") {
+			<div class="overflow-x-auto">
+				<table class="table table-zebra table-sm">
+					<thead>
+						<tr>
+							<th>Connection</th>
+							<th>Provider</th>
+							<th>Status</th>
+							<th class="text-right">Accounts</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr class="hover:bg-base-200">
+							<td>Chase</td>
+							<td><span class="badge badge-ghost badge-xs">plaid</span></td>
+							<td><span class="badge badge-soft badge-success badge-sm">Active</span></td>
+							<td class="bb-amount">3</td>
+						</tr>
+						<tr class="hover:bg-base-200">
+							<td>Capital One</td>
+							<td><span class="badge badge-ghost badge-xs">teller</span></td>
+							<td><span class="badge badge-soft badge-warning badge-sm">Reauth</span></td>
+							<td class="bb-amount">2</td>
+						</tr>
+						<tr class="hover:bg-base-200">
+							<td>Ally Savings</td>
+							<td><span class="badge badge-ghost badge-xs">csv</span></td>
+							<td><span class="badge badge-soft badge-neutral badge-sm">Disconnected</span></td>
+							<td class="bb-amount">1</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		}
+		@designExample("Compact (table-xs)", "For embedded tables inside detail pages.") {
+			<div class="overflow-x-auto">
+				<table class="table table-xs">
+					<thead>
+						<tr>
+							<th>Account</th>
+							<th>Mask</th>
+							<th class="text-right">Balance</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr><td>Total Checking</td><td class="font-mono text-xs">0123</td><td class="bb-amount">$3,421.55</td></tr>
+						<tr><td>Sapphire Reserve</td><td class="font-mono text-xs">9876</td><td class="bb-amount">−$842.10</td></tr>
+					</tbody>
+				</table>
+			</div>
+		}
+	</div>
+}
+
+// ─── Tags ──────────────────────────────────────────────────────────────
+
+templ SectionTags() {
+	<div class="flex flex-col gap-6">
+		@designExample("Tag sizes", "Pill-shaped, colored via --tag-color CSS variable.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="bb-tag-sm" style="--tag-color:#f59e0b">
+					<i data-lucide="inbox"></i>
+					<span>Needs review</span>
+				</span>
+				<span class="bb-tag" style="--tag-color:#10b981">
+					<i data-lucide="check"></i>
+					<span>Reconciled</span>
+				</span>
+				<span class="bb-tag-lg" style="--tag-color:#6366f1">
+					<i data-lucide="bookmark"></i>
+					<span>Subscription</span>
+				</span>
+			</div>
+		}
+		@designExample("Ghost (unselected filter state)", "Faded variant for filter-bar tag toggles.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="bb-tag bb-tag-ghost" style="--tag-color:#0ea5e9">
+					<i data-lucide="building"></i>
+					<span>Business</span>
+				</span>
+				<span class="bb-tag bb-tag-ghost" style="--tag-color:#a855f7">
+					<i data-lucide="plane"></i>
+					<span>Travel</span>
+				</span>
+			</div>
+		}
+		@designExample("Add (dashed)", "Ghost \"+ Add tag\" chip — same shape, dashed border.") {
+			<button type="button" class="bb-tag bb-tag-add">
+				<i data-lucide="plus"></i>
+				<span>Add tag</span>
+			</button>
+		}
+		@designExample("Interactive + removable", "Inline × button. Hover the chip to reveal.") {
+			<span class="bb-tag bb-tag-interactive" style="--tag-color:#ef4444">
+				<i data-lucide="tag"></i>
+				<span>Refund</span>
+				<button type="button" class="bb-tag-remove" aria-label="Remove tag">
+					<i data-lucide="x"></i>
+				</button>
+			</span>
+		}
+	</div>
+}
+
+// ─── Menus & dropdowns ─────────────────────────────────────────────────
+
+templ SectionMenusDropdowns() {
+	<div class="flex flex-col gap-6">
+		@designExample("Overflow action menu", "When a card has ≥2 secondary actions, prefer one ellipsis dropdown over a cluster of icon buttons.") {
+			<div class="bb-card p-4 max-w-sm">
+				<div class="flex items-center justify-between gap-3">
+					<div>
+						<div class="text-sm font-semibold">Alex Chen</div>
+						<div class="text-xs text-base-content/50">alex@example.com</div>
+					</div>
+					<div class="dropdown dropdown-end">
+						<div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-square rounded-lg opacity-40 hover:opacity-100">
+							<i data-lucide="ellipsis-vertical" class="w-5 h-5"></i>
+						</div>
+						<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1">
+							<li><a><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit profile</a></li>
+							<li><a><i data-lucide="settings" class="w-3.5 h-3.5"></i> Manage login</a></li>
+							<li><a class="text-error"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		}
+		@designExample("Menu (vertical nav list)", "menu-md / menu-sm.") {
+			<ul class="menu bg-base-100 rounded-xl border border-base-300 w-56">
+				<li class="menu-title">Settings</li>
+				<li><a class="menu-active"><i data-lucide="key" class="w-4 h-4"></i> API keys</a></li>
+				<li><a><i data-lucide="users" class="w-4 h-4"></i> Household</a></li>
+				<li><a><i data-lucide="bot" class="w-4 h-4"></i> MCP</a></li>
+			</ul>
+		}
+	</div>
+}
+
+// ─── Modals ────────────────────────────────────────────────────────────
+
+templ SectionModals() {
+	<div class="flex flex-col gap-6">
+		@designExample("Standard modal trigger", "modal-bottom on mobile, modal-middle on sm+. rounded-xl modal-box.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button type="button" class="btn btn-primary btn-sm rounded-xl" onclick="document.getElementById('ds-modal-1').showModal()">
+					Open modal
+				</button>
+				<dialog id="ds-modal-1" class="modal modal-bottom sm:modal-middle">
+					<div class="modal-box rounded-xl max-w-lg">
+						<h3 class="text-base font-semibold mb-2">Delete connection?</h3>
+						<p class="text-sm text-base-content/60 mb-4">All transactions and accounts will be removed. This cannot be undone.</p>
+						<div class="modal-action mt-0 gap-2">
+							<form method="dialog">
+								<button class="btn btn-ghost btn-sm rounded-xl">Cancel</button>
+							</form>
+							<button class="btn btn-error btn-sm rounded-xl">Delete</button>
+						</div>
+					</div>
+					<form method="dialog" class="modal-backdrop">
+						<button>close</button>
+					</form>
+				</dialog>
+			</div>
+		}
+	</div>
+}
+
+// ─── Loading & skeletons ───────────────────────────────────────────────
+
+templ SectionLoading() {
+	<div class="flex flex-col gap-6">
+		@designExample("Spinners", "DaisyUI loading variants in xs/sm/md.") {
+			<div class="flex flex-wrap items-center gap-4">
+				<span class="loading loading-spinner loading-xs"></span>
+				<span class="loading loading-spinner loading-sm"></span>
+				<span class="loading loading-spinner loading-md"></span>
+				<span class="loading loading-dots loading-sm"></span>
+				<span class="loading loading-ring loading-sm"></span>
+				<span class="loading loading-bars loading-sm"></span>
+			</div>
+		}
+		@designExample("Skeletons", "DaisyUI skeleton for placeholder blocks.") {
+			<div class="space-y-3 max-w-md">
+				<div class="skeleton h-4 w-2/3"></div>
+				<div class="skeleton h-4 w-1/2"></div>
+				<div class="skeleton h-12 w-full rounded-xl"></div>
+			</div>
+		}
+		@designExample("Progress", "Indeterminate + determinate.") {
+			<div class="space-y-3 max-w-md">
+				<progress class="progress progress-primary w-full"></progress>
+				<progress class="progress progress-primary w-full" value="38" max="100"></progress>
+			</div>
+		}
+	</div>
+}
+
+// ─── Icons & tiles ─────────────────────────────────────────────────────
+
+templ SectionIcons() {
+	<div class="flex flex-col gap-6">
+		@designExample("Lucide sizes", "Buttons → w-4 h-4 (sm) / w-3.5 h-3.5 (xs). Section headers → w-5 h-5. Empty states → w-8 h-8.") {
+			<div class="flex flex-wrap items-center gap-4 text-base-content/70">
+				<i data-lucide="receipt" class="w-3.5 h-3.5"></i>
+				<i data-lucide="receipt" class="w-4 h-4"></i>
+				<i data-lucide="receipt" class="w-5 h-5"></i>
+				<i data-lucide="receipt" class="w-6 h-6"></i>
+				<i data-lucide="receipt" class="w-8 h-8"></i>
+			</div>
+		}
+		@designExample("Icon tiles (bb-icon-tile)", "Colored 40×40 squares for sectioned form-card headers.") {
+			<div class="flex flex-wrap items-center gap-3">
+				<div class="bb-icon-header__tile bb-icon-tile--primary">
+					<i data-lucide="user-plus" class="w-5 h-5"></i>
+				</div>
+				<div class="bb-icon-header__tile bb-icon-tile--success">
+					<i data-lucide="check" class="w-5 h-5"></i>
+				</div>
+				<div class="bb-icon-header__tile bb-icon-tile--warning">
+					<i data-lucide="alert-triangle" class="w-5 h-5"></i>
+				</div>
+				<div class="bb-icon-header__tile bb-icon-tile--error">
+					<i data-lucide="x" class="w-5 h-5"></i>
+				</div>
+			</div>
+		}
+		@designExample("Icon header (form card top)", "bb-icon-header pairs the tile with title + subtitle.") {
+			<div class="bb-icon-header">
+				<div class="bb-icon-header__tile bb-icon-tile--primary">
+					<i data-lucide="key" class="w-5 h-5"></i>
+				</div>
+				<div class="bb-icon-header__text">
+					<h3 class="text-sm font-semibold">New API key</h3>
+					<p class="text-xs text-base-content/45">Give your script a way to talk to Breadbox.</p>
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// ─── Page header ───────────────────────────────────────────────────────
+
+templ SectionPageHeader() {
+	<div class="flex flex-col gap-6">
+		@designExample("Title only", "Just the page title.") {
+			<div class="bb-page-header mb-0">
+				<div>
+					<h1 class="bb-page-title">Connections</h1>
+				</div>
+			</div>
+		}
+		@designExample("With subtitle", "Common on detail pages and forms.") {
+			<div class="bb-page-header mb-0">
+				<div>
+					<h1 class="bb-page-title">Create API key</h1>
+					<p class="text-sm text-base-content/50 mt-1">Generate a new key for API or MCP access</p>
+				</div>
+			</div>
+		}
+		@designExample("With primary action", "Trailing slot reserved for the page's single primary action.") {
+			<div class="bb-page-header mb-0">
+				<div>
+					<h1 class="bb-page-title">Rules</h1>
+					<p class="text-sm text-base-content/50 mt-1">Auto-categorize transactions as they arrive.</p>
+				</div>
+				<a href="#" class="btn btn-primary btn-sm rounded-xl gap-2">
+					<i data-lucide="plus" class="w-4 h-4"></i>
+					New rule
+				</a>
+			</div>
+		}
+	</div>
+}
+
+// ─── Empty states ──────────────────────────────────────────────────────
+
+templ SectionEmptyStates() {
+	<div class="flex flex-col gap-6">
+		@designExample("Standard (no data yet)", "Card-wrapped, icon + title + description + CTA.") {
+			<div class="bb-card p-12 text-center max-w-md mx-auto">
+				<div class="flex flex-col items-center">
+					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
+						<i data-lucide="inbox" class="w-7 h-7 text-base-content/30"></i>
+					</div>
+					<h3 class="text-base font-semibold mb-1">No connections yet</h3>
+					<p class="text-base-content/50 text-sm mb-5 max-w-sm">Link a bank to start importing transactions.</p>
+					<a href="#" class="btn btn-primary btn-sm rounded-xl gap-2">
+						<i data-lucide="plus" class="w-4 h-4"></i>
+						Add connection
+					</a>
+				</div>
+			</div>
+		}
+		@designExample("Compact (filtered no results)", "Inline, no card chrome.") {
+			<div class="flex flex-col items-center text-center py-10">
+				<i data-lucide="search-x" class="w-8 h-8 text-base-content/30 mb-3"></i>
+				<p class="text-sm text-base-content/50">No transactions match these filters.</p>
+			</div>
+		}
+	</div>
+}
+
+// ─── Layout helpers ────────────────────────────────────────────────────
+
+// designExample wraps a demo block with a heading + caption row above
+// the live markup. Used by every Section* component above.
+templ designExample(title, caption string) {
+	<div>
+		<div class="flex items-baseline gap-3 mb-3">
+			<h3 class="text-sm font-semibold">{ title }</h3>
+			if caption != "" {
+				<p class="text-xs text-base-content/50">{ caption }</p>
+			}
+		</div>
+		<div class="rounded-xl border border-base-300/60 bg-base-100 p-5">
+			{ children... }
+		</div>
+	</div>
+}
+
+// designSwatch renders a single color token tile with its name + class label.
+templ designSwatch(name, classes string) {
+	<div class="flex flex-col gap-1">
+		<div class={ "h-14 rounded-xl flex items-center justify-center text-xs font-medium", classes }>
+			{ name }
+		</div>
+		<code class="text-[0.65rem] text-base-content/50 font-mono px-1">.{ classes }</code>
+	</div>
+}

--- a/internal/templates/components/pages/design_smoke_test.go
+++ b/internal/templates/components/pages/design_smoke_test.go
@@ -1,0 +1,104 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"breadbox/internal/templates/components"
+)
+
+// TestDesignGalleryRenders is a smoke test: every DesignSections() entry
+// must render without error, and the gallery itself must inline the
+// section markup. Catches missing templ functions, prop mismatches, or
+// templates that silently emit nothing — none of which the Go compiler
+// catches but all of which would break the sandbox at runtime.
+func TestDesignGalleryRenders(t *testing.T) {
+	sections := DesignSections()
+	if len(sections) == 0 {
+		t.Fatal("DesignSections() returned empty slice")
+	}
+
+	// Per-section render: each section's Render() must produce non-empty
+	// output. Silent-empty would mean the templ function returned NopComponent.
+	for _, sec := range sections {
+		if sec.Slug == "" || sec.Title == "" {
+			t.Errorf("section %+v has empty slug or title", sec)
+		}
+		if sec.Render == nil {
+			t.Errorf("section %q has nil Render", sec.Slug)
+			continue
+		}
+		var buf bytes.Buffer
+		if err := sec.Render().Render(context.Background(), &buf); err != nil {
+			t.Errorf("section %q: render error: %v", sec.Slug, err)
+			continue
+		}
+		if buf.Len() < 50 {
+			t.Errorf("section %q: render output too small (%d bytes) — likely NopComponent or stub", sec.Slug, buf.Len())
+		}
+	}
+
+	// Gallery render: must include the anchor for every section's slug.
+	var buf bytes.Buffer
+	props := DesignGalleryProps{
+		Sections:    sections,
+		Breadcrumbs: []components.Breadcrumb{{Label: "Design system"}},
+	}
+	if err := DesignGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("gallery render error: %v", err)
+	}
+	gallery := buf.String()
+	for _, sec := range sections {
+		if !strings.Contains(gallery, `id="`+sec.Slug+`"`) {
+			t.Errorf("gallery missing anchor id=%q for section %q", sec.Slug, sec.Title)
+		}
+		if !strings.Contains(gallery, "/design/c/"+sec.Slug) {
+			t.Errorf("gallery missing standalone link to /design/c/%s", sec.Slug)
+		}
+	}
+
+	// FindDesignSection round-trips known slugs and rejects unknown.
+	for _, sec := range sections {
+		got, ok := FindDesignSection(sec.Slug)
+		if !ok {
+			t.Errorf("FindDesignSection(%q) returned !ok", sec.Slug)
+		}
+		if got.Title != sec.Title {
+			t.Errorf("FindDesignSection(%q): title=%q want %q", sec.Slug, got.Title, sec.Title)
+		}
+	}
+	if _, ok := FindDesignSection("not-a-real-slug"); ok {
+		t.Error("FindDesignSection accepted unknown slug")
+	}
+}
+
+// TestDesignComponentRenders confirms the standalone single-section page
+// renders for every section without error.
+func TestDesignComponentRenders(t *testing.T) {
+	for _, sec := range DesignSections() {
+		var buf bytes.Buffer
+		props := DesignComponentProps{
+			Section: sec,
+			Breadcrumbs: []components.Breadcrumb{
+				{Label: "Design system", Href: "/design"},
+				{Label: sec.Title},
+			},
+		}
+		if err := DesignComponent(props).Render(context.Background(), &buf); err != nil {
+			t.Errorf("section %q standalone render error: %v", sec.Slug, err)
+			continue
+		}
+		out := buf.String()
+		if len(out) < 200 {
+			t.Errorf("section %q standalone page too small (%d bytes)", sec.Slug, len(out))
+		}
+		// The breadcrumb back link should always be present.
+		if !strings.Contains(out, `href="/design"`) {
+			t.Errorf("section %q standalone page missing back link to /design", sec.Slug)
+		}
+	}
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -1,0 +1,142 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"breadbox/internal/templates/components"
+
+	"github.com/a-h/templ"
+)
+
+// DesignGalleryProps is the prop bag for the /design page — the full
+// component gallery rendered on one scrollable page with section anchors.
+type DesignGalleryProps struct {
+	Breadcrumbs []components.Breadcrumb
+	Sections    []DesignSection
+}
+
+// DesignComponentProps is the prop bag for /design/c/{slug} — a single
+// component rendered in isolation so agents (and humans) can focus
+// screenshots on one piece at a time.
+type DesignComponentProps struct {
+	Breadcrumbs []components.Breadcrumb
+	Section     DesignSection
+}
+
+// DesignSection describes one entry in the design system gallery.
+// Render must be a no-arg constructor for the section's templ component
+// (kept as a closure so the slice of sections can be built once at
+// package init without templ generics gymnastics).
+type DesignSection struct {
+	Slug        string
+	Title       string
+	Description string
+	Render      func() templ.Component
+}
+
+// DesignSections returns the canonical, ordered list of gallery sections.
+// Each entry maps a URL slug to a templ component that demonstrates the
+// component family. To add a new section: write a `templ SectionFoo()`
+// component in design_sections.templ and append an entry here.
+//
+// The slice is rebuilt on every call (cheap — just struct literals) so
+// new sections are picked up without server restarts under
+// BREADBOX_DEV_RELOAD when paired with `templ generate`.
+func DesignSections() []DesignSection {
+	return []DesignSection{
+		{
+			Slug:        "foundations",
+			Title:       "Foundations",
+			Description: "Color tokens, typography scale, spacing, radius — the raw material every component is built from.",
+			Render:      func() templ.Component { return SectionFoundations() },
+		},
+		{
+			Slug:        "buttons",
+			Title:       "Buttons",
+			Description: "Primary / ghost / outline / destructive / icon-only variants at sm + xs sizes.",
+			Render:      func() templ.Component { return SectionButtons() },
+		},
+		{
+			Slug:        "badges",
+			Title:       "Badges",
+			Description: "Status chips (badge-soft) and metadata chips (badge-ghost). Pairs with statusBadge() helper.",
+			Render:      func() templ.Component { return SectionBadges() },
+		},
+		{
+			Slug:        "alerts",
+			Title:       "Alerts & flash",
+			Description: "Page-level alert variants, inline bb-form-error, soft alerts.",
+			Render:      func() templ.Component { return SectionAlerts() },
+		},
+		{
+			Slug:        "cards",
+			Title:       "Cards",
+			Description: "bb-card variants — simple, sectioned, interactive, danger-zone, empty-state.",
+			Render:      func() templ.Component { return SectionCards() },
+		},
+		{
+			Slug:        "form-controls",
+			Title:       "Form controls",
+			Description: "Inputs, selects, textareas, checkboxes, toggles, file inputs.",
+			Render:      func() templ.Component { return SectionFormControls() },
+		},
+		{
+			Slug:        "tables",
+			Title:       "Tables",
+			Description: "Zebra, sm/md/xs, hover row, sticky header, amount columns.",
+			Render:      func() templ.Component { return SectionTables() },
+		},
+		{
+			Slug:        "tags",
+			Title:       "Tags",
+			Description: "Pill-shaped colored tags — bb-tag, bb-tag-sm, bb-tag-lg, bb-tag-ghost, bb-tag-add.",
+			Render:      func() templ.Component { return SectionTags() },
+		},
+		{
+			Slug:        "menus-dropdowns",
+			Title:       "Menus & dropdowns",
+			Description: "DaisyUI dropdown / menu, overflow action menu pattern.",
+			Render:      func() templ.Component { return SectionMenusDropdowns() },
+		},
+		{
+			Slug:        "modals",
+			Title:       "Modals",
+			Description: "DaisyUI modal-bottom sm:modal-middle, rounded-xl modal-box.",
+			Render:      func() templ.Component { return SectionModals() },
+		},
+		{
+			Slug:        "loading",
+			Title:       "Loading & skeletons",
+			Description: "DaisyUI loading spinners, progress bars, skeleton placeholders.",
+			Render:      func() templ.Component { return SectionLoading() },
+		},
+		{
+			Slug:        "icons",
+			Title:       "Icons & tiles",
+			Description: "Lucide sizing convention, bb-icon-tile color modifiers.",
+			Render:      func() templ.Component { return SectionIcons() },
+		},
+		{
+			Slug:        "page-header",
+			Title:       "Page header",
+			Description: "bb-page-header + bb-page-title + optional primary action slot.",
+			Render:      func() templ.Component { return SectionPageHeader() },
+		},
+		{
+			Slug:        "empty-states",
+			Title:       "Empty states",
+			Description: "Standard no-data and no-results patterns.",
+			Render:      func() templ.Component { return SectionEmptyStates() },
+		},
+	}
+}
+
+// FindDesignSection looks up a section by URL slug.
+func FindDesignSection(slug string) (DesignSection, bool) {
+	for _, s := range DesignSections() {
+		if s.Slug == slug {
+			return s, true
+		}
+	}
+	return DesignSection{}, false
+}


### PR DESCRIPTION
## Summary

Stand up the design-system sandbox infrastructure: a gallery page at `/design` with anchored sections per component family, and a standalone single-component viewer at `/design/c/{slug}` for focused screenshots / agent testing.

Foundation only — per-section variants get fleshed out in follow-up sprint PRs driven by the audit (PR #2 in this stack).

## What's here

- **`internal/admin/design.go`** — two handlers, registered in the editor+ scope (developer tooling, not user-facing).
- **`internal/templates/components/pages/design_types.go`** — `DesignSection` data model + `DesignSections()` ordered list + `FindDesignSection(slug)` lookup. Adding a new section is two lines of code: write the templ, append the entry.
- **`design_gallery.templ`** — sticky TOC + anchored sections.
- **`design_component.templ`** — single-section standalone viewer.
- **`design_sections.templ`** — seed examples for 14 families (foundations, buttons, badges, alerts, cards, forms, tables, tags, menus, modals, loading, icons, page header, empty states).
- **`design_smoke_test.go`** — confirms every section renders non-empty, gallery inlines every anchor, `FindDesignSection` round-trips.

## Why a sandbox

Every consolidated component lands here first with its variant matrix before pages start adopting it. Reviewers can hit `/design` to see the canonical shape, hit `/design/c/<slug>` to take a clean screenshot of any single component, and the smoke test guards against regressions.

## URLs

- `/design` — full gallery (one scroll, 14 anchored sections)
- `/design/c/buttons` — standalone single-component viewer (one URL per family)

## Stack context

Editor+ scope (not admin-only) so any teammate working on the UI can hit it. No DB calls, no side effects.

## Test plan

- [ ] `go test ./internal/templates/components/pages/...` passes
- [ ] `go build ./...` is green
- [ ] `templ generate` produces clean output for all 4 new .templ files
- [ ] Browser walk-through of `/design` + a few `/design/c/<slug>` after merging into the sprint base

Validation in a real browser happens as part of the populate-sandbox PRs (when there's something interesting to look at beyond the seed). The smoke test covers the rendering contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
