### PR TITLE
feat(design): canonical Amount component + consolidate 23 call sites

### DIFF
--- a/input.css
+++ b/input.css
@@ -1087,25 +1087,15 @@
     @apply text-[0.5rem] font-semibold leading-none;
   }
 
-  /* ── Transaction amount styling ── */
-  .bb-tx-amount {
-    @apply text-sm font-semibold tabular-nums text-base-content;
-  }
-
-  .bb-tx-amount--income {
-    color: oklch(0.62 0.14 155);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-tx-amount--income {
-      color: oklch(0.70 0.14 155);
-    }
-  }
-
-  /* Pending transactions: the amount is provisional, so we soften it (dimmed
-     glyph + leading clock icon via the row template) instead of tacking a
-     warning chip onto the name line where it competes with tag pills.
-     No italic / no underline — just a quieter number. */
+  /* ── Transaction amount pending modifier ──
+     Pending transactions are provisional, so we soften the amount glyph
+     (dimmed + leading clock icon at the call site) instead of tacking a
+     warning chip onto the name line. No italic / no underline — just a
+     quieter number. Applied by components.Amount when Pending: true.
+     The sibling --income tone (success green for negative values) and
+     the base .bb-tx-amount typography rule were retired with the
+     components.Amount migration — sign + color now flow through the
+     component's tabular-nums + text-success classes instead. */
   .bb-tx-amount--pending {
     opacity: 0.55;
   }

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -857,10 +857,10 @@ func buildConnectionDetailProps(in connectionDetailInput) pages.ConnectionDetail
 			Excluded:            a.Excluded,
 		}
 		if a.BalanceCurrent.Valid {
-			row.BalanceCurrentText = formatNumericAbsCurrency(a.BalanceCurrent)
+			row.BalanceCurrentAbs = numericAbsFloat(a.BalanceCurrent)
 		}
 		if a.BalanceAvailable.Valid {
-			row.BalanceAvailableText = formatNumericAbsCurrency(a.BalanceAvailable)
+			row.BalanceAvailableAbs = numericAbsFloat(a.BalanceAvailable)
 		}
 		props.Accounts = append(props.Accounts, row)
 	}
@@ -906,18 +906,20 @@ type connectionDaySync struct {
 	Total      int
 }
 
