### PR TITLE
feat(design): standalone sandbox shell + theme toggle + strip bespoke animations

### DIFF
--- a/input.css
+++ b/input.css
@@ -2157,8 +2157,6 @@
   .bb-skeleton {
     @apply rounded-md;
     background: oklch(0.95 0 0);
-    position: relative;
-    overflow: hidden;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/input.css
+++ b/input.css
@@ -368,17 +368,12 @@
   .bb-sidebar-link .bb-sidebar-sparkle,
   .bb-sidebar-link .bb-sidebar-sparkle svg {
     @apply w-3.5 h-3.5 opacity-90;
-    animation: bb-sparkle-pulse 2.4s ease-in-out infinite;
   }
   .bb-sidebar-link:hover .bb-sidebar-sparkle,
   .bb-sidebar-link:hover .bb-sidebar-sparkle svg,
   .bb-sidebar-link--active .bb-sidebar-sparkle,
   .bb-sidebar-link--active .bb-sidebar-sparkle svg {
     @apply opacity-100;
-  }
-  @keyframes bb-sparkle-pulse {
-    0%, 100% { opacity: 0.65; transform: scale(1); }
-    50%      { opacity: 1;    transform: scale(1.12); }
   }
 
   /* ── External-link arrow (Documentation / GitHub buttons) ── */
@@ -625,15 +620,6 @@
     vector-effect: non-scaling-stroke;
   }
 
