### PR TITLE
fix(ui): contain overscroll on sidebar nav + modal-box

### DIFF
--- a/input.css
+++ b/input.css
@@ -324,6 +324,9 @@
     @apply flex flex-col gap-0.5 flex-1 overflow-y-auto pb-4;
     scrollbar-width: thin;
     scrollbar-color: transparent transparent;
+    /* Contain the iOS rubber-band — without this, dragging past either end
+       of the nav list pulls the page underneath the drawer along with it. */
+    overscroll-behavior: contain;
   }
 
   .bb-sidebar-nav:hover,
@@ -1112,6 +1115,18 @@
   /* ── Mobile sidebar overlay above sticky navbar ── */
   .drawer-side {
     z-index: 40 !important;
+  }
+
+  /* ── Modal scroll containment ──────────────────────────────────────
+   * When the daisy modal-box body scrolls past its top/bottom (a
+   * long form in a `<dialog class="modal">`), iOS Safari rubber-bands
+   * the page underneath the backdrop instead of just bouncing the
+   * modal's own scroll. `contain` keeps the bounce local to the
+   * modal — matches the platform feel the bespoke pickers already
+   * have on their inner scroll regions (.bb-cmdk-list, etc).
+   * ──────────────────────────────────────────────────────────── */
+  .modal-box {
+    overscroll-behavior: contain;
   }
 
 


### PR DESCRIPTION
## Summary

Adds `overscroll-behavior: contain` to two scroll surfaces that were rubber-banding into the page underneath on iOS Safari:

1. **`.bb-sidebar-nav`** — the mobile drawer's nav list. When there are enough items to scroll, dragging past either end pulls the page underneath the drawer along with it. The four bespoke pickers (`.bb-cmdk-list`, `.bb-catpicker-list`, `.bb-tagpicker-body`, `.bb-shortcuts-dialog`) already had this guard; the sidebar nav was the outlier.

2. **`.modal-box`** — daisyUI's native dialog body. Same issue when a long modal form (create-link, bulk-comment, future migrations from the bespoke dialogs) scrolls past its bounds.

## Why pure CSS, no JS

`overscroll-behavior: contain` is the spec-blessed way to stop scroll chaining at a container boundary. Safari 16+, no polyfill needed, no event handlers, no measuring.

## Why not on `.bb-confirm-dialog`

It uses `overflow-hidden` and never scrolls — confirms are short and capped at ~420px wide. Adding the property would be a no-op and noise.

## Test plan

- [ ] On iPhone Safari, open the drawer, scroll the nav list past the top/bottom, confirm the page underneath stays put (previously rubber-banded).
- [ ] On iPhone Safari, open any modal with scrollable content (e.g. /connections "New Link"), scroll past the top/bottom of the modal body, confirm the page underneath stays put.
- [ ] On macOS with a trackpad: same two checks, two-finger scroll past bounds → modal/drawer bounces locally, page underneath is unaffected.
- [ ] On Android Chrome: no visible change (Chrome already contains by default for many cases; this just makes it explicit).
