### PR TITLE
feat(design): port shadcn/ui default palette to daisyUI light/dark themes

### DIFF
--- a/input.css
+++ b/input.css
@@ -23,6 +23,116 @@
   themes: light --default, dark --prefersdark;
 }
 
+/* ─── shadcn-flavored daisyUI themes ──────────────────────────────────
+ * Faithful port of the shadcn/ui new-york default palette (oklch source
+ * values from shadcn-ui/ui@apps/v4/app/globals.css) onto daisyUI 5's
+ * token model. Near-zero-chroma grays, inverted primary (dark stamp in
+ * light, light stamp in dark), red destructive.
+ *
+ * Theme names are kept as `light` / `dark` so they override daisyUI's
+ * built-ins — the existing theme-toggle in base.html writes
+ * data-theme="light"/"dark" verbatim, no markup changes needed.
+ *
+ * Semantic colors that shadcn doesn't define (warning/success/info) are
+ * aliased to Tailwind palette tokens — same shades shadcn users compose
+ * inline (amber/emerald/sky 500 → 400 in dark). This keeps daisy
+ * components like alert-warning / badge-success rendering without
+ * inventing a new tone vocabulary.
+ * ──────────────────────────────────────────────────────────────── */
+@plugin "daisyui/theme" {
+  name: "light";
+  default: true;
+  prefersdark: false;
+  color-scheme: light;
+
+  --color-base-100: oklch(1 0 0);
+  --color-base-200: oklch(0.97 0 0);
+  --color-base-300: oklch(0.922 0 0);
+  --color-base-content: oklch(0.145 0 0);
+
+  --color-primary: oklch(0.205 0 0);
+  --color-primary-content: oklch(0.985 0 0);
+
+  --color-secondary: oklch(0.97 0 0);
+  --color-secondary-content: oklch(0.205 0 0);
+
+  --color-accent: oklch(0.97 0 0);
+  --color-accent-content: oklch(0.205 0 0);
+
+  --color-neutral: oklch(0.205 0 0);
+  --color-neutral-content: oklch(0.985 0 0);
+
+  --color-info: var(--color-sky-500);
+  --color-info-content: oklch(0.985 0 0);
+
+  --color-success: var(--color-emerald-500);
+  --color-success-content: oklch(0.145 0 0);
+
+  --color-warning: var(--color-amber-500);
+  --color-warning-content: oklch(0.145 0 0);
+
+  --color-error: oklch(0.577 0.245 27.325);
+  --color-error-content: oklch(0.985 0 0);
+
+  --radius-selector: 0.25rem;
+  --radius-field: 0.5rem;
+  --radius-box: 0.625rem;
+
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
+
+@plugin "daisyui/theme" {
+  name: "dark";
+  default: false;
+  prefersdark: true;
+  color-scheme: dark;
+
+  --color-base-100: oklch(0.145 0 0);
+  --color-base-200: oklch(0.205 0 0);
+  --color-base-300: oklch(0.269 0 0);
+  --color-base-content: oklch(0.985 0 0);
+
+  --color-primary: oklch(0.922 0 0);
+  --color-primary-content: oklch(0.205 0 0);
+
+  --color-secondary: oklch(0.269 0 0);
+  --color-secondary-content: oklch(0.985 0 0);
+
+  --color-accent: oklch(0.371 0 0);
+  --color-accent-content: oklch(0.985 0 0);
+
+  --color-neutral: oklch(0.97 0 0);
+  --color-neutral-content: oklch(0.205 0 0);
+
+  --color-info: var(--color-sky-400);
+  --color-info-content: oklch(0.145 0 0);
+
+  --color-success: var(--color-emerald-400);
+  --color-success-content: oklch(0.145 0 0);
+
+  --color-warning: var(--color-amber-400);
+  --color-warning-content: oklch(0.145 0 0);
+
+  --color-error: oklch(0.704 0.191 22.216);
+  --color-error-content: oklch(0.145 0 0);
+
+  --radius-selector: 0.25rem;
+  --radius-field: 0.5rem;
+  --radius-box: 0.625rem;
+
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
+
 /* Force-include classes that Tailwind's content scanner can't see
    because they live inside dynamic strings (Alpine :class, runtime
    templ expressions, JS className builders).


### PR DESCRIPTION
## Summary

- Override daisyUI's stock `light` + `dark` themes with the shadcn/ui **new-york** default palette (oklch values sourced from [`shadcn-ui/ui@apps/v4/app/globals.css`](https://github.com/shadcn-ui/ui/blob/main/apps/v4/app/globals.css)).
- Theme names kept as `light` / `dark` — the sidebar theme toggle in `base.html` writes `data-theme="dark"` verbatim, so it works **with zero markup changes**.
- Signature shadcn cues: achromatic near-zero-chroma grays, **inverted primary** (near-black stamp in light / near-white stamp in dark), shadcn's destructive red, rounded-md (`0.5rem`) fields, rounded-lg (`0.625rem`) boxes.

## Warning / success / info — and why they're Tailwind aliases

shadcn deliberately ships only `--destructive` as a chromatic semantic token. For everything else they expect callers to compose Tailwind shades inline. daisyUI components (`alert-warning`, `badge-success`, `btn-info`) require those tokens to render, so this PR aliases them to the same Tailwind shades a shadcn user would reach for:

```css
--color-warning: var(--color-amber-500);   /* amber-400 in dark */
--color-success: var(--color-emerald-500); /* emerald-400 in dark */
--color-info:    var(--color-sky-500);     /* sky-400 in dark */
```

No new tone vocabulary, no synthesized oklch, no shadcn-themes-community-registry tokens.

## Visual evidence

### `/design` foundations — the token palette side-by-side

<table>
  <tr><th>Light</th><th>Dark</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/prv1zbserz.jpg" width="400" alt="design — light"></td>
    <td><img src="https://i.img402.dev/vefr247hsb.jpg" width="400" alt="design — dark"></td>
  </tr>
</table>

Note the **inverted primary** (black tile in light, white tile in dark) and the Tailwind-aliased warning/success/info.

### Dashboard `/`

<table>
  <tr><th>Light</th><th>Dark</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/l11dxhjem8.jpg" width="400" alt="home — light"></td>
    <td><img src="https://i.img402.dev/62m1wr6lxz.jpg" width="400" alt="home — dark"></td>
  </tr>
</table>

### `/transactions` — high-density real data

<table>
  <tr><th>Light</th><th>Dark</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ow07df97g1.jpg" width="400" alt="transactions — light"></td>
    <td><img src="https://i.img402.dev/j4hq9knwb7.jpg" width="400" alt="transactions — dark"></td>
  </tr>
</table>

## Theme toggle verification

The sidebar sun/moon toggle writes `data-theme="dark"` / `data-theme="light"` to `<html>` and persists to `localStorage`. Verified working — the dark screenshots above were captured by injecting `data-theme="dark"` on a `prefers-color-scheme: light` system; daisyUI's `[data-theme=dark]` selector beats the prefers-color-scheme block as expected.

## Known cosmetic carryover

Flagged at the top of `input.css` already, not addressed in this PR — these will read 1–2% off until cleaned up in a follow-up:

- `.bb-card` dark-mode `color-mix` lift, `.bb-comment-bubble` background mix, `.bb-tx-avatar--uncategorized`, focus rings, scrollbar thumb, `.bb-cmdk-kbd` — all hardcode oklch values against the prior palette.

## Test plan

- [ ] Toggle the sidebar sun/moon — light → dark → light works without reload.
- [ ] Spot-check `/`, `/transactions`, `/reviews`, `/rules`, `/design` in light + dark.
- [ ] Confirm warning/success/info badges and alerts read amber/emerald/sky as expected.
- [ ] Sanity-check `getComputedStyle` on `.btn-primary` — should be `oklch(0.205 0 0)` in light, `oklch(0.922 0 0)` in dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
