### PR TITLE
refactor(design): adopt shadcn full-width SidebarInset layout

### DIFF
--- a/internal/templates/components/pages/agent_form.templ
+++ b/internal/templates/components/pages/agent_form.templ
@@ -22,13 +22,13 @@ import (
 // same CSRF token.
 templ AgentForm(p AgentFormProps) {
 	@components.BreadcrumbNav(agentFormBreadcrumbs(p))
-	<div class="bb-page-header max-w-2xl mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">{ p.Title }</h1>
 			<p class="text-sm text-base-content/50 mt-1">Configure when this agent runs, which tools it can use, and what prompt drives it.</p>
 		</div>
 	</div>
-	<div class="max-w-2xl mx-auto">
+	<div class="max-w-2xl">
 		if p.FormError != "" {
 			<div role="alert" class="bb-form-error mb-4">
 				<i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>

--- a/internal/templates/components/pages/api_key_created.templ
+++ b/internal/templates/components/pages/api_key_created.templ
@@ -9,13 +9,13 @@ import "breadbox/internal/templates/components"
 // Alpine clipboard binding, same revealed-once flow, same "Done" link.
 templ APIKeyCreated(p APIKeyCreatedProps) {
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">API Key Created</h1>
 			<p class="text-sm text-base-content/50 mt-1">Copy your key now -- you won't see it again</p>
 		</div>
 	</div>
-	<div class="bb-card p-6 max-w-lg mx-auto">
+	<div class="bb-card p-6 max-w-lg">
 		<div class="flex items-center gap-3 mb-5">
 			<div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
 				<i data-lucide="check" class="w-5 h-5 text-success"></i>

--- a/internal/templates/components/pages/api_key_new.templ
+++ b/internal/templates/components/pages/api_key_new.templ
@@ -10,13 +10,13 @@ import "breadbox/internal/templates/components"
 // admin/apikeys.go.
 templ APIKeyNew(p APIKeyNewProps) {
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Create API Key</h1>
 			<p class="text-sm text-base-content/50 mt-1">Generate a new key for API or MCP access</p>
 		</div>
 	</div>
-	<div class="bb-card p-6 max-w-lg mx-auto">
+	<div class="bb-card p-6 max-w-lg">
 		<form method="POST" action="/settings/api-keys/new">
 			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 			<fieldset class="fieldset mb-5">

--- a/internal/templates/components/pages/category_form.templ
+++ b/internal/templates/components/pages/category_form.templ
@@ -23,7 +23,7 @@ templ CategoryForm(p CategoryFormProps) {
 	@components.CategoryPickerScript()
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	@components.CategoryPickerStyles()
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">
 				if p.IsEdit {
@@ -41,7 +41,7 @@ templ CategoryForm(p CategoryFormProps) {
 			</p>
 		</div>
 	</div>
-	<div class="max-w-lg mx-auto" x-data="categoryForm()">
+	<div class="max-w-lg" x-data="categoryForm()">
 		<form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
 			<div class="p-5 sm:p-6">
 				<!-- Live preview icon header -->

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -18,7 +18,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 	     from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/connection_new.js"></script>
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Connect New Bank</h1>
 			<p class="text-sm text-base-content/50 mt-1">Link a bank account to start syncing transactions</p>
@@ -26,7 +26,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 	</div>
 	if !p.HasPlaid && !p.HasTeller {
 		<!-- No providers configured -->
-		<div class="bb-card p-8 max-w-lg mx-auto">
+		<div class="bb-card p-8 max-w-lg">
 			<div class="flex flex-col items-center text-center">
 				<div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
 					<i data-lucide="plug-zap" class="w-8 h-8 text-warning"></i>
@@ -41,7 +41,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 	} else {
 		<div x-data="connectionNew" data-teller-env={ p.TellerEnv }>
 			<div id="step-select">
-				<div class="bb-card p-8 max-w-lg mx-auto">
+				<div class="bb-card p-8 max-w-lg">
 					<div class="flex items-center gap-3 mb-6">
 						@components.IconTile("primary", "user-plus")
 						<div>
@@ -111,7 +111,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 				</div>
 			</div>
 			<div id="step-link" class="hidden">
-				<div class="bb-card p-8 max-w-lg mx-auto">
+				<div class="bb-card p-8 max-w-lg">
 					<div class="flex flex-col items-center text-center">
 						<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
 							<i data-lucide="link" class="w-8 h-8 text-primary"></i>

--- a/internal/templates/components/pages/connection_reauth.templ
+++ b/internal/templates/components/pages/connection_reauth.templ
@@ -42,13 +42,13 @@ templ ConnectionReauth(p ConnectionReauthProps) {
 	}
 	<script src="/static/js/admin/components/connection_reauth.js"></script>
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Re-authenticate</h1>
 			<p class="text-sm text-base-content/50 mt-1">{ p.InstitutionName } needs to be re-connected</p>
 		</div>
 	</div>
-	<div class="bb-card p-8 max-w-lg mx-auto">
+	<div class="bb-card p-8 max-w-lg">
 		<div
 			x-data="connectionReauth"
 			data-conn-id={ p.ConnID }

--- a/internal/templates/components/pages/create_login.templ
+++ b/internal/templates/components/pages/create_login.templ
@@ -24,13 +24,13 @@ templ CreateLogin(p CreateLoginProps) {
 }
 
 templ createLoginManage(p CreateLoginProps) {
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Manage Login</h1>
 			<p class="text-sm text-base-content/50 mt-1">Login account for { p.UserName }</p>
 		</div>
 	</div>
-	<div class="max-w-lg mx-auto">
+	<div class="max-w-lg">
 		<div
 			class="bb-card p-0 overflow-hidden"
 			x-data={ manageLoginRoleAlpine(p) }
@@ -166,13 +166,13 @@ templ createLoginManage(p CreateLoginProps) {
 }
 
 templ createLoginNew(p CreateLoginProps) {
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Create Login</h1>
 			<p class="text-sm text-base-content/50 mt-1">Create a sign-in account for { p.UserName }</p>
 		</div>
 	</div>
-	<div class="max-w-lg mx-auto" x-data={ newLoginAlpine(p) }>
+	<div class="max-w-lg" x-data={ newLoginAlpine(p) }>
 		<template x-if="!done">
 			<form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
 				<!-- Header + fields -->

--- a/internal/templates/components/pages/my_account.templ
+++ b/internal/templates/components/pages/my_account.templ
@@ -11,7 +11,7 @@ package pages
 // Endpoint URLs are passed via data-* attrs so the same factory drives
 // admin scope (/-/users/{id}/*) and self scope (/settings/account/*).
 templ MyAccount(p MyAccountProps) {
-	<div class="max-w-2xl mx-auto">
+	<div class="max-w-2xl">
 		<div class="bb-page-header">
 			<div class="min-w-0">
 				<h1 class="bb-page-title">Account</h1>
@@ -52,7 +52,7 @@ templ MyProfile(p MyAccountProps) {
 	// Synchronous (no defer): the page script registers its alpine:init
 	// listener before Alpine fires the event. See user_form.js.
 	<script src="/static/js/admin/components/user_form.js"></script>
-	<div class="max-w-2xl mx-auto">
+	<div class="max-w-2xl">
 		<div class="bb-page-header">
 			<div class="min-w-0">
 				<h1 class="bb-page-title">Profile</h1>

--- a/internal/templates/components/pages/oauth_client_created.templ
+++ b/internal/templates/components/pages/oauth_client_created.templ
@@ -20,13 +20,13 @@ templ OAuthClientCreated(p OAuthClientCreatedProps) {
 	     from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/oauth_client_created.js"></script>
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">OAuth Client Created</h1>
 			<p class="text-sm text-base-content/50 mt-1">Copy your credentials now -- you won't see the secret again</p>
 		</div>
 	</div>
-	<div class="bb-card p-6 max-w-lg mx-auto" x-data="oauthClientCreated" data-secret={ p.ClientSecret }>
+	<div class="bb-card p-6 max-w-lg" x-data="oauthClientCreated" data-secret={ p.ClientSecret }>
 		<div class="flex items-center gap-3 mb-5">
 			<div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
 				<i data-lucide="check" class="w-5 h-5 text-success"></i>

--- a/internal/templates/components/pages/oauth_client_new.templ
+++ b/internal/templates/components/pages/oauth_client_new.templ
@@ -11,13 +11,13 @@ import "breadbox/internal/templates/components"
 // admin/oauth.go.
 templ OAuthClientNew(p OAuthClientNewProps) {
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Create OAuth Client</h1>
 			<p class="text-sm text-base-content/50 mt-1">Generate credentials for an external connector (e.g., Claude)</p>
 		</div>
 	</div>
-	<div class="bb-card p-6 max-w-lg mx-auto">
+	<div class="bb-card p-6 max-w-lg">
 		<form method="POST" action="/oauth-clients/new">
 			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 			<fieldset class="fieldset mb-5">

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -25,13 +25,13 @@ templ RuleForm(p RuleFormProps) {
 		@templ.JSONScript("rule-form-data", p.Rule)
 	}
 	<div x-data="ruleForm" data-is-edit={ ruleFormIsEditAttr(p.IsEdit) }>
-		<div class="bb-page-header max-w-2xl mx-auto">
+		<div class="bb-page-header">
 			<div>
 				<h1 class="bb-page-title" x-text="isEdit ? 'Edit Rule' : 'New Rule'"></h1>
 				<p class="text-sm text-base-content/50 mt-1">When transactions match the conditions, the actions are applied automatically.</p>
 			</div>
 		</div>
-		<div class="max-w-2xl mx-auto">
+		<div class="max-w-2xl">
 			<form @submit.prevent="submitRule()" class="bb-card p-0 overflow-hidden">
 				<!-- Top section: icon header + rule name -->
 				<div class="p-5 sm:p-6">

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -8,7 +8,7 @@ import "breadbox/internal/templates/components"
 // Alpine submit flow) is preserved.
 templ TagForm(p TagFormProps) {
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">
 				if p.IsEdit {
@@ -26,7 +26,7 @@ templ TagForm(p TagFormProps) {
 			</p>
 		</div>
 	</div>
-	<div class="max-w-lg mx-auto" x-data="tagForm()">
+	<div class="max-w-lg" x-data="tagForm()">
 		<form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
 			<div class="p-5 sm:p-6">
 				<div class="bb-icon-header">

--- a/internal/templates/components/pages/user_form.templ
+++ b/internal/templates/components/pages/user_form.templ
@@ -13,7 +13,7 @@ templ UserForm(p UserFormProps) {
 	// trail behind this rule.
 	<script src="/static/js/admin/components/user_form.js"></script>
 	@components.BreadcrumbNav(p.Breadcrumbs)
-	<div class="bb-page-header max-w-lg mx-auto">
+	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">
 				if p.IsEdit {
@@ -41,7 +41,7 @@ templ UserForm(p UserFormProps) {
 // userFormCreate renders the create flow (Alpine `userForm` factory in
 // static/js/admin/components/user_form.js).
 templ userFormCreate() {
-	<div x-data="userForm" class="max-w-lg mx-auto">
+	<div x-data="userForm" class="max-w-lg">
 		<!-- Success state: show setup URL after login creation -->
 		<template x-if="setupURL">
 			<div class="bb-card p-8">
@@ -171,7 +171,7 @@ templ userFormCreate() {
 // static/js/admin/components/user_form.js). User UUID and the initial
 // hasCustomAvatar flag flow via data-* attrs on the x-data root.
 templ userFormEdit(p UserFormProps) {
-	<div x-data="avatarEditor" data-user-id={ p.UserID } data-has-custom-avatar={ userFormHasAvatarStr(p.User) } class="max-w-lg mx-auto">
+	<div x-data="avatarEditor" data-user-id={ p.UserID } data-has-custom-avatar={ userFormHasAvatarStr(p.User) } class="max-w-lg">
 		<form @submit.prevent="submitForm()" class="bb-card p-0 overflow-hidden">
 			<!-- Header + fields -->
 			<div class="p-5 sm:p-6">

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -377,7 +377,7 @@
         </div>
       </div>
       <!-- Page content -->
-      <main class="p-4 sm:p-6 max-w-6xl mx-auto min-h-screen">
+      <main class="p-4 sm:p-6 min-h-screen">
         {{template "flash" .}}
         {{- /* TemplContent slot — set by TemplateRenderer.RenderWithTempl to
               render a templ-generated body inside the base layout without


### PR DESCRIPTION
## Summary

Replaces #1467's centered-column approach with shadcn's `SidebarInset` pattern: the drawer-content `<main>` fills all available width, and form pages drop their per-page centering.

**Why:** #1467 centered the 1152px `max-w-6xl` cap with `mx-auto` to avoid stranded empty space on the right. Looking at how [shadcn dashboards](https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/new-york-v4/blocks/dashboard-01/page.tsx) and [sidebar blocks](https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/new-york-v4/blocks/sidebar-07/page.tsx) actually structure their layouts, none of them apply a max-width to the content area — `SidebarInset` fills the available width, and grids reflow via container queries (`@xl/main:grid-cols-2 @5xl/main:grid-cols-4`) so wider monitors get *more columns*, not centered whitespace.

**Changes:**
- Drop `max-w-6xl mx-auto` from the drawer-content `<main>` — full-width, like shadcn's `SidebarInset`.
- Revert #1467's form-page `mx-auto` on `bb-page-header` + form wrappers. Forms return to being left-anchored within their existing `max-w-Xxl` cap, matching shadcn's pattern of forms in full-width sections (or dialogs).
- Auth shell (no sidebar) keeps its `max-w-6xl mx-auto` — it's a focused single-flow layout where centering is appropriate.

Net diff = clean revert of #1467 + one extra single-class deletion on the drawer `<main>`.

**Why now and not via grid reflow:** Our feed dashboard already uses `grid-cols-2 lg:grid-cols-4` (viewport-based), which gives the same 4-column reflow as container queries given our fixed sidebar width. Container-query conversion is a separate (small) follow-up if we ever add a collapsible sidebar.

## Evidence — 1440×900

**Feed (dashboard fills width, hero tiles span 4 columns):**

<img src="https://i.img402.dev/nfa05jt32m.jpg" width="800" alt="Feed — after">

**Transactions (table fills width):**

<img src="https://i.img402.dev/mg11t9ap2p.jpg" width="800" alt="Transactions — after">

**Add Category (form left-anchored, capped at max-w-lg):**

<img src="https://i.img402.dev/wa1bdcb6z7.jpg" width="800" alt="Add Category — after">

**New Rule (header + form aligned at max-w-2xl):**

<img src="https://i.img402.dev/1w4x4p4fi8.jpg" width="800" alt="New Rule — after">

**Add Tag (same pattern as Add Category):**

<img src="https://i.img402.dev/zakd3zosrx.jpg" width="800" alt="Add Tag — after">

## Test plan
- [x] Wide monitor: dashboard / transactions fill the full sidebar-inset width
- [x] Dashboard hero tiles still wrap to 4 columns at `lg`
- [x] Form pages (`/categories/new`, `/rules/new`, `/tags/new`) — header + form anchored left, capped at their per-page `max-w-Xxl`
- [ ] Mobile / narrow widths unchanged (verified visually at desktop only)
- [ ] Auth pages (`/login`) still centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)