### PR TITLE
feat(admin): 5 shared templ components — EmptyState, StatTile, TabBar, OverflowMenu, SectionHeader

### DIFF
--- a/internal/templates/components/empty_state.templ
+++ b/internal/templates/components/empty_state.templ
@@ -1,0 +1,78 @@
+package components
+
+// EmptyState is the canonical "no data" / "no results" card.
+// Replaces the ~18 hand-rolled `bb-card p-12 text-center flex flex-col
+// items-center` blocks across the admin templ tree (see
+// docs/design-system-audit/components-inventory.md §4).
+//
+// Two shapes:
+//
+//   - Default (Compact=false): full-card hero with a 56×56 tinted icon
+//     tile, title, body copy, and a primary CTA. Used as the page-level
+//     "you have nothing yet" state.
+//   - Compact (Compact=true): inline-block with a small bare icon and
+//     one line of text. Used inside lists/tables for "filters returned
+//     no rows" — no card chrome, no body, no CTA tile.
+//
+// CTA precedence: if CustomCTA is set, it renders instead of the
+// simple href/label pair (use when you need multiple buttons, Alpine
+// data attributes, POST forms, etc.). Otherwise a primary
+// `btn-sm rounded-xl` is rendered iff CTAHref and CTALabel are both
+// non-empty. Compact mode never renders a CTA — keep it one line.
+//
+// Usage:
+//
+//	@components.EmptyState(components.EmptyStateProps{
+//	  Icon:     "fingerprint",
+//	  Title:    "No OAuth clients yet",
+//	  Body:     "Create an OAuth client to connect external AI services to your Breadbox MCP server.",
+//	  CTAHref:  templ.SafeURL("/settings/oauth-clients/new"),
+//	  CTAIcon:  "plus",
+//	  CTALabel: "Create your first client",
+//	})
+
+type EmptyStateProps struct {
+	Icon      string // Lucide name, e.g. "inbox", "search-x"
+	Title     string // required
+	Body      string // optional supporting copy
+	CTAHref   templ.SafeURL
+	CTAIcon   string
+	CTALabel  string
+	CustomCTA templ.Component // overrides the simple href/label CTA
+	Compact   bool            // inline "no results" variant; no card, no CTA
+}
+
+templ EmptyState(p EmptyStateProps) {
+	if p.Compact {
+		<div class="flex flex-col items-center text-center py-10">
+			if p.Icon != "" {
+				<i data-lucide={ p.Icon } class="w-8 h-8 text-base-content/30 mb-3"></i>
+			}
+			<p class="text-sm text-base-content/50">{ p.Title }</p>
+		</div>
+	} else {
+		<div class="bb-card p-12 text-center">
+			<div class="flex flex-col items-center">
+				if p.Icon != "" {
+					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
+						<i data-lucide={ p.Icon } class="w-7 h-7 text-base-content/30"></i>
+					</div>
+				}
+				<h3 class="text-base font-semibold mb-1">{ p.Title }</h3>
+				if p.Body != "" {
+					<p class="text-base-content/50 text-sm mb-5 max-w-sm">{ p.Body }</p>
+				}
+				if p.CustomCTA != nil {
+					@p.CustomCTA
+				} else if p.CTAHref != "" && p.CTALabel != "" {
+					<a href={ p.CTAHref } class="btn btn-primary btn-sm rounded-xl gap-2">
+						if p.CTAIcon != "" {
+							<i data-lucide={ p.CTAIcon } class="w-4 h-4"></i>
+						}
+						{ p.CTALabel }
+					</a>
+				}
+			</div>
+		</div>
+	}
+}