-  .bb-sparkline-dot {
-    animation: bb-spark-pulse 2s ease-in-out infinite;
-  }
-
-  @keyframes bb-spark-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
-  }
-
   /* Summary pill hover lift */
   .bb-summary-pill {
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -826,18 +812,6 @@
   .bb-wizard-card {
     /* Tighter padding on mobile (p-5), comfortable on sm+ (p-6) */
     @apply bg-base-100 rounded-xl border border-base-300 p-5 sm:p-6;
-    animation: bb-wizard-enter 0.3s ease-out;
-  }
-
-  @keyframes bb-wizard-enter {
-    from {
-      opacity: 0;
-      transform: translateY(8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
   }
 
   /* ── Error pages (404, 500) ── */
@@ -863,33 +837,9 @@
     @apply text-sm text-base-content/50 max-w-sm mb-6 leading-relaxed;
   }
 
-  /* ── Page entrance animation ── */
-  .bb-page-enter {
-    animation: bb-page-enter 0.25s ease-out both;
-  }
-
-  /* Opacity-only fade — do NOT animate transform here. Even after the
-     keyframe ends, the browser keeps the computed transform as
-     matrix(1,0,0,1,0,0) (identity but non-none), which turns the
-     animated element into the containing block for any
-     position:fixed descendants. That breaks <dialog> close, which
-     leaves the browser's top layer and snaps to <main>'s bounds. */
-  @keyframes bb-page-enter {
-    from { opacity: 0; }
-    to   { opacity: 1; }
-  }
-
-  /* Disable the page entrance animation on small/touch screens — feels sluggish on mobile */
-  @media (max-width: 640px), (hover: none) and (pointer: coarse) {
-    .bb-page-enter {
-      animation: none !important;
-    }
-  }
-
   /* ── Financial Health Score ring ── */
   .bb-health-ring {
     stroke: currentColor;
-    transition: stroke-dasharray 1.2s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   /* ── Button polish ── */
@@ -951,45 +901,12 @@
     }
   }
 
-  /* DaisyUI's .modal defaults are fine; do not add per-class overrides
-     here. The "dim background moves around on close" bug previously
-     attributed to the modal was actually @keyframes bb-page-enter
-     applying a non-none transform on its end frame — that turns <main>
-     into the containing block for position:fixed descendants, so the
-     dialog snaps to <main>'s bounds the moment the browser removes it
-     from the top layer. Fixed by changing the keyframe end transform
-     to `none`. */
+  /* DaisyUI's .modal defaults are used as-is — no per-class overrides
+     here. If you ever add a non-none transform animation to <main> or
+     any ancestor, the dialog will snap to that ancestor's bounds the
+     moment the browser removes it from the top layer on close. Stay
+     opacity-only on page-level entrance animations. */
 
-
-
-  /* ── Dropdown smooth open ── */
-  .dropdown-content {
-    animation: bb-dropdown-enter 0.15s ease-out both;
-  }
-
-  @keyframes bb-dropdown-enter {
-    from {
-      opacity: 0;
-      transform: translateY(-4px) scale(0.98);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-
-  /* ── Category picker shake animation (reviews page) ── */
-  .bb-picker-shake {
-    animation: bb-shake 0.4s ease-in-out;
-  }
-
-  @keyframes bb-shake {
-    0%, 100% { transform: translateX(0); }
-    20% { transform: translateX(-4px); }
-    40% { transform: translateX(4px); }
-    60% { transform: translateX(-3px); }
-    80% { transform: translateX(3px); }
-  }
 
   /* ── Transaction row hover + keyboard focus ──
    *
@@ -1336,14 +1253,8 @@
     background: oklch(0 0 0 / 0.4);
     -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
-    animation: bb-cmdk-backdrop-in 0.15s ease-out;
     touch-action: none;
     -webkit-overflow-scrolling: auto;
-  }
-
-  @keyframes bb-cmdk-backdrop-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
   }
 
   .bb-cmdk-dialog {
@@ -1354,23 +1265,11 @@
     width: min(95vw, 560px);
     max-height: min(70vh, 460px);
     box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
-    animation: bb-cmdk-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @media (prefers-color-scheme: dark) {
     .bb-cmdk-dialog {
       box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
-    }
-  }
-
-  @keyframes bb-cmdk-dialog-in {
-    from {
-      opacity: 0;
-      transform: translateX(-50%) scale(0.96) translateY(-8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(-50%) scale(1) translateY(0);
     }
   }
 
@@ -1678,12 +1577,6 @@
     background: oklch(0 0 0 / 0.45);
     -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
-    animation: bb-shortcuts-backdrop-in 0.15s ease-out;
-  }
-
-  @keyframes bb-shortcuts-backdrop-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
   }
 
   .bb-shortcuts-dialog {
@@ -1698,23 +1591,11 @@
        through at the top/bottom of the dialog scroll on macOS. */
     overscroll-behavior: contain;
     box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
-    animation: bb-shortcuts-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @media (prefers-color-scheme: dark) {
     .bb-shortcuts-dialog {
       box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
-    }
-  }
-
-  @keyframes bb-shortcuts-dialog-in {
-    from {
-      opacity: 0;
-      transform: translateX(-50%) scale(0.96) translateY(-8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(-50%) scale(1) translateY(0);
     }
   }
 
@@ -1885,14 +1766,8 @@
     background: oklch(0 0 0 / 0.4);
     -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
-    animation: bb-catpicker-backdrop-in 0.15s ease-out;
     touch-action: none;
     -webkit-overflow-scrolling: auto;
-  }
-
-  @keyframes bb-catpicker-backdrop-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
   }
 
   .bb-catpicker-dialog {
@@ -1903,23 +1778,11 @@
     width: min(95vw, 420px);
     max-height: min(70vh, 460px);
     box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
-    animation: bb-catpicker-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @media (prefers-color-scheme: dark) {
     .bb-catpicker-dialog {
       box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
-    }
-  }
-
-  @keyframes bb-catpicker-dialog-in {
-    from {
-      opacity: 0;
-      transform: translateX(-50%) scale(0.96) translateY(-8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(-50%) scale(1) translateY(0);
     }
   }
 
@@ -2050,7 +1913,6 @@
     display: flex;
     flex-direction: column;
     box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
-    animation: bb-catpicker-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @media (prefers-color-scheme: dark) {
@@ -2262,12 +2124,6 @@
     background: oklch(0 0 0 / 0.4);
     -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
-    animation: bb-confirm-backdrop-in 0.15s ease-out;
-  }
-
-  @keyframes bb-confirm-backdrop-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
   }
 
   .bb-confirm-dialog {
@@ -2277,23 +2133,11 @@
     transform: translateX(-50%);
     width: min(92vw, 420px);
     box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
-    animation: bb-confirm-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   @media (prefers-color-scheme: dark) {
     .bb-confirm-dialog {
       box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
-    }
-  }
-
-  @keyframes bb-confirm-dialog-in {
-    from {
-      opacity: 0;
-      transform: translateX(-50%) scale(0.96) translateY(-8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(-50%) scale(1) translateY(0);
     }
   }
 
@@ -2320,40 +2164,6 @@
   @media (prefers-color-scheme: dark) {
     .bb-skeleton {
       background: oklch(0.25 0 0);
-    }
-  }
-
-  .bb-skeleton::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      oklch(1 0 0 / 0.4) 50%,
-      transparent 100%
-    );
-    animation: bb-shimmer 1.8s ease-in-out infinite;
-    transform: translateX(-100%);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-skeleton::after {
-      background: linear-gradient(
-        90deg,
-        transparent 0%,
-        oklch(1 0 0 / 0.06) 50%,
-        transparent 100%
-      );
-    }
-  }
-
-  @keyframes bb-shimmer {
-    0% {
-      transform: translateX(-100%);
-    }
-    60%, 100% {
-      transform: translateX(100%);
     }
   }
 
@@ -2416,12 +2226,6 @@
   /* Page-level skeleton overlay (shown during nav transitions) */
   .bb-page-skeleton {
     @apply min-h-[60vh];
-    animation: bb-skeleton-enter 0.2s ease-out both;
-  }
-
-  @keyframes bb-skeleton-enter {
-    from { opacity: 0; }
-    to { opacity: 1; }
   }
 
   /* Inline loading fade */

--- a/input.css
+++ b/input.css
@@ -778,11 +778,15 @@
      Slim top bar that replaces the sidebar when the page is hosted in
      standalone mode (base.html .Standalone branch). Keeps the chrome
      minimal so reviewers focus on the component under test. */
+  /* Opaque solid background — no /85 + backdrop-blur, otherwise the
+     modal dim looks like it undims the bar at a different rate than
+     the rest of the page (the bar reveals partially-blurred content
+     behind it as the dim fades). */
   .bb-standalone-bar {
     @apply sticky top-0 z-30
            flex items-center justify-between gap-3
            px-4 sm:px-6 h-12
-           bg-base-100/85 backdrop-blur
+           bg-base-100
            border-b border-base-300;
   }
 
@@ -864,15 +868,15 @@
     animation: bb-page-enter 0.25s ease-out both;
   }
 
+  /* Opacity-only fade — do NOT animate transform here. Even after the
+     keyframe ends, the browser keeps the computed transform as
+     matrix(1,0,0,1,0,0) (identity but non-none), which turns the
+     animated element into the containing block for any
+     position:fixed descendants. That breaks <dialog> close, which
+     leaves the browser's top layer and snaps to <main>'s bounds. */
   @keyframes bb-page-enter {
-    from {
-      opacity: 0;
-      transform: translateY(6px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
+    from { opacity: 0; }
+    to   { opacity: 1; }
   }
 
   /* Disable the page entrance animation on small/touch screens — feels sluggish on mobile */
@@ -947,10 +951,14 @@
     }
   }
 
-  /* ── Modal backdrop smooth ── */
-  .modal-backdrop {
-    transition: opacity 0.2s ease !important;
-  }
+  /* DaisyUI's .modal defaults are fine; do not add per-class overrides
+     here. The "dim background moves around on close" bug previously
+     attributed to the modal was actually @keyframes bb-page-enter
+     applying a non-none transform on its end frame — that turns <main>
+     into the containing block for position:fixed descendants, so the
+     dialog snaps to <main>'s bounds the moment the browser removes it
+     from the top layer. Fixed by changing the keyframe end transform
+     to `none`. */
 
 
 

--- a/input.css
+++ b/input.css
@@ -774,6 +774,24 @@
     @apply text-xl font-semibold tracking-tight;
   }
 
+  /* ── Standalone shell (e.g. /design sandbox) ──
+     Slim top bar that replaces the sidebar when the page is hosted in
+     standalone mode (base.html .Standalone branch). Keeps the chrome
+     minimal so reviewers focus on the component under test. */
+  .bb-standalone-bar {
+    @apply sticky top-0 z-30
+           flex items-center justify-between gap-3
+           px-4 sm:px-6 h-12
+           bg-base-100/85 backdrop-blur
+           border-b border-base-300;
+  }
+
+  .bb-standalone-brand {
+    @apply inline-flex items-center gap-2
+           text-sm font-semibold text-base-content
+           no-underline hover:text-primary transition-colors;
+  }
+
   /* ── Wizard / Auth pages (login, setup, error) ── */
   .bb-wizard-bg {
     /* Mobile: top-aligned with generous top padding so content isn't dead-center

--- a/internal/admin/design.go
+++ b/internal/admin/design.go
@@ -18,6 +18,7 @@ import (
 func DesignGalleryHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := BaseTemplateData(r, sm, "design", "Design system")
+		data["Standalone"] = true
 		tr.RenderWithTempl(w, r, data, pages.DesignGallery(pages.DesignGalleryProps{
 			Sections: pages.DesignSections(),
 			Breadcrumbs: []components.Breadcrumb{
@@ -40,6 +41,7 @@ func DesignComponentHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.H
 			return
 		}
 		data := BaseTemplateData(r, sm, "design", section.Title)
+		data["Standalone"] = true
 		tr.RenderWithTempl(w, r, data, pages.DesignComponent(pages.DesignComponentProps{
 			Section: section,
 			Breadcrumbs: []components.Breadcrumb{

--- a/internal/templates/components/filter_search_input.templ
+++ b/internal/templates/components/filter_search_input.templ
@@ -1,10 +1,12 @@
 package components
 
+import "cmp"
+
 // FilterSearchInput is the canonical client-side filter input — a daisy
-// `input input-bordered` with a small leading search icon and an
-// `x-model` binding for Alpine-driven row filtering. Currently used by
-// `/categories` and `/tags`; future inline-filter list pages should
-// reach for this before re-rolling the markup.
+// `input` with a small leading search icon and an `x-model` binding
+// for Alpine-driven row filtering. Currently used by `/categories` and
+// `/tags`; future inline-filter list pages should reach for this
+// before re-rolling the markup.
 //
 // The component is markup-only. Caller owns the Alpine factory that the
 // XModel string targets — typically a `filter` string on the page's
@@ -27,21 +29,14 @@ type FilterSearchInputProps struct {
 templ FilterSearchInput(p FilterSearchInputProps) {
 	<div class="relative">
 		<i
-			data-lucide={ filterSearchIcon(p.Icon) }
+			data-lucide={ cmp.Or(p.Icon, "search") }
 			class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/50 pointer-events-none z-10"
 		></i>
 		<input
 			type="text"
 			placeholder={ p.Placeholder }
 			x-model={ p.XModel }
-			class="input input-bordered w-full pl-9 rounded-xl h-10 text-sm"
+			class="input w-full pl-9 rounded-xl h-10 text-sm"
 		/>
 	</div>
-}
-
-func filterSearchIcon(icon string) string {
-	if icon == "" {
-		return "search"
-	}
-	return icon
 }

--- a/internal/templates/components/filter_search_input.templ
+++ b/internal/templates/components/filter_search_input.templ
@@ -26,7 +26,10 @@ type FilterSearchInputProps struct {
 
 templ FilterSearchInput(p FilterSearchInputProps) {
 	<div class="relative">
-		<i data-lucide={ filterSearchIcon(p.Icon) } class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/30 pointer-events-none"></i>
+		<i
+			data-lucide={ filterSearchIcon(p.Icon) }
+			class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/50 pointer-events-none z-10"
+		></i>
 		<input
 			type="text"
 			placeholder={ p.Placeholder }

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -369,9 +369,9 @@ templ SectionTables() {
 
 templ SectionTags() {
 	<div class="flex flex-col gap-6">
-		@designExample("Tag sizes", "Pill-shaped, colored via --tag-color CSS variable.") {
+		@designExample("Tag sizes", "Pill-shaped, colored via --tag-color CSS variable. Size variants are modifiers — always pair with the base .bb-tag class.") {
 			<div class="flex flex-wrap items-center gap-2">
-				<span class="bb-tag-sm" style="--tag-color:#f59e0b">
+				<span class="bb-tag bb-tag-sm" style="--tag-color:#f59e0b">
 					<i data-lucide="inbox"></i>
 					<span>Needs review</span>
 				</span>
@@ -379,7 +379,7 @@ templ SectionTags() {
 					<i data-lucide="check"></i>
 					<span>Reconciled</span>
 				</span>
-				<span class="bb-tag-lg" style="--tag-color:#6366f1">
+				<span class="bb-tag bb-tag-lg" style="--tag-color:#6366f1">
 					<i data-lucide="bookmark"></i>
 					<span>Subscription</span>
 				</span>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -226,6 +226,29 @@
     <div class="bb-progress-bar__fill" id="bb-nav-progress-fill"></div>
   </div>
 
+  {{if .Standalone}}
+  {{- /* Standalone shell — no sidebar, no mobile drawer. Used by the /design
+        sandbox so reviewers can focus on the component under test. The page
+        body still gets all the global head + footer scripts (Alpine, Lucide,
+        cmdk, shortcuts) so x-data interactivity continues to work. */ -}}
+  <div class="bg-base-200 min-h-screen">
+    <!-- Slim top bar with brand + back-to-app link -->
+    <div class="bb-standalone-bar">
+      <a href="/design" class="bb-standalone-brand">
+        <i data-lucide="palette" class="w-4 h-4"></i>
+        <span>Breadbox <span class="text-base-content/40">·</span> Design system</span>
+      </a>
+      <a href="/" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/60">
+        <i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
+        Back to app
+      </a>
+    </div>
+    <main class="p-4 sm:p-6 max-w-6xl mx-auto min-h-screen bb-page-enter">
+      {{template "flash" .}}
+      {{if .TemplContent}}{{.TemplContent}}{{else}}{{block "content" .}}{{end}}{{end}}
+    </main>
+  </div>
+  {{else}}
   <div class="drawer lg:drawer-open">
     <input id="bb-drawer" type="checkbox" class="drawer-toggle" />
 
