### PR TITLE
refactor(ui): adopt EmptyState across 9 admin list pages

### DIFF
--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -1,6 +1,10 @@
 package pages
 
-import "fmt"
+import (
+	"fmt"
+
+	"breadbox/internal/templates/components"
+)
 
 // Access renders the combined API Keys + OAuth Clients page body. Hosts
 // inside the base layout via TemplateRenderer.RenderWithTempl — the handler
@@ -68,19 +72,14 @@ templ accessOAuthClientsSection(p AccessProps) {
 				</div>
 			}
 		} else {
-			<div class="bb-card p-8 sm:p-12 text-center">
-				<div class="flex flex-col items-center">
-					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
-						<i data-lucide="fingerprint" class="w-7 h-7 text-base-content/30"></i>
-					</div>
-					<h3 class="text-base font-semibold mb-1">No OAuth clients yet</h3>
-					<p class="text-base-content/50 text-sm mb-5 max-w-sm">Create an OAuth client to connect external AI services to your Breadbox MCP server.</p>
-					<a href="/settings/oauth-clients/new" class="btn btn-primary btn-sm rounded-xl gap-2">
-						<i data-lucide="plus" class="w-4 h-4"></i>
-						Create your first client
-					</a>
-				</div>
-			</div>
+			@components.EmptyState(components.EmptyStateProps{
+				Icon:     "fingerprint",
+				Title:    "No OAuth clients yet",
+				Body:     "Create an OAuth client to connect external AI services to your Breadbox MCP server.",
+				CTAHref:  templ.SafeURL("/settings/oauth-clients/new"),
+				CTAIcon:  "plus",
+				CTALabel: "Create your first client",
+			})
 		}
 	</div>
 }
@@ -199,19 +198,14 @@ templ accessAPIKeysSection(p AccessProps) {
 				</div>
 			}
 		} else {
-			<div class="bb-card p-8 sm:p-12 text-center">
-				<div class="flex flex-col items-center">
-					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
-						<i data-lucide="key" class="w-7 h-7 text-base-content/30"></i>
-					</div>
-					<h3 class="text-base font-semibold mb-1">No API keys yet</h3>
-					<p class="text-base-content/50 text-sm mb-5 max-w-sm">Create an API key to connect MCP agents or integrate with external tools.</p>
-					<a href="/settings/api-keys/new" class="btn btn-primary btn-sm rounded-xl gap-2">
-						<i data-lucide="plus" class="w-4 h-4"></i>
-						Create your first key
-					</a>
-				</div>
-			</div>
+			@components.EmptyState(components.EmptyStateProps{
+				Icon:     "key",
+				Title:    "No API keys yet",
+				Body:     "Create an API key to connect MCP agents or integrate with external tools.",
+				CTAHref:  templ.SafeURL("/settings/api-keys/new"),
+				CTAIcon:  "plus",
+				CTALabel: "Create your first key",
+			})
 		}
 	</div>
 }

--- a/internal/templates/components/pages/account_link_detail.templ
+++ b/internal/templates/components/pages/account_link_detail.templ
@@ -168,15 +168,11 @@ templ accountLinkDetailConfidenceBadge(confidence string) {
 }
 
 templ accountLinkDetailEmpty() {
-	<div class="bb-card p-12 text-center">
-		<div class="flex flex-col items-center">
-			<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-				<i data-lucide="check-circle-2" class="w-8 h-8 text-base-content/25"></i>
-			</div>
-			<h3 class="text-lg font-semibold mb-1">No Matches Yet</h3>
-			<p class="text-sm text-base-content/50 max-w-sm">Run reconciliation to find matching transactions between the linked accounts.</p>
-		</div>
-	</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:  "check-circle-2",
+		Title: "No Matches Yet",
+		Body:  "Run reconciliation to find matching transactions between the linked accounts.",
+	})
 }
 
 // accountLinkDetailMatchedOn mirrors the original `{{range .MatchedOn}}{{.}} {{end}}`

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"breadbox/internal/templates/components"
 )
 
 // AgentsList renders the admin /agents page — the list of agent
