### PR TITLE
docs(rules): .claude/rules/daisyui.md — codify daisy-first as enforced rule

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -1,0 +1,177 @@
+---
+paths:
+  - "internal/templates/**"
+  - "internal/admin/**"
+  - "input.css"
+  - "static/**"
+---
+
+# DaisyUI adherence
+
+The v1 admin UI is built on **DaisyUI 5 + Tailwind CSS v4**. This rule
+codifies how we use it. The short version: **daisy first, custom only
+when daisy can't reach**, and document every exception. The audit at
+`docs/design-system-audit/` enumerates the current state.
+
+## The decision tree
+
+Before reaching for inline Tailwind utilities or writing a new
+`bb-*` class, walk this in order:
+
+1. **Is there a DaisyUI component for this?** Check
+   [daisyui.com/llms.txt](https://daisyui.com/llms.txt). If yes →
+   use it. Apply our spec'd overlays (e.g. `rounded-xl` on `btn-sm`,
+   `badge-soft` for status) but do not re-build the component.
+2. **Is there a DaisyUI modifier for the variant?** `btn-soft`,
+   `btn-dash`, `badge-outline`, `card-border`, `tabs-border`,
+   `collapse-arrow`, `kbd-xs`, `skeleton-text`, etc. Prefer modifier
+   over hand-rolled tone.
+3. **Does an existing `bb-*` class already capture this pattern?**
+   Search `input.css` and the templ tree before authoring a new one.
+   See "Justified `bb-*` extensions" below.
+4. **Is the pattern repeated 3+ times in the codebase?** If yes,
+   author a templ component (preferred — typed, testable) or a new
+   `bb-*` CSS class. **Do not author a `bb-*` class for a single
+   caller** — the spec's "3+ uses" threshold is non-negotiable.
+5. **Falling all the way through** → inline Tailwind utilities are
+   fine for one-off layout glue.
+
+## Components: daisy-first inventory
+
+Always use the daisy component (with our standard overlays only):
+
+| Daisy | Standard overlay | Notes |
+|---|---|---|
+| `btn` | `btn-sm` → `rounded-xl gap-2`; `btn-xs` → `rounded-lg gap-1.5` | Two sizes only. Icon size `w-4 h-4` (sm) / `w-3.5 h-3.5` (xs). |
+| `badge` | `badge-soft badge-{tone} badge-sm` for status; `badge-ghost badge-xs` for metadata; solid `badge-{tone} badge-xs` for counts | Never add `rounded-lg`/`rounded-xl` to a badge. |
+| `alert` | `alert alert-{tone} rounded-xl` for page-level; `alert-soft` for less prominent inline | Use `bb-form-error` inside a form card (tighter). |
+| `modal` | `modal modal-bottom sm:modal-middle`; `modal-box rounded-xl` | Use for all confirm/dialog UX. See "Anti-patterns" below for the bespoke shells we're retiring. |
+| `dropdown` + `menu` | `dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1` | Standard overflow-menu shape. |
+| `table` | `table table-sm table-zebra` + `hover:bg-base-200` on `<tr>` | `table-md` for transaction list; `table-xs` for embedded. |
+| `toast` | `toast toast-center toast-bottom` | One toast pattern. |
+| `tooltip` | `tooltip tooltip-top` + `data-tip="…"` | Don't roll your own tooltip. |
+| `loading` | `loading loading-spinner loading-xs/sm/md` | Only `loading-spinner` in practice — acceptable. |
+| `drawer` | `drawer lg:drawer-open` | Single use in `base.html`. |
+| `steps` | `steps steps-horizontal` | Wizard progress. CSV import should be on this. |
+| `tabs` | `tabs tabs-border` (or `tabs-box` for filter-tabs) | **Adopt — currently 0 callers.** See `docs/design-system-audit/daisyui-coverage.md`. |
+| `stat` / `stats` | `stats stats-horizontal` | **Adopt for dashboard tiles — currently 0 callers.** |
+| `skeleton` | `skeleton` + Tailwind sizing | **Adopt — `bb-skeleton*` is being retired.** |
+| `kbd` | `kbd kbd-xs/sm` | **Adopt — `bb-*-kbd` duplication is being retired.** |
+| `join` | `join` + `join-item btn` | For segmented controls + pagination — use instead of new `.bb-*-toggle` classes. |
+| `fieldset` + `fieldset-legend` | Use the legend, drop the parallel `<label>` | Currently 19 fieldsets use a redundant external label. |
+| `checkbox`, `radio`, `toggle`, `textarea`, `file-input` | Native daisy with our `rounded-xl` where applicable | Faithful. |
+
+## Justified `bb-*` extensions (do not rewrite to daisy)
+
+These exist because daisy doesn't cover the case. Keep using them; do
+**not** open a PR migrating them to daisy.
+
+| `bb-*` class | Why kept |
+|---|---|
+| `.bb-card` | shadcn flat-border aesthetic + dark-mode `color-mix` lift. Daisy `card` ships shadow + `border-base-200`. Used in 82 files. |
+| `.bb-tag` (+ `bb-tag-sm`/`-lg`/`-ghost`/`-interactive`/`-add`/`-remove`) | data-driven `--tag-color` from DB; daisy badges only support palette colours. |
+| `.bb-tx-avatar` (+ variants) | data-driven category color via `color-mix(--avatar-color, …)`. |
+| `.bb-tx-row*` | imperative bulk-selection driven by JS store; daisy has no row primitive. |
+| `.bb-sidebar*` | hover/active/icon-opacity choreography + iOS-26 scroll fade gradients daisy `menu` doesn't expose. |
+| `.bb-timeline*` | GitHub-style continuous rail through 24/28px tiles. Daisy `timeline` is a different shape. |
+| `.bb-comment-bubble` | flat top-left corner pointing at rail avatar. |
+| `.bb-progress-bar` | fixed-top SPA navigation indicator (YouTube/GitHub style). |
+| `.bb-mobile-navbar` | sticky + backdrop-blur + safe-area inset on top of daisy `navbar`. |
+| `.bb-icon-header__tile` (+ tone modifiers) | 40×40 colored tile slot inside form cards. |
+| `.bb-form-input` / `.bb-form-select` | focus-bg shift on top of daisy `input` / `select`. |
+| `.bb-action-row` | sectioned-card bottom action row. |
+| `.bb-danger-card` | soft-error tinted card modifier. |
+| `.bb-wizard-*`, `.bb-error-*` | isolated wizard/error page layouts. |
+| `.bb-page-header` | page title row primitive (being promoted to a templ component soon). |
+| `.bb-info-grid` | detail-page key-value grid. |
+| `.bb-filter-bar`, `.bb-filter-label`, `.bb-filter-toggle`, `.bb-filter-form` | filter row scaffold. |
+| `.bb-amount` (+ `bb-tx-amount*`) | tabular-nums + per-state styling for currency values. |
+
+If you find yourself wanting to write a new `bb-*` class that
+overlaps with daisy, **stop**: either adopt the daisy primitive or
+write a templ component that wraps it.
+
+## Anti-patterns (actively being removed)
+
+Do not write more of these. Migration PRs are queued in the
+design-system sprint.
+
+- **Bespoke modal shells.** `.bb-confirm-dialog`, `.bb-cmdk-dialog`,
+  `.bb-shortcuts-dialog`, `.bb-catpicker-dialog`,
+  `.bb-tagpicker-dialog` — ~250 LOC of duplicate CSS. New global
+  dialogs use `<dialog class="modal">` with `modal-box`.
+- **`bb-skeleton*` family.** 9 hand-rolled size variants with custom
+  shimmer keyframe. Use daisy `skeleton` + `skeleton-text` with
+  Tailwind sizing.
+- **Hand-rolled tabs.** `mcp_guide` uses `btn-primary`/`btn-ghost`
+  toggle. New tab UIs use daisy `tabs tabs-border`.
+- **Hand-rolled paginator buttons.** `.bb-paginator__btn*`. Use
+  daisy `join` + `join-item btn btn-sm` + `btn-active`.
+- **Hand-rolled kbd badges.** `.bb-cmdk-kbd`, `.bb-shortcuts-kbd`,
+  `.bb-cmdk-footer kbd`, `.bb-catpicker-footer kbd` — all duplicates
+  of `.bb-kbd`. Use the shared `Kbd`/`KbdCombo` templ components
+  (`internal/templates/components/kbd.templ`).
+- **Hand-rolled rounded-full chips that bypass `badge`.** Several
+  sites use `inline-flex … rounded-full bg-{tone}/10 text-{tone}` —
+  use `badge badge-soft badge-{tone}`.
+- **Hand-rolled empty-state scaffolds.** `bb-card p-12 text-center
+  flex flex-col items-center` ... etc. 18 callers, 5 variants. Use
+  the upcoming `EmptyState` templ component.
+- **Hand-rolled page-header `<div><h1><p>` blocks.** 37 callers.
+  Use the upcoming `PageHeader` templ component.
+- **Multiple destructive-confirm patterns.** Inline-confirm + daisy
+  modal + `bb-confirm-*` overlay coexist. Standardise on
+  `bb-confirm-*` (richest UX, already wired in `base.html`).
+
+## DaisyUI 5 specifics
+
+- **`input-bordered` / `select-bordered` are redundant in daisy 5.**
+  The bordered look is now the default. The classes still ship for
+  backwards compat — drop them when touching nearby code.
+- **`appearance: base-select` strips backgrounds in dark mode.** Our
+  `.select::picker(select)` overrides in `input.css:1024-1046`
+  patch this. **Keep them — do not delete.**
+- **Daisy 5 ships new components we should use:** `validator`,
+  `status`, `list`, `filter`, `card-dash`. Don't roll equivalents.
+
+## Spec'd overrides (the only `!important` and only deep overrides)
+
+These are documented load-bearing overrides — leave them alone.
+Don't pile new `!important` onto daisy classes.
+
+| Selector | Why |
+|---|---|
+| `.btn { transition: …; !important }` + `.btn:active { transform: scale(0.97) !important }` | Adds the press feedback daisy lacks; `!important` because daisy ships a same-specificity rule. |
+| `.modal-backdrop { transition: opacity 0.2s ease !important }` | Small backdrop polish. |
+| `[x-collapse] { transition: height …; !important }` | Alpine's `x-collapse` plugin sets inline styles; the rule overrides. |
+| `.drawer-side { z-index: 40 !important }` | Stacks above the sticky mobile navbar (z-30). |
+| `.checkbox { transition: bg + border only }` (`input.css:1136`) | Scope daisy's `transition: all` to avoid paint thrash on tx rows. |
+| `.select::picker(select)` dark-mode block | Workaround for daisy 5 `appearance: base-select` bug in dark mode. |
+| `.bb-timeline-prominent` overrides at the bottom of `input.css` | Scaled-up timeline tile/leading targets. |
+
+## When daisy isn't enough
+
+Open a sprint PR — **don't** write a new `bb-*` class quietly. The
+checklist:
+
+1. Add a section to `docs/design-system-audit/daisyui-coverage.md`
+   explaining why daisy can't reach this case.
+2. Author the templ component (preferred) or `bb-*` class.
+3. Add it to the `/design` sandbox (`internal/templates/components/pages/design_sections.templ` — new section in
+   `DesignSections()` in `design_types.go`) with a representative
+   variant matrix.
+4. Update `docs/design-system.md` with the canonical usage.
+
+The sandbox-first rule ensures every new shared component has at
+least one place reviewers can see it without reading the call site.
+
+## References
+
+- `docs/design-system.md` — canonical spec
+- `docs/design-system-audit/components-inventory.md` — every recurring
+  v1 admin pattern, with file:line citations
+- `docs/design-system-audit/daisyui-coverage.md` — coverage matrix +
+  remediation roadmap
+- `.claude/rules/ui.md` — general admin UI conventions
+- `https://daisyui.com/llms.txt` — canonical machine-readable
+  component list (always check before writing custom)