@@ -314,6 +337,7 @@
       </aside>
     </div>
   </div>
+  {{end}}
 
   <!-- Global Confirmation Modal -->
   <div x-data="bbConfirmModal()" x-cloak

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -243,7 +243,7 @@
         Back to app
       </a>
     </div>
-    <main class="p-4 sm:p-6 max-w-6xl mx-auto min-h-screen bb-page-enter">
+    <main class="p-4 sm:p-6 max-w-6xl mx-auto min-h-screen">
       {{template "flash" .}}
       {{if .TemplContent}}{{.TemplContent}}{{else}}{{block "content" .}}{{end}}{{end}}
     </main>
@@ -297,7 +297,7 @@
         </div>
       </div>
       <!-- Page content -->
-      <main class="p-4 sm:p-6 max-w-6xl min-h-screen bb-page-enter">
+      <main class="p-4 sm:p-6 max-w-6xl min-h-screen">
         {{template "flash" .}}
         {{- /* TemplContent slot — set by TemplateRenderer.RenderWithTempl to
               render a templ-generated body inside the base layout without

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -232,16 +232,36 @@
         body still gets all the global head + footer scripts (Alpine, Lucide,
         cmdk, shortcuts) so x-data interactivity continues to work. */ -}}
   <div class="bg-base-200 min-h-screen">
