### PR TITLE
perf(ui): adopt native View Transitions, color-scheme, and sidebar prefetch

### DIFF
--- a/input.css
+++ b/input.css
@@ -33,6 +33,37 @@
 /* Utility: hide Alpine.js elements until initialized */
 [x-cloak] { display: none !important; }
 
+/* ─── Native browser polish ──────────────────────────────────────────
+ * Two top-level hooks the platform now offers for free:
+ *
+ *   color-scheme: light dark
+ *     Tells the browser to render native widgets (scrollbars, form
+ *     controls, <dialog> backdrops, input UA styles) with dark-mode
+ *     awareness driven by prefers-color-scheme. Without this they
+ *     stay light against our dark theme. Safe everywhere.
+ *
+ *   @view-transition { navigation: auto }
+ *     Opt-in to cross-document View Transitions on same-origin nav.
+ *     Browsers that support it (Chrome 126+, Safari 18.2+) cross-fade
+ *     between full page loads automatically; others do regular nav.
+ *     Doesn't disable bfcache or the iOS swipe-back gesture — the spec
+ *     layers transitions on top of native navigation.
+ *
+ *     Reduced-motion guard zeros out the animations rather than turning
+ *     the at-rule off, which is the pattern recommended by the spec.
+ * ──────────────────────────────────────────────────────────────── */
+:root { color-scheme: light dark; }
+
+@view-transition { navigation: auto; }
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}
+
 /* ─── shadcn-inspired global overrides ─── */
 @layer base {
   /* Ensure Lucide SVG icons don't steal clicks from interactive parents. */

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -37,6 +37,22 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>body { font-family: 'Inter', system-ui, -apple-system, sans-serif; }</style>
+  <!--
+    Speculation Rules — Chromium-only predictive prefetch of sidebar nav.
+    Chrome 122+ fetches matching links when it predicts the user is about
+    to navigate (intersection + hover heuristics). Safari ignores the
+    script entirely, so this is purely additive — iOS gets the equivalent
+    win from the hover/touchstart prefetch listener below in body scripts.
+  -->
+  <script type="speculationrules">
+    {
+      "prefetch": [{
+        "source": "document",
+        "where": { "selector_matches": "a.bb-sidebar-link" },
+        "eagerness": "moderate"
+      }]
+    }
+  </script>
   <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.15.11/dist/cdn.min.js" integrity="sha384-NArNwzWsUSF+kY2lgW4YriEkjLqi+J+za6HrENUn/3nZqkBnWbxV22kCJEK5Uu6n" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js" integrity="sha384-WPtu0YHhJ3arcykfnv1JgUffWDSKRnqnDeTpJUbOc2os2moEmLkIdaeR0trPN4be" crossorigin="anonymous"></script>
   <!-- Lucide: self-hosted + deferred so the browser fetches it in parallel with HTML parsing
@@ -938,6 +954,64 @@
           }
         }, 50);
       }).observe(document.body, { childList: true, subtree: true });
+    })();
+
+    // Sidebar nav prefetch — instant.page-style hover/touch warmup.
+    //
+    // When the user lingers on a sidebar nav link for ≥65ms (or starts a
+    // touch / focuses it via keyboard), inject <link rel="prefetch"> so
+    // the browser preloads the next page's HTML into the HTTP cache. On
+    // click, the navigation resolves from cache, eliminating the network
+    // round-trip without giving up bfcache, native scroll restoration, or
+    // the iOS swipe-back gesture.
+    //
+    // Chromium also gets the Speculation Rules block in <head>, which is
+    // strictly more capable. This listener is the Safari/Firefox path.
+    //
+    // Scoped to a.bb-sidebar-link only — a bounded set of canonical
+    // destinations — so we never speculatively fetch unbounded lists
+    // (transaction rows, search results, etc.). Skips cross-origin,
+    // current URL, [data-no-prefetch], and save-data connections.
+    (function() {
+      var conn = navigator.connection || {};
+      if (conn.saveData) return;
+      var prefetched = new Set();
+      function shouldSkip(a) {
+        if (!a.href || a.target === '_blank' || a.hasAttribute('download')) return true;
+        if (a.dataset.noPrefetch !== undefined) return true;
+        try {
+          var u = new URL(a.href, location.href);
+          if (u.origin !== location.origin) return true;
+          if (u.pathname + u.search === location.pathname + location.search) return true;
+        } catch (_) { return true; }
+        return prefetched.has(a.href);
+      }
+      function prefetch(url) {
+        if (prefetched.has(url)) return;
+        prefetched.add(url);
+        var link = document.createElement('link');
+        link.rel = 'prefetch';
+        link.as = 'document';
+        link.href = url;
+        document.head.appendChild(link);
+      }
+      var HOVER_DELAY = 65;
+      document.addEventListener('mouseover', function(e) {
+        var a = e.target.closest('a.bb-sidebar-link');
+        if (!a || shouldSkip(a)) return;
+        var timer = setTimeout(function() { prefetch(a.href); }, HOVER_DELAY);
+        a.addEventListener('mouseleave', function() { clearTimeout(timer); }, { once: true });
+      });
+      document.addEventListener('touchstart', function(e) {
+        var a = e.target.closest('a.bb-sidebar-link');
+        if (!a || shouldSkip(a)) return;
+        prefetch(a.href);
+      }, { passive: true, capture: true });
+      document.addEventListener('focusin', function(e) {
+        var a = e.target.closest('a.bb-sidebar-link');
+        if (!a || shouldSkip(a)) return;
+        prefetch(a.href);
+      });
     })();
 
     // Button loading state helpers for async actions


