### PR TITLE
fix(agents): always show "Prompt library" label on mobile

### DIFF
--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -74,7 +74,7 @@ templ AgentsList(p AgentsListProps) {
 templ agentsListPromptLibraryAction() {
 	<a href="/agent-prompts" class="btn btn-ghost btn-sm gap-2" title="Prompt library">
 		<i data-lucide="book-open" class="w-4 h-4"></i>
-		<span class="hidden sm:inline">Prompt library</span>
+		<span>Prompt library</span>
 	</a>
 }
 


### PR DESCRIPTION
## Summary

The `/agents` page header's secondary action (`Prompt library`) wraps its label in `<span class="hidden sm:inline">`, so below the `sm` breakpoint (640px) the button collapses to an icon-only chip. The `title="Prompt library"` tooltip is a poor mobile substitute — there's no hover on touch — so the affordance is essentially invisible.

Drop the modifier so the label renders at every viewport. The primary "New agent" button already does this, so they're now consistent.

## Change

`internal/templates/components/pages/agents_list.templ` — one-line diff inside `agentsListPromptLibraryAction`:

```diff
-<span class="hidden sm:inline">Prompt library</span>
+<span>Prompt library</span>
```

## Validation

Captured in a real browser (headless Chromium / Playwright) against a freshly seeded `breadbox serve` on this branch:

<table>
  <tr>
    <th>Mobile (390×844) — before</th>
    <th>Mobile (390×844) — after</th>
  </tr>
  <tr>
    <td>`&lt;img src="https://i.img402.dev/0oxj4j3hzl.jpg" width="380" alt="agents page mobile before — Prompt library icon-only"&gt;`</td>
    <td>`&lt;img src="https://i.img402.dev/8m4zoc36g9.jpg" width="380" alt="agents page mobile after — Prompt library label visible"&gt;`</td>
  </tr>
</table>

Desktop (1280×800) — unchanged, included to confirm no regression:

`&lt;img src="https://i.img402.dev/8zmgqd9tzl.jpg" width="800" alt="agents page desktop — after"&gt;`

## Test plan

- [x] `go vet ./internal/templates/components/pages/...`
- [x] `go test ./internal/templates/components/pages/...`
- [x] Manual: mobile (390px) screenshot shows the label; desktop (1280px) unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01MXPSVKpA69Jxvgj9KkRT35)_