--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -40,6 +40,16 @@ Caveats:
 
 Use `make dev` (no watch) when you specifically want the production embedded-FS behavior — e.g. validating an embed regression.
 
+## DaisyUI adherence
+
+DaisyUI 5 is the source of truth for component shapes. The decision
+tree (daisy first → daisy modifier → existing `bb-*` → templ component
+→ inline) and the list of justified `bb-*` extensions vs the
+anti-patterns being retired live in **`.claude/rules/daisyui.md`** —
+read it before adding a new `bb-*` class or hand-rolling something
+daisy ships. The two audits in `docs/design-system-audit/` show the
+current state.
+
 ## Footguns
 
 ### Never use `bg-base-200/50` (or any `/opacity` modifier) on `<select>` elements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,4 +135,5 @@ Scoped rules in `.claude/rules/` load when you touch matching files:
 - `providers.md` — provider integrations
 - `sync.md` — sync engine patterns
 - `ui.md` — admin UI, CSS, Alpine, icons
+- `daisyui.md` — **daisy-first decision tree**: when to use a daisy primitive, when a `bb-*` extension is justified, which bespoke patterns are being retired
 - `stacked-prs.md` — `gt` workflow and stack conventions (read before creating a stack)


### PR DESCRIPTION
## Summary

Establishes `.claude/rules/daisyui.md` — the daisy-first decision tree the user explicitly asked for as part of the design-system sprint.

