### PR TITLE
chore(dx): cache dev ENCRYPTION_KEY for worktree sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -73,15 +73,32 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
       echo "    Set DATABASE_URL"
     fi
 
-    # ENCRYPTION_KEY — grab from running breadbox process
+    # ENCRYPTION_KEY — try running process first (freshest), then on-disk cache.
+    # Cache survives between sessions so a fresh worktree with no `breadbox serve`
+    # running still gets the key without a manual `ps eww` round-trip.
     if [ -z "${ENCRYPTION_KEY:-}" ]; then
+      KEY_CACHE="$HOME/.local/share/breadbox/dev-encryption-key"
+      EK=""
       RUNNING_PID="$(pgrep -f 'breadbox serve' | head -1 || true)"
       if [ -n "$RUNNING_PID" ]; then
         EK="$(ps eww -p "$RUNNING_PID" 2>/dev/null | tr ' ' '\n' | grep '^ENCRYPTION_KEY=' | cut -d= -f2 || true)"
         if [ -n "$EK" ]; then
-          echo "ENCRYPTION_KEY=$EK" >> "$CLAUDE_ENV_FILE"
-          echo "    Set ENCRYPTION_KEY from running process"
+          mkdir -p "$(dirname "$KEY_CACHE")"
+          umask 077
+          printf '%s\n' "$EK" > "$KEY_CACHE"
+          echo "    Set ENCRYPTION_KEY from running process (cached for future sessions)"
         fi
+      fi
+      if [ -z "$EK" ] && [ -f "$KEY_CACHE" ]; then
+        EK="$(head -1 "$KEY_CACHE" 2>/dev/null || true)"
+        if [ -n "$EK" ]; then
+          echo "    Set ENCRYPTION_KEY from cache ($KEY_CACHE)"
+        fi
+      fi
+      if [ -n "$EK" ]; then
+        echo "ENCRYPTION_KEY=$EK" >> "$CLAUDE_ENV_FILE"
+      else
+        echo "WARN: ENCRYPTION_KEY not found. Start \`breadbox serve\` once in any worktree, or write the 64-char hex key to $KEY_CACHE"
       fi
     fi
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -73,32 +73,62 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
       echo "    Set DATABASE_URL"
     fi
 
-    # ENCRYPTION_KEY — try running process first (freshest), then on-disk cache.
-    # Cache survives between sessions so a fresh worktree with no `breadbox serve`
-    # running still gets the key without a manual `ps eww` round-trip.
+    # ENCRYPTION_KEY — precedence: .local.env (source of truth) > running process > cache.
+    # .local.env is the canonical store (loaded by godotenv at server start), so we read
+    # it first to avoid the regression where a stale cache silently shadows a rotated key.
+    # Cache survives between sessions so a fresh worktree with no `.local.env` and no
+    # `breadbox serve` running still gets the key without a manual `ps eww` round-trip.
     if [ -z "${ENCRYPTION_KEY:-}" ]; then
       KEY_CACHE="$HOME/.local/share/breadbox/dev-encryption-key"
       EK=""
-      RUNNING_PID="$(pgrep -f 'breadbox serve' | head -1 || true)"
-      if [ -n "$RUNNING_PID" ]; then
-        EK="$(ps eww -p "$RUNNING_PID" 2>/dev/null | tr ' ' '\n' | grep '^ENCRYPTION_KEY=' | cut -d= -f2 || true)"
-        if [ -n "$EK" ]; then
-          mkdir -p "$(dirname "$KEY_CACHE")"
-          umask 077
-          printf '%s\n' "$EK" > "$KEY_CACHE"
-          echo "    Set ENCRYPTION_KEY from running process (cached for future sessions)"
+      EK_SRC=""
+
+      # 1) .local.env in the worktree (copied in by .worktreeinclude)
+      LOCAL_ENV="$PROJECT_DIR/.local.env"
+      if [ -f "$LOCAL_ENV" ]; then
+        CAND="$(grep -E '^ENCRYPTION_KEY=' "$LOCAL_ENV" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"'"'"'\r\n' || true)"
+        if [[ "$CAND" =~ ^[0-9a-fA-F]{64}$ ]]; then
+          EK="$CAND"
+          EK_SRC=".local.env"
         fi
       fi
+
+      # 2) running `breadbox serve` process
+      if [ -z "$EK" ]; then
+        RUNNING_PID="$(pgrep -f 'breadbox serve' | head -1 || true)"
+        if [ -n "$RUNNING_PID" ]; then
+          CAND="$(ps eww -p "$RUNNING_PID" 2>/dev/null | tr ' ' '\n' | grep '^ENCRYPTION_KEY=' | cut -d= -f2- | tr -d '\r' || true)"
+          if [[ "$CAND" =~ ^[0-9a-fA-F]{64}$ ]]; then
+            EK="$CAND"
+            EK_SRC="running process"
+            # Persist to cache for future sessions (atomic write, subshell-scoped umask)
+            mkdir -p "$(dirname "$KEY_CACHE")"
+            (
+              umask 077
+              printf '%s\n' "$EK" > "$KEY_CACHE.tmp" && mv -f "$KEY_CACHE.tmp" "$KEY_CACHE"
+            ) || echo "WARN: failed to persist ENCRYPTION_KEY cache at $KEY_CACHE"
+          fi
+        fi
+      fi
+
+      # 3) on-disk cache (fallback when neither above worked)
       if [ -z "$EK" ] && [ -f "$KEY_CACHE" ]; then
