### PR TITLE
fix(settings): close mobile dropdown on tab select

### DIFF
--- a/internal/templates/components/settings_modal.templ
+++ b/internal/templates/components/settings_modal.templ
@@ -79,20 +79,22 @@ templ settingsModalHeader() {
 	</div>
 }
 
-// settingsModalMobileRail renders a <details> dropdown on viewports <lg.
-// Matches the desktop rail's tab list but folds into a single pill so the
-// content area gets the full width on phones.
+// settingsModalMobileRail renders a daisy <details class="dropdown"> on
+// viewports <lg. Matches the desktop rail's tab list but folds into a
+// single pill so the content area gets the full width on phones. Daisy's
+// `.dropdown > summary` already hides the native disclosure marker — no
+// list-style hacks needed on the summary.
 templ settingsModalMobileRail(p SettingsModalProps) {
 	<div class="lg:hidden shrink-0 px-4 sm:px-6 py-3 border-b border-base-300 bg-base-100">
 		<details class="dropdown w-full" x-ref="mobileDropdown">
-			<summary class="list-none flex items-center justify-between w-full px-3 py-2.5 rounded-xl bg-base-200/60 ring-1 ring-base-content/10 cursor-pointer hover:bg-base-200 transition-colors [&::-webkit-details-marker]:hidden">
+			<summary class="flex items-center justify-between w-full px-3 py-2.5 rounded-xl bg-base-200/60 border border-base-content/10 cursor-pointer hover:bg-base-200 transition-colors">
 				<span class="flex items-center gap-2.5 min-w-0">
 					<i :data-lucide="currentTabIcon()" class="w-4 h-4 text-base-content opacity-70 shrink-0"></i>
 					<span class="text-sm font-medium truncate" x-text="currentTabLabel()"></span>
 				</span>
 				<i data-lucide="chevron-down" class="w-4 h-4 text-base-content opacity-40 shrink-0"></i>
 			</summary>
-			<ul class="dropdown-content menu mt-2 z-20 w-full bg-base-100 shadow-xl ring-1 ring-base-content/10 p-1 gap-0.5 rounded-xl">
+			<ul class="dropdown-content menu mt-2 z-20 w-full bg-base-100 shadow-xl border border-base-content/10 p-1 gap-0.5 rounded-xl">
 				@settingsModalRailItems(p, true)
 			</ul>
 		</details>

--- a/static/js/admin/components/settings_modal.js
+++ b/static/js/admin/components/settings_modal.js
@@ -90,7 +90,12 @@ document.addEventListener('alpine:init', function () {
       // Switches tabs inside an already-open modal. No dialog open/close
       // churn — just a body swap + URL push.
       switchTo: function (tab) {
-        if (!tab || tab === this.currentTab) return;
+        if (!tab) return;
+        // Collapse the mobile dropdown the moment a row is tapped — even
+        // when the tap re-selects the current tab — so the user gets
+        // instant feedback instead of staring at the still-open list.
+        this._closeMobileDropdown();
+        if (tab === this.currentTab) return;
         var self = this;
         this._loadTab(tab).then(function () {
           self._pushUrl(tab, /*replace=*/ false);


### PR DESCRIPTION
## Summary

The mobile rail in the settings modal is a daisyUI `<details class="dropdown">` with a `<ul class="dropdown-content menu">` payload — a native daisy dropdown — but selecting a row only swapped the tab body; the dropdown stayed open and covered the freshly-loaded content. Close the dropdown at the top of `switchTo()` so the menu collapses on every tap, including a re-tap of the current row. Light templ polish on the side: drop two utilities from the `<summary>` that daisy 5 already handles (`list-none`, `[&::-webkit-details-marker]:hidden`) and swap the two `ring-1` outlines for plain `border` so the dropdown panel matches daisy's standard menu shape.

## Test plan

Verified in a headless Chromium at the iPhone-14-Pro viewport (390×844) against a freshly-seeded dev server:

- [x] `/settings/account` deep-link opens the modal with the mobile pill showing the active tab + chevron.
- [x] Tapping the pill expands the daisy dropdown with all 10 tabs.
- [x] Tapping a different tab (e.g. **Sync**) closes the dropdown, updates the pill label to **Sync**, and swaps the body to the Sync tab.
- [x] Confirmed via `document.querySelector('details[x-ref="mobileDropdown"]').open === false` after select (was `true` before this PR).
- [x] `go vet ./...` and `go build ./...` clean.

## Evidence

**Before — dropdown stays open after selecting Sync (the bug):**

`&lt;img src="https://i.img402.dev/6iaj8gisg7.jpg" width="380" alt="before: mobile dropdown stays open after selecting Sync, covering the page"&gt;`

**After — selecting Sync swaps the tab and collapses the dropdown:**

`&lt;img src="https://i.img402.dev/1pn5jlaufy.jpg" width="380" alt="after: dropdown closed, Sync tab visible, pill label updated to Sync"&gt;`

**The dropdown is a native daisy `dropdown` + `menu` (open state):**

`&lt;img src="https://i.img402.dev/xke8gh9a0e.jpg" width="380" alt="mobile dropdown open showing all 10 tab rows via daisyUI menu"&gt;`

https://claude.ai/code/session_0137FPQTN8ynT2WpKQugN7Gx

---
_Generated by [Claude Code](https://claude.ai/code/session_0137FPQTN8ynT2WpKQugN7Gx)_