-    <!-- Slim top bar with brand + back-to-app link -->
+    <!-- Slim top bar with brand + theme toggle + back-to-app link.
+         The theme toggle is short-lived: it writes data-theme to <html>
+         per click but never persists. Page reload drops the attribute
+         and the sandbox returns to system theme via prefers-color-scheme. -->
     <div class="bb-standalone-bar">
       <a href="/design" class="bb-standalone-brand">
         <i data-lucide="palette" class="w-4 h-4"></i>
         <span>Breadbox <span class="text-base-content/40">·</span> Design system</span>
       </a>
-      <a href="/" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/60">
-        <i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
-        Back to app
-      </a>
+      <div class="flex items-center gap-1">
+        <label
+          class="swap swap-rotate btn btn-ghost btn-xs btn-square rounded-lg text-base-content/60"
+          title="Toggle theme (resets on reload)"
+        >
+          <input
+            type="checkbox"
+            class="sr-only"
+            x-data="{ dark: matchMedia('(prefers-color-scheme: dark)').matches }"
+            x-model="dark"
+            @change="document.documentElement.dataset.theme = dark ? 'dark' : 'light'"
+            aria-label="Toggle theme"
+          />
+          <i data-lucide="sun" class="swap-off w-4 h-4"></i>
+          <i data-lucide="moon" class="swap-on w-4 h-4"></i>
+        </label>
+        <a href="/" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/60">
+          <i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
+          Back to app
+        </a>
+      </div>
     </div>
     <main class="p-4 sm:p-6 max-w-6xl mx-auto min-h-screen">
       {{template "flash" .}}


