### PR TITLE
refactor(ui): migrate hardcoded OKLCH to daisyUI semantic tokens

### DIFF
--- a/input.css
+++ b/input.css
@@ -166,45 +166,26 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     /* Match safe area bars to content background */
-    background-color: oklch(0.97 0 0);
-  }
-  @media (prefers-color-scheme: dark) {
-    body { background-color: oklch(0.205 0 0); }
+    background-color: var(--color-base-200);
   }
 
   /* ── Themed text selection ── */
   ::selection {
-    background: oklch(0.205 0 0 / 0.15);
-    color: oklch(0.145 0 0);
-  }
-  @media (prefers-color-scheme: dark) {
-    ::selection {
-      background: oklch(0.922 0 0 / 0.2);
-      color: oklch(0.985 0 0);
-    }
+    background: oklch(from var(--color-base-content) l c h / 0.15);
+    color: var(--color-base-content);
   }
 
   /* ── Focus rings: accessible, consistent, shadcn-style ── */
   :focus-visible {
-    outline: 2px solid oklch(0.205 0 0 / 0.4);
+    outline: 2px solid oklch(from var(--color-base-content) l c h / 0.4);
     outline-offset: 2px;
     border-radius: inherit;
-  }
-  @media (prefers-color-scheme: dark) {
-    :focus-visible {
-      outline-color: oklch(0.922 0 0 / 0.4);
-    }
   }
 
   /* ── Thin scrollbars ── */
   * {
     scrollbar-width: thin;
-    scrollbar-color: oklch(0.922 0 0 / 0.5) transparent;
-  }
-  @media (prefers-color-scheme: dark) {
-    * {
-      scrollbar-color: oklch(0.269 0 0 / 0.7) transparent;
-    }
+    scrollbar-color: oklch(from var(--color-base-content) l c h / 0.25) transparent;
   }
   ::-webkit-scrollbar {
     width: 6px;
@@ -214,19 +195,11 @@
     background: transparent;
   }
   ::-webkit-scrollbar-thumb {
-    background: oklch(0.922 0 0 / 0.5);
+    background: oklch(from var(--color-base-content) l c h / 0.25);
     border-radius: 3px;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: oklch(0.922 0 0 / 0.7);
-  }
-  @media (prefers-color-scheme: dark) {
-    ::-webkit-scrollbar-thumb {
-      background: oklch(0.269 0 0 / 0.7);
-    }
-    ::-webkit-scrollbar-thumb:hover {
-      background: oklch(0.4 0 0 / 0.7);
-    }
+    background: oklch(from var(--color-base-content) l c h / 0.4);
   }
 
   /* ── Global link transitions ── */
