### PR TITLE
feat(ui): FilterSearchInput component + adopt on /categories + /tags

### DIFF
--- a/internal/templates/components/filter_search_input.templ
+++ b/internal/templates/components/filter_search_input.templ
@@ -1,0 +1,44 @@
+package components
+
+// FilterSearchInput is the canonical client-side filter input — a daisy
+// `input input-bordered` with a small leading search icon and an
+// `x-model` binding for Alpine-driven row filtering. Currently used by
+// `/categories` and `/tags`; future inline-filter list pages should
+// reach for this before re-rolling the markup.
+//
+// The component is markup-only. Caller owns the Alpine factory that the
+// XModel string targets — typically a `filter` string on the page's
+// root `x-data` object that each row reads via
+// `x-show="!filter || ($el.dataset.search || '').includes(filter.toLowerCase())"`.
+//
+// Usage:
+//
+//	@components.FilterSearchInput(components.FilterSearchInputProps{
+//	    Placeholder: "Filter tags...",
+//	    XModel:      "filter",
+//	})
+
+type FilterSearchInputProps struct {
+	Placeholder string // required: e.g. "Filter categories..."
+	XModel      string // required: Alpine state binding, e.g. "filter"
+	Icon        string // optional: Lucide icon name, defaults to "search"
+}
+
+templ FilterSearchInput(p FilterSearchInputProps) {
+	<div class="relative">
+		<i data-lucide={ filterSearchIcon(p.Icon) } class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/30 pointer-events-none"></i>
+		<input
+			type="text"
+			placeholder={ p.Placeholder }
+			x-model={ p.XModel }
+			class="input input-bordered w-full pl-9 rounded-xl h-10 text-sm"
+		/>
+	</div>
+}
+
+func filterSearchIcon(icon string) string {
+	if icon == "" {
+		return "search"
+	}
+	return icon
+}

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -40,15 +40,10 @@ templ Categories(p CategoriesProps) {
 	-->
 	<div x-data x-init="$store.shortcuts.setScope('categories')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div x-data="categoriesPage" class="space-y-4">
-		<div class="relative">
-			<i data-lucide="search" class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/30 pointer-events-none"></i>
-			<input
-				type="text"
-				placeholder="Filter categories..."
-				x-model="filter"
-				class="input input-bordered w-full pl-9 rounded-xl h-10 text-sm"
-			/>
-		</div>
+		@components.FilterSearchInput(components.FilterSearchInputProps{
+			Placeholder: "Filter categories...",
+			XModel:      "filter",
+		})
 		if len(p.Categories) > 0 {
 			<div class="text-xs text-base-content/40 px-1">
 				{ fmt.Sprintf("%d top-level categories", len(p.Categories)) }

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -816,3 +816,23 @@ templ designSwatch(name, classes string) {
 		<code class="text-[0.65rem] text-base-content/50 font-mono px-1">.{ classes }</code>
 	</div>
 }
+
+templ SectionFilterSearchInput() {
+	<div x-data="{ filter: '' }" class="space-y-6">
+		@designExample("Default", "components.FilterSearchInput — default search icon + Filter placeholder.") {
+			@components.FilterSearchInput(components.FilterSearchInputProps{
+				Placeholder: "Filter categories...",
+				XModel:      "filter",
+			})
+			<p class="text-xs text-base-content/40 mt-2">Bound to <code>filter</code> on the sandbox x-data — type above and the value below updates live.</p>
+			<p class="text-sm mt-1">filter = <code x-text="JSON.stringify(filter)"></code></p>
+		}
+		@designExample("Custom icon", "Pass Icon to override the default search glyph.") {
+			@components.FilterSearchInput(components.FilterSearchInputProps{
+				Placeholder: "Filter by hashtag...",
+				XModel:      "filter",
+				Icon:        "hash",
+			})
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -152,6 +152,12 @@ func DesignSections() []DesignSection {
 			Description: "Icon + h2 + count + optional action — for section headings INSIDE pages. Use components.SectionHeader (PageHeader is for top-of-page titles).",
 			Render:      func() templ.Component { return SectionSectionHeader() },
 		},
+		{
+			Slug:        "filter-search-input",
+			Title:       "Filter search input",
+			Description: "Client-side filter input — daisy input + leading search icon + x-model binding for Alpine-driven row filtering. Use components.FilterSearchInput on /categories, /tags, and future inline-filter list pages.",
+			Render:      func() templ.Component { return SectionFilterSearchInput() },
+		},
 	}
 }
 

--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -23,15 +23,10 @@ templ Tags(p TagsProps) {
 		Action:               components.PageHeaderAction("/tags/new", "plus", "Add Tag"),
 	})
 	<div x-data="tags" class="space-y-4">
-		<div class="relative">
-			<i data-lucide="search" class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/30 pointer-events-none"></i>
-			<input
-				type="text"
-				placeholder="Filter tags..."
-				x-model="filter"
-				class="input input-bordered w-full pl-9 rounded-xl h-10 text-sm"
-			/>
-		</div>
+		@components.FilterSearchInput(components.FilterSearchInputProps{
+			Placeholder: "Filter tags...",
+			XModel:      "filter",
+		})
 		if len(p.Tags) > 0 {
 			<div class="text-xs text-base-content/40 px-1">
 				{ fmt.Sprintf("%d tags", len(p.Tags)) }


### PR DESCRIPTION
Wave-2 follow-up #15 from the design-system audit. The "leading search icon + daisy input + `x-model` filter binding" markup appeared **verbatim** on `/categories` and `/tags` — two sites with byte-identical templ blocks (only the placeholder differed). Extracted as a small templ component and migrated both callers.

## API

```go
type FilterSearchInputProps struct {
    Placeholder string // required, e.g. "Filter tags..."
    XModel      string // Alpine state binding, e.g. "filter"
    Icon        string // optional, defaults to "search"
}
```

The component is markup-only — the caller still owns the Alpine factory whose state the `XModel` binds to.

## Sandbox

Lands at `/design/c/filter-search-input` with a live-bound default example (sandbox `x-data` filter state echoed below the input) and a Custom-icon variant.

<img src="https://i.img402.dev/0k4s3dat9h.jpg" width="800" alt="/design/c/filter-search-input — default + custom icon">

## What

- New component: `internal/templates/components/filter_search_input.templ`
- Sandbox section + slug `filter-search-input` in `design_types.go` / `design_sections.templ`
- Migrated callers: `pages/categories.templ` + `pages/tags.templ`

**Net**: +78 LOC, -18 LOC (component scaffolding + sandbox example dominate; every additional adopter is a pure deletion).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `templ generate` regenerates 4 files cleanly
- [x] `/design/c/filter-search-input` renders both variants with live `filter` echo
- [x] `/tags` still renders the filter input + filters rows on input
