### PR TITLE
feat(admin): dedicated /accounts page + provider filter on /connections

### DIFF
--- a/internal/admin/accounts.go
+++ b/internal/admin/accounts.go
@@ -1,0 +1,251 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"math"
+	"net/http"
+	"sort"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components/pages"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// AccountsListPageHandler serves GET /admin/accounts — a flat, sortable
+// table of every account across every connection. Mirrors the access scoping
+// of the connections list (members see only their linked-user's accounts;
+// editors+ see all). Edit/exclude actions reuse the existing
+// /-/accounts/{id}/{excluded,display-name} endpoints.
+func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var (
+			allRows  []db.ListAccountsRow
+			userRows []db.ListAccountsByUserRow
+			useUser  bool
+		)
+
+		// Same scoping rule as ConnectionsListHandler: viewers see only the
+		// accounts on their own linked user's connections.
+		memberUserID := SessionUserID(sm, r)
+		if !IsEditor(sm, r) && memberUserID != "" {
+			var uid pgtype.UUID
+			if scanErr := uid.Scan(memberUserID); scanErr == nil {
+				rows, err := a.Queries.ListAccountsByUser(ctx, uid)
+				if err != nil {
+					a.Logger.Error("list accounts by user", "error", err)
+					http.Error(w, "Internal server error", http.StatusInternalServerError)
+					return
+				}
+				userRows = rows
+				useUser = true
+			}
+		}
+		if !useUser {
+			rows, err := a.Queries.ListAccounts(ctx)
+			if err != nil {
+				a.Logger.Error("list accounts", "error", err)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+			allRows = rows
+		}
+
+		// Lookup of household member display name by user short_id. Built
+		// from a single ListUsers call rather than the per-account N+1 the
+		// connections page does — accounts can be hundreds of rows.
+		users, _ := a.Queries.ListUsers(ctx)
+		userNameByShort := make(map[string]string, len(users))
+		for _, u := range users {
+			userNameByShort[u.ShortID] = u.Name
+		}
+
+		// Build typed rows + running totals.
+		var rows []pages.AccountsListRow
+		var totalAssets, totalLiabilities float64
+		var hasAnyBalance bool
+
+		appendRow := func(row pages.AccountsListRow) {
+			if row.HasBalance {
+				hasAnyBalance = true
+				if row.IsLiability {
+					totalLiabilities += math.Abs(row.BalanceFloat)
+				} else {
+					totalAssets += row.BalanceFloat
+				}
+			}
+			rows = append(rows, row)
+		}
+
+		if useUser {
+			for _, r := range userRows {
+				appendRow(accountRowFromListByUser(r, userNameByShort))
+			}
+		} else {
+			for _, r := range allRows {
+				appendRow(accountRowFromListAll(r, userNameByShort))
+			}
+		}
+
+		// Default ordering: liabilities & no-balance at the bottom; biggest
+		// asset first. The Alpine factory re-sorts client-side when the user
+		// clicks a header.
+		sort.SliceStable(rows, func(i, j int) bool {
+			a, b := rows[i], rows[j]
+			if a.HasBalance != b.HasBalance {
+				return a.HasBalance
+			}
+			return a.BalanceFloat > b.BalanceFloat
+		})
+
+		netWorth := totalAssets - totalLiabilities
+
+		data := map[string]any{
+			"PageTitle":   "Accounts",
+			"CurrentPage": "accounts",
+			"CSRFToken":   GetCSRFToken(r),
+			"Flash":       GetFlash(ctx, sm),
+		}
+
+		props := pages.AccountsListProps{
+			CSRFToken:        GetCSRFToken(r),
+			NetWorth:         netWorth,
+			TotalAssets:      totalAssets,
+			TotalLiabilities: totalLiabilities,
+			HasAnyBalance:    hasAnyBalance,
+			Accounts:         rows,
+		}
+
+		// Only editors/admins see the household filter (members are already
+		// scoped to themselves at the query layer).
+		if IsEditor(sm, r) {
+			// Sort users by number of accounts (descending) so the most active
+			// household member surfaces first, like the connections page.
+			accountsPerUser := make(map[string]int)
+			for _, row := range rows {
+				if row.UserID != "" {
+					accountsPerUser[row.UserID]++
+				}
+			}
+			usersCopy := make([]db.User, len(users))
+			copy(usersCopy, users)
+			sort.Slice(usersCopy, func(i, j int) bool {
+				ci := accountsPerUser[pgconv.FormatUUID(usersCopy[i].ID)]
+				cj := accountsPerUser[pgconv.FormatUUID(usersCopy[j].ID)]
+				if ci != cj {
+					return ci > cj
+				}
+				return usersCopy[i].Name < usersCopy[j].Name
+			})
+			for _, u := range usersCopy {
+				first := ""
+				if u.Name != "" {
+					first = u.Name[:1]
+				}
+				props.Users = append(props.Users, pages.AccountsListUserFilter{
+					ID:    pgconv.FormatUUID(u.ID),
+					Name:  u.Name,
+					First: first,
+				})
+			}
+		}
+
+		tr.RenderWithTempl(w, r, data, pages.AccountsList(props))
+	}
+}
+
+// accountRowFromListAll converts an editor/admin-scope ListAccountsRow into
+// the typed templ row. Sign on BalanceFloat is adjusted so liabilities render
+// as negatives in the table.
+func accountRowFromListAll(r db.ListAccountsRow, userNameByShort map[string]string) pages.AccountsListRow {
+	row := pages.AccountsListRow{
+		ID:                pgconv.FormatUUID(r.ID),
+		DisplayName:       accountListDisplayName(r.DisplayName, r.Name),
+		Type:              r.Type,
+		SubtypeValid:      r.Subtype.Valid,
+		Subtype:           r.Subtype.String,
+		MaskValid:         r.Mask.Valid,
+		Mask:              r.Mask.String,
+		InstitutionName:   r.InstitutionName.String,
+		ConnectionShortID: r.ConnectionShortID.String,
+		IsDependentLinked: r.IsDependentLinked,
+		Excluded:          r.Excluded,
+		IsLiability:       IsLiabilityAccount(r.Type),
+	}
+	if r.ConnectionStatus.Valid {
+		row.ConnectionStatus = string(r.ConnectionStatus.ConnectionStatus)
+	}
+	if r.UserShortID.Valid {
+		row.UserID = r.UserShortID.String
+		if name, ok := userNameByShort[r.UserShortID.String]; ok && name != "" {
+			row.OwnerName = name
+			row.OwnerFirst = name[:1]
+		}
+	}
+	if v, ok := pgconv.NumericToFloat(r.BalanceCurrent); ok {
+		row.HasBalance = true
+		if row.IsLiability {
+			row.BalanceFloat = -math.Abs(v)
+		} else {
+			row.BalanceFloat = v
+		}
+	}
+	if r.IsoCurrencyCode.Valid {
+		row.IsoCurrencyCode = r.IsoCurrencyCode.String
+	}
+	return row
+}
+
+// accountRowFromListByUser mirrors accountRowFromListAll for the
+// per-household-member query (which omits the optional connection_id check
+// since users only see accounts on their own connections).
+func accountRowFromListByUser(r db.ListAccountsByUserRow, userNameByShort map[string]string) pages.AccountsListRow {
+	row := pages.AccountsListRow{
+		ID:                pgconv.FormatUUID(r.ID),
+		DisplayName:       accountListDisplayName(r.DisplayName, r.Name),
+		Type:              r.Type,
+		SubtypeValid:      r.Subtype.Valid,
+		Subtype:           r.Subtype.String,
+		MaskValid:         r.Mask.Valid,
+		Mask:              r.Mask.String,
+		InstitutionName:   r.InstitutionName.String,
+		ConnectionShortID: r.ConnectionShortID,
+		ConnectionStatus:  string(r.ConnectionStatus),
+		IsDependentLinked: r.IsDependentLinked,
+		Excluded:          r.Excluded,
+		IsLiability:       IsLiabilityAccount(r.Type),
+	}
+	if r.UserShortID.Valid {
+		row.UserID = r.UserShortID.String
+		if name, ok := userNameByShort[r.UserShortID.String]; ok && name != "" {
+			row.OwnerName = name
+			row.OwnerFirst = name[:1]
+		}
+	}
+	if v, ok := pgconv.NumericToFloat(r.BalanceCurrent); ok {
+		row.HasBalance = true
+		if row.IsLiability {
+			row.BalanceFloat = -math.Abs(v)
+		} else {
+			row.BalanceFloat = v
+		}
+	}
+	if r.IsoCurrencyCode.Valid {
+		row.IsoCurrencyCode = r.IsoCurrencyCode.String
+	}
+	return row
+}
+
+func accountListDisplayName(displayName pgtype.Text, fallback string) string {
+	if displayName.Valid && displayName.String != "" {
+		return displayName.String
+	}
+	return fallback
+}

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -206,22 +206,29 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 			})
 		}
 
