### PR TITLE
feat(design): toolbar inherits daisy radius + mobile collapse

### DIFF
--- a/internal/templates/components/multi_select_toolbar.templ
+++ b/internal/templates/components/multi_select_toolbar.templ
@@ -8,8 +8,9 @@ package components
 // Geometry — pinned 1.5rem from the viewport bottom, horizontally
 // centered, with `pointer-events-none` when hidden so it doesn't
 // intercept clicks before it's shown. Children render inside a
-// `bg-base-100 border rounded-2xl shadow-lg` pill matching the bulk-bar
-// shape from the transactions page.
+// `bg-base-100 border rounded-field shadow-lg` pill. The radius
+// matches the daisy button token (`var(--radius-field)`) so the pill
+// and its child `.btn`s share corner geometry.
 //
 // Visibility is Alpine-driven: pass `XShow` (an Alpine boolean
 // expression — typically `selecting && count > 0` or
@@ -44,6 +45,13 @@ type MultiSelectToolbarProps struct {
 	// stays compact on phones.
 	CountLabel string
 
+	// CountHideOnMobile hides the entire count chip (number + label
+	// + the trailing divider) under the sm breakpoint. Use when the
+	// bar already has 3+ actions and the count is taking room from
+	// what the user actually came to tap. Default false — the chip
+	// stays visible and only its trailing "selected" label collapses.
+	CountHideOnMobile bool
+
 	// CountToggleEvent is the custom event dispatched when the user
 	// clicks the count chip — Gmail-style "select all / clear" toggle.
 	// Default `multi-select-toggle-all`. Set to empty string to make
@@ -76,11 +84,11 @@ templ MultiSelectToolbar(p MultiSelectToolbarProps) {
 			x-transition:leave-end="opacity-0 translate-y-2"
 		}
 	>
-		<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5 max-w-[calc(100vw-2rem)]">
+		<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-field shadow-lg px-4 py-2.5 max-w-[calc(100vw-2rem)]">
 			if p.CountToggleEvent != "" || p.CountExpr != "" {
 				@multiSelectCount(p)
+				<div class={ "w-px h-6 bg-base-300", templ.KV("hidden sm:block", p.CountHideOnMobile) }></div>
 			}
-			<div class="w-px h-6 bg-base-300"></div>
 			{ children... }
 			if p.CloseEvent != "" || p.XShow != "" {
 				<button
@@ -102,7 +110,9 @@ templ MultiSelectToolbar(p MultiSelectToolbarProps) {
 // hotkey-hint kbd). For richer slots (split-button, dropdown, modal
 // trigger) just render a raw `<button>` instead.
 //
-// Variant ""/"ghost" → btn-ghost; "primary" → btn-primary. Always
+// Variant ""/"ghost" → btn-ghost (label collapses to icon-only
+// under sm); "primary" → btn-primary (label stays visible at every
+// breakpoint so the headline action is always tappable). Always
 // btn-sm to match the bulk-bar shape.
 //
 // OnClick is an Alpine handler expression (rendered as `@click`); use
@@ -130,7 +140,7 @@ templ MultiSelectToolbarAction(p MultiSelectToolbarActionProps) {
 			<i data-lucide={ p.Icon } class="w-3.5 h-3.5"></i>
 		}
 		if p.Label != "" {
-			<span class="hidden sm:inline">{ p.Label }</span>
+			<span class={ multiSelectLabelClass(p.Variant) }>{ p.Label }</span>
 		}
 		if p.Hotkey != "" {
 			<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">{ p.Hotkey }</span>
@@ -142,14 +152,14 @@ templ multiSelectCount(p MultiSelectToolbarProps) {
 	if p.CountToggleEvent != "" {
 		<button
 			type="button"
-			class="btn btn-ghost btn-sm gap-1.5"
+			class={ "btn btn-ghost btn-sm gap-1.5", templ.KV("hidden sm:inline-flex", p.CountHideOnMobile) }
 			title="Select all / clear"
 			@click={ dispatchEventJS(p.CountToggleEvent) }
 		>
 			@multiSelectCountInner(p)
 		</button>
 	} else {
-		<div class="px-2 inline-flex items-center gap-1.5 text-sm">
+		<div class={ "px-2 inline-flex items-center gap-1.5 text-sm", templ.KV("hidden sm:inline-flex", p.CountHideOnMobile) }>
 			@multiSelectCountInner(p)
 		</div>
 	}
@@ -182,4 +192,15 @@ func multiSelectActionClass(variant string) string {
 		return "btn btn-primary btn-sm gap-2"
 	}
 	return "btn btn-ghost btn-sm gap-2"
+}
+
+// multiSelectLabelClass chooses the responsive visibility for the
+// action's text label. Ghost actions collapse to icon-only under sm
+// to keep the bar compact on phones; primary actions always show
+// the label so the headline action stays clearly tappable.
+func multiSelectLabelClass(variant string) string {
+	if variant == "primary" {
+		return "inline"
+	}
+	return "hidden sm:inline"
 }

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -945,7 +945,7 @@ templ SectionKbd() {
 		}
 		@designExample("Inline in a toolbar (live ref)", "How the bulk action bar surfaces hotkey hints — passed as Hotkey on MultiSelectToolbarAction.") {
 			<div role="toolbar" aria-label="Selection actions (preview)" class="inline-block">
-				<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5">
+				<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-field shadow-lg px-4 py-2.5">
 					<button type="button" class="btn btn-ghost btn-sm gap-2">
 						<i data-lucide="tag" class="w-3.5 h-3.5"></i>
 						<span>Tag</span>
@@ -1030,7 +1030,7 @@ templ SectionToast() {
 
 templ SectionMultiSelectToolbar() {
 	<div x-data="{ open: false, count: 3 }" class="flex flex-col gap-6">
-		@designExample("Live demo", "Toggle the floating toolbar. Real-world wiring listens for `multi-select-close` and `multi-select-toggle-all` events to clear / select-all.") {
+		@designExample("Live demo", "Toggle the floating toolbar. Narrow the viewport to see the mobile collapse: ghost actions go icon-only, the primary action stays expanded, and the count chip is hidden when CountHideOnMobile is true. Real-world wiring listens for `multi-select-close` and `multi-select-toggle-all` events to clear / select-all.") {
 			<div class="flex flex-wrap items-center gap-2">
 				<button type="button" class="btn btn-primary btn-sm" @click="open = !open">
 					<span x-show="!open">Show toolbar</span>
@@ -1041,10 +1041,11 @@ templ SectionMultiSelectToolbar() {
 				<span class="text-xs text-base-content/50 ml-2">count = <span x-text="count"></span></span>
 			</div>
 			@components.MultiSelectToolbar(components.MultiSelectToolbarProps{
-				XShow:            "open",
-				CountExpr:        "count",
-				CountToggleEvent: "design-bulk-toggle-all",
-				CloseEvent:       "design-bulk-close",
+				XShow:             "open",
+				CountExpr:         "count",
+				CountToggleEvent:  "design-bulk-toggle-all",
+				CloseEvent:        "design-bulk-close",
+				CountHideOnMobile: true,
 			}) {
 				@components.MultiSelectToolbarAction(components.MultiSelectToolbarActionProps{
 					Icon:    "message-square",
@@ -1071,9 +1072,9 @@ templ SectionMultiSelectToolbar() {
 				@design-bulk-toggle-all.window="count = count > 0 ? 0 : 12"
 			></div>
 		}
-		@designExample("Inline shape (static)", "The pill rendered without the fixed wrapper, for layout reference.") {
+		@designExample("Inline shape (static)", "The pill rendered without the fixed wrapper, for layout reference. The primary action keeps its label at every breakpoint; ghost actions collapse to icon-only under sm.") {
 			<div role="toolbar" aria-label="Selection actions (preview)" class="inline-block">
-				<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5">
+				<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-field shadow-lg px-4 py-2.5">
 					<button type="button" class="btn btn-ghost btn-sm gap-1.5">
 						<span class="font-bold tabular-nums">3</span>
 						<span class="hidden sm:inline text-base-content/60 font-normal">selected</span>
@@ -1090,7 +1091,7 @@ templ SectionMultiSelectToolbar() {
 					</button>
 					<button type="button" class="btn btn-primary btn-sm gap-2" title="Categorize">
 						<i data-lucide="tags" class="w-3.5 h-3.5"></i>
-						<span class="hidden sm:inline">Categorize</span>
+						<span class="inline">Categorize</span>
 						<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
 					</button>
 					<button type="button" class="btn btn-ghost btn-sm btn-square" title="Clear selection" aria-label="Clear selection">

--- a/static/js/admin/components/transactions.js
+++ b/static/js/admin/components/transactions.js
@@ -941,12 +941,12 @@ document.addEventListener('DOMContentLoaded', function() {
   var bar = document.createElement('div');
   bar.id = 'bb-bulk-bar';
   bar.style.cssText = 'position:fixed;bottom:1.5rem;left:50%;z-index:40;opacity:0;transform:translateX(-50%) translateY(1rem);pointer-events:none;transition:opacity 0.2s ease,transform 0.2s ease';
-  bar.innerHTML = '<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-4 py-2.5 max-w-[calc(100vw-2rem)]">'
-    + '<button type="button" id="bb-bulk-count-toggle" class="btn btn-ghost btn-sm gap-1.5" title="Select all / clear">'
+  bar.innerHTML = '<div class="flex items-center gap-2 bg-base-100 border border-base-300 rounded-field shadow-lg px-4 py-2.5 max-w-[calc(100vw-2rem)]">'
+    + '<button type="button" id="bb-bulk-count-toggle" class="btn btn-ghost btn-sm gap-1.5 hidden sm:inline-flex" title="Select all / clear">'
     +   '<span id="bb-bulk-count" class="font-bold tabular-nums">0</span>'
     +   '<span class="hidden sm:inline text-base-content/60 font-normal">selected</span>'
     + '</button>'
-    + '<div class="w-px h-6 bg-base-300"></div>'
+    + '<div class="w-px h-6 bg-base-300 hidden sm:block"></div>'
     + '<button type="button" id="bb-bulk-comment" class="btn btn-ghost btn-sm gap-2" title="Add comment">'
     +   '<i data-lucide="message-square" class="w-3.5 h-3.5"></i>'
     +   '<span class="hidden sm:inline">Comment</span>'
@@ -958,7 +958,7 @@ document.addEventListener('DOMContentLoaded', function() {
     + '</button>'
     + '<button type="button" id="bb-bulk-categorize" class="btn btn-primary btn-sm gap-2" title="Categorize selected">'
     +   '<i data-lucide="tags" class="w-3.5 h-3.5"></i>'
-    +   '<span class="hidden sm:inline">Categorize</span>'
+    +   '<span>Categorize</span>'
     +   '<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>'
     + '</button>'
     + '<button type="button" id="bb-bulk-clear" class="btn btn-ghost btn-sm btn-square" title="Exit select mode">'


### PR DESCRIPTION
## Summary

- `MultiSelectToolbar` pill now uses `rounded-field` instead of `rounded-2xl`, so the corner inherits `var(--radius-field)` — the same token the daisy `.btn` already uses. No more bespoke per-caller radius drift between the pill and its buttons.
- New `CountHideOnMobile bool` prop on `MultiSelectToolbarProps`. When `true`, the count chip + its trailing divider drop under `sm` so phones surface the actual actions instead of the "3 selected" badge. Wired into the `/design/c/multi-select-toolbar` live demo.
- Primary action labels are now always visible at every breakpoint (`multiSelectLabelClass`), while ghost actions still collapse to icon-only under `sm`. Keeps the headline action clearly tappable while the bar stays compact on phones.
- Same three changes mirrored in the hand-rolled tx-list `#bb-bulk-bar` (`static/js/admin/components/transactions.js`) until that bar gets migrated to the templ component.

Validated in a headless Chromium against the worktree's compiled CSS. Computed `border-radius` for the pill and the daisy `.btn` both come back as `4px` (= `var(--radius-field)` in the current theme).

## Screenshots

<table>
  <tr><th>Desktop (full bar, <code>CountHideOnMobile: true</code>)</th><th>Mobile (≤640px)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/zrahggos0t.jpg" width="500" alt="Toolbar — desktop after"></td>
    <td><img src="https://i.img402.dev/zn5ik4a9b5.jpg" width="320" alt="Toolbar — mobile after"></td>
  </tr>
</table>

Mobile expectation (visible in the right column): count chip + divider hidden, ghost actions collapse to icon-only, Categorize keeps its label.

## Test plan

- [ ] `/design/c/multi-select-toolbar` — desktop: full bar; resize <640px: count chip + divider hide, Comment/Tag collapse to icons, Categorize stays expanded
- [ ] `/transactions` with rows selected — same behavior on the live tx-list bulk bar
- [ ] Computed `border-radius` of the pill matches the daisy `.btn` (`var(--radius-field)`)
- [ ] `go build ./...` and `go vet ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
