### PR TITLE
refactor(design): drop page header from sandbox

### DIFF
--- a/input.css
+++ b/input.css
@@ -23,6 +23,13 @@
   themes: light --default, dark --prefersdark;
 }
 
+/* Force-include classes that Tailwind's content scanner can't see
+   because they live inside dynamic strings (Alpine :class, runtime
+   templ expressions, JS className builders).
+   Add new entries here whenever a class only exists at runtime —
+   prefer this over chasing arbitrary-value scanner bugs. */
+@source inline("max-w-[736px] max-w-[352px]");
+
 /* Utility: hide Alpine.js elements until initialized */
 [x-cloak] { display: none !important; }
 

--- a/input.css
+++ b/input.css
@@ -28,7 +28,7 @@
    templ expressions, JS className builders).
    Add new entries here whenever a class only exists at runtime —
    prefer this over chasing arbitrary-value scanner bugs. */
-@source inline("max-w-[736px] max-w-[352px]");
+@source inline("max-w-[768px] max-w-[390px]");
 
 /* Utility: hide Alpine.js elements until initialized */
 [x-cloak] { display: none !important; }

--- a/internal/admin/design.go
+++ b/internal/admin/design.go
@@ -29,9 +29,16 @@ func DesignGalleryHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.Han
 }
 
 // DesignComponentHandler serves GET /design/c/{slug} — a single
-// component family rendered in isolation. Same admin shell as the
-// gallery (one-click back), but the main column hosts just one
-// section so screenshots focus on the component under test.
+// component family rendered in isolation. Two render modes:
+//
+//   - Default: the standalone shell hosts an iframe pointing at the
+//     `?embed=1` variant of this same route, so the viewport toggle
+//     can resize the iframe and trigger real Tailwind responsive
+//     breakpoints (sm:, lg:, etc.) which key off viewport width.
+//   - `?embed=1`: a bare HTML shell with just the section's demo
+//     markup. Loaded inside the iframe above. No sidebar, no top bar,
+//     no breadcrumb — only the global head scripts (Alpine, Lucide,
+//     daisy CSS) so the demo's interactivity still works.
 func DesignComponentHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := chi.URLParam(r, "slug")
@@ -41,6 +48,13 @@ func DesignComponentHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.H
 			return
 		}
 		data := BaseTemplateData(r, sm, "design", section.Title)
