### PR TITLE
fix(agents): persist transcripts across container restarts + show run errors

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -9,6 +9,19 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      # Agent NDJSON transcripts are written to /app/transcripts inside
+      # the container (see app_config key agent.transcript_dir, default
+      # "transcripts/agents"). Without this named volume, every
+      # `docker compose up -d` recreates the container and silently
+      # wipes the transcript history — the admin "open transcript" link
+      # then 404s for every prior run. Keep this mount even if you
+      # don't use the agents feature; the directory is empty until an
+      # agent runs.
+      - breadbox_transcripts:/app/transcripts
+      # Uncomment to enable one-click updates from the admin dashboard.
+      # This gives the container access to the Docker daemon.
+      # - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/health/ready"]
       interval: 30s
@@ -19,10 +32,6 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    # Uncomment to enable one-click updates from the admin dashboard.
-    # This gives the container access to the Docker daemon.
-    # volumes:
-    #   - /var/run/docker.sock:/var/run/docker.sock
 
   db:
     image: postgres:16-alpine
@@ -68,5 +77,6 @@ services:
 
 volumes:
   postgres_data:
+  breadbox_transcripts:
   caddy_data:
   caddy_config:

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -346,6 +346,10 @@ func agentRunRowFromResponse(run service.AgentRunResponse) pages.AgentRunRowProp
 	if run.OperatorNote != nil {
 		row.Note = *run.OperatorNote
 	}
+	if run.ErrorMessage != nil {
+		row.ErrorMessage = *run.ErrorMessage
+		row.ErrorMessageFriendly = pages.AgentRunFriendlyError(row.ErrorMessage)
+	}
 	return row
 }
 

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -268,6 +268,9 @@ templ AgentRunDetail(p AgentRunDetailProps) {
 	}
 	@components.BreadcrumbNav(agentRunDetailBreadcrumbs(p))
 	@agentRunDetailHeader(p)
+	if p.Run.Status == "error" && p.Run.ErrorMessage != "" {
+		@agentRunErrorAlert(p.Run)
+	}
 	if p.Error != "" {
 		<div class="alert alert-error alert-soft mb-4">
 			<i data-lucide="triangle-alert" class="w-4 h-4"></i>
@@ -304,6 +307,30 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 			}
 		</div>
 	</div>
+}
+
+// agentRunErrorAlert renders the run's error_message above the metadata
+// card. When the message has a known friendly translation (e.g. the
+// startup orphan-cleanup string) we render the friendly text as the
+// headline and keep the raw message in a smaller secondary line so
+// operators can still grep / paste the original when reporting a bug.
+// Restart-interrupted runs surface as `alert-warning` (retriable);
+// every other error stays `alert-error`.
+templ agentRunErrorAlert(run AgentRunRowProps) {
+	if run.ErrorMessageFriendly != "" {
+		<div class="alert alert-warning alert-soft mb-4">
+			<i data-lucide="rotate-cw" class="w-4 h-4"></i>
+			<div>
+				<div class="font-medium">{ run.ErrorMessageFriendly }</div>
+				<div class="text-xs opacity-70 mt-0.5 font-mono">{ run.ErrorMessage }</div>
+			</div>
+		</div>
+	} else {
+		<div class="alert alert-error alert-soft mb-4">
+			<i data-lucide="triangle-alert" class="w-4 h-4"></i>
+			<span class="whitespace-pre-wrap break-words">{ run.ErrorMessage }</span>
+		</div>
+	}
 }
 
 // agentRunDetailBreadcrumbs builds the breadcrumb trail for the detail

--- a/internal/templates/components/pages/agent_runs_helpers.go
+++ b/internal/templates/components/pages/agent_runs_helpers.go
@@ -1,0 +1,35 @@
+//go:build !headless && !lite
+
+package pages
+
+import "strings"
+
+// AgentRunFriendlyError maps known raw error_message strings on an
+// agent_run row to operator-friendly text. Returns "" when no mapping
+// applies — callers should fall back to the raw message.
+//
+// Mirrors the shape of internal/sync/errors.go (sync logs) but is a
+// separate list because the failure modes differ: the only overlap
+// today is the startup orphan-cleanup message, which both subsystems
+// write verbatim and both want to surface as "safe to retry".
+func AgentRunFriendlyError(raw string) string {
+	lower := strings.ToLower(raw)
+	for _, m := range AgentRunFriendlyErrorMappings {
+		if strings.Contains(lower, m.pattern) {
+			return m.message
+		}
+	}
+	return ""
+}
+
+type agentRunErrorMapping struct {
+	pattern string
+	message string
+}
+
+var AgentRunFriendlyErrorMappings = []agentRunErrorMapping{
+	{
+		pattern: "interrupted by server restart",
+		message: "Interrupted by a server restart — safe to re-run.",
+	},
+}

--- a/internal/templates/components/pages/agent_runs_types.go
+++ b/internal/templates/components/pages/agent_runs_types.go
@@ -76,6 +76,14 @@ type AgentRunRowProps struct {
 	HitCap     string
 	Turns      int
 	Note       string
+
+	// ErrorMessage is the raw error_message column. Empty for non-errored
+	// runs. ErrorMessageFriendly is the operator-friendly translation
+	// (e.g. "interrupted by server restart" → "Interrupted by server
+	// restart — safe to re-run."); empty when no special mapping applies,
+	// in which case the raw message should be rendered as-is.
+	ErrorMessage         string
+	ErrorMessageFriendly string
 }
 
 // AgentRunDetailProps powers the per-run page at /agents/runs/{shortId}.


### PR DESCRIPTION
## Summary

Two related fixes for the Agent SDK subsystem, both prompted by debugging missing transcripts and a "failed" manual run on `breadbox.exe.xyz`.

- **Persist agent transcripts across container restarts.** `deploy/docker-compose.prod.yml` had no volume mounted at `/app/transcripts`, so every `docker compose up -d` (which the deploy job runs on every push to `main`) silently wiped the NDJSON transcript directory. Every "open transcript" link 404'd for any run that predated the last deploy. The change adds a `breadbox_transcripts` named volume; the directory is empty on a fresh install, so the mount is harmless when the agents feature isn't in use.
- **Surface `error_message` on the per-run detail page.** A run that fails — including the common case where startup orphan-cleanup marks an in-progress run as `interrupted by server restart` — previously showed only a red status badge with no explanation. The detail page now renders the message as an alert above the metadata card. Restart-interrupted runs get a soft-warning "safe to re-run" hint while the raw message is preserved below for paste-into-bug-report purposes. Mirrors the friendly-error pattern already used for sync logs.

The same compose change has already been applied to the running `breadbox.exe.xyz` `/opt/breadbox/docker-compose.yml` (the deploy CI only runs `docker compose pull && up -d` against the on-VM compose file, so this PR doesn't re-apply that — it brings self-hosters and future fresh installs in sync).

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` are green (locally green).
- [ ] `docker compose -f deploy/docker-compose.prod.yml config -q` validates.
- [ ] On a fresh install or self-hosted upgrade, kicking off an agent run produces a transcript file that survives `docker compose up -d`.
- [ ] Viewing `/agents/runs/<shortId>` for a run with `status=error` now shows the error message banner.
- [ ] Specifically, an "interrupted by server restart" run renders the friendly warning + raw message, not a bare red badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
