### PR TITLE
fix(design): tinted-surface backgrounds invisible in dark mode

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1127,7 +1127,7 @@ templ designExample(title, caption string) {
 				<p class="text-xs text-base-content/50">{ caption }</p>
 			}
 		</div>
-		<div class="rounded-xl border border-base-300/60 bg-base-100 p-5">
+		<div class="rounded-xl border border-base-300 bg-base-100 p-5">
 			{ children... }
 		</div>
 	</div>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1149,7 +1149,7 @@ templ designSwatch(name, classes string) {
 // the reader sees (often equal to key, but "alt / opt" and
 // "F2 (passthrough)" diverge).
 templ kbdGlyphRefRow(label, key string) {
-	<div class="flex items-center justify-between gap-2 py-1.5 px-2 rounded-lg bg-base-200/40">
+	<div class="flex items-center justify-between gap-2 py-1.5 px-2 rounded-lg bg-base-200/60">
 		<code class="text-xs text-base-content/60">{ label }</code>
 		@components.Kbd(key)
 	</div>
@@ -1299,7 +1299,7 @@ templ SectionToast() {
 					Fire info
 				</button>
 			</div>
-			<pre class="mt-3 text-xs bg-base-200/40 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-words sm:whitespace-pre sm:break-normal"><code>{ toastDispatchExample() }</code></pre>
+			<pre class="mt-3 text-xs bg-base-200/60 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-words sm:whitespace-pre sm:break-normal"><code>{ toastDispatchExample() }</code></pre>
 		}
 		@designExample("Variants (visual reference)", "All four type values rendered as static pills. Real toasts auto-dismiss after ~3 s.") {
 			<div class="flex flex-col gap-2 max-w-md">
@@ -1668,7 +1668,7 @@ templ SectionTransactionRows() {
 		     and the canonical `Amount` component (see `tx_row_atoms.templ`),
 		     so the visual language stays in sync; the differences below are
 		     purely about what affordances each surface needs. -->
-		<div class="rounded-xl border border-base-300/50 bg-base-200/30 px-4 py-3 text-xs text-base-content/60">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
 			<p class="font-semibold text-base-content/80 mb-1">When to use which</p>
 			<ul class="space-y-1 list-disc pl-4">
 				<li><code>TxRow</code> — bulk-select + inline category picker + expand panel. The /transactions list and any surface that wants the same editing affordances (account detail, rule detail preview).</li>
@@ -1834,7 +1834,7 @@ templ SectionTransactionRows() {
 // caption on the left, the live Amount on the right, with the props
 // printed below for copy-paste reference.
 templ amountSandboxRow(label string, p components.AmountProps) {
-	<div class="flex flex-col gap-1 py-2 px-3 rounded-lg bg-base-200/40">
+	<div class="flex flex-col gap-1 py-2 px-3 rounded-lg bg-base-200/60">
 		<div class="flex items-baseline justify-between gap-3">
 			<span class="text-xs text-base-content/50">{ label }</span>
 			@components.Amount(p)


### PR DESCRIPTION
Companion to #1482 (designExample border) in the mobile dark-mode sandbox audit.

## Problem

In DaisyUI's dark theme the base palette is highly compressed:

| Token | Dark oklch(L%) |
|---|---|
| `base-100` (card surface) | 25.33 % |
| `base-200` | 23.26 % |

A `bg-base-200/40` tint over a `base-100` card produces an effective lightness of **≈ 24.5 %** — a delta of under 1 pp against the card surface. That's invisible in dark mode. Four spots in the sandbox relied on these low-opacity tints to structure their content:

| Location | Before | Problem in dark |
|---|---|---|
| `kbdGlyphRefRow` | `bg-base-200/40` | kbd glyph reference rows lose row zebra background |
| `amountSandboxRow` | `bg-base-200/40` | amount display rows lose their background strip |
| Toast section code block | `bg-base-200/40` | `<pre>` dispatch example loses code-block background |
| TxRow variant-policy callout | `border-base-300/50 bg-base-200/30` | callout has no visible border or fill |

## Fix

Bump `/40` → `/60` and `/30` → `/50` on the fill; use full `border-base-300` on the callout border. This keeps the intent (subtle depth cues) while being visible in dark mode.

The `/60` fill at dark-mode values gives ≈ 24.1 % effective, a delta of ≈ 1.2 pp — perceptible. Light mode is unaffected; these are still gently subtle there.

## Screenshot context

These are inside the sandbox embed pages; the static demo renders in dark at 390 × 844. The before state is the same card surface shown in PR #1482 — the same invisible-border issue is compounded by invisible fills here.

## Related

- #1482 — designExample wrapper border (same sprint, this PR goes further)
- #1470 – #1473 — parallel light-mode + mobile-layout fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)