### PR TITLE
fix(design): auto-size component sandbox iframe to content

### DIFF
--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -20,6 +20,7 @@ templ DesignComponent(p DesignComponentProps) {
 			vp: 'desktop',
 			freeWidth: 1320,
 			dragging: false,
+			iframeHeight: 0,
 			onDragStart(e) {
 				e.preventDefault();
 				const self = this;
@@ -30,6 +31,25 @@ templ DesignComponent(p DesignComponentProps) {
 				const onUp = function() { self.dragging = false; window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
 				window.addEventListener('mousemove', onMove);
 				window.addEventListener('mouseup', onUp);
+			},
+			syncIframeHeight(iframe) {
+				const self = this;
+				try {
+					const doc = iframe.contentDocument;
+					if (!doc || !doc.body) return;
+					const measure = function() {
+						const h = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight);
+						if (h > 0) self.iframeHeight = h;
+					};
+					measure();
+					if (typeof ResizeObserver !== 'undefined') {
+						const ro = new ResizeObserver(measure);
+						ro.observe(doc.documentElement);
+						ro.observe(doc.body);
+					}
+					const mo = new MutationObserver(measure);
+					mo.observe(doc.body, { childList: true, subtree: true, attributes: true, characterData: true });
+				} catch (err) { /* cross-origin or detached; keep last height */ }
 			}
 		}"
 		x-effect="
@@ -118,9 +138,11 @@ templ DesignComponent(p DesignComponentProps) {
 			<iframe
 				src={ templ.SafeURL("/design/c/" + p.Section.Slug + "?embed=1") }
 				title={ p.Section.Title + " preview" }
-				class="h-[80vh] border-0 bg-base-100"
+				class="block border-0 bg-base-100"
 				:class="vp === 'free' ? 'w-[calc(100%-32px)]' : 'w-full'"
-				:style="dragging ? 'pointer-events: none' : ''"
+				:style="'height: ' + (iframeHeight || 480) + 'px' + (dragging ? '; pointer-events: none' : '')"
+				@load="syncIframeHeight($el)"
+				scrolling="no"
 				loading="lazy"
 			></iframe>
 			<!-- Right-edge resize grabber. x-show keeps the element in


### PR DESCRIPTION
## Summary

The standalone component sandbox iframe (`/design/c/{slug}`) was hardcoded to `h-[80vh]`, which clipped tall demos (transaction-rows, amounts, timeline all overflowed and grew an inner scrollbar) and left whitespace under short ones (buttons, tags).

This wires the iframe height to its embed document's `scrollHeight` via an Alpine helper that:

- measures once on `@load`,
- re-measures on `ResizeObserver` events for both `documentElement` and `body`, so width-toggle reflows resize the iframe accordingly,
- re-measures on `MutationObserver` (subtree + attributes + characterData) to catch interactive collapses/expansions inside the embed,
- falls back to 480px if measurement fails (e.g. cross-origin or detached doc — shouldn't happen with same-origin embed, but cheap insurance).

Also drops `scrolling="no"` on the iframe to suppress the inner scrollbar entirely; the parent page does the scrolling.

## Validated heights (1440×900 viewport)

| Slug | Before | After (= contentScrollHeight) |
| --- | --- | --- |
| `buttons` | 720 | 674 |
| `amounts` | 720 (clipped from 2112) | 2112 |
| `transaction-rows` | 720 (clipped from 1552) | 1552 |
| `tags` | 720 | 516 |
| `timeline` | 720 (clipped from 2105) | 2105 |
| `tables` | 720 | 480 (fallback floor — content is shorter) |

## Test plan

- [ ] Visit `/design/c/amounts`, `/design/c/transaction-rows`, `/design/c/timeline` — confirm full demo is visible with no inner scrollbar.
- [ ] Visit `/design/c/buttons`, `/design/c/tags` — confirm no extra whitespace below the demo.
- [ ] Toggle Mobile / Tablet / Desktop / Free — iframe re-measures on each reflow.
- [ ] Drag the Free-mode resize grabber — iframe height tracks content as width changes.