@@ -87,24 +89,22 @@ templ agentsListStatusBanner(s AgentSubsystemStatusProps) {
 }
 
 templ agentsListEmpty() {
-	<div class="bb-card">
-		<div class="flex flex-col items-center text-center py-16 px-6">
-			<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-				<i data-lucide="bot" class="w-8 h-8 text-primary"></i>
-			</div>
-			<h2 class="text-lg font-semibold mb-1">No agents yet</h2>
-			<p class="text-base-content/50 text-sm mb-4 max-w-sm">
-				Create an agent to run a prompt on a schedule. You can also browse the prompt library for ready-made ideas.
-			</p>
-			<div class="flex items-center gap-2">
-				<a href="/agents/new" class="btn btn-primary btn-sm rounded-xl">
-					<i data-lucide="plus" class="w-4 h-4"></i> Create your first agent
-				</a>
-				<a href="/agent-prompts" class="btn btn-ghost btn-sm rounded-xl">
-					<i data-lucide="book-open" class="w-4 h-4"></i> Prompt library
-				</a>
-			</div>
-		</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:      "bot",
+		Title:     "No agents yet",
+		Body:      "Create an agent to run a prompt on a schedule. You can also browse the prompt library for ready-made ideas.",
+		CustomCTA: agentsListEmptyCTAs(),
+	})
+}
+
+templ agentsListEmptyCTAs() {
+	<div class="flex items-center gap-2">
+		<a href="/agents/new" class="btn btn-primary btn-sm rounded-xl">
+			<i data-lucide="plus" class="w-4 h-4"></i> Create your first agent
+		</a>
+		<a href="/agent-prompts" class="btn btn-ghost btn-sm rounded-xl">
+			<i data-lucide="book-open" class="w-4 h-4"></i> Prompt library
+		</a>
 	</div>
 }
 

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -229,18 +229,14 @@ templ categoriesNewCategoryAction() {
 }
 
 templ categoriesEmpty() {
-	<div class="bb-card">
-		<div class="flex flex-col items-center text-center py-16 px-6">
-			<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-				<i data-lucide="tag" class="w-8 h-8 text-primary"></i>
-			</div>
-			<h2 class="text-lg font-semibold mb-1">No categories yet</h2>
-			<p class="text-base-content/50 text-sm mb-6 max-w-sm">Create your first category to start organizing transactions into a clean taxonomy.</p>
-			<a href="/categories/new" class="btn btn-primary btn-sm rounded-xl gap-2">
-				<i data-lucide="plus" class="w-4 h-4"></i> Add Category
-			</a>
-		</div>
-	</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:     "tag",
+		Title:    "No categories yet",
+		Body:     "Create your first category to start organizing transactions into a clean taxonomy.",
+		CTAHref:  templ.SafeURL("/categories/new"),
+		CTAIcon:  "plus",
+		CTALabel: "Add Category",
+	})
 }
 
 // deleteCategoryModal renders the shared confirmation dialog. Listens for

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -134,20 +134,14 @@ templ Connections(p ConnectionsProps) {
 					}
 				</div>
 			} else {
-				<!-- Empty State -->
-				<div class="bb-card">
-					<div class="flex flex-col items-center text-center py-16 px-6">
-						<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-							<i data-lucide="building-2" class="w-8 h-8 text-base-content/20"></i>
-						</div>
-						<h3 class="text-lg font-semibold mb-1">No bank connections yet</h3>
-						<p class="text-sm text-base-content/60 max-w-sm mb-4">Connect your first bank to start syncing transactions and tracking your finances.</p>
-						<a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
-							<i data-lucide="plus" class="w-4 h-4"></i>
-							Connect Your First Bank
-						</a>
-					</div>
-				</div>
+				@components.EmptyState(components.EmptyStateProps{
+					Icon:     "building-2",
+					Title:    "No bank connections yet",
+					Body:     "Connect your first bank to start syncing transactions and tracking your finances.",
+					CTAHref:  templ.SafeURL("/connections/new"),
+					CTAIcon:  "plus",
+					CTALabel: "Connect Your First Bank",
+				})
 			}
 		</div>
 		<!-- /connections tab -->

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -361,24 +361,24 @@ templ logsSyncRow(l LogsSyncRow) {
 }
 
 templ logsSyncEmpty(p LogsProps) {
-	<div class="bb-card p-12 text-center">
-		<div class="flex flex-col items-center">
-			<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-				<i data-lucide="refresh-cw" class="w-8 h-8 text-base-content/25"></i>
-			</div>
-			<h3 class="text-lg font-semibold mb-1">No sync logs found</h3>
-			<p class="text-sm text-base-content/50 mb-5">
-				if hasAnySyncFilter(p) {
-					Try adjusting your filters.
-				} else {
-					Sync logs will appear here after your first bank sync.
-				}
-			</p>
-			if hasAnySyncFilter(p) {
-				<a href="/logs?tab=syncs" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
-			}
-		</div>
-	</div>
+	if hasAnySyncFilter(p) {
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:      "refresh-cw",
+			Title:     "No sync logs found",
+			Body:      "Try adjusting your filters.",
+			CustomCTA: logsClearFiltersCTA("/logs?tab=syncs"),
+		})
+	} else {
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:  "refresh-cw",
+			Title: "No sync logs found",
+			Body:  "Sync logs will appear here after your first bank sync.",
+		})
+	}
+}
+
+templ logsClearFiltersCTA(href string) {
+	<a href={ templ.SafeURL(href) } class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
 }
 
 // ====================================================================