--- a/internal/templates/components/overflow_menu.templ
+++ b/internal/templates/components/overflow_menu.templ
@@ -1,0 +1,99 @@
+package components
+
+// OverflowMenu is the kebab "more actions" dropdown used on row lists
+// (tags, rules, categories, OAuth clients, household users). Replaces the
+// duplicated 12-line `dropdown dropdown-end` + `menu` block scattered
+// across 6+ templ files with subtly different geometry.
+//
+// Pins (do not deviate when calling):
+//   - Trigger:  `btn btn-ghost btn-sm btn-square rounded-lg` + icon `w-5 h-5`
+//   - Menu:     `dropdown-content menu bg-base-100 rounded-xl shadow-lg`
+//               `border border-base-300 z-50 w-44 p-1`
+//   - Item icon: `w-3.5 h-3.5`
+//   - Destructive items: `text-error` on the inner element
+//   - Disabled items: `disabled` class on the <li>
+//
+// Items render in the order provided. Pass `Href` for link items,
+// `OnClick` (an Alpine handler string, e.g. `"delete(...)"`) for button
+// items. If both are set, `Href` wins.
+
+type OverflowMenuItem struct {
+	Label       string
+	Icon        string // Lucide name, e.g. "pencil"
+	Href        templ.SafeURL
+	OnClick     string // Alpine handler (rendered as `@click`). Ignored if Href set.
+	Destructive bool   // applies `text-error` to the inner element
+	Disabled    bool   // renders <li class="disabled"> and inert span instead of button/link
+	AriaLabel   string // optional per-item label (overrides the visible Label)
+}
+
+type OverflowMenuProps struct {
+	AriaLabel string             // REQUIRED, e.g. "Category Income actions"
+	Items     []OverflowMenuItem // rendered in order
+	Position  string             // "end" (default) or "start"
+}
+
+templ OverflowMenu(p OverflowMenuProps) {
+	<div class={ overflowMenuRootClass(p.Position) }>
+		<div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-square rounded-lg opacity-40 hover:opacity-100 transition-opacity" aria-label={ p.AriaLabel }>
+			<i data-lucide="ellipsis-vertical" class="w-5 h-5"></i>
+		</div>
+		<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1">
+			for _, it := range p.Items {
+				@overflowMenuItem(it)
+			}
+		</ul>
+	</div>
+}
+
+templ overflowMenuItem(it OverflowMenuItem) {
+	if it.Disabled {
+		<li class="disabled">
+			<span class="text-base-content/40 cursor-not-allowed" aria-label={ overflowAria(it) }>
+				if it.Icon != "" {
+					<i data-lucide={ it.Icon } class="w-3.5 h-3.5"></i>
+				}
+				{ it.Label }
+			</span>
+		</li>
+	} else if it.Href != "" {
+		<li>
+			<a href={ it.Href } class={ overflowItemClass(it.Destructive) } aria-label={ overflowAria(it) }>
+				if it.Icon != "" {
+					<i data-lucide={ it.Icon } class="w-3.5 h-3.5"></i>
+				}
+				{ it.Label }
+			</a>
+		</li>
+	} else {
+		<li>
+			<button type="button" class={ overflowItemClass(it.Destructive) } aria-label={ overflowAria(it) } @click={ it.OnClick }>
+				if it.Icon != "" {
+					<i data-lucide={ it.Icon } class="w-3.5 h-3.5"></i>
+				}
+				{ it.Label }
+			</button>
+		</li>
+	}
+}
+
+func overflowMenuRootClass(pos string) string {
+	if pos == "start" {
+		return "dropdown dropdown-start"
+	}
+	return "dropdown dropdown-end"
+}
+
+func overflowItemClass(destructive bool) string {
+	if destructive {
+		return "text-error"
+	}
+	return ""
+}
+
+func overflowAria(it OverflowMenuItem) string {
+	if it.AriaLabel != "" {
+		return it.AriaLabel
+	}
+	return it.Label
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -616,6 +616,176 @@ templ SectionEmptyStates() {
 				<p class="text-sm text-base-content/50">No transactions match these filters.</p>
 			</div>
 		}
+		@designExample("Live: components.EmptyState (default)", "The new shared component — replaces the 18+ duplicated scaffolds. Use this going forward.") {
+			<div class="max-w-md mx-auto">
+				@components.EmptyState(components.EmptyStateProps{
+					Icon:     "inbox",
+					Title:    "No connections yet",
+					Body:     "Link a bank to start importing transactions.",
+					CTAHref:  "#",
+					CTAIcon:  "plus",
+					CTALabel: "Add connection",
+				})
+			</div>
+		}
+		@designExample("Live: components.EmptyState (compact)", "Filter-returned-no-rows variant — no card chrome.") {
+			@components.EmptyState(components.EmptyStateProps{
+				Icon:    "search-x",
+				Title:   "No transactions match these filters.",
+				Compact: true,
+			})
+		}
+	</div>
+}
+
+// ─── Stat tiles ────────────────────────────────────────────────────────
+
+templ SectionStatTiles() {
+	<div class="flex flex-col gap-6">
+		@designExample("4-up tile row (canonical dashboard pattern)", "StatTileRow lays out the 2-up / 4-up grid. Tones drive the icon-tile color.") {
+			@components.StatTileRow() {
+				@components.StatTile(components.StatTileProps{
+					Icon:  "target",
+					Label: "Times matched",
+					Value: "1,284",
+					Tone:  components.StatTonePrimary,
+				})
+				@components.StatTile(components.StatTileProps{
+					Icon:  "layers",
+					Label: "Transactions",
+					Value: "342",
+					Tone:  components.StatToneInfo,
+				})
+				@components.StatTile(components.StatTileProps{
+					Icon:        "alert-circle",
+					Label:       "Pending",
+					Value:       "12",
+					Tone:        components.StatToneWarning,
+					Description: "review needed",
+				})
+				@components.StatTile(components.StatTileProps{
+					Icon:  "clock",
+					Label: "Last active",
+					Value: "2h ago",
+					Href:  "#",
+				})
+			}
+		}
+		@designExample("Without icon (label-only)", "Omit Icon when there's no meaningful glyph.") {
+			<div class="max-w-sm">
+				@components.StatTile(components.StatTileProps{
+					Label: "Total volume (USD)",
+					Value: "$48,201.55",
+				})
+			</div>
+		}
+	</div>
+}
+
+// ─── Tabs ──────────────────────────────────────────────────────────────
+
+templ SectionTabs() {
+	<div class="flex flex-col gap-6">
+		@designExample("Navigation tabs (tabs-border)", "Top-of-page tab navigation. Use Variant=\"border\" or omit (default).") {
+			@components.TabBar(components.TabBarProps{
+				AriaLabel: "Demo navigation tabs",
+				Items: []components.TabBarItem{
+					{Label: "Sync logs", Href: "#", Icon: "refresh-cw", Active: true},
+					{Label: "Webhooks", Href: "#", Icon: "webhook"},
+					{Label: "Sessions", Href: "#", Icon: "bot"},
+				},
+			})
+		}
+		@designExample("Filter-as-tabs (tabs-box)", "Segmented control feel for in-page filters.") {
+			@components.TabBar(components.TabBarProps{
+				Variant:   "box",
+				AriaLabel: "Demo filter tabs",
+				Items: []components.TabBarItem{
+					{Label: "All", Href: "#", Icon: "layers", Active: true},
+					{Label: "Syncs", Href: "#", Icon: "refresh-cw"},
+					{Label: "Reports", Href: "#", Icon: "file-text"},
+					{Label: "Comments", Href: "#", Icon: "message-square"},
+				},
+			})
+		}
+		@designExample("With badge counts", "Pass Count: &N on any item.") {
+			@components.TabBar(components.TabBarProps{
+				AriaLabel: "Demo tabs with counts",
+				Items: []components.TabBarItem{
+					{Label: "All", Href: "#", Count: components.SectionHeaderIntPtr(12), Active: true},
+					{Label: "Active", Href: "#", Count: components.SectionHeaderIntPtr(8)},
+					{Label: "Disconnected", Href: "#", Count: components.SectionHeaderIntPtr(2)},
+				},
+			})
+		}
+	</div>
+}
+
+// ─── Overflow menu ─────────────────────────────────────────────────────
+
+templ SectionOverflowMenu() {
+	<div class="flex flex-col gap-6">
+		@designExample("Standard kebab", "Mix link items (Href) and button items (OnClick). Mark destructive items with Destructive: true.") {
+			<div class="bb-card p-4 max-w-sm">
+				<div class="flex items-center justify-between gap-3">
+					<div>
+						<div class="text-sm font-semibold">Coffee &amp; Cafés</div>
+						<div class="text-xs text-base-content/50">Food &amp; Drink → Coffee</div>
+					</div>
+					@components.OverflowMenu(components.OverflowMenuProps{
+						AriaLabel: "Category Coffee actions",
+						Items: []components.OverflowMenuItem{
+							{Label: "Edit", Icon: "pencil", Href: "#"},
+							{Label: "View transactions", Icon: "receipt", Href: "#"},
+							{Label: "Delete", Icon: "trash-2", OnClick: "deleteCategory()", Destructive: true},
+						},
+					})
+				</div>
+			</div>
+		}
+		@designExample("With a disabled item", "System-protected entries render disabled.") {
+			<div class="bb-card p-4 max-w-sm">
+				<div class="flex items-center justify-between gap-3">
+					<div class="text-sm font-semibold">Uncategorized (system)</div>
+					@components.OverflowMenu(components.OverflowMenuProps{
+						AriaLabel: "Category Uncategorized actions",
+						Items: []components.OverflowMenuItem{
+							{Label: "Edit", Icon: "pencil", Href: "#"},
+							{Label: "Delete", Icon: "trash-2", OnClick: "noop()", Destructive: true, Disabled: true},
+						},
+					})
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// ─── Section header ────────────────────────────────────────────────────
+
+templ SectionSectionHeader() {
+	<div class="flex flex-col gap-6">
+		@designExample("Bare (icon + title)", "For section dividers inside a card.") {
+			@components.SectionHeader(components.SectionHeaderProps{
+				Icon:  "receipt",
+				Title: "Transactions",
+			})
+		}
+		@designExample("With count", "Count helps users scan list size at a glance.") {
+			@components.SectionHeader(components.SectionHeaderProps{
+				Icon:       "receipt",
+				Title:      "Transactions",
+				Count:      components.SectionHeaderIntPtr(342),
+				CountLabel: "total",
+			})
+		}
+		@designExample("With trailing action", "Pair with PageHeaderAction for the common case.") {
+			@components.SectionHeader(components.SectionHeaderProps{
+				Icon:   "fingerprint",
+				Title:  "OAuth clients",
+				Count:  components.SectionHeaderIntPtr(3),
+				Action: components.PageHeaderAction("#", "plus", "Create client"),
+			})
+		}
 	</div>
 }
 

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -125,8 +125,32 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "empty-states",
 			Title:       "Empty states",
-			Description: "Standard no-data and no-results patterns.",
+			Description: "Standard no-data and no-results patterns. Use components.EmptyState.",
 			Render:      func() templ.Component { return SectionEmptyStates() },
+		},
+		{
+			Slug:        "stat-tiles",
+			Title:       "Stat tiles",
+			Description: "4-up dashboard metric tiles — icon-on-left, big tabular-nums value. Use components.StatTile + StatTileRow.",
+			Render:      func() templ.Component { return SectionStatTiles() },
+		},
+		{
+			Slug:        "tabs",
+			Title:       "Tabs",
+			Description: "Daisy tabs-border (navigation) and tabs-box (filter-as-tabs). Use components.TabBar. Nest a second TabBar inside an active tab's content for multi-level.",
+			Render:      func() templ.Component { return SectionTabs() },
+		},
+		{
+			Slug:        "overflow-menu",
+			Title:       "Overflow menu",
+			Description: "Kebab dropdown for row actions. Use components.OverflowMenu.",
+			Render:      func() templ.Component { return SectionOverflowMenu() },
+		},
+		{
+			Slug:        "section-header",
+			Title:       "Section header",
+			Description: "Icon + h2 + count + optional action — for section headings INSIDE pages. Use components.SectionHeader (PageHeader is for top-of-page titles).",
+			Render:      func() templ.Component { return SectionSectionHeader() },
 		},
 	}
 }