@@ -254,26 +227,7 @@
 
   .bb-card--interactive:hover {
     @apply bg-base-200/50;
-    border-color: oklch(0.85 0 0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    /* In dark mode the body background equals --color-base-100 (oklch 0.205),
-     * so a stock .bb-card painted bg-base-100 is invisible — same colour as
-     * the page underneath. Lift the card surface 4–5% toward white via
-     * color-mix so cards/tiles read as elevated panels. Targeted (no light-
-     * mode change). Pairs with the body=base-100 dark-theme convention; the
-     * cleaner alternative (flip body to base-200) was rejected as too high
-     * blast-radius. See PR for /feed dark-mode contrast pass. */
-    .bb-card {
-      background-color: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
-    }
-    .bb-card--interactive:hover {
-      border-color: oklch(0.35 0 0);
-      /* Hover should read as more elevated than rest, not less. Default
-       * bg-base-200/50 in dark mode dips below the body — reverse that. */
-      background-color: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
-    }
+    border-color: var(--color-base-300);
   }
 
   /* ── Form card primitives ── */
@@ -321,18 +275,11 @@
     position: sticky;
     top: 0;
     z-index: 30;
-    border-bottom: 1px solid oklch(0 0 0 / 0.06);
+    border-bottom: 1px solid oklch(from var(--color-base-content) l c h / 0.06);
     /* Subtle backdrop blur for depth when content scrolls underneath */
     -webkit-backdrop-filter: blur(8px);
             backdrop-filter: blur(8px);
     background-color: color-mix(in oklch, var(--color-base-100) 92%, transparent);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-mobile-navbar {
-      border-bottom-color: oklch(1 0 0 / 0.08);
-      background-color: color-mix(in oklch, var(--color-base-100) 88%, transparent);
-    }
   }
 
   .bb-mobile-search-btn {
@@ -525,7 +472,7 @@
    *   </span>
    */
   .bb-tag {
-    --tag-color: oklch(0.6 0 0);
+    --tag-color: oklch(from var(--color-base-content) l c h / 0.4);
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
@@ -942,29 +889,53 @@
   /* ── Select dropdown popup (base-select appearance) ── */
   /* DaisyUI 5 uses appearance: base-select which renders a custom dropdown popup.
      In dark mode the popup and option backgrounds default to transparent,
-     causing content behind to bleed through. Fix by setting explicit backgrounds. */
+     causing content behind to bleed through. Fix by setting explicit backgrounds.
+     Paired with an explicit [data-theme="dark"] selector so the override also
+     fires when the user toggles the theme on a light-OS system. */
   @media (prefers-color-scheme: dark) {
-    .select::picker(select) {
-      background-color: oklch(0.205 0 0);
-      border: 1px solid oklch(0.35 0 0);
+    :root:not([data-theme="light"]) .select::picker(select) {
+      background-color: var(--color-base-100);
+      border: 1px solid var(--color-base-300);
       border-radius: 0.75rem;
       box-shadow: 0 8px 32px oklch(0 0 0 / 0.5);
       padding: 0.25rem;
     }
 
-    .select option {
-      color: oklch(0.985 0 0);
+    :root:not([data-theme="light"]) .select option {
+      color: var(--color-base-content);
       border-radius: 0.5rem;
       padding: 0.375rem 0.75rem;
     }
 
-    .select option:hover {
-      background-color: oklch(0.269 0 0);
+    :root:not([data-theme="light"]) .select option:hover {
+      background-color: var(--color-base-200);
     }
 
-    .select option:checked {
-      background-color: oklch(0.269 0 0);
+    :root:not([data-theme="light"]) .select option:checked {
+      background-color: var(--color-base-200);
     }
+  }
+
+  [data-theme="dark"] .select::picker(select) {
+    background-color: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    border-radius: 0.75rem;
+    box-shadow: 0 8px 32px oklch(0 0 0 / 0.5);
+    padding: 0.25rem;
+  }
+
+  [data-theme="dark"] .select option {
+    color: var(--color-base-content);
+    border-radius: 0.5rem;
+    padding: 0.375rem 0.75rem;
+  }
+
+  [data-theme="dark"] .select option:hover {
+    background-color: var(--color-base-200);
+  }
+
+  [data-theme="dark"] .select option:checked {
+    background-color: var(--color-base-200);
   }
 
   /* DaisyUI's .modal defaults are used as-is — no per-class overrides
@@ -1039,15 +1010,19 @@
   .bb-tx-row--focused {
     @apply bg-primary/5;
     --bb-row-bg: color-mix(in oklab, var(--color-primary) 5%, var(--color-base-100));
-    box-shadow: inset 3px 0 0 oklch(0.55 0.15 250);
+    box-shadow: inset 3px 0 0 var(--color-primary);
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-tx-row--focused {
+    :root:not([data-theme="light"]) .bb-tx-row--focused {
       @apply bg-primary/10;
       --bb-row-bg: color-mix(in oklab, var(--color-primary) 10%, var(--color-base-100));
-      box-shadow: inset 3px 0 0 oklch(0.65 0.15 250);
     }
+  }
+
+  [data-theme="dark"] .bb-tx-row--focused {
+    @apply bg-primary/10;
+    --bb-row-bg: color-mix(in oklab, var(--color-primary) 10%, var(--color-base-100));
   }
 
   /* ── Compact tx row (command palette, dashboard recents) ──
@@ -1063,7 +1038,7 @@
   /* ── Transaction category avatar ── */
   .bb-tx-avatar {
     @apply w-9 h-9 rounded-xl flex items-center justify-center shrink-0;
-    --avatar-color: oklch(0.65 0 0);
+    --avatar-color: oklch(from var(--color-base-content) l c h / 0.5);
     background: color-mix(in oklch, var(--avatar-color) 12%, transparent);
     color: var(--avatar-color);
   }
@@ -1089,19 +1064,25 @@
    * transaction has no category yet, so the visual signal "needs a
    * category" is consistent regardless of where the row appears. */
   .bb-tx-avatar--uncategorized {
-    --avatar-color: oklch(0.205 0 0);
-    background: oklch(0.205 0 0 / 0.06);
-    color: oklch(0.205 0 0 / 0.45);
+    --avatar-color: var(--color-base-content);
+    background: oklch(from var(--color-base-content) l c h / 0.06);
+    color: oklch(from var(--color-base-content) l c h / 0.45);
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-tx-avatar {
+    :root:not([data-theme="light"]) .bb-tx-avatar {
       background: color-mix(in oklch, var(--avatar-color) 18%, transparent);
     }
-    .bb-tx-avatar--uncategorized {
-      background: oklch(0.985 0 0 / 0.08);
-      color: oklch(0.985 0 0 / 0.45);
+    :root:not([data-theme="light"]) .bb-tx-avatar--uncategorized {
+      background: oklch(from var(--color-base-content) l c h / 0.08);
     }
+  }
+
+  [data-theme="dark"] .bb-tx-avatar {
+    background: color-mix(in oklch, var(--avatar-color) 18%, transparent);
+  }
+  [data-theme="dark"] .bb-tx-avatar--uncategorized {
+    background: oklch(from var(--color-base-content) l c h / 0.08);
   }
 
   /* ── Owner-identity badge on the tx avatar ──
@@ -1149,15 +1130,18 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-tx-amount--pending {
+    :root:not([data-theme="light"]) .bb-tx-amount--pending {
       opacity: 0.65;
     }
+  }
+  [data-theme="dark"] .bb-tx-amount--pending {
+    opacity: 0.65;
   }
 
   /* ── Rule category badge ── */
   .bb-rule-cat-badge {
     @apply inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full;
-    --cat-color: oklch(0.55 0 0);
+    --cat-color: oklch(from var(--color-base-content) l c h / 0.55);
     background: color-mix(in oklch, var(--cat-color) 10%, transparent);
     color: var(--cat-color);
   }
@@ -1168,9 +1152,12 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-rule-cat-badge {
+    :root:not([data-theme="light"]) .bb-rule-cat-badge {
       background: color-mix(in oklch, var(--cat-color) 15%, transparent);
     }
+  }
+  [data-theme="dark"] .bb-rule-cat-badge {
+    background: color-mix(in oklch, var(--cat-color) 15%, transparent);
   }
 
   /* ── Smooth collapse for filter panels ── */
@@ -1300,9 +1287,12 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-cmdk-dialog {
-      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    :root:not([data-theme="light"]) .bb-cmdk-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
     }
+  }
+  [data-theme="dark"] .bb-cmdk-dialog {
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
   }
 
   .bb-cmdk-input-wrap {
@@ -1577,9 +1567,12 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-shortcuts-dialog {
-      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    :root:not([data-theme="light"]) .bb-shortcuts-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
     }
+  }
+  [data-theme="dark"] .bb-shortcuts-dialog {
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
   }
 
   .bb-shortcuts-header {
@@ -1627,10 +1620,14 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-shortcuts-section--page {
+    :root:not([data-theme="light"]) .bb-shortcuts-section--page {
       background: oklch(from var(--color-info) l c h / 0.10);
       border-color: oklch(from var(--color-info) l c h / 0.3);
     }
+  }
+  [data-theme="dark"] .bb-shortcuts-section--page {
+    background: oklch(from var(--color-info) l c h / 0.10);
+    border-color: oklch(from var(--color-info) l c h / 0.3);
   }
 
   /* Accent rail down the left edge so it's instantly readable as "scoped". */
@@ -1743,9 +1740,12 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-catpicker-dialog {
-      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    :root:not([data-theme="light"]) .bb-catpicker-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
     }
+  }
+  [data-theme="dark"] .bb-catpicker-dialog {
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
   }
 
   .bb-catpicker-input-wrap {
@@ -1878,9 +1878,12 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-tagpicker-dialog {
-      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    :root:not([data-theme="light"]) .bb-tagpicker-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
     }
+  }
+  [data-theme="dark"] .bb-tagpicker-dialog {
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
   }
 
   @media (max-width: 640px) {
@@ -1922,14 +1925,14 @@
 
   /* Present: solid 1.5px ring in the tag's own color. */
   .bb-tagpicker-chip--present {
-    box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--tag-color, oklch(0.65 0 0)) 55%, transparent);
+    box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--tag-color, oklch(from var(--color-base-content) l c h / 0.4)) 55%, transparent);
   }
 
   /* Mixed: dashed ring signals indeterminate, like Finder/macOS checkboxes. */
   .bb-tagpicker-chip--mixed {
     background-color: color-mix(in srgb, var(--tag-color) 6%, transparent);
     border-style: dashed;
-    box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--tag-color, oklch(0.65 0 0)) 45%, transparent);
+    box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--tag-color, oklch(from var(--color-base-content) l c h / 0.4)) 45%, transparent);
   }
 
   /* Pending add: green ring + glyph in success. Chip pre-renders as "applied". */