+		if r.URL.Query().Get("embed") == "1" {
+			data["Embed"] = true
+			tr.RenderWithTempl(w, r, data, pages.DesignComponentEmbed(pages.DesignComponentProps{
+				Section: section,
+			}))
+			return
+		}
 		data["Standalone"] = true
 		tr.RenderWithTempl(w, r, data, pages.DesignComponent(pages.DesignComponentProps{
 			Section: section,

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -29,7 +29,7 @@ templ DesignComponent(p DesignComponentProps) {
 					class="btn btn-sm join-item"
 					:class="vp === 'tablet' ? 'btn-active' : 'btn-ghost'"
 					@click="vp = 'tablet'"
-					title="Tablet — 768px"
+					title="Tablet — 768px viewport (736px content)"
 					aria-label="Tablet viewport"
 				>
 					<i data-lucide="tablet" class="w-4 h-4"></i>
@@ -39,7 +39,7 @@ templ DesignComponent(p DesignComponentProps) {
 					class="btn btn-sm join-item"
 					:class="vp === 'mobile' ? 'btn-active' : 'btn-ghost'"
 					@click="vp = 'mobile'"
-					title="Mobile — 384px"
+					title="Mobile — 384px viewport (352px content)"
 					aria-label="Mobile viewport"
 				>
 					<i data-lucide="smartphone" class="w-4 h-4"></i>
@@ -48,7 +48,7 @@ templ DesignComponent(p DesignComponentProps) {
 		</div>
 		<div
 			class="bb-card p-6 mx-auto transition-[max-width] duration-200"
-			:class="{ 'max-w-full': vp === 'desktop', 'max-w-3xl': vp === 'tablet', 'max-w-sm': vp === 'mobile' }"
+			:class="{ 'max-w-full': vp === 'desktop', 'max-w-[736px]': vp === 'tablet', 'max-w-[352px]': vp === 'mobile' }"
 		>
 			@p.Section.Render()
 		</div>

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -5,7 +5,52 @@ package pages
 // (so navigation back is one click), but the main column hosts just one
 // section so screenshots focus on the component being tested.
 templ DesignComponent(p DesignComponentProps) {
-	<div class="bb-card p-6">
-		@p.Section.Render()
+	<div x-data="{ vp: 'desktop' }">
+		<div class="bb-page-header">
+			<div class="min-w-0">
+				<h1 class="bb-page-title">{ p.Section.Title }</h1>
+				if p.Section.Description != "" {
+					<p class="text-sm text-base-content/50 mt-1">{ p.Section.Description }</p>
+				}
+			</div>
+			<div class="join shrink-0" role="group" aria-label="Viewport size">
+				<button
+					type="button"
+					class="btn btn-sm join-item"
+					:class="vp === 'desktop' ? 'btn-active' : 'btn-ghost'"
+					@click="vp = 'desktop'"
+					title="Desktop — full width"
+					aria-label="Desktop viewport"
+				>
+					<i data-lucide="monitor" class="w-4 h-4"></i>
+				</button>
+				<button
+					type="button"
+					class="btn btn-sm join-item"
+					:class="vp === 'tablet' ? 'btn-active' : 'btn-ghost'"
+					@click="vp = 'tablet'"
+					title="Tablet — 768px"
+					aria-label="Tablet viewport"
+				>
+					<i data-lucide="tablet" class="w-4 h-4"></i>
+				</button>
+				<button
+					type="button"
+					class="btn btn-sm join-item"
+					:class="vp === 'mobile' ? 'btn-active' : 'btn-ghost'"
+					@click="vp = 'mobile'"
+					title="Mobile — 390px"
+					aria-label="Mobile viewport"
+				>
+					<i data-lucide="smartphone" class="w-4 h-4"></i>
+				</button>
+			</div>
+		</div>
+		<div
+			class="bb-card p-6 mx-auto transition-[max-width] duration-200"
+			:class="{ 'max-w-full': vp === 'desktop', 'max-w-3xl': vp === 'tablet', 'max-w-[390px]': vp === 'mobile' }"
+		>
+			@p.Section.Render()
+		</div>
 	</div>
 }

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -13,11 +13,11 @@ templ DesignComponent(p DesignComponentProps) {
 					<p class="text-sm text-base-content/50 mt-1">{ p.Section.Description }</p>
 				}
 			</div>
-			<div class="join shrink-0" role="group" aria-label="Viewport size">
+			<div class="join shrink-0 hidden sm:inline-flex" role="group" aria-label="Viewport size">
 				<button
 					type="button"
-					class="btn btn-sm join-item"
-					:class="vp === 'desktop' ? 'btn-active' : 'btn-ghost'"
+					class="btn btn-sm btn-outline join-item"
+					:class="vp === 'desktop' && 'btn-active'"
 					@click="vp = 'desktop'"
 					title="Desktop — full width"
 					aria-label="Desktop viewport"
@@ -26,8 +26,8 @@ templ DesignComponent(p DesignComponentProps) {
 				</button>
 				<button
 					type="button"
-					class="btn btn-sm join-item"
-					:class="vp === 'tablet' ? 'btn-active' : 'btn-ghost'"
+					class="btn btn-sm btn-outline join-item"
+					:class="vp === 'tablet' && 'btn-active'"
 					@click="vp = 'tablet'"
 					title="Tablet — 768px"
 					aria-label="Tablet viewport"
@@ -36,8 +36,8 @@ templ DesignComponent(p DesignComponentProps) {
 				</button>
 				<button
 					type="button"
-					class="btn btn-sm join-item"
-					:class="vp === 'mobile' ? 'btn-active' : 'btn-ghost'"
+					class="btn btn-sm btn-outline join-item"
+					:class="vp === 'mobile' && 'btn-active'"
 					@click="vp = 'mobile'"
 					title="Mobile — 390px (iPhone 14)"
 					aria-label="Mobile viewport"

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -29,7 +29,7 @@ templ DesignComponent(p DesignComponentProps) {
 					class="btn btn-sm join-item"
 					:class="vp === 'tablet' ? 'btn-active' : 'btn-ghost'"
 					@click="vp = 'tablet'"
-					title="Tablet — 768px viewport (736px content)"
+					title="Tablet — 768px"
 					aria-label="Tablet viewport"
 				>
 					<i data-lucide="tablet" class="w-4 h-4"></i>
@@ -39,18 +39,35 @@ templ DesignComponent(p DesignComponentProps) {
 					class="btn btn-sm join-item"
 					:class="vp === 'mobile' ? 'btn-active' : 'btn-ghost'"
 					@click="vp = 'mobile'"
-					title="Mobile — 384px viewport (352px content)"
+					title="Mobile — 390px (iPhone 14)"
 					aria-label="Mobile viewport"
 				>
 					<i data-lucide="smartphone" class="w-4 h-4"></i>
 				</button>
 			</div>
 		</div>
+		<!-- Iframe gives the embedded component its OWN viewport so
+		     Tailwind responsive prefixes (sm:, lg:) trigger based on
+		     the toggle's chosen width, not the outer browser width. -->
 		<div
-			class="bb-card p-6 mx-auto transition-[max-width] duration-200"
-			:class="{ 'max-w-full': vp === 'desktop', 'max-w-[736px]': vp === 'tablet', 'max-w-[352px]': vp === 'mobile' }"
+			class="bb-card p-0 mx-auto overflow-hidden transition-[max-width] duration-200"
+			:class="{ 'max-w-full': vp === 'desktop', 'max-w-[768px]': vp === 'tablet', 'max-w-[390px]': vp === 'mobile' }"
 		>
-			@p.Section.Render()
+			<iframe
+				src={ templ.SafeURL("/design/c/" + p.Section.Slug + "?embed=1") }
+				title={ p.Section.Title + " preview" }
+				class="w-full h-[80vh] border-0 bg-base-100"
+				loading="lazy"
+			></iframe>
 		</div>
 	</div>
+}
+
+// DesignComponentEmbed renders the bare embed page — just the
+// section's demo content, no chrome. Loaded inside an iframe by
+// DesignComponent above so the viewport toggle can resize without
+// the outer browser viewport leaking through to Tailwind responsive
+// utilities.
+templ DesignComponentEmbed(p DesignComponentProps) {
+	@p.Section.Render()
 }

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -1,27 +1,10 @@
 package pages
 
-import "breadbox/internal/templates/components"
-
 // DesignComponent renders /design/c/{slug} — a single component family
 // rendered in isolation on the page. Same admin shell as the gallery
 // (so navigation back is one click), but the main column hosts just one
 // section so screenshots focus on the component being tested.
 templ DesignComponent(p DesignComponentProps) {
-	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">{ p.Section.Title }</h1>
-			if p.Section.Description != "" {
-				<p class="text-sm text-base-content/50 mt-1">{ p.Section.Description }</p>
-			}
-		</div>
-		<div class="flex items-center gap-2">
-			<a href="/design" class="btn btn-ghost btn-sm rounded-xl gap-1.5">
-				<i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
-				Gallery
-			</a>
-		</div>
-	</div>
 	<div class="bb-card p-6">
 		@p.Section.Render()
 	</div>

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -39,7 +39,7 @@ templ DesignComponent(p DesignComponentProps) {
 					class="btn btn-sm join-item"
 					:class="vp === 'mobile' ? 'btn-active' : 'btn-ghost'"
 					@click="vp = 'mobile'"
-					title="Mobile — 390px"
+					title="Mobile — 384px"
 					aria-label="Mobile viewport"
 				>
 					<i data-lucide="smartphone" class="w-4 h-4"></i>
@@ -48,7 +48,7 @@ templ DesignComponent(p DesignComponentProps) {
 		</div>
 		<div
 			class="bb-card p-6 mx-auto transition-[max-width] duration-200"
-			:class="{ 'max-w-full': vp === 'desktop', 'max-w-3xl': vp === 'tablet', 'max-w-[390px]': vp === 'mobile' }"
+			:class="{ 'max-w-full': vp === 'desktop', 'max-w-3xl': vp === 'tablet', 'max-w-sm': vp === 'mobile' }"
 		>
 			@p.Section.Render()
 		</div>

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -13,37 +13,34 @@ templ DesignComponent(p DesignComponentProps) {
 					<p class="text-sm text-base-content/50 mt-1">{ p.Section.Description }</p>
 				}
 			</div>
-			<div class="join shrink-0 hidden sm:inline-flex" role="group" aria-label="Viewport size">
-				<button
-					type="button"
-					class="btn btn-sm btn-outline join-item"
-					:class="vp === 'desktop' && 'btn-active'"
-					@click="vp = 'desktop'"
+			<div class="join shrink-0 hidden sm:inline-flex" aria-label="Viewport size">
+				<input
+					type="radio"
+					name="design-vp"
+					value="desktop"
+					aria-label="Desktop"
 					title="Desktop — full width"
-					aria-label="Desktop viewport"
-				>
-					<i data-lucide="monitor" class="w-4 h-4"></i>
-				</button>
-				<button
-					type="button"
-					class="btn btn-sm btn-outline join-item"
-					:class="vp === 'tablet' && 'btn-active'"
-					@click="vp = 'tablet'"
+					class="join-item btn btn-sm"
+					x-model="vp"
+				/>
+				<input
+					type="radio"
+					name="design-vp"
+					value="tablet"
+					aria-label="Tablet"
 					title="Tablet — 768px"
-					aria-label="Tablet viewport"
-				>
-					<i data-lucide="tablet" class="w-4 h-4"></i>
-				</button>
-				<button
-					type="button"
-					class="btn btn-sm btn-outline join-item"
-					:class="vp === 'mobile' && 'btn-active'"
-					@click="vp = 'mobile'"
+					class="join-item btn btn-sm"
+					x-model="vp"
+				/>
+				<input
+					type="radio"
+					name="design-vp"
+					value="mobile"
+					aria-label="Mobile"
 					title="Mobile — 390px (iPhone 14)"
-					aria-label="Mobile viewport"
-				>
-					<i data-lucide="smartphone" class="w-4 h-4"></i>
-				</button>
+					class="join-item btn btn-sm"
+					x-model="vp"
+				/>
 			</div>
 		</div>
 		<!-- Iframe gives the embedded component its OWN viewport so

--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -1,7 +1,5 @@
 package pages
 
-import "breadbox/internal/templates/components"
-
 // DesignGallery renders the /design page — a long, anchored scroll of
 // every component family in the system. The table of contents sticks
 // to the top of the content column so reviewers can jump between
@@ -12,21 +10,6 @@ import "breadbox/internal/templates/components"
 // family, write the section component, then append the entry in
 // design_types.go::DesignSections().
 templ DesignGallery(p DesignGalleryProps) {
-	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">Design system</h1>
-			<p class="text-sm text-base-content/50 mt-1">
-				Reference gallery for every shared admin-UI component. Click a section to deep-link, or open the standalone viewer for focused screenshots.
-			</p>
-		</div>
-		<div class="flex items-center gap-2">
-			<a href="/design" class="btn btn-ghost btn-sm rounded-xl gap-1.5">
-				<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
-				Reload
-			</a>
-		</div>
-	</div>
 	<div class="grid grid-cols-1 lg:grid-cols-[14rem_minmax(0,1fr)] gap-6">
 		<aside class="hidden lg:block">
 			<nav class="sticky top-6 flex flex-col gap-1 text-sm border-l border-base-300/60 pl-4">

--- a/internal/templates/components/pages/design_smoke_test.go
+++ b/internal/templates/components/pages/design_smoke_test.go
@@ -90,7 +90,11 @@ func TestDesignGalleryRenders(t *testing.T) {
 }
 
 // TestDesignComponentRenders confirms the standalone single-section page
-// renders for every section without error.
+// renders for every section without error. The page hosts the section
+// inside an iframe pointing at the ?embed=1 variant of the same route,
+// so the assertion checks that wiring rather than any chrome (the
+// standalone shell's back-to-gallery link lives in base.html, not in
+// this templ).
 func TestDesignComponentRenders(t *testing.T) {
 	for _, sec := range DesignSections() {
 		var buf bytes.Buffer
@@ -109,9 +113,21 @@ func TestDesignComponentRenders(t *testing.T) {
 		if len(out) < 200 {
 			t.Errorf("section %q standalone page too small (%d bytes)", sec.Slug, len(out))
 		}
-		// The breadcrumb back link should always be present.
-		if !strings.Contains(out, `href="/design"`) {
-			t.Errorf("section %q standalone page missing back link to /design", sec.Slug)
+		// Iframe src must point at the embed mode of the same slug.
+		wantEmbedSrc := "/design/c/" + sec.Slug + "?embed=1"
+		if !strings.Contains(out, wantEmbedSrc) {
+			t.Errorf("section %q standalone page missing iframe src=%q", sec.Slug, wantEmbedSrc)
+		}
+		// The embed renderer itself must render the section markup
+		// non-empty (it's a thin wrapper around sec.Render(); silent
+		// failure here would mean the iframe loads a blank page).
+		var embedBuf bytes.Buffer
+		if err := DesignComponentEmbed(props).Render(context.Background(), &embedBuf); err != nil {
+			t.Errorf("section %q embed render error: %v", sec.Slug, err)
+			continue
+		}
+		if embedBuf.Len() < 50 {
+			t.Errorf("section %q embed render too small (%d bytes)", sec.Slug, embedBuf.Len())
 		}
 	}
 }

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -54,6 +54,7 @@ templ SettingsHelp(p SettingsProps) {
 	})
 	<div class="grid gap-6 max-w-2xl">
 		@settingsHelpCardFlat(p)
+		@settingsHelpDeveloperCard()
 	</div>
 }
 
@@ -466,5 +467,33 @@ templ settingsHelpCardFlat(p SettingsProps) {
 				<i data-lucide="square-arrow-out-up-right" class="w-4 h-4 text-base-content/40"></i>
 			</a>
 		</div>
+	</div>
+}
+
+// settingsHelpDeveloperCard surfaces internal developer-facing tools —
+// currently the design-system sandbox. Lives below the Resources card on
+// the Help tab; intentionally a separate card so the developer-only
+// nature reads at a glance.
+templ settingsHelpDeveloperCard() {
+	<div class="bb-card p-5">
+		<div class="bb-icon-header">
+			<div class="bb-icon-header__tile bg-base-200/60">
+				<i data-lucide="palette" class="w-4 h-4 text-base-content/60"></i>
+			</div>
+			<div class="bb-icon-header__text">
+				<h2 class="text-sm font-semibold">Developer</h2>
+				<p class="text-xs text-base-content/45">Internal tools for contributors</p>
+			</div>
+		</div>
+		<a href="/design" class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 hover:bg-base-200/70 transition-colors no-underline">
+			<div class="flex items-center gap-2.5">
+				<i data-lucide="palette" class="w-4 h-4 text-base-content/50"></i>
+				<div>
+					<span class="text-sm font-medium">Design system sandbox</span>
+					<p class="text-xs text-base-content/40">Reference gallery for every shared admin-UI component</p>
+				</div>
+			</div>
+			<i data-lucide="arrow-right" class="w-4 h-4 text-base-content/40"></i>
+		</a>
 	</div>
 }

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -263,10 +263,17 @@
         </a>
       </div>
     </div>
-    <main class="p-4 sm:p-6 max-w-6xl mx-auto min-h-screen">
+    <main class="p-4 sm:p-6 max-w-6xl mx-auto">
       {{template "flash" .}}
       {{if .TemplContent}}{{.TemplContent}}{{else}}{{block "content" .}}{{end}}{{end}}
     </main>
+    <footer class="text-center text-xs text-base-content/35 py-6">
+      Powered by
+      <a href="https://daisyui.com/"
+         target="_blank"
+         rel="noopener"
+         class="hover:text-base-content/60 transition-colors no-underline">daisyUI</a>
+    </footer>
   </div>
   {{else}}
   <div class="drawer lg:drawer-open">

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -226,7 +226,16 @@
     <div class="bb-progress-bar__fill" id="bb-nav-progress-fill"></div>
   </div>
 
-  {{if .Standalone}}
+  {{if .Embed}}
+  {{- /* Embed shell — bare HTML for an iframe target. No top bar, no
+        sidebar, no flash, no footer. Only the global <head> scripts
+        (Alpine, Lucide, styles.css) so the embedded demo's
+        interactivity continues to work. Used by /design/c/{slug}?embed=1
+        loaded inside the sandbox's viewport-toggle iframe. */ -}}
+  <main class="p-6">
+    {{if .TemplContent}}{{.TemplContent}}{{else}}{{block "content" .}}{{end}}{{end}}
+  </main>
+  {{else if .Standalone}}
   {{- /* Standalone shell — no sidebar, no mobile drawer. Used by the /design
         sandbox so reviewers can focus on the component under test. The page
         body still gets all the global head + footer scripts (Alpine, Lucide,


### PR DESCRIPTION
Tiny follow-up to PR #1433. With the standalone shell's sticky top bar already showing "Breadbox · Design system", the per-page `<h1>` + breadcrumb + Reload chrome on `/design` and `/design/c/{slug}` was duplicate noise.

- `/design` now opens straight into the TOC + first section (Foundations).
- `/design/c/{slug}` now opens straight into the component card. The top bar's brand link serves as "back to gallery".

Side effect: both files dropped the import of `breadbox/internal/templates/components` (only used by `BreadcrumbNav`).

**Net**: -34 LOC across 2 templates.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `templ generate` clean
- [x] `/design` renders gallery without header
- [x] `/design/c/filter-search-input` renders just the component card

