### PR TITLE
fix(ui): stop Lucide stroke overlaps from stacking into darker pixels

### DIFF
--- a/input.css
+++ b/input.css
@@ -32,6 +32,23 @@
   svg.lucide, svg.lucide * { pointer-events: none; }
 
   /*
+   * Lucide icons are composed of multiple sibling <path> elements that share
+   * `stroke="currentColor"`. If the inherited color carries alpha (Tailwind
+   * v4's `text-COLOR/NN` syntax), every path strokes at that alpha
+   * independently and overlapping strokes — the curl-arrows of `repeat`, the
+   * stem of `circle-dollar-sign`, the check on `shield-check`, etc — stack
+   * into visibly darker pixels at intersections.
+   *
+   * Strip alpha at the SVG so each stroke renders fully opaque. To dim a
+   * Lucide icon, use `opacity-NN` on the <i> (Lucide preserves the class on
+   * the generated <svg>), which composites the whole icon as a single layer
+   * before applying transparency. `text-COLOR/NN` on Lucide icons is treated
+   * the same as `text-COLOR` here — call sites that wanted dimming should
+   * use `opacity-NN`.
+   */
+  svg.lucide { color: rgb(from currentColor r g b); }
+
+  /*
    * Pre-hydration size for Lucide placeholders.
    *
    * Before lucide.createIcons() swaps `<i data-lucide="x">` for `<svg>`, the

--- a/internal/templates/components/empty_state.templ
+++ b/internal/templates/components/empty_state.templ
@@ -62,7 +62,7 @@ templ EmptyState(p EmptyStateProps) {
 			<div class="flex flex-col items-center">
 				if p.Icon != "" {
 					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
-						<i data-lucide={ p.Icon } class="w-7 h-7 text-base-content/30"></i>
+						<i data-lucide={ p.Icon } class="w-7 h-7 text-base-content opacity-30"></i>
 					</div>
 				}
 				<h3 class="text-base font-semibold mb-1">{ p.Title }</h3>
@@ -87,7 +87,7 @@ templ EmptyState(p EmptyStateProps) {
 templ emptyStateCompactBody(p EmptyStateProps) {
 	<div class="flex flex-col items-center text-center py-12 px-6">
 		if p.Icon != "" {
-			<i data-lucide={ p.Icon } class="w-12 h-12 text-base-content/20 mb-2"></i>
+			<i data-lucide={ p.Icon } class="w-12 h-12 text-base-content opacity-20 mb-2"></i>
 		}
 		<p class="text-sm text-base-content/60">{ p.Title }</p>
 		if p.CustomCTA != nil {

--- a/internal/templates/components/filter_search_input.templ
+++ b/internal/templates/components/filter_search_input.templ
@@ -30,7 +30,7 @@ templ FilterSearchInput(p FilterSearchInputProps) {
 	<div class="relative">
 		<i
 			data-lucide={ cmp.Or(p.Icon, "search") }
-			class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/50 pointer-events-none z-10"
+			class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content opacity-50 pointer-events-none z-10"
 		></i>
 		<input
 			type="text"

--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -132,7 +132,7 @@ templ accessActiveClientRow(c AccessClientRow, isAdmin bool, csrfToken string) {
 templ accessRevokedClientRow(c AccessClientRow) {
 	<div class="flex items-center gap-3 px-3 sm:px-4 py-3">
 		<div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/40 shrink-0">
-			<i data-lucide="fingerprint" class="w-3.5 h-3.5 text-base-content/25"></i>
+			<i data-lucide="fingerprint" class="w-3.5 h-3.5 text-base-content opacity-25"></i>
 		</div>
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2 flex-wrap">
@@ -261,7 +261,7 @@ templ accessActiveKeyRow(k AccessKeyRow, isAdmin bool, csrfToken string) {
 templ accessRevokedKeyRow(k AccessKeyRow) {
 	<div class="flex items-center gap-3 px-3 sm:px-4 py-3">
 		<div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/40 shrink-0">
-			<i data-lucide="key" class="w-3.5 h-3.5 text-base-content/25"></i>
+			<i data-lucide="key" class="w-3.5 h-3.5 text-base-content opacity-25"></i>
 		</div>
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2 flex-wrap">

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -57,7 +57,7 @@ templ acctHeader(p AccountDetailProps) {
 	<div class="bb-page-header">
 		<div class="flex items-center gap-4">
 			<div class="w-12 h-12 rounded-xl bg-base-200 flex items-center justify-center">
-				<i data-lucide={ acctTypeIcon(p.Account.Type) } class="w-6 h-6 text-base-content/50"></i>
+				<i data-lucide={ acctTypeIcon(p.Account.Type) } class="w-6 h-6 text-base-content opacity-50"></i>
 			</div>
 			<div>
 				<h1 class="bb-page-title">{ acctDisplayLabel(p.Account) }</h1>
@@ -169,10 +169,10 @@ templ acctSettings(p AccountDetailProps) {
 	<div class="bb-card p-0 overflow-hidden mb-6" x-data="{ open: false }">
 		<button class="w-full flex items-center justify-between px-4 sm:px-5 py-3 cursor-pointer" @click="open = !open">
 			<div class="flex items-center gap-2">
-				<i data-lucide="settings" class="w-4 h-4 text-base-content/50"></i>
+				<i data-lucide="settings" class="w-4 h-4 text-base-content opacity-50"></i>
 				<span class="text-sm font-semibold text-base-content/50">Account Settings</span>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="open && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-40 transition-transform duration-200" :class="open && 'rotate-180'"></i>
 		</button>
 		<div x-show="open" x-cloak x-collapse>
 			<div class="px-4 sm:px-5 pb-4 border-t border-base-300/50">

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -365,7 +365,7 @@ templ agentRunDetailMetadata(p AgentRunDetailProps) {
 templ agentRunDetailNote(p AgentRunDetailProps) {
 	<div class="bb-card p-4 mb-4">
 		<h2 class="text-sm font-semibold mb-2 flex items-center gap-2">
-			<i data-lucide="sticky-note" class="w-4 h-4 text-base-content/60"></i>
+			<i data-lucide="sticky-note" class="w-4 h-4 text-base-content opacity-60"></i>
 			Operator note
 		</h2>
 		<form method="POST" action={ templ.SafeURL(fmt.Sprintf("/-/agents/runs/%s/note", p.Run.ShortID)) }>
@@ -388,7 +388,7 @@ templ agentRunDetailPrompt(p AgentRunDetailProps) {
 	if p.SystemPrompt != "" || p.Prompt != "" || p.PromptPrefix != "" {
 		<div class="bb-card p-4 mb-4">
 			<h2 class="text-sm font-semibold mb-2 flex items-center gap-2">
-				<i data-lucide="message-square" class="w-4 h-4 text-base-content/60"></i>
+				<i data-lucide="message-square" class="w-4 h-4 text-base-content opacity-60"></i>
 				Prompt
 			</h2>
 			if p.PromptPrefix != "" {
@@ -417,7 +417,7 @@ templ agentRunDetailTranscript(p AgentRunDetailProps) {
 	<div class="bb-card p-4">
 		<div class="flex items-center justify-between mb-3">
 			<h2 class="text-sm font-semibold flex items-center gap-2">
-				<i data-lucide="scroll-text" class="w-4 h-4 text-base-content/60"></i>
+				<i data-lucide="scroll-text" class="w-4 h-4 text-base-content opacity-60"></i>
 				Transcript
 			</h2>
 			if len(p.Transcript) > 0 {

--- a/internal/templates/components/pages/agent_wizard.templ
+++ b/internal/templates/components/pages/agent_wizard.templ
@@ -118,7 +118,7 @@ templ AgentWizard(p AgentWizardProps) {
 				<!-- Custom Agent (no card factory — direct link) -->
 				<a href="/agent-wizard/custom" class="bb-card p-0 overflow-hidden hover:shadow-md transition-all duration-200 cursor-pointer group no-underline flex items-center border-l-4 border-l-base-300 border-dashed">
 					<div class="w-12 h-12 rounded-xl bg-base-300/50 flex items-center justify-center group-hover:bg-base-300/70 transition-colors flex-shrink-0 ml-4">
-						<i data-lucide="plus" class="w-5 h-5 text-base-content/40"></i>
+						<i data-lucide="plus" class="w-5 h-5 text-base-content opacity-40"></i>
 					</div>
 					<div class="flex-1 px-4 py-3.5 min-w-0">
 						<div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
@@ -127,7 +127,7 @@ templ AgentWizard(p AgentWizardProps) {
 						<p class="text-xs text-base-content/50 leading-relaxed">Start from scratch with your own goals and instructions. Full access to all prompt blocks.</p>
 					</div>
 					<div class="flex-shrink-0 pr-4">
-						<i data-lucide="arrow-right" class="w-4 h-4 text-base-content/20 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+						<i data-lucide="arrow-right" class="w-4 h-4 text-base-content opacity-20 group-hover:text-base-content group-hover:opacity-40 group-hover:translate-x-0.5 transition-all"></i>
 					</div>
 				</a>
 			</div>

--- a/internal/templates/components/pages/agents.templ
+++ b/internal/templates/components/pages/agents.templ
@@ -102,7 +102,7 @@ templ agentsActivity(p AgentsProps) {
 	} else {
 		<div class="card bg-base-100 shadow-sm">
 			<div class="card-body items-center text-center py-12 gap-4">
-				<i data-lucide="scroll-text" class="w-12 h-12 text-base-content/20 mb-1"></i>
+				<i data-lucide="scroll-text" class="w-12 h-12 text-base-content opacity-20 mb-1"></i>
 				<div>
 					<h3 class="font-medium text-base-content/70">No agent sessions yet</h3>
 					<p class="text-sm text-base-content/50 max-w-md mt-1">Agent activity appears here once an MCP client connects to Breadbox. Start by configuring your first agent.</p>
@@ -149,7 +149,7 @@ templ agentsSessionCard(s AgentsSessionRow) {
 						<span>{ s.CreatedAtRel }</span>
 					</div>
 				</div>
-				<i data-lucide="chevron-right" class="w-4 h-4 text-base-content/30 shrink-0 mt-1"></i>
+				<i data-lucide="chevron-right" class="w-4 h-4 text-base-content opacity-30 shrink-0 mt-1"></i>
 			</div>
 		</div>
 	</a>

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -48,7 +48,7 @@ templ agentsSettingsInstructionsCard(p AgentsSettingsProps) {
 				<p class="text-xs text-base-content/40" x-show="!expanded">Custom instructions sent to agents when they connect via MCP</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Instructions sent to agents when they connect via MCP</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse>
 			<div class="px-4 sm:px-5 py-4">
@@ -89,7 +89,7 @@ templ agentsSettingsReviewGuidelinesCard(p AgentsSettingsProps) {
 				<p class="text-xs text-base-content/40" x-show="!expanded">Served as <code class="text-xs">breadbox://review-guidelines</code> to agents during reviews</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Guidelines for reviewing transactions and creating rules — agents read this resource before processing reviews</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
@@ -126,7 +126,7 @@ templ agentsSettingsReportFormatCard(p AgentsSettingsProps) {
 				<p class="text-xs text-base-content/40" x-show="!expanded">Served as <code class="text-xs">breadbox://report-format</code> to agents when submitting reports</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Report structure templates and formatting guidelines — agents read this resource before submitting reports</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
@@ -159,7 +159,7 @@ templ agentsSettingsToolsCard(p AgentsSettingsProps) {
 				<p class="text-xs text-base-content/40" x-show="!expanded">{ agentsSettingsToolsSummary(p) }</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Enable or disable individual MCP tools</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
@@ -218,7 +218,7 @@ templ agentsSettingsConnectionCard() {
 				<h2 class="font-semibold">Connection</h2>
 				<p class="text-xs text-base-content/40">Endpoints and config for connecting MCP agents</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4 space-y-5">

--- a/internal/templates/components/pages/backups.templ
+++ b/internal/templates/components/pages/backups.templ
@@ -108,7 +108,7 @@ templ backupsScheduleSection(p BackupsProps) {
 	<!-- Schedule Configuration -->
 	<div id="schedule" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#schedule' }">
 		<div class="px-4 sm:px-5 py-4 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
-			<i data-lucide="clock" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+			<i data-lucide="clock" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Schedule</h2>
 				<p class="text-xs text-base-content/40" x-show="!expanded">
@@ -120,7 +120,7 @@ templ backupsScheduleSection(p BackupsProps) {
 				</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Configure automatic backup frequency and retention</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
@@ -184,7 +184,7 @@ templ backupsListSection(p BackupsProps) {
 	<!-- Backup List -->
 	<div class="bb-card p-0 overflow-hidden">
 		<div class="px-4 sm:px-5 py-4 flex items-center gap-3 border-b border-base-300">
-			<i data-lucide="archive" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+			<i data-lucide="archive" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 			<h2 class="font-semibold">Backup Files</h2>
 			<span class="text-xs text-base-content/40 ml-auto tabular-nums">{ fmt.Sprintf("%d files", p.BackupCount) }</span>
 		</div>
@@ -225,7 +225,7 @@ templ backupsRow(b BackupRow, csrf string) {
 	<tr>
 		<td>
 			<div class="flex items-center gap-2">
-				<i data-lucide="file-archive" class="w-4 h-4 text-base-content/30 flex-shrink-0"></i>
+				<i data-lucide="file-archive" class="w-4 h-4 text-base-content opacity-30 flex-shrink-0"></i>
 				<span class="font-mono text-xs">{ b.Filename }</span>
 			</div>
 		</td>
@@ -295,13 +295,13 @@ templ backupsRestoreSection(p BackupsProps) {
 	<!-- Restore from Upload -->
 	<div id="restore" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#restore' }">
 		<div class="px-4 sm:px-5 py-4 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
-			<i data-lucide="upload" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+			<i data-lucide="upload" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Restore from File</h2>
 				<p class="text-xs text-base-content/40" x-show="!expanded">Upload a .sql.gz backup file to restore</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Upload a previously downloaded backup to restore</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -82,7 +82,7 @@ templ categoryRow(c service.CategoryResponse) {
 			<div class="flex items-center gap-2 min-w-0 flex-1">
 				<i
 					data-lucide="chevron-right"
-					class="w-3.5 h-3.5 text-base-content/30 transition-transform duration-200 shrink-0"
+					class="w-3.5 h-3.5 text-base-content opacity-30 transition-transform duration-200 shrink-0"
 					:class={ fmt.Sprintf("isOpen('%s') ? 'rotate-90' : ''", c.ID) }
 				></i>
 				<span class={ "font-semibold text-sm truncate", templ.KV("text-base-content/40", c.IsSystem), templ.KV("text-base-content/40 italic", c.Hidden && !c.IsSystem) }>
@@ -179,7 +179,7 @@ templ categoryTileInner(c service.CategoryResponse, child bool) {
 		if child {
 			<span class="w-2 h-2 rounded-full bg-base-content/20"></span>
 		} else {
-			<i data-lucide="tag" class="w-5 h-5 text-primary/60"></i>
+			<i data-lucide="tag" class="w-5 h-5 text-primary opacity-60"></i>
 		}
 	}
 }

--- a/internal/templates/components/pages/connection_detail_helpers.go
+++ b/internal/templates/components/pages/connection_detail_helpers.go
@@ -115,15 +115,15 @@ func connDetailAccountIcon(t string) string {
 func connDetailAccountIconColor(t string) string {
 	switch t {
 	case "depository":
-		return "text-info/60"
+		return "text-info opacity-60"
 	case "credit":
-		return "text-warning/70"
+		return "text-warning opacity-70"
 	case "loan":
-		return "text-error/60"
+		return "text-error opacity-60"
 	case "investment":
-		return "text-success/60"
+		return "text-success opacity-60"
 	default:
-		return "text-base-content/40"
+		return "text-base-content opacity-40"
 	}
 }
 

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -62,7 +62,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 											class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
                         peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300"
 										>
-											<i data-lucide="building-2" class="w-6 h-6 text-base-content/60"></i>
+											<i data-lucide="building-2" class="w-6 h-6 text-base-content opacity-60"></i>
 											<span class="text-sm font-medium">Plaid</span>
 										</div>
 									</label>
@@ -78,7 +78,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 											class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
                         peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300"
 										>
-											<i data-lucide="landmark" class="w-6 h-6 text-base-content/60"></i>
+											<i data-lucide="landmark" class="w-6 h-6 text-base-content opacity-60"></i>
 											<span class="text-sm font-medium">Teller</span>
 										</div>
 									</label>
@@ -89,7 +89,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 										class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
                         peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300"
 									>
-										<i data-lucide="file-spreadsheet" class="w-6 h-6 text-base-content/60"></i>
+										<i data-lucide="file-spreadsheet" class="w-6 h-6 text-base-content opacity-60"></i>
 										<span class="text-sm font-medium">CSV</span>
 									</div>
 								</label>

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -157,7 +157,7 @@ templ Connections(p ConnectionsProps) {
 				<div class="bb-card p-12 text-center">
 					<div class="flex flex-col items-center">
 						<div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
-							<i data-lucide="link-2" class="w-8 h-8 text-base-content/25"></i>
+							<i data-lucide="link-2" class="w-8 h-8 text-base-content opacity-25"></i>
 						</div>
 						<h3 class="text-lg font-semibold mb-1">No Account Links</h3>
 						<p class="text-sm text-base-content/50 mb-5 max-w-sm">
@@ -328,13 +328,13 @@ templ connectionsAccountRow(a ConnectionsAccountRow) {
 			<div class="w-7 h-7 rounded-md bg-base-200/60 flex items-center justify-center shrink-0">
 				switch a.Type {
 					case "credit":
-						<i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 					case "loan":
-						<i data-lucide="landmark" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="landmark" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 					case "investment":
-						<i data-lucide="trending-up" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="trending-up" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 					default:
-						<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 				}
 			</div>
 			<div class="min-w-0">
@@ -390,8 +390,8 @@ templ connectionsLinkRow(l ConnectionsLinkRow, csrfToken string) {
 							<span class="text-xs text-base-content/40">{ l.PrimaryUserName }</span>
 						</div>
 					</div>
-					<i data-lucide="arrow-right" class="w-4 h-4 text-base-content/30 shrink-0 hidden sm:block"></i>
-					<i data-lucide="arrow-down" class="w-4 h-4 text-base-content/30 shrink-0 sm:hidden ml-3"></i>
+					<i data-lucide="arrow-right" class="w-4 h-4 text-base-content opacity-30 shrink-0 hidden sm:block"></i>
+					<i data-lucide="arrow-down" class="w-4 h-4 text-base-content opacity-30 shrink-0 sm:hidden ml-3"></i>
 					<div class="flex items-center gap-2 min-w-0 sm:ml-0 ml-3">
 						<div class="flex items-center justify-center w-8 h-8 rounded-lg bg-secondary/8 shrink-0">
 							<i data-lucide="credit-card" class="w-4 h-4 text-secondary"></i>

--- a/internal/templates/components/pages/csv_import.templ
+++ b/internal/templates/components/pages/csv_import.templ
@@ -82,7 +82,7 @@ templ CSVImport(p CSVImportProps) {
 				</div>
 				if p.ConnectionID != "" {
 					<div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-base-200/50 mb-6">
-						<i data-lucide="link" class="w-4 h-4 text-base-content/50"></i>
+						<i data-lucide="link" class="w-4 h-4 text-base-content opacity-50"></i>
 						<div class="text-sm">
 							<span class="text-base-content/50">Re-importing to:</span>
 							<span class="font-medium">{ p.ExistingConnectionName }</span>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -599,7 +599,7 @@ templ SectionEmptyStates() {
 			<div class="bb-card p-12 text-center max-w-md mx-auto">
 				<div class="flex flex-col items-center">
 					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
-						<i data-lucide="inbox" class="w-7 h-7 text-base-content/30"></i>
+						<i data-lucide="inbox" class="w-7 h-7 text-base-content opacity-30"></i>
 					</div>
 					<h3 class="text-base font-semibold mb-1">No connections yet</h3>
 					<p class="text-base-content/50 text-sm mb-5 max-w-sm">Link a bank to start importing transactions.</p>
@@ -612,7 +612,7 @@ templ SectionEmptyStates() {
 		}
 		@designExample("Compact (filtered no results)", "Inline, no card chrome.") {
 			<div class="flex flex-col items-center text-center py-10">
-				<i data-lucide="search-x" class="w-8 h-8 text-base-content/30 mb-3"></i>
+				<i data-lucide="search-x" class="w-8 h-8 text-base-content opacity-30 mb-3"></i>
 				<p class="text-sm text-base-content/50">No transactions match these filters.</p>
 			</div>
 		}

--- a/internal/templates/components/pages/errors.templ
+++ b/internal/templates/components/pages/errors.templ
@@ -8,7 +8,7 @@ templ NotFound() {
 	<div class="bb-error-page">
 		<p class="bb-error-code">404</p>
 		<div class="bb-error-icon bg-base-200/80">
-			<i data-lucide="compass" class="w-7 h-7 text-base-content/40"></i>
+			<i data-lucide="compass" class="w-7 h-7 text-base-content opacity-40"></i>
 		</div>
 		<h1 class="bb-error-title">Page not found</h1>
 		<p class="bb-error-message">The page you're looking for doesn't exist or has been moved.</p>
@@ -25,7 +25,7 @@ templ InternalError() {
 	<div class="bb-error-page">
 		<p class="bb-error-code">500</p>
 		<div class="bb-error-icon bg-error/10">
-			<i data-lucide="alert-triangle" class="w-7 h-7 text-error/60"></i>
+			<i data-lucide="alert-triangle" class="w-7 h-7 text-error opacity-60"></i>
 		</div>
 		<h1 class="bb-error-title">Something went wrong</h1>
 		<p class="bb-error-message">An unexpected error occurred. Please try again. If the problem persists, check the application logs.</p>
@@ -50,7 +50,7 @@ templ NotFoundPublic() {
 		<div class="bb-error-page">
 			<p class="bb-error-code">404</p>
 			<div class="bb-error-icon bg-base-200/80">
-				<i data-lucide="compass" class="w-7 h-7 text-base-content/40"></i>
+				<i data-lucide="compass" class="w-7 h-7 text-base-content opacity-40"></i>
 			</div>
 			<h1 class="bb-error-title">Page not found</h1>
 			<p class="bb-error-message">The page you're looking for doesn't exist or has been moved.</p>
@@ -70,7 +70,7 @@ templ InternalErrorPublic() {
 		<div class="bb-error-page">
 			<p class="bb-error-code">500</p>
 			<div class="bb-error-icon bg-error/10">
-				<i data-lucide="alert-triangle" class="w-7 h-7 text-error/60"></i>
+				<i data-lucide="alert-triangle" class="w-7 h-7 text-error opacity-60"></i>
 			</div>
 			<h1 class="bb-error-title">Something went wrong</h1>
 			<p class="bb-error-message">An unexpected error occurred. Please try again.</p>

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -84,7 +84,7 @@ templ feedHero(p FeedProps) {
 templ feedHeroTile(icon, label, value, sub string) {
 	<div class="bb-card p-4">
 		<div class="flex items-center gap-2">
-			<i data-lucide={ icon } class="w-3.5 h-3.5 text-base-content/40"></i>
+			<i data-lucide={ icon } class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/40">{ label }</div>
 		</div>
 		<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5">{ value }</div>
@@ -97,7 +97,7 @@ templ feedHeroTile(icon, label, value, sub string) {
 templ feedHeroSyncTile(p FeedProps) {
 	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline group block" aria-label="Last sync — view sync logs">
 		<div class="flex items-center gap-2">
-			<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/40"></i>
+			<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/40">Last sync</div>
 			<span class={ "ml-auto inline-block w-1.5 h-1.5 rounded-full", feedSyncDotClass(p.Hero.LastSyncStatus) } aria-hidden="true"></span>
 		</div>
@@ -256,7 +256,7 @@ templ feedEmptyState(p FeedProps) {
 // button rather than a quiet link.
 templ feedEmptyFirstRun() {
 	<div class="bb-card p-10 sm:p-12 text-center">
-		<i data-lucide="landmark" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+		<i data-lucide="landmark" class="w-10 h-10 mx-auto mb-3 text-base-content opacity-20"></i>
 		<h2 class="text-lg font-semibold mb-1">Welcome to Breadbox</h2>
 		<p class="text-sm text-base-content/55 max-w-md mx-auto mb-5">
 			Connect your first bank to start filling your feed.
@@ -274,7 +274,7 @@ templ feedEmptyFirstRun() {
 // has a clear way out without scrolling back up.
 templ feedEmptyFiltered(filter string) {
 	<div class="bb-card p-10 sm:p-12 text-center">
-		<i data-lucide="filter" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+		<i data-lucide="filter" class="w-10 h-10 mx-auto mb-3 text-base-content opacity-20"></i>
 		<h2 class="text-lg font-semibold mb-1">{ feedEmptyFilteredHeadline(filter) }</h2>
 		<p class="text-sm text-base-content/55 mb-5">
 			Nothing in this slice today.
@@ -294,7 +294,7 @@ templ feedEmptyNoRecent(p FeedProps) {
 	if p.IsAdmin {
 		<script src="/static/js/admin/components/feed.js"></script>
 		<div class="bb-card p-10 sm:p-12 text-center" x-data="feedSyncNow">
-			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content opacity-20"></i>
 			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
 			<p class="text-sm text-base-content/55 mb-5">
 				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
@@ -317,7 +317,7 @@ templ feedEmptyNoRecent(p FeedProps) {
 		</div>
 	} else {
 		<div class="bb-card p-10 sm:p-12 text-center">
-			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content opacity-20"></i>
 			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
 			<p class="text-sm text-base-content/55 mb-5">
 				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
@@ -494,7 +494,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 	}
 	if len(s.RuleOutcomes) > 0 {
 		<div class="mt-1 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			<i data-lucide="zap" class="w-3 h-3 text-primary/70"></i>
+			<i data-lucide="zap" class="w-3 h-3 text-primary opacity-70"></i>
 			for i, ro := range s.RuleOutcomes {
 				if i > 0 {
 					<span class="text-base-content/25">·</span>
@@ -595,7 +595,7 @@ templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
 		</div>
 		if breakdown := feedSessionBreakdown(s); breakdown != "" {
 			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-				<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+				<i data-lucide="sparkles" class="w-3 h-3 text-primary opacity-70"></i>
 				<span>{ breakdown }</span>
 				if dur := feedSessionDuration(s); dur != "" {
 					<span class="text-base-content/30 mx-1">·</span>
@@ -673,7 +673,7 @@ templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
 		if b.Kind == "mixed" {
 			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
 				<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-					<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+					<i data-lucide="sparkles" class="w-3 h-3 text-primary opacity-70"></i>
 					<span>{ breakdown }</span>
 				</div>
 			}

--- a/internal/templates/components/pages/feed_pending_test.go
+++ b/internal/templates/components/pages/feed_pending_test.go
@@ -73,7 +73,7 @@ func TestFeedTxRefRowPendingPill(t *testing.T) {
 			},
 			mustContain: []string{
 				`data-lucide="clock"`,
-				"text-warning/70",
+				"text-warning opacity-70",
 				"Pending — not yet posted",
 				"(pending)",
 				"Whole Foods",

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -34,22 +34,22 @@ templ GettingStarted(p GettingStartedProps) {
 			if p.TransactionCount > 0 {
 				<div class="flex flex-wrap gap-4 text-sm tabular-nums">
 					<div class="flex items-center gap-1.5">
-						<i data-lucide="link" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="link" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						<span class="text-base-content/50">Connections</span>
 						<span class="font-semibold">{ components.CommaInt(p.ConnectionCount) }</span>
 					</div>
 					<div class="flex items-center gap-1.5">
-						<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						<span class="text-base-content/50">Accounts</span>
 						<span class="font-semibold">{ components.CommaInt(p.AccountCount) }</span>
 					</div>
 					<div class="flex items-center gap-1.5">
-						<i data-lucide="receipt" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="receipt" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						<span class="text-base-content/50">Transactions</span>
 						<span class="font-semibold">{ components.CommaInt(p.TransactionCount) }</span>
 					</div>
 					<div class="flex items-center gap-1.5">
-						<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						<span class="text-base-content/50">Syncs</span>
 						<span class="font-semibold">{ components.CommaInt(p.SuccessfulSyncs) }</span>
 					</div>

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -148,7 +148,7 @@ templ logsSyncStats(p LogsProps) {
 			<div class="bb-card p-4">
 				<div class="flex items-center gap-3">
 					<div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-						<i data-lucide="timer" class="w-4 h-4 text-base-content/40"></i>
+						<i data-lucide="timer" class="w-4 h-4 text-base-content opacity-40"></i>
 					</div>
 					<div>
 						<div class="text-2xl font-semibold tabular-nums leading-none">
@@ -167,13 +167,13 @@ templ logsSyncFilterBar(p LogsProps) {
 		<div class="p-0">
 			<button type="button" class="bb-filter-toggle" @click="filtersOpen = !filtersOpen">
 				<div class="flex items-center gap-2">
-					<i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
+					<i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content opacity-60"></i>
 					<span>Filters</span>
 					if p.HasAdvancedFilters {
 						<span class="badge badge-primary badge-xs">Active</span>
 					}
 				</div>
-				<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="filtersOpen ? 'rotate-180' : ''"></i>
+				<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-40 transition-transform duration-200" :class="filtersOpen ? 'rotate-180' : ''"></i>
 			</button>
 			<form
 				method="GET"
@@ -304,7 +304,7 @@ templ logsSyncRow(l LogsSyncRow) {
 							case "in_progress":
 								<i data-lucide="loader" class="w-3.5 h-3.5 text-warning animate-spin"></i>
 							default:
-								<i data-lucide="minus" class="w-3.5 h-3.5 text-base-content/30"></i>
+								<i data-lucide="minus" class="w-3.5 h-3.5 text-base-content opacity-30"></i>
 						}
 					</div>
 				</div>
@@ -391,7 +391,7 @@ templ logsWebhookStats(p LogsProps) {
 			<div class="bb-card p-4">
 				<div class="flex items-center gap-3">
 					<div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-						<i data-lucide="webhook" class="w-4 h-4 text-base-content/40"></i>
+						<i data-lucide="webhook" class="w-4 h-4 text-base-content opacity-40"></i>
 					</div>
 					<div>
 						<div class="text-2xl font-semibold tabular-nums leading-none">{ strconv.FormatInt(p.WHStats.TotalEvents, 10) }</div>
@@ -591,7 +591,7 @@ templ logsWebhookRow(e LogsWebhookRow) {
 				</div>
 				if e.ErrorMessage != nil && *e.ErrorMessage != "" {
 					<div class="flex items-start gap-2 text-xs mt-2">
-						<i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/60 shrink-0 mt-0.5"></i>
+						<i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error opacity-60 shrink-0 mt-0.5"></i>
 						<p class="text-error/80 font-mono break-all leading-relaxed">{ *e.ErrorMessage }</p>
 					</div>
 				}
@@ -641,7 +641,7 @@ templ logsSessionsBody(p LogsProps) {
 templ logsSessionRow(s LogsSessionRow) {
 	<a href={ templ.SafeURL("/logs/sessions/" + s.ShortID) } class="bb-card bb-card--interactive group flex items-start gap-3 py-3 px-4 no-underline">
 		<div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0 mt-0.5">
-			<i data-lucide="bot" class="w-3.5 h-3.5 text-base-content/40"></i>
+			<i data-lucide="bot" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 		</div>
 		<div class="flex-1 min-w-0">
 			<div class="flex items-center gap-2 flex-wrap">
@@ -671,7 +671,7 @@ templ logsSessionRow(s LogsSessionRow) {
 				<span>{ s.CreatedAtRelative }</span>
 			</div>
 		</div>
-		<i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 shrink-0 mt-1"></i>
+		<i data-lucide="chevron-right" class="w-4 h-4 text-base-content opacity-20 shrink-0 mt-1"></i>
 	</a>
 }
 
@@ -791,9 +791,9 @@ func errorBg(hasErrors bool) string {
 
 func errorIconClass(hasErrors bool) string {
 	if hasErrors {
-		return "text-error/70"
+		return "text-error opacity-70"
 	}
-	return "text-base-content/40"
+	return "text-base-content opacity-40"
 }
 
 func errorTextClass(hasErrors bool) string {

--- a/internal/templates/components/pages/mcp_settings.templ
+++ b/internal/templates/components/pages/mcp_settings.templ
@@ -109,7 +109,7 @@ templ mcpSettingsEditableCard(c mcpSettingsCardSpec) {
 					@templ.Raw(c.SubtitleExp)
 				</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse>
 			<div class="px-4 sm:px-5 py-4">
@@ -160,7 +160,7 @@ templ mcpSettingsToolsCard(p MCPSettingsProps) {
 				</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Enable or disable individual MCP tools</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
@@ -219,7 +219,7 @@ templ mcpSettingsConnectionCard() {
 				<h2 class="font-semibold">Connection</h2>
 				<p class="text-xs text-base-content/40">Endpoints and config for connecting MCP agents</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4 space-y-5">

--- a/internal/templates/components/pages/my_account.templ
+++ b/internal/templates/components/pages/my_account.templ
@@ -187,7 +187,7 @@ templ myAccountPasswordCard(csrfToken string) {
 		<div class="p-5 sm:p-6">
 			<div class="bb-icon-header">
 				<div class="bb-icon-header__tile bg-base-200/60">
-					<i data-lucide="lock" class="w-4 h-4 text-base-content/50"></i>
+					<i data-lucide="lock" class="w-4 h-4 text-base-content opacity-50"></i>
 				</div>
 				<div class="bb-icon-header__text">
 					<h2 class="text-sm font-semibold">Change password</h2>

--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -154,7 +154,7 @@ templ providersPlaidCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 						<!-- Webhook instructions -->
 						<div class="border-t border-base-300 pt-4">
 							<div class="flex items-center gap-1.5 mb-2">
-								<i data-lucide="webhook" class="w-3.5 h-3.5 text-base-content/40"></i>
+								<i data-lucide="webhook" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 								<h3 class="text-sm font-medium">Webhook Setup</h3>
 							</div>
 							<p class="text-xs text-base-content/50 mb-2">Plaid can push real-time transaction updates via webhooks. Set the webhook URL above, then configure Plaid to send events to:</p>
@@ -311,7 +311,7 @@ templ providersTellerCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 						<!-- Webhook instructions -->
 						<div class="border-t border-base-300 pt-4">
 							<div class="flex items-center gap-1.5 mb-2">
-								<i data-lucide="webhook" class="w-3.5 h-3.5 text-base-content/40"></i>
+								<i data-lucide="webhook" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 								<h3 class="text-sm font-medium">Webhook Setup</h3>
 							</div>
 							<p class="text-xs text-base-content/50 mb-2">Teller sends webhooks for account disconnections and other events. To enable:</p>
@@ -357,18 +357,18 @@ templ providersCSVCard(h *service.ProviderHealthSummary) {
 			if h != nil {
 				<div class="flex flex-wrap gap-x-6 gap-y-2 text-sm">
 					<div class="flex items-center gap-1.5">
-						<i data-lucide="file-up" class="w-3.5 h-3.5 text-base-content/30"></i>
+						<i data-lucide="file-up" class="w-3.5 h-3.5 text-base-content opacity-30"></i>
 						<span class="text-base-content/50">Imports:</span>
 						<span class="font-medium">{ fmt.Sprintf("%d", h.ConnectionCount) }</span>
 					</div>
 					<div class="flex items-center gap-1.5">
-						<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/30"></i>
+						<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content opacity-30"></i>
 						<span class="text-base-content/50">Accounts:</span>
 						<span class="font-medium">{ fmt.Sprintf("%d", h.AccountCount) }</span>
 					</div>
 					if h.LastSyncTime != nil {
 						<div class="flex items-center gap-1.5">
-							<i data-lucide="clock" class="w-3.5 h-3.5 text-base-content/30"></i>
+							<i data-lucide="clock" class="w-3.5 h-3.5 text-base-content opacity-30"></i>
 							<span class="text-base-content/50">Last import:</span>
 							<span class="font-medium">{ *h.LastSyncTime }</span>
 						</div>
@@ -412,18 +412,18 @@ templ providersStats(h *service.ProviderHealthSummary) {
 	if h != nil {
 		<div class="flex flex-wrap gap-x-6 gap-y-2 text-sm min-w-0">
 			<div class="flex items-center gap-1.5">
-				<i data-lucide="link" class="w-3.5 h-3.5 text-base-content/30 flex-shrink-0"></i>
+				<i data-lucide="link" class="w-3.5 h-3.5 text-base-content opacity-30 flex-shrink-0"></i>
 				<span class="text-base-content/50">Connections:</span>
 				<span class="font-medium">{ fmt.Sprintf("%d", h.ConnectionCount) }</span>
 			</div>
 			<div class="flex items-center gap-1.5">
-				<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/30 flex-shrink-0"></i>
+				<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content opacity-30 flex-shrink-0"></i>
 				<span class="text-base-content/50">Accounts:</span>
 				<span class="font-medium">{ fmt.Sprintf("%d", h.AccountCount) }</span>
 			</div>
 			if h.LastSyncTime != nil {
 				<div class="flex items-center gap-1.5 min-w-0">
-					<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/30 flex-shrink-0"></i>
+					<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content opacity-30 flex-shrink-0"></i>
 					<span class="text-base-content/50 flex-shrink-0">Last sync:</span>
 					switch h.LastSyncStatus {
 						case "success":
@@ -438,7 +438,7 @@ templ providersStats(h *service.ProviderHealthSummary) {
 				</div>
 			} else if h.ConnectionCount > 0 {
 				<div class="flex items-center gap-1.5">
-					<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/30 flex-shrink-0"></i>
+					<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content opacity-30 flex-shrink-0"></i>
 					<span class="text-base-content/40">Never synced</span>
 				</div>
 			}

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -58,7 +58,7 @@ templ Reports(p ReportsProps) {
 	} else {
 		<div class="bb-card px-5 py-16 text-center">
 			<div class="w-14 h-14 rounded-xl bg-base-200/50 mx-auto mb-4 flex items-center justify-center">
-				<i data-lucide="inbox" class="w-6 h-6 text-base-content/25"></i>
+				<i data-lucide="inbox" class="w-6 h-6 text-base-content opacity-25"></i>
 			</div>
 			<p class="text-base font-medium text-base-content/70 mb-1">{ reportsEmptyTitle(p.FilterStatus) }</p>
 			<p class="text-sm text-base-content/40 max-w-md mx-auto">{ reportsEmptyMessage(p.FilterStatus) }</p>
@@ -117,7 +117,7 @@ templ reportsRow(r ReportsItem) {
 						<i data-lucide="check" class="w-4 h-4"></i>
 					</button>
 				}
-				<i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25 group-hover:text-base-content/50 transition-colors"></i>
+				<i data-lucide="chevron-right" class="w-4 h-4 text-base-content opacity-25 group-hover:text-base-content group-hover:opacity-50 transition-colors"></i>
 			</div>
 		</div>
 	</a>

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -72,7 +72,7 @@ templ ruleDetailHeader(p RuleDetailProps) {
 			<div class="flex items-center gap-4">
 				<div class={ "w-12", "h-12", "rounded-xl", "flex", "items-center", "justify-center", ruleHeaderTileClass(p.Rule.Enabled, isSystem) }>
 					if !p.Rule.Enabled {
-						<i data-lucide="pause" class="w-6 h-6 text-base-content/30"></i>
+						<i data-lucide="pause" class="w-6 h-6 text-base-content opacity-30"></i>
 					} else if isSystem {
 						<i data-lucide="shield" class="w-6 h-6 text-info"></i>
 					} else {
@@ -189,7 +189,7 @@ templ ruleDetailActionRow(p RuleDetailProps, a service.RuleAction) {
 					if p.Rule != nil && p.Rule.CategoryIcon != nil {
 						<i data-lucide={ *p.Rule.CategoryIcon } class="w-4 h-4" style={ ruleCategoryIconColorStyle(p.Rule) }></i>
 					} else {
-						<i data-lucide="tag" class="w-4 h-4 text-base-content/50"></i>
+						<i data-lucide="tag" class="w-4 h-4 text-base-content opacity-50"></i>
 					}
 				</div>
 				<div class="flex-1 min-w-0">
@@ -231,7 +231,7 @@ templ ruleDetailActionRow(p RuleDetailProps, a service.RuleAction) {
 				</div>
 			default:
 				<div class="w-8 h-8 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
-					<i data-lucide="settings" class="w-4 h-4 text-base-content/40"></i>
+					<i data-lucide="settings" class="w-4 h-4 text-base-content opacity-40"></i>
 				</div>
 				<div class="flex-1 min-w-0">
 					<p class="text-sm">Unknown action type: <span class="font-semibold">{ a.Type }</span></p>
@@ -505,7 +505,7 @@ templ ruleDetailSyncActivity(p RuleDetailProps) {
 				<span class="label-text text-sm font-medium">Sync Log</span>
 				<span class="text-xs text-base-content/40 ml-2">{ fmt.Sprintf("%d recent syncs", len(p.SyncHistory)) }</span>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform" :class="open ? 'rotate-180' : ''"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-40 transition-transform" :class="open ? 'rotate-180' : ''"></i>
 		</button>
 		<div x-show="open" x-cloak class="px-5 pb-5 space-y-2">
 			for _, h := range p.SyncHistory {

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -99,7 +99,7 @@ templ RuleForm(p RuleFormProps) {
 								<span>Pipeline stage</span>
 								<span class="text-base-content/40 group-hover:text-base-content/60 transition-colors" x-text="'· ' + (priorityPresets.find(p => p.value === form.priority)?.label || form.priority)"></span>
 							</div>
-							<i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/40 group-hover:text-base-content/60 transition-all shrink-0" :class="stageOpen ? 'rotate-180' : ''"></i>
+							<i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content opacity-40 group-hover:text-base-content group-hover:opacity-60 transition-all shrink-0" :class="stageOpen ? 'rotate-180' : ''"></i>
 						</button>
 						<div x-show="stageOpen" x-cloak x-collapse class="mt-3 ml-2 pl-4 border-l border-base-300/70">
 							<div class="flex items-center gap-1 bg-base-200/60 rounded-xl p-1">
@@ -245,7 +245,7 @@ templ RuleForm(p RuleFormProps) {
 								<input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'"/>
 								<!-- Remove -->
 								<button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
-									<i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
+									<i data-lucide="x" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 								</button>
 							</div>
 						</template>
@@ -293,7 +293,7 @@ templ RuleForm(p RuleFormProps) {
 								     the end) so flex-wrap places it on row 1 at mobile. Ordered last
 								     on sm+ via order-last so the inline layout matches the original. -->
 								<button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0 mt-px order-2 sm:order-last" @click="removeAction(idx)" :disabled="form.actions.length === 1" :title="form.actions.length === 1 ? 'A rule needs at least one action' : 'Remove this action'">
-									<i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
+									<i data-lucide="x" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 								</button>
 								<!-- Flex-wrap break: forces the value input onto its own row at
 								     mobile so the input/textarea gets the full width. Hidden on sm+

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -241,7 +241,7 @@ templ rulesAvatar(r RulesRow) {
 		</div>
 	} else if !r.Enabled {
 		<div class="w-9 h-9 rounded-xl bg-base-200 flex items-center justify-center">
-			<i data-lucide="pause" class="w-5 h-5 text-base-content/30"></i>
+			<i data-lucide="pause" class="w-5 h-5 text-base-content opacity-30"></i>
 		</div>
 	} else if r.IsSystem {
 		<div class="w-9 h-9 rounded-xl bg-info/10 flex items-center justify-center" title="System rule">

--- a/internal/templates/components/pages/session_detail.templ
+++ b/internal/templates/components/pages/session_detail.templ
@@ -50,7 +50,7 @@ templ SessionDetail(p SessionDetailProps) {
 	} else {
 		<div class="card bg-base-100 shadow-sm">
 			<div class="card-body items-center text-center py-12">
-				<i data-lucide="scroll-text" class="w-12 h-12 text-base-content/20 mb-3"></i>
+				<i data-lucide="scroll-text" class="w-12 h-12 text-base-content opacity-20 mb-3"></i>
 				<h3 class="font-medium text-base-content/70">No tool calls recorded</h3>
 				<p class="text-sm text-base-content/50">This session has no recorded tool calls yet.</p>
 			</div>
@@ -90,7 +90,7 @@ templ sessionDetailToolCard(c SessionDetailToolCall) {
 					if c.HasDuration {
 						<span class="text-xs text-base-content/40 tabular-nums">{ strconv.FormatInt(int64(c.DurationMs), 10) }ms</span>
 					}
-					<i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/30 transition-transform" :class="expanded && 'rotate-180'"></i>
+					<i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content opacity-30 transition-transform" :class="expanded && 'rotate-180'"></i>
 				</span>
 			</div>
 			if c.Reason != "" {

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -70,7 +70,7 @@ templ settingsSyncCard(p SettingsProps) {
 			@keydown.enter.prevent="expanded = !expanded"
 			@keydown.space.prevent="expanded = !expanded"
 		>
-			<i data-lucide="refresh-cw" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+			<i data-lucide="refresh-cw" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Sync</h2>
 				<p class="text-xs text-base-content/40" x-show="!expanded">
@@ -82,7 +82,7 @@ templ settingsSyncCard(p SettingsProps) {
 				</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Schedule and log retention</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div id="sync-panel" x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
@@ -184,7 +184,7 @@ templ settingsSecurityCard(p SettingsProps) {
 			@keydown.enter.prevent="expanded = !expanded"
 			@keydown.space.prevent="expanded = !expanded"
 		>
-			<i data-lucide="shield" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+			<i data-lucide="shield" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Security</h2>
 				<p class="text-xs text-base-content/40" x-show="!expanded">
@@ -192,14 +192,14 @@ templ settingsSecurityCard(p SettingsProps) {
 				</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Encryption key status · Change password in <a href="/settings/account" class="link link-hover">My Account</a></p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div id="security-panel" x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
 				<!-- Encryption Key Status -->
 				<div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40">
 					<div class="flex items-center gap-2.5">
-						<i data-lucide="key-round" class="w-4 h-4 text-base-content/50"></i>
+						<i data-lucide="key-round" class="w-4 h-4 text-base-content opacity-50"></i>
 						<span class="text-sm font-medium">Encryption Key</span>
 					</div>
 					if p.HasEncryptionKey {
@@ -227,7 +227,7 @@ templ settingsSystemCard(p SettingsProps) {
 	<div id="system" class="bb-card p-5">
 		<div class="flex items-center justify-between gap-3 mb-4">
 			<div class="flex items-center gap-3">
-				<i data-lucide="cpu" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+				<i data-lucide="cpu" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 				<h2 class="font-semibold">System</h2>
 			</div>
 			if p.UpdateAvailable {
@@ -265,20 +265,20 @@ templ settingsHelpCard(p SettingsProps) {
 			@keydown.enter.prevent="expanded = !expanded"
 			@keydown.space.prevent="expanded = !expanded"
 		>
-			<i data-lucide="life-buoy" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+			<i data-lucide="life-buoy" class="w-5 h-5 text-base-content opacity-40 flex-shrink-0"></i>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Help</h2>
 				<p class="text-xs text-base-content/40" x-show="!expanded">Setup guide and documentation</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Resources and guides</p>
 			</div>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>
 		<div id="help-panel" x-show="expanded" x-collapse x-cloak>
 			<div class="px-4 sm:px-5 py-4">
 				<div class="flex flex-col gap-3">
 					<div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40">
 						<div class="flex items-center gap-2.5">
-							<i data-lucide="compass" class="w-4 h-4 text-base-content/50"></i>
+							<i data-lucide="compass" class="w-4 h-4 text-base-content opacity-50"></i>
 							<div>
 								<span class="text-sm font-medium">Getting Started Guide</span>
 								<p class="text-xs text-base-content/40">Step-by-step setup walkthrough</p>
@@ -316,7 +316,7 @@ templ settingsSyncSchedule(p SettingsProps) {
 	<div class="bb-card p-5">
 		<div class="bb-icon-header">
 			<div class="bb-icon-header__tile bg-base-200/60">
-				<i data-lucide="refresh-cw" class="w-4 h-4 text-base-content/60"></i>
+				<i data-lucide="refresh-cw" class="w-4 h-4 text-base-content opacity-60"></i>
 			</div>
 			<div class="bb-icon-header__text">
 				<h2 class="text-sm font-semibold">Schedule</h2>
@@ -360,7 +360,7 @@ templ settingsSyncRetention(p SettingsProps) {
 	<div class="bb-card p-5">
 		<div class="bb-icon-header">
 			<div class="bb-icon-header__tile bg-base-200/60">
-				<i data-lucide="archive" class="w-4 h-4 text-base-content/60"></i>
+				<i data-lucide="archive" class="w-4 h-4 text-base-content opacity-60"></i>
 			</div>
 			<div class="bb-icon-header__text">
 				<h2 class="text-sm font-semibold">Log Retention</h2>
@@ -395,7 +395,7 @@ templ settingsSecurityCardFlat(p SettingsProps) {
 	<div class="bb-card p-5">
 		<div class="bb-icon-header">
 			<div class="bb-icon-header__tile bg-base-200/60">
-				<i data-lucide="shield" class="w-4 h-4 text-base-content/60"></i>
+				<i data-lucide="shield" class="w-4 h-4 text-base-content opacity-60"></i>
 			</div>
 			<div class="bb-icon-header__text">
 				<h2 class="text-sm font-semibold">Encryption Key</h2>
@@ -404,7 +404,7 @@ templ settingsSecurityCardFlat(p SettingsProps) {
 		</div>
 		<div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40">
 			<div class="flex items-center gap-2.5">
-				<i data-lucide="key-round" class="w-4 h-4 text-base-content/50"></i>
+				<i data-lucide="key-round" class="w-4 h-4 text-base-content opacity-50"></i>
 				<span class="text-sm font-medium">ENCRYPTION_KEY</span>
 			</div>
 			if p.HasEncryptionKey {
@@ -430,7 +430,7 @@ templ settingsHelpCardFlat(p SettingsProps) {
 	<div class="bb-card p-5">
 		<div class="bb-icon-header">
 			<div class="bb-icon-header__tile bg-base-200/60">
-				<i data-lucide="life-buoy" class="w-4 h-4 text-base-content/60"></i>
+				<i data-lucide="life-buoy" class="w-4 h-4 text-base-content opacity-60"></i>
 			</div>
 			<div class="bb-icon-header__text">
 				<h2 class="text-sm font-semibold">Resources</h2>
@@ -440,7 +440,7 @@ templ settingsHelpCardFlat(p SettingsProps) {
 		<div class="flex flex-col gap-3">
 			<div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40">
 				<div class="flex items-center gap-2.5">
-					<i data-lucide="compass" class="w-4 h-4 text-base-content/50"></i>
+					<i data-lucide="compass" class="w-4 h-4 text-base-content opacity-50"></i>
 					<div>
 						<span class="text-sm font-medium">Getting Started Guide</span>
 						<p class="text-xs text-base-content/40">Step-by-step setup walkthrough</p>
@@ -457,13 +457,13 @@ templ settingsHelpCardFlat(p SettingsProps) {
 			</div>
 			<a href="https://docs.breadbox.sh" target="_blank" rel="noopener noreferrer" class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 hover:bg-base-200/70 transition-colors no-underline">
 				<div class="flex items-center gap-2.5">
-					<i data-lucide="book-open" class="w-4 h-4 text-base-content/50"></i>
+					<i data-lucide="book-open" class="w-4 h-4 text-base-content opacity-50"></i>
 					<div>
 						<span class="text-sm font-medium">Documentation</span>
 						<p class="text-xs text-base-content/40">docs.breadbox.sh</p>
 					</div>
 				</div>
-				<i data-lucide="square-arrow-out-up-right" class="w-4 h-4 text-base-content/40"></i>
+				<i data-lucide="square-arrow-out-up-right" class="w-4 h-4 text-base-content opacity-40"></i>
 			</a>
 		</div>
 	</div>

--- a/internal/templates/components/pages/settings_layout.templ
+++ b/internal/templates/components/pages/settings_layout.templ
@@ -75,14 +75,14 @@ templ settingsRailMobile(p SettingsLayoutProps) {
 		-->
 		<summary class="list-none flex items-center justify-between w-full px-4 py-3 rounded-xl bg-base-100 ring-1 ring-base-content/10 shadow-sm cursor-pointer hover:bg-base-200 transition-colors [&::-webkit-details-marker]:hidden">
 			<span class="flex items-center gap-2.5 min-w-0">
-				<i data-lucide="settings" class="w-4 h-4 text-base-content/60 shrink-0"></i>
+				<i data-lucide="settings" class="w-4 h-4 text-base-content opacity-60 shrink-0"></i>
 				<span class="text-sm font-medium truncate">
 					<span class="text-base-content/50">Settings</span>
-					<i data-lucide="chevron-right" class="inline-block w-3 h-3 text-base-content/30 mx-0.5 align-[-2px]"></i>
+					<i data-lucide="chevron-right" class="inline-block w-3 h-3 text-base-content opacity-30 mx-0.5 align-[-2px]"></i>
 					<span>{ settingsTabLabel(p.CurrentTab) }</span>
 				</span>
 			</span>
-			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 shrink-0"></i>
+			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-40 shrink-0"></i>
 		</summary>
 		<!--
 			ring-base-content/10 gives a theme-aware separator (a faint
@@ -253,7 +253,7 @@ func settingsTabClass(current, tab string) string {
 // up together.
 func settingsTabIconClass(current, tab string) string {
 	if current == tab {
-		return "text-base-content/75"
+		return "text-base-content opacity-75"
 	}
 	return ""
 }

--- a/internal/templates/components/pages/sync_log_detail.templ
+++ b/internal/templates/components/pages/sync_log_detail.templ
@@ -88,7 +88,7 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 		<div class="bb-card p-0 overflow-hidden mb-6 border-warning/20">
 			<div class="px-5 py-3.5 border-b border-warning/10 bg-warning/5">
 				<div class="flex items-center gap-2">
-					<i data-lucide="alert-triangle" class="w-4 h-4 text-warning/70"></i>
+					<i data-lucide="alert-triangle" class="w-4 h-4 text-warning opacity-70"></i>
 					<h2 class="text-sm font-semibold text-warning/90">Warning</h2>
 				</div>
 			</div>
@@ -102,7 +102,7 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 		<div class="bb-card p-0 overflow-hidden mb-6 border-error/20">
 			<div class="px-5 py-3.5 border-b border-error/10 bg-error/5">
 				<div class="flex items-center gap-2">
-					<i data-lucide="alert-circle" class="w-4 h-4 text-error/70"></i>
+					<i data-lucide="alert-circle" class="w-4 h-4 text-error opacity-70"></i>
 					<h2 class="text-sm font-semibold text-error/90">Error Details</h2>
 				</div>
 			</div>
@@ -154,7 +154,7 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 				for _, a := range p.Accounts {
 					<div class="flex items-center gap-4 px-5 py-3">
 						<div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-							<i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content/40"></i>
+							<i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						</div>
 						<div class="flex-1 min-w-0">
 							<span class="text-sm font-medium truncate block">{ a.AccountName }</span>
@@ -189,7 +189,7 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 		<div class="bb-card p-8 text-center">
 			<div class="flex flex-col items-center">
 				<div class="w-12 h-12 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
-					<i data-lucide="layers" class="w-6 h-6 text-base-content/25"></i>
+					<i data-lucide="layers" class="w-6 h-6 text-base-content opacity-25"></i>
 				</div>
 				<h3 class="text-sm font-semibold mb-1">No account breakdown</h3>
 				<p class="text-xs text-base-content/40">Per-account details are tracked for new syncs only.</p>
@@ -209,7 +209,7 @@ templ syncDetailHeaderIcon(status string) {
 		case "in_progress":
 			<i data-lucide="loader" class="w-6 h-6 text-warning animate-spin"></i>
 		default:
-			<i data-lucide="minus-circle" class="w-6 h-6 text-base-content/30"></i>
+			<i data-lucide="minus-circle" class="w-6 h-6 text-base-content opacity-30"></i>
 	}
 }
 

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -93,7 +93,7 @@ templ txdHero(p TransactionDetailProps) {
 				}
 			>
 				if p.Transaction.Pending {
-					<i data-lucide="clock" class="w-5 h-5 shrink-0 text-warning/70"></i>
+					<i data-lucide="clock" class="w-5 h-5 shrink-0 text-warning opacity-70"></i>
 				}
 				<span class={ templ.KV("bb-tx-amount--pending", p.Transaction.Pending) }>{ components.FormatAmount(p.Transaction.Amount) }</span>
 			</p>
@@ -109,7 +109,7 @@ templ txdAccountBanner(p TransactionDetailProps) {
 	<div class="bb-card p-0 mb-4 sm:mb-6 overflow-hidden">
 		<div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 sm:py-3.5">
 			<div class="w-9 h-9 rounded-lg bg-base-200/70 flex items-center justify-center shrink-0">
-				<i data-lucide="building-2" class="w-5 h-5 text-base-content/40"></i>
+				<i data-lucide="building-2" class="w-5 h-5 text-base-content opacity-40"></i>
 			</div>
 			<div class="flex-1 min-w-0">
 				<div class="flex items-center gap-2 flex-wrap">
@@ -240,7 +240,7 @@ templ txdMain(p TransactionDetailProps) {
 					<button type="button" class="w-full flex items-center gap-3 p-3 rounded-xl bg-base-200/50 hover:bg-base-200 transition-colors" @click="openPicker()">
 						<template x-if="displayColor"><span class="w-3 h-3 rounded-full shrink-0" :style="'background-color:' + displayColor"></span></template>
 						<span x-text="displayLabel" class="text-sm font-medium flex-1 text-left"></span>
-						<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30"></i>
+						<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-30"></i>
 					</button>
 				</div>
 				<div class="flex items-center gap-2 mt-3">
@@ -344,7 +344,7 @@ templ txdActivity(p TransactionDetailProps) {
 		} else {
 			<section aria-labelledby="activity-heading">
 				<header class="flex items-center gap-2 pb-4 mb-4 border-b border-base-300/60">
-					<i data-lucide="activity" class="w-4 h-4 text-base-content/50" aria-hidden="true"></i>
+					<i data-lucide="activity" class="w-4 h-4 text-base-content opacity-50" aria-hidden="true"></i>
 					<h2 id="activity-heading" class="text-base font-semibold text-base-content">Activity</h2>
 				</header>
 				@txdTimelineEmptyComposer(p)
@@ -404,7 +404,7 @@ templ txdTimelineRow(e service.ActivityEntry, now time.Time) {
 // markup so the migration is byte-equivalent.
 templ txdDeletedCommentTile() {
 	<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
-		<i data-lucide="trash-2" class="w-3 h-3 text-base-content/40"></i>
+		<i data-lucide="trash-2" class="w-3 h-3 text-base-content opacity-40"></i>
 	</span>
 }
 
@@ -513,7 +513,7 @@ templ txdSystemIcon(e service.ActivityEntry) {
 		</span>
 	} else if e.Type == "sync" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
-			<i data-lucide="landmark" class="w-3 h-3 text-base-content/60"></i>
+			<i data-lucide="landmark" class="w-3 h-3 text-base-content opacity-60"></i>
 		</span>
 	} else if e.Type == "review" {
 		<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", txdReviewBg(e.ReviewStatus) } aria-hidden="true">
@@ -524,12 +524,12 @@ templ txdSystemIcon(e service.ActivityEntry) {
 			} else if e.ReviewStatus == "skipped" {
 				<i data-lucide="skip-forward" class="w-3 h-3 text-warning"></i>
 			} else {
-				<i data-lucide="scan-search" class="w-3 h-3 text-base-content/50"></i>
+				<i data-lucide="scan-search" class="w-3 h-3 text-base-content opacity-50"></i>
 			}
 		</span>
 	} else {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
-			<i data-lucide="circle" class="w-3 h-3 text-base-content/40"></i>
+			<i data-lucide="circle" class="w-3 h-3 text-base-content opacity-40"></i>
 		</span>
 	}
 }
@@ -552,11 +552,11 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 		</span>
 	} else if e.CategoryIcon != nil && *e.CategoryIcon != "" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
-			<i data-lucide={ *e.CategoryIcon } class="w-3 h-3 text-base-content/60"></i>
+			<i data-lucide={ *e.CategoryIcon } class="w-3 h-3 text-base-content opacity-60"></i>
 		</span>
 	} else {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
-			<i data-lucide="folder" class="w-3 h-3 text-base-content/50"></i>
+			<i data-lucide="folder" class="w-3 h-3 text-base-content opacity-50"></i>
 		</span>
 	}
 }
@@ -649,7 +649,7 @@ templ txdTimelineComposer(p TransactionDetailProps) {
 templ txdTimelineEmptyComposer(p TransactionDetailProps) {
 	<div class="px-4 sm:px-5 pb-5">
 		<div class="pt-2 pb-5 text-center">
-			<i data-lucide="clock" class="w-5 h-5 text-base-content/20 mx-auto" aria-hidden="true"></i>
+			<i data-lucide="clock" class="w-5 h-5 text-base-content opacity-20 mx-auto" aria-hidden="true"></i>
 			<p class="text-xs text-base-content/40 mt-1.5">No activity yet. Comments, tag changes, and rule hits appear here.</p>
 		</div>
 		<div class="pt-4 border-t border-base-200">
@@ -829,7 +829,7 @@ templ txdInlineCategoryChip(e service.ActivityEntry) {
 			if e.CategoryColor != nil && *e.CategoryColor != "" {
 				<i data-lucide={ *e.CategoryIcon } class="w-3.5 h-3.5 shrink-0" style={ "color: " + *e.CategoryColor }></i>
 			} else {
-				<i data-lucide={ *e.CategoryIcon } class="w-3.5 h-3.5 shrink-0 text-base-content/60"></i>
+				<i data-lucide={ *e.CategoryIcon } class="w-3.5 h-3.5 shrink-0 text-base-content opacity-60"></i>
 			}
 		}
 		<strong class="font-semibold text-base-content break-words">{ e.CategoryName }</strong>

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -296,13 +296,13 @@ templ txFilters(p TransactionsProps) {
 			<div class="border-t border-base-200 pt-4 mb-4" x-data={ txSearchModeInit(p.FilterSearchMode) }>
 				<div class="grid grid-cols-2 sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1">
 					<div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 hidden sm:flex">
-						<i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="search" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						Search
 					</div>
 					<div class="text-[0.65rem] text-base-content/40 hidden sm:block">Search in</div>
 					<div class="text-[0.65rem] text-base-content/40 hidden sm:block">Match type</div>
 					<div class="col-span-2 sm:hidden text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 mb-1">
-						<i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="search" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						Search
 					</div>
 					<input type="text" name="search" value={ p.FilterSearch } placeholder="Search transactions..." class="input input-sm input-bordered w-full col-span-2 sm:col-span-1"/>
@@ -325,7 +325,7 @@ templ txFilters(p TransactionsProps) {
 			<div class="border-t border-base-200 pt-4 mb-4" x-data="tagFilter">
 				<div class="flex items-center justify-between mb-2">
 					<div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2">
-						<i data-lucide="tags" class="w-3.5 h-3.5 text-base-content/40"></i>
+						<i data-lucide="tags" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						Tags
 					</div>
 					<label class="flex items-center gap-1.5 text-[0.65rem] text-base-content/50 cursor-pointer">

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -192,7 +192,7 @@ templ usersMemberCard(u UsersEnrichedRow) {
 			<!-- No accounts state -->
 			<div class="border-t border-base-300 px-4 sm:px-5 py-8 bg-base-200/20 flex-1 flex flex-col items-center justify-center text-center">
 				<div class="w-12 h-12 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
-					<i data-lucide="landmark" class="w-6 h-6 text-base-content/25"></i>
+					<i data-lucide="landmark" class="w-6 h-6 text-base-content opacity-25"></i>
 				</div>
 				<p class="text-sm text-base-content/40 mb-3">No bank accounts connected</p>
 				<a href="/connections/new" class="btn btn-ghost btn-sm rounded-xl">
@@ -218,15 +218,15 @@ templ usersAccountRow(a UsersAccountRow) {
 		<div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0 hidden sm:flex">
 			switch a.Type {
 				case "depository":
-					<i data-lucide="landmark" class="w-3.5 h-3.5 text-base-content/40"></i>
+					<i data-lucide="landmark" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 				case "credit":
-					<i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content/40"></i>
+					<i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 				case "loan":
-					<i data-lucide="banknote" class="w-3.5 h-3.5 text-base-content/40"></i>
+					<i data-lucide="banknote" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 				case "investment":
-					<i data-lucide="trending-up" class="w-3.5 h-3.5 text-base-content/40"></i>
+					<i data-lucide="trending-up" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 				default:
-					<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/40"></i>
+					<i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 			}
 		</div>
 		<div class="flex-1 min-w-0">

--- a/internal/templates/components/section_header.templ
+++ b/internal/templates/components/section_header.templ
@@ -31,7 +31,7 @@ type SectionHeaderProps struct {
 templ SectionHeader(p SectionHeaderProps) {
 	<header class="flex items-center gap-2 mb-3">
 		if p.Icon != "" {
-			<i data-lucide={ p.Icon } class="w-4 h-4 text-base-content/60 shrink-0"></i>
+			<i data-lucide={ p.Icon } class="w-4 h-4 text-base-content opacity-60 shrink-0"></i>
 		}
 		<h2 class="text-sm font-semibold">{ p.Title }</h2>
 		if p.Count != nil {

--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -72,7 +72,7 @@ func statTileIcon(t StatTileTone) string {
 	case StatToneInfo:
 		return "text-info"
 	default:
-		return "text-base-content/40"
+		return "text-base-content opacity-40"
 	}
 }
 

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -108,7 +108,7 @@ templ timelineCard(p TimelineProps) {
 		if p.Heading != "" {
 			<header class="px-4 sm:px-5 pt-5 pb-4 flex items-center gap-2">
 				if p.HeadingIcon != "" {
-					<i data-lucide={ p.HeadingIcon } class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>
+					<i data-lucide={ p.HeadingIcon } class="w-4 h-4 text-base-content opacity-40" aria-hidden="true"></i>
 				}
 				<h2 id={ timelineHeadingID(p.Heading) } class="text-sm font-semibold text-base-content/60">{ p.Heading }</h2>
 				if p.EventCount > 0 {
@@ -155,7 +155,7 @@ templ timelineProminent(p TimelineProps) {
 		if p.Heading != "" {
 			<header class="flex items-center gap-2.5 pb-4 mb-5 border-b border-base-300">
 				if p.HeadingIcon != "" {
-					<i data-lucide={ p.HeadingIcon } class="w-5 h-5 text-base-content/70" aria-hidden="true"></i>
+					<i data-lucide={ p.HeadingIcon } class="w-5 h-5 text-base-content opacity-70" aria-hidden="true"></i>
 				}
 				<h2 id={ timelineHeadingID(p.Heading) } class="text-lg font-semibold text-base-content tracking-tight">{ p.Heading }</h2>
 				if p.EventCount > 0 {
@@ -322,7 +322,7 @@ templ TimelineCommentRowRaw(avatar templ.Component, attrs templ.Attributes) {
 // the divider; this primitive renders only the icon + message.
 templ TimelineEmpty(message string) {
 	<div class="text-center">
-		<i data-lucide="clock" class="w-5 h-5 text-base-content/20 mx-auto" aria-hidden="true"></i>
+		<i data-lucide="clock" class="w-5 h-5 text-base-content opacity-20 mx-auto" aria-hidden="true"></i>
 		<p class="text-xs text-base-content/40 mt-1.5">{ message }</p>
 	</div>
 }
@@ -355,7 +355,7 @@ templ timelineCommentAvatar(actor TimelineActor) {
 // background. The card variant keeps base-100 verbatim.
 templ TimelineCommentTile() {
 	<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
-		<i data-lucide="message-square" class="w-3 h-3 text-base-content/55"></i>
+		<i data-lucide="message-square" class="w-3 h-3 text-base-content opacity-55"></i>
 	</span>
 }
 

--- a/internal/templates/components/timeline_helpers.go
+++ b/internal/templates/components/timeline_helpers.go
@@ -73,7 +73,7 @@ func timelineIconColor(tone string) string {
 	case "error":
 		return "text-error"
 	default:
-		return "text-base-content/40"
+		return "text-base-content opacity-40"
 	}
 }
 

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -218,7 +218,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 				if tx.Pending {
 					<i
 						data-lucide="clock"
-						class="w-3 h-3 shrink-0 text-warning/70"
+						class="w-3 h-3 shrink-0 text-warning opacity-70"
 						title="Pending — not yet posted"
 					></i>
 					<span class="sr-only">(pending)</span>

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -78,7 +78,7 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 				if tx.Pending {
 					<i
 						data-lucide="clock"
-						class="w-3 h-3 shrink-0 text-warning/70"
+						class="w-3 h-3 shrink-0 text-warning opacity-70"
 						title="Pending — not yet posted"
 					></i>
 					<span class="sr-only">(pending)</span>

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -80,7 +80,7 @@ templ TxRowFeed(p TxRowFeedProps) {
 		}
 		<!-- Pending mark, kept inline so the row height stays stable. -->
 		if p.Pending {
-			<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning/70" title="Pending — not yet posted"></i>
+			<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning opacity-70" title="Pending — not yet posted"></i>
 			<span class="sr-only">(pending)</span>
 		}
 		<!-- Amount: leading sign so income (negative in our convention)


### PR DESCRIPTION
## Summary
- Long-standing visual bug across the admin UI: Lucide icons rendered overlapping strokes as visibly darker pixels at intersections — the curl-arrows on `repeat-*`, the stem of `circle-dollar-sign`, the check mark on `shield-check`, etc.
- Root cause: every Lucide icon is multiple `<path>` siblings sharing `stroke="currentColor"`. Tailwind v4's `text-COLOR/NN` syntax bakes alpha into `currentColor`, so each path strokes independently at that alpha — overlapping strokes stack into darker pixels (`α + (1−α)·α` per overlap).
- Fix has two parts so the bug can never silently come back:
  1. **CSS safety net** in `input.css`: `svg.lucide { color: rgb(from currentColor r g b) }` strips alpha from `currentColor` at the SVG. Any future call site that uses `text-COLOR/NN` on a Lucide icon will simply lose the dimming (intentional inert) — strokes can never stack again.
  2. **Codemod**: rewrote 145 literal class lists across 37 templ/html files plus 4 Go helper return values from `text-COLOR/NN` → `text-COLOR opacity-NN`. Opacity-on-the-SVG composites the icon as a single layer before applying transparency, so dimming is preserved without per-stroke alpha. Visually equivalent against any backdrop.

## Before / after
The top row is what the bug looks like (force-disabled safety net to simulate the old behavior). Notice the darker pixels at every stroke intersection — most obvious on the dollar sign's stem crossing the S, the shield-check vertex, and the repeat icon's arrowheads. Middle row is the new convention (`opacity-NN`). Bottom row demonstrates the safety net catching a missed call site.

<img src="https://i.img402.dev/sxpxjf1b7l.jpg" width="900" alt="lucide icons before and after fix">

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (updated `TestFeedTxRefRowPendingPill` to match the new class form)
- [x] `make css` — verified `svg.lucide{color:rgb(from currentColor r g b)}` lands in `static/css/styles.css`
- [x] Headless render of the actual built CSS bundle + lucide.min.js (the image above)
- [ ] Spot-check a few live admin pages after merge (timeline, settings tabs, connection-detail account icons, log error icons) to confirm dimming is preserved
