### PR TITLE
fix(deploy): persist scheduled backups across container restarts

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -19,6 +19,14 @@ services:
       # don't use the agents feature; the directory is empty until an
       # agent runs.
       - breadbox_transcripts:/app/transcripts
+      # Scheduled pg_dump backups are written to /var/lib/breadbox/backups
+      # when ENVIRONMENT=docker (see internal/cli/serve.go). Without this
+      # named volume, files live in the container's writable layer and
+      # every `docker compose up -d` wipes them — Settings → Backups
+      # then shows an empty list after every redeploy. Keep this mount
+      # even if you haven't enabled a schedule yet; the directory is
+      # empty until a backup runs.
+      - breadbox_backups:/var/lib/breadbox/backups
       # Uncomment to enable one-click updates from the admin dashboard.
       # This gives the container access to the Docker daemon.
       # - /var/run/docker.sock:/var/run/docker.sock
@@ -78,5 +86,6 @@ services:
 volumes:
   postgres_data:
   breadbox_transcripts:
+  breadbox_backups:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## Summary

- Scheduled `pg_dump` backups in `breadbox serve` write to `/var/lib/breadbox/backups` when `ENVIRONMENT=docker`, but the prod compose template only mounted `/app/transcripts` — the backups directory lived in the container's writable layer.
- On `breadbox.exe.xyz`, every merge to `main` auto-deploys via SSH (`docker compose up -d`), recreating the container and silently wiping any backups. Settings → Backups showed an empty list after each redeploy.
- Add a named `breadbox_backups` volume mount to `deploy/docker-compose.prod.yml` so scheduled backups survive redeploys. Same shape as the `breadbox_transcripts` fix from #1494.
- Audit context: on the VM right now, `pg_dump 16.13` is in the container, `app_config.backup_schedule = daily_2am` (30-day retention), the hourly cron is registered — only the missing volume mount stopped backups from persisting.

## Test plan

- [ ] Merge → auto-deploy completes on `breadbox.exe.xyz`
- [ ] `docker exec breadbox-breadbox-1 ls -la /var/lib/breadbox/backups` shows the directory mounted (created on first scheduled run)
- [ ] `docker inspect breadbox-breadbox-1 --format '{{json .Mounts}}'` lists `breadbox_backups`
- [ ] After the next 02:00 UTC firing, Settings → Backups shows the new `breadbox_scheduled_*.sql.gz` file
- [ ] Trigger a `docker compose up -d` after a backup exists; verify the file is still there afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
