### PR TITLE
refactor(design): swap daisyUI depth for shadcn-style drop shadows

### DIFF
--- a/input.css
+++ b/input.css
@@ -82,7 +82,7 @@
   --size-field: 0.25rem;
 
   --border: 1px;
-  --depth: 2;
+  --depth: 0;
   --noise: 0;
 }
 
@@ -129,7 +129,7 @@
   --size-field: 0.25rem;
 
   --border: 1px;
-  --depth: 2;
+  --depth: 0;
   --noise: 0;
 }
 
@@ -977,6 +977,17 @@
 
   .btn:active:not(:disabled) {
     transform: scale(0.97) !important;
+  }
+
+  /*
+   * Subtle drop shadow matching shadcn's Button component (shadow-xs).
+   * With --depth: 0 the daisyUI inset/3D shadow stack evaluates to
+   * transparent, so the button reads as completely flat without this
+   * override. shadcn doesn't shadow transparent buttons (ghost/link),
+   * so they opt out via :not().
+   */
+  .btn:not(.btn-ghost):not(.btn-link) {
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   }
 
   /* Button radius convention — see unlayered .btn-sm / .btn-xs override

--- a/input.css
+++ b/input.css
@@ -82,7 +82,7 @@
   --size-field: 0.25rem;
 
   --border: 1px;
-  --depth: 1;
+  --depth: 2;
   --noise: 0;
 }
 
@@ -129,7 +129,7 @@
   --size-field: 0.25rem;
 
   --border: 1px;
-  --depth: 1;
+  --depth: 2;
   --noise: 0;
 }
 
@@ -325,9 +325,15 @@
   .breadcrumbs { scrollbar-width: none; -ms-overflow-style: none; }
   .breadcrumbs::-webkit-scrollbar { display: none; }
 
-  /* ── Cards: shadcn-style — border, not shadow ── */
+  /* ── Cards: shadcn-style — 1px border + subtle drop shadow ──
+   * shadcn's Card component ships `border ... shadow-sm` (both, not
+   * border-only). The prior "border, not shadow" stance read flatter
+   * than shadcn in side-by-side comparison — added shadow-sm to get
+   * the same gentle lift. Dark mode keeps the color-mix surface lift
+   * below; shadows on dark BG read as a barely-visible halo and
+   * the surface lift carries the elevation cue. */
   .bb-card {
-    @apply bg-base-100 rounded-xl border border-base-300;
+    @apply bg-base-100 rounded-xl border border-base-300 shadow-sm;
     transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.2s ease;
   }
 


### PR DESCRIPTION
## Summary

Replace daisyUI's `--depth` 3D feel with **pure drop shadows**, matching how shadcn actually does elevation.

shadcn's elevation language is drop-shadow only — every component sources elevation from Tailwind's `shadow-*` scale, never from inset highlights, never from text-shadow, never from border-darkening. daisyUI's `--depth` multiplier is the opposite philosophy: a Material-style 3D feel with top white highlights, colored outset shadows, and darkened borders. The two are visually incompatible.

This PR:

- **`--depth: 0`** in both light and dark themes — kills daisyUI's inset/highlight/3D stack.
- **`.bb-card`** ships `border + shadow-sm` to match shadcn's [`Card`](https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/new-york-v4/ui/card.tsx) (`border bg-card text-card-foreground shadow-sm`).
- **`.btn:not(.btn-ghost):not(.btn-link)`** gets `box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05)` — shadcn's [`Button`](https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/new-york-v4/ui/button.tsx) default-variant shadow (`shadow-xs`). Ghost/link variants opt out — shadcn doesn't shadow transparent buttons either.

Net diff is +13/-2 in `input.css`.

## Why no shadow on inputs / modals / dropdowns in this pass

shadcn ships shadows on those too (`Input` → `shadow-xs`, `DropdownMenu` → `shadow-md`, `Dialog` → `shadow-lg`). Punting to a follow-up so this PR stays one concern (depth → shadow translation). Their current daisy-default appearance is acceptable; not regressing.

## Visual evidence — before / after

### Cards (`.bb-card`)

<table>
  <tr><th>Light · before</th><th>Light · after</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/429abvg9xr.jpg" width="400" alt="cards light before"></td>
    <td><img src="https://i.img402.dev/svkwvd3d6g.jpg" width="400" alt="cards light after"></td>
  </tr>
  <tr><th>Dark · before</th><th>Dark · after</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/8v27e0rlkp.jpg" width="400" alt="cards dark before"></td>
    <td><img src="https://i.img402.dev/nr2pm6dj32.jpg" width="400" alt="cards dark after"></td>
  </tr>
</table>

### Buttons — note the lack of text-highlight and border-darkening on the AFTER

<table>
  <tr><th>Light · before</th><th>Light · after</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/gx25dsivsd.jpg" width="400" alt="buttons light before"></td>
    <td><img src="https://i.img402.dev/95vabtnlq1.jpg" width="400" alt="buttons light after"></td>
  </tr>
  <tr><th>Dark · before</th><th>Dark · after</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/wk54lmbel4.jpg" width="400" alt="buttons dark before"></td>
    <td><img src="https://i.img402.dev/g22c9ff6ju.jpg" width="400" alt="buttons dark after"></td>
  </tr>
</table>

### Form controls — flat, no daisy top-inset

<table>
  <tr><th>Light · before</th><th>Light · after</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/cs3h9mafmc.jpg" width="400" alt="form-controls light before"></td>
    <td><img src="https://i.img402.dev/vtygcolo15.jpg" width="400" alt="form-controls light after"></td>
  </tr>
  <tr><th>Dark · before</th><th>Dark · after</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/h92uc47llu.jpg" width="400" alt="form-controls dark before"></td>
    <td><img src="https://i.img402.dev/vw8w6tudq8.jpg" width="400" alt="form-controls dark after"></td>
  </tr>
</table>

## Test plan

- [ ] `/design/c/cards` — `.bb-card` has a clean drop shadow under the border, no inset highlight.
- [ ] `/design/c/buttons` — Primary / Destructive / Secondary / Outline carry a subtle drop shadow; Ghost / Link have none.
- [ ] `/design/c/form-controls` — Inputs/selects are flat (no top white inset).
- [ ] Dark mode — no visible inset highlights anywhere; card lift is carried entirely by the surface color-mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
