### PR TITLE
fix(design): designExample border disappears in dark mode

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1127,7 +1127,7 @@ templ designExample(title, caption string) {
 				<p class="text-xs text-base-content/50">{ caption }</p>
 			}
 		</div>
-		<div class="rounded-xl border border-base-300/60 bg-base-100 p-5">
+		<div class="rounded-xl border border-base-300 bg-base-100 p-5">
 			{ children... }
 		</div>
 	</div>


### PR DESCRIPTION
Part of the mobile dark-mode sandbox audit (companion to #1470–#1473 which covered light-mode + other mobile issues).

## Problem

The `designExample` wrapper — the box that surrounds every component demo in the `/design` sandbox — used `border border-base-300/60`. In DaisyUI's stock dark theme the token values are:

| Token | Dark value |
|---|---|
| `base-100` (card surface) | oklch(25.33%) |
| `base-300` (border) | oklch(21.15%) |

At 60 % opacity, `base-300` composites to ≈ oklch(22.8 %) against the card surface — a lightness delta of only **2.5 pp**. The border is effectively invisible in dark mode. Every single component demo box suffers from this because `designExample` is the shared wrapper function for all sandbox sections.

## Fix

Drop the `/60` opacity modifier. `border-base-300` (full opacity) gives a clean, legible edge in both themes.

## Before / After (dark mode, 390 × 844)

| Before | |
|---|---|
| <img src="https://i.img402.dev/x9qaa58o35.jpg" width="390" alt="stat-tiles — before, dark mode, barely-visible example box border"> | Note how the rounded container boxes have a barely-perceptible edge against the page background. The `border-base-300/60` blends into the surrounding `base-200` page color. |

| Before (tags page) | |
|---|---|
| <img src="https://i.img402.dev/ye8pf7xiyr.jpg" width="390" alt="tags — before, dark mode"> | Same issue on tags: example boxes are barely distinguishable from the page background. |

After: example boxes have a clean, visible edge matching the design intent (the same as light mode, where the /60 modifier is also subtle but the higher luminance range makes the contrast readable).

## Scope

Sandbox-only (`design_sections.templ`). No production UI affected.

## Related

- #1470 — designExample title/caption layout (light + dark, mobile)
- #1471 — StatTile sizing (light mode)
- #1472 — toast code snippet wrap (light mode)
- #1473 — TxRow Uncategorized truncation (light mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)