### PR TITLE
fix(design): hide T/C hotkey hints on mobile in kbd toolbar preview

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -932,12 +932,12 @@ templ SectionKbd() {
 					<button type="button" class="btn btn-ghost btn-sm rounded-xl gap-2">
 						<i data-lucide="tag" class="w-3.5 h-3.5"></i>
 						<span>Tag</span>
-						<span class="ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">T</span>
+						<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">T</span>
 					</button>
 					<button type="button" class="btn btn-primary btn-sm rounded-xl gap-2">
 						<i data-lucide="tags" class="w-3.5 h-3.5"></i>
 						<span>Categorize</span>
-						<span class="ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
+						<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

Follow-up to #1435. The static "Inline in a toolbar (live ref)" preview under the Keyboard shortcuts sandbox section had two hand-rolled hotkey-hint spans (the T and C badges) without the `hidden sm:inline` guard the real `MultiSelectToolbarAction` uses, so they leaked onto mobile viewports. Match the live component's behavior so the preview is consistent across breakpoints.

## After

The T/C badges on Tag/Categorize disappear at &lt;640px; live `MultiSelectToolbarAction` already behaves this way.

<img src="https://i.img402.dev/ztua7zmo9y.jpg" width="320" alt="kbd sandbox toolbar preview on mobile — no T/C hotkey badges">

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/templates/components/pages/...` passes
- [x] Verified at 390px viewport: Tag/Categorize buttons render without the T/C hotkey badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)
