### PR TITLE
fix(agents): stable sidecar binary + transcript dir across worktrees

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -179,6 +179,32 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
         echo "WARN: no available port in 8081-8099"
       fi
     fi
+
+    # BREADBOX_AGENT_TRANSCRIPT_DIR — share one transcript dir across every
+    # worktree-resident `breadbox serve`. Without this each worktree writes
+    # transcripts to its own ./transcripts/agents/ (cwd-relative default),
+    # so a run launched from worktree A is unreadable when the admin UI is
+    # served by worktree B's process. The path lives outside any worktree
+    # so it survives `claude --rm` and switching branches.
+    if [ -z "${BREADBOX_AGENT_TRANSCRIPT_DIR:-}" ]; then
+      TX_DIR="$HOME/.local/share/breadbox/transcripts/agents"
+      mkdir -p "$TX_DIR" 2>/dev/null || true
+      echo "BREADBOX_AGENT_TRANSCRIPT_DIR=$TX_DIR" >> "$CLAUDE_ENV_FILE"
+      echo "    Set BREADBOX_AGENT_TRANSCRIPT_DIR ($TX_DIR)"
+    fi
+
+    # breadbox-agent binary — auto-discovery checks ./bin, then
+    # ~/.breadbox/agent-bin, then $PATH. Verify at least one slot resolves
+    # and hint if not so the first `breadbox agent test` doesn't fail
+    # with a cryptic "binary not found".
+    if [ ! -x "$PROJECT_DIR/bin/breadbox-agent" ] \
+       && [ ! -x "$HOME/.breadbox/agent-bin/breadbox-agent" ] \
+       && ! command -v breadbox-agent &>/dev/null; then
+      echo "    Note: breadbox-agent sidecar not found in any discovery slot."
+      echo "          Run \`make agent-sidecar-install-user\` in the main repo to"
+      echo "          install it once at ~/.breadbox/agent-bin/breadbox-agent —"
+      echo "          every worktree will pick it up automatically thereafter."
+    fi
   fi
 
   echo "==> Worktree setup complete."

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -31,6 +31,13 @@ breadbox mcp                       ← MCP tool registry (read-only or full-acce
 
 When in doubt about where new code belongs, ask: is it admin page shell / form state → `internal/admin/` + the matching `.templ`; is it user input/response shaping → `api/`; is it stateful behavior → `service/`; is it the runner protocol / event shapes → `internal/agent/`; is it sidecar logic → `agent/sidecar/`.
 
+## Local dev across worktrees
+
+Two paths bite worktree workflows because each `claude -w` worktree is a fresh checkout sharing one dev DB:
+
+- **Sidecar binary**: install once with `make agent-sidecar-install-user`. Writes to `~/.breadbox/agent-bin/breadbox-agent` (the priority-4 discovery slot). Per-worktree `bin/breadbox-agent` is NOT in `.worktreeinclude` — it'd cost 50 MB per worktree to copy and the user-home install achieves the same thing once.
+- **Transcript dir**: `agent.DefaultTranscriptDir()` (`internal/agent/transcript_dir.go`) checks `BREADBOX_AGENT_TRANSCRIPT_DIR` before falling back to the cwd-relative default. The session-start hook exports it to `~/.local/share/breadbox/transcripts/agents` for worktree sessions so every local server reads the same dir. Docker / prod containers don't set the env var, so they still default to `/app/transcripts/agents` (which the prod compose file mounts as a named volume). When you add a new call site that resolves `agent.transcript_dir`, use `agent.DefaultTranscriptDir()` as the appconfig fallback — don't hardcode `"transcripts/agents"`.
+
 ## Locked invariants
 
 These are easy to break and painful to re-discover.

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ internal/db/*.sql.go
 # Backups
 backups/
 
+# Agent SDK transcripts — written cwd-relative by `breadbox serve` /
+# `breadbox agent test` when neither app_config nor
+# BREADBOX_AGENT_TRANSCRIPT_DIR points elsewhere.
+transcripts/
+
 # OS
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export
 
 TAILWIND_BIN := ./tailwindcss-extra
 
-.PHONY: dev dev-watch dev-stop build build-headless build-lite test test-integration lint lint-headless lint-lite generate migrate-up migrate-down migrate-create sqlc sqlc-install sqlc-tag seed db db-stop docker-up docker-down css css-watch css-install air-install templ templ-install templ-check openapi-validate agent-sidecar agent-sidecar-install agent-sidecar-typecheck
+.PHONY: dev dev-watch dev-stop build build-headless build-lite test test-integration lint lint-headless lint-lite generate migrate-up migrate-down migrate-create sqlc sqlc-install sqlc-tag seed db db-stop docker-up docker-down css css-watch css-install air-install templ templ-install templ-check openapi-validate agent-sidecar agent-sidecar-install agent-sidecar-install-user agent-sidecar-typecheck
 
 PORT ?= 8080
 
@@ -134,7 +134,10 @@ build-lite:
 # server exec's per Claude Agent SDK run. Output is bin/breadbox-agent —
 # a self-contained binary with the Bun runtime embedded (~50 MB).
 # The Go server discovers this binary via app_config agent.runtime_path,
-# the BREADBOX_AGENT_BIN env var, or by falling back to ./bin/breadbox-agent.
+# the BREADBOX_AGENT_BIN env var, ./bin/breadbox-agent (cwd-relative),
+# ~/.breadbox/agent-bin/breadbox-agent (per-user — see -install-user
+# target below), then $PATH. Local dev: build once with -install-user and
+# every worktree picks it up; production: the Docker image bakes it in.
 agent-sidecar-install:
 	@if ! command -v bun &>/dev/null; then \
 		echo "Error: bun is not installed. Install via 'curl -fsSL https://bun.sh/install | bash'."; \
@@ -147,6 +150,19 @@ agent-sidecar: agent-sidecar-install
 	@mkdir -p bin
 	@cp agent/sidecar/bin/breadbox-agent bin/breadbox-agent 2>/dev/null || true
 	@echo "Built bin/breadbox-agent (also at agent/sidecar/bin/breadbox-agent)."
+
+# agent-sidecar-install-user: build the sidecar (if not already built) and
+# copy it to ~/.breadbox/agent-bin/breadbox-agent — the per-user slot in
+# LocateBinary's discovery chain (priority 4). Run this ONCE on a fresh
+# machine; from then on every worktree's `breadbox serve` finds it without
+# having to bake a per-worktree `bin/breadbox-agent`. This is the canonical
+# local-dev install path; the worktree session-start hook checks for this
+# file and hints to run this target when missing.
+agent-sidecar-install-user: agent-sidecar
+	@mkdir -p $$HOME/.breadbox/agent-bin
+	@cp bin/breadbox-agent $$HOME/.breadbox/agent-bin/breadbox-agent
+	@chmod +x $$HOME/.breadbox/agent-bin/breadbox-agent
+	@echo "Installed $$HOME/.breadbox/agent-bin/breadbox-agent — discoverable by every worktree."
 
 agent-sidecar-typecheck: agent-sidecar-install
 	cd agent/sidecar && bun run typecheck

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -16,10 +16,12 @@ Recurring AI-powered workflows that run via the Claude Agent SDK and call breadb
      chmod +x ~/.breadbox/agent-bin/breadbox-agent
      ```
    - **Docker image**: nothing to do — the published image bundles `breadbox-agent` at `/usr/local/bin/breadbox-agent`.
-   - **From source** (dev / contributors): `make agent-sidecar` writes `bin/breadbox-agent` next to your repo checkout. Requires `bun`:
+   - **From source** (dev / contributors): `make agent-sidecar-install-user` builds the sidecar and installs it to `~/.breadbox/agent-bin/breadbox-agent` — the per-user slot in the discovery chain. Run it once; every clone and every git worktree picks it up automatically. Requires `bun`:
      ```sh
      curl -fsSL https://bun.sh/install | bash
+     make agent-sidecar-install-user
      ```
+     (`make agent-sidecar` alone writes only `bin/breadbox-agent` next to your repo checkout, which doesn't transfer to sibling worktrees.)
 
    Discovery order is: `agent.runtime_path` (Settings → Agents) → `$BREADBOX_AGENT_BIN` → `./bin/breadbox-agent` (cwd) → `~/.breadbox/agent-bin/breadbox-agent` → `$PATH` lookup.
 3. **Pick a starter agent** from `/agents`. Five defaults are seeded on fresh installs (disabled):
@@ -64,6 +66,15 @@ Exit codes (full reference):
 | 3    | No Anthropic credential configured                       | Paste a token in Settings → Agents (subscription or API key)                |
 | 5    | Sidecar binary not found                                 | Download `breadbox-agent-<os>-<arch>` from [the latest release](https://github.com/canalesb93/breadbox/releases/latest) into `~/.breadbox/agent-bin/` (or your PATH), use the Docker image, or `make agent-sidecar` from source |
 | 1    | Test ran but the sidecar crashed or the model errored    | Re-run with `--verbose` (planned) or check server logs for the sidecar stderr |
+
+### Local development across worktrees
+
+When you work on agents from multiple `claude -w` worktrees against the shared dev DB, two paths bite if they're not stable per machine:
+
+- **Sidecar binary**. Each worktree is a fresh checkout with no `./bin/breadbox-agent`, so the auto-discovery chain has to find the binary somewhere outside the worktree. Run `make agent-sidecar-install-user` once in your main checkout — it installs to `~/.breadbox/agent-bin/breadbox-agent`, which every worktree's `breadbox serve` picks up via priority-4 discovery.
+- **Transcript dir**. The default `agent.transcript_dir` is cwd-relative (`transcripts/agents`), so each worktree's server writes to its own directory. The session-start hook exports `BREADBOX_AGENT_TRANSCRIPT_DIR=$HOME/.local/share/breadbox/transcripts/agents` for worktree sessions so every local server reads + writes from the same place. Operator overrides via Settings → Agents still win (the env var is a fallback default, not an override).
+
+You can verify both are wired by running `breadbox agent test` from any worktree — it should report the resolved binary path and complete a smoke run in under 2s.
 
 ## Architecture (one-line view per layer)
 

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"breadbox/internal/agent"
 	"breadbox/internal/appconfig"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
@@ -213,7 +214,7 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 			path = *run.TranscriptPath
 		}
 		if path == "" && run.ID != "" {
-			dir := appconfig.String(ctx, svc.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
+			dir := appconfig.String(ctx, svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
 			if dir != "" {
 				path = filepath.Join(dir, run.ID+".ndjson")
 			}

--- a/internal/agent/sidecar_test.go
+++ b/internal/agent/sidecar_test.go
@@ -99,6 +99,18 @@ func TestSidecarRun_BinaryNotFound(t *testing.T) {
 	s := &Sidecar{} // no BinaryPath, no env, no ./bin/breadbox-agent
 	t.Setenv("BREADBOX_AGENT_BIN", "")
 	t.Setenv("PATH", "/nonexistent-for-test")
+	// Shadow $HOME so a real ~/.breadbox/agent-bin/breadbox-agent install
+	// (created locally by `make agent-sidecar-install-user`) doesn't
+	// accidentally satisfy step 4 of LocateBinary and bypass the
+	// not-found branch this test is exercising.
+	t.Setenv("HOME", t.TempDir())
+	// And cd into a fresh dir without ./bin/breadbox-agent so step 3
+	// doesn't shortcut either.
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
 
 	res, err := s.Run(context.Background(), JobSpec{
 		RunID:  "x",

--- a/internal/agent/transcript_dir.go
+++ b/internal/agent/transcript_dir.go
@@ -1,0 +1,31 @@
+//go:build !lite
+
+package agent
+
+import "os"
+
+// TranscriptDirEnvVar is the env-var name that supplies the fallback
+// transcript_dir when app_config has no explicit value.
+const TranscriptDirEnvVar = "BREADBOX_AGENT_TRANSCRIPT_DIR"
+
+// DefaultTranscriptDir resolves the fallback transcript directory used
+// when `app_config.agent.transcript_dir` is empty.
+//
+// Precedence (highest first):
+//
+//  1. operator config in app_config — handled by the caller via
+//     appconfig.String(..., KeyAgentTranscriptDir, DefaultTranscriptDir())
+//  2. BREADBOX_AGENT_TRANSCRIPT_DIR env var — local-dev hook for sharing
+//     one transcript dir across multiple worktree servers
+//  3. "transcripts/agents" — cwd-relative, matches the Docker image's
+//     /app/transcripts/agents working directory
+//
+// The Docker image still resolves to /app/transcripts/agents because the
+// env var is unset and the working directory is /app. Local worktree
+// sessions get a stable home-shared dir via the session-start hook.
+func DefaultTranscriptDir() string {
+	if v := os.Getenv(TranscriptDirEnvVar); v != "" {
+		return v
+	}
+	return "transcripts/agents"
+}

--- a/internal/agent/transcript_dir_test.go
+++ b/internal/agent/transcript_dir_test.go
@@ -1,0 +1,28 @@
+//go:build !lite
+
+package agent_test
+
+import (
+	"testing"
+
+	"breadbox/internal/agent"
+)
+
+func TestDefaultTranscriptDir(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "unset → cwd-relative default", env: "", want: "transcripts/agents"},
+		{name: "set → honored", env: "/var/lib/breadbox/transcripts/agents", want: "/var/lib/breadbox/transcripts/agents"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(agent.TranscriptDirEnvVar, tc.env)
+			if got := agent.DefaultTranscriptDir(); got != tc.want {
+				t.Fatalf("DefaultTranscriptDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -425,7 +425,7 @@ func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
 			path = *run.TranscriptPath
 		}
 		if path == "" && run.ID != "" {
-			dir := appconfig.String(r.Context(), svc.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
+			dir := appconfig.String(r.Context(), svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
 			if dir != "" {
 				path = filepath.Join(dir, run.ID+".ndjson")
 			}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -150,7 +150,7 @@ func runAgentRun(parent context.Context, slug string, jsonOut bool, promptPrefix
 	// process; the in-memory semaphore is just belt-and-suspenders).
 	sidecar := &agent.Sidecar{
 		BinaryPath:    appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, ""),
-		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents"),
+		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir()),
 	}
 	orch := service.NewOrchestrator(a.Service, sidecar, 1, cfg.EncryptionKey, logger)
 
@@ -232,7 +232,7 @@ func runAgentTest(parent context.Context) error {
 	defer a.DB.Close()
 
 	binaryPath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
-	transcriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
+	transcriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
 	sidecar := &agent.Sidecar{
 		BinaryPath:    binaryPath,
 		TranscriptDir: transcriptDir,

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -139,7 +139,7 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	// via Settings → Agents → "breadbox-agent transcripts dir" if they
 	// want them elsewhere. Daily cleanup (iter-25) still prunes whatever
 	// path is in effect.
-	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
+	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
 	agentSidecar := &agent.Sidecar{
 		BinaryPath:    agentRuntimePath,
 		TranscriptDir: agentTranscriptDir,

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -66,7 +66,7 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSe
 	runtimePath := appconfig.String(ctx, s.Queries, appconfig.KeyAgentRuntimePath, "")
 	// Default matches serve.go fallback — keeps the Settings → Agents
 	// form showing the active path on a fresh install rather than blank.
-	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, "transcripts/agents")
+	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
 	globalBudget := readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)
 
 	return &AgentSettingsResponse{


### PR DESCRIPTION
## Summary

Local Claude Agent SDK work was unusable across `claude -w` worktrees because two cwd-relative paths shifted with the worktree root:

- **Sidecar binary.** `./bin/breadbox-agent` is gitignored and not in `.worktreeinclude`, so every fresh worktree started with no discoverable sidecar — `breadbox agent test` immediately exited 5 with "binary not found".
- **Transcript dir.** `agent.transcript_dir` defaults to `transcripts/agents` (cwd-relative), so a transcript written by worktree A's `breadbox serve` was a 404 in worktree B's admin UI even though both read the same DB.

This PR fixes both with stable per-user locations that the existing `LocateBinary` discovery chain already supports — no new env vars to remember, no per-worktree builds.

### What changed

- **`make agent-sidecar-install-user`** builds the sidecar and copies it to `~/.breadbox/agent-bin/breadbox-agent` (LocateBinary priority-4). Run once on a machine and every worktree's `breadbox serve` picks it up via auto-discovery.
- **`BREADBOX_AGENT_TRANSCRIPT_DIR`** is a new fallback default that sits between the cwd-relative hardcoded default and operator-controlled `app_config`. When `app_config.agent.transcript_dir` is empty, the env var wins. Docker / prod don't set it, so they still default to `/app/transcripts/agents` (the named volume from #1494).
- **Session-start hook** exports the env var to `~/.local/share/breadbox/transcripts/agents` for worktree sessions, hints when the sidecar isn't installed in any discovery slot.
- **`agent.DefaultTranscriptDir()`** new helper threaded through every existing call site (serve, agent CLI x2, REST API, admin handler, settings service) so the precedence is consistent everywhere.
- **Latent test fix**: `TestSidecarRun_BinaryNotFound` would fail on any machine that actually has the per-user install. Now shadows `$HOME` the same way `TestLocateBinary_UserInstallDir` already does.
- **Docs + rule**: `docs/agents.md` now has a "Local development across worktrees" section; `.claude/rules/agents.md` documents the new helper + precedence for future contributors.

### Validation

`go test ./...` and `make test-integration` both clean.

A general-purpose subagent was spawned in a fresh isolated worktree (via `Agent isolation: worktree`) with this branch checked out, no local `./bin/breadbox-agent`, and instructed to run the smoke test. Result:

```
🔎 breadbox agent test

  ✗ smoke run failed

smoke: run sidecar: Claude Code process exited with code 1
```

The key signal: it did **not** fail with `ErrBinaryNotFound` (exit 5) — the sidecar at `~/.breadbox/agent-bin/breadbox-agent` was discovered and spawned, and only the final Anthropic round-trip failed because the local dev DB's subscription token is stale (pre-existing issue, out of scope here).

The `DefaultTranscriptDir` unit test verifying env-var precedence also passes:
```
ok  breadbox/internal/agent  0.179s
```

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] `make test-integration` clean
- [x] `make agent-sidecar-install-user` writes `~/.breadbox/agent-bin/breadbox-agent`
- [x] `breadbox agent test` in a fresh worktree discovers the sidecar (validated via subagent)
- [ ] First-time setup on a new machine: run `make agent-sidecar-install-user` once, then `breadbox agent test` from any worktree
- [ ] Operator override still wins: setting `agent.transcript_dir` in Settings → Agents overrides the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