-		// Fetch users for the family member filter subtabs, sorted by account count (descending).
-		users, _ := a.Queries.ListUsers(ctx)
-		// Count accounts per user from the enriched connections.
-		userAccountCount := make(map[[16]byte]int)
+		// Build the provider filter strip: one chip per provider that
+		// actually has a connection in the list, ordered by descending
+		// connection count then alphabetically. The shape of the strip
+		// (chips with icon + label + count) is built here so the templ
+		// can stay markup-only.
+		providerCounts := make(map[string]int)
 		for _, conn := range enriched {
-			if conn.UserID.Valid {
-				userAccountCount[conn.UserID.Bytes] += len(conn.Accounts)
-			}
+			providerCounts[string(conn.Provider)]++
 		}
-		sort.Slice(users, func(i, j int) bool {
-			ci := userAccountCount[users[i].ID.Bytes]
-			cj := userAccountCount[users[j].ID.Bytes]
-			if ci != cj {
-				return ci > cj
+		var providers []pages.ConnectionsProviderFilter
+		for slug, count := range providerCounts {
+			providers = append(providers, pages.ConnectionsProviderFilter{
+				Slug:  slug,
+				Label: providerLabel(slug),
+				Icon:  providerIcon(slug),
+				Count: count,
+			})
+		}
+		sort.Slice(providers, func(i, j int) bool {
+			if providers[i].Count != providers[j].Count {
+				return providers[i].Count > providers[j].Count
 			}
-			return users[i].Name < users[j].Name
+			return providers[i].Label < providers[j].Label
 		})
 
 		data := map[string]any{
@@ -234,7 +241,7 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 			Tab:              tab,
 			CSRFToken:        GetCSRFToken(r),
 			Connections:      enriched,
-			Users:            users,
+			Providers:        providers,
 			Links:            links,
 			LinkAccounts:     linkAccounts,
 			NetWorth:         netWorth,
@@ -246,6 +253,36 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 	}
 }
 
+// providerLabel maps a canonical provider slug to the display label shown
+// on the connections filter chips.
+func providerLabel(p string) string {
+	switch p {
+	case "plaid":
+		return "Plaid"
+	case "teller":
+		return "Teller"
+	case "csv":
+		return "CSV"
+	default:
+		return p
+	}
+}
+
+// providerIcon mirrors the per-card icon choice in connections.templ so the
+// chip and the card stay visually consistent.
+func providerIcon(p string) string {
+	switch p {
+	case "plaid":
+		return "building-2"
+	case "teller":
+		return "landmark"
+	case "csv":
+		return "file-spreadsheet"
+	default:
+		return "link"
+	}
+}
+
 // connectionsListInput collects the values the handler computes for the
 // list page. Building props through this struct keeps the conversion from
 // db rows + ad-hoc maps into typed templ props in one place.
@@ -253,7 +290,7 @@ type connectionsListInput struct {
 	Tab              string
 	CSRFToken        string
 	Connections      []ConnectionWithAccounts
-	Users            []db.User
+	Providers        []pages.ConnectionsProviderFilter
 	Links            []service.AccountLinkResponse
 	LinkAccounts     []AccountForLink
 	NetWorth         float64
@@ -274,17 +311,7 @@ func buildConnectionsProps(in connectionsListInput) pages.ConnectionsProps {
 		HasAnyBalance:    in.HasAnyBalance,
 	}
 
-	for _, u := range in.Users {
-		first := ""
-		if u.Name != "" {
-			first = u.Name[:1]
-		}
-		props.Users = append(props.Users, pages.ConnectionsUserFilter{
-			ID:    pgconv.FormatUUID(u.ID),
-			Name:  u.Name,
-			First: first,
-		})
-	}
+	props.Providers = in.Providers
 
 	for _, c := range in.Connections {
 		row := pages.ConnectionsRow{

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -83,6 +83,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/transactions", TransactionListHandler(a, sm, tr, svc))
 		r.Get("/transactions/search", TransactionSearchHandler(a, sm, tr, svc))
 		r.Get("/transactions/{id}", TransactionDetailHandler(a, sm, tr, svc))
+		r.Get("/accounts", AccountsListPageHandler(a, svc, sm, tr))
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 
 		// The review queue is tag-backed — "needs-review" transactions. The

--- a/internal/templates/components/filter_search_input.templ
+++ b/internal/templates/components/filter_search_input.templ
@@ -4,14 +4,25 @@ import "cmp"
 
 // FilterSearchInput is the canonical client-side filter input — a daisy
 // `input` with a small leading search icon and an `x-model` binding
-// for Alpine-driven row filtering. Currently used by `/categories` and
-// `/tags`; future inline-filter list pages should reach for this
-// before re-rolling the markup.
+// for Alpine-driven row filtering. Currently used by `/accounts`,
+// `/categories`, and `/tags`; future inline-filter list pages should
+// reach for this before re-rolling the markup.
 //
 // The component is markup-only. Caller owns the Alpine factory that the
 // XModel string targets — typically a `filter` string on the page's
 // root `x-data` object that each row reads via
 // `x-show="!filter || ($el.dataset.search || '').includes(filter.toLowerCase())"`.
+//
+// Spec hooks:
+//
+//   - `type="search"` is the HTML standard for a free-text filter input
+//     — it carries the right ARIA semantics ("searchbox" role), gets the
+//     browser-native clear affordance, and is what assistive tech expects.
+//   - Pressing Escape on a `type="search"` input is a long-standing
+//     convention in WebKit/Chromium: clear the value, then blur. The
+//     inline handler below mirrors that on the Alpine model so x-model
+//     stays in sync and the behavior is consistent across browsers
+//     (including Firefox, which doesn't ship the native Escape clear).
 //
 // Usage:
 //
@@ -33,10 +44,16 @@ templ FilterSearchInput(p FilterSearchInputProps) {
 			class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content opacity-50 pointer-events-none z-10"
 		></i>
 		<input
-			type="text"
+			type="search"
+			role="searchbox"
 			placeholder={ p.Placeholder }
 			x-model={ p.XModel }
+			@keydown.escape.prevent.stop="$el.value = ''; $el.dispatchEvent(new Event('input', { bubbles: true })); $el.blur()"
 			class="input w-full pl-9 h-10 text-sm"
+			autocomplete="off"
+			autocorrect="off"
+			autocapitalize="none"
+			spellcheck="false"
 		/>
 	</div>
 }

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -55,6 +55,9 @@ templ Nav(p NavProps) {
 		<a href="/transactions" class={ "bb-sidebar-link", navActive(p.CurrentPage, "transactions") }>
 			<i data-lucide="receipt"></i> Transactions
 		</a>
+		<a href="/accounts" class={ "bb-sidebar-link", navActive(p.CurrentPage, "accounts") }>
+			<i data-lucide="wallet"></i> Accounts
+		</a>
 		if p.IsAdmin {
 			<a href="/reports" class={ "bb-sidebar-link", navActive(p.CurrentPage, "reports") }>
 				<i data-lucide="file-text"></i>

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -1,0 +1,325 @@
+package pages
+
+import (
+	"fmt"
+	"strings"
+
+	"breadbox/internal/templates/components"
+)
+
+// AccountsList renders the flat /accounts admin page — a single sortable,
+// filterable table of every account the viewer is allowed to see. The
+// per-connection list view still lives on /connections; this page is the
+// account-centric counterpart so the user doesn't have to crack open each
+// connection to find a single account.
+//
+// Alpine factory `accountsList` (filter + sort) lives in
+// static/js/admin/components/accounts.js. Loaded synchronously (no defer)
+// per the convention in docs/design-system.md → "Alpine page components".
+templ AccountsList(p AccountsListProps) {
+	<script src="/static/js/admin/components/accounts.js"></script>
+	<div x-data x-init="$store.shortcuts.setScope('accounts')" x-destroy="$store.shortcuts.setScope('global')"></div>
+	<div x-data="accountsList">
+		@components.PageHeader(components.PageHeaderProps{
+			Title:                "Accounts",
+			Subtitle:             "Every account across all your connections, in one sortable view.",
+			SubtitleHideOnMobile: true,
+		})
+		<!-- Family-member filter strip (only when 2+ household members) -->
+		if len(p.Users) > 1 {
+			<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto overflow-y-hidden">
+				<button
+					@click="filterUser = 'all'"
+					:class="filterUser === 'all' ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'"
+					class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
+				>
+					<span class="w-5 h-5 rounded-full bg-base-300/60 flex items-center justify-center text-[0.6rem] font-semibold text-base-content/50 shrink-0">
+						<i data-lucide="users" class="w-3 h-3"></i>
+					</span>
+					All
+				</button>
+				for _, u := range p.Users {
+					@accountsListUserFilterBtn(u)
+				}
+			</div>
+		}
+		if p.HasAnyBalance {
+			<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterUser === 'all'">
+				<div class="grid grid-cols-3 divide-x divide-base-300">
+					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Net Worth</div>
+						<div class="truncate">
+							@components.Amount(components.AmountProps{
+								Value:  p.NetWorth,
+								Intent: components.AmountBalance,
+								Class:  "text-sm sm:text-2xl font-semibold tracking-tight",
+							})
+						</div>
+					</div>
+					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Assets</div>
+						<div class="truncate">
+							@components.Amount(components.AmountProps{
+								Value:  p.TotalAssets,
+								Intent: components.AmountBalance,
+								Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-success",
+							})
+						</div>
+					</div>
+					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Liabilities</div>
+						<div class="truncate">
+							@components.Amount(components.AmountProps{
+								Value:  p.TotalLiabilities,
+								Intent: components.AmountCost,
+								Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-error",
+							})
+						</div>
+					</div>
+				</div>
+			</div>
+		}
+		@components.FilterSearchInput(components.FilterSearchInputProps{
+			Placeholder: "Filter accounts...",
+			XModel:      "filter",
+		})
+		<div class="mt-4">
+			if len(p.Accounts) > 0 {
+				@accountsListTable(p)
+			} else {
+				@components.EmptyState(components.EmptyStateProps{
+					Icon:     "wallet",
+					Title:    "No accounts yet",
+					Body:     "Once you connect a bank, every account synced from it shows up here.",
+					CTAHref:  templ.SafeURL("/connections/new"),
+					CTAIcon:  "plus",
+					CTALabel: "Connect a Bank",
+				})
+			}
+		</div>
+	</div>
+	<script>
+		document.addEventListener('DOMContentLoaded', function() { lucide.createIcons(); });
+	</script>
+}
+
+templ accountsListUserFilterBtn(u AccountsListUserFilter) {
+	<button
+		@click={ fmt.Sprintf("filterUser = %q", u.ID) }
+		:class={ fmt.Sprintf("filterUser === %q ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'", u.ID) }
+		class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
+	>
+		<span class="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center text-[0.6rem] font-semibold text-primary shrink-0 uppercase">{ u.First }</span>
+		{ u.Name }
+	</button>
+}
+
+// accountsListTable wraps the data table in a bb-card. Header is clickable to
+// drive client-side sort via the accountsList Alpine factory.
+templ accountsListTable(p AccountsListProps) {
+	<div class="bb-card overflow-hidden">
+		<div class="overflow-x-auto">
+			<table class="table table-sm">
+				<thead class="text-xs text-base-content/60">
+					<tr>
+						@accountsListSortHeader("name", "Account", "min-w-[12rem]")
+						@accountsListSortHeader("institution", "Institution", "hidden md:table-cell")
+						@accountsListSortHeader("type", "Type", "hidden lg:table-cell")
+						@accountsListSortHeader("owner", "Owner", "hidden lg:table-cell")
+						@accountsListSortHeader("balance", "Balance", "text-right")
+						<th class="w-8"></th>
+					</tr>
+				</thead>
+				<tbody>
+					for _, a := range p.Accounts {
+						@accountsListRow(a, p.CSRFToken)
+					}
+				</tbody>
+			</table>
+		</div>
+	</div>
+}
+
+// accountsListSortHeader emits one clickable column header. The chevron icon
+// rotates based on the active sort direction.
+templ accountsListSortHeader(key, label, extraClass string) {
+	<th class={ "cursor-pointer select-none whitespace-nowrap", extraClass } @click={ fmt.Sprintf("setSort(%q)", key) }>
+		<span class="inline-flex items-center gap-1">
+			{ label }
+			<span x-show={ fmt.Sprintf("sortKey === %q", key) } x-cloak>
+				<i data-lucide="chevron-down" class="w-3 h-3" :class="sortDir === 'desc' ? '' : 'rotate-180'"></i>
+			</span>
+		</span>
+	</th>
+}
+
+templ accountsListRow(a AccountsListRow, csrfToken string) {
+	<tr
+		data-account-row
+		data-account-id={ a.ID }
+		data-name={ strings.ToLower(a.DisplayName) }
+		data-institution={ strings.ToLower(a.InstitutionName) }
+		data-type={ a.Type }
+		data-owner={ strings.ToLower(a.OwnerName) }
+		data-balance={ fmt.Sprintf("%f", a.BalanceFloat) }
+		data-has-balance={ accountsListBool(a.HasBalance) }
+		data-search={ accountsListSearchIndex(a) }
+		data-filter-user={ a.UserID }
+		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && matches($el)"
+		x-cloak
+		class="hover:bg-base-200/30 transition-colors"
+	>
+		<!-- Account name + icon -->
+		<td>
+			<a href={ templ.SafeURL("/accounts/" + a.ID) } class="flex items-center gap-3 no-underline">
+				<div class="w-8 h-8 rounded-md bg-base-200/60 flex items-center justify-center shrink-0">
+					@accountsListTypeIcon(a.Type)
+				</div>
+				<div class="min-w-0">
+					<div class="flex items-center gap-1.5 flex-wrap">
+						<span class="text-sm font-medium truncate text-base-content">{ a.DisplayName }</span>
+						if a.IsDependentLinked {
+							<span class="badge badge-soft badge-info badge-xs" title="Dependent-linked: balance attributed to a linked user">Linked</span>
+						}
+						if a.Excluded {
+							<span class="badge badge-soft badge-warning badge-xs" title="Excluded from totals and sync">Excluded</span>
+						}
+					</div>
+					<div class="text-xs text-base-content/40 md:hidden">
+						{ a.InstitutionName }
+						if a.MaskValid {
+							<span class="text-base-content/25">&middot;</span>
+							{ " ····" + a.Mask }
+						}
+					</div>
+				</div>
+			</a>
+		</td>
+		<!-- Institution (md+) -->
+		<td class="hidden md:table-cell text-sm text-base-content/70">
+			<div class="flex items-center gap-2 min-w-0">
+				<span class="truncate">{ a.InstitutionName }</span>
+				if a.MaskValid {
+					<span class="text-xs text-base-content/40">&middot; ····{ a.Mask }</span>
+				}
+				if a.ConnectionStatus == "error" || a.ConnectionStatus == "pending_reauth" {
+					<span class="badge badge-soft badge-warning badge-xs" title="Connection needs attention">Reauth</span>
+				} else if a.ConnectionStatus == "disconnected" {
+					<span class="badge badge-soft badge-error badge-xs">Disconnected</span>
+				}
+			</div>
+		</td>
+		<!-- Type (lg+) -->
+		<td class="hidden lg:table-cell text-sm text-base-content/70 capitalize">
+			{ accountsListTypeLabel(a.Type, a.Subtype, a.SubtypeValid) }
+		</td>
+		<!-- Owner (lg+) -->
+		<td class="hidden lg:table-cell text-sm text-base-content/70">
+			if a.OwnerName != "" {
+				<span class="inline-flex items-center gap-1.5">
+					<span class="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center text-[0.6rem] font-semibold text-primary shrink-0 uppercase">{ a.OwnerFirst }</span>
+					{ a.OwnerName }
+				</span>
+			} else {
+				<span class="text-base-content/30">—</span>
+			}
+		</td>
+		<!-- Balance -->
+		<td class="text-right">
+			if a.HasBalance {
+				if a.BalanceFloat < 0 {
+					@components.Amount(components.AmountProps{
+						Value:  a.BalanceFloat,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-medium text-error",
+					})
+				} else {
+					@components.Amount(components.AmountProps{
+						Value:  a.BalanceFloat,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-medium",
+					})
+				}
+			} else {
+				<span class="text-xs text-base-content/30">—</span>
+			}
+		</td>
+		<td class="text-right">
+			@components.OverflowMenu(components.OverflowMenuProps{
+				AriaLabel: fmt.Sprintf("Actions for %s", a.DisplayName),
+				Size:      "xs",
+				Items:     accountsListRowItems(a),
+			})
+		</td>
+	</tr>
+}
+
+templ accountsListTypeIcon(t string) {
+	switch t {
+		case "credit":
+			<i data-lucide="credit-card" class="w-4 h-4 text-base-content opacity-40"></i>
+		case "loan":
+			<i data-lucide="landmark" class="w-4 h-4 text-base-content opacity-40"></i>
+		case "investment":
+			<i data-lucide="trending-up" class="w-4 h-4 text-base-content opacity-40"></i>
+		default:
+			<i data-lucide="wallet" class="w-4 h-4 text-base-content opacity-40"></i>
+	}
+}
+
+// accountsListRowItems builds the overflow-menu items for one row.
+func accountsListRowItems(a AccountsListRow) []components.OverflowMenuItem {
+	items := []components.OverflowMenuItem{
+		{
+			Label:     "View details",
+			Icon:      "external-link",
+			Href:      templ.SafeURL("/accounts/" + a.ID),
+			AriaLabel: fmt.Sprintf("Open %s detail", a.DisplayName),
+		},
+	}
+	if a.Excluded {
+		items = append(items, components.OverflowMenuItem{
+			Label:     "Include in totals",
+			Icon:      "eye",
+			OnClick:   fmt.Sprintf("$dispatch('account-set-excluded', {id: %q, name: %q, excluded: false})", a.ID, a.DisplayName),
+			AriaLabel: fmt.Sprintf("Include %s in totals", a.DisplayName),
+		})
+	} else {
+		items = append(items, components.OverflowMenuItem{
+			Label:     "Exclude from totals",
+			Icon:      "eye-off",
+			OnClick:   fmt.Sprintf("$dispatch('account-set-excluded', {id: %q, name: %q, excluded: true})", a.ID, a.DisplayName),
+			AriaLabel: fmt.Sprintf("Exclude %s from totals", a.DisplayName),
+		})
+	}
+	return items
+}
+
+// accountsListTypeLabel composes the type column text. Falls back to the
+// primary type when subtype is empty.
+func accountsListTypeLabel(t, subtype string, subtypeValid bool) string {
+	if subtypeValid && subtype != "" {
+		return strings.ReplaceAll(subtype, "_", " ")
+	}
+	return t
+}
+
+// accountsListSearchIndex builds the lowercase haystack used by the filter
+// search input.
+func accountsListSearchIndex(a AccountsListRow) string {
+	parts := []string{a.DisplayName, a.InstitutionName, a.Type, a.OwnerName}
+	if a.SubtypeValid {
+		parts = append(parts, a.Subtype)
+	}
+	if a.MaskValid {
+		parts = append(parts, a.Mask)
+	}
+	return strings.ToLower(strings.Join(parts, " "))
+}
+
+func accountsListBool(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}

--- a/internal/templates/components/pages/accounts_list_types.go
+++ b/internal/templates/components/pages/accounts_list_types.go
@@ -1,0 +1,59 @@
+//go:build !headless && !lite
+
+package pages
+
+// AccountsListProps is the typed input for the /accounts admin page.
+type AccountsListProps struct {
+	CSRFToken string
+
+	// Net totals across all displayed accounts (computed per-viewer).
+	// HasAnyBalance is the gate the templ uses to render the summary row.
+	NetWorth         float64
+	TotalAssets      float64
+	TotalLiabilities float64
+	HasAnyBalance    bool
+
+	// Household-member filter strip. Only rendered when len > 1.
+	Users []AccountsListUserFilter
+
+	// One row per account.
+	Accounts []AccountsListRow
+}
+
+// AccountsListUserFilter mirrors ConnectionsUserFilter — one chip in the
+// "filter by household member" strip.
+type AccountsListUserFilter struct {
+	ID    string // formatted UUID — drives the x-show filter value
+	Name  string
+	First string // first letter for the avatar circle
+}
+
+// AccountsListRow is one table row. Fields are pre-formatted (display_name
+// applied, balance sign adjusted for liabilities, currency carried alongside).
+type AccountsListRow struct {
+	ID          string // formatted UUID
+	UserID      string // formatted UUID — used by the x-show filter
+	DisplayName string // display_name with fallback to name
+	Type        string // canonical account type ("depository", "credit", ...)
+	SubtypeValid bool
+	Subtype     string
+	MaskValid   bool
+	Mask        string
+	OwnerName   string // empty when no linked household member
+	OwnerFirst  string // first letter for the avatar dot
+	InstitutionName string
+
+	// Connection context — lets the row pill out reauth/disconnected state
+	// without fetching connection rows again.
+	ConnectionShortID string
+	ConnectionStatus  string // "active" | "error" | "pending_reauth" | "disconnected" | ""
+
+	IsDependentLinked bool
+	Excluded          bool
+
+	HasBalance   bool
+	BalanceFloat float64 // sign-adjusted (negative for liabilities)
+	IsoCurrencyCode string
+
+	IsLiability bool
+}

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -30,7 +30,7 @@ templ Connections(p ConnectionsProps) {
 	-->
 	<div x-data x-init="$store.shortcuts.setScope('connections')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div
-		x-data={ fmt.Sprintf("{ tab: %q, filterUser: 'all' }", p.Tab) }
+		x-data={ fmt.Sprintf("{ tab: %q, filterProvider: 'all' }", p.Tab) }
 		x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })"
 	>
 		@components.PageHeader(components.PageHeaderProps{
@@ -58,21 +58,21 @@ templ Connections(p ConnectionsProps) {
 				Account Links
 			</button>
 		</div>
-		<!-- Family Member Filter -->
-		if len(p.Users) > 1 {
+		<!-- Provider filter — only providers actually configured show up here -->
+		if len(p.Providers) > 1 {
 			<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto overflow-y-hidden" x-show="tab === 'connections'">
 				<button
-					@click="filterUser = 'all'"
-					:class="filterUser === 'all' ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'"
+					@click="filterProvider = 'all'"
+					:class="filterProvider === 'all' ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'"
 					class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
 				>
 					<span class="w-5 h-5 rounded-full bg-base-300/60 flex items-center justify-center text-[0.6rem] font-semibold text-base-content/50 shrink-0">
-						<i data-lucide="users" class="w-3 h-3"></i>
+						<i data-lucide="layers" class="w-3 h-3"></i>
 					</span>
 					All
 				</button>
-				for _, u := range p.Users {
-					@connectionsUserFilterBtn(u)
+				for _, prov := range p.Providers {
+					@connectionsProviderFilterBtn(prov)
 				}
 			</div>
 		}
@@ -81,7 +81,7 @@ templ Connections(p ConnectionsProps) {
 			if len(p.Connections) > 0 {
 				<!-- Financial Summary Bar -->
 				if p.HasAnyBalance {
-					<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterUser === 'all'">
+					<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterProvider === 'all'">
 						<div class="grid grid-cols-3 divide-x divide-base-300">
 							<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 								<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Net Worth</div>
@@ -172,14 +172,16 @@ templ Connections(p ConnectionsProps) {
 	<!-- /alpine x-data tabs -->
 }
 
-templ connectionsUserFilterBtn(u ConnectionsUserFilter) {
+templ connectionsProviderFilterBtn(prov ConnectionsProviderFilter) {
 	<button
-		@click={ fmt.Sprintf("filterUser = %q", u.ID) }
-		:class={ fmt.Sprintf("filterUser === %q ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'", u.ID) }
+		@click={ fmt.Sprintf("filterProvider = %q", prov.Slug) }
+		:class={ fmt.Sprintf("filterProvider === %q ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'", prov.Slug) }
 		class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
 	>
-		<span class="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center text-[0.6rem] font-semibold text-primary shrink-0 uppercase">{ u.First }</span>
-		{ u.Name }
+		<span class="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+			<i data-lucide={ prov.Icon } class="w-3 h-3"></i>
+		</span>
+		{ prov.Label }
 	</button>
 }
 
@@ -189,8 +191,8 @@ templ connectionsCard(c ConnectionsRow) {
 		data-connection-row
 		data-open-url={ "/connections/" + c.ID }
 		data-edit-url={ "/connections/" + c.ID }
-		data-filter-user={ c.UserID }
-		x-show={ fmt.Sprintf("filterUser === 'all' || filterUser === %q", c.UserID) }
+		data-filter-provider={ c.Provider }
+		x-show={ fmt.Sprintf("filterProvider === 'all' || filterProvider === %q", c.Provider) }
 	>
 		<!-- Connection Header — non-nested interactives (a11y: link + sibling button) -->
 		<div class="group px-4 py-3 sm:px-5 sm:py-4 flex items-center justify-between gap-2 sm:gap-4">

--- a/internal/templates/components/pages/connections_types.go
+++ b/internal/templates/components/pages/connections_types.go
@@ -14,8 +14,9 @@ type ConnectionsProps struct {
 	TotalLiabilities float64
 	HasAnyBalance    bool
 
-	// Family member filter buttons (only rendered when len(Users) > 1)
-	Users []ConnectionsUserFilter
+	// Provider filter strip (only rendered when len(Providers) > 1) —
+	// shows just the providers actually configured in this household.
+	Providers []ConnectionsProviderFilter
 
 	// Connection cards
 	Connections []ConnectionsRow
@@ -25,11 +26,14 @@ type ConnectionsProps struct {
 	LinkAccounts []ConnectionsLinkAccount
 }
 
-// ConnectionsUserFilter is one button in the family-member filter strip.
-type ConnectionsUserFilter struct {
-	ID    string // formatted UUID — used both as filter value and href
-	Name  string
-	First string // first letter for the avatar circle
+// ConnectionsProviderFilter is one chip in the provider filter strip.
+// Only providers actually present on the connections list get a chip — we
+// don't render chips for providers that aren't configured.
+type ConnectionsProviderFilter struct {
+	Slug  string // canonical provider name ("plaid" | "teller" | "csv") — filter value
+	Label string // human-readable name shown on the chip ("Plaid", "Teller", "CSV")
+	Icon  string // Lucide icon name (matches the per-card provider icon)
+	Count int    // # of connections under this provider — used only to sort chips by usage, not displayed
 }
 
 // ConnectionsRow is one bank-connection card on the page.

--- a/static/js/admin/components/accounts.js
+++ b/static/js/admin/components/accounts.js
@@ -1,0 +1,108 @@
+// Accounts list page Alpine component for /accounts.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// Owns the client-side filter (search input + family-member chip strip)
+// and sort state for the flat accounts table.
+(function () {
+  function restorePageState() {
+    if (window.bbProgress && window.bbProgress.finish) window.bbProgress.finish();
+    var main = document.querySelector('main');
+    if (main) {
+      main.style.opacity = '';
+      main.style.filter = '';
+      main.style.pointerEvents = '';
+    }
+  }
+
+  function toast(message, type) {
+    window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
+  }
+
+  document.addEventListener('alpine:init', function () {
+    Alpine.data('accountsList', function () {
+      return {
+        filter: '',
+        filterUser: 'all',
+        sortKey: 'balance',
+        sortDir: 'desc',
+
+        init: function () {
+          var self = this;
+          // Listen for excluded-toggle dispatches from the row overflow menu.
+          window.addEventListener('account-set-excluded', function (e) {
+            self.setExcluded(e.detail.id, e.detail.excluded);
+          });
+          // Initial sort on mount so SSR-ordered rows respect the default key.
+          this.applySort();
+        },
+
+        matches: function (el) {
+          if (!this.filter) return true;
+          return (el.dataset.search || '').includes(this.filter.toLowerCase());
+        },
+
+        setSort: function (key) {
+          if (this.sortKey === key) {
+            this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+          } else {
+            this.sortKey = key;
+            // Balance defaults to descending (largest first); text columns ascending.
+            this.sortDir = key === 'balance' ? 'desc' : 'asc';
+          }
+          this.applySort();
+        },
+
+        applySort: function () {
+          var tbody = document.querySelector('[data-account-row]');
+          if (!tbody) return;
+          tbody = tbody.parentElement;
+          if (!tbody) return;
+          var rows = Array.prototype.slice.call(tbody.querySelectorAll('[data-account-row]'));
+          var key = this.sortKey;
+          var dir = this.sortDir === 'asc' ? 1 : -1;
+          rows.sort(function (a, b) {
+            var av, bv;
+            if (key === 'balance') {
+              // Rows without a balance sink to the bottom regardless of direction.
+              var aHas = a.dataset.hasBalance === '1';
+              var bHas = b.dataset.hasBalance === '1';
+              if (aHas !== bHas) return aHas ? -1 : 1;
+              av = parseFloat(a.dataset.balance) || 0;
+              bv = parseFloat(b.dataset.balance) || 0;
+              return (av - bv) * dir;
+            }
+            av = (a.dataset[key] || '');
+            bv = (b.dataset[key] || '');
+            if (av < bv) return -1 * dir;
+            if (av > bv) return 1 * dir;
+            return 0;
+          });
+          for (var i = 0; i < rows.length; i++) tbody.appendChild(rows[i]);
+        },
+
+        setExcluded: function (accountId, excluded) {
+          fetch('/-/accounts/' + accountId + '/excluded', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ excluded: excluded })
+          })
+            .then(function (res) {
+              if (res.ok) {
+                toast(excluded ? 'Account excluded from totals.' : 'Account included in totals.', 'success');
+                window.location.reload();
+              } else {
+                restorePageState();
+                return res.json().then(function (data) {
+                  toast((data.error && data.error.message) || data.error || 'Failed to update account.');
+                });
+              }
+            })
+            .catch(function () {
+              restorePageState();
+              toast('Network error. Please try again.');
+            });
+        },
+      };
+    });
+  });
+})();

--- a/static/js/admin/components/connections.js
+++ b/static/js/admin/components/connections.js
@@ -19,7 +19,7 @@
 // per .claude/rules/ui.md → "Keyboard shortcuts".
 
 // Keyboard navigation for the connections list. Reads the DOM for visible
-// rows (respecting the family-member filter via data-filter-user + Alpine's
+// rows (respecting the provider filter via data-filter-provider + Alpine's
 // x-show display:none) instead of mirroring connection data into a store.
 // The base.html dispatcher already guards against input focus, overlays,
 // and touch devices, so these handlers just do the thing.


### PR DESCRIPTION
## Summary

- New `/accounts` admin page under the Overview sidebar section — a flat, sortable, filterable table of every account across every connection. Surfaces account name, institution + mask, type, owner, balance, with an overflow menu for the include/exclude-from-totals toggle.
- Connections list filter switched from household-member chips to provider chips (only providers actually configured render). Accounts still listed inline on each connection card per the original UX — connections page stays the place to manage *connection-level* concerns (provider, sync, reauth), `/accounts` handles the *account-centric* view.
- Upgraded the shared `FilterSearchInput` component to `type="search"` + `role="searchbox"` with an explicit Escape handler that clears the bound x-model value and blurs the input. Normalizes the WebKit/Chromium convention across browsers (Firefox doesn't ship the native type=search Escape clear). Picks up `/accounts`, `/categories`, `/tags`, and any future inline-filter list page.

## Files

- New: `internal/admin/accounts.go`, `internal/templates/components/pages/accounts_list.templ` (+ `_types.go`), `static/js/admin/components/accounts.js`
- Changed: `internal/admin/connections.go`, `internal/admin/router.go`, `internal/templates/components/nav.templ`, `internal/templates/components/pages/connections.templ` (+ `_types.go`), `internal/templates/components/filter_search_input.templ`, `static/js/admin/components/connections.js`

Reuses existing `/-/accounts/{id}/excluded` and `/-/accounts/{id}/display-name` admin endpoints — no new write routes. Member viewers see only their own linked-user's accounts (same scoping as the connections list).

## Test plan

- [ ] Visit `/accounts` as admin — verify table renders, sort by clicking column headers, owner avatars + balance signs correct
- [ ] Type in the filter input — rows narrow by name/institution/owner; press Escape — input clears and blurs (no native Esc-clear fallthrough)
- [ ] Overflow menu → exclude/include — confirm toast + reload behavior
- [ ] Visit `/connections` — provider filter strip shows only configured providers (Teller, Plaid, CSV); selecting one hides cards from other providers; "All" restores
- [ ] Mobile (390px) — `/accounts` collapses to Account/Balance columns with institution + mask stacked under the name
- [ ] Member-role login (non-editor) — sees only their household member's accounts; no family-member filter strip on `/accounts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
