### PR TITLE
fix(design): sandbox outline + anchors clear the standalone navbar

### DIFF
--- a/input.css
+++ b/input.css
@@ -784,28 +784,6 @@
     @apply text-xl font-semibold tracking-tight;
   }
 
-  /* ── Standalone shell (e.g. /design sandbox) ──
-     Slim top bar that replaces the sidebar when the page is hosted in
-     standalone mode (base.html .Standalone branch). Keeps the chrome
-     minimal so reviewers focus on the component under test. */
-  /* Opaque solid background — no /85 + backdrop-blur, otherwise the
-     modal dim looks like it undims the bar at a different rate than
-     the rest of the page (the bar reveals partially-blurred content
-     behind it as the dim fades). */
-  .bb-standalone-bar {
-    @apply sticky top-0 z-30
-           flex items-center justify-between gap-3
-           px-4 sm:px-6 h-12
-           bg-base-100
-           border-b border-base-300;
-  }
-
-  .bb-standalone-brand {
-    @apply inline-flex items-center gap-2
-           text-sm font-semibold text-base-content
-           no-underline hover:text-primary transition-colors;
-  }
-
   /* ── Wizard / Auth pages (login, setup, error) ── */
   .bb-wizard-bg {
     /* Mobile: top-aligned with generous top padding so content isn't dead-center

--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -13,17 +13,19 @@ package pages
 templ DesignGallery(p DesignGalleryProps) {
 	<div class="grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-6">
 		<aside class="hidden lg:block">
-			// `h-[calc(100vh-3rem)]` (not max-h) pins the nav to viewport
-			// height so it always has a defined scroll context. `top-6`
-			// matches the 3rem offset so the nav sits exactly between the
-			// top of the visible viewport and the bottom edge.
+			// Offsets account for the sticky standalone navbar above (daisy
+			// `navbar` ≈ 4rem). `top-[5.5rem]` = navbar (4rem) + 1.5rem gap
+			// so the outline sits just below the bar. `h-[calc(100vh-7rem)]`
+			// (not max-h) pins it to viewport height with the same 1.5rem
+			// gap mirrored at the bottom, giving a defined scroll context
+			// even when the catalog overflows.
 			<nav
 				x-data="{
 				  allOpen: true,
 				  inputs() { return Array.from(this.$root.querySelectorAll('input[type=checkbox][name^=design-nav-]')); },
 				  toggleAll() { this.allOpen = !this.allOpen; this.inputs().forEach(i => { i.checked = this.allOpen; }); },
 				}"
-				class="sticky top-6 flex flex-col gap-1 h-[calc(100vh-3rem)] overflow-y-auto pr-1 -mr-1"
+				class="sticky top-[5.5rem] flex flex-col gap-1 h-[calc(100vh-7rem)] overflow-y-auto pr-1 -mr-1"
 			>
 				<div class="flex items-center justify-between px-2 pb-1 -mb-1">
 					<span class="text-[0.65rem] font-semibold uppercase tracking-wider text-base-content/30">Catalog</span>
@@ -90,7 +92,7 @@ templ designSidebarGroup(group DesignSectionGroup, sections []DesignSection) {
 // (e.g. /design#group-feedback).
 templ designSectionGroupBlock(group DesignSectionGroup, sections []DesignSection) {
 	if len(sections) > 0 {
-		<section id={ "group-" + group.Slug } class="scroll-mt-6">
+		<section id={ "group-" + group.Slug } class="scroll-mt-[5.5rem]">
 			<header class="mb-6 pb-2 border-b border-base-300/60">
 				<h2 class="text-xs font-semibold uppercase tracking-wider text-base-content/50">{ group.Label }</h2>
 			</header>
@@ -112,7 +114,7 @@ templ designSectionGroupBlock(group DesignSectionGroup, sections []DesignSection
 // of mb-6 = 24px + card padding-top of 24px = 48px to first inner
 // content). H3 → description is mb-1 so they read as a tight pair.
 templ designSectionBlock(sec DesignSection) {
-	<section id={ sec.Slug } class="scroll-mt-6">
+	<section id={ sec.Slug } class="scroll-mt-[5.5rem]">
 		<div class="flex items-baseline justify-between gap-3 mb-1">
 			<h3 class="text-lg font-semibold tracking-tight">{ sec.Title }</h3>
 			<a href={ templ.SafeURL("/design/c/" + sec.Slug) } class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1">

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -241,18 +241,26 @@
         body still gets all the global head + footer scripts (Alpine, Lucide,
         cmdk, shortcuts) so x-data interactivity continues to work. */ -}}
   <div class="bg-base-200 min-h-screen">
