### PR TITLE
fix(design): wrap toast sandbox code snippet on mobile

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1299,7 +1299,7 @@ templ SectionToast() {
 					Fire info
 				</button>
 			</div>
-			<pre class="mt-3 text-xs bg-base-200/40 rounded-lg p-3 overflow-x-auto"><code>{ toastDispatchExample() }</code></pre>
+			<pre class="mt-3 text-xs bg-base-200/40 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-words sm:whitespace-pre sm:break-normal"><code>{ toastDispatchExample() }</code></pre>
 		}
 		@designExample("Variants (visual reference)", "All four type values rendered as static pills. Real toasts auto-dismiss after ~3 s.") {
 			<div class="flex flex-col gap-2 max-w-md">


### PR DESCRIPTION
## Summary

`SectionToast` shows a `window.dispatchEvent(...)` code sample inside a `<pre class="overflow-x-auto">`. On mobile the lines are wider than the card, so the snippet is clipped at the right edge and the horizontal scrollbar fades in iOS Safari — easy to miss. Switch to `whitespace-pre-wrap break-words` on mobile and restore the strict `whitespace-pre` behavior from `sm:`.

Part of the `mobile-sandbox-polish` sprint.

## Before / after — `/design/c/toast?embed=1` at 390×844

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/4yl46cwz6k.jpg" width="380" alt="toast before"></td>
    <td><img src="https://i.img402.dev/xg0ykf3x23.jpg" width="380" alt="toast after"></td>
  </tr>
</table>

> The header label "Trigger via bb-toast event" still wraps awkwardly in this branch because the `designExample` stack fix lives in #1470 — both land cleanly together.

## Test plan

- [x] `go build ./...` clean
- [x] `templ generate` regenerates `design_sections_templ.go`
- [x] Mobile (390×844) — code snippet wraps inside the card, no clipping
- [ ] Desktop (≥sm) — snippet keeps strict pre-formatted layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