@@ -601,24 +601,20 @@ templ logsWebhookRow(e LogsWebhookRow) {
 }
 
 templ logsWebhookEmpty(p LogsProps) {
-	<div class="bb-card p-12 text-center">
-		<div class="flex flex-col items-center">
-			<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-				<i data-lucide="webhook" class="w-8 h-8 text-base-content/25"></i>
-			</div>
-			<h3 class="text-lg font-semibold mb-1">No webhook events</h3>
-			<p class="text-sm text-base-content/50 mb-5">
-				if p.WHFilterProvider != "" || p.WHFilterStatus != "" {
-					Try adjusting your filters.
-				} else {
-					Webhook events will appear here when providers send notifications.
-				}
-			</p>
-			if p.WHFilterProvider != "" || p.WHFilterStatus != "" {
-				<a href="/logs?tab=webhooks" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
-			}
-		</div>
-	</div>
+	if p.WHFilterProvider != "" || p.WHFilterStatus != "" {
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:      "webhook",
+			Title:     "No webhook events",
+			Body:      "Try adjusting your filters.",
+			CustomCTA: logsClearFiltersCTA("/logs?tab=webhooks"),
+		})
+	} else {
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:  "webhook",
+			Title: "No webhook events",
+			Body:  "Webhook events will appear here when providers send notifications.",
+		})
+	}
 }
 
 // ====================================================================
@@ -680,19 +676,19 @@ templ logsSessionRow(s LogsSessionRow) {
 }
 
 templ logsSessionsEmpty() {
-	<div class="bb-card p-12 text-center">
-		<div class="flex flex-col items-center">
-			<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-				<i data-lucide="bot" class="w-8 h-8 text-base-content/25"></i>
-			</div>
-			<h3 class="text-lg font-semibold mb-1">No agent sessions yet</h3>
-			<p class="text-sm text-base-content/50 mb-5 max-w-md">Sessions appear here once an MCP agent connects to Breadbox and starts making tool calls.</p>
-			<a href="/agent-prompts" class="btn btn-ghost btn-sm rounded-xl no-underline">
-				<i data-lucide="bot-message-square" class="w-4 h-4"></i>
-				Browse agent prompts
-			</a>
-		</div>
-	</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:      "bot",
+		Title:     "No agent sessions yet",
+		Body:      "Sessions appear here once an MCP agent connects to Breadbox and starts making tool calls.",
+		CustomCTA: logsBrowseAgentPromptsCTA(),
+	})
+}
+
+templ logsBrowseAgentPromptsCTA() {
+	<a href="/agent-prompts" class="btn btn-ghost btn-sm rounded-xl no-underline">
+		<i data-lucide="bot-message-square" class="w-4 h-4"></i>
+		Browse agent prompts
+	</a>
 }
 
 // logsSessionsPaginator is a simple Prev / Next strip — sessions don't

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -83,18 +83,14 @@ templ rulesSortOption(value, label string, selected bool) {
 }
 
 templ rulesEmpty() {
-	<div class="bb-card">
-		<div class="flex flex-col items-center text-center py-16 px-6">
-			<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-				<i data-lucide="list-filter" class="w-8 h-8 text-primary"></i>
-			</div>
-			<h2 class="text-lg font-semibold mb-1">No rules yet</h2>
-			<p class="text-base-content/50 text-sm mb-4 max-w-sm">Create a rule to automatically categorize, tag, or comment on transactions during sync.</p>
-			<a href="/rules/new" class="btn btn-primary btn-sm rounded-xl">
-				<i data-lucide="plus" class="w-4 h-4"></i> Create Rule
-			</a>
-		</div>
-	</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:     "list-filter",
+		Title:    "No rules yet",
+		Body:     "Create a rule to automatically categorize, tag, or comment on transactions during sync.",
+		CTAHref:  templ.SafeURL("/rules/new"),
+		CTAIcon:  "plus",
+		CTALabel: "Create Rule",
+	})
 }
 
 templ rulesRow(r RulesRow) {

--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -125,16 +125,12 @@ templ tagListRow(t TagRow) {
 }
 
 templ tagsEmpty() {
-	<div class="bb-card">
-		<div class="flex flex-col items-center text-center py-16 px-6">
-			<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-				<i data-lucide="tags" class="w-8 h-8 text-primary"></i>
-			</div>
-			<h2 class="text-lg font-semibold mb-1">No tags yet</h2>
-			<p class="text-base-content/50 text-sm mb-6 max-w-sm">Tags coordinate work on transactions — add "needs-review" to flag items for follow-up, or custom tags to group related charges.</p>
-			<a href="/tags/new" class="btn btn-primary btn-sm rounded-xl gap-2">
-				<i data-lucide="plus" class="w-4 h-4"></i> Add Tag
-			</a>
-		</div>
-	</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:     "tags",
+		Title:    "No tags yet",
+		Body:     "Tags coordinate work on transactions — add \"needs-review\" to flag items for follow-up, or custom tags to group related charges.",
+		CTAHref:  templ.SafeURL("/tags/new"),
+		CTAIcon:  "plus",
+		CTALabel: "Add Tag",
+	})
 }

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -263,17 +263,12 @@ templ usersAccountRow(a UsersAccountRow) {
 
 // usersEmpty renders the "no family members" empty state.
 templ usersEmpty() {
-	<div class="bb-card p-12 text-center">
-		<div class="flex flex-col items-center">
-			<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-				<i data-lucide="users" class="w-8 h-8 text-base-content/25"></i>
-			</div>
-			<h3 class="text-lg font-semibold mb-1">No family members yet</h3>
-			<p class="text-sm text-base-content/50 mb-5 max-w-sm">Add family members to connect their bank accounts and track spending across the household.</p>
-			<a href="/settings/household/new" class="btn btn-primary btn-sm rounded-xl">
-				<i data-lucide="plus" class="w-4 h-4"></i>
-				Add your first member
-			</a>
-		</div>
-	</div>
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:     "users",
+		Title:    "No family members yet",
+		Body:     "Add family members to connect their bank accounts and track spending across the household.",
+		CTAHref:  templ.SafeURL("/settings/household/new"),
+		CTAIcon:  "plus",
+		CTALabel: "Add your first member",
+	})
 }


