### PR TITLE
fix(ui): make Lucide alpha-strip safety net actually strip alpha

### DIFF
--- a/input.css
+++ b/input.css
@@ -45,8 +45,15 @@
    * before applying transparency. `text-COLOR/NN` on Lucide icons is treated
    * the same as `text-COLOR` here — call sites that wanted dimming should
    * use `opacity-NN`.
+   *
+   * The explicit `/ 1` matters: in CSS relative color syntax, an omitted
+   * alpha defaults to the *origin* color's alpha (not 100%), so
+   * `rgb(from currentColor r g b)` alone passes the parent's alpha straight
+   * through — making this rule a no-op whenever the parent sets
+   * `text-COLOR/NN` (e.g. the sidebar's `.bb-sidebar-link`
+   * `text-base-content/60`). `/ 1` forces opaque output.
    */
-  svg.lucide { color: rgb(from currentColor r g b); }
+  svg.lucide { color: rgb(from currentColor r g b / 1); }
 
   /*
    * Pre-hydration size for Lucide placeholders.


### PR DESCRIPTION
## Summary

PR #1437 shipped a defense-in-depth rule meant to keep Lucide stroke overlaps from stacking into darker pixels whenever the inherited `currentColor` carries alpha:

```css
svg.lucide { color: rgb(from currentColor r g b); }
```

The rule is a no-op as written. In [CSS relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors), an omitted alpha **defaults to the origin color's alpha — not 100%**. When `.bb-sidebar-link { text-base-content/60 }` passes a 0.6-alpha `currentColor` down to the SVG, the rule extracts `r g b` from it and reassembles the exact same `r g b / 0.6` it received. Every `<path stroke="currentColor">` then strokes at α=0.6, and intersections stack — which is exactly what the user reported on the sidebar after #1437 landed.

The fix is a single character: `/ 1` forces the result opaque.

```css
svg.lucide { color: rgb(from currentColor r g b / 1); }
```

The codemod in #1437 already converted every direct `text-COLOR/NN` on a Lucide icon to `text-COLOR opacity-NN`, so the only remaining alpha-leak path is *parent → icon via `currentColor`*. That's the sidebar's chain (link uses `text-base-content/60`; icon uses `opacity-50`). With this fix the SVG composites at the icon's own `opacity: 0.5` cleanly — no stroke stacking, dimming preserved.

## Verification

Computed style on the Transactions sidebar icon's path:

| | `color` | `stroke` |
|---|---|---|
| Before | `color(srgb 0.094 0.094 0.106 / 0.6)` | `color(srgb 0.094 0.094 0.106 / 0.6)` |
| After  | `color(srgb 0.094 0.094 0.106)`         | `color(srgb 0.094 0.094 0.106)`         |

Sidebar render — most visible on Connections (link), Rules (zap), Logs (scroll-text), and Transactions (receipt):

<table>
  <tr><th>Before (PR #1437 only)</th><th>After (this PR)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/6qig3s4642.jpg" width="380" alt="sidebar before"></td>
    <td><img src="https://i.img402.dev/h3ri4tnc5e.jpg" width="380" alt="sidebar after"></td>
  </tr>
</table>

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `make css` — verified `svg.lucide{color:rgb(from currentColor r g b / 1)}` lands in `static/css/styles.css`
- [x] Validated on a live `breadbox serve` (sidebar icons no longer show stroke-intersection darkening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)