--- a/internal/templates/components/section_header.templ
+++ b/internal/templates/components/section_header.templ
@@ -1,0 +1,57 @@
+package components
+
+import "strconv"
+
+// SectionHeader is the icon + h2 + optional-count + optional-action
+// row that appears above lists INSIDE a page (above the OAuth clients
+// table, above the accounts list on connection detail, above the
+// transactions list on account detail, etc.).
+//
+// NOT a page title — top-of-page titles use `PageHeader`. This component
+// stays small (`text-sm font-semibold`) because it sits inside a card
+// or page region, often several per page.
+//
+// Slots:
+//   - Icon:       optional Lucide name; rendered muted (`text-base-content/60`)
+//   - Title:      required
+//   - Count:      optional `*int`; renders "N items" after the title
+//   - CountLabel: optional override for "items" (e.g. "active", "total",
+//                 "matches"). Defaults to "items".
+//   - Action:     optional templ.Component slot, right-aligned via `ml-auto`.
+//                 Use for trailing "Add X" buttons or filter toggles.
+
+type SectionHeaderProps struct {
+	Icon       string
+	Title      string
+	Count      *int
+	CountLabel string // defaults to "items"
+	Action     templ.Component
+}
+
+templ SectionHeader(p SectionHeaderProps) {
+	<header class="flex items-center gap-2 mb-3">
+		if p.Icon != "" {
+			<i data-lucide={ p.Icon } class="w-4 h-4 text-base-content/60 shrink-0"></i>
+		}
+		<h2 class="text-sm font-semibold">{ p.Title }</h2>
+		if p.Count != nil {
+			<span class="text-xs text-base-content/40">{ strconv.Itoa(*p.Count) } { sectionHeaderCountLabel(p) }</span>
+		}
+		if p.Action != nil {
+			<div class="ml-auto shrink-0">
+				@p.Action
+			</div>
+		}
+	</header>
+}
+
+func sectionHeaderCountLabel(p SectionHeaderProps) string {
+	if p.CountLabel != "" {
+		return p.CountLabel
+	}
+	return "items"
+}
+
+// SectionHeaderIntPtr is a small helper to take the address of an int
+// literal inline at the call site (Go doesn't allow `&3`).
+func SectionHeaderIntPtr(n int) *int { return &n }

