### PR TITLE
feat(design): consolidate Toast + MultiSelectToolbar, group sandbox

### DIFF
--- a/internal/templates/components/kbd.templ
+++ b/internal/templates/components/kbd.templ
@@ -23,7 +23,13 @@ templ Kbd(key string) {
 // `Kbd`. Calling with 0 or 1 keys degrades gracefully.
 templ KbdChord(keys ...string) {
 	if len(keys) > 0 {
-		<span class="inline-flex items-center gap-1 hidden sm:inline-flex" x-show="!$store.device.isTouch">
+		// Order matters: `hidden` must come AFTER the layout class, and the
+		// base layout class must NOT be `inline-flex` — Tailwind emits the
+		// `inline-flex` utility after `hidden` in the generated CSS, so an
+		// `inline-flex hidden` combo silently shows the element on mobile.
+		// `sm:inline-flex` handles the desktop layout; nothing competes with
+		// `hidden` at the base breakpoint.
+		<span class="hidden sm:inline-flex items-center gap-1" x-show="!$store.device.isTouch">
 			for i, k := range keys {
 				if i > 0 {
 					<span class="bb-shortcuts-then">then</span>

--- a/internal/templates/components/multi_select_toolbar.templ
+++ b/internal/templates/components/multi_select_toolbar.templ
@@ -1,0 +1,185 @@
+package components
+
+// MultiSelectToolbar is the floating bottom toolbar that surfaces bulk
+// actions on a multi-selection. Pattern reference: the transactions
+// list's bulk-action bar (`#bb-bulk-bar` in
+// `static/js/admin/components/transactions.js`).
+//
+// Geometry — pinned 1.5rem from the viewport bottom, horizontally
+// centered, with `pointer-events-none` when hidden so it doesn't
+// intercept clicks before it's shown. Children render inside a
+// `bg-base-100 border rounded-2xl shadow-lg` pill matching the bulk-bar
+// shape from the transactions page.
+//
+// Visibility is Alpine-driven: pass `XShow` (an Alpine boolean
+// expression — typically `selecting && count > 0` or
+// `$store.bulk.sel.length > 0`) and the toolbar fades + slides up. Pass
+// an empty `XShow` to always render (useful for the sandbox).
+//
+// Slots:
+//   - the `Count` button reads `CountExpr` (e.g. `$store.bulk.sel.length`)
+//     and dispatches `CountToggleEvent` on click — a "select all / clear"
+//     toggle. Set `CountLabel` to override the default "selected".
+//   - children render between the count chip's divider and the close
+//     button — caller's `<button>` actions (Comment / Tag / Categorize /
+//     etc.) go here.
+//   - the trailing × button dispatches `CloseEvent` (default
+//     `multi-select-close`) so callers can wire it to whatever clears
+//     selection state.
+
+type MultiSelectToolbarProps struct {
+	// XShow is an Alpine boolean expression. Empty = always visible
+	// (sandbox / static demos). When provided, the toolbar uses
+	// `x-show` plus transitions instead of being unconditionally
+	// rendered.
+	XShow string
+
+	// CountExpr is an Alpine expression that resolves to the
+	// currently-selected count. Rendered with tabular-nums so digits
+	// don't jitter as the user adds/removes selections. REQUIRED.
+	CountExpr string
+
+	// CountLabel is the trailing word after the number. Default
+	// "selected". The label hides under sm breakpoints so the bar
+	// stays compact on phones.
+	CountLabel string
+
+	// CountToggleEvent is the custom event dispatched when the user
+	// clicks the count chip — Gmail-style "select all / clear" toggle.
+	// Default `multi-select-toggle-all`. Set to empty string to make
+	// the count chip non-interactive (renders as a static badge).
+	CountToggleEvent string
+
+	// CloseEvent is the custom event dispatched when the user clicks
+	// the trailing × button. Default `multi-select-close`. Callers
+	// listen with `@multi-select-close.window` and clear their state.
+	CloseEvent string
+
+	// AriaLabel labels the toolbar landmark for screen readers.
+	// Default "Selection actions".
+	AriaLabel string
+}
+
+templ MultiSelectToolbar(p MultiSelectToolbarProps) {
+	<div
+		role="toolbar"
+		aria-label={ orDefault(p.AriaLabel, "Selection actions") }
+		class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2"
+		if p.XShow != "" {
+			x-show={ p.XShow }
+			x-cloak
+			x-transition:enter="transition ease-out duration-200"
+			x-transition:enter-start="opacity-0 translate-y-2"
+			x-transition:enter-end="opacity-100 translate-y-0"
+			x-transition:leave="transition ease-in duration-150"
+			x-transition:leave-start="opacity-100 translate-y-0"
+			x-transition:leave-end="opacity-0 translate-y-2"
+		}
+	>
+		<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5 max-w-[calc(100vw-2rem)]">
+			if p.CountToggleEvent != "" || p.CountExpr != "" {
+				@multiSelectCount(p)
+			}
+			<div class="w-px h-6 bg-base-300"></div>
+			{ children... }
+			if p.CloseEvent != "" || p.XShow != "" {
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm btn-square rounded-xl"
+					title="Clear selection"
+					aria-label="Clear selection"
+					@click={ dispatchEventJS(orDefault(p.CloseEvent, "multi-select-close")) }
+				>
+					<i data-lucide="x" class="w-4 h-4"></i>
+				</button>
+			}
+		</div>
+	</div>
+}
+
+// MultiSelectToolbarAction renders one action button inside the
+// toolbar. Use it for the common case (icon + label + optional
+// hotkey-hint kbd). For richer slots (split-button, dropdown, modal
+// trigger) just render a raw `<button>` instead.
+//
+// Variant ""/"ghost" → btn-ghost; "primary" → btn-primary. Always
+// btn-sm rounded-xl to match the bulk-bar shape.
+//
+// OnClick is an Alpine handler expression (rendered as `@click`); use
+// it to dispatch a CustomEvent so callers wire to a single listener.
+
+type MultiSelectToolbarActionProps struct {
+	Icon      string // Lucide name, REQUIRED
+	Label     string // visible on sm+, hidden under sm to keep the bar narrow
+	OnClick   string // Alpine handler, e.g. `dispatchOpenComment()`
+	Variant   string // "" / "ghost" / "primary"
+	Hotkey    string // optional uppercase hint shown as a kbd-like badge ("T", "C")
+	Title     string // tooltip / aria-label; defaults to Label
+	AriaLabel string // overrides Title for the aria-label only
+}
+
+templ MultiSelectToolbarAction(p MultiSelectToolbarActionProps) {
+	<button
+		type="button"
+		class={ multiSelectActionClass(p.Variant) }
+		title={ orDefault(p.Title, p.Label) }
+		aria-label={ orDefault(p.AriaLabel, orDefault(p.Title, p.Label)) }
+		@click={ p.OnClick }
+	>
+		if p.Icon != "" {
+			<i data-lucide={ p.Icon } class="w-3.5 h-3.5"></i>
+		}
+		if p.Label != "" {
+			<span class="hidden sm:inline">{ p.Label }</span>
+		}
+		if p.Hotkey != "" {
+			<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">{ p.Hotkey }</span>
+		}
+	</button>
+}
+
+templ multiSelectCount(p MultiSelectToolbarProps) {
+	if p.CountToggleEvent != "" {
+		<button
+			type="button"
+			class="btn btn-ghost btn-sm rounded-xl gap-1.5"
+			title="Select all / clear"
+			@click={ dispatchEventJS(p.CountToggleEvent) }
+		>
+			@multiSelectCountInner(p)
+		</button>
+	} else {
+		<div class="px-2 inline-flex items-center gap-1.5 text-sm">
+			@multiSelectCountInner(p)
+		</div>
+	}
+}
+
+templ multiSelectCountInner(p MultiSelectToolbarProps) {
+	<span class="font-bold tabular-nums" x-text={ p.CountExpr }>0</span>
+	<span class="hidden sm:inline text-base-content/60 font-normal">{ orDefault(p.CountLabel, "selected") }</span>
+}
+
+// orDefault returns s when non-empty, otherwise fallback. Used to keep
+// optional prop defaults inline at the call site instead of one
+// per-prop helper.
+func orDefault(s, fallback string) string {
+	if s != "" {
+		return s
+	}
+	return fallback
+}
+
+// dispatchEventJS renders the Alpine `@click` handler that fires a
+// window-scoped CustomEvent. The component's caller listens with
+// `@<event>.window` on a sibling node.
+func dispatchEventJS(event string) string {
+	return "window.dispatchEvent(new CustomEvent('" + event + "'))"
+}
+
+func multiSelectActionClass(variant string) string {
+	if variant == "primary" {
+		return "btn btn-primary btn-sm rounded-xl gap-2"
+	}
+	return "btn btn-ghost btn-sm rounded-xl gap-2"
+}

--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -3,14 +3,15 @@ package pages
 import "breadbox/internal/templates/components"
 
 // DesignGallery renders the /design page — a long, anchored scroll of
-// every component family in the system. The table of contents sticks
-// to the top of the content column so reviewers can jump between
-// sections without losing place.
+// every component family in the system. The sidebar groups sections
+// under collapsible top-level buckets so the navigation stays scannable
+// as the catalog grows.
 //
 // Per-section markup lives in design_sections.templ (one
 // `templ SectionX()` per entry in DesignSections). When you add a new
 // family, write the section component, then append the entry in
-// design_types.go::DesignSections().
+// design_types.go::DesignSections() and tag it with a Group slug from
+// design_types.go::DesignSectionGroups().
 templ DesignGallery(p DesignGalleryProps) {
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
@@ -27,36 +28,110 @@ templ DesignGallery(p DesignGalleryProps) {
 			</a>
 		</div>
 	</div>
-	<div class="grid grid-cols-1 lg:grid-cols-[14rem_minmax(0,1fr)] gap-6">
+	<div class="grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-6">
 		<aside class="hidden lg:block">
-			<nav class="sticky top-6 flex flex-col gap-1 text-sm border-l border-base-300/60 pl-4">
-				for _, sec := range p.Sections {
-					<a href={ templ.SafeURL("#" + sec.Slug) } class="text-base-content/60 hover:text-base-content transition-colors">
-						{ sec.Title }
-					</a>
+			// `h-[calc(100vh-3rem)]` (not max-h) pins the nav to viewport
+			// height so it always has a defined scroll context. `top-6`
+			// matches the 3rem offset so the nav sits exactly between the
+			// top of the visible viewport and the bottom edge.
+			<nav
+				x-data="{
+				  allOpen: true,
+				  inputs() { return Array.from(this.$root.querySelectorAll('input[type=checkbox][name^=design-nav-]')); },
+				  toggleAll() { this.allOpen = !this.allOpen; this.inputs().forEach(i => { i.checked = this.allOpen; }); },
+				}"
+				class="sticky top-6 flex flex-col gap-1 h-[calc(100vh-3rem)] overflow-y-auto pr-1 -mr-1"
+			>
+				<div class="flex items-center justify-between px-2 pb-1 -mb-1">
+					<span class="text-[0.65rem] font-semibold uppercase tracking-wider text-base-content/30">Catalog</span>
+					<button
+						type="button"
+						class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md hover:bg-base-200/40 transition-colors"
+						@click="toggleAll()"
+						x-text="allOpen ? 'Collapse all' : 'Expand all'"
+					>Collapse all</button>
+				</div>
+				for _, group := range DesignSectionGroups() {
+					@designSidebarGroup(group, SectionsByGroup(p.Sections, group.Slug))
 				}
 			</nav>
 		</aside>
 		<div class="flex flex-col gap-12 min-w-0">
-			for _, sec := range p.Sections {
-				@designSectionBlock(sec)
+			for _, group := range DesignSectionGroups() {
+				@designSectionGroupBlock(group, SectionsByGroup(p.Sections, group.Slug))
 			}
 		</div>
 	</div>
+}
+
+// designSidebarGroup renders one collapsible group in the sidebar.
+// Uses DaisyUI's `collapse collapse-arrow` with a hidden checkbox so
+// the open/closed state survives without JS. Every group renders
+// pre-opened (`checked`) so the full catalog is visible on first
+// load; users can collapse individual groups to focus.
+//
+// Items inside the group are flat anchor links — they jump to the
+// section's id in the main column.
+templ designSidebarGroup(group DesignSectionGroup, sections []DesignSection) {
+	if len(sections) > 0 {
+		// `overflow-visible` is critical: daisy's .collapse defaults to
+		// overflow:hidden, which prevents the parent <nav> from measuring
+		// the content rows for scroll. Letting the content overflow the
+		// grid box restores normal flow inside the scrollable <nav>.
+		<div class="collapse collapse-arrow bg-transparent rounded-none overflow-visible">
+			<input type="checkbox" name={ "design-nav-" + group.Slug } checked/>
+			<div class="collapse-title px-2 py-1.5 min-h-0 text-xs font-semibold uppercase tracking-wider text-base-content/50">
+				{ group.Label }
+			</div>
+			<div class="collapse-content px-0">
+				<ul class="flex flex-col gap-0.5 pl-3 border-l border-base-300/60 ml-2">
+					for _, sec := range sections {
+						<li>
+							<a
+								href={ templ.SafeURL("#" + sec.Slug) }
+								class="block text-sm text-base-content/60 hover:text-base-content transition-colors py-1 px-2 rounded-md hover:bg-base-200/40"
+							>
+								{ sec.Title }
+							</a>
+						</li>
+					}
+				</ul>
+			</div>
+		</div>
+	}
+}
+
+// designSectionGroupBlock renders one whole top-level group: a sticky
+// group header followed by each section's block. The group header acts
+// as the deep-link target for navigating to a group from elsewhere
+// (e.g. /design#group-feedback).
+templ designSectionGroupBlock(group DesignSectionGroup, sections []DesignSection) {
+	if len(sections) > 0 {
+		<section id={ "group-" + group.Slug } class="scroll-mt-6">
+			<header class="mb-6 pb-2 border-b border-base-300/60">
+				<h2 class="text-xs font-semibold uppercase tracking-wider text-base-content/50">{ group.Label }</h2>
+			</header>
+			<div class="flex flex-col gap-12">
+				for _, sec := range sections {
+					@designSectionBlock(sec)
+				}
+			</div>
+		</section>
+	}
 }
 
 // designSectionBlock wraps one DesignSection in the standard gallery
 // frame: anchor, title row with "Open standalone" link, description, then
 // the rendered demo inside a bordered card surface.
 //
-// Spacing intent — the H2 sits inside roughly equal whitespace above
+// Spacing intent — the H3 sits inside roughly equal whitespace above
 // (parent gap-12 = 48px from prev card) and below (heading-group bottom
 // of mb-6 = 24px + card padding-top of 24px = 48px to first inner
-// content). H2 → description is mb-1 so they read as a tight pair.
+// content). H3 → description is mb-1 so they read as a tight pair.
 templ designSectionBlock(sec DesignSection) {
 	<section id={ sec.Slug } class="scroll-mt-6">
 		<div class="flex items-baseline justify-between gap-3 mb-1">
-			<h2 class="text-lg font-semibold tracking-tight">{ sec.Title }</h2>
+			<h3 class="text-lg font-semibold tracking-tight">{ sec.Title }</h3>
 			<a href={ templ.SafeURL("/design/c/" + sec.Slug) } class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1">
 				<i data-lucide="external-link" class="w-3 h-3"></i>
 				Open standalone

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -828,6 +828,263 @@ templ designSwatch(name, classes string) {
 	</div>
 }
 
+// kbdGlyphRefRow renders one row in the SectionKbd glyph mapping
+// reference: a label code-chip on the left, the rendered Kbd on the
+// right. `key` is the token passed through kbdGlyph; `label` is what
+// the reader sees (often equal to key, but "alt / opt" and
+// "F2 (passthrough)" diverge).
+templ kbdGlyphRefRow(label, key string) {
+	<div class="flex items-center justify-between gap-2 py-1.5 px-2 rounded-lg bg-base-200/40">
+		<code class="text-xs text-base-content/60">{ label }</code>
+		@components.Kbd(key)
+	</div>
+}
+
+type kbdGlyphRef struct{ label, key string }
+
+func kbdGlyphRefs() []kbdGlyphRef {
+	return []kbdGlyphRef{
+		{"cmd / meta", "cmd"},
+		{"shift", "shift"},
+		{"ctrl", "ctrl"},
+		{"alt / opt", "alt"},
+		{"enter", "enter"},
+		{"esc", "esc"},
+		{"tab", "tab"},
+		{"space", "space"},
+		{"up", "up"},
+		{"down", "down"},
+		{"left", "left"},
+		{"right", "right"},
+		{"k (letter)", "k"},
+		{"?", "?"},
+		{"/", "/"},
+		{"F2 (passthrough)", "F2"},
+	}
+}
+
+// ─── Keyboard shortcut badges ──────────────────────────────────────────
+
+templ SectionKbd() {
+	<div class="flex flex-col gap-6">
+		@designExample("Single key (Kbd)", "Use for one-key shortcuts. Hides on touch devices via $store.device.isTouch + sm: breakpoint.") {
+			<div class="flex flex-col gap-3 text-sm max-w-sm">
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Focus search</span>
+					@components.Kbd("k")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Open keyboard shortcuts</span>
+					@components.Kbd("?")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Close any overlay</span>
+					@components.Kbd("esc")
+				</div>
+			</div>
+		}
+		@designExample("Modifier combo (KbdCombo)", "One blended pill — modifier + letter fused with a hairline divider. ⌘ / ⇧ / ⌃ / ⌥ glyphs auto-render.") {
+			<div class="flex flex-col gap-3 text-sm max-w-sm">
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Open command palette</span>
+					@components.KbdCombo("cmd", "k")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Submit form</span>
+					@components.KbdCombo("cmd", "enter")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Force quit</span>
+					@components.KbdCombo("cmd", "shift", "q")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Toggle theme</span>
+					@components.KbdCombo("ctrl", "alt", "t")
+				</div>
+			</div>
+		}
+		@designExample("Chord (KbdChord)", "Sequential keys separated by a faint \"then\" label — for vim-style g-prefixed navigation.") {
+			<div class="flex flex-col gap-3 text-sm max-w-sm">
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Go to dashboard</span>
+					@components.KbdChord("g", "d")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Go to transactions</span>
+					@components.KbdChord("g", "t")
+				</div>
+				<div class="flex items-center justify-between gap-3 py-1">
+					<span class="text-base-content/70">Go to rules</span>
+					@components.KbdChord("g", "r")
+				</div>
+			</div>
+		}
+		@designExample("Glyph mapping reference", "Tokens auto-translate to symbols via kbdGlyph (Go) / bbKbdGlyph (JS). Keep the two in sync when adding new glyphs.") {
+			<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 text-sm">
+				for _, g := range kbdGlyphRefs() {
+					@kbdGlyphRefRow(g.label, g.key)
+				}
+			</div>
+		}
+		@designExample("Inline in a toolbar (live ref)", "How the bulk action bar surfaces hotkey hints — passed as Hotkey on MultiSelectToolbarAction.") {
+			<div role="toolbar" aria-label="Selection actions (preview)" class="inline-block">
+				<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5">
+					<button type="button" class="btn btn-ghost btn-sm rounded-xl gap-2">
+						<i data-lucide="tag" class="w-3.5 h-3.5"></i>
+						<span>Tag</span>
+						<span class="ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">T</span>
+					</button>
+					<button type="button" class="btn btn-primary btn-sm rounded-xl gap-2">
+						<i data-lucide="tags" class="w-3.5 h-3.5"></i>
+						<span>Categorize</span>
+						<span class="ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
+					</button>
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// ─── Toast ─────────────────────────────────────────────────────────────
+
+templ SectionToast() {
+	<div class="flex flex-col gap-6">
+		@designExample("Trigger via bb-toast event", "Every admin page mounts one global Toast container (see internal/templates/components/toast.templ — also inlined in base.html). Dispatch the event from anywhere; no per-page wiring.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button
+					type="button"
+					class="btn btn-sm rounded-xl gap-2 border border-success/30 bg-success/10 text-success hover:bg-success/15"
+					onclick="window.dispatchEvent(new CustomEvent('bb-toast', {detail: {message: 'Saved', type: 'success'}}))"
+				>
+					<i data-lucide="check" class="w-3.5 h-3.5"></i>
+					Fire success
+				</button>
+				<button
+					type="button"
+					class="btn btn-sm rounded-xl gap-2 border border-error/30 bg-error/10 text-error hover:bg-error/15"
+					onclick="window.dispatchEvent(new CustomEvent('bb-toast', {detail: {message: 'Could not save: provider rejected the request', type: 'error'}}))"
+				>
+					<i data-lucide="x-circle" class="w-3.5 h-3.5"></i>
+					Fire error
+				</button>
+				<button
+					type="button"
+					class="btn btn-sm rounded-xl gap-2 border border-warning/30 bg-warning/10 text-warning hover:bg-warning/15"
+					onclick="window.dispatchEvent(new CustomEvent('bb-toast', {detail: {message: '2 rows updated, 1 skipped', type: 'warning'}}))"
+				>
+					<i data-lucide="alert-triangle" class="w-3.5 h-3.5"></i>
+					Fire warning
+				</button>
+				<button
+					type="button"
+					class="btn btn-sm rounded-xl gap-2 border border-info/30 bg-info/10 text-info hover:bg-info/15"
+					onclick="window.dispatchEvent(new CustomEvent('bb-toast', {detail: {message: 'Sync starting in the background', type: 'info'}}))"
+				>
+					<i data-lucide="info" class="w-3.5 h-3.5"></i>
+					Fire info
+				</button>
+			</div>
+			<pre class="mt-3 text-xs bg-base-200/40 rounded-lg p-3 overflow-x-auto"><code>{ toastDispatchExample() }</code></pre>
+		}
+		@designExample("Variants (visual reference)", "All four type values rendered as static pills. Real toasts auto-dismiss after ~3 s.") {
+			<div class="flex flex-col gap-2 max-w-md">
+				<div class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2" role="status">
+					<i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i>
+					<span class="text-sm font-medium">Saved.</span>
+				</div>
+				<div class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2" role="alert">
+					<i data-lucide="x-circle" class="w-4 h-4 text-error shrink-0"></i>
+					<span class="text-sm font-medium">Could not revoke API key.</span>
+				</div>
+				<div class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2" role="status">
+					<i data-lucide="alert-triangle" class="w-4 h-4 text-warning shrink-0"></i>
+					<span class="text-sm font-medium">2 rows updated, 1 skipped.</span>
+				</div>
+				<div class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2" role="status">
+					<i data-lucide="info" class="w-4 h-4 text-info shrink-0"></i>
+					<span class="text-sm font-medium">Sync scheduled.</span>
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// ─── Multi-select toolbar ──────────────────────────────────────────────
+
+templ SectionMultiSelectToolbar() {
+	<div x-data="{ open: false, count: 3 }" class="flex flex-col gap-6">
+		@designExample("Live demo", "Toggle the floating toolbar. Real-world wiring listens for `multi-select-close` and `multi-select-toggle-all` events to clear / select-all.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button type="button" class="btn btn-primary btn-sm rounded-xl" @click="open = !open">
+					<span x-show="!open">Show toolbar</span>
+					<span x-show="open" x-cloak>Hide toolbar</span>
+				</button>
+				<button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="count++">+1 selection</button>
+				<button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="count = Math.max(0, count - 1)">−1 selection</button>
+				<span class="text-xs text-base-content/50 ml-2">count = <span x-text="count"></span></span>
+			</div>
+			@components.MultiSelectToolbar(components.MultiSelectToolbarProps{
+				XShow:            "open",
+				CountExpr:        "count",
+				CountToggleEvent: "design-bulk-toggle-all",
+				CloseEvent:       "design-bulk-close",
+			}) {
+				@components.MultiSelectToolbarAction(components.MultiSelectToolbarActionProps{
+					Icon:    "message-square",
+					Label:   "Comment",
+					OnClick: "$dispatch('bb-toast', { message: 'Comment dispatched (demo)', type: 'info' })",
+				})
+				@components.MultiSelectToolbarAction(components.MultiSelectToolbarActionProps{
+					Icon:    "tag",
+					Label:   "Tag",
+					Hotkey:  "T",
+					OnClick: "$dispatch('bb-toast', { message: 'Tag dispatched (demo)', type: 'info' })",
+				})
+				@components.MultiSelectToolbarAction(components.MultiSelectToolbarActionProps{
+					Icon:    "tags",
+					Label:   "Categorize",
+					Hotkey:  "C",
+					Variant: "primary",
+					OnClick: "$dispatch('bb-toast', { message: 'Categorize dispatched (demo)', type: 'info' })",
+				})
+			}
+			<div
+				class="hidden"
+				@design-bulk-close.window="open = false"
+				@design-bulk-toggle-all.window="count = count > 0 ? 0 : 12"
+			></div>
+		}
+		@designExample("Inline shape (static)", "The pill rendered without the fixed wrapper, for layout reference.") {
+			<div role="toolbar" aria-label="Selection actions (preview)" class="inline-block">
+				<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5">
+					<button type="button" class="btn btn-ghost btn-sm rounded-xl gap-1.5">
+						<span class="font-bold tabular-nums">3</span>
+						<span class="hidden sm:inline text-base-content/60 font-normal">selected</span>
+					</button>
+					<div class="w-px h-6 bg-base-300"></div>
+					<button type="button" class="btn btn-ghost btn-sm rounded-xl gap-2" title="Comment">
+						<i data-lucide="message-square" class="w-3.5 h-3.5"></i>
+						<span class="hidden sm:inline">Comment</span>
+					</button>
+					<button type="button" class="btn btn-ghost btn-sm rounded-xl gap-2" title="Tag">
+						<i data-lucide="tag" class="w-3.5 h-3.5"></i>
+						<span class="hidden sm:inline">Tag</span>
+						<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">T</span>
+					</button>
+					<button type="button" class="btn btn-primary btn-sm rounded-xl gap-2" title="Categorize">
+						<i data-lucide="tags" class="w-3.5 h-3.5"></i>
+						<span class="hidden sm:inline">Categorize</span>
+						<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
+					</button>
+					<button type="button" class="btn btn-ghost btn-sm btn-square rounded-xl" title="Clear selection" aria-label="Clear selection">
+						<i data-lucide="x" class="w-4 h-4"></i>
+					</button>
+				</div>
+			</div>
+		}
+	</div>
+}
+
 templ SectionFilterSearchInput() {
 	<div x-data="{ filter: '' }" class="space-y-6">
 		@designExample("Default", "components.FilterSearchInput — default search icon + Filter placeholder.") {

--- a/internal/templates/components/pages/design_smoke_test.go
+++ b/internal/templates/components/pages/design_smoke_test.go
@@ -22,11 +22,24 @@ func TestDesignGalleryRenders(t *testing.T) {
 		t.Fatal("DesignSections() returned empty slice")
 	}
 
+	// Build a set of known group slugs so we can assert every section
+	// declares a real one (a typo would silently exile the section from
+	// the sidebar).
+	groupSlugs := map[string]bool{}
+	for _, g := range DesignSectionGroups() {
+		groupSlugs[g.Slug] = true
+	}
+
 	// Per-section render: each section's Render() must produce non-empty
 	// output. Silent-empty would mean the templ function returned NopComponent.
 	for _, sec := range sections {
 		if sec.Slug == "" || sec.Title == "" {
 			t.Errorf("section %+v has empty slug or title", sec)
+		}
+		if sec.Group == "" {
+			t.Errorf("section %q has empty Group — every section must be assigned to a top-level group", sec.Slug)
+		} else if !groupSlugs[sec.Group] {
+			t.Errorf("section %q has unknown Group=%q (not in DesignSectionGroups)", sec.Slug, sec.Group)
 		}
 		if sec.Render == nil {
 			t.Errorf("section %q has nil Render", sec.Slug)

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -27,11 +27,51 @@ type DesignComponentProps struct {
 // Render must be a no-arg constructor for the section's templ component
 // (kept as a closure so the slice of sections can be built once at
 // package init without templ generics gymnastics).
+//
+// Group categorises the section into one of the top-level buckets used
+// by the sandbox sidebar (see DesignSectionGroups). Sections with the
+// same Group render under one collapsible header.
 type DesignSection struct {
 	Slug        string
 	Title       string
 	Description string
+	Group       string // one of the slugs in DesignSectionGroups
 	Render      func() templ.Component
+}
+
+// DesignSectionGroup is one collapsible top-level bucket in the
+// sandbox sidebar. Groups render in the declared order — the first
+// group is open by default.
+type DesignSectionGroup struct {
+	Slug  string // URL-safe id, used for the <input> name + anchors
+	Label string // visible header
+}
+
+// DesignSectionGroups returns the canonical ordered list of top-level
+// sandbox groups. Group slugs must match the Group field on each
+// DesignSection. Order is fixed and shapes the sidebar.
+func DesignSectionGroups() []DesignSectionGroup {
+	return []DesignSectionGroup{
+		{Slug: "foundations", Label: "Foundations"},
+		{Slug: "layout", Label: "Layout"},
+		{Slug: "navigation", Label: "Navigation"},
+		{Slug: "forms", Label: "Forms"},
+		{Slug: "data", Label: "Data display"},
+		{Slug: "feedback", Label: "Feedback"},
+		{Slug: "patterns", Label: "Patterns"},
+	}
+}
+
+// SectionsByGroup returns the subset of `sections` whose Group matches
+// `groupSlug`, preserving the input order.
+func SectionsByGroup(sections []DesignSection, groupSlug string) []DesignSection {
+	out := make([]DesignSection, 0, len(sections))
+	for _, s := range sections {
+		if s.Group == groupSlug {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // DesignSections returns the canonical, ordered list of gallery sections.
@@ -44,121 +84,184 @@ type DesignSection struct {
 // BREADBOX_DEV_RELOAD when paired with `templ generate`.
 func DesignSections() []DesignSection {
 	return []DesignSection{
+		// ── Foundations ─────────────────────────────────────────────
 		{
 			Slug:        "foundations",
 			Title:       "Foundations",
 			Description: "Color tokens, typography scale, spacing, radius — the raw material every component is built from.",
+			Group:       "foundations",
 			Render:      func() templ.Component { return SectionFoundations() },
-		},
-		{
-			Slug:        "buttons",
-			Title:       "Buttons",
-			Description: "Primary / ghost / outline / destructive / icon-only variants at sm + xs sizes.",
-			Render:      func() templ.Component { return SectionButtons() },
-		},
-		{
-			Slug:        "badges",
-			Title:       "Badges",
-			Description: "Status chips (badge-soft) and metadata chips (badge-ghost). Pairs with statusBadge() helper.",
-			Render:      func() templ.Component { return SectionBadges() },
-		},
-		{
-			Slug:        "alerts",
-			Title:       "Alerts & flash",
-			Description: "Page-level alert variants, inline bb-form-error, soft alerts.",
-			Render:      func() templ.Component { return SectionAlerts() },
-		},
-		{
-			Slug:        "cards",
-			Title:       "Cards",
-			Description: "bb-card variants — simple, sectioned, interactive, danger-zone, empty-state.",
-			Render:      func() templ.Component { return SectionCards() },
-		},
-		{
-			Slug:        "form-controls",
-			Title:       "Form controls",
-			Description: "Inputs, selects, textareas, checkboxes, toggles, file inputs.",
-			Render:      func() templ.Component { return SectionFormControls() },
-		},
-		{
-			Slug:        "tables",
-			Title:       "Tables",
-			Description: "Zebra, sm/md/xs, hover row, sticky header, amount columns.",
-			Render:      func() templ.Component { return SectionTables() },
-		},
-		{
-			Slug:        "tags",
-			Title:       "Tags",
-			Description: "Pill-shaped colored tags — bb-tag, bb-tag-sm, bb-tag-lg, bb-tag-ghost, bb-tag-add.",
-			Render:      func() templ.Component { return SectionTags() },
-		},
-		{
-			Slug:        "menus-dropdowns",
-			Title:       "Menus & dropdowns",
-			Description: "DaisyUI dropdown / menu, overflow action menu pattern.",
-			Render:      func() templ.Component { return SectionMenusDropdowns() },
-		},
-		{
-			Slug:        "modals",
-			Title:       "Modals",
-			Description: "DaisyUI modal-bottom sm:modal-middle, rounded-xl modal-box.",
-			Render:      func() templ.Component { return SectionModals() },
-		},
-		{
-			Slug:        "loading",
-			Title:       "Loading & skeletons",
-			Description: "DaisyUI loading spinners, progress bars, skeleton placeholders.",
-			Render:      func() templ.Component { return SectionLoading() },
 		},
 		{
 			Slug:        "icons",
 			Title:       "Icons & tiles",
 			Description: "Lucide sizing convention, bb-icon-tile color modifiers.",
+			Group:       "foundations",
 			Render:      func() templ.Component { return SectionIcons() },
 		},
+		{
+			Slug:        "kbd",
+			Title:       "Keyboard shortcuts",
+			Description: "Kbd, KbdChord, KbdCombo — single key, sequential \"g then d\" chord, and modifier-fused pill. Hidden on touch devices via $store.device.isTouch + sm: breakpoint.",
+			Group:       "foundations",
+			Render:      func() templ.Component { return SectionKbd() },
+		},
+
+		// ── Layout ──────────────────────────────────────────────────
 		{
 			Slug:        "page-header",
 			Title:       "Page header",
 			Description: "bb-page-header + bb-page-title + optional primary action slot.",
+			Group:       "layout",
 			Render:      func() templ.Component { return SectionPageHeader() },
+		},
+		{
+			Slug:        "section-header",
+			Title:       "Section header",
+			Description: "Icon + h2 + count + optional action — for section headings INSIDE pages. Use components.SectionHeader (PageHeader is for top-of-page titles).",
+			Group:       "layout",
+			Render:      func() templ.Component { return SectionSectionHeader() },
+		},
+		{
+			Slug:        "cards",
+			Title:       "Cards",
+			Description: "bb-card variants — simple, sectioned, interactive, danger-zone, empty-state.",
+			Group:       "layout",
+			Render:      func() templ.Component { return SectionCards() },
 		},
 		{
 			Slug:        "empty-states",
 			Title:       "Empty states",
 			Description: "Standard no-data and no-results patterns. Use components.EmptyState.",
+			Group:       "layout",
 			Render:      func() templ.Component { return SectionEmptyStates() },
 		},
 		{
 			Slug:        "stat-tiles",
 			Title:       "Stat tiles",
 			Description: "4-up dashboard metric tiles — icon-on-left, big tabular-nums value. Use components.StatTile + StatTileRow.",
+			Group:       "layout",
 			Render:      func() templ.Component { return SectionStatTiles() },
 		},
+
+		// ── Navigation ──────────────────────────────────────────────
 		{
 			Slug:        "tabs",
 			Title:       "Tabs",
 			Description: "Daisy tabs-border (navigation) and tabs-box (filter-as-tabs). Use components.TabBar. Nest a second TabBar inside an active tab's content for multi-level.",
+			Group:       "navigation",
 			Render:      func() templ.Component { return SectionTabs() },
+		},
+		{
+			Slug:        "menus-dropdowns",
+			Title:       "Menus & dropdowns",
+			Description: "DaisyUI dropdown / menu, overflow action menu pattern.",
+			Group:       "navigation",
+			Render:      func() templ.Component { return SectionMenusDropdowns() },
 		},
 		{
 			Slug:        "overflow-menu",
 			Title:       "Overflow menu",
 			Description: "Kebab dropdown for row actions. Use components.OverflowMenu.",
+			Group:       "navigation",
 			Render:      func() templ.Component { return SectionOverflowMenu() },
 		},
+
+		// ── Forms ───────────────────────────────────────────────────
 		{
-			Slug:        "section-header",
-			Title:       "Section header",
-			Description: "Icon + h2 + count + optional action — for section headings INSIDE pages. Use components.SectionHeader (PageHeader is for top-of-page titles).",
-			Render:      func() templ.Component { return SectionSectionHeader() },
+			Slug:        "buttons",
+			Title:       "Buttons",
+			Description: "Primary / ghost / outline / destructive / icon-only variants at sm + xs sizes.",
+			Group:       "forms",
+			Render:      func() templ.Component { return SectionButtons() },
+		},
+		{
+			Slug:        "form-controls",
+			Title:       "Form controls",
+			Description: "Inputs, selects, textareas, checkboxes, toggles, file inputs.",
+			Group:       "forms",
+			Render:      func() templ.Component { return SectionFormControls() },
 		},
 		{
 			Slug:        "filter-search-input",
 			Title:       "Filter search input",
 			Description: "Client-side filter input — daisy input + leading search icon + x-model binding for Alpine-driven row filtering. Use components.FilterSearchInput on /categories, /tags, and future inline-filter list pages.",
+			Group:       "forms",
 			Render:      func() templ.Component { return SectionFilterSearchInput() },
 		},
+
+		// ── Data display ────────────────────────────────────────────
+		{
+			Slug:        "tables",
+			Title:       "Tables",
+			Description: "Zebra, sm/md/xs, hover row, sticky header, amount columns.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionTables() },
+		},
+		{
+			Slug:        "badges",
+			Title:       "Badges",
+			Description: "Status chips (badge-soft) and metadata chips (badge-ghost). Pairs with statusBadge() helper.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionBadges() },
+		},
+		{
+			Slug:        "tags",
+			Title:       "Tags",
+			Description: "Pill-shaped colored tags — bb-tag, bb-tag-sm, bb-tag-lg, bb-tag-ghost, bb-tag-add.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionTags() },
+		},
+
+		// ── Feedback ────────────────────────────────────────────────
+		{
+			Slug:        "alerts",
+			Title:       "Alerts & flash",
+			Description: "Page-level alert variants, inline bb-form-error, soft alerts.",
+			Group:       "feedback",
+			Render:      func() templ.Component { return SectionAlerts() },
+		},
+		{
+			Slug:        "toast",
+			Title:       "Toast",
+			Description: "Floating notification pill. Fire from anywhere via the bb-toast custom event — every admin page mounts the global container in base.html. Use components.Toast for embedded contexts.",
+			Group:       "feedback",
+			Render:      func() templ.Component { return SectionToast() },
+		},
+		{
+			Slug:        "loading",
+			Title:       "Loading & skeletons",
+			Description: "DaisyUI loading spinners, progress bars, skeleton placeholders.",
+			Group:       "feedback",
+			Render:      func() templ.Component { return SectionLoading() },
+		},
+		{
+			Slug:        "modals",
+			Title:       "Modals",
+			Description: "DaisyUI modal-bottom sm:modal-middle, rounded-xl modal-box.",
+			Group:       "feedback",
+			Render:      func() templ.Component { return SectionModals() },
+		},
+
+		// ── Patterns ────────────────────────────────────────────────
+		{
+			Slug:        "multi-select-toolbar",
+			Title:       "Multi-select toolbar",
+			Description: "Floating bottom toolbar that surfaces bulk actions on a multi-selection. Reference: the transactions list's bulk action bar. Use components.MultiSelectToolbar.",
+			Group:       "patterns",
+			Render:      func() templ.Component { return SectionMultiSelectToolbar() },
+		},
 	}
+}
+
+// toastDispatchExample returns the canonical dispatch snippet used in
+// the Toast section of the sandbox. Lives here as a helper because
+// literal `{` / `}` characters confuse templ's lexer when embedded in
+// markup.
+func toastDispatchExample() string {
+	return "window.dispatchEvent(new CustomEvent('bb-toast', {\n" +
+		"  detail: { message: 'Saved', type: 'success' }\n" +
+		"}));"
 }
 
 // FindDesignSection looks up a section by URL slug.

--- a/internal/templates/components/toast.templ
+++ b/internal/templates/components/toast.templ
@@ -1,0 +1,76 @@
+package components
+
+// Toast is the canonical floating-notification container. One instance
+// is mounted globally from base.html (the `<div … @bb-toast.window>` at
+// the bottom of every admin page) — virtually every page just *fires*
+// toasts and the global container catches them. Use this component
+// directly only when a page needs its own scoped container (e.g. a
+// stand-alone preview or a modal that wants in-modal feedback).
+//
+// API — emit a toast from any handler with a CustomEvent:
+//
+//	window.dispatchEvent(new CustomEvent('bb-toast', {
+//	    detail: { message: 'Saved', type: 'success' },
+//	}));
+//
+// Recognised `type` values: `success` (default), `error`, `warning`,
+// `info`. Each variant ships its own icon (check / x-circle /
+// alert-triangle / info). Toasts auto-dismiss after ~3 s and can be
+// dismissed early via the × button; the underlying alpine state
+// preserves multiple stacked toasts with unique ids.
+//
+// Markup is intentionally identical to the inline copy in
+// `internal/templates/layout/base.html` so the two never drift.
+
+templ Toast() {
+	<div
+		class="fixed bottom-8 left-1/2 z-50 -translate-x-1/2 flex flex-col items-center gap-2 pointer-events-none"
+		role="region"
+		aria-live="polite"
+		aria-label="Notifications"
+		x-data="{
+		     toasts: [],
+		     nextId: 0,
+		     add(detail) {
+		       const id = (typeof crypto !== 'undefined' && crypto.randomUUID)
+		         ? crypto.randomUUID()
+		         : ('t-' + (++this.nextId) + '-' + Math.random().toString(36).slice(2));
+		       const toast = { message: detail.message, type: detail.type || 'success', id: id };
+		       this.toasts.push(toast);
+		       setTimeout(() => { this.toasts = this.toasts.filter(t2 => t2.id !== id); }, 3500);
+		     },
+		     dismiss(id) { this.toasts = this.toasts.filter(t2 => t2.id !== id); },
+		   }"
+		@bb-toast.window="add($event.detail)"
+	>
+		<template x-for="t in toasts" :key="t.id">
+			<div
+				x-data="{ show: false }"
+				x-init="$nextTick(() => { show = true; if (window.lucide) lucide.createIcons({nodes:[$el]}); setTimeout(() => show = false, 3000) })"
+				x-show="show"
+				:role="t.type === 'error' ? 'alert' : 'status'"
+				x-transition:enter="transition ease-out duration-200"
+				x-transition:enter-start="opacity-0 translate-y-2 scale-95"
+				x-transition:enter-end="opacity-100 translate-y-0 scale-100"
+				x-transition:leave="transition ease-in duration-150"
+				x-transition:leave-start="opacity-100 translate-y-0"
+				x-transition:leave-end="opacity-0 translate-y-2"
+				class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2 pointer-events-auto max-w-[calc(100vw-2rem)]"
+			>
+				<template x-if="t.type === 'success'"><i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i></template>
+				<template x-if="t.type === 'error'"><i data-lucide="x-circle" class="w-4 h-4 text-error shrink-0"></i></template>
+				<template x-if="t.type === 'warning'"><i data-lucide="alert-triangle" class="w-4 h-4 text-warning shrink-0"></i></template>
+				<template x-if="t.type === 'info'"><i data-lucide="info" class="w-4 h-4 text-info shrink-0"></i></template>
+				<span class="text-sm font-medium" x-text="t.message"></span>
+				<button
+					type="button"
+					class="ml-1 -mr-1 p-1 rounded-lg text-base-content/40 hover:text-base-content hover:bg-base-200 transition-colors shrink-0"
+					aria-label="Dismiss notification"
+					@click="dismiss(t.id)"
+				>
+					<i data-lucide="x" class="w-3.5 h-3.5"></i>
+				</button>
+			</div>
+		</template>
+	</div>
+}


### PR DESCRIPTION
## Summary

- Reorganize `/design` sandbox into 7 collapsible top-level groups (Foundations, Layout, Navigation, Forms, Data display, Feedback, Patterns) with a Collapse-all / Expand-all toggle and a viewport-pinned scrollable sidebar.
- Consolidate the global `bb-toast` container into a typed templ component and surface a Toast section in the sandbox under Feedback.
- Add a reusable `MultiSelectToolbar` + `MultiSelectToolbarAction` (the transactions bulk-action bar pattern) under Patterns.
- Add a Keyboard shortcuts section under Foundations covering `Kbd` / `KbdCombo` / `KbdChord` + glyph mapping.
- Fix `KbdChord` showing on mobile — Tailwind v4 emits `.inline-flex` after `.hidden`, so the chord's `inline-flex hidden` was silently winning the cascade and overriding the touch-hide.

## Gallery — collapsible groups + viewport-pinned scroll

<img src="https://i.img402.dev/thorpkd48e.jpg" width="800" alt="/design gallery with collapsible group sidebar">

## New Patterns: Multi-select toolbar (floating)

<img src="https://i.img402.dev/n8akxhthgf.jpg" width="800" alt="MultiSelectToolbar live demo">

## New Foundations: Keyboard shortcuts

<img src="https://i.img402.dev/gq85h9p7eu.jpg" width="800" alt="Kbd / KbdCombo / KbdChord sandbox section">

## KbdChord mobile fix

Before: the chord glyphs leaked onto mobile. After: the wrapper resolves to `display: none` at &lt;640px, only the action label renders.

<img src="https://i.img402.dev/hh1b8d2i96.jpg" width="320" alt="kbd page on mobile — all kbd glyphs hidden, only labels remain">

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/templates/components/pages/...` passes (group-coverage assertion added to the existing smoke test)
- [x] Manually walked `/design` and `/design/c/{slug}` for every group; gallery anchors + standalone viewer both work
- [x] Verified KbdChord computed `display: none` at 390px viewport for every chord wrapper
- [x] Verified sidebar overflow at 500h viewport: `scrollHeight=1030, clientHeight=452, scrollTop reaches 578`
- [x] Toast dispatch buttons fire `bb-toast` events; global container catches them
- [x] Multi-select toolbar live demo toggles + count chip + close button all wired to events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
