### PR TITLE
feat(design): highlight topmost visible section in /design outline

### DIFF
--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -23,6 +23,11 @@ import (
 // that disables the command palette on this page in favor of focusing
 // the filter input.
 templ DesignGallery(p DesignGalleryProps) {
+	// Section-slug → group-slug map consumed by the Alpine factory's
+	// scroll-spy so it can force-open the containing collapse when a
+	// section scrolls into view. Must precede the <script src> below so
+	// the IIFE finds the payload at parse time.
+	@templ.JSONScript("design-section-groups", DesignSectionGroupMap(p.Sections))
 	<script src="/static/js/admin/components/design_gallery.js"></script>
 	<div
 		x-data="designGallery"
@@ -143,10 +148,23 @@ templ designSidebarGroup(group DesignSectionGroup, sections []DesignSection) {
 			<div class="collapse-content px-0">
 				<ul class="flex flex-col gap-0.5 pl-3 border-l border-base-300/60 ml-2">
 					for _, sec := range sections {
-						<li x-show={ "match('" + sec.Title + "')" }>
+						<li
+							x-show={ "match('" + sec.Title + "')" }
+							class="relative"
+						>
+							// Primary-tinted bar overlays the parent UL's
+							// border-l so the active item reads as a left
+							// accent. `-left-3` lines up with the ul's pl-3.
+							<span
+								x-cloak
+								x-show={ "activeSlug === '" + sec.Slug + "'" }
+								aria-hidden="true"
+								class="absolute -left-3 top-1 bottom-1 w-0.5 rounded-full bg-primary"
+							></span>
 							<a
 								href={ templ.SafeURL("#" + sec.Slug) }
-								class="block text-sm text-base-content/60 hover:text-base-content transition-colors py-1 px-2 rounded-md hover:bg-base-200/40"
+								class="block text-sm transition-colors py-1 px-2 rounded-md"
+								:class={ "activeSlug === '" + sec.Slug + "' ? 'bg-base-200/60 text-base-content font-medium' : 'text-base-content/60 hover:text-base-content hover:bg-base-200/40'" }
 							>
 								{ sec.Title }
 							</a>
@@ -193,6 +211,7 @@ templ designSectionBlock(sec DesignSection) {
 	<section
 		id={ sec.Slug }
 		class="scroll-mt-[5.5rem]"
+		data-design-section="true"
 		x-show={ "match('" + sec.Title + "')" }
 	>
 		<div class="flex items-baseline justify-between gap-3 mb-1">

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -79,6 +79,18 @@ func SectionsByGroup(sections []DesignSection, groupSlug string) []DesignSection
 	return out
 }
 
+// DesignSectionGroupMap returns a slug → group-slug lookup used by the
+// gallery's scroll-spy: when a section becomes active the Alpine factory
+// resolves the containing group via this map so it can force-open the
+// collapsed group in the sidebar.
+func DesignSectionGroupMap(sections []DesignSection) map[string]string {
+	m := make(map[string]string, len(sections))
+	for _, s := range sections {
+		m[s.Slug] = s.Group
+	}
+	return m
+}
+
 // DesignSections returns the canonical, ordered list of gallery sections.
 // Each entry maps a URL slug to a templ component that demonstrates the
 // component family. To add a new section: write a `templ SectionFoo()`

--- a/static/js/admin/components/design_gallery.js
+++ b/static/js/admin/components/design_gallery.js
@@ -2,18 +2,29 @@
 //
 // Convention reference: docs/design-system.md → "Alpine page components".
 //
-// Owns the inline section filter, per-group open state, and the page-scoped
-// keyboard wiring. Sets shortcuts scope to 'design' on mount so the global
-// `/` binding (which normally opens the command palette) gets shadowed by
-// the design-page binding registered here — pressing `/` focuses the
-// filter input. `cmd+k` is intercepted via a capture-phase window
-// listener so commandPalette()'s @keydown.window handler in base.html
-// never fires on this page; we focus the filter instead.
+// Owns the inline section filter, per-group open state, the page-scoped
+// keyboard wiring, and the scroll-spy that highlights the topmost visible
+// section in the outline sidebar. Sets shortcuts scope to 'design' on
+// mount so the global `/` binding (which normally opens the command
+// palette) gets shadowed by the design-page binding registered here —
+// pressing `/` focuses the filter input. `cmd+k` is intercepted via a
+// capture-phase window listener so commandPalette()'s @keydown.window
+// handler in base.html never fires on this page; we focus the filter
+// instead.
 
 document.addEventListener('alpine:init', function () {
   Alpine.data('designGallery', function () {
     return {
       filter: '',
+      // Slug of the section that's currently topmost on screen. Drives
+      // the active-state styling on every sidebar link.
+      activeSlug: '',
+      // slug → group-slug lookup, seeded from the JSONScript tag emitted
+      // by the templ. Used to auto-expand the containing collapse when a
+      // section becomes active.
+      _groupMap: {},
+      _scrollHandler: null,
+      _scrollTicking: false,
 
       // Per-group accordion state. Keys match the slugs in
       // DesignSectionGroups() (design_types.go). Initialized to all open
@@ -30,24 +41,40 @@ document.addEventListener('alpine:init', function () {
 
       init: function () {
         var reg = window.Alpine && Alpine.store('shortcuts');
-        if (!reg) return;
-        reg.setScope('design');
-        var self = this;
-        reg.register({
-          id: 'design.focus-filter',
-          keys: '/',
-          description: 'Focus section filter',
-          group: 'Actions',
-          scope: 'design',
-          action: function () { self.focusFilter(); },
-        });
+        if (reg) {
+          reg.setScope('design');
+          var self = this;
+          reg.register({
+            id: 'design.focus-filter',
+            keys: '/',
+            description: 'Focus section filter',
+            group: 'Actions',
+            scope: 'design',
+            action: function () { self.focusFilter(); },
+          });
+        }
+
+        // Seed the section→group map from the JSONScript emitted in
+        // the templ. Missing tag = no scroll-spy, but the rest of the
+        // page still works.
+        try {
+          var el = document.getElementById('design-section-groups');
+          if (el) this._groupMap = JSON.parse(el.textContent) || {};
+        } catch (_) { this._groupMap = {}; }
+
+        this.setupScrollSpy();
       },
 
       destroy: function () {
         var reg = window.Alpine && Alpine.store('shortcuts');
-        if (!reg) return;
-        reg.unregister('design.focus-filter');
-        reg.setScope('global');
+        if (reg) {
+          reg.unregister('design.focus-filter');
+          reg.setScope('global');
+        }
+        if (this._scrollHandler) {
+          window.removeEventListener('scroll', this._scrollHandler);
+          window.removeEventListener('resize', this._scrollHandler);
+        }
       },
 
       // True iff the section's title matches the active filter (case-insensitive
@@ -107,6 +134,87 @@ document.addEventListener('alpine:init', function () {
         e.preventDefault();
         e.stopImmediatePropagation();
         this.focusFilter();
+      },
+
+      // Sets up a rAF-throttled scroll listener that finds the topmost
+      // visible section and reflects it in `activeSlug`. Uses the
+      // navbar offset (5.5rem = 88px) — matches the `scroll-mt-[5.5rem]`
+      // applied to each section so a section becomes "active" the
+      // moment its sticky-anchor target crosses the navbar line.
+      setupScrollSpy: function () {
+        var self = this;
+        function sections() {
+          return Array.from(document.querySelectorAll('[data-design-section]'));
+        }
+        if (!sections().length) return;
+
+        var navbarOffset = 88 + 1;
+
+        function pickActive() {
+          var list = sections();
+          var active = '';
+          for (var i = 0; i < list.length; i++) {
+            var s = list[i];
+            // x-show hides via display:none → offsetParent is null. Skip
+            // filtered-out sections so the active state ignores them.
+            if (s.offsetParent === null) continue;
+            var top = s.getBoundingClientRect().top;
+            if (top <= navbarOffset) {
+              active = s.id;
+            } else if (active) {
+              // First section below the cutoff after we already locked
+              // one in — stop. activeSlug stays on the highest one above.
+              break;
+            } else {
+              // Nothing has crossed the cutoff yet (page is at the very
+              // top). Highlight the first visible section anyway so the
+              // outline reflects what's on screen.
+              active = s.id;
+              break;
+            }
+          }
+          if (active && active !== self.activeSlug) {
+            self.activeSlug = active;
+            self.ensureGroupOpen(active);
+            self.scrollSidebarToActive(active);
+          }
+        }
+
+        function onScroll() {
+          if (self._scrollTicking) return;
+          self._scrollTicking = true;
+          window.requestAnimationFrame(function () {
+            self._scrollTicking = false;
+            pickActive();
+          });
+        }
+
+        this._scrollHandler = onScroll;
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll, { passive: true });
+
+        // Initial pick on next frame so x-show has applied display:none
+        // to filtered sections before we measure offsets.
+        window.requestAnimationFrame(pickActive);
+      },
+
+      // Force-open the collapse that contains the active section so the
+      // highlighted link is actually visible in the sidebar. Leaves
+      // other groups alone — collapsing a different group above the
+      // active one is the user's choice.
+      ensureGroupOpen: function (slug) {
+        var group = this._groupMap[slug];
+        if (group && !this.open[group]) this.open[group] = true;
+      },
+
+      // Scrolls the sidebar so the active link stays in view. Uses
+      // `block: 'nearest'` so this is a no-op when the link is already
+      // visible, and only nudges the scroll position when needed.
+      scrollSidebarToActive: function (slug) {
+        var link = document.querySelector('aside a[href="#' + slug + '"]');
+        if (link && link.scrollIntoView) {
+          link.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
       },
     };
   });


### PR DESCRIPTION
## Summary

- Adds scroll-spy to the design system sandbox at `/design`: the section currently topmost on screen is highlighted in the outline with a primary-tinted left bar + bold + soft background.
- Active state updates as you scroll (rAF-throttled on `window.scroll` + `resize`), auto-expands the collapsed group containing the active section, and nudges the sidebar via `scrollIntoView({ block: 'nearest' })` so the highlighted item stays visible.
- Hidden sections (`x-show` filter) are skipped — the active selection only walks visible content.

### How it works

- Each gallery section block carries `data-design-section`; the Alpine factory walks them in document order and picks the topmost whose top edge has crossed the `5.5rem` navbar offset (matching each section's `scroll-mt-[5.5rem]`).
- A new `DesignSectionGroupMap` helper emits a slug → group-slug map via `@templ.JSONScript("design-section-groups", …)` so the spy can force-open the containing daisy `collapse` when a section becomes active.

### Visuals

<table>
<tr><th>At top — Foundations active</th><th>Mid-scroll — Keyboard shortcuts active</th></tr>
<tr>
<td><img src="https://i.img402.dev/7tbfkbzfv5.jpg" width="420" alt="design sandbox — top of page, Foundations active in outline"></td>
<td><img src="https://i.img402.dev/2bapg6b290.jpg" width="420" alt="design sandbox — scrolled into Keyboard shortcuts, active state moved"></td>
</tr>
<tr><th>Layout — Cards active</th><th>Bottom — Activity timeline active</th></tr>
<tr>
<td><img src="https://i.img402.dev/l9xrqydx7d.jpg" width="420" alt="design sandbox — scrolled into Cards section"></td>
<td><img src="https://i.img402.dev/0wn0g4j9c2.jpg" width="420" alt="design sandbox — bottom of page, timeline active"></td>
</tr>
</table>

### Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] `go test ./internal/templates/components/pages/...` passes
- [x] Headless Chromium walkthrough at `/design`: scroll positions 0 / 2400 / 5200 / max → `activeSlug` moves through `foundations` → `kbd` → `cards` → `timeline`, and the active link's `font-weight: 500` + soft background apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
