### PR TITLE
fix(design): truncate TxRow "Uncategorized" label with ellipsis

### DIFF
--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -86,7 +86,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 						</span>
 					} else {
 						<span class="xl:hidden text-base-content/20 shrink-0">&middot;</span>
-						<span class="xl:hidden text-base-content/25 truncate shrink-0">Uncategorized</span>
+						<span class="xl:hidden text-base-content/25 truncate min-w-0">Uncategorized</span>
 					}
 					<!-- Slot 3 — Tags. Chips at xl+ (rendered via the JS-managed
 					     bb-tx-tag-container so add/remove updates in place); a
@@ -140,11 +140,11 @@ templ TxRow(tx service.AdminTransactionRow) {
 							<span class="text-base-content/50 truncate">{ deref(tx.CategoryDisplayName) }</span>
 						</span>
 					} else {
-						<span class="text-base-content/20">&middot;</span>
-						<span class="text-base-content/25 truncate shrink-0">Uncategorized</span>
+						<span class="text-base-content/20 shrink-0">&middot;</span>
+						<span class="text-base-content/25 truncate min-w-0">Uncategorized</span>
 					}
 					if len(tx.Tags) > 0 {
-						<span class="text-base-content/20">&middot;</span>
+						<span class="text-base-content/20 shrink-0">&middot;</span>
 						<span class="inline-flex items-center gap-0.5 text-base-content/40 shrink-0" title={ fmt.Sprintf("%d tag%s", len(tx.Tags), pluralS(len(tx.Tags))) }>
 							<i data-lucide="tag" class="w-3 h-3"></i>
 							<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(len(tx.Tags)) }</span>


### PR DESCRIPTION
## Summary

The Uncategorized branch of `TxRow`'s meta line used
`truncate shrink-0`, which means the span stays at its intrinsic
content width (no shrink) and `truncate` never engages — the
parent's `overflow-hidden` just hard-cuts the text, producing
"Uncategoriz" with no ellipsis on a phone.

Swap `shrink-0` for `min-w-0` on the label so `truncate` engages,
and pin `shrink-0` on the leading `·` separator so it doesn't
collapse. Applies to both the mobile sub-line (`<sm`) and the
in-between meta line (`sm:flex … xl:hidden`).

Part of the `mobile-sandbox-polish` sprint.

## Before / after — `/design/c/transaction-rows?embed=1` at 390×844

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ykdagpdscn.jpg" width="380" alt="transaction-rows before"></td>
    <td><img src="https://i.img402.dev/nh4dmfe9nk.jpg" width="380" alt="transaction-rows after"></td>
  </tr>
</table>

The fix is most visible on `Acme Payroll` and `USPS PO 12345` —
the "Uncategoriz" raw cut becomes "Uncateg…" with the ellipsis.

## Test plan

- [x] `go build ./...` clean
- [x] `templ generate` regenerates `tx_row_templ.go`
- [x] Mobile (390×844) — Uncategorized label truncates with ellipsis
- [ ] Desktop / xl: the inline category picker takes over so this code path is dormant — verify the row still reads correctly on `/transactions` at xl+

🤖 Generated with [Claude Code](https://claude.com/claude-code)
