### PR TITLE
fix(design): stack remaining sandbox section headers on mobile

### DIFF
--- a/internal/templates/components/pages/design_gallery.templ
+++ b/internal/templates/components/pages/design_gallery.templ
@@ -215,7 +215,7 @@ templ designSectionBlock(sec DesignSection) {
 		data-design-section="true"
 		x-show={ "match('" + sec.Title + "')" }
 	>
-		<div class="flex items-baseline justify-between gap-3 mb-1">
+		<div class="flex flex-col gap-1 mb-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-3">
 			<h3 class="text-lg font-semibold tracking-tight">{ sec.Title }</h3>
 			<a href={ templ.SafeURL("/design/c/" + sec.Slug) } class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1">
 				<i data-lucide="external-link" class="w-3 h-3"></i>


### PR DESCRIPTION
Applies the same mobile-stack fix from PR #1470 (`designExample`) to the one remaining surface that still wraps on 390px: the `designSectionBlock` header in the /design gallery page.

## What was broken

`designSectionBlock` in `internal/templates/components/pages/design_gallery.templ` pairs each section title (`h3`) with an "Open standalone" link using `flex items-baseline justify-between gap-3 mb-1`. At iPhone 14 width (390px) the flex row forces both items to compete for horizontal space, collapsing the `text-lg` title to its longest word and wrapping it across 2-3 lines.

## Fix

One-line change — same pattern as #1470:

```diff
-<div class="flex items-baseline justify-between gap-3 mb-1">
+<div class="flex flex-col gap-1 mb-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-3">
```

Stack vertically below `sm:` (390px phones), restore the side-by-side justified layout at `sm:` (640px+).

## Surfaces audited

| Surface | File | Status |
|---|---|---|
| `designExample` title + caption | `design_sections.templ:1124` | ✅ Already fixed by #1470 |
| `designSectionBlock` title + "Open standalone" link | `design_gallery.templ:218` | ✅ Fixed in this PR |
| `design_component.templ` page header | `design_component.templ:80` | ✅ Already safe — viewport toggle is `hidden sm:inline-flex`, title is alone on mobile |
| Other `flex items-center justify-between` rows in design_sections.templ | Various | ✅ All are inside demo cards, not section-level headers — demonstrating the components themselves, not broken layout |

## Before / After

The before state is visible in the /design gallery page on mobile: each section title like "Foundations" appears with the "Open standalone" link competing for width, forcing the title to wrap. After the fix, the title takes the full width on mobile and the link drops below it; on `sm:` and wider, both sit on the same baseline row as before.

_Screenshots pending Chrome DevTools MCP recovery — the before wrapping pattern is identical to what was shown for `designExample` in #1470._

## Verification

- `templ fmt` — no changes
- `go build ./...` — clean
- `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)