### PR TITLE
refactor(design): page-header secondary actions use btn-secondary, not ghost

### DIFF
--- a/internal/templates/components/entity_header.templ
+++ b/internal/templates/components/entity_header.templ
@@ -28,10 +28,11 @@ package components
 //                      Visible at every breakpoint — this is the entity's
 //                      subtitle.
 //   - Action:          trailing primary action. Always visible.
-//   - SecondaryAction: trailing secondary (ghost) action. Hidden below
-//                      sm: — keep the destination reachable from the
-//                      page body (info grid, overflow menu, etc.) if it
-//                      matters on mobile.
+//   - SecondaryAction: trailing secondary action (btn-secondary by
+//                      convention). Hidden below sm: — keep the
+//                      destination reachable from the page body
+//                      (info grid, overflow menu, etc.) if it matters
+//                      on mobile.
 //
 // Mobile (< sm) collapse: the icon tile shrinks to 40×40, badges and the
 // secondary action are hidden so the header stays compact (icon + title

--- a/internal/templates/components/page_header.templ
+++ b/internal/templates/components/page_header.templ
@@ -10,8 +10,8 @@ package components
 //   - Action:   optional templ.Component for the page's PRIMARY action
 //               (typically a btn-primary). Right-aligned.
 //   - SecondaryAction: optional templ.Component for one secondary action
-//               (ghost-styled by convention — e.g. "Sync All"). Rendered
-//               just before Action.
+//               (secondary-styled by convention — e.g. "Sync All").
+//               Rendered just before Action.
 //   - SubtitleHideOnMobile: when true, applies `hidden sm:block` so the
 //               subtitle disappears on small screens (used on dense
 //               list pages where the subtitle is decorative).
