### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -81,7 +81,7 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 		data := BaseTemplateData(r, sm, "agents-settings", "Agents settings")
 		data["CSRFToken"] = props.CSRFToken
 		data["Flash"] = nil
-		renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabAgents, pages.AgentSDKSettings(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabAgents, pages.AgentSDKSettings(props))
 	}
 }
 

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -119,7 +119,7 @@ func AccessPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templat
 
 // renderAccess wraps the Access tab body in the unified Settings shell.
 func renderAccess(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager, tr *TemplateRenderer, data map[string]any, props pages.AccessProps) {
-	renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabAccess, pages.Access(props))
+	renderSettingsTab(tr, w, r, data, pages.SettingsTabAccess, pages.Access(props))
 }
 
 // buildAccessKeyRow flattens a service.APIKeyResponse into the templ-side
@@ -165,7 +165,7 @@ func APIKeyNewPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.Han
 // renderAPIKeyNew hosts the typed APIKeyNewProps inside the Settings
 // shell as a sub-view of the API Keys tab so the rail stays visible.
 func renderAPIKeyNew(w http.ResponseWriter, r *http.Request, tr *TemplateRenderer, data map[string]any, props pages.APIKeyNewProps) {
-	renderSettingsTab(tr, w, r, tr.sm, data, pages.SettingsTabAccess, pages.APIKeyNew(props))
+	renderSettingsTab(tr, w, r, data, pages.SettingsTabAccess, pages.APIKeyNew(props))
 }
 
 // APIKeyCreatePageHandler serves POST /admin/api-keys/new.
@@ -219,7 +219,7 @@ func APIKeyCreatedPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http
 // renderAPIKeyCreated hosts the typed APIKeyCreatedProps inside the
 // Settings shell as a sub-view of the API Keys tab.
 func renderAPIKeyCreated(w http.ResponseWriter, r *http.Request, tr *TemplateRenderer, data map[string]any, props pages.APIKeyCreatedProps) {
-	renderSettingsTab(tr, w, r, tr.sm, data, pages.SettingsTabAccess, pages.APIKeyCreated(props))
+	renderSettingsTab(tr, w, r, data, pages.SettingsTabAccess, pages.APIKeyCreated(props))
 }
 
 // APIKeyRevokePageHandler serves POST /admin/api-keys/{id}/revoke.

--- a/internal/admin/backups.go
+++ b/internal/admin/backups.go
@@ -88,7 +88,7 @@ func BackupsPageHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 
 // renderBackups wraps the Backups tab body in the unified Settings shell.
 func renderBackups(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager, tr *TemplateRenderer, data map[string]any, props pages.BackupsProps) {
-	renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabBackups, pages.Backups(props))
+	renderSettingsTab(tr, w, r, data, pages.SettingsTabBackups, pages.Backups(props))
 }
 
 // CreateBackupHandler serves POST /-/backups/create — triggers a manual backup.

--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -215,7 +215,7 @@ func MyAccountHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) 
 		props, data := buildMyAccountProps(a, sm, r)
 		data["PageTitle"] = "Account"
 		data["CurrentPage"] = "account"
-		renderSettingsTab(tr, w, r, tr.sm, data, pages.SettingsTabAccount, pages.MyAccount(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabAccount, pages.MyAccount(props))
 	}
 }
 

--- a/internal/admin/providers.go
+++ b/internal/admin/providers.go
@@ -78,7 +78,7 @@ func ProvidersGetHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 
 // renderProviders wraps the Providers tab body in the unified Settings shell.
 func renderProviders(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager, tr *TemplateRenderer, data map[string]any, props pages.ProvidersProps) {
-	renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabProviders, pages.Providers(props))
+	renderSettingsTab(tr, w, r, data, pages.SettingsTabProviders, pages.Providers(props))
 }
 
 // ProvidersSavePlaidHandler serves POST /admin/providers/plaid.

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -94,7 +94,7 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		data["PageTitle"] = "Sync"
 		data["CurrentPage"] = "sync"
 		data["Flash"] = GetFlash(r.Context(), sm)
