### PR TITLE
fix(connections): lock user-filter tabs to horizontal scroll only

### DIFF
--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -60,7 +60,7 @@ templ Connections(p ConnectionsProps) {
 		</div>
 		<!-- Family Member Filter -->
 		if len(p.Users) > 1 {
-			<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto" x-show="tab === 'connections'">
+			<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto overflow-y-hidden" x-show="tab === 'connections'">
 				<button
 					@click="filterUser = 'all'"
 					:class="filterUser === 'all' ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'"


### PR DESCRIPTION
The family-member filter row sets overflow-x-auto, but its child
buttons use -mb-px (negative margin to overlap the parent border).
Per CSS spec, when one overflow axis is auto/scroll, the other
axis becomes auto instead of visible, so that 1px of vertical
overflow turned the row into a vertical scroller too. Add
overflow-y-hidden so only horizontal scrolling remains.