### PR TITLE
docs(design-system): v1 audit reports — components + daisyUI coverage

### DIFF
--- a/docs/design-system-audit/README.md
+++ b/docs/design-system-audit/README.md
@@ -1,0 +1,43 @@
+# Design system audit (2026-05-24)
+
+These two reports were produced by parallel audit agents during the
+design-system sprint to inventory the current v1 admin UI surface and
+identify consolidation opportunities.
+
+- [`components-inventory.md`](./components-inventory.md) — every
+  recurring UI pattern across `internal/templates/**`, with file:line
+  citations, variant counts, daisyUI mapping, and consolidation
+  recommendations. ~45 components catalogued.
+- [`daisyui-coverage.md`](./daisyui-coverage.md) — coverage matrix of
+  every DaisyUI 5 component vs our current usage, marked ✅ used / ⚠️
+  overridden / 🔁 hand-rolled / 🚫 N/A / ❌ should-use-but-isn't. Includes
+  deep dives on the largest divergences (the 5 bespoke dialog shells,
+  `bb-skeleton*`, `bb-paginator`, kbd duplication, card divergence).
+
+## Synthesis — what's coming next
+
+The two reports converge on the same handful of priorities. The
+remediation phase of the sprint will land as a sequence of small PRs:
+
+1. **`PageHeader` templ component** — 37 callers, mechanical extraction.
+2. **`EmptyState` templ component** — 18 callers with 5 visual variants.
+3. **`ResourceListSection`** — the `access.templ` OAuth/API-Keys
+   duplication kills 150+ lines on a single page.
+4. **`StatTile` / adopt daisy `stats`** — dashboard + feed metrics
+   currently re-derive the typography by hand.
+5. **`TabBar` (daisy `tabs-border`)** — mcp_guide tabs and settings
+   layout currently use ad-hoc btn-toggle patterns.
+6. **`OverflowMenu` templ component** — 6 callers, normalises dropdown
+   width and icon size.
+7. **Standardise destructive-confirm UX** — 3 incompatible patterns
+   (inline, dialog, overlay) reduce to one.
+8. **Adopt daisy `skeleton`, `toast`, `kbd`, `join`** — kill ~400 lines
+   of duplicate CSS.
+9. **Retire dead `bb-*` classes** (`bb-summary-pill`, `bb-sparkline`,
+   `bb-health-ring`, `bb-rule-cat-badge`, `bb-page-skeleton`).
+10. **Establish `.claude/rules/daisyui.md`** — codify daisyUI-first as
+    a hard rule so future contributions don't drift back to hand-rolled.
+
+The sandbox at `/design` is the proving ground: every new shared
+component lands there first with its variant matrix before pages start
+adopting it.

