### PR TITLE
refactor(ui): drop bb-stagger entrance animations

### DIFF
--- a/input.css
+++ b/input.css
@@ -857,51 +857,9 @@
     }
   }
 
-  /* Staggered children animation */
-  .bb-stagger > * {
-    animation: bb-card-enter 0.35s ease-out both;
-  }
-  .bb-stagger > *:nth-child(1)  { animation-delay: 0ms; }
-  .bb-stagger > *:nth-child(2)  { animation-delay: 30ms; }
-  .bb-stagger > *:nth-child(3)  { animation-delay: 60ms; }
-  .bb-stagger > *:nth-child(4)  { animation-delay: 90ms; }
-  .bb-stagger > *:nth-child(5)  { animation-delay: 120ms; }
-  .bb-stagger > *:nth-child(6)  { animation-delay: 150ms; }
-  .bb-stagger > *:nth-child(7)  { animation-delay: 180ms; }
-  .bb-stagger > *:nth-child(8)  { animation-delay: 210ms; }
-  .bb-stagger > *:nth-child(9)  { animation-delay: 240ms; }
-  .bb-stagger > *:nth-child(10) { animation-delay: 270ms; }
-  .bb-stagger > *:nth-child(11) { animation-delay: 300ms; }
-  .bb-stagger > *:nth-child(12) { animation-delay: 330ms; }
-  .bb-stagger > *:nth-child(13) { animation-delay: 360ms; }
-  .bb-stagger > *:nth-child(14) { animation-delay: 390ms; }
-  .bb-stagger > *:nth-child(15) { animation-delay: 420ms; }
-  .bb-stagger > *:nth-child(16) { animation-delay: 450ms; }
-  .bb-stagger > *:nth-child(17) { animation-delay: 480ms; }
-  .bb-stagger > *:nth-child(18) { animation-delay: 510ms; }
-  .bb-stagger > *:nth-child(19) { animation-delay: 540ms; }
-  .bb-stagger > *:nth-child(20) { animation-delay: 570ms; }
-  .bb-stagger > *:nth-child(21) { animation-delay: 600ms; }
-  .bb-stagger > *:nth-child(22) { animation-delay: 630ms; }
-  .bb-stagger > *:nth-child(23) { animation-delay: 660ms; }
-  .bb-stagger > *:nth-child(24) { animation-delay: 690ms; }
-  .bb-stagger > *:nth-child(25) { animation-delay: 720ms; }
-
-  @keyframes bb-card-enter {
-    from {
-      opacity: 0;
-      transform: translateY(8px) scale(0.98);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-
-  /* Disable entrance animations on small/touch screens — feels sluggish on mobile */
+  /* Disable the page entrance animation on small/touch screens — feels sluggish on mobile */
   @media (max-width: 640px), (hover: none) and (pointer: coarse) {
-    .bb-page-enter,
-    .bb-stagger > * {
+    .bb-page-enter {
       animation: none !important;
     }
   }

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -104,7 +104,7 @@ templ acctHeader(p AccountDetailProps) {
 
 templ acctSummaryCards(p AccountDetailProps) {
 	<!-- Financial Summary Cards -->
-	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8 bb-stagger">
+	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
 		<!-- Balance Card (with credit utilization inline for credit cards) -->
 		<div class="bb-card p-5">
 			<div class="text-xs font-medium text-base-content/50 mb-1">Current Balance</div>

--- a/internal/templates/components/pages/account_link_detail.templ
+++ b/internal/templates/components/pages/account_link_detail.templ
@@ -53,7 +53,7 @@ templ AccountLinkDetail(p AccountLinkDetailProps) {
 			</table>
 		</div>
 		<!-- Mobile card list -->
-		<div class="md:hidden space-y-3 mt-4 bb-stagger">
+		<div class="md:hidden space-y-3 mt-4">
 			for _, m := range p.Matches {
 				@accountLinkDetailMobileCard(m, p.CSRFToken)
 			}

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -29,7 +29,7 @@ templ AgentSDKSettings(p AgentSDKSettingsProps) {
 			<span>{ p.FormSuccess }</span>
 		</div>
 	}
-	<div class="grid gap-6 bb-stagger">
+	<div class="grid gap-6">
 		@agentSDKStatusCard(p.Status)
 		@agentSDKFormCard(p)
 		@agentSDKToolsCard(p.CSRFToken)

--- a/internal/templates/components/pages/agent_wizard.templ
+++ b/internal/templates/components/pages/agent_wizard.templ
@@ -13,7 +13,7 @@ templ AgentWizard(p AgentWizardProps) {
 		<i data-lucide="rocket" class="w-4 h-4"></i>
 		<span>New to MCP agents? Follow the <a href="/agents?tab=guide" class="link font-medium">Getting Started guide</a> to connect your first agent.</span>
 	</div>
-	<div class="space-y-8 bb-stagger">
+	<div class="space-y-8">
 		<!-- Section: Bulk Reviews -->
 		<div>
 			<div class="flex items-center gap-2 mb-3">

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -17,7 +17,7 @@ templ AgentsSettings(p AgentsSettingsProps) {
 			<p class="text-sm text-base-content/50 mt-1">Server instructions, review guidelines, report format, and per-tool toggles</p>
 		</div>
 	</div>
-	<div class="grid gap-6 bb-stagger">
+	<div class="grid gap-6">
 		@agentsSettingsInstructionsCard(p)
 		@agentsSettingsReviewGuidelinesCard(p)
 		@agentsSettingsReportFormatCard(p)

--- a/internal/templates/components/pages/backups.templ
+++ b/internal/templates/components/pages/backups.templ
@@ -39,7 +39,7 @@ templ Backups(p BackupsProps) {
 			}
 		</div>
 	</div>
-	<div class="grid gap-6 bb-stagger">
+	<div class="grid gap-6">
 		<!-- Encryption Key Warning -->
 		<div class="alert alert-warning rounded-xl">
 			<i data-lucide="shield-alert" class="w-5 h-5 flex-shrink-0"></i>

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -54,7 +54,7 @@ templ Categories(p CategoriesProps) {
 				{ fmt.Sprintf("%d top-level categories", len(p.Categories)) }
 			</div>
 			<div class="bb-card overflow-hidden">
-				<div class="divide-y divide-base-300/40 bb-stagger">
+				<div class="divide-y divide-base-300/40">
 					for _, parent := range p.Categories {
 						@categoryRow(parent)
 					}

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -363,7 +363,7 @@ templ connDetailAccounts(p ConnectionDetailProps) {
 				}
 			</span>
 		</div>
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 bb-stagger">
+		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
 			for _, a := range p.Accounts {
 				@connDetailAccountCard(a)
 			}

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -128,7 +128,7 @@ templ Connections(p ConnectionsProps) {
 					</div>
 				}
 				<!-- Connection Cards -->
-				<div class="flex flex-col gap-4 bb-stagger" id="bb-connections-list">
+				<div class="flex flex-col gap-4" id="bb-connections-list">
 					for _, c := range p.Connections {
 						@connectionsCard(c)
 					}
@@ -154,7 +154,7 @@ templ Connections(p ConnectionsProps) {
 		<!-- ==================== ACCOUNT LINKS TAB ==================== -->
 		<div x-show="tab === 'links'" x-cloak>
 			if len(p.Links) > 0 {
-				<div class="space-y-3 bb-stagger">
+				<div class="space-y-3">
 					for _, l := range p.Links {
 						@connectionsLinkRow(l, p.CSRFToken)
 					}

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -22,7 +22,7 @@ templ GettingStarted(p GettingStartedProps) {
 		</div>
 	</div>
 	<!-- Progress summary -->
-	<div class="bb-card p-4 sm:p-5 mb-6 bb-stagger">
+	<div class="bb-card p-4 sm:p-5 mb-6">
 		<div class="flex flex-col sm:flex-row sm:items-center gap-4">
 			<div class="flex-1">
 				<div class="flex items-center gap-2 mb-2">
@@ -58,7 +58,7 @@ templ GettingStarted(p GettingStartedProps) {
 		</div>
 	</div>
 	<!-- Steps -->
-	<div class="grid gap-4 bb-stagger">
+	<div class="grid gap-4">
 		<!-- Step 1: Create a family member -->
 		@gsStep1(p)
 		<!-- Step 2: Configure a provider -->
@@ -71,7 +71,7 @@ templ GettingStarted(p GettingStartedProps) {
 		@gsStep5(p)
 	</div>
 	<!-- Dismiss section -->
-	<div class="mt-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 bb-stagger">
+	<div class="mt-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
 		if !p.OnboardingDismissed {
 			<form method="POST" action="/getting-started/dismiss">
 				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -63,7 +63,7 @@ templ Logs(p LogsProps) {
 					{ fmt.Sprintf("%d sync log%s", p.Total, components.PluralS(p.Total)) }
 				</div>
 				<!-- Timeline view -->
-				<div class="space-y-1 bb-stagger">
+				<div class="space-y-1">
 					for _, l := range p.Logs {
 						@logsSyncRow(l)
 					}
@@ -89,7 +89,7 @@ templ Logs(p LogsProps) {
 					{ fmt.Sprintf("%d webhook event%s", p.WHTotal, components.PluralS(p.WHTotal)) }
 				</div>
 				<!-- Event list -->
-				<div class="space-y-1 bb-stagger">
+				<div class="space-y-1">
 					for _, e := range p.WHEvents {
 						@logsWebhookRow(e)
 					}
@@ -109,7 +109,7 @@ templ Logs(p LogsProps) {
 // ====================================================================
 templ logsSyncStats(p LogsProps) {
 	if p.Stats != nil {
-		<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6 bb-stagger">
+		<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
 			<!-- Success Rate -->
 			<div class="bb-card p-4">
 				<div class="flex items-center gap-3">
@@ -386,7 +386,7 @@ templ logsSyncEmpty(p LogsProps) {
 // ====================================================================
 templ logsWebhookStats(p LogsProps) {
 	if p.WHStats != nil {
-		<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6 bb-stagger">
+		<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
 			<!-- Total Events -->
 			<div class="bb-card p-4">
 				<div class="flex items-center gap-3">
@@ -629,7 +629,7 @@ templ logsSessionsBody(p LogsProps) {
 		<div class="text-xs text-base-content/40 mb-3 px-1">
 			{ fmt.Sprintf("%d session%s", p.SessionsTotal, components.PluralS(p.SessionsTotal)) }
 		</div>
-		<div class="space-y-2 bb-stagger">
+		<div class="space-y-2">
 			for _, s := range p.Sessions {
 				@logsSessionRow(s)
 			}

--- a/internal/templates/components/pages/mcp_guide.templ
+++ b/internal/templates/components/pages/mcp_guide.templ
@@ -12,7 +12,7 @@ templ MCPGuide(p MCPGuideProps) {
 		<li class="step step-primary">Connect Agent</li>
 		<li class="step step-primary">Start Using</li>
 	</ul>
-	<div x-data="mcpGuide" data-mcp-url={ p.MCPServerURL } class="grid gap-6 bb-stagger">
+	<div x-data="mcpGuide" data-mcp-url={ p.MCPServerURL } class="grid gap-6">
 		<!-- Step 1: Your MCP Server -->
 		<div class="bb-card p-0 overflow-hidden">
 			<div class="px-4 sm:px-5 py-4 border-b border-base-300 flex items-center gap-3">

--- a/internal/templates/components/pages/mcp_settings.templ
+++ b/internal/templates/components/pages/mcp_settings.templ
@@ -17,7 +17,7 @@ templ MCPSettings(p MCPSettingsProps) {
 		ReportFormat:            p.ReportFormat,
 		DefaultReportFormat:     p.DefaultReportFormat,
 	})
-	<div class="grid gap-6 bb-stagger">
+	<div class="grid gap-6">
 		<!-- Card 1: Server Instructions -->
 		@mcpSettingsEditableCard(mcpSettingsCardSpec{
 			Slug:        "instructions",

--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -28,7 +28,7 @@ templ Providers(p ProvidersProps) {
 			<p class="text-sm text-base-content/50 mt-1">Configure bank data providers for syncing accounts and transactions</p>
 		</div>
 	</div>
-	<div class="grid gap-4 bb-stagger">
+	<div class="grid gap-4">
 		@providersPlaidCard(p, p.ProviderHealth["plaid"])
 		@providersTellerCard(p, p.ProviderHealth["teller"])
 		@providersCSVCard(p.ProviderHealth["csv"])

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -49,7 +49,7 @@ templ Reports(p ReportsProps) {
 	<!-- Reports Inbox -->
 	if len(p.Reports) > 0 {
 		<div class="bb-card" x-data="reportsPage">
-			<div class="divide-y divide-base-200/60 bb-stagger">
+			<div class="divide-y divide-base-200/60">
 				for _, r := range p.Reports {
 					@reportsRow(r)
 				}

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -56,7 +56,7 @@ templ Rules(p RulesProps) {
 		if len(p.Rules) == 0 {
 			@rulesEmpty()
 		}
-		<div class="space-y-3 bb-stagger">
+		<div class="space-y-3">
 			for _, r := range p.Rules {
 				@rulesRow(r)
 			}

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -16,7 +16,7 @@ templ SettingsSync(p SettingsProps) {
 		Title:    "Sync",
 		Subtitle: "Schedule and log retention",
 	})
-	<div class="grid gap-6 bb-stagger max-w-2xl">
+	<div class="grid gap-6 max-w-2xl">
 		@settingsSyncSchedule(p)
 		@settingsSyncRetention(p)
 	</div>
@@ -29,7 +29,7 @@ templ SettingsSecurity(p SettingsProps) {
 		Title:    "Security",
 		Subtitle: "Encryption key status",
 	})
-	<div class="grid gap-6 bb-stagger max-w-2xl">
+	<div class="grid gap-6 max-w-2xl">
 		@settingsSecurityCardFlat(p)
 	</div>
 }
@@ -40,7 +40,7 @@ templ SettingsSystem(p SettingsProps) {
 		Title:    "System",
 		Subtitle: "Version and runtime information",
 	})
-	<div class="grid gap-6 bb-stagger max-w-2xl">
+	<div class="grid gap-6 max-w-2xl">
 		@settingsSystemCard(p)
 	</div>
 }
@@ -52,7 +52,7 @@ templ SettingsHelp(p SettingsProps) {
 		Title:    "Help",
 		Subtitle: "Setup guide and resources",
 	})
-	<div class="grid gap-6 bb-stagger max-w-2xl">
+	<div class="grid gap-6 max-w-2xl">
 		@settingsHelpCardFlat(p)
 	</div>
 }

--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -37,7 +37,7 @@ templ Tags(p TagsProps) {
 				{ fmt.Sprintf("%d tags", len(p.Tags)) }
 			</div>
 			<div class="bb-card overflow-hidden">
-				<div class="divide-y divide-base-300/40 bb-stagger">
+				<div class="divide-y divide-base-300/40">
 					for _, t := range p.Tags {
 						@tagListRow(t)
 					}

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -35,7 +35,7 @@ templ Users(p UsersProps) {
 		@usersUnlinkedPrompt(p)
 	}
 	if len(p.EnrichedUsers) > 0 {
-		<div class="flex flex-col gap-5 bb-stagger">
+		<div class="flex flex-col gap-5">
 			for _, u := range p.EnrichedUsers {
 				@usersMemberCard(u)
 			}

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -37,7 +37,7 @@ type TxResultsProps struct {
 templ TxResults(p TxResultsProps) {
 	<!-- ═══ GROUPED VIEW ═══ -->
 	<template x-if="$store.txView.mode === 'grouped'">
-		<div class="space-y-1 bb-stagger">
+		<div class="space-y-1">
 			for _, g := range p.DateGroups {
 				<div class="bb-date-group" data-date-group={ g.Date }>
 					<!-- Date Header -->

--- a/static/js/admin/components/transactions.js
+++ b/static/js/admin/components/transactions.js
@@ -385,7 +385,7 @@ document.addEventListener('alpine:init', function () {
               // Check if response has any transaction rows
               var hasResults = html.indexOf('bb-tx-row') !== -1;
               if (hasResults) {
-                results.innerHTML = html.replace(/bb-stagger/g, '');
+                results.innerHTML = html;
                 results.querySelectorAll('script').forEach(function (s) { eval(s.textContent); });
                 Alpine.initTree(results);
                 if (window.lucide) lucide.createIcons();
@@ -465,7 +465,7 @@ document.addEventListener('alpine:init', function () {
             .then(function (html) {
               var results = document.getElementById('bb-tx-results');
               if (results) {
-                results.innerHTML = html.replace(/bb-stagger/g, '');
+                results.innerHTML = html;
                 results.querySelectorAll('script').forEach(function (s) { eval(s.textContent); });
                 Alpine.initTree(results);
                 if (window.lucide) lucide.createIcons();


### PR DESCRIPTION
First PR in the design-system wave-2 follow-up: retiring the page-level `bb-stagger` entrance animation.

## Why

Every list/grid page on v1 opted into a `bb-stagger` class that fired a `bb-card-enter` fade-in on each child with a `nth-child` animation-delay ladder (0ms → 720ms across 25 children). It was page-level customization on top of the global `bb-page-enter` transition, doubling the perceived entry delay and making every page lightly animated for no real UX win. It was also already disabled on small/touch screens, which means most mobile users never saw it. Continues the design-system sprint goal of reducing per-page customization.

## What

- **`input.css`**: deleted the `.bb-stagger` selector + 25 `nth-child` rules + the `@keyframes bb-card-enter` block. Kept `bb-page-enter` (single global on `<main>`) since it's not per-page customization.
- **Templates (21 files)**: stripped the `bb-stagger` class from every caller — `account_detail`, `account_link_detail`, `agent_sdk_settings`, `agent_wizard`, `agents_settings`, `backups`, `categories`, `connection_detail`, `connections`, `getting_started`, `logs`, `mcp_guide`, `mcp_settings`, `providers`, `reports`, `rules`, `settings`, `tags`, `users`, plus `tx_results`.
- **`static/js/admin/components/transactions.js`**: dropped the two `html.replace(/bb-stagger/g, '')` calls in the search-results inject path — no longer needed.

Net change: 34 insertions, 76 deletions (mostly the CSS deletion).

## Validation

Booted dev server on :8082 with `BREADBOX_DEV_RELOAD=1`, verified via `getComputedStyle`:

- `.bb-stagger` selector count in DOM: **0**
- `bb-card-enter` keyframe rule in stylesheets: **false**
- `.bb-page-enter` on `<main>`: **true** (global entrance kept)

### Connections page

<img src="https://i.img402.dev/unqq5ahr13.jpg" width="800" alt="connections — after">

### Rules page

<img src="https://i.img402.dev/08v8gf2uem.jpg" width="800" alt="rules — after">

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `templ generate` clean (21 templates regenerated)
- [x] `make css` rebuilds without `bb-stagger`/`bb-card-enter` (0 occurrences in output)
- [x] Renders correctly on `/connections`, `/rules`
