### PR TITLE
fix(agents): admin Run-now async + fresh ctx for persist

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -163,7 +163,16 @@ func RunAgentNowAdminHandler(a *app.App, svc *service.Service) http.HandlerFunc 
 			return
 		}
 
-		run, err := orchestrator.RunNowWith(r.Context(), def, service.RunOverrides{
+		// Async dispatch: returns the in_progress row immediately, hands the
+		// sidecar invocation + completion + revoke to a goroutine that owns a
+		// fresh 30-minute context. Critical because spending-report / bulk-review
+		// runs routinely exceed the exe.dev proxy's ~8s HTTP timeout; the sync
+		// variant left rows stuck in_progress when the request context cancelled
+		// mid-run (sidecar's orphaned Node child still completed via MCP, but
+		// the persist step failed with context canceled). The list-page UI
+		// already calls window.location.reload() 800ms after the response, so
+		// it doesn't need the completed row — only that the run started.
+		run, err := orchestrator.RunNowAsyncWith(r.Context(), def, service.RunOverrides{
 			PromptPrefix:   promptPrefix,
 			PromptOverride: promptOverride,
 		})
@@ -172,10 +181,18 @@ func RunAgentNowAdminHandler(a *app.App, svc *service.Service) http.HandlerFunc 
 				writeError(w, http.StatusServiceUnavailable, "CONCURRENCY_LOCKED", "Another run is in progress")
 				return
 			}
+			if errors.Is(err, agent.ErrAuthNotConfigured) {
+				writeError(w, http.StatusUnprocessableEntity, "AUTH_NOT_CONFIGURED", err.Error())
+				return
+			}
+			if errors.Is(err, agent.ErrBinaryNotFound) {
+				writeError(w, http.StatusUnprocessableEntity, "BINARY_NOT_FOUND", err.Error())
+				return
+			}
 			writeError(w, http.StatusUnprocessableEntity, "RUN_FAILED", err.Error())
 			return
 		}
-		writeJSON(w, http.StatusOK, run)
+		writeJSON(w, http.StatusAccepted, run)
 	}
 }
 

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -322,14 +322,20 @@ func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionRespo
 		}
 		result, runErr := o.runner.Run(runCtx, *spec, handler)
 