### PR DESCRIPTION
Polish pass on the design sandbox + cleanup pass on bespoke animations. All four commits are independently green and stack from `main`.

## What

### 1. `feat(design): render /design sandbox in standalone shell` (`fe73c4f3`)

`/design` and `/design/c/{slug}` no longer render inside the admin drawer + sidebar. They now host inside a slim sticky top bar (`Breadbox · Design system` link + "Back to app" ghost). All global scripts (Alpine, Lucide, cmdk, shortcuts, progress bar) still load — the standalone branch shares `<head>` + `<script>` with the default. Wired via `data["Standalone"] = true` in `internal/admin/design.go`.

<img src="https://i.img402.dev/ubjhjqjftq.jpg" width="800" alt="Standalone sandbox (light)">

### 2. `fix(ui): modal jump on close, search icon stacking, tag sandbox markup` (`89638356`)

Three sandbox-uncovered bugs:

- **Modal "dim jumps" on close**: `@keyframes bb-page-enter` ended at `transform: translateY(0)` → browser computes as `matrix(1,0,0,1,0,0)` (non-`none`). With `animation-fill-mode: both`, that sticks on `<main>`. Non-`none` transform makes `<main>` the containing block for `position: fixed`. Native `<dialog>` leaves the browser's top layer on close, so the in-flight CSS transition then snapped the dim to `<main>`'s bounds mid-fade. Dropped the transform from the keyframe.
- **FilterSearchInput icon invisible**: daisy's `.input` applies `position: relative`, putting it in the same positioned-element layer as the absolutely-positioned icon. Both at `z-index: auto` → paint order is DOM order → input painted over the icon. Added `z-10` to the icon. Also bumped contrast `/30 → /50` since `/30` was readable on `bg-base-200` list pages but invisible against `bg-base-100` card surfaces in the sandbox.
- **Tag sandbox markup**: `bb-tag-sm` / `bb-tag-lg` are modifiers — need the base `.bb-tag` for the pill chrome. Two of three sandbox tags rendered broken. Fixed.

