### PR TITLE
feat(design): migrate Feed hero to PageHeader; drop Refresh button

### DIFF
--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -47,31 +47,15 @@ templ feedActiveFilterBanner(p FeedProps) {
 // ── Hero band ─────────────────────────────────────────────────────────────
 templ feedHero(p FeedProps) {
 	<header class="mb-6">
-		<div class="flex flex-wrap items-end justify-between gap-3 mb-4">
-			<div class="min-w-0">
-				<h1 class="text-3xl font-bold tracking-tight text-base-content">Feed</h1>
-				<p class="text-sm text-base-content/55 mt-1">
-					<span>Everything that happened in your breadbox</span>
-					<span class="hidden sm:inline">&middot; { p.Hero.Generated }</span>
-				</p>
-			</div>
-			<div class="flex items-center gap-2 shrink-0">
-				<button
-					type="button"
-					class="btn btn-sm btn-ghost"
-					onclick="window.location.reload()"
-					title="Refresh"
-					aria-label="Refresh feed"
-				>
-					<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
-					<span class="hidden sm:inline">Refresh</span>
-				</button>
-				<a href="/connections/new" class="btn btn-sm btn-primary" aria-label="Connect a new bank">
-					<i data-lucide="plus" class="w-3.5 h-3.5"></i>
-					<span class="hidden sm:inline">Connect bank</span>
-				</a>
-			</div>
-		</div>
+		@components.PageHeader(components.PageHeaderProps{
+			Title:    "Feed",
+			Subtitle: "Everything that happened in your breadbox · " + p.Hero.Generated,
+			Action: components.PageHeaderAction(
+				templ.SafeURL("/connections/new"),
+				"plus",
+				"Connect bank",
+			),
+		})
 		<div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
 			@feedHeroTile("activity", "Events today", fmt.Sprintf("%d", p.Hero.EventsToday), feedHeroSubEvents(p))
 			@feedHeroTile("download-cloud", "New transactions", fmt.Sprintf("%d", p.Hero.NewTransactionsToday), "synced today")


### PR DESCRIPTION
## Summary

Follow-up to #1458. Feed (the home `/` page) was the last remaining bespoke hero-band header. Migrated to `components.PageHeader`:

- **Title** "Feed" via canonical `bb-page-title` (drops the larger `text-3xl font-bold` hero scale per discussion).
- **Subtitle** combines the original two-line message + generated timestamp into a single line: *"Everything that happened in your breadbox · {Generated}"*.
- **Action** Connect bank (`/connections/new`).
- **Refresh button removed** — page already reloads on navigation; explicit affordance was noise.
- The 4-up stat-tile grid stays as a sibling block below the header.

## Test plan

- [x] `templ generate` + `go build ./...` clean.
- [x] Visual check at 1280×800 via Chrome DevTools:
  - `<h1>` renders with `bb-page-title` class.
  - Connect bank link points to `/connections/new`.
  - Refresh button no longer in DOM.
  - `documentElement.scrollWidth === clientWidth` (no horizontal overflow).
- [ ] Visual sweep at mobile (390px) to confirm Connect bank stays on-canvas.