### PR TITLE
polish(ui): name persistent chrome + tighter view-transition timing

### DIFF
--- a/input.css
+++ b/input.css
@@ -56,6 +56,36 @@
 
 @view-transition { navigation: auto; }
 
+/* ─── View Transitions chrome polish ────────────────────────────────
+ * Default cross-document transition fades the WHOLE viewport, which
+ * makes the persistent sidebar/navbar look like they "flashed" too.
+ * Giving them a view-transition-name tells the browser "this is the
+ * same element on both pages" and confines the fade to <main>.
+ *
+ * Tighter duration + iOS-standard ease so the fade feels coincident
+ * with a server-rendered MPA's <100ms TTFB rather than a slow 250ms
+ * default that reads as artificial delay.
+ *
+ * NOTE: We deliberately do NOT name the active sidebar link as its
+ * own group. With a name, the browser interpolates the old and new
+ * bounding boxes, which makes the highlight visibly glide across the
+ * column from the previous link to the new one. Sounds delightful in
+ * theory; in practice it's distracting, especially when the two
+ * active links are far apart or the glide crosses category headers.
+ * Without a name, the active state cross-fades inside the sidebar
+ * group — old highlight fades out in place, new one fades in in
+ * place. Calmer.
+ * ──────────────────────────────────────────────────────────── */
+.bb-sidebar       { view-transition-name: app-sidebar; }
+.bb-mobile-navbar { view-transition-name: app-navbar; }
+.bb-progress-bar  { view-transition-name: app-progress; }
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 180ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
 /* Universal reduced-motion guard. Honors the OS-level "Reduce Motion"
  * toggle (iOS Accessibility, macOS Accessibility, Windows Animations,
  * Linux GNOME Animations) by collapsing every transition/animation to


### PR DESCRIPTION
## Summary

Layers on top of the cross-document View Transitions opt-in from #1448 so the default whole-viewport fade gives way to something more meaningful:

| Class | `view-transition-name` |
|---|---|
| `.bb-sidebar` | `app-sidebar` |
| `.bb-mobile-navbar` | `app-navbar` |
| `.bb-progress-bar` | `app-progress` |

Naming an element tells the browser it's the *same* element on old and new pages, so it morphs the bounding box instead of cross-fading. Result: only `<main>` cross-fades; sidebar/navbar visually stay put.

## Timing

Default cross-document duration is ~250ms, which reads as artificial delay on a server-rendered MPA where TTFB is often <100ms. Dropped to 180ms with `cubic-bezier(0.2, 0, 0, 1)` — the iOS-standard ease curve. Matches the iOS swipe-back animation so transitions and gestures feel consistent.

## What was tried and pulled back

An earlier iteration named `.bb-sidebar-link--active` as its own group (`nav-active`) so the active highlight would *glide* across the column from the previous link to the new one. Sounded delightful, looked distracting in practice — especially when the two active links are far apart or the glide crosses category headers. Pulled it. The active state now cross-fades inside the sidebar group: old highlight fades out in place, new one fades in in place. Calmer.

## Why this is safe

- View transitions are still cross-document — bfcache, swipe-back, scroll restoration all preserved.
- Reduce Motion still zeros the animation out (via the universal guard from PR-04 and the per-feature guard from #1448).
- Browsers without View Transitions support ignore the names — no regression.

## Test plan

- [ ] On Chrome 126+ / Safari 18.2+: navigate between sidebar items. Sidebar and (on mobile) navbar visually stay put; only the main content cross-fades.
- [ ] Active sidebar highlight fades in/out in place (not gliding) when the active link changes.
- [ ] Mobile: tap a sidebar link with the drawer open. Drawer slides closed (PR-01), then page transition runs — the navbar stays put through both.
- [ ] On older Chrome / Safari 17: no transition, normal navigation.
- [ ] Reduce Motion on: no animation, instant nav.
- [ ] Sanity: `getComputedStyle(document.querySelector('.bb-sidebar')).viewTransitionName === 'app-sidebar'`.
