### PR TITLE
feat(ui): adopt native input type=search + enterkeyhint + Esc-blur

### DIFF
--- a/input.css
+++ b/input.css
@@ -1136,6 +1136,21 @@
     overscroll-behavior: contain;
   }
 
+  /* ── Suppress WebKit's native search-clear (×) on overlay pickers ──
+   * The cmdk / catpicker / tagpicker inputs are now type="search" so
+   * iOS gets the proper "Search" keyboard key. The flip side is that
+   * WebKit renders a small × clear button at the inline-end edge,
+   * which would visually compete with the existing `esc` kbd chip
+   * already rendered in the same wrap. Hide it on these three only;
+   * standalone search inputs (tx quick-search, filters) keep the
+   * native ×, which is genuinely useful there.
+   * ──────────────────────────────────────────────────────────── */
+  .bb-cmdk-input::-webkit-search-cancel-button,
+  .bb-catpicker-input::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
 
 
   /* ── Mobile-friendly info grid ── */

--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -62,6 +62,7 @@ templ DesignGallery(p DesignGalleryProps) {
 						x-model="filter"
 						@keydown.escape.stop="filter = ''; $el.blur()"
 						type="search"
+						enterkeyhint="search"
 						placeholder="Filter sections..."
 						aria-label="Filter sections"
 						autocomplete="off"

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -177,7 +177,8 @@ templ txFilters(p TransactionsProps) {
 					<circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path>
 				</svg>
 				<input
-					type="text"
+					type="search"
+					enterkeyhint="search"
 					id="bb-quick-search"
 					placeholder="Search transactions..."
 					class="input pl-9 pr-9 w-full text-sm bg-base-100 border-base-300 focus:border-primary/40 transition-all duration-200 h-10"
@@ -311,7 +312,7 @@ templ txFilters(p TransactionsProps) {
 						<i data-lucide="search" class="w-3.5 h-3.5 text-base-content opacity-40"></i>
 						Search
 					</div>
-					<input type="text" name="search" value={ p.FilterSearch } placeholder="Search transactions..." class="input input-sm w-full col-span-2 sm:col-span-1"/>
+					<input type="search" enterkeyhint="search" name="search" value={ p.FilterSearch } placeholder="Search transactions..." class="input input-sm w-full col-span-2 sm:col-span-1"/>
 					<select name="search_field" class="select select-sm w-full">
 						@txSearchFieldOption("all", "Name & Merchant", p.FilterSearchField, true)
 						@txSearchFieldOption("name", "Name only", p.FilterSearchField, false)

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -575,7 +575,8 @@
       <!-- Search input -->
       <div class="bb-catpicker-input-wrap">
         <i data-lucide="tag"></i>
-        <input type="text"
+        <input type="search"
+          enterkeyhint="search"
           class="bb-catpicker-input"
           placeholder="Search categories..."
           x-ref="catPickerInput"
@@ -647,7 +648,8 @@
       <!-- Search / create input -->
       <div class="bb-catpicker-input-wrap gap-2">
         <i data-lucide="tag"></i>
-        <input type="text"
+        <input type="search"
+          enterkeyhint="search"
           class="bb-catpicker-input"
           placeholder="Filter tags or type to create…"
           x-ref="tagPickerInput"
@@ -783,7 +785,8 @@
       <!-- Search input -->
       <div class="bb-cmdk-input-wrap">
         <i data-lucide="search"></i>
-        <input type="text"
+        <input type="search"
+          enterkeyhint="search"
           class="bb-cmdk-input"
           placeholder="Type a command or search..."
           x-ref="cmdkInput"

--- a/static/js/admin/components/transactions.js
+++ b/static/js/admin/components/transactions.js
@@ -482,6 +482,17 @@ document.addEventListener('alpine:init', function () {
       },
 
       clear: function () {
+        // Two-stage Esc behavior on the search bar:
+        //   1st Esc (input has content) → clear the query, keep focus so the
+        //                                 user can immediately type a new one.
+        //   2nd Esc (already empty)     → blur the field, "escape out" of the
+        //                                 search. Native browser default for
+        //                                 <input type="search"> doesn't do
+        //                                 this — surprising but true.
+        if (!this.query) {
+          if (this.$refs.searchInput) this.$refs.searchInput.blur();
+          return;
+        }
         this.query = '';
         if (this._abortCtrl) this._abortCtrl.abort();
         this.$refs.searchInput.value = '';


### PR DESCRIPTION
## Summary

Six search/filter inputs converted from `type="text"` to `type="search"`, with `enterkeyhint="search"` for the spec-correct return-key label, plus a small Esc-key UX fix on the transactions search bar.

| File | Input |
|---|---|
| `base.html` | cmdk command palette |
| `base.html` | category picker |
| `base.html` | tag picker |
| `transactions.templ` | quick-search bar |
| `transactions.templ` | filter form search |
| `design_gallery.templ` | section filter |

## What the user sees on iOS Safari

- **"Search" key** on the virtual keyboard instead of the generic "Go".
- **Native (×) clear button** in the input (where appropriate — see below).
- Voice Control and Siri-style suggestions treat the field as a search box.
- ARIA + assistive tech announces the field as `searchbox`, not `textbox`.

## Two-stage Esc on the tx quick-search

Native browser default for `type="search"` doesn't blur on Esc — second Esc after clearing the value is a no-op, which is surprising. Fixed in the Alpine `clear()` method:

- **1st Esc** (input has content) → clear the query, keep focus.
- **2nd Esc** (input is empty) → blur the field, "escape out" of the search.

## Why suppress the native × on the overlay pickers

The cmdk / catpicker / tagpicker already render an `esc` kbd chip in the same input wrap, which would visually compete with the WebKit `::-webkit-search-cancel-button`. Hidden on those three classes only. Standalone inputs (`#bb-quick-search`, the filter form input, the design gallery filter) keep the native × — it's a useful affordance there.

## Test plan

- [ ] On iPhone Safari, open the command palette (⌘K / drawer search) — virtual keyboard shows "Search" key, no native (×) clutter.
- [ ] On `/transactions` quick-search bar — keyboard shows "Search", input gets a native (×) when populated.
- [ ] Type something in tx search → press Esc → query clears, focus stays. Press Esc again → field blurs.
- [ ] Tap (×) on the populated tx search → input clears, list refreshes.
- [ ] On desktop, the change is invisible apart from the (×) clear button on focused/populated standalone inputs.
- [ ] Screen reader announces "search" instead of "text" on each input.