--- a/docs/design-system-audit/components-inventory.md
+++ b/docs/design-system-audit/components-inventory.md
@@ -1,0 +1,369 @@
+# v1 Admin UI Component Inventory
+
+**Date:** 2026-05-24. **Scope:** `internal/templates/{components,components/pages,layout,partials}/*.{templ,html}`, `input.css`, and `static/js/admin/components/*.js`. v2 SPA (`web/`) is excluded. **Methodology:** for each candidate pattern I greped the templ + html source for class anchors (`bb-*`, `btn btn-*`, `bb-card …`, `<dialog`, etc.), counted distinct variants and call sites, cross-referenced against the canonical spec in `docs/design-system.md`, and read the larger pages (`access.templ`, `users.templ`, `categories.templ`, `connection_detail.templ`, `feed.templ`, `logs.templ`, `transaction_detail.templ`, `transactions.templ`, `settings*.templ`, `agents_settings.templ`) end-to-end to surface duplicated 30-100 line blocks. Numbers are exact greps across the templ tree (generated `*_templ.go` excluded), not estimates.
+
+The codebase is ~14k lines of templ + 1 monolithic 2.4k-line `base.html` + 3.2k-line `input.css`. The `pages/` directory is the body of the audit — `pages/_templ_shell.html` and `partials/*.html` are 5-11 line stubs (only `breadcrumb.html`, `category_picker.html`, `flash.html`, `nav.html`, `tx_row.html` remain), so the html/template surface area is effectively retired.
+
+## Summary table
+
+| # | Component / pattern | Variant count | Callers (count) | DaisyUI native? | Recommendation |
+|---|---|---|---|---|---|
+| 1 | Page header (`.bb-page-header`) | 1 spec, ~3 in-use | 37 templ files | partial (`navbar`) | Extract to templ component `PageHeader(title, subtitle, action)` |
+| 2 | Breadcrumb | 1 | 22 (via `@components.BreadcrumbNav`) | none | Healthy — keep as is |
+| 3 | Card (`.bb-card`) | 87 distinct class combos | 166 occurrences | `card` (rejected for shadow) | Healthy primitive; document the canonical variants in spec |
+| 4 | Sectioned card (`.bb-card p-0 overflow-hidden` + `bb-action-row`) | 1 spec, 6 in-use | 28 | none | Extract `FormCard(IconHeader, body, ActionRow)` templ component |
+| 5 | Icon-header tile (`.bb-icon-header__tile`) | 4 colour modifiers + ~6 ad-hoc | 51 | none | Strong primitive; migrate the ad-hoc `w-10 h-10 rounded-xl bg-X/8` blocks (15 sites) to it |
+| 6 | Action row (`.bb-action-row`) | 1 | 9 | none | Healthy — only 9 callers because most pages still hand-roll the bottom row |
+| 7 | Form-input primitive (`.bb-form-input` / `.bb-form-select`) | 2 | 18 (in 8 files) | partial (`input input-bordered`) | Adopted in form pages; ~30 other `input input-bordered` sites should migrate |
+| 8 | Form-error inline (`.bb-form-error`) | 1 spec | 0 in templ (defined in input.css §299) | none | **Bug: defined CSS class with zero callers.** Either adopt or retire |
+| 9 | Buttons (`btn btn-*`) | 28+ distinct combos | 176 | yes (`btn`) | Healthy with caveats; see Cross-cutting (size-only inconsistencies) |
+| 10 | Badges (`badge badge-*`) | 46 distinct combos | 186 | yes (`badge`) | Add a `Badge(tone, size)` templ helper to dedupe; most are status / count chips |
+| 11 | Status badge (`StatusBadge()`, `SyncBadge()` helpers) | 1 each | 9 of 37 status-rendering sites | none | Underused — only 9 callers; rest of status renderings still hand-roll badges |
+| 12 | Tag chip (`.bb-tag` + variants) | 5 (sm / lg / ghost / interactive / add) | 6 direct templ + heavy JS | none | Healthy; well-documented variants |
+| 13 | Tables (`table table-sm/md/xs`) | 4 in-use | 4 templ tables | yes (`table`) | Underused — most "tables" are flex rows; keep as is |
+| 14 | Filter bar (`.bb-filter-bar`) | 2 (legacy + `.bb-filter-toggle` collapse) | 2 callers | none | Spec says 3+ usage required for a `bb-*` class; 2 callers → retire or document as obsolete |
+| 15 | Filter toggle / form (`.bb-filter-toggle`, `.bb-filter-form`) | 1 | 1 (`logs.templ`) | none | **Single caller** — likely premature abstraction |
+| 16 | Empty state | 1 spec, 5 visual variants | 18 sites (counted `bb-card p-12 text-center` / `p-8 sm:p-12` / `bb-card` + flex-col) | none | Extract `EmptyState(icon, title, body, cta)` templ — duplicated 80+ lines across the codebase |
+| 17 | Overflow action menu (`dropdown dropdown-end` + ellipsis) | 1 spec, 2 sizes | 6 | yes (`dropdown` + `menu`) | Extract `OverflowMenu(items)` templ |
+| 18 | Confirm-inline pattern (`x-data="{ confirming: false }"`) | 1 | 4 (`access`, `connection_detail`, others) | none | Wrap as templ component or shared Alpine factory |
+| 19 | Modal (`<dialog class="modal">`) | 1 spec | 3 | yes (`modal`) | Healthy — only 3 modals total |
+| 20 | Confirm overlay (`.bb-confirm-*` in `base.html`) | 1 | 1 global | none | Healthy — replaces `confirm()` |
+| 21 | Cmd+K palette (`.bb-cmdk-*`) | 1 | 1 global + JS | none | Healthy, isolated |
+| 22 | Category picker overlay (`.bb-catpicker-*`) | 1 | 1 global + JS | none | Healthy, isolated |
+| 23 | Tag picker overlay (`.bb-tagpicker-*`) | 1 | 1 global + JS | none | Healthy, isolated |
+| 24 | Shortcuts help overlay (`.bb-shortcuts-*`) | 1 | 1 global | none | Healthy, isolated |
+| 25 | Kbd hints (`.bb-kbd`, `.bb-kbd-combo`) | 2 | 8 (`@components.Kbd*`) + 5 hand-rolled | yes (`kbd`) | Strong primitive; replace remaining hand-rolled `<kbd class="bb-kbd">` and `<kbd class="bb-shortcuts-kbd">` |
+| 26 | Toast (`bb-toast` event) | 1 | global | yes (`toast`) | Healthy |
+| 27 | Alerts (`alert alert-*`) | 5 in-use | 13 | yes (`alert`) | Healthy; every caller adds `rounded-xl` — fold into a `PageAlert` templ |
+| 28 | Triage row (`.bb-triage-*`) | 1 | 0 in templ (used by `reviews.js` only) | none | **No templ caller for ~200 lines of CSS.** Verify it's still wired via `/reviews` JS-render path |
+| 29 | Sparkline / summary-pill (`.bb-sparkline`, `.bb-summary-pill`) | 1 each | **0 templ callers** | none | Dead CSS — retire after confirming no JS-render path |
+| 30 | Stagger animation (`.bb-stagger`, `.bb-page-enter`) | 1 each | 30 (`bb-stagger`) + 1 (`bb-page-enter`) | none | Healthy entrance pattern |
+| 31 | Skeleton (`.bb-skeleton*`) | 7 size variants | **0 templ callers** | none | Dead CSS (~110 lines) — retire or wire into a real loading state |
+| 32 | View toggle (`.bb-view-toggle`) | 1 | 1 (`transactions.templ`) | none | Single caller — retire or generalize |
+| 33 | Table header (`.bb-table-header`) | 1 | 2 (`tx_results`, `account_detail`) | none | 2 callers — below the spec's 3+ threshold |
+| 34 | Pagination (`.bb-paginator`) | 1 | 1 (`tx_results`) | yes (`join`) | Single caller — but well-designed; retain |
+| 35 | Tx-row primitives (`.bb-tx-row`, `.bb-tx-avatar`, `.bb-tx-amount`) | 3 base + variants | 23 | none | Healthy domain primitive |
+| 36 | Tx-row component (`@components.TxRow*`) | 3 (full / compact / feed) | (replaces `partials/tx_row.html`) | none | Healthy |
+| 37 | Activity timeline (`@components.Timeline*`) | 6 primitives + prominent override | 17 | none | Healthy; large but well-organized |
+| 38 | Sidebar (`.bb-sidebar*`) | 1 | 1 (`nav.templ`) | yes (`drawer`/`menu`) | Healthy custom-styled sidebar |
+| 39 | Mobile navbar (`.bb-mobile-navbar`) | 1 | 1 (`base.html`) | yes (`navbar`) | Healthy |
+| 40 | Rule badge (`.bb-rule-cat-badge`, `.bb-rule-creator-badge`) | 2 | 0 in templ | none | **Dead CSS** — retire |
+| 41 | Wizard layout (`.bb-wizard-*`) | 1 | 4 (login, setup, error pages) | none | Healthy isolated layout |
+| 42 | Error page (`.bb-error-*`) | 1 | 1 (`errors.templ`) | none | Healthy |
+| 43 | Comment bubble (`.bb-comment-bubble`) | 1 + markdown subselectors | 2 | none | Healthy primitive, well-isolated to feed + transaction-detail |
+| 44 | Report body (`.bb-report-body`) | 1 + markdown subselectors | 1 | none | Single caller but justified — markdown styling is page-specific |
+| 45 | Settings rail (mobile dropdown + desktop list) | 1 templ | 1 (`settings_layout.templ`) | none | Healthy isolated layout |
+
+## Per-component sections
+
+### 1. Page header (`.bb-page-header`)
+
+- **What it is:** Top of every admin page — title + optional subtitle on the left, optional primary action on the right.
+- **Where used:** 37 templ files, e.g. `pages/access.templ:10`, `pages/categories.templ:27`, `pages/connection_new.templ:21`, `pages/connections.templ:37`, `pages/feed.templ:49`, `pages/getting_started.templ:15`, `pages/logs.templ:20`, `pages/my_account.templ:15` and `:56`, `pages/settings.templ:15`/`:30`/`:43`/`:58`, `pages/transactions.templ:92`, `pages/users.templ:19`.
+- **Variants in use:** (a) title only; (b) title + subtitle paragraph; (c) title + counts; (d) title + primary-action button on the right; (e) title with leading icon (`getting_started.templ:17`).
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Raw `<div class="bb-page-header"><div><h1 class="bb-page-title">…</h1><p>…</p></div>[<a class="btn …">CTA</a>]</div>` copy-pasted across 37 files.
+- **Issues:** The `<div><h1><p>` left-side scaffold is duplicated verbatim every time. Some headers (`getting_started.templ:17`) attach an inline icon directly to the title; others use a subtitle paragraph with slightly different `mt-1` vs `mt-0.5` spacing.
+- **Recommendation:** Extract `PageHeader(props PageHeaderProps)` templ component (`Title`, `Subtitle`, `Icon`, `Action templ.Component`) — replaces ~150 lines of duplication and forces consistent subtitle margin.
+
+### 2. Sectioned form card (`bb-card p-0 overflow-hidden`)
+
+- **What it is:** The canonical create/edit form pattern: icon header + form body + bottom action row.
+- **Where used:** `pages/create_login.templ:43`, `pages/user_form.templ` (multiple), `pages/category_form.templ`, `pages/tag_form.templ`, `pages/rule_form.templ`, `pages/my_account.templ:169`/`:234`, `pages/agents_settings.templ` (3 instances).
+- **Variants in use:** The full pattern (icon-header + bb-action-row) appears 6 times; loose `bb-card p-0 overflow-hidden` (without the action row) appears 22 more — sectioned panels in `connection_detail.templ`, `settings.templ`, `categories.templ`.
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Hand-rolled wrapper + inline `<div class="bb-icon-header">…</div>` + manual `<div class="bb-action-row">`.
+- **Issues:** Every caller re-writes the icon-header + action-row scaffold. `bb-action-row` is documented but only used 9 times — most pages still hand-roll the bottom row (`pages/agents_settings.templ:262` uses `mt-4 flex justify-end gap-2`; `connection_detail.templ:51` does its own thing).
+- **Recommendation:** Extract `FormCard(IconHeaderProps, body templ.Component, ActionRowProps)` templ component — would cover ~80% of the form pages.
+
+### 3. Icon-header tile (`.bb-icon-header__tile`)
+
+- **What it is:** 40×40 rounded colored square hosting a Lucide icon at the top of form cards or as a row indicator.
+- **Where used:** 51 occurrences. Spec'd variants: `bb-icon-tile--primary|success|warning|error`.
+- **Variants in use:** 4 spec'd modifiers + **at least 6 ad-hoc colour combos that bypass the modifier classes**: `bg-info/8 text-info` (`providers.templ:46`), `bg-warning/8 text-warning` (`providers.templ:346`, `csv_import.templ:246`), `bg-success/8 text-success` (`providers.templ:187`), `bg-primary/8 text-primary` (`csv_import.templ:75`, `access.templ:221`), `bg-warning/10` (no text color, in `rules.templ:241`). Plus a separate strand of `w-10 h-10 rounded-xl bg-X/8` panels not using `bb-icon-header__tile` at all (15 sites in `providers.templ`, `csv_import.templ`, `agents_settings.templ`, `mcp_settings.templ`).
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Mixed — half use the modifier class, half use raw Tailwind tile geometry with ad-hoc tints.
+- **Issues:** Spec says `bg-primary/8` and `bg-success/10` (different opacities) which makes the spec internally inconsistent. The 15 ad-hoc `w-10 h-10 rounded-xl bg-X/8` sites visually match `bb-icon-tile--*` but skip the abstraction.
+- **Recommendation:** Pick one alpha (`/10` is the majority in spec table), update `bb-icon-tile--*` to match, and migrate ad-hoc sites. Also add `info` and `neutral` tones.
+
+### 4. Empty state card
+
+- **What it is:** "No X yet" centered card with icon-in-tinted-square + heading + body + primary CTA.
+- **Where used:** 18 distinct sites; e.g. `pages/access.templ:71` and `:202` (essentially identical 14-line blocks for OAuth Clients / API Keys), `pages/connections.templ:138` and `:163`, `pages/categories.templ:227`, `pages/tags.templ:131`, `pages/users.templ:259`, `pages/account_link_detail.templ:171`, `pages/rules.templ:84`, `pages/feed.templ:258` / `:276` / `:296` / `:319` (4 variants), `pages/logs.templ:364` / `:604` / `:683`, `pages/connection_detail.templ:151` and `:454`.
+- **Variants in use:** 5 visual variants — `bb-card p-12 text-center` (canonical), `bb-card p-8 sm:p-12 text-center` (access.templ — extra mobile padding), `bb-card p-10 sm:p-12 text-center` (feed.templ), `bb-card` + `flex flex-col items-center text-center py-16 px-6` (categories, connections), and compact "no results with filters" inline blocks (`account_detail.templ:402`, `transactions.templ:466`).
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Copy-pasted 12-20 line scaffold; each caller hand-codes icon size (`w-7 h-7` vs `w-8 h-8` vs `w-10 h-10`) and tile geometry (`w-14 h-14` vs `w-16 h-16`).
+- **Issues:** Multiple sizing conventions, multiple padding conventions, identical content shape. `access.templ` literally duplicates the OAuth-Clients block as the API-Keys block (lines 71-84 ≈ 202-215, lines 88-131 ≈ 219-265). This is the single largest extraction win in the codebase.
+- **Recommendation:** Extract `EmptyState(props EmptyStateProps)` templ — `Icon`, `Title`, `Body`, `CTA templ.Component`, optional `Compact bool` for the "no results" variant. Migrate all 18 sites. Saves ~250 lines.
+
+### 5. Resource-list rows (active / revoked pattern)
+
+- **What it is:** A `bb-card divide-y divide-base-300` containing one row per item (avatar + name + metadata + dropdown / inline-confirm action), optionally with a collapsed "N revoked" disclosure below it.
+- **Where used:** `pages/access.templ:46-67` (OAuth Clients) and `:178-199` (API Keys) — visually identical patterns with parameterised icon/label/badge. Also `pages/users.templ:179` (accounts inside member card), `pages/rule_detail.templ:327` and `:406` (applications), `pages/account_link_detail.templ:36` (accounts).
+- **Variants in use:** Two — "active row with dropdown actions" and "revoked row with line-through + opacity-60".
+- **DaisyUI native equivalent:** None (DaisyUI's `list` is too plain).
+- **Current implementation:** `access.templ` has two 78-line blocks (lines 22-149, 152-283) that differ only in icon name, plural label, badge tone, and dropdown action URL.
+- **Issues:** `access.templ` is the canonical example of pure duplication — the two sections are 99% identical. The collapsed-revoked disclosure pattern (`x-data="{ open: false }"` + `x-collapse`) is repeated verbatim.
+- **Recommendation:** Extract `ResourceListSection(props)` templ — covers active + revoked + collapsed-revoked + empty-state branches. Apply to `access.templ` first (saves ~150 lines) then propagate to anywhere that lists "things with a status, that can be revoked or archived".
+
+### 6. Overflow action menu
+
+- **What it is:** Ellipsis-vertical icon button that opens a small dropdown of actions (edit, manage, delete).
+- **Where used:** 6 sites — `pages/rules.templ:185`, `pages/tags.templ:102`, `pages/access.templ:109` / `:243`, `pages/users.templ:155`, `pages/categories.templ:199`.
+- **Variants in use:** Two icon sizes — `w-4 h-4` (5 sites) and `w-5 h-5` (`users.templ:157` only). Two button shells — `btn-xs btn-square rounded-lg` (4 sites) and `btn-sm btn-square rounded-lg opacity-40` (`users.templ:156`).
+- **DaisyUI native equivalent:** `dropdown` + `menu` (used here).
+- **Current implementation:** Hand-rolled with `dropdown dropdown-end` + `dropdown-content menu …`. Width varies (`w-40`, `w-44`).
+- **Issues:** `users.templ:157` uses a larger icon than the rest. Spec says `w-3.5 h-3.5` icons inside dropdown rows but several use `w-3 h-3`.
+- **Recommendation:** Extract `OverflowMenu(items []OverflowMenuItem)` templ — pins the icon-button geometry, menu width, and item icon size. Reduces 6 ~12-line blocks.
+
+### 7. Inline-confirm destructive action
+
+- **What it is:** Click ellipsis → "Revoke…" → menu collapses → inline "Confirm / Cancel" buttons appear in place of the menu.
+- **Where used:** `pages/access.templ:108-129` and `:242-263` (identical except for endpoint URL); also `pages/connection_detail.templ:135`, `pages/categories.templ` (modal-based variant).
+- **Variants in use:** Inline buttons in a `<span>` (access) vs modal `<dialog>` (categories).
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** `x-data="{ confirming: false }"` paired with `x-show="!confirming"` and `x-show="confirming"`.
+- **Issues:** State machine pattern is duplicated; some pages have `@click="document.activeElement.blur()"` to close the dropdown, others don't.
+- **Recommendation:** Add a shared `confirmInline` Alpine factory + a templ wrapper. Or unify on the existing `bb-confirm-*` overlay (in `base.html`) so destructive confirms are always the modal.
+
+### 8. Buttons
+
+- **What it is:** Standard primary/ghost/error/outline buttons with size variants and rounded corners.
+- **Where used:** 176 button instances across the templ pages.
+- **Variants in use:** 28+ distinct class combinations seen in greps. Common patterns: `btn btn-primary btn-sm rounded-xl`, `btn btn-ghost btn-sm rounded-xl`, `btn btn-ghost btn-sm btn-square rounded-xl`, `btn btn-error btn-sm rounded-xl`, `btn btn-error btn-xs btn-soft rounded-lg`, `btn btn-ghost btn-xs rounded-lg`, `btn btn-ghost btn-xs btn-square rounded-lg`, plus oddballs: `btn btn-primary btn-sm btn-soft rounded-xl` (`access.templ:40`, `:171`), `btn btn-primary btn-sm rounded-xl gap-2 text-xs relative overflow-hidden`, `btn btn-error btn-sm btn-outline rounded-xl` (`my_account.templ:258`).
+- **DaisyUI native equivalent:** `btn` (used).
+- **Current implementation:** Spec-compliant for the most part. Spec calls for `btn-sm` → `rounded-xl` and `btn-xs` → `rounded-lg` (and `gap-2` vs `gap-1.5`). Most callers obey this.
+- **Issues:** (a) Inline `text-xs` overrides on `btn-sm` (`pages/mcp_settings.templ`); (b) `min-w-32` is sometimes added for jitter-prevention, sometimes not; (c) icon size inside `btn-sm` is mostly `w-4 h-4` but some use `w-3.5 h-3.5` (spec says `w-3.5 h-3.5` on primary submit, `w-4 h-4` everywhere else — internally contradictory).
+- **Recommendation:** Either tighten the spec (one icon size per button size, no exceptions) **or** introduce a `Button(variant, size, icon, label)` templ helper for the common 6 shapes. The spec table at `docs/design-system.md:131-141` looks complete but enforcement is weak; a helper would prevent drift.
+
+### 9. Badges
+
+- **What it is:** Tag-like status / count chips.
+- **Where used:** 186 badge instances; 46 distinct class combinations.
+- **Variants in use:** Spec says three shapes — `badge-soft badge-{color} badge-sm` (status), `badge-ghost badge-xs` (metadata), `badge-{color} badge-xs` (counts). In practice: many sizes mixed (`badge-xs` and `badge-sm` for similar use), several `gap-1` suffixes, `tabular-nums` extras, and `uppercase tracking-wide` for some.
+- **DaisyUI native equivalent:** `badge` (used).
+- **Current implementation:** Direct DaisyUI classes; only 9 sites call the `StatusBadge()` / `SyncBadge()` Go helpers. Hand-rolled "rounded-full bg-X/10 text-X" chips (`connection_detail.templ:78` `:225`, `reports.templ:91-94`, `report_detail.templ:52-57`) bypass the badge system entirely.
+- **Issues:** (a) Hand-rolled rounded chips diverge in spacing (`px-1.5 py-0.5` vs `px-2 py-0.5`); (b) `report_detail.templ:52` uses `bg-error/10 text-error/90` (off-spec tone); (c) `StatusBadge` is only 9 callers when many more sites render connection/sync status from scratch.
+- **Recommendation:** (a) Make `StatusBadge()` and `SyncBadge()` the only legitimate sources of those badges (lint or audit). (b) Add `CountBadge(n, tone)` and `MetaBadge(label)` helpers. (c) Migrate the 6+ hand-rolled rounded-full chips into the badge system or a new `bb-pill` primitive.
+
+### 10. Ad-hoc colored icon panels
+
+- **What it is:** A 40×40 (or 32×32, 36×36, 56×56, 64×64) rounded colored square holding a Lucide icon — used as a section/card marker, an empty-state hero icon, an inline "row indicator", a status-flag tile.
+- **Where used:** 30+ ad-hoc sites. `pages/providers.templ:46`, `:187`, `:346`; `pages/agents_settings.templ:43`, `:84`, `:121`, `:154`, `:214`; `pages/mcp_settings.templ:150`, `:215`; `pages/csv_import.templ:75`, `:219`, `:246`, `:283`; `pages/rules.templ:86`, `:241`, `:245`, `:249`, `:253`; `pages/access.templ:73`, `:204`, `:221`, `:269`; `pages/users.templ:212`; `pages/connections.templ:140`, `:165`, `:193`, `:210`; `pages/categories.templ:230`, `:254`; `pages/sync_log_detail.templ:223`.
+- **Variants in use:** 6 sizes (`w-7 h-7`, `w-8 h-8`, `w-9 h-9`, `w-10 h-10`, `w-12 h-12`, `w-14 h-14`, `w-16 h-16`) and 6 tones (`bg-base-200/40`, `bg-base-200/60`, `bg-primary/10`, `bg-info/10`, `bg-warning/10`, `bg-success/10`, `bg-error/10`) + the `/8` variants in some pages. Almost no consistency.
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Raw Tailwind utilities.
+- **Issues:** Size + tone combinations are accidental. Spec defines `bb-icon-tile--*` for the 40×40 case but doesn't cover the others. The 56×56 / 64×64 sizes show up in empty states, the 32×32 / 36×36 sizes in list rows.
+- **Recommendation:** Generalize `bb-icon-tile` with size modifiers (`--xs|--sm|--md|--lg`) and tone modifiers (extend with `info`, `neutral`). Migrate all 30+ sites. Big readability win.
+
+### 11. Confirmation patterns (modal vs inline vs overlay)
+
+- **What it is:** Three different mechanisms for confirming a destructive action.
+- **Where used:** (1) Inline-confirm (`x-data="{ confirming: false }"`): `access.templ`, `connection_detail.templ`. (2) DaisyUI `<dialog class="modal">`: `categories.templ:246` (delete category), `connections.templ:461` (create link). (3) Global `.bb-confirm-*` overlay in `base.html`: `bbConfirm()` JS function fired from elsewhere.
+- **Variants in use:** 3 incompatible patterns side-by-side.
+- **DaisyUI native equivalent:** `modal`.
+- **Current implementation:** Mix of three patterns.
+- **Issues:** No consistent UX for "are you sure?" interactions. Destructive deletes go through three different paths depending on the page.
+- **Recommendation:** Standardize on the `bb-confirm-*` overlay (richest UX, supports `danger` vs `warning` variants). Migrate the two `<dialog>` modals + the four inline-confirm sites.
+
+### 12. Form-input primitive (`.bb-form-input`, `.bb-form-select`)
+
+- **What it is:** App-styled input/select with bg-base-200/50 surface that clears on focus.
+- **Where used:** `bb-form-input` in 18 sites (in 8 files: `my_account`, `category_form`, `rule_form`, `tag_form`, `user_form`, `create_login`). `bb-form-select` in 2 sites (`create_login`, `rule_form`).
+- **Variants in use:** 1 each.
+- **DaisyUI native equivalent:** `input input-bordered`.
+- **Current implementation:** `@apply input w-full rounded-xl bg-base-200/50 focus:bg-base-100 transition-colors`.
+- **Issues:** Adopted in newer form pages (post-shared-form-card refactor) but ~30 other form pages still ship `input input-bordered w-full rounded-xl bg-base-200/50` raw. Same shape, different class.
+- **Recommendation:** Migrate the rest of the form pages to `.bb-form-input` and `.bb-form-select`. Codify a templ helper `FormInput(props)` / `FormSelect(props)` to enforce one shape per element.
+
+### 13. `<select>` with `bg-base-200/50` (spec violation)
+
+- **What it is:** The footgun documented in `.claude/rules/ui.md` — alpha on `<select>` renders fully transparent.
+- **Where used:** **One offender** — `pages/category_form.templ:107`: `<button type="button" class="select select-bordered w-full text-left flex items-center gap-2 rounded-xl bg-base-200/50" …>`. Technically a `<button>` styled as a select, so the bug doesn't fire, but the spec violation is visible.
+- **DaisyUI native equivalent:** N/A.
+- **Issues:** The class string matches a `<select>` enough that a future agent might copy it onto a real `<select>`.
+- **Recommendation:** Replace with solid `bg-base-200`. Trivial.
+
+### 14. Inline `style=""` attributes
+
+- **What it is:** Raw `style=""` attributes for cases CSS classes can't reach.
+- **Where used:** 36 occurrences total. Legitimate use cases (15): dynamic per-row category colors (`tx_row.templ:197`, `account_detail.templ:290`, `category_form.templ:49-51`, `tag_form.templ:60`) and dynamic SVG bar heights (`connection_detail.templ:241-261`). Borderline (12): drag-state styling in `prompt_builder.templ:124-206`. Removable (9): `base.html:465` (`opacity:0.6`), `base.html:500/571/708/2330` (`font-size:0.6rem`), `base.html:725/731/737` (`pointer-events:none`), `tx_results.templ:156` (`display:none`).
+- **DaisyUI native equivalent:** N/A.
+- **Issues:** The "removable" ones could be utility classes. The dynamic ones are inherent to runtime color binding.
+- **Recommendation:** Convert the 9 removable ones to utility classes. Leave the rest.
+
+### 15. Translucent surface patterns (`bg-base-200/{20-50}`)
+
+- **What it is:** Subtle grey wash used as background for read-only inputs, info panels, action-row footers.
+- **Where used:** 82 occurrences. Common shape: `bg-base-200/50`, `/40`, `/30`, `/20`. Examples: `rule_form.templ:96/119/169/260/281`, `csv_import.templ:84/165/179/227`, `account_link_detail.templ`, `condition_row.templ:21`.
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Inline Tailwind utilities scattered across pages.
+- **Issues:** The opacity step varies (20 / 30 / 40 / 50 / 60) without justification — visually they all look like "subtle grey".
+- **Recommendation:** Define `bb-surface-muted` (one tone) + `bb-surface-subtle` (lighter) — two named tones max. Migrate.
+
+### 16. Translucent borders for danger / warning surfaces
+
+- **What it is:** `border-error/20|30|40`, `bg-error/[0.02]|5|10` used on warning panels and danger-zone cards.
+- **Where used:** 15+ sites. `my_account.templ:246` (`bb-card border-error/20`), `pages/feed.templ:132` (`alert alert-warning`), `connections.templ:300` (`text-warning bg-warning/10`), `connection_detail.templ:30` (`bg-error/10`), `settings.templ:221/462` (`text-error/80 bg-error/5`).
+- **DaisyUI native equivalent:** `alert alert-warning`, `bb-danger-card`.
+- **Current implementation:** Mixed — some use `bb-danger-card`, others use `alert alert-warning rounded-xl`, others go fully ad-hoc.
+- **Issues:** Three different patterns for "this is a warning surface". `bb-danger-card` is defined in spec but only `create_login.templ:130` uses it.
+- **Recommendation:** Pick one — `bb-danger-card` for in-card destructive zones, `alert alert-{tone}` for floating banners. Migrate the rest.
+
+### 17. Stat-tile cards (4-up dashboards)
+
+- **What it is:** Small bb-cards rendered in a 2x2 / 4x1 grid with a colored tile + big tabular-nums value + small label.
+- **Where used:** `pages/rule_detail.templ:247-307` (4-tile rule stats), `pages/logs.templ:140-160` (similar), `pages/connection_detail.templ:215-225` (4-up stat row), `pages/getting_started.templ:34-56`.
+- **Variants in use:** Different sizes (`w-9 h-9` vs `w-10 h-10`), different value typography (`text-2xl font-semibold leading-none` vs `text-xl font-bold`).
+- **DaisyUI native equivalent:** `stat` / `stats` (not used — DaisyUI's defaults don't match the design).
+- **Current implementation:** Hand-rolled card + flex row.
+- **Issues:** Repeated 4-tile dashboards differ in tile geometry and label position.
+- **Recommendation:** Either adopt DaisyUI `stat` with custom theming, or extract a `StatTile(icon, tone, value, label)` templ component.
+
+### 18. Section header (icon + h2/h3 + counter)
+
+- **What it is:** `<i data-lucide="…"> <h2>Heading</h2> <span class="text-xs text-base-content/40">N items</span>` — appears above lists.
+- **Where used:** `access.templ:25-44` (twice, OAuth + API Keys), `rule_detail.templ` (several), `users.templ:30` flash-alert variant, `connection_detail.templ` (multiple), `categories.templ`.
+- **Variants in use:** Heading element size (`text-sm` vs `text-lg`), icon size (`w-4 h-4` vs `w-5 h-5`), counter formatting.
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Hand-rolled flex row.
+- **Issues:** Different sites use different heading levels and counter formats.
+- **Recommendation:** Extract `SectionHeader(icon, title, count, action)` templ component.
+
+### 19. Copy-to-clipboard pattern
+
+- **What it is:** Readonly input + clipboard-icon button that swaps to a checkmark for 2s.
+- **Where used:** `api_key_created.templ:30-39` (1 instance), `oauth_client_created.templ:40-79` (3 instances), `mcp_guide.templ:31/147/169/177/214/247` (6 instances), `user_form.templ:66`, `create_login.templ:110`, `agents_settings.templ:239` (1-off).
+- **Variants in use:** Inline-Alpine (`navigator.clipboard.writeText…`) and shared-helper (`copyAndFlash`) — two patterns.
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Inline `@click` handlers ~80 chars long, plus a `copyAndFlash(content, $data)` helper in `mcp_guide.js`.
+- **Issues:** Two patterns for the same UI affordance.
+- **Recommendation:** Unify around `copyAndFlash` and extract a `CopyableField(label, value)` templ component.
+
+### 20. Activity timeline primitives
+
+- **What it is:** GitHub-style activity timeline used on transaction-detail, feed, sync logs.
+- **Where used:** `feed.templ:188`, `transaction_detail.templ:610`, `sync_log_detail.templ`.
+- **Variants in use:** Two — card mode (default) and prominent mode (used on `/feed` and `/transactions/{id}`).
+- **DaisyUI native equivalent:** None.
+- **Current implementation:** Well-organized templ component family (`Timeline`, `TimelineDay`, `TimelineSystemRow`, `TimelineCommentRow`, `TimelineEmpty`).
+- **Issues:** None functional. The `.bb-timeline-prominent` CSS overrides (lines 2881-3174 of input.css) are 300+ lines of `:has()`-based selectors riding on Tailwind utility class names (`w-6.h-6`, `leading-6`, `flex-1.text-sm.leading-6`). Brittle to any markup change inside the timeline primitives. Spec calls this out (input.css:822-826) but the brittleness remains.
+- **Recommendation:** Refactor the prominent-mode overrides to use stable data attributes (`data-timeline-tile`, `data-timeline-body`) instead of `:has()` + utility-class selectors. Reduces future-breakage risk.
+
+### 21. Spacing / divider patterns
+
+- **What it is:** Bottom-border separator between sections inside a card.
+- **Where used:** `border-t border-base-300/50` + `border-base-300/40` + `border-base-300/60` appear in multiple files. Spec calls for `/50`.
+- **Variants in use:** 4 opacity values (`/40`, `/50`, `/60`, default `border-base-300`).
+- **Issues:** Three values for what should be one divider.
+- **Recommendation:** Canonicalize on `/50` (spec) and ban the rest. Or define `.bb-divider` utility.
+
+### 22. Dead / orphaned CSS classes
+
+- **What it is:** Classes defined in input.css with zero or near-zero templ callers.
+- **Where used:** `.bb-skeleton*` (~110 lines, lines 2402-2515, 0 callers); `.bb-summary-pill` + `.bb-sparkline` + `.bb-health-ring` (0 templ callers); `.bb-rule-cat-badge`, `.bb-rule-creator-badge` (0 templ callers); `.bb-triage-*` (~225 lines, lines 2577-2818, no direct templ callers — possibly rendered by `reviews.js`); `.bb-page-skeleton`, `.bb-loading-fade` (0 callers).
+- **Recommendation:** Retire entirely unless you can prove a JS-side render path. Saves ~400 lines of CSS.
+
+### 23. Single-caller `bb-*` primitives
+
+- **What it is:** Classes meeting the "appears 3+ times" threshold the spec mandates but with only 1-2 sites.
+- **Where used:** `.bb-filter-toggle` + `.bb-filter-form` (1 caller — `logs.templ:168/184`); `.bb-filter-bar` (2 callers); `.bb-table-header` (2 callers); `.bb-view-toggle*` (1 caller — `transactions.templ:103-108`); `.bb-paginator*` (1 caller — `tx_results.templ:91-130` for ~30 lines); `.bb-rule-creator-badge--user` / `--agent` (0 templ callers).
+- **Recommendation:** Inline back to utilities, or commit to broader adoption. The spec's "3+ uses" rule is being violated by the spec itself.
+
+### 24. Modal padding / safe-area pattern
+
+- **What it is:** `[padding-bottom:calc(1.5rem+env(safe-area-inset-bottom,0px))] sm:[padding-bottom:1.5rem]` — iOS safe-area bottom padding for mobile modal.
+- **Where used:** 3 modal sites (`categories.templ:252`, `connections.templ:462`). All identical.
+- **Recommendation:** Extract as `bb-modal-box` class. Trivial.
+
+### 25. Inline `<header>` inside cards
+
+- **What it is:** Inline header bar — `<header class="flex items-center gap-2 pb-4 mb-4 border-b border-base-300/60">…</header>`.
+- **Where used:** `timeline.templ:109/156`, `feed.templ:49`, `transaction_detail.templ:346`.
+- **Variants in use:** 4 — different padding / margin / border opacity each time.
+- **Recommendation:** Pick one — probably the canonical `px-4 sm:px-5 py-3` from the sectioned-card spec.
+
+## Cross-cutting findings
+
+### Hackiness inventory
+
+- **`!important`** appears 13 times in input.css. Most are intentional (Tailwind utility shadowing): `.bb-tx-checkbox` display rules (lines 1110, 1126, 1138), `.bb-tx-date` visibility (lines 1378-1382), button `transform: scale()` (`btn` :active line 998), select transition (line 1017), modal-backdrop (1050), x-collapse (1304), drawer-side z-index (1310), triage-row focused background (2593, 2604), progress-bar `--done` (2340). All defensible; document the "fights utilities" rationale once and stop adding.
+- **Raw `style=""` attributes** — 36 total. Removable: 9 (see component #14). Necessary: 27 (dynamic colors, dynamic SVG dimensions).
+- **`opacity` modifiers on surfaces** (e.g. `bg-base-200/50`) — 82 sites. The footgun is documented for `<select>` but the broader proliferation across 5 opacity steps (20/30/40/50/60) is uncontrolled.
+- **Duplicated 50+ line blocks:**
+  - `access.templ:22-149` ≡ `access.templ:152-283` (OAuth Clients ≡ API Keys, 130 lines each).
+  - `oauth_client_created.templ:39-61` (Client ID / Client Secret blocks, identical except labels).
+  - `feed.templ:258-330` (4 empty-state variants, near-identical scaffolds).
+  - `agents_settings.templ:39-180` (4 textarea cards with identical icon-header + textarea + counter shape).
+  - `settings.templ:15-100` (4 successive `bb-page-header` blocks).
+- **Hand-rolled rounded-full chips** that bypass the badge system (6+ sites): `connection_detail.templ:78`, `:225`, `reports.templ:91-94`, `report_detail.templ:52-57`. Different sizes, different paddings.
+- **Inline tooltip without DaisyUI `tooltip`** — `connections.templ:227-235` ("Sync Error" tooltip via `group/err` + `group-hover/err:block`), `connection_detail.templ:266-272` (day-bar tooltip).
+
+### Off-spec drift
+
+- **`bg-primary/8` vs spec `bg-primary/10`** — spec table at `docs/design-system.md:194-196` says `bg-primary/8 text-primary` but lines 195-197 say `bg-success/10`, `bg-warning/10`, `bg-error/10`. The spec itself is inconsistent. Actual usage: `/8` is used 6 times for tiles, `/10` 12 times. **The spec is the source of confusion.**
+- **`bg-info/8` and `bg-success/8`** — not in spec at all; introduced via `connection_detail_helpers.go:85-91` and `csv_import.templ`. Should match the spec or extend it.
+- **Spec calls for `rounded-xl` on `btn-sm` and `rounded-lg` on `btn-xs`** — fully obeyed except `oauth_client_created.templ:44/55/74` use `btn-sm rounded-xl` and look fine, while `tags.templ:78` mixes `rounded` (default) for a code chip.
+- **Spec calls for `gap-2` on `btn-sm` icon+text, `gap-1.5` on `btn-xs`** — partially obeyed; many sites use `gap-1.5` on `btn-sm`.
+- **Spec forbids `rounded-lg`/`rounded-xl` on badges** — looks like nobody violates this currently.
+- **`p-8` on form-card top section** — spec at `docs/design-system.md:489` explicitly says "do **not** use `p-8`". Actual offenders: `connection_new.templ` (`bb-card p-8 max-w-lg`), `oauth_authorize.templ`, `errors.templ`, `getting_started.templ`. Centered auth-form variants — possibly intentional but the spec says no.
+- **`bb-card max-w-md w-full p-6 bg-base-100 shadow-xl rounded-2xl`** (`feed.templ`) — combines `bb-card` (which already paints `bg-base-100 rounded-xl border border-base-300`) with explicit `shadow-xl` and `rounded-2xl` — three conflicts in one selector.
+- **`shadow-xl` ring sometimes added to cards** — spec says cards are border-based, not shadow-based. Drift sites: `feed.templ`, `oauth_authorize.templ`.
+
+### Missing primitives (3+ repetitions, no shared abstraction)
+
+Ranked by call count, highest-impact first:
+
+1. **`EmptyState`** — 18 callers, 5 visual variants. Single biggest extraction win.
+2. **`PageHeader`** — 37 callers. Easy extract, kills `<div><h1><p>` boilerplate.
+3. **`SectionHeader` (icon + title + count + action)** — 6+ callers.
+4. **`StatTile` (icon + value + label)** — 4+ callers, all subtly different.
+5. **`OverflowMenu` (kebab dropdown)** — 6 callers.
+6. **`FormCard` (icon-header + body + action-row scaffold)** — 6-10 callers depending on definition.
+7. **`ResourceListSection` (active + revoked + empty)** — 4+ callers, `access.templ` is 99% duplicated.
+8. **`CopyableField`** — 10+ callers, two competing implementations.
+9. **`ConfirmInline` Alpine helper** — 4 callers, 3 different state machines.
+10. **`Badge` Go helper (status, count, meta)** — there are already `StatusBadge`/`SyncBadge` but they cover only 9 of the 186 badge sites.
+
+### Over-abstracted (`bb-*` used only once or twice)
+
+Candidates for retirement if not promoted:
+
+- `.bb-skeleton*` family (0 callers, 110 lines)
+- `.bb-summary-pill`, `.bb-sparkline`, `.bb-health-ring` (0 callers)
+- `.bb-rule-cat-badge`, `.bb-rule-creator-badge`, `.bb-rule-creator-badge--agent|--user` (0 templ callers)
+- `.bb-page-skeleton`, `.bb-loading-fade` (0 callers)
+- `.bb-view-toggle*` (1 caller — transactions)
+- `.bb-filter-toggle`, `.bb-filter-form` (1 caller — logs)
+- `.bb-paginator*` (1 caller — tx_results)
+- `.bb-table-header` (2 callers)
+- `.bb-filter-bar` (2 callers)
+- `.bb-triage-*` (no templ callers; possibly used by `/reviews` JS render — verify before retiring)
+
+If retained, the spec's "appears 3+ times" rule should be amended to acknowledge that some single-caller `bb-*` classes exist because the surface is unique (e.g. one paginator, one command palette).
+
+### Specific bugs to call out
+
+- **`pages/category_form.templ:107`** — `<button class="select select-bordered … bg-base-200/50">`. The styled-as-select button doesn't trigger the `<select>` opacity bug but the class string is identical to the documented footgun.
+- **`pages/feed.templ:296`** — `class="bb-card max-w-md w-full p-6 bg-base-100 shadow-xl rounded-2xl"` — five class conflicts/redundancies in one selector (bb-card already sets bg + rounding; `shadow-xl` violates the "border not shadow" spec; `rounded-2xl` overrides `rounded-xl`).
+- **`.bb-form-error`** (input.css:299) — class defined, zero callers. Either remove or migrate inline `bg-error/10 text-error px-4 py-3` blocks (`csv_import.templ:108`) onto it.
+- **`access.templ:71` vs `:202`** — `bb-card p-8 sm:p-12 text-center` is used twice but the canonical empty-state padding in spec is `p-12 text-center` only.
+- **`pages/agent_wizard.templ:120`** — `bg-base-300/50 ... group-hover:bg-base-300/70` — base-300 with opacity for an interactive surface; uncommon and likely off-tone.
+- **`base.html:465`** — inline `style="opacity:0.6"` on a `.bb-shortcuts-label` — should be a class.
+- **`base.html:500/571/708`** — `style="font-size:0.6rem"` inline — `text-[0.6rem]` would work.
+- **Tooltip overrides** — `.bb-tag.tooltip` rule at the very bottom of input.css (line 2877) is unlayered to defeat DaisyUI's deeper sub-layer; a one-off but flagged because it's load-bearing — see comment.
+
+## Priorities (top 10)
+
+1. **Extract `EmptyState` templ component.** (M) Replaces 18 sites of duplicated 12-20 line scaffolds with one component. Forces consistent padding/sizing. Net saving ~250 lines.
+2. **Extract `PageHeader` templ component.** (S) 37 callers; trivially mechanical. Kills `<div><h1><p>` boilerplate.
+3. **Fold `access.templ` OAuth + API Keys into a `ResourceListSection` component.** (M) The two sections are 99% identical (130 lines each). Apply to any "things with status + dropdown actions + revoked-collapsed list" page. ~150 lines saved on access.templ alone.
+4. **Retire dead CSS classes.** (S) `bb-skeleton*`, `bb-summary-pill`, `bb-sparkline`, `bb-health-ring`, `bb-rule-cat-badge`, `bb-rule-creator-badge`, `bb-page-skeleton`, `bb-loading-fade`. ~400 lines from input.css. Validate `bb-triage-*` against `reviews.js` first.
+5. **Fix spec self-contradictions in `bb-icon-tile--*` alpha values.** (S) Pick `/10` (majority), update CSS modifier classes to match, migrate the `/8` strays. While there, extend with `info` and `neutral` modifiers and add size variants for the 6 different ad-hoc tile sizes (30+ sites). One spec change, many migrations.
+6. **Extract `OverflowMenu` templ + `SectionHeader` templ.** (S) 6 + 6 callers respectively. Mechanical wins, normalizes icon size + width inside dropdown rows.
+7. **Standardize destructive-confirm UX.** (M) Pick one of (inline-confirm, `<dialog>` modal, `bb-confirm-*` overlay) and migrate the other two. Current state has 3 incompatible patterns. Recommend `bb-confirm-*` overlay because it already exists in `base.html` with full keyboard + a11y support.
+8. **Migrate hand-rolled rounded-full chips into the badge system.** (S) 6+ sites that bypass `badge badge-*`. While there, audit the `StatusBadge()`/`SyncBadge()` Go helpers and require their use everywhere a connection-status or sync-status pill is rendered (currently 9 of ~37 sites use the helper).
+9. **Consolidate translucent surface tones.** (M) Define `bb-surface-muted` + `bb-surface-subtle` and replace `bg-base-200/{20,30,40,50,60}` proliferation (82 sites). Define `bb-divider` for `border-base-300/{40,50,60}`. Disambiguates the visual hierarchy.
+10. **De-brittle the prominent-mode timeline overrides.** (L) The 300-line `:has()` + utility-class selector block in input.css:2881-3174 will break the next time someone changes a Tailwind class inside the timeline primitives. Add stable `data-timeline-*` attributes on the primitives and rewrite the overrides against those.
+
+Effort key: S ≤ 1 day, M ≤ 3 days, L ≤ 1 week.

--- a/docs/design-system-audit/daisyui-coverage.md
+++ b/docs/design-system-audit/daisyui-coverage.md
@@ -1,0 +1,326 @@
+# DaisyUI 5 Coverage Audit
+
+**Date:** 2026-05-24. **Scope:** v1 admin UI only — `internal/templates/components/**/*.templ` (52 templ pages + 12 shared), `internal/templates/layout/base.html` (the app shell, 2.4k lines), `internal/templates/partials/*.html` (5 thin bridges to templ), `input.css` (3.2k lines, ~190 `bb-*` classes), and Alpine factories in `static/js/admin/components/`. The v2 React SPA under `web/` is explicitly out of scope.
+
+**Methodology:** Fetched daisyUI 5's canonical component list from `daisyui.com/llms.txt`, then `grep`-counted every component + modifier across the templ tree, cross-referenced against the `bb-*` class inventory in `input.css`, and read every shared primitive (`nav.templ`, `breadcrumb.templ`, `kbd.templ`, `flash.templ`, `tag_chip.templ`, `timeline.templ`, `base.html`) plus a sample of feature pages (`transactions.templ`, `mcp_guide.templ`, `csv_import.templ`, `connections.templ`, `categories.templ`, `agents.templ`).
+
+**Headline numbers.** `btn` (387 `btn-sm`, 280 `btn-ghost`, 196 `btn-primary`) and `badge` (116 `badge-xs`, 98 `badge-soft`) are the workhorses — both used natively with consistent conventions. Daisy `card` is used **2x** (only on `/agents` and `/agents/sessions/{id}`); everywhere else (82 templ files) uses the hand-rolled `.bb-card`. Daisy `stat`, `breadcrumbs`, `pagination`, `collapse`, `accordion`, `tabs`, `timeline`, `kbd`, `chat`, `hero`, `divider`, `indicator`, `mockup`, `avatar`, `skeleton`, `radial-progress` — **all hand-rolled or absent**. The repo has ~190 `bb-*` classes, of which roughly 35 duplicate something daisy ships.
+
+---
+
+## Coverage matrix
+
+Legend: ✅ used natively · ⚠️ used with significant overrides · 🔁 hand-rolled equivalent in `bb-*` · 🚫 N/A · ❌ should be used but isn't
+
+### Actions
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Actions | button | ✅ | 448 templ matches; `.btn` polish + `transition` + `:active scale(0.97)` in `input.css:990-998`. Convention enforced (`rounded-xl` on `btn-sm`, `rounded-lg` on `btn-xs`) in `docs/design-system.md`. | keep |
+| Actions | FAB | 🚫 | Not used; not appropriate for desktop admin. | none |
+| Actions | swap | 🚫 | Not used; `bb-tx-checkbox` is imperatively toggled, not via swap. | none |
+
+### Data display
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Data display | badge | ⚠️ | 214 matches, heavy use of `badge-soft badge-{color} badge-{size}`. But 6+ bespoke badge clones in `input.css`: `.bb-tag` (`:515`), `.bb-rule-cat-badge` (`:1262`), `.bb-rule-creator-badge` (`:1281`), `.bb-nav-badge` (`:474`), `.bb-triage-badge` (`:2632`), `.bb-tagpicker-diff-pill` (`:2292`). | consolidate (see deep-dive) |
+| Data display | card | 🔁 | Daisy `card` used 2x only (`agents.templ`, `session_detail.templ`). Everywhere else: `.bb-card` (`input.css:244`) — `bg-base-100 rounded-xl border border-base-300` with dark-mode color-mix lift. 82 templ files import. | keep `bb-card` (extends daisy with a needed dark lift), but document divergence (see deep-dive) |
+| Data display | chat | 🔁 | Hand-rolled `.bb-comment-bubble` (`input.css:727`) for the transaction-detail timeline — flat top-left corner pointing at avatar; markdown styling rules `:747-787`. | consider daisy `chat` + `chat-bubble` (see deep-dive) |
+| Data display | countdown | 🚫 | Not needed. | none |
+| Data display | diff | 🚫 | Not needed. | none |
+| Data display | divider | ❌ | 0 uses of `.divider`. We hand-roll dividers with `border-t border-base-300/50` inside sectioned cards (`docs/design-system.md` §4). | low priority — Tailwind border is fine here |
+| Data display | indicator | ❌ | 0 uses. `.bb-nav-badge` (sidebar count pill) could be a daisy `indicator` + `badge`. | consider for sidebar counts |
+| Data display | loading | ✅ | 48 `loading-spinner` + 46 `loading-xs`. Faithful. | keep |
+| Data display | mask | 🚫 | 1 incidental usage (`mask-image` Tailwind utility, not daisy mask). Not applicable. | none |
+| Data display | progress | ⚠️ | 1 daisy usage; the SPA nav progress bar is hand-rolled `.bb-progress-bar` (`input.css:2313`) because daisy `progress` doesn't do the fixed-top-strip rolling animation we need. | keep custom (justified) |
+| Data display | radial-progress | ❌ | 0 uses; we have `.bb-health-ring` (`input.css:984`) hand-rolled SVG for financial health score. | consider daisy `radial-progress` |
+| Data display | skeleton | 🔁 | 0 uses of daisy `skeleton`. Full bespoke system: `.bb-skeleton`, `.bb-skeleton--text/text-sm/text-xs/badge/circle/circle-sm/amount/card/table-row/page-skeleton` (`input.css:2402-2510`) with shimmer animation. | adopt daisy `skeleton` + `skeleton-text` (see deep-dive) |
+| Data display | stat | ❌ | 0 uses of daisy `stat`/`stat-value`/`stat-title`. We render stats as `bb-card p-4` with ad-hoc grid. Spec docs reference `stat-value` (`design-system.md:763`) but no page uses it. | adopt for dashboard / overview tiles (see deep-dive) |
+| Data display | status | ❌ | 0 uses. New in daisy 5 — dot-style state indicator. Could replace ad-hoc colored `.bb-tx-row__indicator` (`input.css:2613`). | low priority |
+| Data display | table | ✅ | 8 `table-sm` matches; sticky headers via `table-pin-rows`. Tables are the right size + zebra config per spec (`design-system.md` §6). | keep |
+| Data display | timeline | 🔁 | Daisy ships a vertical timeline component. We hand-roll everything in `internal/templates/components/timeline.templ` (387 LOC of templ) + `.bb-timeline`, `.bb-timeline-prominent`, `.bb-timeline-count` (`input.css:813-824` and unlayered overrides `input.css:2881-3174`). Our needs (continuous left rail through 24px tiles, comment-bubble tail, `:has()` rail-mask CSS) exceed what daisy timeline provides. | keep custom (justified — daisy timeline doesn't do rail-threading) |
+
+### Navigation
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Navigation | breadcrumbs | 🔁 | 0 uses of daisy `breadcrumbs`. We hand-roll `.bb-breadcrumb` + `.bb-breadcrumb-item/sep/current` (`input.css:206-241`) with chevron SVGs. `BreadcrumbNav` templ at `breadcrumb.templ:14`. | consider daisy `breadcrumbs` (see deep-dive) |
+| Navigation | dock | 🚫 | Not used; not appropriate for desktop admin. | none |
+| Navigation | menu | ⚠️ | 7 uses, all in `dropdown-content menu` rows for ellipsis overflow menus (`tags.templ:106`, `rules.templ:189`, `access.templ:113`/`:247`, `users.templ:159`, `categories.templ:203`, `settings_layout.templ:92`). Sidebar nav is **NOT** daisy `menu` — it's `.bb-sidebar-nav` + `.bb-sidebar-link` (`input.css:362-456`) to get hover/active/icon-opacity choreography daisy `menu` doesn't provide. | keep custom sidebar (justified); keep `menu` in dropdowns |
+| Navigation | navbar | ⚠️ | Used in `base.html:235` as `bb-mobile-navbar` (extends `.navbar` with sticky positioning, backdrop blur, safe-area). | keep (extension is justified) |
+| Navigation | pagination | 🔁 | 0 daisy `pagination`/`join` for paging. Hand-rolled `.bb-paginator` + `.bb-paginator__btn/btn--active/ellipsis/info/nav/per-page` (`input.css:1384-1421`). | consider daisy `join`+`btn-square` pattern (see deep-dive) |
+| Navigation | steps | ✅ | Used natively in `mcp_guide.templ` (3-step indicator) + `csv_import.templ` (custom hand-rolled steps using utility classes — should use daisy `steps`). | normalize CSV importer to daisy `steps` |
+| Navigation | tabs | ❌ | 0 uses of daisy `tabs`/`tabs-box`/`tab-active`. The `mcp_guide` "agent tabs" (`mcp_guide.templ:87`) hand-roll with `role="tablist"` + `btn-primary`/`btn-ghost` toggling. `settings_layout.templ` uses a dropdown-menu pattern instead of tabs. | adopt daisy `tabs-box` or `tabs-border` (see deep-dive) |
+
+### Feedback
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Feedback | alert | ⚠️ | 26 matches with proper modifiers (`alert-info/success/warning/error`, `alert-soft` per spec). But `csv_import.templ:202` hand-rolls one as `flex items-start gap-3 rounded-xl bg-error/10 text-error px-4 py-3` instead of `alert alert-error alert-soft rounded-xl`. Also `.bb-form-error` (`input.css:299`) is a near-duplicate of `alert-error alert-soft` for inline form errors. | normalize csv_import; document `bb-form-error` as the inline-tight variant |
+| Feedback | modal | ⚠️ | 4 native `<dialog class="modal">` uses (`categories.templ:252`, `connections.templ:462`, `create-link-modal`, `delete-modal`). Convention from `design-system.md` followed. But the global confirm/cmdk/shortcuts/category-picker/tag-picker dialogs in `base.html` are **all bespoke** (`.bb-confirm-dialog`, `.bb-cmdk-dialog`, `.bb-shortcuts-dialog`, `.bb-catpicker-dialog`, `.bb-tagpicker-dialog` — 5 nearly identical dialog shells in `input.css`). | consolidate the 5 bespoke dialog shells (see deep-dive) |
+| Feedback | toast | ⚠️ | 1 native `class="toast toast-top toast-center"` (`report_detail.templ:34`). The global toast in `base.html:353` uses bespoke `fixed bottom-8 left-1/2 -translate-x-1/2` markup instead of daisy `toast toast-center toast-bottom`. | adopt daisy `toast` for the global pill |
+| Feedback | tooltip | ✅ | 20 `tooltip-top` uses; `data-tip` attribute pattern. Faithful. One unlayered-CSS hack `.bb-tag.tooltip { display: inline-flex }` (`input.css:2877`) to fix tag-chip + tooltip combo. | keep |
+
+### Data input
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Data input | checkbox | ✅ | 22 native uses with `checkbox-sm`/`-xs`/`-primary`/`-warning`. | keep |
+| Data input | file input | ✅ | 7 native `file-input file-input-bordered` uses (`csv_import`, `providers`, `backups`). | keep |
+| Data input | filter | ❌ | 0 daisy `filter`/`filter-reset` uses. Our `.bb-filter-bar` (`input.css:668`) wraps `input-sm`/`select-sm` and a Reset button. Daisy `filter` is a radio-driven slot — semantically different, probably not a fit. | none (different scope) |
+| Data input | input (text) | ⚠️ | 76 `input-bordered` uses. **Note:** daisy 5 dropped `input-bordered` as a separate modifier — the bordered look is now the `input` default. Our usage works because daisy still ships the class, but it's redundant. Custom `.bb-form-input` (`input.css:295`) adds focus-bg shift. | strip `input-bordered` (daisy 5 default) — non-urgent |
+| Data input | label | ⚠️ | Three label patterns coexist: daisy `<label class="label"><span class="label-text">`, `.bb-filter-label` (filter bars), and `<label class="text-sm font-medium text-base-content/70 mb-1.5 block">` (form fields). Documented in `design-system.md:227-230`. Form pages have drifted toward the third (most common in `csv_import.templ`, `agents_settings.templ`). | consider standardizing on daisy `fieldset`+`label`+`legend` |
+| Data input | radio | ✅ | 6 native uses with `radio-sm radio-primary`. | keep |
+| Data input | range | 🚫 | Not used. | none |
+| Data input | rating | 🚫 | Not used. | none |
+| Data input | select | ⚠️ | 92 `select-bordered` uses. Same daisy-5 redundancy as `input-bordered`. Custom `.bb-form-select` (`input.css:296`) adds bg-200. `<select>` has its own dark-mode `::picker(select)` overrides (`input.css:1024-1046`) — necessary because daisy 5's `appearance: base-select` strips backgrounds in dark mode. | strip `select-bordered`; keep `::picker` overrides (justified bug fix) |
+| Data input | textarea | ✅ | 12 native uses. | keep |
+| Data input | toggle | ✅ | 12 `toggle-primary` + 14 `toggle-sm`. Faithful. | keep |
+| Data input | validator | ❌ | 0 uses. New in daisy 5 — pure-CSS form validation. Worth a look for inline-edit on `connection_detail` and form pages, but Alpine validation already does most of this. | low priority |
+
+### Layout
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Layout | avatar | ❌ | 0 uses of daisy `.avatar`/`avatar-placeholder`/`avatar-group`. We have `.bb-tx-avatar` (`input.css:1171`, category-colored 36×36 tile) and `.bb-sidebar-profile-avatar` (raw `<img class="rounded-full">`). Owner-badge avatar overlay (`.bb-tx-owner-badge`) is also custom. | consider `.avatar` chrome for sidebar profile + cmdk; `.bb-tx-avatar` is data-driven (color-mix from category), keep custom |
+| Layout | carousel | 🚫 | Not used. | none |
+| Layout | collapse / accordion | 🔁 | 0 uses of daisy `collapse`/`collapse-arrow`/`accordion`. Filter panels use `x-collapse` (Alpine) wrapped in `.bb-filter-toggle` + `.bb-filter-form` (`input.css:1349-1364`). Settings page uses native `<details><summary>`. | consider daisy `collapse-arrow` for filter panel (see deep-dive) |
+| Layout | drawer | ✅ | 1 use in `base.html:229` — the canonical app shell drawer. Faithful (`drawer lg:drawer-open`, `drawer-toggle`, `drawer-content`, `drawer-side`, `drawer-overlay`). Bespoke focus-trap JS added on top. | keep |
+| Layout | dropdown | ✅ | 14 `dropdown-content` + 12 `dropdown-end`. Convention: `dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1`. | keep |
+| Layout | fieldset | ⚠️ | 19 `class="fieldset"` (no daisy modifiers, no `fieldset-legend`). Most are `<fieldset class="fieldset">` with our custom `<label class="text-sm font-medium...">` instead of daisy `<legend class="fieldset-legend">`. We're using the daisy fieldset _frame_ but not its legend. | adopt `fieldset-legend` consistently (see deep-dive) |
+| Layout | footer | 🚫 | Admin has no footer. | none |
+| Layout | hero | 🚫 | Not used. | none |
+| Layout | join | ⚠️ | 1 use (`mcp_guide.templ:102`) — `join rounded-lg border border-base-300` wrapping two `join-item btn` for Guide/Config toggle. Faithful but rare. The bb-view-toggle (`input.css:1331`) is essentially a re-implementation of join+btn. | consider daisy `join` for `bb-view-toggle` |
+| Layout | list | ❌ | 0 uses of daisy 5's new `list`/`list-row` component. Several pages have card-list patterns that could use it (agents list, rules list, users grid). | low priority — bb-card grid is fine |
+| Layout | stack | 🚫 | Not used. | none |
+
+### Mockup / Other
+| Category | Component | Status | Our usage / hand-rolled equivalent | Action |
+|---|---|---|---|---|
+| Mockup | browser/code/phone/window | 🚫 | Not appropriate for a financial admin. | none |
+| Other | calendar | 🚫 | We use native `<input type="date">` everywhere — fine. | none |
+| Other | kbd | 🔁 | 0 uses of daisy `kbd`/`kbd-xs/sm/md/lg/xl`. We hand-roll `.bb-kbd` + `.bb-kbd-combo`/`.bb-kbd-combo__key` (`input.css:2525-2575`), plus near-duplicates `.bb-cmdk-kbd` (`:1593`), `.bb-shortcuts-kbd` (`:1945`), `.bb-cmdk-footer kbd` (`:1625`), and another in `.bb-catpicker-footer kbd` (`:2103`). 4 near-identical shadow + bg + border definitions. | consolidate (see deep-dive) |
+| Other | link | ✅ | 39 uses (`link link-primary`, `link link-hover`). Mostly inside paragraphs of explainer text. | keep |
+| Other | theme-controller | 🚫 | We auto-switch via `prefers-color-scheme`; no user-facing theme toggle. | none |
+
+---
+
+## Per-component deep dives
+
+### Skeleton — full bespoke replacement
+- **DaisyUI status:** daisy 5 ships `skeleton` (base) + `skeleton-text` modifier. Single class with built-in shimmer.
+- **Our usage:** zero daisy `skeleton`. We have an entire `bb-skeleton` system at `input.css:2402-2510`: `bb-skeleton`, `bb-skeleton--text`, `bb-skeleton--text-sm`, `bb-skeleton--text-xs`, `bb-skeleton--badge`, `bb-skeleton--circle`, `bb-skeleton--circle-sm`, `bb-skeleton--amount`, `bb-skeleton--card`, `bb-skeleton-table-row`, `bb-page-skeleton`. Used inline in `base.html:727-744` for cmdk loading rows. Bespoke shimmer keyframe `bb-shimmer`.
+- **What we're doing instead:** ~110 lines of CSS replicating daisy's animation, plus 9 size variants instead of using Tailwind utility sizes on top of `skeleton`.
+- **Recommended action:** delete `bb-skeleton*` entirely; replace with `<div class="skeleton w-16 h-3"></div>` patterns. For "card-shaped" skeletons, pair `skeleton` with `bb-card` chrome.
+- **Effort:** M (touches `base.html` cmdk loaders, transactions list, rules table, agents page; ~10 call sites).
+- **Risk:** cosmetic — shimmer timing/curve will visibly change.
+
+### Kbd badges — 4-way duplication
+- **DaisyUI status:** daisy 5 ships `kbd` with `kbd-xs..xl` sizes.
+- **Our usage:** zero daisy `kbd`. Four near-identical definitions in `input.css`:
+  - `.bb-kbd` (`:2525`) — shared
+  - `.bb-cmdk-kbd` (`:1593`) — `base.html` cmdk
+  - `.bb-shortcuts-kbd` (`:1945`) — `?` help modal
+  - `.bb-cmdk-footer kbd` + `.bb-catpicker-footer kbd` — same shadow/border, different selector
+  - Plus `.bb-kbd-combo` + `.bb-kbd-combo__key` for the ⌘│K blended pill
+- All four duplicate the same `bg + border + box-shadow + dark-mode flip` recipe (~50 lines each).
+- **What we're doing instead:** the templ `Kbd`/`KbdCombo` components (`kbd.templ`) emit `.bb-kbd`/`.bb-kbd-combo` — that part is fine. The duplication is in `input.css` because the cmdk/help dialogs were prototyped before the shared `bb-kbd` rule was hoisted.
+- **Recommended action:** alias `.bb-cmdk-kbd`, `.bb-shortcuts-kbd`, footer `kbd` to `@apply bb-kbd` (one-line forward) or just use `bb-kbd` directly in `base.html`. Optional: swap `bb-kbd` itself for a `<kbd class="kbd kbd-xs">` daisy build with custom variables on `--kbd-bg` etc.
+- **Effort:** S (3 selector consolidations).
+- **Risk:** none — pixel-identical recipe.
+
+### Card — daisy bypassed almost entirely
+- **DaisyUI status:** `card`, `card-body`, `card-title`, `card-actions`, `card-border`, `card-dash`, `card-side`, `image-full`, `card-xs..xl`.
+- **Our usage:** daisy `card` appears only in `agents.templ` + `session_detail.templ`. Every other surface uses `.bb-card` (`input.css:244-275`). 82 templ files use it.
+- **What we're doing instead:** `.bb-card` is `bg-base-100 rounded-xl border border-base-300` + dark-mode `color-mix(in oklch, base-100 92%, white 8%)` lift. Daisy `card` adds a `shadow-md` default and uses `border-base-200` — both inconsistent with our shadcn-inspired flat-with-border aesthetic.
+- **Recommended action:** **keep `bb-card`** — it's a justified extension. But document the divergence in `design-system.md`: daisy's `card` defaults don't match our spec (we explicitly want border-not-shadow per `:243` comment), and the dark-mode lift is the load-bearing reason for the custom rule. Consider renaming the inconsistent `agents.templ`/`session_detail.templ` uses to `bb-card` so the codebase is uniform.
+- **Effort:** S (~4 templ edits in agents pages).
+- **Risk:** cosmetic.
+
+### Chat / comment bubble — daisy chat is a fit
+- **DaisyUI status:** `chat`, `chat-start`/`chat-end`, `chat-image`, `chat-header`, `chat-footer`, `chat-bubble` with colour variants.
+- **Our usage:** zero daisy `chat`. The transaction-detail activity timeline uses `.bb-comment-bubble` (`input.css:727`) — chat-style bubble with flat top-left corner pointing at the avatar on the rail. Markdown styling rules `:747-787`.
+- **What we're doing instead:** ~70 lines of bubble + markdown + dark-mode adjustments, plus `bb-timeline-prominent`'s comment-card override (unlayered, `:2974-3110`).
+- **Recommended action:** the prominent-mode comment-card treatment is too custom (header bar + body + ::before/::after tail) to fit daisy chat. The card-mode `.bb-comment-bubble` could become a `chat-bubble`. But: the rail-anchor geometry is load-bearing and daisy chat puts the avatar to the left as a separate slot, not centred on a rail. **Keep custom** but consider whether daisy `chat-bubble` colours could replace the `color-mix` chrome.
+- **Effort:** M.
+- **Risk:** behavioural — the rail tail geometry is hard-coded against the 28px tile centre.
+
+### Breadcrumbs
+- **DaisyUI status:** `breadcrumbs` class on a wrapper around `<ul>` with automatic separators.
+- **Our usage:** zero. `breadcrumb.templ:14` renders inline chevron SVGs inside a custom `<nav class="bb-breadcrumb">` (CSS at `input.css:206-241`).
+- **What we're doing instead:** custom horizontal-scroll behavior with `overflow-y: clip` to handle SVG sub-pixel mismatch (comment at `:213-218`), and bespoke colour treatment for current page (`bb-breadcrumb-current`).
+- **Recommended action:** daisy `breadcrumbs` handles the same separator+scroll pattern in fewer lines. Migration would let us delete `~35 lines` of CSS. But the explicit chevron SVG (not arrow `>`) and the bespoke 3-tier colour ramp (`base-content/40` → `base-content/25` → `base-content/70`) would have to be preserved as overrides.
+- **Effort:** S.
+- **Risk:** cosmetic — verify separator glyph still reads as a chevron, not a slash.
+
+### Pagination — handrolled, daisy `join` would shorten it
+- **Our usage:** `.bb-paginator` + 4 modifier classes (`input.css:1384-1421`). Numbered buttons with ellipsis.
+- **DaisyUI pattern:** daisy 5 routes pagination through `join` + `join-item btn` — see `daisyui.com/llms.txt` Pagination section.
+- **Recommended action:** rewrite `.bb-paginator` as `<div class="join">` with `<button class="join-item btn btn-sm">` + `btn-active`. Drop `.bb-paginator__btn`, `.bb-paginator__btn--active`, `.bb-paginator__ellipsis`. Keep `.bb-paginator__info`/`__per-page` for the surrounding layout.
+- **Effort:** M (touches the paginator partial + every list page that uses it).
+- **Risk:** cosmetic.
+
+### Tabs — hand-rolled with btn toggling
+- **Our usage:** `mcp_guide.templ:87` uses `flex flex-wrap gap-1.5` + `role="tablist"` + `btn-primary`/`btn-ghost` switching. `settings_layout.templ` uses a dropdown-menu (mobile) + sidebar links (desktop) instead of tabs.
+- **DaisyUI offer:** `tabs`, `tabs-box`, `tabs-border`, `tabs-lift`, `tab-active`, `tabs-top`/`tabs-bottom`.
+- **Recommended action:** convert `mcp_guide` to `tabs tabs-border` with `<a role="tab" class="tab">` and `tab-active`. Daisy supports the radio-driven variant for pure-CSS state, but our Alpine factory already handles it.
+- **Effort:** S.
+- **Risk:** none.
+
+### Stat — completely unused, perfect fit for dashboard metrics
+- **Our usage:** zero. The dashboard tiles render as `bb-card p-4` with hand-laid grid + custom typography.
+- **DaisyUI offer:** `stat`, `stat-title`, `stat-value`, `stat-desc`, `stat-figure`, `stat-actions`, `stats stats-horizontal`/`stats-vertical`.
+- **Recommended action:** adopt `stats stats-horizontal` for dashboard / feed hero cards. The `stat-value` typography (large + tracking) matches what we want for amounts. Daisy `stat-figure` is the right slot for the trending icon.
+- **Effort:** M (touches `feed.templ`, dashboard, possibly `account_detail.templ`).
+- **Risk:** cosmetic — typography spec slightly different.
+
+### Modal dialogs — 5 bespoke shells in `base.html`
+- **DaisyUI offer:** native `<dialog class="modal modal-bottom sm:modal-middle">` + `modal-box` (already used in the 4 documented `<dialog>` modals).
+- **Our usage:** the global confirm/cmdk/shortcuts/category-picker/tag-picker dialogs in `base.html` use bespoke `.bb-confirm-dialog`/`.bb-cmdk-dialog`/`.bb-shortcuts-dialog`/`.bb-catpicker-dialog`/`.bb-tagpicker-dialog` — each with its own `position: fixed; z-50` + `width: min(...)` + `box-shadow` + `bb-*-dialog-in` keyframe + dark-mode shadow override + mobile safe-area top calc. ~250 lines of CSS for what is essentially "centered modal with custom width".
+- **Why they're bespoke:** they need custom width tiers (cmdk: 560px; tagpicker: 520px; catpicker: 420px; shortcuts: 640px; confirm: 420px) and the cmdk + tagpicker have header/body/footer scroll regions. None of those are blockers for daisy `modal` — they're just bespoke because they were prototyped without daisy in mind.
+- **Recommended action:** convert each to `<dialog class="modal">` with `<div class="modal-box w-full sm:max-w-[Npx]">`. Drop the 5 bespoke backdrop animations; daisy modal's built-in transition is fine. Will collapse `~250 LOC` of CSS into ~30.
+- **Effort:** L (touches global dialog scripts; the Alpine state machines need to switch from `.bb-*-dialog` visibility to dialog.showModal()).
+- **Risk:** behavioural — focus management, scroll lock (`bbLockScroll`), and the `@keydown.escape` handlers need to be re-tested.
+
+### Toast — global pill is custom; one daisy instance exists
+- **DaisyUI offer:** `toast`, `toast-start/center/end`, `toast-top/middle/bottom`.
+- **Our usage:** `report_detail.templ:34` uses `toast toast-top toast-center` natively. But the global toast in `base.html:353` is hand-rolled `fixed bottom-8 left-1/2 z-50 -translate-x-1/2 flex flex-col items-center gap-2`.
+- **Recommended action:** change `base.html:353` to `<div class="toast toast-center toast-bottom z-50 ...">`. Same visual result, daisy-faithful.
+- **Effort:** S.
+- **Risk:** cosmetic.
+
+### Fieldset — using the frame, not the legend
+- **Our usage:** 19 `<fieldset class="fieldset">` with custom `<label class="text-sm font-medium text-base-content/70 mb-1.5 block">` inside instead of daisy's `<legend class="fieldset-legend">`. In `csv_import.templ` alone there are 11 such fieldsets, each with a redundant external label.
+- **Recommended action:** adopt `fieldset-legend` for the form-field label, drop the parallel `<label>`. Adds proper semantic structure for screen readers.
+- **Effort:** S/M.
+- **Risk:** cosmetic — verify `fieldset-legend` typography matches our existing `text-sm font-medium text-base-content/70`.
+
+### Avatar — daisy `.avatar` could ground tx-avatar
+- **Our usage:** `.bb-tx-avatar` (`input.css:1171`, `--avatar-color` CSS variable) is data-driven (category color mix). `.bb-sidebar-profile-avatar` and the cmdk `.bb-cmdk-item-icon` are raw `<img class="rounded-full">` or coloured tiles.
+- **DaisyUI offer:** `.avatar`, `.avatar-placeholder`, `.avatar-group`, `.avatar-online`/`offline`.
+- **Recommended action:** `.bb-tx-avatar` is justified custom (color-mix from category, can't be expressed as a daisy modifier). But the sidebar profile + cmdk could wrap their `<img>` in `<div class="avatar"><div class="w-8 rounded-full">` for the daisy chrome. Low value.
+- **Effort:** S.
+- **Risk:** none.
+
+### Collapse / accordion — Alpine x-collapse instead of daisy
+- **Our usage:** filter panels use `x-collapse` (Alpine). The "Collapsible panels" pattern in `design-system.md` is a custom `.bb-filter-toggle` + `<details>` or Alpine state.
+- **DaisyUI offer:** `collapse`, `collapse-arrow`, `collapse-plus`, `collapse-title`, `collapse-content`, accordion via radio inputs.
+- **Recommended action:** Alpine `x-collapse` is a richer animation; keep it. But `collapse-arrow` adds a built-in caret that some of our `.bb-filter-toggle` could borrow.
+- **Effort:** S, low value.
+- **Risk:** none.
+
+### Triage badges — 4th badge dialect
+- **Our usage:** `.bb-triage-badge` + `--info/--warning/--error/--neutral` (`input.css:2632-2671`) — a 4th colour-tinted badge dialect. Bespoke `text-[0.6rem]` size, bespoke `bg-X/12 + text-X-darker` mix.
+- **What it duplicates:** `badge badge-soft badge-{info|warning|error}` does ~95% of this with one fewer custom class. The bespoke version uses smaller text and a slightly different alpha — both achievable with `badge-xs` + a thin override.
+- **Recommended action:** drop `.bb-triage-badge*`, use `badge badge-soft badge-xs badge-{info|warning|error|neutral}`. Saves 40 lines.
+- **Effort:** S.
+- **Risk:** cosmetic — text size will shift slightly.
+
+### Rule creator badge / rule category badge / tag chip — all custom-pill species
+- **Our usage:** three near-identical "small coloured pill" classes:
+  - `.bb-tag` (`input.css:515`) — generic pill with `--tag-color` driving bg + border
+  - `.bb-rule-cat-badge` (`:1262`) — same shape, `--cat-color`
+  - `.bb-rule-creator-badge` (`:1281`) — same shape, neutral colours
+- **What's justified:** `.bb-tag` is data-driven via CSS variables (per-tag color from DB), which `badge-soft badge-{color}` can't do — the color isn't from the daisy palette. Keep `.bb-tag`.
+- **What isn't:** `.bb-rule-creator-badge--agent`/`--user` could be `badge badge-soft badge-primary badge-xs` and `badge badge-ghost badge-xs`.
+- **Recommended action:** delete `.bb-rule-creator-badge` family (3 modifiers + dark-mode override). Keep `.bb-tag` and `.bb-rule-cat-badge` (data-driven).
+- **Effort:** S.
+- **Risk:** none.
+
+### View toggle (`.bb-view-toggle`)
+- **Our usage:** `transactions.templ:103` — Grouped/List pill toggle. CSS at `input.css:1330-1347`.
+- **What's nearby in daisy:** `join` + `join-item btn` (e.g. the `mcp_guide` Guide/Config toggle).
+- **Recommended action:** replace `.bb-view-toggle` with `<div class="join border border-base-300 bg-base-200"><button class="join-item btn btn-xs btn-ghost">…</button></div>`. Aligns with the one existing `join` use.
+- **Effort:** S.
+- **Risk:** cosmetic.
+
+---
+
+## Gaps & wins
+
+### DaisyUI components we should adopt (ranked)
+1. **`skeleton`** — replaces the bespoke `bb-skeleton*` system (~110 LOC saved, 10 variants → 1).
+2. **`stat` / `stats`** — never used; perfect fit for dashboard/feed metric tiles.
+3. **`tabs-box` or `tabs-border`** — replaces the hand-rolled `mcp_guide` tab toggle (and could replace `settings_layout.templ`'s mobile dropdown).
+4. **`toast`** — convert the global pill in `base.html`; one-line fix.
+5. **`breadcrumbs`** — replaces `bb-breadcrumb*` family (~35 LOC saved).
+6. **`join` + `join-item`** — replaces `bb-view-toggle` and the bespoke `bb-paginator` numbered-button row.
+7. **`fieldset-legend`** — fix 19 fieldsets currently using redundant external labels.
+8. **`kbd`** — fold 4 duplicate kbd-style definitions into one.
+9. **`modal`** (for global overlays) — collapse 5 bespoke dialog shells in `base.html`.
+10. **`card` / standardize** — either migrate `bb-card` callers to daisy `card` with our overrides documented as theme variables, OR migrate the 2 outlier `agents.templ` daisy-card uses back to `bb-card`. Don't keep both.
+
+### Hand-rolled `bb-*` classes that duplicate daisy
+| `bb-*` class | Daisy equivalent | Notes |
+|---|---|---|
+| `.bb-skeleton*` (9 variants) | `skeleton`, `skeleton-text` | full replacement available |
+| `.bb-kbd`, `.bb-cmdk-kbd`, `.bb-shortcuts-kbd`, `.bb-cmdk-footer kbd`, `.bb-catpicker-footer kbd` | `kbd kbd-xs/sm` | 4 of 5 are bug-prone duplicates |
+| `.bb-triage-badge--*` | `badge badge-soft badge-xs badge-{info\|warn\|error}` | replace |
+| `.bb-rule-creator-badge--agent/user` | `badge badge-soft badge-primary badge-xs` / `badge badge-ghost badge-xs` | replace |
+| `.bb-view-toggle` + `.bb-view-toggle__btn` | `join` + `join-item btn` | replace |
+| `.bb-paginator__btn*` | `join` + `join-item btn btn-sm` | replace |
+| `.bb-breadcrumb*` | `breadcrumbs` | replace (verify chevron glyph) |
+| `.bb-form-input` / `.bb-form-select` | `input` / `select` (daisy 5 dropped `-bordered` redundancy) | strip `-bordered`; keep `bb-form-*` only if focus-bg shift matters |
+| `.bb-confirm-dialog`, `.bb-cmdk-dialog`, `.bb-shortcuts-dialog`, `.bb-catpicker-dialog`, `.bb-tagpicker-dialog` | `modal modal-box` | replace (largest win) |
+| `.bb-tagpicker-diff-pill--add/remove` | `badge badge-soft badge-success badge-xs` / `badge badge-error` | replace |
+
+### Hand-rolled `bb-*` classes that justifiably extend daisy
+| `bb-*` class | Why kept |
+|---|---|
+| `.bb-card` | shadcn flat-border aesthetic + dark-mode `color-mix` lift (load-bearing dark contrast; daisy `card` ships shadow + `border-base-200`) |
+| `.bb-tag` | data-driven `--tag-color` from DB; daisy badges only support palette colours |
+| `.bb-tx-avatar` | data-driven category color via `color-mix(--avatar-color, …)`; daisy avatars are chrome only |
+| `.bb-tx-row*` | imperative bulk-selection driven by JS store; daisy doesn't have a row primitive |
+| `.bb-sidebar*` | hover/active/icon-opacity choreography + iOS-26 scroll fade gradients daisy `menu` doesn't expose |
+| `.bb-timeline*` | GitHub-style continuous rail through 24/28px tiles with `:has()` rail-mask + tail SVG; daisy `timeline` is a different shape |
+| `.bb-comment-bubble` | flat top-left corner pointing at rail avatar; markdown styling specific to our pipeline |
+| `.bb-progress-bar` | fixed-top SPA navigation indicator (YouTube/GitHub style); daisy `progress` is form-input style |
+| `.bb-cmdk-*`, `.bb-tagpicker-*`, `.bb-catpicker-*`, `.bb-shortcuts-*` content | the input + list + footer interiors are fine; only the dialog _shells_ should switch to daisy `modal` |
+| `.bb-mobile-navbar` | sticky + backdrop-blur + safe-area inset on top of daisy `navbar` — justified extension |
+
+### DaisyUI components we override too aggressively
+- **`.select::picker(select)` dark-mode overrides** (`input.css:1024-1046`) — justified workaround for daisy 5's `appearance: base-select` transparent-background bug in dark mode. Document and keep.
+- **`.btn { transition … !important }`** (`input.css:990`) — overrides daisy's transition shorthand to add `transform: scale(0.97)` on `:active`. The `!important` is load-bearing because daisy's `.btn` rule sits at the same specificity. Acceptable but flag as a layer-order workaround.
+- **`.modal-backdrop { transition: opacity 0.2s ease !important }`** (`input.css:1049`) — small polish, acceptable.
+- **`.checkbox` transition clamp** (`input.css:1136`) — daisy 5's checkbox ships `transition: all` which causes paint thrash on tx rows; we scope it to background + border only. Justified bug fix; document.
+- **`.dropdown-content { animation: bb-dropdown-enter }`** (`input.css:1056`) — small polish.
+
+---
+
+## Modifiers we should be using
+
+| Modifier family | Usage today | Recommendation |
+|---|---|---|
+| `btn-soft` | 16 uses (mostly destructive `btn-error btn-soft`) | adopt for non-destructive secondary buttons too (currently we use `btn-ghost`) |
+| `btn-dash` | 0 | adopt for "Add tag" / "New rule condition" affordances currently using `.bb-tag-add` dashed border |
+| `btn-outline` | 20 uses | consistent |
+| `badge-soft` | 98 uses — primary modifier per spec | keep |
+| `badge-dash` | 0 | could replace `.bb-tag-add` dashed pill |
+| `badge-outline` | 0 | could replace `.bb-rule-creator-badge--user` |
+| `card-border`, `card-dash` | 0 | only relevant if we migrate to daisy `card` |
+| `tabs-box` / `tabs-border` / `tabs-lift` | 0 | adopt one for `mcp_guide` |
+| `input-ghost` | 2 uses | mostly we use `input-bordered`; consider `input-ghost` for inline-edit |
+| `select-ghost` | 0 | candidate for inline-edit dropdowns |
+| `loading-dots` / `loading-ring` / `loading-bars` | 0 | only `loading-spinner` used — acceptable per spec |
+| `menu-disabled`, `menu-active`, `menu-focus` | 0 | not used because we don't use daisy `menu` for the sidebar |
+| `alert-soft` | 10 uses — matches spec | keep |
+| `alert-dash` | 0 | low value |
+| `tooltip-{color}` | 0 (only `tooltip-top`) | could colour error tooltips, but adds noise |
+| `collapse-arrow` / `collapse-plus` | 0 | candidates for `.bb-filter-toggle` |
+| `dropdown-hover` | 0 — all our dropdowns are click | keep click |
+| `kbd-{size}` | 0 | adopt when consolidating `bb-kbd` |
+| `skeleton-text` | 0 | adopt when replacing `bb-skeleton--text*` |
+
+---
+
+## Priorities (top 10)
+
+1. **Consolidate the 5 bespoke dialog shells in `base.html` to daisy `modal`** — biggest mechanical win, ~250 LOC of CSS deleted, unifies focus/scroll/backdrop behaviour. Effort: L. Risk: behavioural (test focus traps).
+2. **Replace `bb-skeleton*` with daisy `skeleton`** — ~110 LOC deleted, 1 daisy primitive replaces 9 size variants. Effort: M.
+3. **Adopt `kbd` and collapse the 4 duplicate kbd recipes** — one-line alias, prevents drift. Effort: S.
+4. **Convert global toast in `base.html` to `toast toast-center toast-bottom`** — one-line markup change for consistency with `report_detail.templ`'s native daisy usage. Effort: S.
+5. **Adopt daisy `stat` / `stats` for dashboard + feed hero tiles** — the typography is right, and we're currently re-deriving it. Effort: M.
+6. **Rewrite `mcp_guide` agent tabs as `tabs tabs-border`** — first real use of daisy tabs in the codebase; sets the convention. Effort: S.
+7. **Replace `.bb-paginator` numbered-button row with `join` + `join-item btn`** — aligns with daisy 5 idiom and removes 4 custom classes. Effort: M.
+8. **Replace `.bb-view-toggle` with `join` + `join-item btn`** — one widget on `transactions.templ`, sets the pattern for future segmented controls. Effort: S.
+9. **Drop `input-bordered` / `select-bordered` (daisy 5 redundancy) + standardize on `fieldset-legend`** — modernization pass on form pages. Effort: M.
+10. **Drop `.bb-triage-badge*` and `.bb-rule-creator-badge*`; use `badge badge-soft badge-xs badge-{info|warning|error|primary|ghost}`** — removes ~70 lines of duplicate badge CSS. Effort: S.
+
+---
+
+**Closing note.** The codebase is largely faithful to daisy on the input/button/badge/alert/modal/dropdown/menu/loading axes — 90%+ of `.btn`/`.badge` rows are pure daisy with our documented `rounded-xl` overlay. The custom bloat is concentrated in five areas: (1) the 5 bespoke dialog shells in `base.html`, (2) the bb-skeleton system, (3) the bb-paginator system, (4) the kbd duplication, and (5) the divergence between `.bb-card` (used in 82 files) and daisy `card` (used in 2). Fixing #1, #2, and #5 alone would shed ~400 lines of `input.css` while making the v1 admin meaningfully more daisy-canonical.


### PR DESCRIPTION
## Summary

Docs only. Two parallel audits to ground the design-system sprint, plus a short synthesis README that ranks the remediation roadmap.

## What's here

- **`docs/design-system-audit/components-inventory.md`** — every recurring UI pattern across `internal/templates/**`, with file:line citations, variant counts, daisyUI mapping, and consolidation recommendations. ~45 components catalogued. Top extraction wins: `EmptyState` (18 callers, 5 visual variants), `PageHeader` (37 callers), `ResourceListSection` (`access.templ` is 99% duplicated — 150 LOC saved), `OverflowMenu`, `StatTile`.
- **`docs/design-system-audit/daisyui-coverage.md`** — coverage matrix for every DaisyUI 5 component, marked ✅ / ⚠️ / 🔁 / 🚫 / ❌. Walks llms.txt category by category. Deep dives on the largest divergences:
  - 5 bespoke dialog shells in `base.html` (`.bb-confirm-dialog`, `.bb-cmdk-dialog`, `.bb-shortcuts-dialog`, `.bb-catpicker-dialog`, `.bb-tagpicker-dialog`) — ~250 LOC of duplicate CSS, all replaceable with daisy `modal`.
  - `.bb-skeleton*` family (~110 LOC, 9 size variants → 1 daisy `skeleton`)
  - `.bb-paginator` (handrolled → daisy `join + join-item btn`)
  - kbd 4-way duplication
  - `bb-card` vs daisy `card` divergence (used in 82 vs 2 files respectively — pick one)
- **`docs/design-system-audit/README.md`** — synthesis + ordered remediation roadmap.

## Key numbers

- ~190 `bb-*` classes in `input.css`; roughly 35 duplicate something daisy ships.
- 387 `btn-sm`, 280 `btn-ghost`, 196 `btn-primary`, 214 `badge` uses — buttons and badges are largely daisy-faithful.
- Daisy `stat`, `breadcrumbs`, `pagination`, `tabs`, `kbd`, `chat`, `skeleton`, `radial-progress` — **all hand-rolled or absent**.
- 5 bespoke modal dialogs + 4 kbd recipes + 9 skeleton variants = the largest concentrations of duplicate CSS.

## Remediation order

Driven by the audit and your additional direction on aggressive consolidation (PageHeader / Stats / Tabs / common rows). Roughly:

1. `PageHeader` templ component (37 callers)
2. `EmptyState` templ component (18 callers)
3. `SectionHeader` + `OverflowMenu` templs
4. `StatTile` + adopt daisy `stat`/`stats` for dashboard/feed
5. `TabBar` (daisy `tabs-border`)
6. `ResourceListSection` for `access.templ` (~150 LOC saved on one page)
7. Retire dead `bb-*` classes
8. Standardise destructive-confirm UX
9. Adopt daisy `skeleton`, `toast`, `kbd`, `join`
10. Establish `.claude/rules/daisyui.md` codifying daisy-first as a hard rule

Each lands as a separate sub-PR against the sprint base, with the new component visible at `/design/c/<slug>` first before being adopted by live pages.

## Test plan

- [ ] Render markdown locally — table formatting + nested code fences look right
- [ ] Verify file:line citations exist in the current codebase (sample: `access.templ:22-149`, `input.css:2402-2510`)
- [ ] No code changes — `go build ./...` already green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
