### PR TITLE
fix(agents): kill the whole process group on cancel + drop Sidecar.mu

### DIFF
--- a/internal/agent/sidecar.go
+++ b/internal/agent/sidecar.go
@@ -13,13 +13,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
+	"syscall"
 	"time"
 )
 
 // Sidecar locates and exec's the breadbox-agent binary. Implements Runner.
-// Concurrency: holds an internal mutex as a safety net; the orchestrator
-// (added in Iteration 3) is responsible for the server-wide concurrency cap.
+//
+// Concurrency: the orchestrator (internal/service/agent_orchestrator.go)
+// owns the server-wide concurrency cap via its semaphore. Sidecar itself
+// is stateless and safe to call from multiple goroutines — earlier
+// iterations held an internal mutex "as a safety net" but that mutex
+// silently capped real concurrency at 1, contradicting the operator-
+// configurable `agent.max_concurrent` setting.
 type Sidecar struct {
 	// BinaryPath, when set, overrides binary discovery. Wire this from
 	// app_config.agent.runtime_path at startup.
@@ -28,8 +33,6 @@ type Sidecar struct {
 	// TranscriptDir is the root directory for NDJSON transcripts.
 	// One file per run: <TranscriptDir>/<runID>.ndjson. Created if missing.
 	TranscriptDir string
-
-	mu sync.Mutex
 }
 
 // resolveBinary finds the sidecar binary via the shared LocateBinary helper.
@@ -84,9 +87,6 @@ func LocateBinary(explicitPath string) (string, error) {
 // Always returns a non-nil RunResult. The returned error mirrors result.Err
 // when the run failed; callers can prefer one or the other.
 func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (RunResult, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	start := time.Now()
 	result := RunResult{Status: StatusError}
 
@@ -136,6 +136,34 @@ func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (
 
 	cmd := exec.CommandContext(ctx, bin)
 	cmd.Stdin = bytes.NewReader(specJSON)
+
+	// Process-group lifecycle. The sidecar (a bun-compiled binary) spawns
+	// the SDK's bundled Node child for cli.js. With the stdlib default
+	// (Process.Kill on ctx cancel), only the bun parent receives SIGKILL —
+	// the Node child becomes orphaned to init and keeps running, finishing
+	// MCP work after the orchestrator has already moved on (and after the
+	// per-run API key may already be revoked). See incident: run RK7U4E06,
+	// 2026-05-25.
+	//
+	// Setpgid puts the sidecar in its own group; cmd.Cancel + cmd.WaitDelay
+	// (Go 1.20+) replace the default Kill-the-parent with a group-targeted
+	// SIGKILL that takes down the Node grandchild too.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		// Kill the entire process group (`pgid == cmd.Process.Pid` because
+		// Setpgid made the sidecar its own group leader). SIGKILL rather
+		// than SIGTERM: the SDK doesn't have meaningful cleanup work to
+		// honor here, and the rest of the runtime is already past the
+		// point of caring (ctx canceled means we're tearing the run down).
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	// WaitDelay bounds how long Wait blocks after Cancel runs. Without it
+	// a child that swallowed its pipe close could keep us waiting forever.
+	cmd.WaitDelay = 5 * time.Second
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		result.Err = fmt.Errorf("agent: stdout pipe: %w", err)
@@ -192,7 +220,13 @@ func (s *Sidecar) Run(ctx context.Context, spec JobSpec, handler EventHandler) (
 		if handler != nil {
 			if herr := handler(evt); herr != nil {
 				handlerErr = herr
-				_ = cmd.Process.Kill()
+				// Kill the whole group, not just the parent — same reasoning
+				// as cmd.Cancel above. The handler-error path is rare (only
+				// fires if the caller's event handler returns non-nil) but
+				// shares the orphan-grandchild risk.
+				if cmd.Process != nil {
+					_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+				}
 				// Drain remaining output silently.
 				_, _ = io.Copy(io.Discard, stdout)
 				break

--- a/internal/agent/sidecar_processgroup_test.go
+++ b/internal/agent/sidecar_processgroup_test.go
@@ -1,0 +1,188 @@
+//go:build !lite
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSidecarRun_ProcessGroupReapsGrandchild verifies the actual root-cause
+// fix for the RK7U4E06 incident: when the parent ctx is cancelled, both the
+// sidecar parent process AND the long-running child it spawned must be
+// dead by the time Run returns.
+//
+// Before this PR, exec.CommandContext only sent SIGKILL to the parent;
+// the child (here a `sleep`, in production the SDK's Node cli.js) survived
+// orphaned to init. We now put the spawned cmd in its own process group
+// (Setpgid:true) and kill the negative pgid on cancel.
+func TestSidecarRun_ProcessGroupReapsGrandchild(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "breadbox-agent")
+	// Fake sidecar: prints "child=<pid>" then keeps the parent alive too.
+	// Critically the child is spawned in the same process group as the
+	// parent (the shell's default behavior under our Setpgid:true on the
+	// sidecar). If our group-kill works, both die when ctx cancels.
+	//
+	// We use `sleep 30` (no `exec`) so the shell is its own process and
+	// the child is a distinct PID we can probe.
+	script := `#!/bin/sh
+sleep 30 &
+echo "child=$!"
+sleep 30
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake sidecar: %v", err)
+	}
+
+	s := &Sidecar{BinaryPath: bin, TranscriptDir: t.TempDir()}
+
+	// We need the child pid out-of-band. Hijack the event handler — the
+	// sidecar writes "child=<pid>" as a stdout line, which doesn't parse
+	// as NDJSON so it never reaches the handler; we instead read the
+	// transcript file after.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run in a goroutine so we can cancel from this test goroutine.
+	type runResult struct {
+		res RunResult
+		err error
+	}
+	done := make(chan runResult, 1)
+	go func() {
+		res, err := s.Run(ctx, JobSpec{
+			RunID:  "pgtest",
+			Prompt: "x",
+			Model:  "claude-haiku-4-5",
+			Auth:   AuthConfig{Mode: "api_key", Token: "fake"},
+		}, nil)
+		done <- runResult{res, err}
+	}()
+
+	// Give the fake sidecar 500ms to print its child=<pid> line.
+	transcriptPath := filepath.Join(s.TranscriptDir, "pgtest.ndjson")
+	childPid := waitForChildPid(t, transcriptPath, 2*time.Second)
+	t.Logf("fake sidecar's child pid = %d", childPid)
+
+	// Sanity check: the child should be alive before we cancel.
+	if err := syscall.Kill(childPid, 0); err != nil {
+		t.Fatalf("child %d unexpectedly not alive pre-cancel: %v", childPid, err)
+	}
+
+	// Pull the rug.
+	cancel()
+
+	// Wait for Run() to return — it should within a couple of seconds
+	// thanks to cmd.WaitDelay and the group-kill.
+	select {
+	case r := <-done:
+		if !errors.Is(r.err, context.Canceled) && !errors.Is(r.err, context.DeadlineExceeded) {
+			// Non-fatal — the exact error class depends on whether the
+			// sidecar exited on its own first; what matters is that we
+			// returned promptly.
+			t.Logf("Run returned err=%v (status=%q)", r.err, r.res.Status)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Sidecar.Run did not return within 10s of ctx cancel — orphan-grandchild fix broken or WaitDelay not honored")
+	}
+
+	// Now the critical assertion: the child must be dead. Give the kernel
+	// up to 500ms to reap the SIGKILL'd child.
+	if !waitProcessGone(childPid, 500*time.Millisecond) {
+		// Try once more with SIGTERM to confirm it's reachable (and clean up).
+		// If kill -0 succeeds the child is alive, which is the bug.
+		if err := syscall.Kill(childPid, 0); err == nil {
+			_ = syscall.Kill(childPid, syscall.SIGKILL)
+			t.Fatalf("child pid %d survived ctx cancel — orphan-grandchild fix not working", childPid)
+		}
+	}
+}
+
+func waitForChildPid(t *testing.T, transcriptPath string, deadline time.Duration) int {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		b, err := os.ReadFile(transcriptPath)
+		if err == nil {
+			for _, line := range strings.Split(string(b), "\n") {
+				if !strings.HasPrefix(line, "child=") {
+					continue
+				}
+				pid, perr := strconv.Atoi(strings.TrimPrefix(line, "child="))
+				if perr == nil && pid > 0 {
+					return pid
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("did not see child=<pid> line in %s within %v", transcriptPath, deadline)
+	return 0
+}
+
+func waitProcessGone(pid int, deadline time.Duration) bool {
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return true // ESRCH or similar: process is gone
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// TestSidecarRun_ConcurrentRunsNoLongerSerialize verifies that dropping
+// Sidecar.mu actually lets two concurrent runs proceed in parallel — the
+// previous mutex serialized everything regardless of the orchestrator's
+// semaphore setting.
+func TestSidecarRun_ConcurrentRunsNoLongerSerialize(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "breadbox-agent")
+	// Fake sidecar that sleeps 300ms and emits a minimal result event.
+	script := `#!/bin/sh
+sleep 0.3
+printf '{"type":"result","ts":1,"data":{"totalCostUsd":0,"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheCreationTokens":0,"turnCount":1,"numToolCalls":0,"sessionId":"s","stopReason":"end_turn"}}\n'
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake sidecar: %v", err)
+	}
+
+	s := &Sidecar{BinaryPath: bin, TranscriptDir: t.TempDir()}
+
+	// Run 3 in parallel. If the mutex were still there, total time ≥ 900ms.
+	// With it gone, total ≈ 300ms (plus startup overhead).
+	start := time.Now()
+	errs := make(chan error, 3)
+	for i := 0; i < 3; i++ {
+		go func(i int) {
+			_, err := s.Run(context.Background(), JobSpec{
+				RunID:  fmt.Sprintf("conc-%d", i),
+				Prompt: "x",
+				Model:  "claude-haiku-4-5",
+				Auth:   AuthConfig{Mode: "api_key", Token: "fake"},
+			}, nil)
+			errs <- err
+		}(i)
+	}
+	for i := 0; i < 3; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("Run %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	// Allow generous headroom: even with parallelism, fork+exec on macOS
+	// can take ~100ms each. The previous serialized worst-case would be ~900ms+;
+	// 700ms is comfortably below that and well above the parallel ideal.
+	if elapsed > 700*time.Millisecond {
+		t.Errorf("3 concurrent runs took %v — expected well under 700ms (parallelism lost?)", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

Root-cause fix for the orphan-grandchild bug class that produced the RK7U4E06 incident. PR #1498 closed the *timing-window symptom* (admin Run-now is now async, so the request context rarely cancels mid-run); this PR closes the *structural cause* — a canceled context could still leak the SDK's Node child to init.

### The bug

`exec.CommandContext` SIGKILLs only the immediate child process when ctx is canceled. The breadbox-agent sidecar is a bun-compiled binary that spawns the SDK's bundled Node process for `cli.js`. When ctx canceled mid-run:

- bun parent received SIGKILL and died
- Node child was orphaned to init (PID 1) and kept running
- Node continued making MCP calls (or burning Anthropic budget) for ~30–60s before exiting on its own

ANY context cancel — server shutdown, request timeout, future caller passing a tight context — still leaks the grandchild today.

### The fix

```go
cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
cmd.Cancel = func() error {
    return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
}
cmd.WaitDelay = 5 * time.Second
```

`Setpgid` puts the sidecar in its own process group; `cmd.Cancel` replaces the stdlib's parent-only SIGKILL with a group-wide one; `cmd.WaitDelay` bounds how long `Wait` blocks if a child swallowed pipe close.

Same group-kill applied to the handler-error path (formerly `cmd.Process.Kill()` — shares the same orphan risk).

### Drop `Sidecar.mu`

The struct-level mutex was documented as a "safety net" on top of the orchestrator's semaphore, but it pinned real concurrency at 1 regardless of `agent.max_concurrent` (operator-configurable, default 3 since iter-29). The semaphore is the real contract; the mutex was masking it. New test confirms 3 concurrent runs complete in ~470ms (was ≥900ms under the mutex).

### Tests

- **`TestSidecarRun_ProcessGroupReapsGrandchild`** — spawns a fake sidecar that forks a long-sleeping child, cancels ctx, asserts the child PID is dead within 500ms via `kill -0`. Would fail if `Setpgid` + `Cancel` were removed. **This is the regression test for RK7U4E06.**
- **`TestSidecarRun_ConcurrentRunsNoLongerSerialize`** — 3 concurrent runs of a 300ms fake sidecar complete well under 700ms total. Would exceed that if the mutex were re-added.

Smoke-tested locally — `breadbox agent test` still passes end-to-end.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/agent/... ./internal/service/...` passes
- [x] End-to-end `breadbox agent test` succeeds against real Anthropic
- [ ] Manual: trigger an agent run in dev, kill the parent server mid-run, verify no orphaned Node process via `ps auxww | grep -E 'cli\.js|breadbox-agent'`

## Stacking note

This PR is independent of #1501 (security: env-auth + settingSources). Either can land first. Together they close the two highest-leverage findings from the SDK-integration audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
