### PR TITLE
refactor(ui): adopt StatTile on rule_detail + sync_log_detail

### DIFF
--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -245,65 +245,29 @@ templ ruleDetailActionRow(p RuleDetailProps, a service.RuleAction) {
 templ ruleDetailStats(p RuleDetailProps) {
 	if p.Rule != nil {
 		<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-			<div class="bb-card p-4">
-				<div class="flex items-center gap-3">
-					<div class="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-						<i data-lucide="target" class="w-4 h-4 text-primary"></i>
-					</div>
-					<div>
-						<div class="text-2xl font-semibold tabular-nums leading-none">{ components.CommaInt(int64(p.Rule.HitCount)) }</div>
-						<div class="text-xs text-base-content/40 mt-0.5">Times matched</div>
-					</div>
-				</div>
-			</div>
-			<div class="bb-card p-4">
-				<div class="flex items-center gap-3">
-					<div class="w-9 h-9 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
-						<i data-lucide="layers" class="w-4 h-4 text-info"></i>
-					</div>
-					<div>
-						<div class="text-2xl font-semibold tabular-nums leading-none">{ components.CommaInt(ruleStatsUnique(p.Stats)) }</div>
-						<div class="text-xs text-base-content/40 mt-0.5">Transactions affected</div>
-					</div>
-				</div>
-			</div>
-			<div class="bb-card p-4">
-				<div class="flex items-center gap-3">
-					{{ pendingActive := p.Preview != nil && p.Preview.MatchCount > 0 }}
-					<div class={ "w-9", "h-9", "rounded-lg", "flex", "items-center", "justify-center", "shrink-0", rulePendingTileClass(pendingActive) }>
-						if pendingActive {
-							<i data-lucide="alert-circle" class="w-4 h-4 text-warning"></i>
-						} else {
-							<i data-lucide="check-circle" class="w-4 h-4 text-success"></i>
-						}
-					</div>
-					<div>
-						<div class="text-2xl font-semibold tabular-nums leading-none">
-							if p.Preview != nil {
-								{ components.CommaInt(p.Preview.MatchCount) }
-							} else {
-								0
-							}
-						</div>
-						<div class="text-xs text-base-content/40 mt-0.5">Untouched matches</div>
-					</div>
-				</div>
-			</div>
-			<div class="bb-card p-4">
-				<div class="flex items-center gap-3">
-					<div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-						<i data-lucide="clock" class="w-4 h-4 text-base-content/40"></i>
-					</div>
-					<div>
-						if p.HasLastActive {
-							<div class="text-sm font-semibold leading-none">{ ruleRelativeTime(p.LastActiveTime) }</div>
-						} else {
-							<div class="text-sm font-semibold leading-none text-base-content/30">Never</div>
-						}
-						<div class="text-xs text-base-content/40 mt-0.5">Last active</div>
-					</div>
-				</div>
-			</div>
+			@components.StatTile(components.StatTileProps{
+				Icon:  "target",
+				Label: "Times matched",
+				Value: components.CommaInt(int64(p.Rule.HitCount)),
+				Tone:  components.StatTonePrimary,
+			})
+			@components.StatTile(components.StatTileProps{
+				Icon:  "layers",
+				Label: "Transactions affected",
+				Value: components.CommaInt(ruleStatsUnique(p.Stats)),
+				Tone:  components.StatToneInfo,
+			})
+			@components.StatTile(components.StatTileProps{
+				Icon:  rulePendingIcon(p),
+				Label: "Untouched matches",
+				Value: rulePendingValue(p),
+				Tone:  rulePendingTone(p),
+			})
+			@components.StatTile(components.StatTileProps{
+				Icon:  "clock",
+				Label: "Last active",
+				Value: ruleLastActiveValue(p),
+			})
 		</div>
 	}
 }

--- a/internal/templates/components/pages/rule_detail_types.go
+++ b/internal/templates/components/pages/rule_detail_types.go
@@ -138,13 +138,40 @@ func ruleCategoryIconColorStyle(rule *service.TransactionRuleResponse) string {
 	return ""
 }
 
-// rulePendingTileClass returns the bg class for the third stat tile
-// (warning when pending matches exist, success otherwise).
-func rulePendingTileClass(pendingActive bool) string {
-	if pendingActive {
-		return "bg-warning/10"
+// rulePendingTone selects the StatTile tone for the pending-matches
+// tile — warning when matches are waiting, success when caught up.
+func rulePendingTone(p RuleDetailProps) components.StatTileTone {
+	if p.Preview != nil && p.Preview.MatchCount > 0 {
+		return components.StatToneWarning
 	}
-	return "bg-success/10"
+	return components.StatToneSuccess
+}
+
+// rulePendingIcon mirrors rulePendingTone: alert when there's
+// untouched-match work, check-circle otherwise.
+func rulePendingIcon(p RuleDetailProps) string {
+	if p.Preview != nil && p.Preview.MatchCount > 0 {
+		return "alert-circle"
+	}
+	return "check-circle"
+}
+
+// rulePendingValue is the numeric body of the pending-matches tile.
+// Falls back to "0" when no preview has been computed yet.
+func rulePendingValue(p RuleDetailProps) string {
+	if p.Preview == nil {
+		return "0"
+	}
+	return components.CommaInt(p.Preview.MatchCount)
+}
+
+// ruleLastActiveValue renders the last-active timestamp; the dash em
+// keeps the tile non-empty when the rule has never matched.
+func ruleLastActiveValue(p RuleDetailProps) string {
+	if !p.HasLastActive {
+		return "—"
+	}
+	return ruleRelativeTime(p.LastActiveTime)
 }
 
 // ruleStatsUnique returns the UniqueTransactions count, defensively

--- a/internal/templates/components/pages/sync_log_detail.templ
+++ b/internal/templates/components/pages/sync_log_detail.templ
@@ -46,73 +46,41 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 	</div>
 	<!-- Summary Stats -->
 	<div class={ "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6", summaryStatsXLClass(len(p.Log.RuleHits) > 0) }>
-		<div class="bb-card p-4">
-			<div class="flex items-center gap-3">
-				<div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
-					<i data-lucide="plus" class="w-4 h-4 text-success"></i>
-				</div>
-				<div>
-					<div class="text-2xl font-semibold tabular-nums leading-none text-success">{ strconv.FormatInt(int64(p.Log.AddedCount), 10) }</div>
-					<div class="text-xs text-base-content/40 mt-0.5">Added</div>
-				</div>
-			</div>
-		</div>
-		<div class="bb-card p-4">
-			<div class="flex items-center gap-3">
-				<div class="w-9 h-9 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
-					<i data-lucide="pencil" class="w-4 h-4 text-info"></i>
-				</div>
-				<div>
-					<div class="text-2xl font-semibold tabular-nums leading-none text-info">{ strconv.FormatInt(int64(p.Log.ModifiedCount), 10) }</div>
-					<div class="text-xs text-base-content/40 mt-0.5">Modified</div>
-				</div>
-			</div>
-		</div>
-		<div class="bb-card p-4">
-			<div class="flex items-center gap-3">
-				<div class="w-9 h-9 rounded-lg bg-error/10 flex items-center justify-center shrink-0">
-					<i data-lucide="minus" class="w-4 h-4 text-error"></i>
-				</div>
-				<div>
-					<div class="text-2xl font-semibold tabular-nums leading-none text-error">{ strconv.FormatInt(int64(p.Log.RemovedCount), 10) }</div>
-					<div class="text-xs text-base-content/40 mt-0.5">Removed</div>
-				</div>
-			</div>
-		</div>
-		<div class="bb-card p-4">
-			<div class="flex items-center gap-3">
-				<div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-					<i data-lucide="equal" class="w-4 h-4 text-base-content/30"></i>
-				</div>
-				<div>
-					<div class="text-2xl font-semibold tabular-nums leading-none text-base-content/40">{ strconv.FormatInt(int64(p.Log.UnchangedCount), 10) }</div>
-					<div class="text-xs text-base-content/40 mt-0.5">Unchanged</div>
-				</div>
-			</div>
-		</div>
-		<div class="bb-card p-4">
-			<div class="flex items-center gap-3">
-				<div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-					<i data-lucide="wallet" class="w-4 h-4 text-base-content/40"></i>
-				</div>
-				<div>
-					<div class="text-2xl font-semibold tabular-nums leading-none">{ strconv.FormatInt(p.Log.AccountsAffected, 10) }</div>
-					<div class="text-xs text-base-content/40 mt-0.5">{ pluralLabel("Account", p.Log.AccountsAffected != 1) }</div>
-				</div>
-			</div>
-		</div>
+		@components.StatTile(components.StatTileProps{
+			Icon:  "plus",
+			Label: "Added",
+			Value: strconv.FormatInt(int64(p.Log.AddedCount), 10),
+			Tone:  components.StatToneSuccess,
+		})
+		@components.StatTile(components.StatTileProps{
+			Icon:  "pencil",
+			Label: "Modified",
+			Value: strconv.FormatInt(int64(p.Log.ModifiedCount), 10),
+			Tone:  components.StatToneInfo,
+		})
+		@components.StatTile(components.StatTileProps{
+			Icon:  "minus",
+			Label: "Removed",
+			Value: strconv.FormatInt(int64(p.Log.RemovedCount), 10),
+			Tone:  components.StatToneError,
+		})
+		@components.StatTile(components.StatTileProps{
+			Icon:  "equal",
+			Label: "Unchanged",
+			Value: strconv.FormatInt(int64(p.Log.UnchangedCount), 10),
+		})
+		@components.StatTile(components.StatTileProps{
+			Icon:  "wallet",
+			Label: pluralLabel("Account", p.Log.AccountsAffected != 1),
+			Value: strconv.FormatInt(p.Log.AccountsAffected, 10),
+		})
 		if len(p.Log.RuleHits) > 0 {
-			<div class="bb-card p-4">
-				<div class="flex items-center gap-3">
-					<div class="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-						<i data-lucide="list-filter" class="w-4 h-4 text-primary"></i>
-					</div>
-					<div>
-						<div class="text-2xl font-semibold tabular-nums leading-none text-primary">{ strconv.Itoa(p.Log.TotalRuleHits) }</div>
-						<div class="text-xs text-base-content/40 mt-0.5">{ pluralLabel("Rule Hit", p.Log.TotalRuleHits != 1) }</div>
-					</div>
-				</div>
-			</div>
+			@components.StatTile(components.StatTileProps{
+				Icon:  "list-filter",
+				Label: pluralLabel("Rule Hit", p.Log.TotalRuleHits != 1),
+				Value: strconv.Itoa(p.Log.TotalRuleHits),
+				Tone:  components.StatTonePrimary,
+			})
 		}
 	</div>
 	<!-- Warning Card -->


### PR DESCRIPTION
Wave-2 follow-up #6 from the design-system audit. `StatTile` shipped in PR #1414 with feed + dashboard callers; `rule_detail` and `sync_log_detail` still hand-rolled the same `bb-card p-4 + w-9 h-9 + text-2xl tabular-nums` shape across **10 tiles**.

## What

### `rule_detail` (4 tiles)

- **Times matched** → `Tone: StatTonePrimary`
- **Transactions affected** → `Tone: StatToneInfo`
- **Untouched matches** → tone switches warning↔success based on pending count. Extracted `rulePendingTone`, `rulePendingIcon`, `rulePendingValue` helpers in `rule_detail_types.go`.
- **Last active** → passes a relative-time string ("13 hours ago" / "—" fallback) through `Value`.

### `sync_log_detail` (6 tiles)

- **Added / Modified / Removed** → success / info / error tones
- **Unchanged / Accounts** → neutral tone (default)
- **Rule Hits** (conditional, only when `len(RuleHits) > 0`) → primary tone

## Note on visual delta

Tiles previously colored their **value text** (e.g. `text-success` on the "Added" count). `StatTile` only tones the icon tile — so the numeric value now renders in the default foreground. This is the intended consistency: per-page customization of the value color goes away, the icon tile carries the tone visually.

**Net**: 90 insertions, 131 deletions (-41 LOC) across 3 files.

## Validation

### `/rules/0192745c-…` — 4 tiles

<img src="https://i.img402.dev/4q6jj1eddt.jpg" width="800" alt="Rule detail page — 4 StatTiles">

### `/logs/sync-logs/88b819c3-…` — 5 tiles (no rule hits in this sync)

<img src="https://i.img402.dev/tz7301kzsl.jpg" width="800" alt="Sync log detail page — 5 StatTiles">

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `templ generate` regenerates both pages cleanly
- [x] Rule detail shows 977 Times matched / 920 Transactions affected / 0 Untouched matches (success tone) / "13 hours ago" Last active
- [x] Sync log detail shows Added/Modified/Removed/Unchanged/Accounts tiles with correct values + uppercase labels