-// formatNumericAbsCurrency formats a NUMERIC balance as |amount| currency,
-// matching the funcMap "formatNumeric" helper that the old template used
-// for both BalanceCurrent and BalanceAvailable.
-func formatNumericAbsCurrency(n pgtype.Numeric) string {
+// numericAbsFloat returns |amount| as a float64 for templates that pass
+// the value through components.Amount (Intent: AmountCost). Returns 0
+// when the NUMERIC is invalid — the caller must gate on the matching
+// BalanceCurrent.Valid / BalanceAvailable.Valid flag, mirroring the
+// original behavior of returning "" from formatNumericAbsCurrency.
+func numericAbsFloat(n pgtype.Numeric) float64 {
 	f, ok := pgconv.NumericToFloat(n)
 	if !ok {
-		return ""
+		return 0
 	}
 	if f < 0 {
 		f = -f
 	}
-	return service.FormatCurrency(f)
+	return f
 }
 
 // ConnectionReauthHandler serves GET /admin/connections/{id}/reauth.

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -844,23 +844,29 @@ func buildConnectionDetailProps(in connectionDetailInput) pages.ConnectionDetail
 
 	for _, a := range in.Accounts {
 		row := pages.AccountRow{
-			ID:                  pgconv.FormatUUID(a.ID),
-			Name:                a.Name,
-			Type:                a.Type,
-			SubtypeValid:        a.Subtype.Valid,
-			SubtypeString:       a.Subtype.String,
-			MaskValid:           a.Mask.Valid,
-			MaskString:          a.Mask.String,
-			BalanceCurrentValid: a.BalanceCurrent.Valid,
-			BalanceAvailableValid: a.BalanceAvailable.Valid,
-			DisplayName:         a.DisplayName.String,
-			Excluded:            a.Excluded,
+			ID:            pgconv.FormatUUID(a.ID),
+			Name:          a.Name,
+			Type:          a.Type,
+			SubtypeValid:  a.Subtype.Valid,
+			SubtypeString: a.Subtype.String,
+			MaskValid:     a.Mask.Valid,
+			MaskString:    a.Mask.String,
+			DisplayName:   a.DisplayName.String,
+			Excluded:      a.Excluded,
 		}
-		if a.BalanceCurrent.Valid {
-			row.BalanceCurrentAbs = numericAbsFloat(a.BalanceCurrent)
+		// Set the Valid flags based on numericAbsFloat's ok return — a
+		// Numeric can be pgtype-Valid yet still fail conversion (NaN,
+		// out-of-range). Gating on .Valid alone would surface a
+		// fabricated "$0.00" on the connection-detail card; the templ
+		// renders the "No balance data" fallback when these flags are
+		// false.
+		if v, ok := numericAbsFloat(a.BalanceCurrent); ok {
+			row.BalanceCurrentValid = true
+			row.BalanceCurrentAbs = v
 		}
-		if a.BalanceAvailable.Valid {
-			row.BalanceAvailableAbs = numericAbsFloat(a.BalanceAvailable)
+		if v, ok := numericAbsFloat(a.BalanceAvailable); ok {
+			row.BalanceAvailableValid = true
+			row.BalanceAvailableAbs = v
 		}
 		props.Accounts = append(props.Accounts, row)
 	}
@@ -907,19 +913,20 @@ type connectionDaySync struct {
 }
 
 // numericAbsFloat returns |amount| as a float64 for templates that pass
-// the value through components.Amount (Intent: AmountCost). Returns 0
-// when the NUMERIC is invalid — the caller must gate on the matching
-// BalanceCurrent.Valid / BalanceAvailable.Valid flag, mirroring the
-// original behavior of returning "" from formatNumericAbsCurrency.
-func numericAbsFloat(n pgtype.Numeric) float64 {
+// the value through components.Amount (Intent: AmountCost). The second
+// return mirrors pgconv.NumericToFloat — false for NaN, infinity,
+// out-of-range, or an invalid Numeric. Callers should treat !ok as
+// "no balance" and skip the Amount render entirely, so a corrupt or
+// missing value never surfaces as a fabricated "$0.00".
+func numericAbsFloat(n pgtype.Numeric) (float64, bool) {
 	f, ok := pgconv.NumericToFloat(n)
 	if !ok {
-		return 0
+		return 0, false
 	}
 	if f < 0 {
 		f = -f
 	}
-	return f
+	return f, true
 }
 
 // ConnectionReauthHandler serves GET /admin/connections/{id}/reauth.

--- a/internal/admin/transactions_filter_chips.go
+++ b/internal/admin/transactions_filter_chips.go
@@ -223,6 +223,10 @@ func lookupTagLabel(tags []service.TagResponse, slug string) string {
 // "$12.34" otherwise. Defers to the canonical components.AmountText with
 // the compact format so chip rendering stays in lock-step with the
 // design-system sandbox; on parse failure we echo the raw input.
+//
+// Uses AmountBalance, not AmountCost, so a min/max filter with a
+// negative value (e.g. ?min_amount=-100) renders the leading "-" — the
+// chip must reflect what the user actually filtered on.
 func formatAmountForChip(raw string) string {
 	v, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
@@ -230,7 +234,7 @@ func formatAmountForChip(raw string) string {
 	}
 	return components.AmountText(components.AmountProps{
 		Value:  v,
-		Intent: components.AmountCost,
+		Intent: components.AmountBalance,
 		Format: components.AmountFormatCompact,
 	})
 }

--- a/internal/admin/transactions_filter_chips.go
+++ b/internal/admin/transactions_filter_chips.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"breadbox/internal/service"
+	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 )
 
@@ -219,15 +220,17 @@ func lookupTagLabel(tags []service.TagResponse, slug string) string {
 }
 
 // formatAmountForChip renders a compact amount label — "$50" if whole,
-// "$12.34" otherwise. The incoming string is already a user-supplied
-// decimal so a single ParseFloat is enough; on failure we echo the raw.
+// "$12.34" otherwise. Defers to the canonical components.AmountText with
+// the compact format so chip rendering stays in lock-step with the
+// design-system sandbox; on parse failure we echo the raw input.
 func formatAmountForChip(raw string) string {
 	v, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
 		return raw
 	}
-	if v == float64(int64(v)) {
-		return "$" + strconv.FormatInt(int64(v), 10)
-	}
-	return "$" + strconv.FormatFloat(v, 'f', 2, 64)
+	return components.AmountText(components.AmountProps{
+		Value:  v,
+		Intent: components.AmountCost,
+		Format: components.AmountFormatCompact,
+	})
 }

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -237,7 +237,7 @@ func buildUsersProps(in usersListInput) pages.UsersProps {
 				Mask:             a.Mask,
 				HasMask:          a.Mask != "",
 				InstitutionName:  a.InstitutionName,
-				BalanceDisplay:   components.FormatAmount(a.BalanceCurrent),
+				BalanceValue:     a.BalanceCurrent,
 				IsoCurrencyCode:  a.IsoCurrencyCode,
 				IsLiability:      a.IsLiability,
 				HasBalance:       a.HasBalance,

--- a/internal/templates/components/amount.go
+++ b/internal/templates/components/amount.go
@@ -34,6 +34,18 @@ const (
 )
 
 // AmountProps configures the canonical Amount component.
+//
+// Class must be a literal class-list (sizes, weights, opacity, layout
+// utilities). Never pass user-derived strings — the value is
+// concatenated unescaped into the rendered class attribute.
+//
+// Tailwind v4 picks the winner on equal-specificity collisions by
+// source order in the compiled stylesheet, not by class-attribute
+// order. Passing a text-{color} utility in Class on a transaction
+// intent (which already emits text-success for income) is therefore
+// undefined — to override the intent color, use the `!` important
+// modifier (e.g. "!text-success/70") or pick an intent that doesn't
+// emit a color (AmountBalance / AmountCost).
 type AmountProps struct {
 	Value     float64
 	Intent    AmountIntent // default AmountTransaction
@@ -149,6 +161,11 @@ func compactCurrency(abs float64) string {
 // commaInt64 inserts thousand-separator commas in a non-negative int64.
 // Defers to CommaInt for values ≥ 1000 so all comma logic lives in one
 // place (helpers.go).
+//
+// Negative input is silently truncated to its magnitude (CommaInt walks
+// digits left-to-right and ignores the sign byte). All current callers
+// Abs the value before passing — keep that invariant for any new
+// caller, or add sign handling upstream.
 func commaInt64(n int64) string {
 	if n < 1000 {
 		return fmt.Sprintf("%d", n)

--- a/internal/templates/components/amount.go
+++ b/internal/templates/components/amount.go
@@ -1,0 +1,157 @@
+//go:build !headless && !lite
+
+package components
+
+import (
+	"fmt"
+	"math"
+)
+
+// AmountIntent picks the sign + color treatment. See Amount for the
+// full doc.
+type AmountIntent string
+
+const (
+	// AmountTransaction is the default. Negative = income (+, green);
+	// positive/zero = expense (no sign, default color).
+	AmountTransaction AmountIntent = ""
+	// AmountBalance preserves the original sign; no color treatment.
+	AmountBalance AmountIntent = "balance"
+	// AmountCost renders the absolute value with no sign or color.
+	AmountCost AmountIntent = "cost"
+)
+
+// AmountFormat picks the display precision. See Amount for the full doc.
+type AmountFormat string
+
+const (
+	// AmountFormatStandard renders "$1,234.56".
+	AmountFormatStandard AmountFormat = ""
+	// AmountFormatAbbreviated renders "$1.2M" at ≥ $1M, otherwise standard.
+	AmountFormatAbbreviated AmountFormat = "abbreviated"
+	// AmountFormatCompact renders "$50" for whole, "$12.34" otherwise.
+	AmountFormatCompact AmountFormat = "compact"
+)
+
+// AmountProps configures the canonical Amount component.
+type AmountProps struct {
+	Value     float64
+	Intent    AmountIntent // default AmountTransaction
+	Format    AmountFormat // default AmountFormatStandard
+	Precision int          // decimals for AmountCost; ignored for other intents (defaults to 2)
+	Pending   bool
+	Class     string
+}
+
+// amountClasses returns the space-separated class list for an Amount
+// span. Always includes tabular-nums; adds text-success for the
+// transaction intent when the value is negative (income); adds the
+// pending opacity modifier when Pending is set; appends caller-provided
+// Class last so it can override sizing/weight but not the core classes.
+func amountClasses(p AmountProps) string {
+	cls := "tabular-nums"
+	if (p.Intent == AmountTransaction || p.Intent == "") && p.Value < 0 {
+		cls += " text-success"
+	}
+	if p.Pending {
+		cls += " bb-tx-amount--pending"
+	}
+	if p.Class != "" {
+		cls += " " + p.Class
+	}
+	return cls
+}
+
+// AmountText returns the formatted text for an Amount, exported so the
+// few non-templ render paths (e.g. command-palette JSON, MCP previews
+// over time) can call the same formatter without rendering markup.
+//
+// Sign rules:
+//   - AmountTransaction (default): negative → "+$X" (income), else "$X".
+//   - AmountBalance: signed — "-$X" for negative, "$X" otherwise.
+//   - AmountCost: absolute — "$X" regardless of sign.
+func AmountText(p AmountProps) string {
+	abs := math.Abs(p.Value)
+	formatted := amountFormatAbs(abs, p.Format, p.Precision)
+	switch p.Intent {
+	case AmountBalance:
+		if p.Value < 0 {
+			return "-" + formatted
+		}
+		return formatted
+	case AmountCost:
+		return formatted
+	default: // AmountTransaction
+		if p.Value < 0 {
+			return "+" + formatted
+		}
+		return formatted
+	}
+}
+
+// amountFormatAbs formats a non-negative value per the requested
+// AmountFormat. precision is honored only for AmountFormatStandard; the
+// abbreviated and compact shapes carry their own fixed precision.
+func amountFormatAbs(abs float64, format AmountFormat, precision int) string {
+	switch format {
+	case AmountFormatAbbreviated:
+		if abs >= 1_000_000 {
+			return fmt.Sprintf("$%.1fM", abs/1_000_000)
+		}
+		return standardCurrency(abs, 2)
+	case AmountFormatCompact:
+		return compactCurrency(abs)
+	default:
+		decimals := precision
+		if decimals <= 0 {
+			decimals = 2
+		}
+		return standardCurrency(abs, decimals)
+	}
+}
+
+// standardCurrency renders "$1,234.56" with thousand-separator commas
+// and the requested decimal precision. Shares rounding behavior with
+// service.FormatCurrency for the 2-decimal case so payloads stay
+// bit-identical with existing call sites.
+func standardCurrency(abs float64, decimals int) string {
+	if decimals == 2 {
+		whole := int64(abs)
+		cents := int(math.Round((abs - float64(whole)) * 100))
+		if cents >= 100 {
+			whole += int64(cents / 100)
+			cents %= 100
+		}
+		return fmt.Sprintf("$%s.%02d", commaInt64(whole), cents)
+	}
+	scale := math.Pow(10, float64(decimals))
+	rounded := math.Round(abs*scale) / scale
+	whole := int64(rounded)
+	frac := rounded - float64(whole)
+	fracInt := int64(math.Round(frac * scale))
+	if fracInt >= int64(scale) {
+		whole += fracInt / int64(scale)
+		fracInt %= int64(scale)
+	}
+	return fmt.Sprintf("$%s.%0*d", commaInt64(whole), decimals, fracInt)
+}
+
+// compactCurrency renders "$50" when whole, else "$12.34".
+func compactCurrency(abs float64) string {
+	rounded := math.Round(abs*100) / 100
+	whole := math.Trunc(rounded)
+	if rounded == whole {
+		return "$" + commaInt64(int64(whole))
+	}
+	return standardCurrency(abs, 2)
+}
+
+// commaInt64 inserts thousand-separator commas in a non-negative int64.
+// Defers to CommaInt for values ≥ 1000 so all comma logic lives in one
+// place (helpers.go).
+func commaInt64(n int64) string {
+	if n < 1000 {
+		return fmt.Sprintf("%d", n)
+	}
+	return CommaInt(n)
+}

--- a/internal/templates/components/amount.templ
+++ b/internal/templates/components/amount.templ
@@ -1,0 +1,63 @@
+package components
+
+// Amount is the canonical renderer for any monetary value in the admin UI.
+//
+// Consolidates: bb-tx-amount markup in tx_row / tx_row_compact,
+// TxRowFeedAmountWithSign in tx_row_feed, dayTotalBadge in tx_results,
+// and the ad-hoc Sprintf("$%.2f", ...) / Sprintf("$%.4f", ...) sites
+// in agents_list, agent_runs, and the connections summary bar.
+//
+// Three intents drive sign + color; pick by what the value MEANS:
+//
+//   - AmountTransaction — a credit/debit pair entry where the value is
+//     stored in breadbox sign convention (negative = income / inflow,
+//     positive = expense / outflow). Renders income as "+$X" in success
+//     green; expense as "$X" with NO sign in the page's default text
+//     color. Use for transaction rows, day totals, transaction detail,
+//     activity feed.
+//
+//   - AmountBalance — a standing balance where the sign reflects the
+//     real direction of the value (negative = liability / debt). Renders
+//     as-is: "$1,234.56" or "-$1,234.56". Default text color; the
+//     caller can wrap in a `text-success`/`text-error` span when context
+//     (assets, liabilities) demands it.
+//
+//   - AmountCost — an always-non-negative value (agent run cost, fees,
+//     monthly spending total). Renders the absolute value, no sign, no
+//     color treatment. Use Precision to pick decimal places.
+//
+// Format covers the three display shapes we use across the app:
+//
+//   - "" (default) — "$1,234.56" with comma-thousands and two decimals.
+//   - "abbreviated" — "$1.2M" for values ≥ $1M, else default. For big
+//     dashboard tiles where the exact cent doesn't matter.
+//   - "compact" — "$50" for whole values, "$12.34" otherwise. For
+//     filter chips and other tight contexts.
+//
+// Pending applies the same opacity dimming used by bb-tx-amount--pending
+// today — softens the glyph for transactions that haven't posted yet.
+//
+// Class is appended to the rendered <span> for size/weight overrides
+// (e.g. "text-3xl font-semibold" on the transaction detail hero, or
+// "text-sm font-medium" inside the activity feed). Tabular-nums is
+// always applied — never override that.
+//
+// Usage:
+//
+//	@components.Amount(components.AmountProps{Value: tx.Amount})                // transaction row
+//	@components.Amount(components.AmountProps{Value: tx.Amount, Pending: true}) // pending
+//	@components.Amount(components.AmountProps{
+//	    Value: account.Balance, Intent: components.AmountBalance,
+//	})
+//	@components.Amount(components.AmountProps{
+//	    Value: cost, Intent: components.AmountCost, Precision: 4,
+//	})
+//	@components.Amount(components.AmountProps{
+//	    Value: netWorth, Intent: components.AmountBalance,
+//	    Format: components.AmountFormatAbbreviated,
+//	    Class:  "text-2xl font-semibold",
+//	})
+
+templ Amount(p AmountProps) {
+	<span class={ amountClasses(p) }>{ AmountText(p) }</span>
+}

--- a/internal/templates/components/amount_test.go
+++ b/internal/templates/components/amount_test.go
@@ -1,0 +1,76 @@
+//go:build !headless && !lite
+
+package components
+
+import "testing"
+
+func TestAmountText(t *testing.T) {
+	tests := []struct {
+		name  string
+		props AmountProps
+		want  string
+	}{
+		// Default intent: AmountTransaction
+		{"transaction expense", AmountProps{Value: 12.34}, "$12.34"},
+		{"transaction income (neg)", AmountProps{Value: -12.34}, "+$12.34"},
+		{"transaction zero", AmountProps{Value: 0}, "$0.00"},
+		{"transaction big expense", AmountProps{Value: 1234567.89}, "$1,234,567.89"},
+		{"transaction big income", AmountProps{Value: -1234.56}, "+$1,234.56"},
+
+		// Balance intent: signed, no sign manipulation
+		{"balance positive", AmountProps{Value: 1234.56, Intent: AmountBalance}, "$1,234.56"},
+		{"balance negative", AmountProps{Value: -1234.56, Intent: AmountBalance}, "-$1,234.56"},
+		{"balance zero", AmountProps{Value: 0, Intent: AmountBalance}, "$0.00"},
+
+		// Cost intent: always absolute
+		{"cost positive", AmountProps{Value: 0.42, Intent: AmountCost}, "$0.42"},
+		{"cost negative absorbed", AmountProps{Value: -0.42, Intent: AmountCost}, "$0.42"},
+		{"cost zero", AmountProps{Value: 0, Intent: AmountCost}, "$0.00"},
+		{"cost precision 4", AmountProps{Value: 0.1234, Intent: AmountCost, Precision: 4}, "$0.1234"},
+		{"cost precision 4 over a buck", AmountProps{Value: 1.5, Intent: AmountCost, Precision: 4}, "$1.5000"},
+
+		// Format: abbreviated (≥ $1M)
+		{"abbreviated under 1M", AmountProps{Value: 999_999.99, Intent: AmountBalance, Format: AmountFormatAbbreviated}, "$999,999.99"},
+		{"abbreviated exactly 1M", AmountProps{Value: 1_000_000, Intent: AmountBalance, Format: AmountFormatAbbreviated}, "$1.0M"},
+		{"abbreviated 1.2M", AmountProps{Value: 1_234_567, Intent: AmountBalance, Format: AmountFormatAbbreviated}, "$1.2M"},
+		{"abbreviated negative balance", AmountProps{Value: -1_500_000, Intent: AmountBalance, Format: AmountFormatAbbreviated}, "-$1.5M"},
+
+		// Format: compact
+		{"compact whole", AmountProps{Value: 50, Intent: AmountCost, Format: AmountFormatCompact}, "$50"},
+		{"compact decimal", AmountProps{Value: 12.34, Intent: AmountCost, Format: AmountFormatCompact}, "$12.34"},
+		{"compact whole large", AmountProps{Value: 12_345, Intent: AmountCost, Format: AmountFormatCompact}, "$12,345"},
+
+		// Rounding edge: 99.999 → $100.00
+		{"rounds cents over", AmountProps{Value: 99.999, Intent: AmountBalance}, "$100.00"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AmountText(tc.props); got != tc.want {
+				t.Errorf("AmountText(%+v) = %q, want %q", tc.props, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAmountClasses(t *testing.T) {
+	tests := []struct {
+		name  string
+		props AmountProps
+		want  string
+	}{
+		{"expense default", AmountProps{Value: 12.34}, "tabular-nums"},
+		{"income default", AmountProps{Value: -12.34}, "tabular-nums text-success"},
+		{"income pending", AmountProps{Value: -12.34, Pending: true}, "tabular-nums text-success bb-tx-amount--pending"},
+		{"balance negative no success color", AmountProps{Value: -100, Intent: AmountBalance}, "tabular-nums"},
+		{"cost no color", AmountProps{Value: -100, Intent: AmountCost}, "tabular-nums"},
+		{"with extra class", AmountProps{Value: 1, Class: "text-3xl font-semibold"}, "tabular-nums text-3xl font-semibold"},
+		{"income with extra class", AmountProps{Value: -1, Class: "text-3xl"}, "tabular-nums text-success text-3xl"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := amountClasses(tc.props); got != tc.want {
+				t.Errorf("amountClasses(%+v) = %q, want %q", tc.props, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -11,14 +11,12 @@ package components
 import (
 	"fmt"
 	"html"
-	"math"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"breadbox/internal/ptrutil"
-	"breadbox/internal/service"
 )
 
 // deref is a templ-friendly alias for ptrutil.Deref[string]. Generated *_templ.go
@@ -78,14 +76,6 @@ func relativeDateAt(s string, now time.Time) string {
 	default:
 		return t.Format("Jan 2, 2006")
 	}
-}
-
-func formatAmount(amount float64) string {
-	formatted := service.FormatCurrency(math.Abs(amount))
-	if amount < 0 {
-		return "-" + formatted
-	}
-	return formatted
 }
 
 func avatarURL(id string) string {
@@ -154,32 +144,9 @@ func amount2f(f float64) string {
 	return fmt.Sprintf("%.2f", f)
 }
 
-// FormatBalance formats an amount for balance display. Values >= $1M are
-// abbreviated ($1.2M); values >= $1K use comma-thousands ($1,234.56); all
-// others use two-decimal notation ($123.45). Sign is ignored — always absolute.
-// Mirrors the "formatBalance" admin funcMap entry; keep them in sync.
-func FormatBalance(amount float64) string {
-	abs := math.Abs(amount)
-	if abs >= 1_000_000 {
-		return fmt.Sprintf("$%.1fM", abs/1_000_000)
-	}
-	if abs >= 1_000 {
-		return fmt.Sprintf("$%s", commaAmount(abs))
-	}
-	return fmt.Sprintf("$%.2f", abs)
-}
-
-// commaAmount formats a non-negative float as "1,234.56" (no $ prefix).
-func commaAmount(f float64) string {
-	whole := int64(f)
-	cents := int(math.Round((f - float64(whole)) * 100))
-	s := CommaInt(whole)
-	return fmt.Sprintf("%s.%02d", s, cents)
-}
-
 // CommaInt formats a non-negative integer with thousands-separator commas:
-// 1234567 → "1,234,567". Used by FormatBalance and templates that need
-// a plain integer count formatted with commas.
+// 1234567 → "1,234,567". Used by components.Amount and templates that
+// need a plain integer count formatted with commas.
 func CommaInt(n int64) string {
 	s := strconv.FormatInt(n, 10)
 	if len(s) <= 3 {
@@ -234,14 +201,6 @@ func FormatDate(s string) string { return formatDate(s) }
 // RelativeDate renders a "2006-01-02" date as "Today", "Yesterday", etc.
 // See relativeDate.
 func RelativeDate(s string) string { return relativeDate(s) }
-
-// FormatAmount renders a signed amount with currency prefix (e.g. "-$1.50").
-// See formatAmount.
-func FormatAmount(amount float64) string { return formatAmount(amount) }
-
-// CommaAmount formats a non-negative float as "1,234.56" (no currency prefix
-// or sign). See commaAmount.
-func CommaAmount(f float64) string { return commaAmount(f) }
 
 // TitleCase rewrites ALL-CAPS or all-lowercase input to Title Case, leaving
 // mixed-case input untouched. See titleCase.

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -93,27 +93,6 @@ func TestRelativeDateAt(t *testing.T) {
 	}
 }
 
-func TestFormatAmount(t *testing.T) {
-	tests := []struct {
-		in   float64
-		want string
-	}{
-		{0, "$0.00"},
-		{1.5, "$1.50"},
-		{-1.5, "-$1.50"},
-		{1234.56, "$1,234.56"},
-		{-1234.56, "-$1,234.56"},
-		{1000000, "$1,000,000.00"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.want, func(t *testing.T) {
-			if got := formatAmount(tc.in); got != tc.want {
-				t.Errorf("formatAmount(%v) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestAvatarURL(t *testing.T) {
 	tests := []struct {
 		in   string
@@ -206,9 +185,6 @@ func TestExportedWrappersDelegate(t *testing.T) {
 	if got, want := FormatDate("2024-03-15"), formatDate("2024-03-15"); got != want {
 		t.Errorf("FormatDate = %q, want %q", got, want)
 	}
-	if got, want := FormatAmount(-1.5), formatAmount(-1.5); got != want {
-		t.Errorf("FormatAmount = %q, want %q", got, want)
-	}
 	if got, want := TitleCase("STARBUCKS"), titleCase("STARBUCKS"); got != want {
 		t.Errorf("TitleCase = %q, want %q", got, want)
 	}
@@ -241,52 +217,6 @@ func TestCommaInt(t *testing.T) {
 		if got := CommaInt(tc.in); got != tc.want {
 			t.Errorf("CommaInt(%d) = %q, want %q", tc.in, got, tc.want)
 		}
-	}
-}
-
-func TestCommaAmount(t *testing.T) {
-	tests := []struct {
-		in   float64
-		want string
-	}{
-		{0, "0.00"},
-		{1.5, "1.50"},
-		{12.34, "12.34"},
-		{1234.56, "1,234.56"},
-		{1000000, "1,000,000.00"},
-		{1234567.89, "1,234,567.89"},
-	}
-	for _, tc := range tests {
-		if got := commaAmount(tc.in); got != tc.want {
-			t.Errorf("commaAmount(%v) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
-func TestFormatBalance(t *testing.T) {
-	tests := []struct {
-		name string
-		in   float64
-		want string
-	}{
-		{"zero", 0, "$0.00"},
-		{"small", 12.34, "$12.34"},
-		{"under 1K rounds cents", 999.995, "$1000.00"}, // edge: cents round up to 1.00, not yet ≥1K branch
-		{"exactly 1K uses commas", 1000, "$1,000.00"},
-		{"mid thousands", 12345.67, "$12,345.67"},
-		{"just under 1M", 999999.99, "$999,999.99"},
-		{"exactly 1M abbreviates", 1_000_000, "$1.0M"},
-		{"1.25M abbreviates with one decimal", 1_250_000, "$1.2M"},
-		{"10M abbreviates", 10_500_000, "$10.5M"},
-		{"negative treated as absolute", -1234.56, "$1,234.56"},
-		{"negative over 1M abbreviates", -2_500_000, "$2.5M"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := FormatBalance(tc.in); got != tc.want {
-				t.Errorf("FormatBalance(%v) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -2,7 +2,6 @@ package pages
 
 import (
 	"fmt"
-	"math"
 	"strings"
 
 	"breadbox/internal/service"
@@ -108,18 +107,25 @@ templ acctSummaryCards(p AccountDetailProps) {
 		<!-- Balance Card (with credit utilization inline for credit cards) -->
 		<div class="bb-card p-5">
 			<div class="text-xs font-medium text-base-content/50 mb-1">Current Balance</div>
-			<div class={ "text-2xl font-semibold tabular-nums tracking-tight", templ.KV("text-error/80", p.IsLiability) }>
-				if p.Account.BalanceCurrent != nil {
-					if p.IsLiability {
-						{ "-" }
-					}
-					{ fmtBalancePtr(p.Account.BalanceCurrent) }
+			if p.Account.BalanceCurrent != nil {
+				if p.IsLiability {
+					@components.Amount(components.AmountProps{
+						Value:  -1 * absFloat(*p.Account.BalanceCurrent),
+						Intent: components.AmountBalance,
+						Class:  "text-2xl font-semibold tracking-tight text-error/80",
+					})
 				} else {
-					<span class="text-base-content/20">
-						@templ.Raw("&mdash;")
-					</span>
+					@components.Amount(components.AmountProps{
+						Value:  *p.Account.BalanceCurrent,
+						Intent: components.AmountBalance,
+						Class:  "text-2xl font-semibold tracking-tight",
+					})
 				}
-			</div>
+			} else {
+				<div class="text-2xl font-semibold tracking-tight text-base-content/20">
+					@templ.Raw("&mdash;")
+				</div>
+			}
 			if p.HasCreditUtil {
 				<div class="mt-3">
 					<div class="flex items-center justify-between mb-1">
@@ -147,9 +153,12 @@ templ acctSummaryCards(p AccountDetailProps) {
 				<span class="text-xs text-base-content/30">30d</span>
 			</div>
 			<div class="flex items-baseline gap-2">
-				<div class="text-2xl font-semibold tabular-nums tracking-tight">
-					{ components.FormatBalance(p.TotalSpending) }
-				</div>
+				@components.Amount(components.AmountProps{
+					Value:  p.TotalSpending,
+					Intent: components.AmountCost,
+					Format: components.AmountFormatAbbreviated,
+					Class:  "text-2xl font-semibold tracking-tight",
+				})
 				if p.HasSpendingChange {
 					<span class="text-xs text-base-content/30">
 						if p.SpendingChangePercent > 0 {
@@ -488,19 +497,28 @@ func acctUtilBarStyle(util float64) string {
 	return fmt.Sprintf("width: %.0f%%", pct)
 }
 
-// fmtBalancePtr mirrors the admin "fmtBalance" funcMap for the
-// *float64 inputs this page uses (BalanceCurrent / BalanceLimit /
-// BalanceAvailable). Returns "" for nil — the caller decides whether
-// to render a fallback.
+// fmtBalancePtr renders a *float64 balance as a signed currency string
+// for the inline "limit" and "available" labels on the account detail
+// page. Returns "" for nil — the caller decides whether to render a
+// fallback. Defers to components.AmountText so the rendered string
+// stays in lock-step with the canonical Amount component.
 func fmtBalancePtr(p *float64) string {
 	if p == nil {
 		return ""
 	}
-	formatted := "$" + components.CommaAmount(math.Abs(*p))
-	if *p < 0 {
-		return "-" + formatted
+	return components.AmountText(components.AmountProps{
+		Value:  *p,
+		Intent: components.AmountBalance,
+	})
+}
+
+// absFloat is a templ-friendly wrapper around math.Abs so the
+// account_detail templates can compute |balance| without importing math.
+func absFloat(v float64) float64 {
+	if v < 0 {
+		return -v
 	}
-	return formatted
+	return v
 }
 
 // subtypeSuffix mirrors the admin funcMap of the same name: returns

--- a/internal/templates/components/pages/account_link_detail.templ
+++ b/internal/templates/components/pages/account_link_detail.templ
@@ -67,7 +67,11 @@ templ accountLinkDetailDesktopRow(m AccountLinkDetailMatchRow, csrfToken string)
 	<tr>
 		<td class="whitespace-nowrap">{ m.Date }</td>
 		<td class="whitespace-nowrap text-right">
-			@components.Amount(components.AmountProps{Value: m.Amount})
+			<!-- AmountBalance: matched pairs in this table compare magnitudes
+			     between linked accounts. Keep the raw sign visible and skip
+			     the success-green income coloring — the row already conveys
+			     which side is the credit via account context. -->
+			@components.Amount(components.AmountProps{Value: m.Amount, Intent: components.AmountBalance})
 		</td>
 		<td>
 			<a href={ templ.SafeURL(fmt.Sprintf("/transactions/%s", m.PrimaryTransactionID)) } class="link link-hover">{ m.PrimaryTxnName }</a>
@@ -114,8 +118,9 @@ templ accountLinkDetailMobileCard(m AccountLinkDetailMatchRow, csrfToken string)
 				@accountLinkDetailConfidenceBadge(m.MatchConfidence)
 			</div>
 			@components.Amount(components.AmountProps{
-				Value: m.Amount,
-				Class: "text-sm font-semibold",
+				Value:  m.Amount,
+				Intent: components.AmountBalance,
+				Class:  "text-sm font-semibold",
 			})
 		</div>
 		<div class="space-y-2">

--- a/internal/templates/components/pages/account_link_detail.templ
+++ b/internal/templates/components/pages/account_link_detail.templ
@@ -66,7 +66,9 @@ templ AccountLinkDetail(p AccountLinkDetailProps) {
 templ accountLinkDetailDesktopRow(m AccountLinkDetailMatchRow, csrfToken string) {
 	<tr>
 		<td class="whitespace-nowrap">{ m.Date }</td>
-		<td class="whitespace-nowrap bb-amount">{ fmt.Sprintf("%.2f", m.Amount) }</td>
+		<td class="whitespace-nowrap text-right">
+			@components.Amount(components.AmountProps{Value: m.Amount})
+		</td>
 		<td>
 			<a href={ templ.SafeURL(fmt.Sprintf("/transactions/%s", m.PrimaryTransactionID)) } class="link link-hover">{ m.PrimaryTxnName }</a>
 			if m.PrimaryTxnMerchant != "" {
@@ -111,7 +113,10 @@ templ accountLinkDetailMobileCard(m AccountLinkDetailMatchRow, csrfToken string)
 				<span class="text-xs text-base-content/40">{ m.Date }</span>
 				@accountLinkDetailConfidenceBadge(m.MatchConfidence)
 			</div>
-			<span class="text-sm font-semibold tabular-nums bb-amount">{ fmt.Sprintf("%.2f", m.Amount) }</span>
+			@components.Amount(components.AmountProps{
+				Value: m.Amount,
+				Class: "text-sm font-semibold",
+			})
 		</div>
 		<div class="space-y-2">
 			<div class="flex items-center gap-2">

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -182,7 +182,9 @@ templ agentRunsRow(r AgentRunRowProps, mode string) {
 		</td>
 		<td class="text-right tabular-nums text-xs">{ formatAgentRunDuration(r.DurationMs) }</td>
 		<td class="text-right tabular-nums text-xs">{ strconv.Itoa(r.Turns) }</td>
-		<td class="text-right tabular-nums text-xs">{ formatAgentRunCost(r.CostUSD) }</td>
+		<td class="text-right text-xs">
+			@agentRunCost(r.CostUSD, "text-xs")
+		</td>
 		<td class="text-right tabular-nums text-xs whitespace-nowrap">{ formatAgentRunTokens(r.TokensIn, r.TokensOut) }</td>
 		<td>
 			if r.HitCap != "" {
@@ -342,7 +344,9 @@ templ agentRunDetailMetadata(p AgentRunDetailProps) {
 			</div>
 			<div>
 				<div class="text-base-content/50 mb-1">Cost</div>
-				<div class="font-medium tabular-nums">{ formatAgentRunCost(p.Run.CostUSD) }</div>
+				<div>
+					@agentRunCost(p.Run.CostUSD, "font-medium")
+				</div>
 			</div>
 			<div>
 				<div class="text-base-content/50 mb-1">Tokens (in / out)</div>
@@ -493,7 +497,9 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 				<div class="grid grid-cols-2 sm:grid-cols-5 gap-3 text-xs">
 					<div>
 						<div class="text-base-content/50">Cost</div>
-						<div class="font-medium tabular-nums">{ formatAgentRunCost(ev.CostUSD) }</div>
+						<div>
+							@agentRunCost(ev.CostUSD, "font-medium")
+						</div>
 					</div>
 					<div>
 						<div class="text-base-content/50">Tokens in</div>
@@ -620,11 +626,21 @@ func formatAgentRunDuration(ms int64) string {
 	return fmt.Sprintf("%.1fm", mins)
 }
 
-func formatAgentRunCost(v float64) string {
-	if v <= 0 {
-		return "—"
+// agentRunCost renders an agent-run cost cell via the canonical Amount
+// component (Intent: AmountCost, Precision: 4 for sub-cent values).
+// Zero/negative costs render an em-dash placeholder, matching the prior
+// formatAgentRunCost behavior.
+templ agentRunCost(v float64, extraClass string) {
+	if v > 0 {
+		@components.Amount(components.AmountProps{
+			Value:     v,
+			Intent:    components.AmountCost,
+			Precision: 4,
+			Class:     extraClass,
+		})
+	} else {
+		<span class="text-base-content/40">—</span>
 	}
-	return fmt.Sprintf("$%.4f", v)
 }
 
 func formatAgentRunTokens(in, out int64) string {

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -182,7 +182,7 @@ templ agentRunsRow(r AgentRunRowProps, mode string) {
 		</td>
 		<td class="text-right tabular-nums text-xs">{ formatAgentRunDuration(r.DurationMs) }</td>
 		<td class="text-right tabular-nums text-xs">{ strconv.Itoa(r.Turns) }</td>
-		<td class="text-right text-xs">
+		<td class="text-right text-xs tabular-nums">
 			@agentRunCost(r.CostUSD, "text-xs")
 		</td>
 		<td class="text-right tabular-nums text-xs whitespace-nowrap">{ formatAgentRunTokens(r.TokensIn, r.TokensOut) }</td>

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -170,11 +170,19 @@ templ agentsListRow(a AgentsListRowProps) {
 				<span class="text-base-content/30">—</span>
 			}
 		</td>
-		<td class="align-middle text-xs text-right tabular-nums">
+		<td class="align-middle text-xs text-right">
 			if a.Cost30dUSD > 0 {
-				<span class="text-base-content/70">{ fmt.Sprintf("$%.2f", a.Cost30dUSD) }</span>
+				@components.Amount(components.AmountProps{
+					Value:  a.Cost30dUSD,
+					Intent: components.AmountCost,
+					Class:  "text-xs text-base-content/70",
+				})
 			} else {
-				<span class="text-base-content/30">$0.00</span>
+				@components.Amount(components.AmountProps{
+					Value:  0,
+					Intent: components.AmountCost,
+					Class:  "text-xs text-base-content/30",
+				})
 			}
 		</td>
 		<td class="align-middle text-center">

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -356,10 +356,16 @@ templ connDetailAccounts(p ConnectionDetailProps) {
 	<div class="mb-6">
 		<div class="flex items-center justify-between mb-3">
 			<h2 class="text-sm font-semibold text-base-content/70">Accounts</h2>
-			<span class="text-xs text-base-content/30">
+			<span class="text-xs text-base-content/30 inline-flex items-baseline gap-1">
 				{ fmt.Sprintf("%d total", len(p.Accounts)) }
 				if p.HasBalance {
-					{ " · " + components.FormatBalance(p.TotalBalance) }
+					<span>·</span>
+					@components.Amount(components.AmountProps{
+						Value:  p.TotalBalance,
+						Intent: components.AmountBalance,
+						Format: components.AmountFormatAbbreviated,
+						Class:  "text-xs",
+					})
 				}
 			</span>
 		</div>
@@ -403,7 +409,11 @@ templ connDetailAccountCard(a AccountRow) {
 					<div class="min-w-0">
 						if a.BalanceCurrentValid {
 							<div class="text-[0.6rem] text-base-content/35 uppercase tracking-wider mb-0.5">Current</div>
-							<div class={ "text-lg font-bold tabular-nums", connDetailBalanceColor(a.Type) }>{ a.BalanceCurrentText }</div>
+							@components.Amount(components.AmountProps{
+								Value:  a.BalanceCurrentAbs,
+								Intent: components.AmountCost,
+								Class:  "text-lg font-bold " + connDetailBalanceColor(a.Type),
+							})
 						} else {
 							<div class="text-xs text-base-content/30">No balance data</div>
 						}
@@ -411,7 +421,11 @@ templ connDetailAccountCard(a AccountRow) {
 					if a.BalanceAvailableValid {
 						<div class="text-right">
 							<div class="text-[0.6rem] text-base-content/35 uppercase tracking-wider mb-0.5">Available</div>
-							<div class="text-sm font-medium tabular-nums text-base-content/60">{ a.BalanceAvailableText }</div>
+							@components.Amount(components.AmountProps{
+								Value:  a.BalanceAvailableAbs,
+								Intent: components.AmountCost,
+								Class:  "text-sm font-medium text-base-content/60",
+							})
 						</div>
 					}
 				</div>

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -409,11 +409,13 @@ templ connDetailAccountCard(a AccountRow) {
 					<div class="min-w-0">
 						if a.BalanceCurrentValid {
 							<div class="text-[0.6rem] text-base-content/35 uppercase tracking-wider mb-0.5">Current</div>
-							@components.Amount(components.AmountProps{
-								Value:  a.BalanceCurrentAbs,
-								Intent: components.AmountCost,
-								Class:  "text-lg font-bold " + connDetailBalanceColor(a.Type),
-							})
+							<div>
+								@components.Amount(components.AmountProps{
+									Value:  a.BalanceCurrentAbs,
+									Intent: components.AmountCost,
+									Class:  "text-lg font-bold " + connDetailBalanceColor(a.Type),
+								})
+							</div>
 						} else {
 							<div class="text-xs text-base-content/30">No balance data</div>
 						}

--- a/internal/templates/components/pages/connection_detail_types.go
+++ b/internal/templates/components/pages/connection_detail_types.go
@@ -96,9 +96,9 @@ type AccountRow struct {
 	MaskValid             bool
 	MaskString            string
 	BalanceCurrentValid   bool
-	BalanceCurrentText    string // pre-formatted via service.FormatCurrency(abs)
+	BalanceCurrentAbs     float64 // |amount| — rendered via components.Amount(Intent: AmountCost)
 	BalanceAvailableValid bool
-	BalanceAvailableText  string
+	BalanceAvailableAbs   float64
 	DisplayName           string
 	Excluded              bool
 }

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -114,15 +114,33 @@ templ Connections(p ConnectionsProps) {
 						<div class="grid grid-cols-3 divide-x divide-base-300">
 							<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 								<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Net Worth</div>
-								<div class="text-sm sm:text-2xl font-semibold tabular-nums tracking-tight truncate">{ components.FormatAmount(p.NetWorth) }</div>
+								<div class="truncate">
+									@components.Amount(components.AmountProps{
+										Value:  p.NetWorth,
+										Intent: components.AmountBalance,
+										Class:  "text-sm sm:text-2xl font-semibold tracking-tight",
+									})
+								</div>
 							</div>
 							<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 								<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Assets</div>
-								<div class="text-sm sm:text-2xl font-semibold tabular-nums tracking-tight text-success truncate">{ components.FormatAmount(p.TotalAssets) }</div>
+								<div class="truncate">
+									@components.Amount(components.AmountProps{
+										Value:  p.TotalAssets,
+										Intent: components.AmountCost,
+										Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-success",
+									})
+								</div>
 							</div>
 							<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 								<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Liabilities</div>
-								<div class="text-sm sm:text-2xl font-semibold tabular-nums tracking-tight text-error truncate">{ components.FormatAmount(p.TotalLiabilities) }</div>
+								<div class="truncate">
+									@components.Amount(components.AmountProps{
+										Value:  p.TotalLiabilities,
+										Intent: components.AmountCost,
+										Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-error",
+									})
+								</div>
 							</div>
 						</div>
 					</div>
@@ -271,7 +289,11 @@ templ connectionsCard(c ConnectionsRow) {
 				<!-- Connection total balance -->
 				if c.HasBalance {
 					<a href={ templ.SafeURL("/connections/" + c.ID) } class="text-right no-underline text-inherit" tabindex="-1" aria-hidden="true">
-						<div class="text-sm sm:text-lg font-semibold tabular-nums tracking-tight">{ components.FormatAmount(c.TotalBalance) }</div>
+						@components.Amount(components.AmountProps{
+						Value:  c.TotalBalance,
+						Intent: components.AmountBalance,
+						Class:  "text-sm sm:text-lg font-semibold tracking-tight",
+					})
 						<div class="text-xs text-base-content/40">
 							{ strconv.FormatInt(c.AccountCount, 10) }
 							<span class="hidden sm:inline">{ connectionsAccountSuffix(c.AccountCount, false) }</span>
@@ -367,7 +389,19 @@ templ connectionsAccountRow(a ConnectionsAccountRow) {
 		</div>
 		<div class="text-right shrink-0">
 			if a.HasBalance {
-				<span class={ "text-sm font-medium tabular-nums", templ.KV("text-error", a.BalanceFloat < 0.0) }>{ components.FormatAmount(a.BalanceFloat) }</span>
+				if a.BalanceFloat < 0 {
+					@components.Amount(components.AmountProps{
+						Value:  a.BalanceFloat,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-medium text-error",
+					})
+				} else {
+					@components.Amount(components.AmountProps{
+						Value:  a.BalanceFloat,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-medium",
+					})
+				}
 			} else {
 				<span class="text-xs text-base-content/30">&mdash;</span>
 			}

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -125,9 +125,12 @@ templ Connections(p ConnectionsProps) {
 							<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 								<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Assets</div>
 								<div class="truncate">
+									<!-- AmountBalance (signed): admin/connections.go sums totalAssets
+									     WITHOUT abs, so an overdrawn checking account contributes
+									     negatively. Strip-sign (AmountCost) would silently hide that. -->
 									@components.Amount(components.AmountProps{
 										Value:  p.TotalAssets,
-										Intent: components.AmountCost,
+										Intent: components.AmountBalance,
 										Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-success",
 									})
 								</div>
@@ -135,6 +138,8 @@ templ Connections(p ConnectionsProps) {
 							<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 								<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Liabilities</div>
 								<div class="truncate">
+									<!-- totalLiabilities is pre-abs'd in admin/connections.go, so
+									     AmountCost (always-non-negative) is safe here. -->
 									@components.Amount(components.AmountProps{
 										Value:  p.TotalLiabilities,
 										Intent: components.AmountCost,
@@ -290,10 +295,10 @@ templ connectionsCard(c ConnectionsRow) {
 				if c.HasBalance {
 					<a href={ templ.SafeURL("/connections/" + c.ID) } class="text-right no-underline text-inherit" tabindex="-1" aria-hidden="true">
 						@components.Amount(components.AmountProps{
-						Value:  c.TotalBalance,
-						Intent: components.AmountBalance,
-						Class:  "text-sm sm:text-lg font-semibold tracking-tight",
-					})
+							Value:  c.TotalBalance,
+							Intent: components.AmountBalance,
+							Class:  "text-sm sm:text-lg font-semibold tracking-tight",
+						})
 						<div class="text-xs text-base-content/40">
 							{ strconv.FormatInt(c.AccountCount, 10) }
 							<span class="hidden sm:inline">{ connectionsAccountSuffix(c.AccountCount, false) }</span>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1104,3 +1104,122 @@ templ SectionFilterSearchInput() {
 		}
 	</div>
 }
+
+// ─── Amounts ───────────────────────────────────────────────────────────
+
+templ SectionAmounts() {
+	<div class="flex flex-col gap-6">
+		@designExample("Transaction intent (default)", "Income (negative in our convention) renders as '+$X' in success green. Expense renders as '$X' with NO sign in the default text color. Use for transaction rows, day totals, transaction detail, activity feed.") {
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl">
+				@amountSandboxRow("Expense (positive)", components.AmountProps{Value: 12.34})
+				@amountSandboxRow("Income (negative)", components.AmountProps{Value: -12.34})
+				@amountSandboxRow("Zero", components.AmountProps{Value: 0})
+				@amountSandboxRow("Big income", components.AmountProps{Value: -1234.56})
+				@amountSandboxRow("Big expense", components.AmountProps{Value: 9876.54})
+				@amountSandboxRow("Pending expense", components.AmountProps{Value: 42.10, Pending: true})
+			</div>
+		}
+		@designExample("Balance intent (signed, neutral color)", "Sign reflects the real balance direction — negative means a liability/debt. No color treatment; the caller wraps in a context color (text-success / text-error) when assets vs. liabilities matters.") {
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl">
+				@amountSandboxRow("Positive balance", components.AmountProps{Value: 4523.18, Intent: components.AmountBalance})
+				@amountSandboxRow("Negative balance (debt)", components.AmountProps{Value: -1284.55, Intent: components.AmountBalance})
+				@amountSandboxRow("Zero balance", components.AmountProps{Value: 0, Intent: components.AmountBalance})
+			</div>
+		}
+		@designExample("Cost intent (absolute, neutral)", "Always-non-negative monetary values: agent run costs, fees, totals. No sign, no color. Precision picks decimal places (default 2; agent runs use 4 for sub-cent costs).") {
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl">
+				@amountSandboxRow("Cost (default precision)", components.AmountProps{Value: 1.50, Intent: components.AmountCost})
+				@amountSandboxRow("Cost (precision 4)", components.AmountProps{Value: 0.1234, Intent: components.AmountCost, Precision: 4})
+				@amountSandboxRow("Cost (negative absorbed)", components.AmountProps{Value: -2.75, Intent: components.AmountCost})
+			</div>
+		}
+		@designExample("Format: abbreviated (≥ $1M)", "Values ≥ $1M collapse to '$1.2M' (one decimal). For big dashboard tiles where exact cents aren't meaningful. Below $1M, falls back to the standard format.") {
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl">
+				@amountSandboxRow("Just under $1M", components.AmountProps{Value: 999_999.99, Intent: components.AmountBalance, Format: components.AmountFormatAbbreviated})
+				@amountSandboxRow("$1.2M", components.AmountProps{Value: 1_234_567, Intent: components.AmountBalance, Format: components.AmountFormatAbbreviated})
+				@amountSandboxRow("Negative $1.5M", components.AmountProps{Value: -1_500_000, Intent: components.AmountBalance, Format: components.AmountFormatAbbreviated})
+				@amountSandboxRow("$42M", components.AmountProps{Value: 42_000_000, Intent: components.AmountBalance, Format: components.AmountFormatAbbreviated})
+			</div>
+		}
+		@designExample("Format: compact", "Whole values drop the .00 ($50). Decimals keep two ($12.34). Used by the transactions filter-chip min/max labels.") {
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-2xl">
+				@amountSandboxRow("Whole", components.AmountProps{Value: 50, Intent: components.AmountCost, Format: components.AmountFormatCompact})
+				@amountSandboxRow("Decimal", components.AmountProps{Value: 12.34, Intent: components.AmountCost, Format: components.AmountFormatCompact})
+				@amountSandboxRow("Large whole", components.AmountProps{Value: 12_345, Intent: components.AmountCost, Format: components.AmountFormatCompact})
+			</div>
+		}
+		@designExample("Size via Class", "Tabular-nums and color come from the component; pass size/weight/extra-color utilities through Class. Class is appended LAST so it can override (but never strip tabular-nums).") {
+			<div class="flex flex-col gap-3">
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">text-sm</span>
+					@components.Amount(components.AmountProps{Value: -1234.56, Class: "text-sm font-medium"})
+				</div>
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">text-base</span>
+					@components.Amount(components.AmountProps{Value: -1234.56, Class: "text-base font-semibold"})
+				</div>
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">text-2xl</span>
+					@components.Amount(components.AmountProps{Value: -1234.56, Class: "text-2xl font-semibold tracking-tight"})
+				</div>
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">text-3xl hero</span>
+					@components.Amount(components.AmountProps{Value: 84.55, Class: "text-3xl font-semibold tracking-tight"})
+				</div>
+			</div>
+		}
+		@designExample("Pending state", "Pending: true applies bb-tx-amount--pending (opacity 0.55 light / 0.65 dark). Soften the glyph for transactions that haven't posted yet. Pair with a leading clock icon at the call site.") {
+			<div class="flex flex-col gap-3">
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">Settled income</span>
+					@components.Amount(components.AmountProps{Value: -52.40, Class: "text-sm font-semibold"})
+				</div>
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">Pending income</span>
+					<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning opacity-70"></i>
+					@components.Amount(components.AmountProps{Value: -52.40, Pending: true, Class: "text-sm font-semibold"})
+				</div>
+				<div class="flex items-baseline gap-4">
+					<span class="text-xs text-base-content/40 w-24 shrink-0">Pending expense</span>
+					<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning opacity-70"></i>
+					@components.Amount(components.AmountProps{Value: 42.10, Pending: true, Class: "text-sm font-semibold"})
+				</div>
+			</div>
+		}
+		@designExample("Anti-patterns (do not do this)", "Each row below shows the OLD ad-hoc pattern next to the canonical component. Migrate any new call site to components.Amount.") {
+			<div class="space-y-3 text-sm">
+				@amountAntiPatternRow("fmt.Sprintf(\"$%.2f\", v) // agents_list", components.AmountProps{Value: 3.45, Intent: components.AmountCost})
+				@amountAntiPatternRow("fmt.Sprintf(\"$%.4f\", v) // agent_runs", components.AmountProps{Value: 0.1234, Intent: components.AmountCost, Precision: 4})
+				@amountAntiPatternRow("-formatAmount(v) // dayTotalBadge income hack", components.AmountProps{Value: -84.55})
+				@amountAntiPatternRow("formatAmount(tx.Amount) // bare, no tabular-nums", components.AmountProps{Value: 12.34})
+			</div>
+		}
+	</div>
+}
+
+// amountSandboxRow renders one labeled row in the SectionAmounts gallery —
+// caption on the left, the live Amount on the right, with the props
+// printed below for copy-paste reference.
+templ amountSandboxRow(label string, p components.AmountProps) {
+	<div class="flex flex-col gap-1 py-2 px-3 rounded-lg bg-base-200/40">
+		<div class="flex items-baseline justify-between gap-3">
+			<span class="text-xs text-base-content/50">{ label }</span>
+			@components.Amount(p)
+		</div>
+		<code class="text-[0.65rem] text-base-content/40 font-mono">{ amountSandboxCode(p) }</code>
+	</div>
+}
+
+// amountAntiPatternRow renders a single before-vs-after row in the
+// SectionAmounts anti-patterns block: legacy code on the left, the
+// canonical components.Amount rendering on the right.
+templ amountAntiPatternRow(legacy string, p components.AmountProps) {
+	<div class="grid grid-cols-[1fr_auto_1fr] gap-3 items-baseline">
+		<code class="text-xs text-base-content/50 truncate">{ legacy }</code>
+		<span class="text-xs text-base-content/40">→</span>
+		<div class="flex items-baseline gap-2">
+			@components.Amount(p)
+			<code class="text-[0.65rem] text-base-content/40 font-mono">{ amountSandboxCode(p) }</code>
+		</div>
+	</div>
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -4,6 +4,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"breadbox/internal/templates/components"
@@ -312,8 +313,12 @@ func amountSandboxCode(p components.AmountProps) string {
 }
 
 // trimFloat formats a float without a trailing ".0" when the value is a
-// whole number, so "Value: 50" reads naturally next to "Value: 12.34".
+// whole number, so "Value: 50" reads naturally next to "Value: 12.34"
+// in the sandbox copy-paste reference rows. Uses FormatFloat with -1
+// precision to drop trailing zeros, and 'f' to avoid the scientific
+// notation %g switches to at ≥ 1e6 — abbreviated-format examples
+// (Value: 1_234_567) would otherwise render as "1.234567e+06" and
+// defeat the rows' copy-paste purpose.
 func trimFloat(f float64) string {
-	s := fmt.Sprintf("%g", f)
-	return s
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -3,6 +3,9 @@
 package pages
 
 import (
+	"fmt"
+	"strings"
+
 	"breadbox/internal/templates/components"
 
 	"github.com/a-h/templ"
@@ -212,6 +215,13 @@ func DesignSections() []DesignSection {
 			Group:       "data",
 			Render:      func() templ.Component { return SectionTags() },
 		},
+		{
+			Slug:        "amounts",
+			Title:       "Amounts",
+			Description: "components.Amount — the canonical renderer for monetary values. Three intents (transaction / balance / cost), three formats (standard / abbreviated / compact), pending modifier. Adopt for every new amount display so coloring and sign don't drift across pages.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionAmounts() },
+		},
 
 		// ── Feedback ────────────────────────────────────────────────
 		{
@@ -272,4 +282,38 @@ func FindDesignSection(slug string) (DesignSection, bool) {
 		}
 	}
 	return DesignSection{}, false
+}
+
+// amountSandboxCode renders an AmountProps literal as a short Go-style
+// code string for the sandbox copy-paste reference rows. Mirrors only
+// the fields a reader is likely to type — drops zero-valued defaults so
+// "{Value: 12.34}" stays terse instead of stringifying every field.
+func amountSandboxCode(p components.AmountProps) string {
+	parts := []string{fmt.Sprintf("Value: %s", trimFloat(p.Value))}
+	switch p.Intent {
+	case components.AmountBalance:
+		parts = append(parts, "Intent: AmountBalance")
+	case components.AmountCost:
+		parts = append(parts, "Intent: AmountCost")
+	}
+	switch p.Format {
+	case components.AmountFormatAbbreviated:
+		parts = append(parts, "Format: AmountFormatAbbreviated")
+	case components.AmountFormatCompact:
+		parts = append(parts, "Format: AmountFormatCompact")
+	}
+	if p.Precision > 0 {
+		parts = append(parts, fmt.Sprintf("Precision: %d", p.Precision))
+	}
+	if p.Pending {
+		parts = append(parts, "Pending: true")
+	}
+	return "AmountProps{" + strings.Join(parts, ", ") + "}"
+}
+
+// trimFloat formats a float without a trailing ".0" when the value is a
+// whole number, so "Value: 50" reads naturally next to "Value: 12.34".
+func trimFloat(f float64) string {
+	s := fmt.Sprintf("%g", f)
+	return s
 }

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -389,9 +389,14 @@ templ ruleDetailPendingMatches(p RuleDetailProps) {
 										<tr>
 											<td class="text-sm">{ m.ProviderName }</td>
 											<td class="text-sm text-right">
+												<!-- Rule preview shows the raw amounts the rule would
+												     match; AmountBalance keeps the stored sign visible
+												     without the success-green income tint that would
+												     mis-read in a rule-match context. -->
 												@components.Amount(components.AmountProps{
-													Value: m.Amount,
-													Class: "text-sm",
+													Value:  m.Amount,
+													Intent: components.AmountBalance,
+													Class:  "text-sm",
 												})
 											</td>
 											<td class="text-sm text-base-content/60">{ m.Date }</td>

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -388,7 +388,12 @@ templ ruleDetailPendingMatches(p RuleDetailProps) {
 									for _, m := range p.Preview.SampleMatches {
 										<tr>
 											<td class="text-sm">{ m.ProviderName }</td>
-											<td class="text-sm text-right tabular-nums bb-amount">{ fmt.Sprintf("%.2f", m.Amount) }</td>
+											<td class="text-sm text-right">
+												@components.Amount(components.AmountProps{
+													Value: m.Amount,
+													Class: "text-sm",
+												})
+											</td>
 											<td class="text-sm text-base-content/60">{ m.Date }</td>
 										</tr>
 									}

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -87,7 +87,7 @@ templ txdHero(p TransactionDetailProps) {
 		</div>
 		<div class="flex flex-row items-baseline justify-between sm:block sm:text-right shrink-0">
 			<p
-				class={ "text-3xl font-semibold tabular-nums inline-flex items-center gap-2 justify-end", templ.KV("text-success", p.Transaction.Amount < 0) }
+				class="inline-flex items-center gap-2 justify-end"
 				if p.Transaction.Pending {
 					title="Pending — not yet posted"
 				}
@@ -95,7 +95,11 @@ templ txdHero(p TransactionDetailProps) {
 				if p.Transaction.Pending {
 					<i data-lucide="clock" class="w-5 h-5 shrink-0 text-warning opacity-70"></i>
 				}
-				<span class={ templ.KV("bb-tx-amount--pending", p.Transaction.Pending) }>{ components.FormatAmount(p.Transaction.Amount) }</span>
+				@components.Amount(components.AmountProps{
+					Value:   p.Transaction.Amount,
+					Pending: p.Transaction.Pending,
+					Class:   "text-3xl font-semibold",
+				})
 			</p>
 			if p.Transaction.IsoCurrencyCode != nil && *p.Transaction.IsoCurrencyCode != "" {
 				<p class="text-xs text-base-content/30 mt-0.5 sm:mt-0.5 ml-1 sm:ml-0">{ *p.Transaction.IsoCurrencyCode }</p>
@@ -135,7 +139,13 @@ templ txdAccountBanner(p TransactionDetailProps) {
 			if p.Account != nil && p.Account.BalanceCurrent != nil {
 				<div class="text-right shrink-0 hidden sm:block">
 					<p class="text-xs text-base-content/40 mb-0.5">Balance</p>
-					<p class="text-sm font-semibold tabular-nums">{ components.FormatAmount(*p.Account.BalanceCurrent) }</p>
+					<p>
+						@components.Amount(components.AmountProps{
+							Value:  *p.Account.BalanceCurrent,
+							Intent: components.AmountBalance,
+							Class:  "text-sm font-semibold",
+						})
+					</p>
 				</div>
 			}
 			<a href={ templ.SafeURL("/accounts/" + p.AccountID) } class="btn btn-ghost btn-xs rounded-lg shrink-0 ml-auto sm:ml-0">

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -250,9 +250,19 @@ templ usersAccountRow(a UsersAccountRow) {
 		</div>
 		<div class="text-right shrink-0">
 			if a.HasBalance {
-				<span class={ "text-sm font-semibold tabular-nums", templ.KV("text-error", a.IsLiability) }>
-					{ a.BalanceDisplay }
-				</span>
+				if a.IsLiability {
+					@components.Amount(components.AmountProps{
+						Value:  a.BalanceValue,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-semibold text-error",
+					})
+				} else {
+					@components.Amount(components.AmountProps{
+						Value:  a.BalanceValue,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-semibold",
+					})
+				}
 				<div class="text-[0.65rem] text-base-content/30 mt-0.5 hidden sm:block">{ a.IsoCurrencyCode }</div>
 			} else {
 				<span class="text-xs text-base-content/30">—</span>

--- a/internal/templates/components/pages/users_types.go
+++ b/internal/templates/components/pages/users_types.go
@@ -106,7 +106,7 @@ type UsersAccountRow struct {
 	Mask             string
 	HasMask          bool
 	InstitutionName  string
-	BalanceDisplay   string // pre-formatted via components.FormatAmount
+	BalanceValue     float64 // rendered via components.Amount(Intent: AmountBalance)
 	IsoCurrencyCode  string
 	IsLiability      bool
 	HasBalance       bool

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -49,8 +49,8 @@ templ TxResults(p TxResultsProps) {
 							</span>
 						</div>
 						<div class="flex items-center gap-3 text-xs tabular-nums">
-							@dayTotalBadge("text-base-content/50", "data-day-spending", g.DaySpending, false)
-							@dayTotalBadge("text-success/70", "data-day-income", g.DayIncome, true)
+							@dayTotalBadge("data-day-spending", g.DaySpending, false)
+							@dayTotalBadge("data-day-income", g.DayIncome, true)
 						</div>
 					</div>
 					<!-- Transaction Rows -->
@@ -143,24 +143,26 @@ templ TxResults(p TxResultsProps) {
 	@txMetaScript(p.Transactions)
 }
 
-templ dayTotalBadge(class, attr string, value float64, income bool) {
-	if value > 0 {
-		<span class={ class } data-attr={ attr } data-value={ fmt.Sprintf("%.2f", value) }>
-			if income {
-				-{ formatAmount(value) }
-			} else {
-				{ formatAmount(value) }
-			}
-		</span>
-	} else {
-		<span class={ class } data-attr={ attr } data-value={ fmt.Sprintf("%.2f", value) } style="display:none">
-			if income {
-				-{ formatAmount(value) }
-			} else {
-				{ formatAmount(value) }
-			}
-		</span>
-	}
+// dayTotalBadge renders the per-day spending / income totals on the
+// grouped-view date header. Both totals arrive as positive aggregates;
+// the income side negates the value so the canonical Amount component
+// reads it as income (negative = inflow, rendered "+$X" in green) —
+// keeping sign/color logic in one place instead of forking a manual
+// "-formatAmount" shape here.
+templ dayTotalBadge(attr string, value float64, income bool) {
+	<span
+		if !(value > 0) {
+			style="display:none"
+		}
+		data-attr={ attr }
+		data-value={ fmt.Sprintf("%.2f", value) }
+	>
+		if income {
+			@Amount(AmountProps{Value: -value, Class: "text-xs"})
+		} else {
+			@Amount(AmountProps{Value: value, Intent: AmountCost, Class: "text-xs text-base-content/50"})
+		}
+	</span>
 }
 
 templ perPageOption(size, current int) {

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -149,6 +149,12 @@ templ TxResults(p TxResultsProps) {
 // reads it as income (negative = inflow, rendered "+$X" in green) —
 // keeping sign/color logic in one place instead of forking a manual
 // "-formatAmount" shape here.
+//
+// Per-side opacity (`text-base-content/50` spending, the dimmed-success
+// override on income) preserves the date-header hierarchy: subtotals
+// stay quieter than the per-row amounts beneath them. Without it the
+// income subtotal would render in full-strength text-success and shout
+// over the row-level numbers.
 templ dayTotalBadge(attr string, value float64, income bool) {
 	<span
 		if !(value > 0) {
@@ -158,7 +164,7 @@ templ dayTotalBadge(attr string, value float64, income bool) {
 		data-value={ fmt.Sprintf("%.2f", value) }
 	>
 		if income {
-			@Amount(AmountProps{Value: -value, Class: "text-xs"})
+			@Amount(AmountProps{Value: -value, Class: "text-xs !text-success/70"})
 		} else {
 			@Amount(AmountProps{Value: value, Intent: AmountCost, Class: "text-xs text-base-content/50"})
 		}

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -223,13 +223,11 @@ templ TxRow(tx service.AdminTransactionRow) {
 					></i>
 					<span class="sr-only">(pending)</span>
 				}
-				<span
-					class={ "bb-tx-amount tabular-nums",
-					templ.KV("bb-tx-amount--income", tx.Amount < 0),
-					templ.KV("bb-tx-amount--pending", tx.Pending) }
-				>
-					{ formatAmount(tx.Amount) }
-				</span>
+				@Amount(AmountProps{
+					Value:   tx.Amount,
+					Pending: tx.Pending,
+					Class:   "text-sm font-semibold",
+				})
 			</div>
 			<!-- Expand chevron. Rotation lives on the wrapper because Lucide
 			     replaces the <i> with an <svg> at runtime. Below the `sm`

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -83,13 +83,11 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 					></i>
 					<span class="sr-only">(pending)</span>
 				}
-				<span
-					class={ "bb-tx-amount tabular-nums",
-					templ.KV("bb-tx-amount--income", tx.Amount < 0),
-					templ.KV("bb-tx-amount--pending", tx.Pending) }
-				>
-					{ formatAmount(tx.Amount) }
-				</span>
+				@Amount(AmountProps{
+					Value:   tx.Amount,
+					Pending: tx.Pending,
+					Class:   "text-sm font-semibold",
+				})
 			</div>
 			<span class="text-[0.65rem] text-base-content/40 tabular-nums">{ relativeDate(tx.Date) }</span>
 		</div>

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -83,19 +83,16 @@ templ TxRowFeed(p TxRowFeedProps) {
 			<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning opacity-70" title="Pending — not yet posted"></i>
 			<span class="sr-only">(pending)</span>
 		}
-		<!-- Amount: leading sign so income (negative in our convention)
-		     reads as "+$X" without the user having to know the sign rule. -->
-		<span class={ "tabular-nums font-medium shrink-0", txRowFeedAmountClass(p.Amount), templ.KV("bb-tx-amount--pending", p.Pending) }>
-			{ TxRowFeedAmountWithSign(p.Amount, p.Currency) }
-		</span>
+		<!-- Amount via the canonical component: income reads as "+$X" in
+		     green, expense as "$X" in the default color. Format=abbreviated
+		     so big values collapse to "$1.2M" in the narrow feed lane. -->
+		@Amount(AmountProps{
+			Value:   p.Amount,
+			Format:  AmountFormatAbbreviated,
+			Pending: p.Pending,
+			Class:   "font-medium shrink-0",
+		})
 	</a>
-}
-
-func txRowFeedAmountClass(amount float64) string {
-	if amount < 0 {
-		return "text-success"
-	}
-	return "text-base-content"
 }
 
 // TxRowFeedTagTitle returns the tooltip text for the inline tag chip,
@@ -105,25 +102,4 @@ func TxRowFeedTagTitle(n int) string {
 		return "1 tag"
 	}
 	return fmt.Sprintf("%d tags", n)
-}
-
-// TxRowFeedAmountWithSign formats an amount for the feed one-liner: a
-// leading "+" for income (breadbox negative) and "−" for outflow so the
-// direction is unambiguous without the reader having to remember the
-// sign convention. Uses an en-dash (U+2212) for the minus so the glyph
-// matches the bookkeeping convention used elsewhere in the admin UI.
-func TxRowFeedAmountWithSign(amount float64, _currency string) string {
-	abs := amount
-	if abs < 0 {
-		abs = -abs
-	}
-	formatted := FormatBalance(abs)
-	switch {
-	case amount < 0:
-		return "+" + formatted
-	case amount > 0:
-		return "−" + formatted
-	default:
-		return formatted
-	}
 }


### PR DESCRIPTION
## Summary

Adds a canonical `components.Amount` templ component as the single source of truth for monetary rendering in the admin UI, with a matching **Amounts** section in `/design/c/amounts`. Migrates every drifted call site so coloring and sign convention stop diverging across pages.

### What was drifting

A quick audit found three different formatters and at least five different sign/color conventions for the same kind of value:

| Drift | Where | Symptom |
|---|---|---|
| Three formatters | `service.FormatCurrency`, `components.formatAmount`, `components.FormatBalance` | Same input, three slightly different outputs (signed vs. absolute, decimal vs. abbreviated). |
| Income sign | Feed showed `+$50` in green; transaction row showed `-$50`; day total showed `-$50` in green (via a manual `-` prefix on a positive aggregate). | Same kind of value, three rendered shapes — readers had to relearn the convention per surface. |
| Income color | `tx_row` used a custom `.bb-tx-amount--income` oklch green; `tx_row_feed` and `transaction_detail` used `text-success` (daisy). | Two greens for the same intent. |
| Coloring intent | `connections.templ` row: `text-error` when value `< 0` (debt). Same page summary bar: `text-error` always (Liabilities = positive aggregate). | Color signal contradicts itself across the same page. |
| Ad-hoc inline | `agents_list` `fmt.Sprintf("$%.2f", ...)`, `agent_runs` `fmt.Sprintf("$%.4f", ...)`, `account_link_detail` `fmt.Sprintf("%.2f", ...)` (no `$` prefix), `rule_detail` preview same. | Bypassed every helper, different precisions side-by-side. |
| Pre-formatted strings in props | `BalanceCurrentText` / `BalanceDisplay` carried strings into templates — coloring decisions migrated up into the handler. | Templates can't apply the canonical color treatment because the formatting decision already happened. |

### The shape

```go
// internal/templates/components/amount.{go,templ}
@components.Amount(components.AmountProps{
    Value:     <signed float64>,
    Intent:    AmountTransaction | AmountBalance | AmountCost,
    Format:    AmountFormatStandard | AmountFormatAbbreviated | AmountFormatCompact,
    Precision: 2, // for AmountCost sub-cent (e.g. agent run costs use 4)
    Pending:   false, // applies bb-tx-amount--pending opacity
    Class:     "text-3xl font-semibold", // size/weight overrides; tabular-nums always wired in
})
```

Per-intent sign + color, established by walking the audit with @canalesb93:

- **AmountTransaction** (default) — income (negative in our breadbox convention) renders `"+$X"` in `text-success`; expense renders `"$X"` with no sign in the page's default text color. Use for transaction rows, day totals, feeds, transaction detail.
- **AmountBalance** — signed as-is; `-$1,234.56` for negative balances. Neutral color; caller wraps in `text-success`/`text-error` when the surrounding context (Assets vs Liabilities) demands a tone.
- **AmountCost** — absolute, no sign, neutral color. Use for non-negative metrics (agent run cost, fees, spending totals).

`AmountText(props)` is exported for the few non-templ callers (filter-chip helper, etc.) so the rendered string stays bit-identical with the component.

### Migrated call sites

- `tx_row.templ`, `tx_row_compact.templ`, `tx_row_feed.templ` — single canonical row markup
- `tx_results.templ` (`dayTotalBadge`) — drop the manual `-` prefix on income aggregates; pass `-DayIncome` and let the component handle sign
- `transaction_detail.templ` — hero amount + account balance ribbon
- `connections.templ` — Net Worth / Assets / Liabilities summary + per-connection totals + per-account rows
- `connection_detail.templ` — account cards (BalanceCurrent/BalanceAvailable now flow through as `float64`, not pre-formatted strings)
- `account_detail.templ` — Current Balance + Spending tile; the `fmtBalancePtr` helper now defers to `AmountText`
- `account_link_detail.templ` (desktop row + mobile card), `rule_detail.templ` preview — kill the raw-decimal `%.2f` pattern
- `agents_list.templ` (30d cost), `agent_runs.templ` (table row + run-detail + result event) — go through `AmountCost` with `Precision: 4`
- `users.templ` — household-member account balance rows
- `admin/transactions_filter_chips.go` — `formatAmountForChip` defers to `AmountText` with the compact format

### What got deleted

- `components.formatAmount`, `components.FormatAmount` — only callers were the templates I migrated
- `components.FormatBalance` — same; replaced by `Amount(Format: AmountFormatAbbreviated)`
- `components.CommaAmount` / `commaAmount` — only `FormatBalance` and `account_detail.fmtBalancePtr` used these
- `admin.formatNumericAbsCurrency` — replaced by `numericAbsFloat`
- `pages.formatAgentRunCost` — replaced by an inline `agentRunCost` templ that wraps `Amount`
- `tx_row_feed.txRowFeedAmountClass` + `TxRowFeedAmountWithSign` — the component covers both
- `input.css`: `.bb-tx-amount` base rule + `.bb-tx-amount--income` (custom oklch). The `--pending` opacity modifier stays; the component applies it.
- `BalanceCurrentText` / `BalanceAvailableText` / `BalanceDisplay` string fields → replaced with float fields the template formats.

`service.FormatCurrency` stays — it's used by `ToTransactionSummary` to build the JSON `amount_label` for command-palette / MCP preview payloads. The component's 2-decimal output is bit-identical with it.

### Tests

`internal/templates/components/amount_test.go` covers 30 cases across intent × format × precision × pending. `go test ./...` is green. `go build ./...` and `go vet ./...` are clean. The smoke test in `design_smoke_test.go` covers the new `SectionAmounts`.

### Evidence

**Sandbox — `/design/c/amounts`:**

<img src="https://i.img402.dev/49tj4qreef.jpg" width="800" alt="Amounts design-system section">

**Transactions list — every variant through the component** (income `+$X` green, expense `$X` default, pending with clock + dim):

<img src="https://i.img402.dev/9rufj1mm2g.jpg" width="800" alt="Transactions page — desktop">

**Connections — summary bar + per-account debt rows:**

<img src="https://i.img402.dev/lgxb29qnds.jpg" width="800" alt="Connections page — desktop">

**Mobile transactions:**

<img src="https://i.img402.dev/vqwzt5oxr6.jpg" width="320" alt="Transactions page — mobile">

---

### Review pass — fixes applied in `47a147e1`

Ran an extra-high-effort multi-angle code review against the first commit; 8 actionable findings turned into a follow-up fix commit. Summary:

**Correctness:**
- `numericAbsFloat` now returns `(float64, bool)`. A pgtype-Valid Numeric that fails conversion (NaN / overflow) no longer surfaces as a fabricated `$0.00` — the templ falls through to the "No balance data" branch instead.
- Assets tile switched from `AmountCost` → `AmountBalance`. `totalAssets` is summed signed in `admin/connections.go:121` (only liabilities are pre-abs'd), so strip-sign rendering would silently hide an overdrawn account.
- Filter-chip `formatAmountForChip` switched to `AmountBalance` so `?min_amount=-100` chips render the leading `-`.
- Account-link and rule-detail match-tables switched to `AmountBalance`. These tables compare magnitudes between linked accounts / preview rule matches; raw sign without the success-green tint reads better in the match context.

**Visual:**
- `dayTotalBadge` income side restores `!text-success/70` softening so date-header subtotals don't shout over the row amounts.
- Agent-run cost `<td>` gets `tabular-nums` back so em-dash placeholder rows align with dollar rows.
- `connection_detail` Current-balance value re-wraps in a `<div>` to match the sibling Available side's layout.
- `connections.templ` TotalBalance block re-indented to pass `templ fmt`.

**Documentation:**
- `AmountProps.Class` doc warns that the prop is concatenated unescaped and that Tailwind v4 utility collisions resolve by source-tree order — use `!` to force-override the intent color.
- `commaInt64` doc notes the signed-input footgun.
- `trimFloat` (sandbox helper) uses `strconv.FormatFloat(-1)` instead of `%g` so abbreviated-example values (1_234_567) render as `1234567`, not `1.234567e+06`.

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` (green locally)
- [ ] `/design/c/amounts` covers every variant
- [ ] Income reads `"+$X"` in green on `/transactions` (grouped + list), `/transactions/{id}`, feed
- [ ] Liabilities column on `/connections` stays red; per-account negative balances stay red
- [ ] Agent-run cost cell on `/agents` and `/agents/{slug}/runs` still shows 4-decimal precision
- [ ] Filter `?min_amount=-100` chip on `/transactions` renders with leading `-`
- [ ] Connection detail with a (synthetic) NaN balance row renders "No balance data", not `$0.00`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
