### PR TITLE
docs(design): add split-button join example (primary + chevron menu)

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -149,6 +149,24 @@ templ SectionButtons() {
 				</button>
 			</div>
 		}
+		@designExample("Join — split button (primary + menu)", "Primary action on the left, chevron dropdown on the right — both share the same join shell. Use for an action with a small set of related variants.") {
+			<div class="join">
+				<button class="btn btn-primary btn-sm join-item gap-2">
+					<i data-lucide="plus" class="w-4 h-4"></i>
+					New transaction
+				</button>
+				<div class="dropdown dropdown-end">
+					<div tabindex="0" role="button" class="btn btn-primary btn-sm join-item btn-square" aria-label="More options">
+						<i data-lucide="chevron-down" class="w-4 h-4"></i>
+					</div>
+					<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-52 p-1 mt-1">
+						<li><a>Manual entry</a></li>
+						<li><a>Import from CSV</a></li>
+						<li><a>From rule template</a></li>
+					</ul>
+				</div>
+			</div>
+		}
 	</div>
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1497. Adds a fourth daisy `join` example to the `/design#buttons` section: the **split button** — primary action on the left, chevron-down dropdown on the right, both sharing the same join shell. This is the GitHub "Enable auto-merge ▾" / Linear "Create issue ▾" shape — useful when there's one obvious default plus a small set of related variants.

## Evidence

`/design#buttons` — fresh viewport (1280×800), default theme. New example at the bottom (`Join — split button`):

<img src="https://i.img402.dev/qdy2iv4fiz.jpg" width="800" alt="design sandbox — split button join example">

## Test plan

- [ ] `templ generate && make css` regenerate cleanly
- [ ] `go vet ./...` passes
- [ ] Visit `/design#buttons` and confirm the split button renders with the chevron-square trigger on the right and an opening dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