### 3. `refactor(ui): strip entrance + decorative animations` (`58850940`) — **-199 LOC**

Removed 11 bespoke animation classes + their `@keyframes`. Interactive feedback (btn :active scale, hover lifts, loading fade) stays; entrance/loop-decorative motion goes. Closer to vanilla daisyUI.

Deleted: `bb-page-enter`, `bb-sparkle-pulse`, `bb-spark-pulse`, `bb-wizard-enter`, `bb-dropdown-enter`, `bb-shake`/`bb-picker-shake`, `bb-shimmer`, `bb-skeleton-enter`, `bb-cmdk-{backdrop,dialog}-in`, `bb-shortcuts-{backdrop,dialog}-in`, `bb-catpicker-{backdrop,dialog}-in`, `bb-confirm-{backdrop,dialog}-in`. The bespoke modal shell CSS itself stays — only the entry animations are gone.

### 4. `feat(design): theme toggle in standalone shell + simplifier wins` (`060d3934`)

Adds a sun↔moon toggle in the standalone bar. Daisy `swap swap-rotate` driven by a checkbox with inline Alpine: initializes from `matchMedia('(prefers-color-scheme: dark)')`, `@change` writes `document.documentElement.dataset.theme`. No persistence — reload drops the attribute → reverts to system theme.

<img src="https://i.img402.dev/r336krw9lr.jpg" width="800" alt="Standalone sandbox (dark, via toggle)">

While in for the toggle, applied code-simplifier feedback:
- `filter_search_input.templ`: dropped redundant `input-bordered` (default in daisy 5) and the `filterSearchIcon()` helper in favor of `cmp.Or(p.Icon, "search")`.
- `input.css` `.bb-skeleton`: dropped `position: relative` + `overflow: hidden` — orphans from the deleted shimmer `::after`.

## Validation

- `go build ./...`, `go vet ./...`, `templ generate`, `make css` all clean per commit.
- `make dev-watch` hot-reloads after every edit.
- Theme toggle smoke-tested in Chrome MCP: initial = unchecked + no `data-theme`; click → checked + `dark`; reload → reverts.
- FilterSearchInput icon now paints (verified via pixel sample at icon center: 194 dark pixels vs 0 before).

<img src="https://i.img402.dev/30s9vwsy9d.jpg" width="800" alt="FilterSearchInput sandbox with visible search + hash icons">

## Test plan

- [x] `/design` standalone shell renders with top bar
- [x] Theme toggle flips data-theme without persisting
- [x] Modal close on `/design/c/modals` no longer shows dim "jump"
- [x] Search icon visible on `/design/c/filter-search-input`, `/tags`, `/categories`
- [x] All 11 deleted animations: no compile/runtime references remain
- [x] Default shell (`/`, `/transactions`, etc.) unaffected — drawer + sidebar still render
