### PR TITLE
fix(agents): keep secrets out of JobSpec JSON + lock down sidecar settings

### DIFF
--- a/agent/sidecar/index.ts
+++ b/agent/sidecar/index.ts
@@ -5,8 +5,11 @@
  * Reads one JobSpec as JSON from stdin, executes a Claude Agent SDK query,
  * streams NDJSON events on stdout, and exits.
  *
- * Auth precedence trap: ANTHROPIC_API_KEY wins over CLAUDE_CODE_OAUTH_TOKEN
- * when both are set. We scrub the unused var before invoking the SDK.
+ * Auth: the Go runner (internal/agent/sidecar.go::authEnvFor) sets exactly
+ * one of {ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN} in our process env
+ * before exec. We still defensively scrub the inactive var here so a
+ * misconfigured Go-side caller can't silently land in the precedence trap
+ * (ANTHROPIC_API_KEY wins over CLAUDE_CODE_OAUTH_TOKEN).
  */
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import cliAsset from "@anthropic-ai/claude-agent-sdk/cli.js" with { type: "file" };
@@ -45,12 +48,16 @@ async function readStdin(): Promise<string> {
 }
 
 function configureAuth(spec: JobSpec): void {
+  // The Go runner sets exactly one auth env var on our process env before
+  // exec; here we only scrub the OTHER one so the SDK's "ANTHROPIC_API_KEY
+  // beats CLAUDE_CODE_OAUTH_TOKEN" precedence rule can't bite if both
+  // happen to be set (e.g. operator has ANTHROPIC_API_KEY in their shell
+  // env and breadbox serve inherited it, then configures subscription
+  // mode — Go already scrubs in that path, this is belt-and-suspenders).
   if (spec.auth.mode === "api_key") {
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    process.env.ANTHROPIC_API_KEY = spec.auth.token;
   } else {
     delete process.env.ANTHROPIC_API_KEY;
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = spec.auth.token;
   }
 }
 