-        EK="$(head -1 "$KEY_CACHE" 2>/dev/null || true)"
-        if [ -n "$EK" ]; then
-          echo "    Set ENCRYPTION_KEY from cache ($KEY_CACHE)"
+        CAND="$(head -1 "$KEY_CACHE" 2>/dev/null | tr -d '\r\n' || true)"
+        if [[ "$CAND" =~ ^[0-9a-fA-F]{64}$ ]]; then
+          EK="$CAND"
+          EK_SRC="cache ($KEY_CACHE)"
+        else
+          echo "WARN: $KEY_CACHE exists but doesn't contain a 64-char hex key; ignoring"
         fi
       fi
+
       if [ -n "$EK" ]; then
         echo "ENCRYPTION_KEY=$EK" >> "$CLAUDE_ENV_FILE"
+        echo "    Set ENCRYPTION_KEY from $EK_SRC"
       else
-        echo "WARN: ENCRYPTION_KEY not found. Start \`breadbox serve\` once in any worktree, or write the 64-char hex key to $KEY_CACHE"
+        echo "WARN: ENCRYPTION_KEY not found. Start \`breadbox serve\` once (so the hook can"
+        echo "      cache the key), or paste just the 64 hex chars (no \`ENCRYPTION_KEY=\`"
+        echo "      prefix, no quotes) into $KEY_CACHE"
       fi
     fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Prefer `make dev-watch` for UI work. See `.claude/rules/ui.md` for the hot-reloa
 
 - Dev DB: `postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable`
 - Test DB: `postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable`
-- Required env when any provider configured: `DATABASE_URL` (set explicitly — pgx's Unix-socket fallback often breaks in worktrees), `ENCRYPTION_KEY` (recover from a running process via `ps eww -p $(pgrep -f 'breadbox serve' | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`).
+- Required env when any provider configured: `DATABASE_URL` (set explicitly — pgx's Unix-socket fallback often breaks in worktrees), `ENCRYPTION_KEY` (the session-start hook injects this automatically from `~/.local/share/breadbox/dev-encryption-key`, which is refreshed whenever a `breadbox serve` is running; if the cache is missing, recover via `ps eww -p $(pgrep -f 'breadbox serve' | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`).
 - Worktrees (`claude -w`): `.worktreeinclude` copies build artifacts; `.claude/hooks/session-start.sh` assigns a port from 8081–8099 and injects env via `CLAUDE_ENV_FILE`, exporting both `PORT` (read by the Makefile) and `SERVER_PORT` (read by the binary) so `make dev` *and* direct `go run ./cmd/breadbox serve` both land on the assigned port. Main repo uses 8080.
 - Stop all dev servers: `make dev-stop`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Prefer `make dev-watch` for UI work. See `.claude/rules/ui.md` for the hot-reloa
 
 - Dev DB: `postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable`
 - Test DB: `postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable`
-- Required env when any provider configured: `DATABASE_URL` (set explicitly — pgx's Unix-socket fallback often breaks in worktrees), `ENCRYPTION_KEY` (the session-start hook injects this automatically from `~/.local/share/breadbox/dev-encryption-key`, which is refreshed whenever a `breadbox serve` is running; if the cache is missing, recover via `ps eww -p $(pgrep -f 'breadbox serve' | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`).
+- Required env when any provider configured: `DATABASE_URL` (set explicitly — pgx's Unix-socket fallback often breaks in worktrees), `ENCRYPTION_KEY` (the session-start hook resolves this with precedence `.local.env` → running `breadbox serve` env → `~/.local/share/breadbox/dev-encryption-key` cache, and seeds the cache whenever the running-process path succeeds; if all three miss, recover manually via `ps eww -p $(pgrep -f 'breadbox serve' | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`).
 - Worktrees (`claude -w`): `.worktreeinclude` copies build artifacts; `.claude/hooks/session-start.sh` assigns a port from 8081–8099 and injects env via `CLAUDE_ENV_FILE`, exporting both `PORT` (read by the Makefile) and `SERVER_PORT` (read by the binary) so `make dev` *and* direct `go run ./cmd/breadbox serve` both land on the assigned port. Main repo uses 8080.
 - Stop all dev servers: `make dev-stop`.
 


### PR DESCRIPTION
## Summary
- Worktree session-start hook now persists the recovered `ENCRYPTION_KEY` to `~/.local/share/breadbox/dev-encryption-key` (chmod 600) whenever a `breadbox serve` is running, then falls back to that cache when no live process is found.
- Documented the cache path in `CLAUDE.md` so future agents know where to look.

## Why
The previous flow only recovered the key from a running process. On a fresh worktree where no server has been started, that returned nothing — and agents would then shell out for `ps eww -p \$(pgrep ...)` themselves, hitting a sandbox prompt for `pgrep` and getting stuck. Now the first session that ever sees a live process seeds the cache, and every subsequent worktree picks the key up automatically.

Running processes still take precedence over the cache, so if you ever rotate the key the next session refreshes the file.

## Test plan
- [x] Hook passes `bash -n`
- [x] Manually primed cache from a running `breadbox serve` process
- [ ] Fresh worktree session injects `ENCRYPTION_KEY` from cache without an active server (verified via a subagent run)