--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -1,0 +1,121 @@
+package components
+
+// StatTile is the canonical 4-up dashboard metric tile: a tinted icon
+// square on the left, big tabular-nums value + small label on the right,
+// optional secondary description line. Replaces the hand-rolled
+// `bb-card p-4 + flex items-center gap-3 + w-9 h-9 rounded-lg bg-{tone}/10`
+// block currently duplicated across rule_detail / logs / feed /
+// connection_detail / getting_started (see audit #17).
+//
+// Custom shell rather than daisy `stat` — daisy enforces value-below-label
+// typography and `place-self: end` for `stat-figure`, both of which
+// fight the icon-tile-on-left shape we already ship. See the agent
+// rationale in PR description.
+//
+// Props:
+//   - Icon:        Lucide name. Optional — omit for label-only tiles.
+//   - Label:       required. Rendered as small uppercase metadata.
+//   - Value:       required. Caller formats (CommaInt, fmt.Sprintf, etc).
+//   - Description: optional secondary line below the value.
+//   - Tone:        "neutral" (default), "primary", "success", "warning",
+//                  "error", "info". Drives icon-tile bg + icon color only.
+//   - Href:        optional. When set, the tile becomes an <a> with
+//                  bb-card--interactive hover.
+
+type StatTileTone string
+
+const (
+	StatToneNeutral StatTileTone = "neutral"
+	StatTonePrimary StatTileTone = "primary"
+	StatToneSuccess StatTileTone = "success"
+	StatToneWarning StatTileTone = "warning"
+	StatToneError   StatTileTone = "error"
+	StatToneInfo    StatTileTone = "info"
+)
+
+type StatTileProps struct {
+	Icon        string
+	Label       string
+	Value       string
+	Description string
+	Tone        StatTileTone
+	Href        templ.SafeURL // optional; if set, tile becomes a link
+}
+
+func statTileBg(t StatTileTone) string {
+	switch t {
+	case StatTonePrimary:
+		return "bg-primary/10"
+	case StatToneSuccess:
+		return "bg-success/10"
+	case StatToneWarning:
+		return "bg-warning/10"
+	case StatToneError:
+		return "bg-error/10"
+	case StatToneInfo:
+		return "bg-info/10"
+	default:
+		return "bg-base-200/60"
+	}
+}
+
+func statTileIcon(t StatTileTone) string {
+	switch t {
+	case StatTonePrimary:
+		return "text-primary"
+	case StatToneSuccess:
+		return "text-success"
+	case StatToneWarning:
+		return "text-warning"
+	case StatToneError:
+		return "text-error"
+	case StatToneInfo:
+		return "text-info"
+	default:
+		return "text-base-content/40"
+	}
+}
+
+templ StatTile(p StatTileProps) {
+	if p.Href != "" {
+		<a href={ p.Href } class="bb-card bb-card--interactive p-4 no-underline block">
+			@statTileBody(p)
+		</a>
+	} else {
+		<div class="bb-card p-4">
+			@statTileBody(p)
+		</div>
+	}
+}
+
+templ statTileBody(p StatTileProps) {
+	<div class="flex items-center gap-3">
+		if p.Icon != "" {
+			<div class={ "w-9 h-9 rounded-lg flex items-center justify-center shrink-0", statTileBg(p.Tone) }>
+				<i data-lucide={ p.Icon } class={ "w-4 h-4", statTileIcon(p.Tone) }></i>
+			</div>
+		}
+		<div class="min-w-0">
+			<div class="text-2xl font-semibold tabular-nums leading-none truncate">{ p.Value }</div>
+			<div class="text-xs text-base-content/40 mt-1 uppercase tracking-wider">{ p.Label }</div>
+			if p.Description != "" {
+				<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate">{ p.Description }</div>
+			}
+		</div>
+	</div>
+}
+
+// StatTileRow wraps StatTile children in the canonical 2-up / 4-up grid
+// so callers don't re-derive the breakpoint. Use Templ's children block:
+//
+//	@components.StatTileRow() {
+//	  @components.StatTile(...)
+//	  @components.StatTile(...)
+//	  @components.StatTile(...)
+//	  @components.StatTile(...)
+//	}
+templ StatTileRow() {
+	<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+		{ children... }
+	</div>
+}