-		renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabSync, pages.SettingsSync(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabSync, pages.SettingsSync(props))
 	}
 }
 
@@ -105,7 +105,7 @@ func SecuritySettingsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 		data["PageTitle"] = "Security"
 		data["CurrentPage"] = "security"
 		data["Flash"] = GetFlash(r.Context(), sm)
-		renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabSecurity, pages.SettingsSecurity(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabSecurity, pages.SettingsSecurity(props))
 	}
 }
 
@@ -116,7 +116,7 @@ func SystemSettingsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 		data["PageTitle"] = "System"
 		data["CurrentPage"] = "system"
 		data["Flash"] = GetFlash(r.Context(), sm)
-		renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabSystem, pages.SettingsSystem(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabSystem, pages.SettingsSystem(props))
 	}
 }
 
@@ -127,7 +127,7 @@ func HelpSettingsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 		data["PageTitle"] = "Help"
 		data["CurrentPage"] = "help"
 		data["Flash"] = GetFlash(r.Context(), sm)
-		renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabHelp, pages.SettingsHelp(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabHelp, pages.SettingsHelp(props))
 	}
 }
 

--- a/internal/admin/settings_agents.go
+++ b/internal/admin/settings_agents.go
@@ -141,6 +141,6 @@ func AgentsSettingsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServe
 		}
 
 		data := BaseTemplateData(r, sm, "mcp", "MCP Settings")
-		renderSettingsTab(tr, w, r, sm, data, pages.SettingsTabMCP, pages.AgentsSettings(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabMCP, pages.AgentsSettings(props))
 	}
 }

--- a/internal/admin/settings_shell.go
+++ b/internal/admin/settings_shell.go
@@ -7,11 +7,9 @@ import (
 	"html/template"
 	"net/http"
 
-	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/a-h/templ"
-	"github.com/alexedwards/scs/v2"
 )
 
 // settingsFragmentHeader marks a request as a Settings modal swap — the
@@ -40,7 +38,6 @@ func renderSettingsTab(
 	tr *TemplateRenderer,
 	w http.ResponseWriter,
 	r *http.Request,
-	sm *scs.SessionManager,
 	data map[string]any,
 	tab string,
 	body templ.Component,
@@ -61,7 +58,3 @@ func renderSettingsTab(
 	data["SettingsInitialBody"] = template.HTML(buf.String())
 	tr.RenderWithTempl(w, r, data, pages.SettingsHost())
 }
-
-// Compile-time guard: keep the import list honest if components ever
-// stops exporting SettingsModalProps. The constant itself is unused.
-var _ = components.SettingsModalTabAccount


### PR DESCRIPTION
## Summary

Daily simplify-drift review of the 48 PRs merged in the last 24 hours. After scanning the changed Go and JS surface (122 files), only one concrete simplification was found — the rest of the recent churn is well-shaped UI/templ work with no obvious dead code.

## PRs reviewed

48 PRs (#1434 — #1486). The relevant one for this cleanup is **#1477 — Redesign settings as a global modal + restructure sidebar**, which introduced `renderSettingsTab` in `internal/admin/settings_shell.go`.

## Changes

- `internal/admin/settings_shell.go` — drop the unused `sm *scs.SessionManager` parameter from `renderSettingsTab`. The body renders through the `TemplateRenderer` and never touches `sm` directly; some callers were already passing `tr.sm` (an inconsistency that hinted at the redundancy).
- `internal/admin/settings_shell.go` — drop the `var _ = components.SettingsModalTabAccount` compile-time guard. Its stated purpose — "keep the import list honest if components ever stops exporting SettingsModalProps" — is already covered by the real uses of `SettingsModalTab*` in `internal/templates/components/pages/settings_tabs.go:18-27`. Removing the guard also lets us drop the now-unused `components` and `scs/v2` imports from the file.
- 7 caller files — mechanical: drop the now-unused argument at each `renderSettingsTab(…)` call site.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`

https://claude.ai/code/session_01Bqcy42Zs44eVJDXm1hXPQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bqcy42Zs44eVJDXm1hXPQ1)_