### PR TITLE
fix(ui): leave mobile drawer open until new page renders

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1161,15 +1161,27 @@
         }
       });
 
-      // Existing behavior: auto-close drawer on mobile when a nav link is tapped.
-      drawerSide.querySelectorAll('a.bb-sidebar-link, button[type="submit"]').forEach(function(link) {
-        link.addEventListener('click', function() {
-          if (isMobile()) {
-            toggle.checked = false;
-            toggle.dispatchEvent(new Event('change'));
-          }
-        });
-      });
+      // INTENTIONALLY no auto-close handler on sidebar nav taps. We let the
+      // drawer stay open right through the navigation — the new document
+      // renders with the drawer closed by default (checkbox state is per-
+      // document, doesn't carry across nav), so visually the drawer covers
+      // the source page until the new page paints over it. No flash of the
+      // source page underneath, no slide-out animation racing the nav.
+      //
+      // On browsers with cross-document View Transitions (Safari 18.2+ /
+      // Chrome 126+), the .bb-sidebar named group (see input.css) makes
+      // this even nicer: the browser interpolates the sidebar's bbox from
+      // "visible on-screen" (old page) to "translated off-screen" (new
+      // page), so the drawer slides out as the main content cross-fades
+      // in — synchronized with the actual nav rather than racing it.
+      //
+      // History: tried defer-until-transitionend (felt slow on prefetched
+      // pages) and snap-close (jarring flash of source page underneath).
+      // Doing nothing turned out to be the cleanest fix.
+      //
+      // Non-nav close paths (Esc, tap outside backdrop, close button) are
+      // handled by the keydown listener above and DaisyUI's native checkbox
+      // toggle — those still animate normally.
     })();
 
     // iOS 26-style scroll fade for mobile sidebar nav


### PR DESCRIPTION
## Summary

Removes the mobile drawer auto-close-on-nav-tap handler entirely. The drawer now stays open through the navigation; the new document renders with the checkbox unchecked by default (drawer state is per-document, doesn't carry across), so visually the drawer covers the source page right up until the new page paints over it. No flash of source page, no race, no animation delay.

## Why no-handler-at-all (after two earlier iterations)

| Iteration | Behavior | Why it didn't work |
|---|---|---|
| 1. Defer-until-`transitionend` | Cancel default nav, slide the drawer closed, then `window.location.href` on transitionend | Felt ~250ms slower on every nav because prefetched pages were ready instantly and had to wait for the slide |
| 2. Snap-close | Disable transition, snap drawer closed, let default nav fire immediately | Briefly exposed the source page underneath ("jarring", per review) |
| 3. **Do nothing** (this PR) | Leave the drawer alone, let nav fire with drawer still open | Drawer covers the source page until new doc paints over it — no flash, no race, no animation delay |

## Bonus: View Transitions integration

On browsers with cross-document View Transitions (Safari 18.2+ / Chrome 126+), PR-05's `view-transition-name: app-sidebar` makes the drawer slide-out smooth and *synchronized* with the page change. The browser snapshots the OLD page (drawer visible on-screen) and NEW page (drawer translated off-screen), then interpolates the bbox of the named group — so the drawer slides out *as* the main content cross-fades in. Tied to the actual nav, not racing it.

Older browsers (no View Transitions): the drawer just disappears with the document replacement. Same visual outcome as snap-close minus the source-page flash.

## What the comment in the code preserves

Future contributors who notice "wait, there's no auto-close handler" should find a comment explaining the three iterations and why we landed on no-handler. Stops the next person from re-adding the snap-close they think is missing.

## Test plan

- [ ] On iPhone Safari, open drawer, tap any sidebar link → drawer stays visible, new page paints over it. No source-page flash.
- [ ] Same on desktop Chrome ≤1023px wide.
- [ ] Cmd-click / middle-click / target=_blank → opens in new tab, source drawer unchanged.
- [ ] Open drawer, press Esc → drawer slides closed normally (animation preserved for non-nav paths).
- [ ] Open drawer, tap the (×) close button → drawer slides closed normally.
- [ ] Open drawer, tap a sidebar `<button type="submit">` (logout) → drawer stays open during the POST round-trip; new page (login screen) renders with drawer closed.
- [ ] On Safari 18.2+ / Chrome 126+: drawer visibly slides out *as* main content cross-fades in.
