### PR TITLE
fix(design): collapse EntityHeader meta + secondary action below sm

### DIFF
--- a/input.css
+++ b/input.css
@@ -361,9 +361,12 @@
   .bb-icon-tile--error   { @apply bg-error/10 text-error; }
   .bb-icon-tile--neutral { @apply bg-base-200 text-base-content/60; }
 
-  /* Detail-page entity header — 48×48 tile sized for the top-of-page
-     row that pairs an icon with the entity name + badges + meta line. */
-  .bb-entity-header__tile { @apply flex items-center justify-center w-12 h-12 rounded-xl shrink-0; }
+  /* Detail-page entity header — 40×40 tile on mobile, 48×48 at sm+
+     for the top-of-page row that pairs an icon with the entity name +
+     badges + meta line. The mobile shrink reclaims horizontal space
+     for the title once the meta row and secondary action are hidden
+     (see EntityHeader templ component). */
+  .bb-entity-header__tile { @apply flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-lg sm:rounded-xl shrink-0; }
 
   /* Action row at the bottom of a sectioned form card.
      Left-aligned on mobile (thumb-reach), right-aligned on sm+. */

--- a/internal/templates/components/entity_header.templ
+++ b/internal/templates/components/entity_header.templ
@@ -21,8 +21,18 @@ package components
 //                      Wrap status chips, "Linked", "Excluded", etc.
 //   - Meta:            text-xs bullet-separated metadata line below.
 //                      Use EntityHeaderMeta(...) for the standard shape.
-//   - Action:          trailing primary action.
-//   - SecondaryAction: trailing secondary (ghost) action.
+//                      Hidden below sm: — duplicate any critical fact in
+//                      the page body / detail grid.
+//   - Action:          trailing primary action. Always visible.
+//   - SecondaryAction: trailing secondary (ghost) action. Hidden below
+//                      sm: — keep the destination reachable from the
+//                      page body (info grid, overflow menu, etc.) if it
+//                      matters on mobile.
+//
+// Mobile (< sm) collapse: the icon tile shrinks to 40×40 and the meta
+// row + secondary action are hidden so the header stays a single visual
+// row (icon + title + badges + primary action). Badges remain because
+// they communicate the entity's current state inline with the title.
 //
 // Conventions match PageHeader: at most one primary + one secondary;
 // larger clusters → OverflowMenu in Action.
@@ -65,25 +75,25 @@ type EntityHeaderProps struct {
 
 templ EntityHeader(p EntityHeaderProps) {
 	<div class="bb-page-header">
-		<div class="flex items-center gap-4 w-full sm:w-auto sm:flex-1 min-w-0">
+		<div class="flex items-center gap-3 sm:gap-4 w-full sm:w-auto sm:flex-1 min-w-0">
 			if p.Icon != "" || p.IconComponent != nil {
 				<div class={ "bb-entity-header__tile", iconToneClass(p.IconTone) }>
 					if p.IconComponent != nil {
 						@p.IconComponent
 					} else {
-						<i data-lucide={ p.Icon } class="w-6 h-6"></i>
+						<i data-lucide={ p.Icon } class="w-5 h-5 sm:w-6 sm:h-6"></i>
 					}
 				</div>
 			}
 			<div class="min-w-0 flex-1">
-				<div class="flex items-center gap-2.5 flex-wrap min-w-0">
+				<div class="flex items-center gap-2 sm:gap-2.5 flex-wrap min-w-0">
 					<h1 class={ "bb-page-title min-w-0 max-w-full", p.TitleClass }>{ p.Title }</h1>
 					if p.Badges != nil {
 						@p.Badges
 					}
 				</div>
 				if p.Meta != nil {
-					<div class="flex items-center gap-1.5 mt-0.5 flex-wrap text-xs text-base-content/40 min-w-0">
+					<div class="hidden sm:flex items-center gap-1.5 mt-0.5 flex-wrap text-xs text-base-content/40 min-w-0">
 						@p.Meta
 					</div>
 				}
@@ -92,7 +102,9 @@ templ EntityHeader(p EntityHeaderProps) {
 		if p.SecondaryAction != nil || p.Action != nil {
 			<div class="flex items-center gap-2 shrink-0 flex-wrap sm:flex-nowrap">
 				if p.SecondaryAction != nil {
-					@p.SecondaryAction
+					<span class="hidden sm:contents">
+						@p.SecondaryAction
+					</span>
 				}
 				if p.Action != nil {
 					@p.Action


### PR DESCRIPTION
## Summary

Mobile detail-page headers (account, connection, rule, sync log, transaction) could stack to **4–5 rows** when a page passed badges + meta + a secondary action — e.g. the "Error tone + actions" sandbox case rendered title → badges → meta → secondary action → primary action, leaving very little of the viewport for the content below.

`EntityHeader` now collapses the genuinely-secondary slots below `sm:`:

- **Meta row hidden** below sm. It's bullet-separated secondary metadata (type, date, account mask, etc.) that is also surfaced in each page's info-grid / body. Reversible per-caller by surfacing the same fact elsewhere.
- **SecondaryAction hidden** below sm. Primary action stays prominent. The secondary destination is reachable from the info grid or an overflow menu.
- **Icon tile shrinks 48×48 → 40×40** below sm to reclaim horizontal space for the title once the meta row is gone.
- **Tile↔title gap** tightens to `gap-3`, **title↔badges gap** to `gap-2` on mobile so the single remaining row reads as one unit.

**Badges are intentionally preserved on mobile** — they communicate the entity's current state ("Active", "Pending reauth", "Excluded") and sit inline with the title.

**Desktop layout is byte-identical** (no `sm:`-or-above class changed shape).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/templates/...` — passing (design_smoke_test still green; component slug + variants unchanged)
- [x] Visually validated in headless Chromium against `/design/c/entity-header?embed=1` at 390×844 (mobile) and 1280×900 (desktop)
- [x] Desktop screenshot is byte-identical before/after (md5 match)

## Evidence

### Mobile (390×844) — before vs after

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>`&lt;img src="https://i.img402.dev/yxqz8d2bhv.jpg" width="320" alt="entity-header mobile — before"&gt;`</td>
    <td>`&lt;img src="https://i.img402.dev/24dv7zn4u1.jpg" width="320" alt="entity-header mobile — after"&gt;`</td>
  </tr>
</table>

The "Error tone + actions" card drops from ~5 stacked rows to ~3 (title + badge wrap + primary action). The default neutral-tile case becomes a single clean row. The icon tile downsizes proportionally.

### Desktop (1280×900) — unchanged

`&lt;img src="https://i.img402.dev/blt1p3iigo.jpg" width="800" alt="entity-header desktop — unchanged"&gt;`

`md5sum` matches the pre-change capture.

## Notes for reviewers

- If a page genuinely needs a secondary action visible on mobile, the right fix is to wrap the secondary action in an `OverflowMenu` inside the primary `Action` slot — that matches the documented PageHeader convention.
- If a page truly needs the meta facts on mobile (rare), the existing pattern is to surface them in the page's info-grid below the header.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbiTUorU4FG5vJLy7Ra5eH)_