The rule distils the v1 audit (PR #1417) into actionable guidance for every future templ / admin / input.css edit. Loaded automatically when agents touch `internal/templates/**`, `internal/admin/**`, `input.css`, or `static/**`.

## What's in the rule

- **Decision tree:** daisy native → daisy modifier → existing `bb-*` → templ component → inline utilities. The "3+ uses" threshold for new `bb-*` classes is now hard.
- **DaisyUI-first inventory:** a table mapping every daisy component we use to its standard overlay (e.g. `btn-sm` → `rounded-xl gap-2`).
- **Justified `bb-*` extensions:** classes that exist because daisy doesn't cover the case (`bb-card`, `bb-tag`, `bb-timeline`, `bb-sidebar`, `bb-progress-bar`, etc.) — these should NOT be migrated.
- **Anti-patterns being retired:** the 5 bespoke dialog shells in `base.html`, `bb-skeleton*`, `bb-paginator`, kbd duplication, hand-rolled tabs / empty-states / page-headers, 3 conflicting destructive-confirm patterns.
- **DaisyUI 5 specifics:** `input-bordered`/`select-bordered` are now redundant; the `base-select` dark-mode fix in `input.css:1024-1046` must stay.
- **Documented overrides:** the only `!important` uses we accept + why they're load-bearing.
- **New-component workflow:** sandbox-first. Every new shared component lands at `/design/c/{slug}` (the sandbox added in PR #1416) before adoption.

## Linkage

- **`CLAUDE.md`** — added the rule to the scoped-rules index.
- **`.claude/rules/ui.md`** — opens with a pointer to `daisyui.md` so the rule surfaces from both directions.

## Test plan

- [ ] `go build ./...` (no code changes; trivially green)
- [ ] Render the rule locally — markdown tables format correctly
- [ ] Glob check: rule paths match `internal/templates/**`, `internal/admin/**`, `input.css`, `static/**` so it loads when expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