### PR DESCRIPTION
Wave-2 follow-up #1 from the design-system audit. The `EmptyState` templ component shipped in PR #1425 with only 2 callers; ~18 hand-rolled "no data" blocks remained scattered across the v1 admin templ tree.

## Migrated (12 callsites across 9 templates)

| Template | What |
|---|---|
| `access.templ` | OAuth Clients + API Keys (2 empty states) |
| `rules.templ` | "No rules yet" |
| `categories.templ` | "No categories yet" |
| `tags.templ` | "No tags yet" |
| `account_link_detail.templ` | "No Matches Yet" (no CTA) |
| `users.templ` | "No family members yet" |
| `connections.templ` | "No bank connections yet" |
| `logs.templ` | Sync logs + Webhooks + Sessions (3 empty states, filter-aware) |
| `agents_list.templ` | "No agents yet" (uses `CustomCTA` for the 2-button group) |

The two filter-aware logs blocks (syncs + webhooks) split into the two `EmptyState` shapes — "with filter active → Clear filters CTA" and "no filter → contextual body" — sharing a tiny `logsClearFiltersCTA(href)` helper to keep the markup clean.

**Net**: 129 insertions, 166 deletions (-37 LOC).

## Deferred for follow-up

These were considered but require an `EmptyState` API extension or have unique constraints:

- **`transactions.templ` / `account_detail.templ` / `agent_runs.templ`** — card-wrapped compact pattern with optional CTA. Neither EmptyState variant matches (Compact has no card; Full has a 56×56 icon tile). Needs a third "card-compact" variant.
- **`feed.templ` × 3** (firstRun / filtered / noRecent) — custom `w-10 h-10` icon size (not the tile treatment) and the admin "Quiet around here" CTA is bound to an Alpine `feedSyncNow` factory. Distinct shape + behavior.

## Validation

Booted dev server on :8082, confirmed the empty state renders on `/settings/api-keys` (zero OAuth clients), `getComputedStyle` matches the EmptyState template.

<img src="https://i.img402.dev/qufrw0tblb.jpg" width="800" alt="API Keys page — OAuth empty state via EmptyState">

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `templ generate` regenerates 9 templates cleanly
- [x] `/settings/api-keys` OAuth empty state renders correctly
