### PR TITLE
fix(design): stack designExample title above caption on mobile

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1121,7 +1121,7 @@ templ SectionSectionHeader() {
 // the live markup. Used by every Section* component above.
 templ designExample(title, caption string) {
 	<div>
-		<div class="flex items-baseline gap-3 mb-3">
+		<div class="flex flex-col gap-1 mb-3 sm:flex-row sm:items-baseline sm:gap-3">
 			<h3 class="text-sm font-semibold">{ title }</h3>
 			if caption != "" {
 				<p class="text-xs text-base-content/50">{ caption }</p>


### PR DESCRIPTION
## Summary

The `/design` sandbox helper `designExample` (`internal/templates/components/pages/design_sections.templ:1122`) pairs each example's title with its caption via `flex items-baseline gap-3`. At iPhone-14 width the flex container forces both children to shrink to their min-content, collapsing every `<h3>` to its longest word. Every sandbox section title wraps to 2-3 awkward lines on mobile.

Stack the pair vertically by default and restore the side-by-side row from `sm:` (≥640px). Single CSS change to one templ helper, applies to all 25 sandbox sections automatically.

Part of the `mobile-sandbox-polish` sprint.

## Before / after — mobile (390×844)

### `/design/c/kbd?embed=1`
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/brsglk1mzd.jpg" width="380" alt="kbd before"></td>
    <td><img src="https://i.img402.dev/ife4n3ll9d.jpg" width="380" alt="kbd after"></td>
  </tr>
</table>

### `/design/c/page-header?embed=1`
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/5rh4new5kv.jpg" width="380" alt="page-header before"></td>
    <td><img src="https://i.img402.dev/uuq3dttjou.jpg" width="380" alt="page-header after"></td>
  </tr>
</table>

### `/design/c/cards?embed=1`
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/qoaozo8inm.jpg" width="380" alt="cards before"></td>
    <td><img src="https://i.img402.dev/pm67xcfwn3.jpg" width="380" alt="cards after"></td>
  </tr>
</table>

## Test plan

- [x] `go build ./...` clean
- [x] `templ generate` regenerates `design_sections_templ.go`
- [x] Mobile (390×844) — re-captured every `/design/c/{slug}?embed=1` page; titles no longer wrap
- [ ] Desktop (≥sm) — layout unchanged from `sm:flex-row sm:items-baseline sm:gap-3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