@@ -2057,17 +2060,10 @@
   .bb-progress-bar__fill {
     @apply h-full;
     width: 0%;
-    background: oklch(0.205 0 0);
+    background: var(--color-base-content);
     border-radius: 0 2px 2px 0;
     transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 0 8px oklch(0.205 0 0 / 0.3);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-progress-bar__fill {
-      background: oklch(0.922 0 0);
-      box-shadow: 0 0 8px oklch(0.922 0 0 / 0.3);
-    }
+    box-shadow: 0 0 8px oklch(from var(--color-base-content) l c h / 0.3);
   }
 
   .bb-progress-bar__fill--done {
@@ -2098,9 +2094,12 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .bb-confirm-dialog {
-      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    :root:not([data-theme="light"]) .bb-confirm-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
     }
+  }
+  [data-theme="dark"] .bb-confirm-dialog {
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.06);
   }
 
   .bb-confirm-body {
@@ -2132,19 +2131,10 @@
     @apply inline-flex items-center justify-center min-w-[1.25rem] h-[1.25rem]
            text-[0.6rem] font-mono font-medium leading-none
            rounded px-1;
-    background: oklch(0.97 0 0);
-    color: oklch(0.4 0 0);
-    border: 1px solid oklch(0.9 0 0);
-    box-shadow: 0 1px 0 oklch(0.88 0 0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-kbd {
-      background: oklch(0.25 0 0);
-      color: oklch(0.7 0 0);
-      border-color: oklch(0.35 0 0);
-      box-shadow: 0 1px 0 oklch(0.15 0 0);
-    }
+    background: var(--color-base-200);
+    color: oklch(from var(--color-base-content) l c h / 0.7);
+    border: 1px solid var(--color-base-300);
+    box-shadow: 0 1px 0 oklch(from var(--color-base-content) l c h / 0.08);
   }
 
   /* Blended modifier pill: ⌘│K rendered as one tight badge with a hairline
@@ -2154,10 +2144,10 @@
   .bb-kbd-combo {
     @apply inline-flex items-center h-[1.25rem] rounded overflow-hidden
            font-mono font-medium text-[0.6rem] leading-none;
-    background: oklch(0.97 0 0);
-    color: oklch(0.4 0 0);
-    border: 1px solid oklch(0.9 0 0);
-    box-shadow: 0 1px 0 oklch(0.88 0 0);
+    background: var(--color-base-200);
+    color: oklch(from var(--color-base-content) l c h / 0.7);
+    border: 1px solid var(--color-base-300);
+    box-shadow: 0 1px 0 oklch(from var(--color-base-content) l c h / 0.08);
   }
 
   .bb-kbd-combo__key {
@@ -2165,25 +2155,13 @@
   }
 
   .bb-kbd-combo__key + .bb-kbd-combo__key {
-    border-left: 1px solid oklch(0.9 0 0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-kbd-combo {
-      background: oklch(0.25 0 0);
-      color: oklch(0.7 0 0);
-      border-color: oklch(0.35 0 0);
-      box-shadow: 0 1px 0 oklch(0.15 0 0);
-    }
-    .bb-kbd-combo__key + .bb-kbd-combo__key {
-      border-left-color: oklch(0.35 0 0);
-    }
+    border-left: 1px solid var(--color-base-300);
   }
 
   /* ── Triage mode: compact review rows ── */
   .bb-triage-row {
     @apply relative;
-    border-bottom: 1px solid oklch(0.922 0 0);
+    border-bottom: 1px solid var(--color-base-300);
     transition: background-color 0.1s ease;
   }
 
@@ -2192,23 +2170,11 @@
   }
 
   .bb-triage-row:hover {
-    background: oklch(0.98 0 0);
+    background: var(--color-base-200);
   }
 
   .bb-triage-row--focused {
-    background: oklch(0.97 0 0) !important;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-triage-row {
-      border-bottom-color: oklch(0.269 0 0);
-    }
-    .bb-triage-row:hover {
-      background: oklch(0.23 0 0);
-    }
-    .bb-triage-row--focused {
-      background: oklch(0.25 0 0) !important;
-    }
+    background: var(--color-base-200) !important;
   }
 
   .bb-triage-row__main {
@@ -2222,13 +2188,7 @@
   }
 
   .bb-triage-row__indicator--active {
-    background: oklch(0.205 0 0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-triage-row__indicator--active {
-      background: oklch(0.922 0 0);
-    }
+    background: var(--color-base-content);
   }
 
   .bb-triage-row__type {
@@ -2294,72 +2254,38 @@
            border border-transparent cursor-pointer;
     transition: all 0.1s ease;
     background: transparent;
-    color: oklch(0.5 0 0);
+    color: oklch(from var(--color-base-content) l c h / 0.6);
   }
 
   /* On mobile, show colored backgrounds so actions are tappable without hover */
   @media (max-width: 639px) {
     .bb-triage-action--accept {
-      color: oklch(0.55 0.14 155);
-      background: oklch(0.62 0.14 155 / 0.08);
-      border-color: oklch(0.62 0.14 155 / 0.2);
+      color: var(--color-success);
+      background: oklch(from var(--color-success) l c h / 0.08);
+      border-color: oklch(from var(--color-success) l c h / 0.2);
     }
     .bb-triage-action--skip {
-      color: oklch(0.45 0 0);
-      background: oklch(0.5 0 0 / 0.05);
-      border-color: oklch(0.5 0 0 / 0.12);
+      color: oklch(from var(--color-base-content) l c h / 0.55);
+      background: oklch(from var(--color-base-content) l c h / 0.05);
+      border-color: oklch(from var(--color-base-content) l c h / 0.12);
     }
   }
 
   .bb-triage-action:hover {
-    border-color: oklch(0.9 0 0);
-    background: oklch(0.97 0 0);
+    border-color: var(--color-base-300);
+    background: var(--color-base-200);
   }
 
   .bb-triage-action--accept:hover {
-    color: oklch(0.55 0.14 155);
-    border-color: oklch(0.62 0.14 155 / 0.3);
-    background: oklch(0.62 0.14 155 / 0.08);
+    color: var(--color-success);
+    border-color: oklch(from var(--color-success) l c h / 0.3);
+    background: oklch(from var(--color-success) l c h / 0.08);
   }
 
   .bb-triage-action--skip:hover {
-    color: oklch(0.45 0 0);
-    border-color: oklch(0.85 0 0);
-    background: oklch(0.95 0 0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-triage-action {
-      color: oklch(0.6 0 0);
-    }
-    .bb-triage-action:hover {
-      border-color: oklch(0.35 0 0);
-      background: oklch(0.25 0 0);
-    }
-    .bb-triage-action--accept:hover {
-      color: oklch(0.75 0.14 155);
-      border-color: oklch(0.70 0.14 155 / 0.3);
-      background: oklch(0.70 0.14 155 / 0.1);
-    }
-    .bb-triage-action--skip:hover {
-      color: oklch(0.7 0 0);
-      border-color: oklch(0.4 0 0);
-      background: oklch(0.28 0 0);
-    }
-  }
-
-  /* Dark mode mobile action buttons */
-  @media (prefers-color-scheme: dark) and (max-width: 639px) {
-    .bb-triage-action--accept {
-      color: oklch(0.75 0.14 155);
-      background: oklch(0.70 0.14 155 / 0.1);
-      border-color: oklch(0.70 0.14 155 / 0.2);
-    }
-    .bb-triage-action--skip {
-      color: oklch(0.7 0 0);
-      background: oklch(0.5 0 0 / 0.08);
-      border-color: oklch(0.5 0 0 / 0.15);
-    }
+    color: oklch(from var(--color-base-content) l c h / 0.55);
+    border-color: var(--color-base-300);
+    background: var(--color-base-200);
   }
 
   .bb-triage-action:disabled {
@@ -2370,15 +2296,8 @@
   /* Triage detail panel */
   .bb-triage-detail {
     @apply px-3 sm:px-6 py-2.5 border-t;
-    border-color: oklch(0.94 0 0);
-    background: oklch(0.985 0 0);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-triage-detail {
-      border-color: oklch(0.28 0 0);
-      background: oklch(0.22 0 0);
-    }
+    border-color: var(--color-base-300);
+    background: var(--color-base-200);
   }
 
   /* Agent report markdown body — lean, design-system-aligned rendering.


### PR DESCRIPTION
## Summary

Migrates hardcoded `oklch(...)` literals in `input.css` to daisyUI 5 semantic tokens so the styles correctly respond to explicit `data-theme` overrides (e.g. from the sidebar theme toggle in #1466) — not only the OS `prefers-color-scheme`.

- **Grayscale `oklch(L 0 0)`** → `var(--color-base-{100,200,300})` or `var(--color-base-content)` based on role (surface vs text vs border).
- **Grayscale with alpha** → `oklch(from var(--color-base-content) l c h / α)` so each rule resolves correctly under either theme.
- **Brand-color literals** → `var(--color-success)`, `var(--color-info)`, `var(--color-primary)` etc.
- **Asymmetric modal-shadow blocks** (dark drop + light hairline rim) keep their `@media (prefers-color-scheme: dark)` rule but the rim now derives from `--color-base-content`, and the same styles are paired under `[data-theme="dark"]` so the explicit toggle path fires too. The `prefers` rule is gated with `:root:not([data-theme="light"])` so an explicit light override on a dark-OS browser still wins.
- **Pure-black scrims** (`oklch(0 0 0 / α)`) kept — intentional theme-neutral modal dim.
- The dark-mode `.bb-card` color-mix lift becomes redundant: body now uses `--color-base-200`, so `.bb-card` (bg-base-100) is naturally elevated in both themes via daisy's stock token spread.

Net: `grep -c oklch input.css`: **123 → 61**, file -81 lines.

## Validation

Captured on this branch (no theme toggle merged yet — `data-theme="dark"` set via DevTools to exercise the explicit-toggle path that was previously broken).

<table>
  <tr><th>Light (OS=light, no override)</th><th>Dark via OS preference</th><th>Dark via <code>data-theme="dark"</code> (toggle path — was broken)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/78818ac2z0.jpg" width="320" alt="Feed light"></td>
    <td><img src="https://i.img402.dev/zatq7r8mr0.jpg" width="320" alt="Feed dark via prefers-color-scheme"></td>
    <td><img src="https://i.img402.dev/6ievfyd79s.jpg" width="320" alt="Feed dark via data-theme toggle"></td>
  </tr>
</table>

The middle and right columns now render identically — that's the fix. Before this change, the right column kept many surfaces in light-mode colors (kbd badges, modal shadows, select picker, scrollbars, focus rings, body safe-area bg, etc.) because they were gated only on `prefers-color-scheme`.

### Other pages — dark via `data-theme="dark"` toggle path

<table>
  <tr><th>/transactions</th><th>/design</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/2hlswcv5d9.jpg" width="400" alt="Transactions dark via toggle"></td>
    <td><img src="https://i.img402.dev/2emm427u5f.jpg" width="400" alt="Design sandbox dark via toggle"></td>
  </tr>
</table>

## Stacks with

- #1466 (sidebar sun/moon toggle) — that PR adds the UI; this PR makes the styles respond to it. Either can land first; they're independent.

## Test plan

- [ ] Toggle theme via #1466's sun/moon (once merged) — every surface flips, no leftover light-mode kbd / scrollbar / modal shadows in dark.
- [ ] OS dark mode still works (set `prefers-color-scheme: dark` with `data-theme` unset).
- [ ] OS dark + `data-theme="light"` set explicitly → page stays light (no `prefers` leak).
- [ ] `make css` recompiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
