### PR TITLE
fix(nav): swap mobile sidebar spinner to CSS-keyframed inline SVG

### DIFF
--- a/input.css
+++ b/input.css
@@ -513,6 +513,27 @@
     @apply opacity-100;
   }
 
+  /* ── Trailing loading spinner on mobile sidebar tap ──
+     Injected by base.html's link-click handler. The visible spin is a
+     CSS @keyframes rotate on an inline SVG (compositor-eligible so it
+     survives the navigation window) — *not* daisy's
+     `loading loading-spinner`, whose SMIL inside `mask-image` is
+     rasterized once by Chromium/WebKit and never animates. */
+  .bb-sidebar-link .bb-sidebar-loading {
+    @apply inline-flex items-center justify-center w-3.5 h-3.5 shrink-0;
+    color: currentColor;
+  }
+  .bb-sidebar-link .bb-sidebar-loading svg {
+    @apply w-3.5 h-3.5 opacity-100;
+    transform-origin: 50% 50%;
+    animation: bb-sidebar-loading-spin 0.7s linear infinite;
+    will-change: transform;
+    backface-visibility: hidden;
+  }
+  @keyframes bb-sidebar-loading-spin {
+    to { transform: rotate(360deg); }
+  }
+
   /* ── Sparkle accent for highlighted sidebar links (e.g. Agent Prompts) ── */
   /* Trailing sparkle icon — overrides the generic icon rule above so it
      gets its own size, accent colour, and a gentle pulse to draw the eye. */

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2276,6 +2276,17 @@
         // stays open through the navigation (see the mobile-drawer IIFE
         // above), so without this the previously-active tab keeps its bold
         // highlight until the new page paints — feels unresponsive.
+        //
+        // The spinner is an inline SVG rotated by a CSS @keyframes
+        // animation, *not* daisy's `loading loading-spinner`. Daisy 5's
+        // spinner relies on SMIL `<animateTransform>` inside a
+        // `mask-image: url("data:…")` data URI, and Chromium / WebKit
+        // rasterize mask SVGs once — the SMIL animation never ticks, and
+        // at frame 0 the stroke-dasharray is `0,150` (zero visible
+        // length), so the spinner appears as an empty box that "freezes"
+        // the instant it's added. A CSS transform animation on an inline
+        // SVG runs on the compositor and stays alive through the
+        // navigation window until paint-holding replaces the document.
         if (window.innerWidth < 1024 && link.classList.contains('bb-sidebar-link')) {
           var sbNav = link.closest('.bb-sidebar-nav');
           if (sbNav) {
@@ -2293,8 +2304,9 @@
             });
             link.classList.add('bb-sidebar-link--active');
             var spinner = document.createElement('span');
-            spinner.className = 'bb-sidebar-loading ml-auto loading loading-spinner loading-xs';
+            spinner.className = 'bb-sidebar-loading ml-auto';
             spinner.setAttribute('aria-hidden', 'true');
+            spinner.innerHTML = '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-dasharray="42 150"/></svg>';
             link.appendChild(spinner);
           }
         }


### PR DESCRIPTION
Daisy 5's `.loading-spinner` uses SMIL `<animateTransform>` inside a
`mask-image: url("data:image/svg+xml,…")` data URI. Chromium and WebKit
rasterize mask SVGs once and never tick SMIL inside them — `getAnimations()`
returns 0 animations for the element, and the dasharray sits at frame 0
(`0,150`, zero visible length). On a mobile sidebar tap the spinner
appears as a near-invisible / static arc that "freezes" immediately,
which is what #1478 was meant to add.

Replace the daisy element with an inline `<svg>` that has a visible static
arc (`stroke-dasharray="42 150"`) and rotate it via a CSS `@keyframes`
animation. The transform animation is GPU-compositable and stays alive
through the navigation window until paint-holding swaps in the new
document — verified end-to-end in headless Chromium:

  old (daisy mask):   getAnimations() → []         (no ticks)
  new (inline + CSS): getAnimations() → [spin]     (transform matrix
                                                    advances each frame)