--- a/internal/templates/components/tab_bar.templ
+++ b/internal/templates/components/tab_bar.templ
@@ -1,0 +1,75 @@
+package components
+
+import "strconv"
+
+// TabBar is the canonical tab/filter-tab primitive for the v1 admin UI.
+// Replaces the hand-rolled `btn-primary`/`btn-ghost` toggle in
+// mcp_guide.templ, the `bg-base-200/60 rounded-lg p-0.5` pill toggles
+// in agents.templ / logs.templ / connections.templ, and the rounded
+// chip filters in feed.templ.
+//
+// Renders the daisy native shape:
+//
+//	<div role="tablist" class="tabs tabs-border" aria-label="...">
+//	  <a role="tab" class="tab tab-active" href="..."> ... </a>
+//	</div>
+//
+// Variants:
+//   - "border" (default) — for top-of-page navigation tabs.
+//   - "box"             — for filter-as-tabs (segmented control feel).
+//
+// All callers SHOULD pass server-rendered `<a href>` items. For pure
+// client-side state (Alpine x-show), still render `<a>` with `href="#"`
+// and an `@click.prevent` handler; daisy markup is identical either way.
+//
+// Multi-level: just nest a second TabBar inside the active tab's content
+// region. Use Variant: "border" for the outer level (navigation) and
+// Variant: "box" for the inner level (filter-segmented control). Both
+// share daisy semantics; screen readers see two adjacent role="tablist"
+// regions with distinct aria-label values — the WAI-ARIA correct shape.
+
+type TabBarItem struct {
+	Label  string
+	Href   templ.SafeURL
+	Active bool
+	Icon   string // optional Lucide icon name
+	Count  *int   // optional badge count; nil = no badge
+}
+
+type TabBarProps struct {
+	Items     []TabBarItem
+	Variant   string // "border" (default) | "box"
+	AriaLabel string // required
+}
+
+templ TabBar(p TabBarProps) {
+	<div role="tablist" class={ "tabs", tabBarVariantClass(p.Variant) } aria-label={ p.AriaLabel }>
+		for _, it := range p.Items {
+			<a
+				role="tab"
+				href={ it.Href }
+				class={ "tab gap-2", templ.KV("tab-active", it.Active) }
+				if it.Active {
+					aria-current="page"
+				}
+			>
+				if it.Icon != "" {
+					<i data-lucide={ it.Icon } class="w-4 h-4"></i>
+				}
+				{ it.Label }
+				if it.Count != nil {
+					<span class={ "badge badge-xs", templ.KV("badge-soft", !it.Active), templ.KV("badge-primary", it.Active) }>
+						{ strconv.Itoa(*it.Count) }
+					</span>
+				}
+			</a>
+		}
+	</div>
+}
+
+func tabBarVariantClass(v string) string {
+	if v == "box" {
+		return "tabs-box"
+	}
+	return "tabs-border"
+}


