### PR TITLE
fix(design): keep StatTile readable in 2-up mobile grid

### DIFF
--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -89,15 +89,15 @@ templ StatTile(p StatTileProps) {
 }
 
 templ statTileBody(p StatTileProps) {
-	<div class="flex items-center gap-3">
+	<div class="flex items-center gap-2.5 sm:gap-3">
 		if p.Icon != "" {
-			<div class={ "w-9 h-9 rounded-lg flex items-center justify-center shrink-0", statTileBg(p.Tone) }>
+			<div class={ "w-8 h-8 sm:w-9 sm:h-9 rounded-lg flex items-center justify-center shrink-0", statTileBg(p.Tone) }>
 				<i data-lucide={ p.Icon } class={ "w-4 h-4", statTileIcon(p.Tone) }></i>
 			</div>
 		}
-		<div class="min-w-0">
-			<div class="text-2xl font-semibold tabular-nums leading-none truncate">{ p.Value }</div>
-			<div class="text-xs text-base-content/40 mt-1 uppercase tracking-wider">{ p.Label }</div>
+		<div class="min-w-0 flex-1">
+			<div class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate">{ p.Value }</div>
+			<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">{ p.Label }</div>
 			if p.Description != "" {
 				<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate">{ p.Description }</div>
 			}


### PR DESCRIPTION
## Summary

`StatTile` value + label clip badly in the 2-up mobile grid:

- `1,234` → `1,2…`, `2h ago` → `2h …` (value column ~95px wide, `text-2xl` tabular-nums doesn't fit)
- `TRANSACTIONS` overflows past the card edge (label has `uppercase tracking-wider` and no `truncate`)

Scale icon / value / label down on mobile and restore the original desktop sizes from `sm:`. Also add `truncate` + `flex-1` to the content column so the label can't escape the tile.

Part of the `mobile-sandbox-polish` sprint.

## Before / after — `/design/c/stat-tiles?embed=1` at 390×844

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/vn484t69wz.jpg" width="380" alt="stat-tiles before"></td>
    <td><img src="https://i.img402.dev/sduvtgw7es.jpg" width="380" alt="stat-tiles after"></td>
  </tr>
</table>

## Test plan

- [x] `go build ./...` clean
- [x] `templ generate` regenerates `stat_tile_templ.go`
- [x] Mobile (390×844) — values now read fully, label fits inside card
- [ ] Desktop (≥sm) — sizes unchanged (`sm:w-9`, `sm:text-2xl`, `sm:text-xs`)
- [ ] Verify on the dashboard pages that actually use `StatTileRow` (rules / connections / logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
