### PR TITLE
feat(design): tag-picker sandbox sections + drop daisy tooltips from tag chips

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -419,6 +419,229 @@ templ SectionTags() {
 	</div>
 }
 
+// ─── Tag picker button ─────────────────────────────────────────────────
+
+// SectionTagPickerButton documents the two canonical triggers that open
+// the global tag picker. Both dispatch the same `open-tag-picker`
+// window event; only the visual shape differs.
+//
+// The picker overlay itself is a singleton in base.html (see
+// SectionTagPicker for its visual states). Triggers are caller-owned
+// markup; there is no shared templ component yet (2 distinct shapes
+// today, below the 3+ uses extraction threshold).
+templ SectionTagPickerButton() {
+	<div class="flex flex-col gap-6">
+		@designExample("Inline chip (bb-tag bb-tag-add)", "Used on the transaction detail page next to the row of present tags. The label flips between \"Add tag\" and \"Edit tags\" based on whether the transaction already has tags. Sizes: default + lg.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button type="button" class="bb-tag bb-tag-add">
+					<i data-lucide="plus"></i>
+					<span>Add tag</span>
+				</button>
+				<button type="button" class="bb-tag bb-tag-add">
+					<i data-lucide="plus"></i>
+					<span>Edit tags</span>
+				</button>
+				<button type="button" class="bb-tag bb-tag-lg bb-tag-add">
+					<i data-lucide="plus"></i>
+					<span>Add tag</span>
+				</button>
+				<button type="button" class="bb-tag bb-tag-lg bb-tag-add">
+					<i data-lucide="plus"></i>
+					<span>Edit tags</span>
+				</button>
+			</div>
+			<p class="text-xs text-base-content/50 mt-3">
+				Canonical site: <code>transaction_detail.templ</code> — sits in the same wrapping row as the present tag chips.
+			</p>
+		}
+		@designExample("Toolbar action (btn btn-ghost btn-sm)", "Used inside the floating multi-select toolbar on /transactions. Same dispatch contract, different visual because it sits next to other toolbar btn actions (Comment, Categorize).") {
+			<div class="inline-flex items-center gap-2 bg-base-100 border border-base-300 rounded-2xl shadow-sm px-3 py-2">
+				<button type="button" class="btn btn-ghost btn-sm gap-2" title="Tag selected">
+					<i data-lucide="tag" class="w-3.5 h-3.5"></i>
+					<span class="hidden sm:inline">Tag</span>
+					<span class="hidden sm:inline ml-1 text-[10px] opacity-50 border border-current/30 rounded px-1 leading-none py-0.5">T</span>
+				</button>
+			</div>
+			<p class="text-xs text-base-content/50 mt-3">
+				Canonical site: <code>static/js/admin/components/transactions.js</code> (<code>#bb-bulk-tag</code>) — injected into the multi-select bar at runtime. Hot-keyed to <code>T</code>.
+			</p>
+		}
+		@designExample("Dispatch contract", "Both triggers fire the same window event. The picker overlay (singleton in base.html) listens via @open-tag-picker.window.") {
+			<pre class="text-xs bg-base-200/60 rounded-lg p-3 overflow-x-auto"><code>{ tagPickerDispatchExample() }</code></pre>
+			<ul class="text-xs text-base-content/60 mt-3 space-y-1 list-disc pl-5">
+				<li><code>sourceId</code> — caller-chosen string echoed back in <code>tag-selection-commit</code>; how the caller knows the commit is for it.</li>
+				<li><code>transactionIds</code> — the transactions whose tags are being edited. 1 for the inline chip, N for the bulk toolbar.</li>
+				<li><code>appliedCounts</code> — map of slug → count present across the selection. count = N means the tag is present on every selected tx (renders as <em>present</em>); 0 &lt; count &lt; N renders as <em>mixed</em>; absent renders as <em>absent</em>.</li>
+				<li><code>availableTags</code> — the registered-tag list to populate chips. Pull from <code>window.__bbAllTags</code>.</li>
+			</ul>
+		}
+	</div>
+}
+
+// ─── Tag picker ────────────────────────────────────────────────────────
+
+// SectionTagPicker documents the global tag picker overlay
+// (.bb-tagpicker-dialog in base.html, driven by the globalTagPicker()
+// Alpine factory). The overlay is a singleton: every trigger across
+// every page opens the same instance.
+//
+// The visual states below are inert HTML — they mirror what the live
+// Alpine factory renders for each chip state. For an end-to-end live
+// demo, the "Open the real picker" button below dispatches the actual
+// open-tag-picker event with sample data, so reviewers can see the
+// singleton in action.
+templ SectionTagPicker() {
+	<div class="flex flex-col gap-6">
+		@designExample("Live demo", "Fires the real open-tag-picker event with sample data. The picker that opens is the singleton from base.html — the same one transactions and transaction detail use. Sample tags are injected inline so the chip grid renders even when no tags are registered on this server.") {
+			<button type="button" class="btn btn-primary btn-sm gap-2" onclick="window.dispatchEvent(new CustomEvent('open-tag-picker', {detail: {sourceId: 'design-sandbox', transactionIds: ['demo-1','demo-2','demo-3'], txCount: 3, appliedCounts: {recurring: 3, 'needs-review': 1}, availableTags: (window.__bbAllTags && window.__bbAllTags.length) ? window.__bbAllTags : [{slug:'recurring',display_name:'Recurring',color:'#10b981',icon:'refresh-cw'},{slug:'needs-review',display_name:'Needs review',color:'#f59e0b',icon:'inbox'},{slug:'subscription',display_name:'subscription',color:'#6366f1',icon:'bookmark'},{slug:'business',display_name:'Business',color:'#0ea5e9',icon:'building'},{slug:'refund',display_name:'Refund',color:'#ef4444',icon:'undo-2'}]}}))">
+				<i data-lucide="tag" class="w-3.5 h-3.5"></i>
+				<span>Open the real picker</span>
+			</button>
+		}
+		@designExample("Chip states", "Each chip in the picker grid carries one of five states. Click cycles a chip through the right column.") {
+			<div class="flex flex-wrap items-center gap-2 max-w-xl">
+				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--absent" style="--tag-color:#0ea5e9">
+					<span class="bb-tagpicker-chip-glyph"><i data-lucide="plus"></i></span>
+					<span class="truncate">absent</span>
+				</span>
+				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--present" style="--tag-color:#10b981">
+					<span class="bb-tagpicker-chip-glyph"><i data-lucide="check"></i></span>
+					<span class="truncate">present</span>
+				</span>
+				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--mixed" style="--tag-color:#f59e0b">
+					<span class="bb-tagpicker-chip-glyph"><i data-lucide="minus"></i></span>
+					<span class="truncate">mixed</span>
+				</span>
+				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-add" style="--tag-color:#6366f1">
+					<span class="bb-tagpicker-chip-glyph"><i data-lucide="plus"></i></span>
+					<span class="truncate">pending-add</span>
+				</span>
+				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-remove" style="--tag-color:#ef4444">
+					<span class="bb-tagpicker-chip-glyph"><i data-lucide="x"></i></span>
+					<span class="truncate">pending-remove</span>
+				</span>
+			</div>
+			<p class="text-xs text-base-content/50 mt-3">
+				Cycle order: <code>absent</code> → <code>pending-add</code> → <code>absent</code>; <code>present</code> → <code>pending-remove</code> → <code>present</code>; <code>mixed</code> → <code>pending-add</code> → <code>pending-remove</code> → <code>mixed</code>. Nothing fires until <em>Apply</em>.
+			</p>
+		}
+		@designExample("Static layout", "The overlay shape — search input, context strip, chip grid, diff strip, footer. Rendered inert here for layout reference; the live picker opens via the Live demo above.") {
+			<div class="bb-tagpicker-dialog" style="position: static; transform: none; width: 100%; max-width: 32rem;">
+				<div class="bb-catpicker-input-wrap gap-2">
+					<i data-lucide="tag"></i>
+					<input type="text" class="bb-catpicker-input" placeholder="Filter tags or type to create…" value="" readonly/>
+					<div class="bb-cmdk-kbd" style="font-size:0.6rem">esc</div>
+				</div>
+				<div class="bb-tagpicker-context">
+					<i data-lucide="receipt"></i>
+					<span>Editing tags for <strong>3</strong> transactions</span>
+				</div>
+				<div class="bb-tagpicker-body">
+					<div class="bb-tagpicker-grid">
+						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--present" style="--tag-color:#10b981">
+							<span class="bb-tagpicker-chip-glyph"><i data-lucide="check"></i></span>
+							<span class="truncate">recurring</span>
+						</button>
+						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--mixed" style="--tag-color:#f59e0b">
+							<span class="bb-tagpicker-chip-glyph"><i data-lucide="minus"></i></span>
+							<span class="truncate">needs-review</span>
+						</button>
+						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-add" style="--tag-color:#6366f1">
+							<span class="bb-tagpicker-chip-glyph"><i data-lucide="plus"></i></span>
+							<span class="truncate">subscription</span>
+						</button>
+						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--absent" style="--tag-color:#0ea5e9">
+							<span class="bb-tagpicker-chip-glyph"><i data-lucide="plus"></i></span>
+							<span class="truncate">business</span>
+						</button>
+						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-remove" style="--tag-color:#ef4444">
+							<span class="bb-tagpicker-chip-glyph"><i data-lucide="x"></i></span>
+							<span class="truncate">refund</span>
+						</button>
+					</div>
+				</div>
+				<div class="bb-tagpicker-diff">
+					<span class="bb-tagpicker-diff-pill bb-tagpicker-diff-pill--add">
+						<i data-lucide="plus"></i>
+						<span>1</span>
+						<span>to add</span>
+					</span>
+					<span class="bb-tagpicker-diff-pill bb-tagpicker-diff-pill--remove">
+						<i data-lucide="x"></i>
+						<span>1</span>
+						<span>to remove</span>
+					</span>
+					<button type="button" class="bb-tagpicker-diff-revert ml-auto">Revert</button>
+				</div>
+				<div class="bb-catpicker-footer">
+					<div class="flex items-center gap-3 flex-wrap">
+						<span class="inline-flex items-center gap-1">
+							@components.Kbd("enter")
+							<span>apply</span>
+						</span>
+						<span class="inline-flex items-center gap-1">
+							@components.Kbd("esc")
+							<span>cancel</span>
+						</span>
+					</div>
+					<div class="flex items-center gap-2">
+						<button type="button" class="btn btn-ghost btn-xs">Cancel</button>
+						<button type="button" class="btn btn-primary btn-xs">Apply</button>
+					</div>
+				</div>
+			</div>
+		}
+		@designExample("Inline create", "When the search query is a valid slug that doesn't exist yet, an inline `Create '<slug>'` button appears. Enter on an empty match also fires it.") {
+			<div class="bb-tagpicker-dialog" style="position: static; transform: none; width: 100%; max-width: 28rem;">
+				<div class="bb-catpicker-input-wrap gap-2">
+					<i data-lucide="tag"></i>
+					<input type="text" class="bb-catpicker-input" value="travel" readonly/>
+				</div>
+				<div class="bb-tagpicker-body">
+					<button type="button" class="bb-tagpicker-create-inline">
+						<i data-lucide="plus"></i>
+						<span>Create</span>
+						<code class="font-mono bg-base-100/60 px-1.5 py-0.5 rounded text-[0.7rem]">travel</code>
+						<span class="ml-auto text-[0.65rem] text-base-content/40">
+							<kbd class="bb-kbd">↵</kbd>
+						</span>
+					</button>
+				</div>
+			</div>
+		}
+		@designExample("Empty states", "Two empty shapes: zero registered tags (left) and no match for a non-sluggable query (right).") {
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				<div class="bb-tagpicker-dialog" style="position: static; transform: none; width: 100%;">
+					<div class="bb-catpicker-input-wrap gap-2">
+						<i data-lucide="tag"></i>
+						<input type="text" class="bb-catpicker-input" placeholder="Filter tags or type to create…" value="" readonly/>
+					</div>
+					<div class="bb-tagpicker-body">
+						<div class="bb-tagpicker-empty">
+							<i data-lucide="tags"></i>
+							<div class="text-sm">No tags yet</div>
+							<div class="text-xs">Type a slug to create the first one.</div>
+						</div>
+					</div>
+				</div>
+				<div class="bb-tagpicker-dialog" style="position: static; transform: none; width: 100%;">
+					<div class="bb-catpicker-input-wrap gap-2">
+						<i data-lucide="tag"></i>
+						<input type="text" class="bb-catpicker-input" value="Foo Bar!" readonly/>
+					</div>
+					<div class="bb-tagpicker-body">
+						<div class="bb-tagpicker-empty">
+							<i data-lucide="search-x"></i>
+							<div class="text-sm">No matching tags</div>
+							<div class="text-[0.65rem]">Slug must be lowercase letters, numbers, hyphens or colons.</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		}
+	</div>
+}
+
 // ─── Menus & dropdowns ─────────────────────────────────────────────────
 
 templ SectionMenusDropdowns() {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -218,6 +218,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionTags() },
 		},
 		{
+			Slug:        "tag-picker-button",
+			Title:       "Tag picker button",
+			Description: "Triggers that open the global tag picker — the inline bb-tag-add chip (transaction detail) and the bulk-toolbar btn-ghost variant (transactions list). Both fire the same open-tag-picker window event.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionTagPickerButton() },
+		},
+		{
 			Slug:        "amounts",
 			Title:       "Amounts",
 			Description: "components.Amount — the canonical renderer for monetary values. Three intents (transaction / balance / cost), three formats (standard / abbreviated / compact), pending modifier. Adopt for every new amount display so coloring and sign don't drift across pages.",
@@ -271,6 +278,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionMultiSelectToolbar() },
 		},
 		{
+			Slug:        "tag-picker",
+			Title:       "Tag picker",
+			Description: "Global picker overlay (singleton in base.html, driven by globalTagPicker()) — multi-tx diff editor: each chip cycles through absent/pending-add/pending-remove/present/mixed states, nothing fires until Apply. Opens via the open-tag-picker window event (see tag-picker-button section for triggers).",
+			Group:       "patterns",
+			Render:      func() templ.Component { return SectionTagPicker() },
+		},
+		{
 			Slug:        "timeline",
 			Title:       "Activity timeline",
 			Description: "GitHub-style row-on-rail primitives shared by /feed and /transactions/{id} — Timeline wrapper (card + prominent variants), day separators, system rows (built-in tones + custom tile), comment rows, inline actor references, and the empty-state.",
@@ -300,6 +314,23 @@ func designTimelineAgo(d time.Duration) string {
 func toastDispatchExample() string {
 	return "window.dispatchEvent(new CustomEvent('bb-toast', {\n" +
 		"  detail: { message: 'Saved', type: 'success' }\n" +
+		"}));"
+}
+
+// tagPickerDispatchExample returns the canonical dispatch snippet for
+// opening the global tag picker. Mirrors the live call sites
+// (transaction_detail.js, transactions.js bulk bar + 't' shortcut). The
+// literal `{` / `}` characters live here as a Go string for the same
+// templ-lexer reason as toastDispatchExample.
+func tagPickerDispatchExample() string {
+	return "window.dispatchEvent(new CustomEvent('open-tag-picker', {\n" +
+		"  detail: {\n" +
+		"    sourceId:       'txd-tag',          // echoed back in tag-selection-commit\n" +
+		"    transactionIds: [txId],             // 1 for inline chip, N for bulk\n" +
+		"    txCount:        1,\n" +
+		"    appliedCounts:  { recurring: 1 },   // {slug: count present across selection}\n" +
+		"    availableTags:  window.__bbAllTags, // registered tags for the chip grid\n" +
+		"  },\n" +
 		"}));"
 }
 

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -55,8 +55,7 @@ templ TagForm(p TagFormProps) {
 					<span class="text-[11px] uppercase tracking-wider text-base-content/40 font-medium shrink-0">Preview</span>
 					<span
 						class="bb-tag"
-						:class="displayName && slug && displayName !== slug ? 'tooltip tooltip-top' : ''"
-						:data-tip="displayName && slug && displayName !== slug ? slug : null"
+						:title="displayName && slug && displayName !== slug ? (displayName + ' — ' + slug) : (slug || 'tag-preview')"
 						:style="'--tag-color:' + (color || '#6366f1')"
 					>
 						<template x-if="icon">

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -278,8 +278,7 @@ templ txdMain(p TransactionDetailProps) {
 					<template x-for="t in tags" :key="t.slug">
 						<span
 							class="bb-tag bb-tag-lg"
-							:class="t.displayName && t.displayName !== t.slug ? 'tooltip tooltip-top' : ''"
-							:data-tip="t.displayName && t.displayName !== t.slug ? t.slug : null"
+							:title="t.displayName && t.displayName !== t.slug ? (t.displayName + ' — ' + t.slug) : t.slug"
 							:style="t.color ? ('--tag-color:' + t.color) : ''"
 						>
 							<template x-if="t.icon"><i :data-lucide="t.icon"></i></template>

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -340,11 +340,8 @@ templ txFilters(p TransactionsProps) {
 						<button
 							type="button"
 							class="bb-tag bb-tag-interactive"
-							:class="{
-								'bb-tag-ghost': !isSelected(t.slug),
-								'tooltip tooltip-top': t.display_name && t.display_name !== t.slug,
-							}"
-							:data-tip="t.display_name && t.display_name !== t.slug ? t.slug : null"
+							:class="{ 'bb-tag-ghost': !isSelected(t.slug) }"
+							:title="t.display_name && t.display_name !== t.slug ? (t.display_name + ' — ' + t.slug) : t.slug"
 							:style="t.color ? ('--tag-color:' + t.color) : ''"
 							@click="toggle(t.slug)"
 						>

--- a/internal/templates/components/tag_chip.templ
+++ b/internal/templates/components/tag_chip.templ
@@ -33,14 +33,11 @@ templ TagChipSm(tag TagChipData) {
 
 templ tagChipBody(class string, tag TagChipData) {
 	<span
-		class={ class, templ.KV("tooltip tooltip-top", tagChipShowTooltip(tag)) }
+		class={ class }
 		if tag.Color != nil {
 			style={ "--tag-color: " + deref(tag.Color) }
 		}
-		if tagChipShowTooltip(tag) {
-			data-tip={ tag.Slug }
-		}
-		title={ tag.Slug }
+		title={ tagChipTitle(tag) }
 	>
 		if tag.Icon != nil {
 			<i data-lucide={ deref(tag.Icon) }></i>
@@ -49,10 +46,13 @@ templ tagChipBody(class string, tag TagChipData) {
 	</span>
 }
 
-// tagChipShowTooltip returns true when the chip's visible label is the
-// display name (so the tooltip reveals what slug it maps to). Tags
-// without a display name already render the slug as their label, so
-// surfacing it in a tooltip would be redundant noise.
-func tagChipShowTooltip(tag TagChipData) bool {
-	return tag.DisplayName != "" && tag.DisplayName != tag.Slug
+// tagChipTitle returns the native `title=` hint surfaced on hover. When
+// the chip's visible label is the display name, the slug is appended so
+// callers can still see what underlying tag they're looking at; when the
+// label already IS the slug, returning just the slug avoids "foo — foo".
+func tagChipTitle(tag TagChipData) string {
+	if tag.DisplayName != "" && tag.DisplayName != tag.Slug {
+		return tag.DisplayName + " — " + tag.Slug
+	}
+	return tag.Slug
 }

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -683,13 +683,11 @@
                   'bb-tagpicker-chip--mixed':          chip.state === 'mixed',
                   'bb-tagpicker-chip--pending-add':    chip.state === 'pending-add',
                   'bb-tagpicker-chip--pending-remove': chip.state === 'pending-remove',
-                  'tooltip tooltip-top':               chip.display_name && chip.display_name !== chip.slug,
                 }"
-                :data-tip="chip.display_name && chip.display_name !== chip.slug ? chip.slug : null"
                 :style="chip.color ? ('--tag-color:' + chip.color) : ''"
                 @click="cycleChip(chip)"
                 x-effect="syncChipGlyph($el, chip.state, chip.icon)"
-                :title="chip.slug">
+                :title="chip.display_name && chip.display_name !== chip.slug ? (chip.display_name + ' — ' + chip.slug) : chip.slug">
                 <!-- Glyph slot — rewritten imperatively on state change.
                      Can't use <template x-if> + lucide here: lucide replaces
                      <i data-lucide> with <svg>, which Alpine no longer tracks,


### PR DESCRIPTION
Adds two sandbox sections documenting the global tag picker — its triggers and the overlay itself — and removes the daisy tooltip from every tag chip in the app along the way (it was clipped by ancestor `overflow` on the picker dialog, the scrollable picker body, and the meta line on tx rows, appearing "behind" nearby content).

## Sandbox sections

Both browsable in the sandbox shell at `/design/c/<slug>`:

**`/design/c/tag-picker-button`** — both canonical triggers side by side: the inline `bb-tag bb-tag-add` chip used on the transaction detail page (default + `bb-tag-lg`, "Add tag" / "Edit tags" labels), and the bulk-toolbar `btn-ghost btn-sm` variant injected from `transactions.js`. Plus the `open-tag-picker` dispatch contract with every `detail` field annotated.

<img src="https://i.img402.dev/6ke36p5uzh.jpg" width="800" alt="/design/c/tag-picker-button — chip variants, toolbar variant, dispatch contract">

**`/design/c/tag-picker`** — the singleton overlay's visual states: chip cycle (absent / present / mixed / pending-add / pending-remove), static layout with diff strip + footer, inline-create button, and the two empty states. A **Live demo** button fires the real `open-tag-picker` event with seeded sample tags so the chip grid renders even on a server with no tags registered.

<img src="https://i.img402.dev/8x35eeve5z.jpg" width="800" alt="/design/c/tag-picker — chip states, static layout, inline create, empty states">
<img src="https://i.img402.dev/559tjx7jcn.jpg" width="800" alt="Live demo: the singleton picker opens over the sandbox page with seeded sample tags">

## Drive-by: drop daisy tooltips from tag chips

The slug-reveal tooltip on `.bb-tag` chips renders behind any ancestor with `overflow: hidden` / `auto` — most notably the tag picker dialog (overflow-hidden) and its scrollable body. The clipped tooltip appears "behind the search field" instead of above the chip.

Every tag-chip site now uses a plain `title=` attribute. Native browser tooltips can't be clipped. Title text is `<display name> — <slug>` when they differ (so the slug stays discoverable on hover) and just `<slug>` when they match.

Touched sites (the shared component plus three remaining hand-rolled chips):

- `tag_chip.templ` — shared `TagChip` / `TagChipSm` (powers every tx row + cmdk feed row + tag-form preview)
- `tag_form.templ` — live tag-edit preview chip
- `transactions.templ` — tag-filter chip toggles in the sidebar
- `transaction_detail.templ` — present-tags row chips
- `base.html` — picker chips inside `globalTagPicker()`

Trade-off worth flagging: native tooltips reveal after the ~700 ms browser delay and inherit OS chrome (no styled bubble). If we want the styled look back inside a scrollable container, the right path is a shared popover-API tooltip primitive that escapes ancestor overflow — none of the current callers warrant that build today.

## Audit flagged but not changed

- **No shared `TagPickerButton` templ component yet.** Two visually-distinct call sites today (chip vs. toolbar btn) — under the 3+ uses threshold from `.claude/rules/daisyui.md`. The moment a third tag-edit affordance lands, all three should be migrated to a shared component.
- **The bulk toolbar's Tag button is hand-built from a JS string** (`transactions.js:954`). The wider design-system sprint is already migrating bulk-toolbar items to `components.MultiSelectToolbarAction`; the Tag button should ride that migration.
- **`rule_form.templ` uses a plain `<input list="bb-tag-slugs">`** for the Add tag / Remove tag rule actions, not the picker. Intentional — rules apply a single fixed slug, not a multi-tx diff.
- **The tag filter on `/transactions`** is an inline chip-toggle row in the sidebar, not the picker. Intentional — filter UX, not assign UX.

## Test plan

- [ ] Open `/design/c/tag-picker-button` — both chip + toolbar variants render; dispatch snippet readable.
- [ ] Open `/design/c/tag-picker` — chip-state row + static layout + inline create + empty states render.
- [ ] Click **Open the real picker** on `/design/c/tag-picker` — singleton dialog opens with seeded sample chips; cancelling closes it.
- [ ] Open a transaction with a tag whose display name differs from its slug on `/transactions/{id}` — hover the chip; native tooltip after delay shows `<display name> — <slug>`.
- [ ] Open the picker via "Edit tags" — hover a chip; no daisy tooltip clipping behind the search field.
- [ ] `/transactions` filter sidebar — tag chip hover shows native tooltip; no clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