### PR DESCRIPTION
## Summary

Four browser-native opt-ins for an SPA-feel admin UI without giving up MPA simplicity. All progressive enhancements — every change is a no-op on browsers that don't support it, and **nothing regresses iOS Safari** (bfcache, swipe-back gesture, and native scroll restoration are all preserved).

- **`@view-transition { navigation: auto }`** in `input.css` — Chrome 126+ and Safari 18.2+ cross-fade between full page loads automatically. The spec layers transitions on top of native navigation, so bfcache and the iOS back-gesture keep working. Reduced-motion guard zeros the animations rather than disabling the at-rule.
- **`:root { color-scheme: light dark }`** — tells the browser to render native scrollbars, form controls, and `<dialog>` backdrops with dark-mode awareness so they don't stay light against our dark theme. Safari 13+.
- **`<script type=\"speculationrules\">`** for `a.bb-sidebar-link` — Chromium 122+ predictive prefetch. Safari ignores the tag entirely (additive only).
- **~50-line inline IIFE** in `base.html` that injects `<link rel=\"prefetch\" as=\"document\">` on mouseover (65ms delay), touchstart, and focusin for sidebar links. The Safari/Firefox path equivalent to Speculation Rules. Scoped to `a.bb-sidebar-link` so we never speculatively fetch unbounded lists; honors `navigator.connection.saveData` and the `[data-no-prefetch]` opt-out; idempotent per URL.

## Why scoped to sidebar nav only?

The sidebar is the bounded set of canonical destinations (~12 links). Broader scope (e.g. every tx row) would trigger unbounded prefetches on long lists — wasted server CPU and bandwidth. We can expand later if other surfaces benefit.

## Validation

Verified live in Chrome via DevTools MCP:

- `getComputedStyle(:root).colorScheme === \"light dark\"` ✓
- `@view-transition` rule present in stylesheet ✓
- Speculation Rules block parsed and well-formed ✓
- Hover on `/transactions` sidebar link injects `<link rel=\"prefetch\">` and the browser fires the GET (visible in network log) ✓
- No new console errors (one pre-existing `apple-mobile-web-app-capable` deprecation warning unchanged) ✓
- Cross-document navigation between `/` and `/transactions` works normally; View Transitions does its thing silently ✓

<img src=\"https://i.img402.dev/0g895cfq9s.jpg\" width=\"800\" alt=\"transactions page — dashboard chrome unchanged, all wins are progressive\">

## Test plan

- [ ] On Chrome 126+ / Safari 18.2+: navigate between sidebar items, observe the smooth cross-fade.
- [ ] On older Chrome / Safari 17: same navigation should work normally (no transition, no error).
- [ ] In Chrome DevTools → Network: hover a sidebar link, see a prefetch request fire for the destination.
- [ ] On iOS Safari: swipe-back gesture and back/forward bfcache still work normally.
- [ ] In macOS dark mode: native scrollbars render dark (previously light against dark theme).
- [ ] In System Settings → Accessibility → Reduce Motion: navigation no longer animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)