### PR TITLE
feat(design): add cmdk shortcut + g+d chord for design sandbox

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -18,7 +18,8 @@ Always available — wired once in `internal/templates/layout/base.html`.
 | `Cmd+K` | Open the command palette |
 | `/` | Open the command palette (alt) — pages may reassign `/` locally (e.g. Transactions uses it to focus search) |
 | `Esc` | Close the open dialog / cancel the current overlay |
-| `g` then `d` | Go to Dashboard |
+| `g` then `o` | Go to Feed (overview) |
+| `g` then `d` | Go to Design system |
 | `g` then `t` | Go to Transactions |
 | `g` then `c` | Go to Connections |
 | `g` then `r` | Go to Reviews |

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1659,7 +1659,7 @@
       // palette hint updates automatically.
       var allItems = [
         // Overview
-        { id: 'nav-feed', shortcutId: 'global.go.d', group: 'Overview', title: 'Feed', desc: 'Activity feed across the household', icon: 'rss', href: '/', keywords: 'home feed activity dashboard overview' },
+        { id: 'nav-feed', shortcutId: 'global.go.o', group: 'Overview', title: 'Feed', desc: 'Activity feed across the household', icon: 'rss', href: '/', keywords: 'home feed activity dashboard overview' },
         { id: 'nav-transactions', shortcutId: 'global.go.t', group: 'Overview', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
         { id: 'nav-reports', group: 'Overview', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
         // Manage
@@ -1676,6 +1676,7 @@
         { id: 'sys-logs', shortcutId: 'global.go.v', group: 'System', title: 'Logs', desc: 'Sync logs, webhook events, agent sessions', icon: 'scroll-text', href: '/logs', keywords: 'sync history errors status webhooks events sessions activity' },
         { id: 'sys-backups', shortcutId: 'global.go.b', group: 'System', title: 'Backups', desc: 'Database backup and restore', icon: 'hard-drive', href: '/settings/backups', keywords: 'backup restore database dump export' },
         { id: 'sys-settings', shortcutId: 'global.go.s', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
+        { id: 'sys-design', shortcutId: 'global.go.d', group: 'System', title: 'Design system', desc: 'DaisyUI + bb-* component sandbox', icon: 'palette', href: '/design', keywords: 'sandbox gallery components ui daisyui tailwind preview' },
         // Quick Actions
         { id: 'act-connect', shortcutId: 'global.new.c', group: 'Quick Actions', title: 'Connect a Bank', desc: 'Add a new bank connection', icon: 'plus-circle', href: '/connections/new', keywords: 'add new link' },
         { id: 'act-import', shortcutId: 'global.new.i', group: 'Quick Actions', title: 'Import CSV', desc: 'Import transactions from CSV', icon: 'upload', href: '/connections/import-csv', keywords: 'upload file' },
@@ -2230,7 +2231,7 @@
       // "Go to" navigation — source of truth for `g+<x>` chords. Still exported
       // as plain maps so M0.5 can reuse them to seed palette entries.
       var goRoutes = {
-        d: { path: '/',                   label: 'Go to Feed' },
+        o: { path: '/',                   label: 'Go to Feed' },
         t: { path: '/transactions',       label: 'Go to Transactions' },
         c: { path: '/connections',        label: 'Go to Connections' },
         r: { path: '/reviews',            label: 'Go to Reviews' },
@@ -2244,7 +2245,8 @@
         m: { path: '/settings/mcp',       label: 'Go to MCP Settings' },
         k: { path: '/settings/api-keys',  label: 'Go to API Keys' },
         f: { path: '/settings/household', label: 'Go to Household' },
-        h: { path: '/agents',             label: 'Go to Agents' }
+        h: { path: '/agents',             label: 'Go to Agents' },
+        d: { path: '/design',             label: 'Go to Design system' }
       };
 
       var newRoutes = {


### PR DESCRIPTION
## Summary

- Adds a **Design system** entry to the command palette (System group, `palette` icon) so the `/design` sandbox is reachable without typing the URL.
- Binds `g` then `d` to it. Feed moves from `g+d` to `g+o` (mnemonic: "overview") — design system is the page we open most during a UI sprint, so it gets the punchier chord.
- Updates `docs/keyboard-shortcuts.md` table accordingly.

`base.html` is the canonical registry: `goRoutes` is the source of truth for `g+X` chords, and the cmdk palette items reference shortcuts by id (`shortcutId: 'global.go.d'`), so the trailing kbd hint in the palette row will render automatically.

## Test plan

- [ ] Press `Cmd+K` → "Design system" appears in the **System** group with a `g d` kbd hint on the right.
- [ ] Search "design" in the palette → entry filters in via the new keywords (`sandbox gallery components ui daisyui tailwind preview`).
- [ ] Outside any input, press `g` then `d` → navigates to `/design`.
- [ ] Outside any input, press `g` then `o` → navigates to `/` (Feed). Confirm the old `g+d` no longer maps to Feed.
- [ ] Open `?` shortcuts help → "Go to Feed" appears under `g o`, "Go to Design system" appears under `g d`.

## Validation note

Browser validation in this session was blocked: booting a fresh dev server in this worktree requires the cached `ENCRYPTION_KEY`, and the auto-mode classifier declined to read it. The change is a small JS data-registry edit (one chord remap + one palette item) — please eyeball before merging or pull locally to confirm the smoke test above.
