### PR TITLE
fix(design): polish SectionHeader mobile responsiveness

### DIFF
--- a/internal/templates/components/section_header.templ
+++ b/internal/templates/components/section_header.templ
@@ -28,17 +28,23 @@ type SectionHeaderProps struct {
 	Action     templ.Component
 }
 
+// Mobile: stacks title row + action onto two rows (mirrors bb-page-header)
+// so a long title / wide action button doesn't force the title and count
+// to wrap mid-word. Desktop (sm:): everything on one row, action right-
+// aligned via sm:ml-auto.
 templ SectionHeader(p SectionHeaderProps) {
-	<header class="flex items-center gap-2 mb-3">
-		if p.Icon != "" {
-			<i data-lucide={ p.Icon } class="w-4 h-4 text-base-content opacity-60 shrink-0"></i>
-		}
-		<h2 class="text-sm font-semibold">{ p.Title }</h2>
-		if p.Count != nil {
-			<span class="text-xs text-base-content/40">{ strconv.Itoa(*p.Count) } { sectionHeaderCountLabel(p) }</span>
-		}
+	<header class="flex flex-col items-start gap-2 sm:flex-row sm:items-center mb-3">
+		<div class="flex items-center gap-2 min-w-0 max-w-full">
+			if p.Icon != "" {
+				<i data-lucide={ p.Icon } class="w-4 h-4 text-base-content opacity-60 shrink-0"></i>
+			}
+			<h2 class="text-sm font-semibold min-w-0">{ p.Title }</h2>
+			if p.Count != nil {
+				<span class="text-xs text-base-content/40 whitespace-nowrap shrink-0">{ strconv.Itoa(*p.Count) } { sectionHeaderCountLabel(p) }</span>
+			}
+		</div>
 		if p.Action != nil {
-			<div class="ml-auto shrink-0">
+			<div class="sm:ml-auto shrink-0">
 				@p.Action
 			</div>
 		}


### PR DESCRIPTION
## Summary

`/design/c/section-header` rendered poorly on mobile when a trailing action was present: the title (`OAuth clients`) and the count (`3 items`) both wrapped mid-word because the single-row `flex items-center` layout had no `min-w-0` on the title, so the `shrink-0` action button forced the rest of the row to break wherever the browser could fit it.

Mirror the existing `bb-page-header` pattern instead — stack the title row + action onto two rows below `sm:`, single row at `sm:` and up. Count is locked to `whitespace-nowrap shrink-0` so `N items` never splits across lines.

Desktop output is byte-identical (verified by re-capturing before/after at 1280×800).

## Changes

- `internal/templates/components/section_header.templ` — wrap icon + title + count in a `min-w-0` flex container; switch root to `flex flex-col items-start gap-2 sm:flex-row sm:items-center`; gate action's `ml-auto` to `sm:`; add `whitespace-nowrap` + `shrink-0` to count.

## Evidence

### Mobile (390×844) — before / after

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>`&lt;img src="https://i.img402.dev/ft5va3v9d3.jpg" width="320" alt="section-header mobile before"&gt;`</td>
    <td>`&lt;img src="https://i.img402.dev/4fybsrpldo.jpg" width="320" alt="section-header mobile after"&gt;`</td>
  </tr>
</table>

### Desktop (1280×800) — after (unchanged from before)

`&lt;img src="https://i.img402.dev/3hkjrxxpac.jpg" width="800" alt="section-header desktop after"&gt;`

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./internal/templates/...` all clean
- [x] Verified mobile rendering at 390×844 — title, count, action all single-line; action drops below
- [x] Verified desktop rendering at 1280×800 — layout byte-identical to pre-change capture

https://claude.ai/code/session_01AnpSt93hbCwZdW7oUB1CgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnpSt93hbCwZdW7oUB1CgN)_