@@ -41,7 +41,7 @@ type PageHeaderProps struct {
 	Icon                 string // optional Lucide icon name
 	SubtitleHideOnMobile bool
 	// SecondaryAction is rendered before Action in the trailing slot.
-	// Convention: ghost-styled button (use PageHeaderSecondaryAction).
+	// Convention: secondary-styled button (use PageHeaderSecondaryAction).
 	SecondaryAction templ.Component
 	// Action is the trailing primary action. Typically constructed with
 	// PageHeaderAction(...) for the common case of a single primary
@@ -93,11 +93,11 @@ templ PageHeaderAction(href templ.SafeURL, icon string, label string) {
 }
 
 // PageHeaderSecondaryAction renders the convention shape for a single
-// secondary action: ghost-styled `<a>` with a leading Lucide icon.
+// secondary action: secondary-styled `<a>` with a leading Lucide icon.
 // For interactive secondary actions (Alpine click handlers, async
 // state) pass a custom templ.Component to PageHeaderProps.SecondaryAction.
 templ PageHeaderSecondaryAction(href templ.SafeURL, icon string, label string) {
-	<a href={ href } class="btn btn-ghost btn-sm gap-2">
+	<a href={ href } class="btn btn-secondary btn-sm gap-2">
 		if icon != "" {
 			<i data-lucide={ icon } class="w-4 h-4"></i>
 		}

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -72,7 +72,7 @@ templ AgentsList(p AgentsListProps) {
 }
 
 templ agentsListPromptLibraryAction() {
-	<a href="/agent-prompts" class="btn btn-ghost btn-sm gap-2" title="Prompt library">
+	<a href="/agent-prompts" class="btn btn-secondary btn-sm gap-2" title="Prompt library">
 		<i data-lucide="book-open" class="w-4 h-4"></i>
 		<span>Prompt library</span>
 	</a>

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -475,7 +475,7 @@ func connectionsSecondaryAction(p ConnectionsProps) templ.Component {
 templ connectionsSyncAllBtn() {
 	<div x-show="tab === 'connections'" x-cloak x-data="syncAllBtn">
 		<button
-			class="btn btn-ghost btn-sm gap-2"
+			class="btn btn-secondary btn-sm gap-2"
 			:disabled="state !== 'idle'"
 			@click="triggerSyncAll()"
 			:title="state === 'syncing' ? 'Syncing all connections...' : 'Sync all connections now'"

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -112,7 +112,7 @@ templ ruleDetailEditBtn(p RuleDetailProps) {
 }
 
 templ ruleDetailToggleBtn(p RuleDetailProps) {
-	<button class="btn btn-sm btn-ghost" @click="toggleRule()">
+	<button class="btn btn-sm btn-secondary" @click="toggleRule()">
 		if p.Rule.Enabled {
 			<i data-lucide="pause" class="w-3.5 h-3.5"></i>
 			Disable

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -112,7 +112,7 @@ func txExportAction(p TransactionsProps) templ.Component {
 }
 
 templ txExportLink(exportURL string) {
-	<a href={ templ.SafeURL(exportURL) } class="btn btn-ghost btn-sm gap-2" title="Export as CSV">
+	<a href={ templ.SafeURL(exportURL) } class="btn btn-secondary btn-sm gap-2" title="Export as CSV">
 		<i data-lucide="download" class="w-4 h-4"></i>
 		Export CSV
 	</a>


### PR DESCRIPTION
## Summary

- Switch the `SecondaryAction` slot convention on `PageHeader` (and the `EntityHeader` sibling) from `btn-ghost` to `btn-secondary` so the trailing secondary control has a visible filled surface alongside the primary action.
- Touches the canonical `PageHeaderSecondaryAction` helper plus four bespoke `SecondaryAction` components: Export CSV on `/transactions`, Sync All on `/connections`, Prompt library on `/agents`, and Enable/Disable on rule detail.
- Convention docstrings on `page_header.templ` and `entity_header.templ` updated to match.

The daisy `btn-secondary` modifier is the natural counterpart to `btn-primary` on the existing `PageHeaderAction`, so this stays inside the daisy-first decision tree in `.claude/rules/daisyui.md` — no new `bb-*` classes.

## Evidence (dark mode — clearest contrast)

`btn-secondary` resolves to `oklch(0.269 0 0)` on a `oklch(0.205 0 0)` page background in dark mode (subtle filled pill); in light mode the theme variable `--color-secondary` is `oklch(0.97 0 0)` which equals `--color-base-100` so it reads near-identical to the previous ghost — flagged below.

<table>
  <tr><th>Page</th><th>Before (btn-ghost)</th><th>After (btn-secondary)</th></tr>
  <tr>
    <td><code>/transactions</code> — Export CSV</td>
    <td><img src="https://i.img402.dev/j42lxj0562.jpg" width="400" alt="transactions header before"></td>
    <td><img src="https://i.img402.dev/z0dzv06xzw.jpg" width="400" alt="transactions header after"></td>
  </tr>
  <tr>
    <td><code>/connections</code> — Sync All</td>
    <td><img src="https://i.img402.dev/q3ybg2vey3.jpg" width="400" alt="connections header before"></td>
    <td><img src="https://i.img402.dev/7r248uybni.jpg" width="400" alt="connections header after"></td>
  </tr>
  <tr>
    <td><code>/agents</code> — Prompt library</td>
    <td><img src="https://i.img402.dev/m1v07lnkdp.jpg" width="400" alt="agents header before"></td>
    <td><img src="https://i.img402.dev/14ygcezgl8.jpg" width="400" alt="agents header after"></td>
  </tr>
</table>

## Heads up — light-mode rendering is a no-op

This theme defines `--color-secondary` identically to `--color-base-100` in light mode (`oklch(0.97 0 0)`), so `btn-secondary` renders flat against the page background and visually matches the previous ghost in light themes. If a more prominent secondary in light mode is preferred we can either (a) shift `--color-secondary` slightly in `input.css`, or (b) swap the convention to `btn-soft` / `btn-outline`. Happy to follow up — flag preference.

## Test plan

- [x] `templ generate` clean (regenerated `*_templ.go` from edited `.templ` sources).
- [x] `go vet ./...` and `go build ./...` pass.
- [x] Headless Chromium capture against a fresh local build of this branch confirms the `class="btn btn-secondary btn-sm gap-2"` is rendered on Export CSV / Sync All / Prompt library.
- [x] Computed styles inspected: dark mode shows the filled secondary surface; light mode flat (theme-variable overlap noted above).
