### PR TITLE
fix(makefile): make dev depends on css (not just generate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,13 @@ templ-check: templ-install
 		exit 1; \
 	}
 
-dev: generate
+# `make dev` runs the prod-like embedded-FS server. We rebuild CSS up front
+# so any template changes (new utility classes, new templ files) are reflected
+# in the bundled styles.css before the binary boots — otherwise Tailwind's
+# scanned class list goes stale and the page renders without the classes
+# this dev session just added. `dev-watch` doesn't need this because
+# tailwindcss-extra --watch is running alongside air.
+dev: generate css
 	@if [ -z "$$DATABASE_URL" ]; then \
 		echo "Error: DATABASE_URL is not set."; \
 		echo "  Set it for local dev:  export DATABASE_URL=postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable"; \


### PR DESCRIPTION
## Summary

`make dev` was wired to `generate` (which only runs `templ generate`) but **not** to `css`. Result: any new utility classes introduced in templ files since the last CSS build silently disappear from the rendered page.

## Repro (from the design-system sprint validation pass)

1. Add a new templ file using a class Tailwind hasn't seen before (e.g. `lg:block`, `lg:grid-cols-[14rem_1fr]`).
2. `templ generate` — writes the `*_templ.go` file.
3. `make dev` — boots the prod-like server with the embedded (stale) `styles.css`.
4. Visit the page — class doesn't exist in the bundle, layout breaks silently.

Confirmed in this session: `lg:block` and the arbitrary grid column class were missing from the served CSS until `make css` was run manually. After the rebuild + browser reload, the gallery's sticky TOC and column grid rendered correctly.

## Fix

Add `css` as an explicit dep on the `dev` target plus a comment explaining why.

`dev-watch` already runs `tailwindcss-extra --watch` alongside air, so it's unaffected — this is for the prod-like embedded-FS loop only.

## Test plan

- [ ] `make dev PORT=8089` on a worktree with new templ classes → CSS rebuilt before binary boots → classes present in served CSS
- [ ] `make dev-watch` still works as before (it bypasses this dep chain via the watcher)
- [ ] CI unchanged (Dockerfile already runs `make css` in the build stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
