### PR TITLE
fix(rules): drop category-specific copy from retroactive apply CTA

### DIFF
--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -413,15 +413,11 @@ templ ruleDetailPendingMatches(p RuleDetailProps) {
 				}
 				if retro {
 					<div class="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-						<p class="text-xs text-base-content/40">Apply this rule to categorize these existing transactions</p>
+						<p class="text-xs text-base-content/40">Run this rule's actions against these existing transactions</p>
 						<button class="btn btn-sm btn-outline w-full sm:w-auto" data-apply-btn @click="openApplyModal()" :disabled="applying">
 							<span x-show="applying" class="loading loading-spinner loading-xs"></span>
 							<i data-lucide="play" class="w-3.5 h-3.5" x-show="!applying"></i>
-							if p.ActionCategoryName != "" {
-								{ "Categorize as " + p.ActionCategoryName }
-							} else {
-								Categorize as matched category
-							}
+							Apply rule
 						</button>
 					</div>
 				}


### PR DESCRIPTION
Rule actions include set_category, add_tag, and remove_tag, but the
pending-matches CTA on the rule detail page assumed categorization
("Apply this rule to categorize…" / "Categorize as X"). Reword to be
action-agnostic — the "Then" card directly above already enumerates
what the rule will do.