### PR DESCRIPTION
## Summary

Wave 1 of the component-extraction phase. 5 shared templ components landed sandbox-first per the daisyUI rule.

Each agent (parallel run) produced the component spec; I integrated. No live-page migrations in this PR — those land per-page after this merges, so individual diffs stay reviewable.

## Components

| File | What | Replaces |
|---|---|---|
| `empty_state.templ` | Full-card / Compact "no data" states with optional CTA slot | 18+ duplicated scaffolds across access/connections/categories/tags/users/feed/account_link/rules |
| `stat_tile.templ` + `StatTileRow` | 4-up dashboard tile (icon-left, big tabular-nums value, label, optional desc, 6 tones, optional Href) | Hand-rolled `bb-card p-4 + flex + bg-{tone}/10` in rule_detail/logs/feed/connection_detail |
| `tab_bar.templ` | Daisy native `tabs-border` (nav) + `tabs-box` (filter-as-tabs), with optional Count badge | btn-primary/btn-ghost toggles in mcp_guide/logs/agents/feed |
| `overflow_menu.templ` | Standardized kebab dropdown (btn-sm + w-5 h-5 + w-44 menu, items can be link/button/destructive/disabled) | 6+ subtly-different `dropdown dropdown-end` blocks |
| `section_header.templ` | icon + h2 + optional count + trailing-action row for IN-PAGE section headings | Hand-rolled flex rows across access/users/connection_detail/categories |