@@ -105,7 +112,19 @@ async function main() {
         maxBudgetUsd: spec.maxBudgetUsd,
         allowedTools: spec.allowedTools.length > 0 ? spec.allowedTools : undefined,
         mcpServers: spec.mcpServers,
+        // Breadbox agents are autonomous — there's no human attached to
+        // answer SDK permission prompts. `dontAsk` denies anything not
+        // pre-approved via allowedTools / our MCP wildcard, which is the
+        // correct posture for a scheduled run.
         permissionMode: "dontAsk",
+        // settingSources defaults to ["user","project","local"] — the SDK
+        // would otherwise load ~/.claude/CLAUDE.md, project-level
+        // .claude/settings.json hooks/skills/permission rules, and any
+        // local override discovered from cwd. In a self-hosted sidecar
+        // the cwd is wherever Go exec'd from, so anyone who can write to
+        // that path can inject agent-run config. Forcing `[]` keeps the
+        // sidecar fully self-contained and reproducible across hosts.
+        settingSources: [],
         resume: spec.sessionId,
         pathToClaudeCodeExecutable,
         executable: "node",

--- a/agent/sidecar/spec.ts
+++ b/agent/sidecar/spec.ts
@@ -15,10 +15,13 @@ const HttpServerConfig = z.object({
 
 export const McpServerConfigSchema = z.union([StdioServerConfig, HttpServerConfig]);
 
-// Auth: exactly one of subscription OAuth token or Anthropic API key.
+// Auth mode: metadata only. The actual secret is delivered via env vars
+// (ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN) set by the Go runner's
+// cmd.Env before exec — NEVER through this spec — so plaintext tokens
+// can't leak via stdin captures, /proc snapshots, or a stray log of the
+// spec object. See internal/agent/sidecar.go::authEnvFor.
 const AuthConfigSchema = z.object({
   mode: z.enum(["subscription", "api_key"]),
-  token: z.string().min(1),
 });
 
 // JobSpec: the JSON document read from stdin.

--- a/internal/agent/auth_env_test.go
+++ b/internal/agent/auth_env_test.go
@@ -1,0 +1,131 @@
+//go:build !lite
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestAuthEnvFor(t *testing.T) {
+	const apiToken = "sk-ant-test-apikey"
+	const subToken = "sk-ant-oat01-test-subscription"
+
+	inherited := []string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_API_KEY=stale-from-shell",
+		"CLAUDE_CODE_OAUTH_TOKEN=stale-from-shell",
+		"BREADBOX_AGENT_TRANSCRIPT_DIR=/tmp/x",
+	}
+
+	cases := []struct {
+		name      string
+		auth      AuthConfig
+		wantSet   string // env var that should be present
+		wantValue string
+		wantUnset string // the OTHER auth var must be absent
+	}{
+		{
+			name:      "api_key mode",
+			auth:      AuthConfig{Mode: "api_key", Token: apiToken},
+			wantSet:   "ANTHROPIC_API_KEY",
+			wantValue: apiToken,
+			wantUnset: "CLAUDE_CODE_OAUTH_TOKEN",
+		},
+		{
+			name:      "subscription mode",
+			auth:      AuthConfig{Mode: "subscription", Token: subToken},
+			wantSet:   "CLAUDE_CODE_OAUTH_TOKEN",
+			wantValue: subToken,
+			wantUnset: "ANTHROPIC_API_KEY",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := authEnvFor(inherited, tc.auth)
+
+			// Both stale entries must be stripped.
+			for _, e := range got {
+				if strings.HasPrefix(e, "ANTHROPIC_API_KEY=stale") ||
+					strings.HasPrefix(e, "CLAUDE_CODE_OAUTH_TOKEN=stale") {
+					t.Errorf("stale auth env survived: %q", e)
+				}
+			}
+			// Non-auth inherited vars are preserved.
+			if !contains(got, "PATH=/usr/bin") {
+				t.Errorf("PATH=/usr/bin missing from result: %v", got)
+			}
+			if !contains(got, "BREADBOX_AGENT_TRANSCRIPT_DIR=/tmp/x") {
+				t.Errorf("BREADBOX_AGENT_TRANSCRIPT_DIR missing from result: %v", got)
+			}
+			// The active var is set, and only once.
+			want := tc.wantSet + "=" + tc.wantValue
+			if !contains(got, want) {
+				t.Errorf("expected %q in result, got %v", want, got)
+			}
+			// The inactive var is absent.
+			for _, e := range got {
+				if strings.HasPrefix(e, tc.wantUnset+"=") {
+					t.Errorf("expected %q to be unset, found %q", tc.wantUnset, e)
+				}
+			}
+		})
+	}
+}
+
+func TestAuthEnvFor_EmptyToken(t *testing.T) {
+	// Empty token (e.g. unit tests, pre-auth smoke) must not lay down an empty
+	// env value — neither var should be set so the SDK fails with its own
+	// clear "no auth" message instead of "auth header malformed".
+	got := authEnvFor([]string{"PATH=/usr/bin"}, AuthConfig{Mode: "api_key", Token: ""})
+	for _, e := range got {
+		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") || strings.HasPrefix(e, "CLAUDE_CODE_OAUTH_TOKEN=") {
+			t.Errorf("empty token should not produce auth env, got %q", e)
+		}
+	}
+}
+
+func TestAuthConfig_JSON_OmitsToken(t *testing.T) {
+	auth := AuthConfig{Mode: "subscription", Token: "sk-ant-oat01-supersecret"}
+	b, err := json.Marshal(auth)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "supersecret") {
+		t.Errorf("plaintext token leaked into JSON wire format: %s", b)
+	}
+	if !strings.Contains(string(b), `"mode":"subscription"`) {
+		t.Errorf("mode missing from JSON: %s", b)
+	}
+}
+
+func TestAuthConfig_String_Redacts(t *testing.T) {
+	auth := AuthConfig{Mode: "api_key", Token: "sk-ant-api03-abcdef1234567890"}
+	s := auth.String()
+	if strings.Contains(s, "abcdef1234567890") {
+		t.Errorf("String() leaked full token: %s", s)
+	}
+	// Last 4 chars are fine for identifying which token is in use during debugging.
+	if !strings.Contains(s, "7890") {
+		t.Errorf("String() should include last-4 for identification, got %q", s)
+	}
+	// %v / %+v / %#v should all go through String()/GoString().
+	if got := fmt.Sprintf("%v", auth); strings.Contains(got, "abcdef1234567890") {
+		t.Errorf("%%v leaked full token: %s", got)
+	}
+	if got := fmt.Sprintf("%#v", auth); strings.Contains(got, "abcdef1234567890") {
+		t.Errorf("%%#v leaked full token: %s", got)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/sidecar.go
+++ b/internal/agent/sidecar.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -136,6 +137,12 @@ func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (
 
 	cmd := exec.CommandContext(ctx, bin)
 	cmd.Stdin = bytes.NewReader(specJSON)
+	// Auth flows via env vars set HERE, not via the JSON spec (Token is
+	// `json:"-"` for exactly this reason — keep plaintext secrets out of the
+	// wire format and out of any future log capture of the spec). The Go side
+	// is the single source of truth for which env var is set; the sidecar
+	// process inherits exactly one of {ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN}.
+	cmd.Env = authEnvFor(os.Environ(), spec.Auth)
 
 	// Process-group lifecycle. The sidecar (a bun-compiled binary) spawns
 	// the SDK's bundled Node child for cli.js. With the stdlib default
@@ -294,4 +301,33 @@ func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (
 	}
 
 	return result, result.Err
+}
+
+// authEnvFor returns a copy of `inherited` with both Anthropic auth env vars
+// stripped and exactly one re-added based on auth.Mode. Centralizes the
+// "exactly one auth var, never both" rule on the Go side so a future
+// sidecar regression (or a different sidecar runtime entirely) can't expose
+// the precedence trap.
+//
+// auth.Token may be empty (e.g. unit tests, smoke before auth configured) —
+// in that case neither var is set and the SDK will fail with its own clear
+// "no auth" error rather than us silently sneaking in an inherited value.
+func authEnvFor(inherited []string, auth AuthConfig) []string {
+	out := make([]string, 0, len(inherited)+1)
+	for _, e := range inherited {
+		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") || strings.HasPrefix(e, "CLAUDE_CODE_OAUTH_TOKEN=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	if auth.Token == "" {
+		return out
+	}
+	switch auth.Mode {
+	case "api_key":
+		out = append(out, "ANTHROPIC_API_KEY="+auth.Token)
+	case "subscription":
+		out = append(out, "CLAUDE_CODE_OAUTH_TOKEN="+auth.Token)
+	}
+	return out
 }

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -15,12 +15,32 @@ type MCPServerConfig struct {
 }
 
 // AuthConfig carries credentials for one run. Mode picks which env var the
-// sidecar sets; the other is unset before invoking the SDK to avoid the
-// precedence trap where ANTHROPIC_API_KEY silently wins over CLAUDE_CODE_OAUTH_TOKEN.
+// runner sets on the sidecar process; the other is unset before exec to
+// avoid the precedence trap where ANTHROPIC_API_KEY silently wins over
+// CLAUDE_CODE_OAUTH_TOKEN.
+//
+// Token is `json:"-"` deliberately: secrets never travel via the sidecar's
+// stdin JSON, only as scoped env vars that Sidecar.Run sets on cmd.Env.
+// This closes the leak class where any future `slog.Warn("spec", spec)`
+// or similar would otherwise put the plaintext token in logs / OTel.
 type AuthConfig struct {
-	Mode  string `json:"mode"`  // "subscription" | "api_key"
-	Token string `json:"token"` // sk-ant-oat01-… (subscription) or sk-ant-… (api_key)
+	Mode  string `json:"mode"`  // "subscription" | "api_key" — metadata, safe on the wire
+	Token string `json:"-"`     // sk-ant-oat01-… or sk-ant-…; flows to sidecar via env, NEVER JSON
 }
+
+// String returns a redacted representation safe for logs / %v formatting.
+// Without this an inadvertent `fmt.Sprintf("%+v", spec)` in any handler
+// would print the plaintext token. Belt-and-suspenders alongside `json:"-"`.
+func (a AuthConfig) String() string {
+	suffix := ""
+	if n := len(a.Token); n >= 4 {
+		suffix = a.Token[n-4:]
+	}
+	return "AuthConfig{Mode=" + a.Mode + ", Token=…" + suffix + "}"
+}
+
+// GoString mirrors String for `%#v` formatting (verbose / debug log style).
+func (a AuthConfig) GoString() string { return a.String() }
 
 // JobSpec is the JSON document written to the sidecar's stdin.
 // camelCase JSON tags match the TypeScript sidecar's zod schema.


### PR DESCRIPTION
## Summary

Two P0 hardening items from the SDK-integration audit that came up while debugging run RK7U4E06.

### 1. Plaintext Anthropic tokens no longer travel through stdin JSON

Previously `AuthConfig.Token` was a JSON-tagged field in `JobSpec`, written verbatim to the sidecar process's stdin. A single `slog.Warn("spec", spec)` or `fmt.Sprintf("%+v", spec)` in any future handler would put `sk-ant-oat01-…` / `sk-ant-api03-…` into logs, OTel exports, or `/proc/<pid>/cmdline`-like captures. None of that exists today — but the auth-precedence trap was already documented as a "one wrong line away" hazard, and the token leak has the same shape.

Now:
- `AuthConfig.Token` is `json:"-"` — never marshals to wire
- `AuthConfig.String()` / `.GoString()` redact to `AuthConfig{Mode=..., Token=…XXXX}` so `%v` / `%#v` formatters can't leak
- New `authEnvFor()` helper lays down exactly one of `{ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN}` on `cmd.Env`, scrubbing both stale entries from the inherited env first. The Go side is now the single source of truth for which auth env var is set
- TS-side `AuthConfigSchema` drops the `token` field; the sidecar reads from env and does only a defensive scrub of the inactive var (belt-and-suspenders if a future caller mis-sets both)

### 2. `settingSources: []` passed to `query()`

Without it the SDK defaults to loading user/project/local settings — `~/.claude/CLAUDE.md`, project `.claude/settings.json`, hooks, skills, slash commands — from whatever directory the sidecar `exec`'d in. In a self-hosted breadbox container the sidecar's cwd is the breadbox working directory; anyone with FS access there could inject permission rules, hooks, or output styles that fire on every agent run.

Forcing `[]` keeps the sidecar fully self-contained and reproducible across hosts. `dontAsk` permission mode stays — breadbox agents are autonomous, there's no operator to answer prompts.

### What was NOT changed

- `permissionMode: "dontAsk"` stays (autonomous agents need it)
- MCP wildcard allowlist stays (read_only scope is enforced server-side via the per-run API key)
- TS-side `configureAuth()` shrunk to only the defensive scrub instead of being deleted; protects against a future Go-side regression silently setting both vars

## Test plan

- [x] `go test ./internal/agent/... ./internal/service/... ./internal/admin/... ./internal/cli/...` pass
- [x] `make test-integration` on touched packages passes
- [x] `make agent-sidecar` rebuilds cleanly, new TS sidecar deployed locally
- [x] `breadbox agent test` against dev DB succeeds end-to-end: token flows from app_config → Go memory → cmd.Env → SDK → Anthropic, never appears in stdin JSON
- [ ] Reviewers: spot-check that no slog/admin handler currently logs the full spec — if any does, this PR is the moment to add the redaction; the helper functions are in place

## Follow-ups (from the same audit)

- Process-group: `Setpgid` + `WaitDelay` + drop `Sidecar.mu` (closes the orphan-grandchild class — the actual root cause of the RK7U4E06 incident)
- Polish: typed `agent.RunError` taxonomy, per-agent `AllowedTools` honored, startup sweep of orphaned `agent:*` API keys, `defer recover()` in async goroutine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
