### PR TITLE
perf(ui): fetchpriority on CSS + reduced-motion guard + mobile-web-app meta

### DIFF
--- a/input.css
+++ b/input.css
@@ -56,7 +56,23 @@
 
 @view-transition { navigation: auto; }
 
+/* Universal reduced-motion guard. Honors the OS-level "Reduce Motion"
+ * toggle (iOS Accessibility, macOS Accessibility, Windows Animations,
+ * Linux GNOME Animations) by collapsing every transition/animation to
+ * a near-zero duration and disabling smooth scroll. Recommended pattern
+ * from web.dev / Eric Bailey — scoped to *::before/::after to catch
+ * pseudo-elements, !important to override Tailwind/daisy/our own rules.
+ *
+ * The view-transition pseudo-elements need their own zero-out below
+ * because they're not matched by the universal selector. */
 @media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
   ::view-transition-group(*),
   ::view-transition-old(*),
   ::view-transition-new(*) {

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -8,13 +8,18 @@
   <!-- Safari: theme color for status bar / tab bar -->
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
-  <!-- Safari: Add to Home Screen support -->
+  <!-- Safari: Add to Home Screen support. The non-prefixed mobile-web-app-capable
+       is the modern equivalent; Safari still reads the apple-* variant, but
+       browsers warn in console without the standard name. Ship both. -->
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Breadbox">
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
-  <link rel="stylesheet" href="/static/css/styles.css">
+  <!-- fetchpriority="high" hints that the app stylesheet is render-blocking and
+       critical. Safari 17.2+ and Chrome 102+ honor it; older browsers ignore. -->
+  <link rel="stylesheet" href="/static/css/styles.css" fetchpriority="high">
   <script>
     // Stash the browser's IANA timezone in a cookie so server-rendered date
     // logic ("Today" buckets, hero "Events today" counters, absolute-time


### PR DESCRIPTION
## Summary

Three small native-platform wins that needed three different lines:

1. **`fetchpriority="high"`** on `<link rel="stylesheet" href="/static/css/styles.css">` — explicit critical-resource hint. Browsers already prioritize stylesheet links in `<head>`, but the attribute makes intent unambiguous and gives Safari 17.2+ and Chrome 102+ a small head-of-queue bump.

2. **`<meta name="mobile-web-app-capable">`** alongside the existing `apple-mobile-web-app-capable` variant. Silences the console deprecation warning we saw on every page without regressing iOS add-to-home-screen (both names coexist).

3. **Universal `@media (prefers-reduced-motion: reduce)` guard** at the top of `input.css` that collapses every transition/animation to 0.01ms and disables smooth-scroll. Honors the OS-level "Reduce Motion" toggle across iOS, macOS, Windows, and Linux. The existing per-feature view-transition zero-out stays — pseudo-elements aren't matched by the universal selector.

## Why this PR does *not* preload the Inter woff2

The audit floated preloading `https://fonts.gstatic.com/s/inter/v20/...woff2` directly. Google rotates the version hash in that URL periodically — a hardcoded preload would 404 silently and waste a request slot. The clean fix is to self-host Inter (one-time download, served from `/static/fonts/`), which is its own ~30-line PR worth doing later. Out of scope here.

## Test plan

- [ ] In Chrome DevTools → Network: the styles.css request has priority "Highest" with the `fetchpriority="high"` attribute set in the initiator.
- [ ] In the browser console: no `apple-mobile-web-app-capable is deprecated` warning anymore.
- [ ] iOS Safari: add-to-home-screen still works as before.
- [ ] In System Settings → Accessibility → Reduce Motion: enable, navigate around the admin. All slide/fade transitions should be instant. View transitions still work but with no animation.
- [ ] In System Settings → Reduce Motion: off → normal smooth transitions.
- [ ] Sanity: `getComputedStyle(document.querySelector('a')).transitionDuration` returns `0.00001s` with Reduce Motion on, `0.15s` off.