-		completedRow, completeErr := o.svc.CompleteAgentRunDB(runCtx, runRow.ID, result, def.MaxTurns)
+		// Use a FRESH context for persist + hit-cap updates so a cancelled
+		// runCtx (timeout, server shutdown, or future caller passing a
+		// shorter parent) doesn't prevent the row from being completed.
+		// Mirrors the runLocked path; same reasoning as the deferred revoke.
+		persistCtx, persistCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer persistCancel()
+		completedRow, completeErr := o.svc.CompleteAgentRunDB(persistCtx, runRow.ID, result, def.MaxTurns)
 		if completeErr != nil {
 			o.logger.Error("orchestrator: persist completed run failed",
 				"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)
 			return
 		}
 		if cap := capFromRunErr(runErr); cap != "" {
-			if _, err := o.svc.SetAgentRunHitCapDB(runCtx, runRow.ID, cap); err != nil {
+			if _, err := o.svc.SetAgentRunHitCapDB(persistCtx, runRow.ID, cap); err != nil {
 				o.logger.Warn("orchestrator: persist hit_cap failed",
 					"agent", def.Slug, "run", runResp.ShortID, "cap", cap, "error", err)
 			}
@@ -422,7 +428,18 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	}
 	result, runErr := o.runner.Run(ctx, *spec, handler)
 
-	completedRow, completeErr := o.svc.CompleteAgentRunDB(ctx, runRow.ID, result, def.MaxTurns)
+	// Persist the completion under a FRESH context. The request-scoped ctx may
+	// already be cancelled — e.g. when the admin "Run now" still went through
+	// the sync path and the exe.dev proxy killed the HTTP request mid-run,
+	// or when the bun-compiled sidecar got SIGKILL'd via CommandContext but
+	// its orphaned Node child kept running and finished the work anyway
+	// (see incident: run RK7U4E06, 2026-05-25). In either case we want the
+	// DB write to succeed so the row reflects reality. The async dispatcher
+	// already passes a fresh ctx so this is a belt-and-suspenders for any
+	// remaining sync callers + future-proofing.
+	persistCtx, persistCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer persistCancel()
+	completedRow, completeErr := o.svc.CompleteAgentRunDB(persistCtx, runRow.ID, result, def.MaxTurns)
 	if completeErr != nil {
 		o.logger.Error("orchestrator: persist completed run failed",
 			"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)
@@ -435,9 +452,9 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 	// Detect cap exhaustion. The sidecar surfaces it through runErr after
 	// having already classified status (max_turns → success, budget → error),
 	// so we record the cap separately for the audit trail without rewriting
-	// status.
+	// status. Same fresh-ctx reasoning as CompleteAgentRunDB above.
 	if cap := capFromRunErr(runErr); cap != "" {
-		if capRow, err := o.svc.SetAgentRunHitCapDB(ctx, runRow.ID, cap); err == nil {
+		if capRow, err := o.svc.SetAgentRunHitCapDB(persistCtx, runRow.ID, cap); err == nil {
 			completedRow = capRow
 		} else {
 			o.logger.Warn("orchestrator: persist hit_cap failed",


### PR DESCRIPTION
## Summary

Two layered fixes for the class of bug that stuck production run `RK7U4E06` in `in_progress` forever even after the underlying agent SDK call successfully submitted a report.

### What happened

Admin `POST /-/agents/{slug}/run` was synchronous — the HTTP request held open while the sidecar ran. The exe.dev proxy cancelled the request after ~8s (a typical `spending-report` run takes ~45s). The request context propagated into `exec.CommandContext`, which `SIGKILL`'d the bun-compiled sidecar's parent process — but the SDK's Node child (bundled `cli.js`) was already **orphaned to init** and kept running. It finished the MCP work and submitted report `Gb2IM5Dm` 37s later. Meanwhile the Go orchestrator passed the *same canceled context* to `CompleteAgentRunDB`, which failed immediately with `context canceled`. The `agent_runs` row stayed `in_progress` until the next server restart's `CleanupOrphanedAgentRuns` sweep.

The REST API endpoint (`/api/v1/agents/{slug}/run`) was already async and unaffected — admin was the outlier.

### Fix layer 1 — admin handler uses `RunNowAsyncWith`

Returns the `in_progress` row immediately and hands the sidecar invocation to a goroutine that owns a fresh 30-minute context. The admin list-page UI already calls `window.location.reload()` 800ms after the response — it expects to navigate to the auto-refreshing detail page, not to receive the completed row.

Also surfaces `ErrAuthNotConfigured` and `ErrBinaryNotFound` as typed responses (`AUTH_NOT_CONFIGURED` / `BINARY_NOT_FOUND`, 422) so a missing token or missing sidecar binary shows a useful toast instead of a generic `RUN_FAILED`. Response code is now `202 Accepted` to match async semantics.

### Fix layer 2 — persist + hit-cap under a fresh context

Inside `runLocked()` AND the `prepareRun()` closure, the `CompleteAgentRunDB` + `SetAgentRunHitCapDB` calls now use `context.WithTimeout(context.Background(), 10s)` — same pattern the deferred revoke already uses. Belt-and-suspenders: even if a future caller passes a doomed parent ctx to the sync `RunNowWith`, the row still gets written.

### Operational note

Row `RK7U4E06` on `breadbox.exe.xyz` was manually marked `status=error` with a diagnostic message in `error_message` so the admin UI stops polling it. The success report (`Gb2IM5Dm`, submitted by the orphaned Node child) is intact and remains visible in the reports inbox.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/{agent,service,admin,api}/...` pass
- [ ] Manual: in dev, click Run now from `/agents` — list page reloads, the new in_progress row is visible, detail page polls and shows completion when the sidecar finishes
- [ ] Manual: trigger Run now then close the page mid-run; verify the row still transitions to success when the sidecar completes
- [ ] Manual: with no Anthropic token configured, Run now shows the "auth not configured" toast (was: generic "Failed to start agent")

## Follow-up

Three audit subagents (TS sidecar / Go runner / MCP+auth) surfaced ~20 deeper improvements while I was here — process-group + `WaitDelay` for proper orphan cleanup, `settingSources: []` to close a filesystem-config surface, plaintext-token-in-JobSpec hygiene, etc. Those will land in a separate sweep PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