-    <!-- Slim top bar with brand + theme toggle + back-to-app link.
+    <!-- Top bar with brand + theme toggle + back-to-app link, built on
+         the native daisy `navbar` component. Sticky so it stays in view
+         while the gallery scrolls; the design gallery's anchor links
+         and sticky outline both offset for this bar's height.
          The theme toggle is short-lived: it writes data-theme to <html>
          per click but never persists. Page reload drops the attribute
          and the sandbox returns to system theme via prefers-color-scheme. -->
-    <div class="bb-standalone-bar">
-      <a href="/design" class="bb-standalone-brand">
-        <i data-lucide="palette" class="w-4 h-4"></i>
-        <span>Breadbox <span class="text-base-content/40">·</span> Design system</span>
-      </a>
-      <div class="flex items-center gap-1">
+    <div class="navbar bg-base-100 border-b border-base-300 sticky top-0 z-30 px-4 sm:px-6">
+      <div class="navbar-start">
+        <a
+          href="/design"
+          class="inline-flex items-center gap-2 text-sm font-semibold text-base-content no-underline hover:text-primary transition-colors"
+        >
+          <i data-lucide="palette" class="w-4 h-4"></i>
+          <span>Breadbox <span class="text-base-content/40">·</span> Design system</span>
+        </a>
+      </div>
+      <div class="navbar-end gap-1">
         <label
-          class="swap swap-rotate btn btn-ghost btn-xs btn-square rounded-lg text-base-content/60"
+          class="swap swap-rotate btn btn-ghost btn-sm btn-square rounded-lg text-base-content/60"
           title="Toggle theme (resets on reload)"
         >
           <input
@@ -266,7 +274,7 @@
           <i data-lucide="sun" class="swap-off w-4 h-4"></i>
           <i data-lucide="moon" class="swap-on w-4 h-4"></i>
         </label>
-        <a href="/" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/60">
+        <a href="/" class="btn btn-ghost btn-sm rounded-lg gap-1.5 text-base-content/60">
           <i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
           Back to app
         </a>


### PR DESCRIPTION
## Summary

The `/design` sandbox sticky outline and section anchors did not account for the standalone top bar — the outline's top edge slid under the bar on scroll, and clicking a sidebar link or deep-linking to `#section` landed the heading behind it. The bar itself was a custom `.bb-standalone-bar` (h-12 hand-rolled flex row); that's now the native daisy `navbar` component, and the gallery offsets are re-derived from its height.

- **base.html** — `.bb-standalone-bar` → `navbar bg-base-100 border-b border-base-300 sticky top-0 z-30 ...` with `navbar-start` / `navbar-end`. Theme toggle + back-to-app bumped `btn-xs` → `btn-sm` so they pair visually with the taller daisy navbar.
- **design_gallery.templ** — sidebar nav: `top-6` → `top-[5.5rem]` (4rem navbar + 1.5rem gap), `h-[calc(100vh-3rem)]` → `h-[calc(100vh-7rem)]` (gap mirrored at bottom); section anchors: `scroll-mt-6` → `scroll-mt-[5.5rem]` so headings land just below the bar on jump.
- **input.css** — drop the unused `.bb-standalone-bar` / `.bb-standalone-brand` rules.

## Screenshots

<table>
  <tr>
    <th>Top of page</th>
    <th>Scrolled (outline pinned below bar)</th>
  </tr>
  <tr>
    <td><img src="https://i.img402.dev/qztyb9qwyk.jpg" width="420" alt="design sandbox — top"></td>
    <td><img src="https://i.img402.dev/b9u8o2j0r2.jpg" width="420" alt="design sandbox — scrolled"></td>
  </tr>
  <tr>
    <th>Deep-link to <code>#buttons</code> (heading clears the bar)</th>
    <th>Mobile</th>
  </tr>
  <tr>
    <td><img src="https://i.img402.dev/rc2lo9tzr8.jpg" width="420" alt="design sandbox — deep-link to buttons"></td>
    <td><img src="https://i.img402.dev/qgvw4basz6.jpg" width="220" alt="design sandbox — mobile"></td>
  </tr>
</table>

Diagnostics from a headless Chromium pass against the running server confirm the math:

```
navbar height 64px, top 0, position sticky, z-index 30
aside  top 88px (= 5.5rem), height 688px (= 800 - 88 - 24)
#buttons scroll-margin-top 88px
```

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/templates/...` passes
- [x] Validated `/design` at 1280×800 and 390×844 — navbar stays at top, outline sits below it, scroll anchors land headings clear of the bar
- [x] Validated `/design/c/buttons` (standalone component view) — navbar + content render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