## Sandbox

`/design` gets 5 new anchored sections. Each demo renders the real component so visual regressions surface immediately:
- `/design/c/empty-states` (Live variants added)
- `/design/c/stat-tiles`
- `/design/c/tabs`
- `/design/c/overflow-menu`
- `/design/c/section-header`

## Notable design call: StatTile is custom (not daisy `stat`)

Daisy's `stat-figure` is positioned via `place-self: end` (side decoration), and `stat-value` is locked to 2.25rem extra-bold. The breadbox pattern has the icon tile on the LEFT with value+label stacked to its right — reproducing that in daisy requires overriding both placement and typography, defeating the point. `StatTile` builds on our justified `bb-card` extension instead.

Daisy `stat` is still worth adopting somewhere — but it'd be a different component (`MetricStat` or similar) for genuinely stat-shaped tiles. For the 4-up tile pattern this audit calls out, custom shell is the right call. Rationale also captured in the file's godoc.

## Test plan

- [ ] `go test ./internal/templates/components/pages/` — smoke test passes (every section renders non-empty, gallery inlines every anchor)
- [ ] `go build ./...` green
- [ ] Browse the 5 new sandbox sections — components render as expected
- [ ] Confirm zero new `bb-*` classes introduced (component CSS uses daisy + existing kept extensions)

## Follow-ups (queued in task list)

- Live-page migrations per component family (37+ callers across the codebase)
- Retire bb-rule-creator-badge, bb-triage-badge, etc. that are obsoleted
- Standardise destructive-confirm UX on bb-confirm overlay (separate PR)
- oklch cleanup pass (separate PR) — replace hardcoded oklch values in input.css with daisy var() refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
