### PR TITLE
fix(settings): submit forms inline so flash stays in modal + X closes cleanly

### DIFF
--- a/internal/admin/settings_shell.go
+++ b/internal/admin/settings_shell.go
@@ -57,7 +57,7 @@ func renderSettingsTab(
 	if r.Header.Get(settingsFragmentHeader) == "1" {
 		if f, ok := data["Flash"].(*Flash); ok && f != nil && f.Message != "" {
 			w.Header().Set(settingsFlashTypeHeader, f.Type)
-			w.Header().Set(settingsFlashMessageHeader, url.QueryEscape(f.Message))
+			w.Header().Set(settingsFlashMessageHeader, url.QueryEscape(truncateFlash(f.Message)))
 		}
 		tr.RenderTemplFragment(w, r, body)
 		return
@@ -73,4 +73,18 @@ func renderSettingsTab(
 	data["SettingsInitialTab"] = tab
 	data["SettingsInitialBody"] = template.HTML(buf.String())
 	tr.RenderWithTempl(w, r, data, pages.SettingsHost())
+}
+
+// truncateFlash bounds flash messages we ship via response headers.
+// Provider error paths (Plaid, Teller) can wrap upstream HTTP bodies
+// with arbitrary length — keeping the header line under ~1KB plays
+// nicely with the default `proxy_buffer_size` in nginx/caddy and
+// avoids leaking pages of provider detail into proxy access logs.
+const settingsFlashMaxLen = 512
+
+func truncateFlash(s string) string {
+	if len(s) <= settingsFlashMaxLen {
+		return s
+	}
+	return s[:settingsFlashMaxLen-1] + "…"
 }

--- a/internal/admin/settings_shell.go
+++ b/internal/admin/settings_shell.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"html/template"
 	"net/http"
+	"net/url"
 
 	"breadbox/internal/templates/components/pages"
 
@@ -13,9 +14,20 @@ import (
 )
 
 // settingsFragmentHeader marks a request as a Settings modal swap — the
-// modal's Alpine factory sends it on every fetch. Handlers branch on it
-// to return just the tab body instead of the full host page.
+// modal's Alpine factory sends it on every fetch (GET tab loads and
+// POST form submits). Handlers branch on it to return just the tab body
+// instead of the full host page; the modal then follows any 303 with
+// the same header so the redirect target also lands as a fragment.
 const settingsFragmentHeader = "X-Settings-Fragment"
+
+// Response headers carrying a one-shot flash inside a fragment response.
+// The modal reads these and renders the message as an in-dialog toast,
+// instead of relying on the layout-level flash partial (which renders
+// inside <main>, behind the open modal).
+const (
+	settingsFlashTypeHeader    = "X-BB-Flash-Type"
+	settingsFlashMessageHeader = "X-BB-Flash-Message"
+)
 
 // renderSettingsTab wraps the given tab body in a settings-host page and
 // renders it inside base.html with the global SettingsModal pre-opened on
@@ -43,6 +55,10 @@ func renderSettingsTab(
 	body templ.Component,
 ) {
 	if r.Header.Get(settingsFragmentHeader) == "1" {
+		if f, ok := data["Flash"].(*Flash); ok && f != nil && f.Message != "" {
+			w.Header().Set(settingsFlashTypeHeader, f.Type)
+			w.Header().Set(settingsFlashMessageHeader, url.QueryEscape(f.Message))
+		}
 		tr.RenderTemplFragment(w, r, body)
 		return
 	}

--- a/internal/templates/components/flash.templ
+++ b/internal/templates/components/flash.templ
@@ -5,7 +5,12 @@ package components
 // the human-readable message. The caller is responsible for the nil check
 // (the html/template facade short-circuits when .Flash is nil).
 templ Flash(flashType, message string) {
-	<div role="alert" class={ "alert", flashClass(flashType), "rounded-xl", "mb-6" }>
+	<div
+		role="alert"
+		class={ "alert", flashClass(flashType), "rounded-xl", "mb-6" }
+		data-bb-flash={ flashType }
+		data-bb-flash-message={ message }
+	>
 		<span>{ message }</span>
 	</div>
 }

--- a/internal/templates/components/pages/backups.templ
+++ b/internal/templates/components/pages/backups.templ
@@ -223,15 +223,15 @@ templ backupsRow(b BackupRow, csrf string) {
 				<form
 					method="POST"
 					action={ templ.SafeURL(b.RestoreAction) }
-					x-data
-					@submit.prevent="$dispatch('bb-confirm', {
+					x-data="{ confirmed: false }"
+					@submit="if (!confirmed) { $event.preventDefault(); $dispatch('bb-confirm', {
                         title: 'Restore this backup?',
                         message: 'This will replace all current data with the contents of this backup. This action cannot be undone.',
                         variant: 'danger',
                         confirmLabel: 'Restore',
                         cancelLabel: 'Cancel',
-                        onConfirm: () => $el.submit()
-                      })"
+                        onConfirm: () => { confirmed = true; $el.requestSubmit(); }
+                      }) }"
 				>
 					<input type="hidden" name="_csrf" value={ csrf }/>
 					<button type="submit" class="btn btn-ghost btn-xs text-warning" title="Restore">
@@ -241,15 +241,15 @@ templ backupsRow(b BackupRow, csrf string) {
 				<form
 					method="POST"
 					action={ templ.SafeURL(b.DeleteAction) }
-					x-data
-					@submit.prevent="$dispatch('bb-confirm', {
+					x-data="{ confirmed: false }"
+					@submit="if (!confirmed) { $event.preventDefault(); $dispatch('bb-confirm', {
                         title: 'Delete this backup?',
                         message: 'The backup file will be permanently removed from disk.',
                         variant: 'danger',
                         confirmLabel: 'Delete',
                         cancelLabel: 'Cancel',
-                        onConfirm: () => $el.submit()
-                      })"
+                        onConfirm: () => { confirmed = true; $el.requestSubmit(); }
+                      }) }"
 				>
 					<input type="hidden" name="_csrf" value={ csrf }/>
 					<button type="submit" class="btn btn-ghost btn-xs text-error" title="Delete">
@@ -296,15 +296,15 @@ templ backupsRestoreSection(p BackupsProps) {
 					method="POST"
 					action="/-/backups/restore"
 					enctype="multipart/form-data"
-					x-data="{ filename: '' }"
-					@submit.prevent="$dispatch('bb-confirm', {
+					x-data="{ filename: '', confirmed: false }"
+					@submit="if (!confirmed) { $event.preventDefault(); $dispatch('bb-confirm', {
                 title: 'Restore database from upload?',
                 message: 'This will replace ALL current data with the contents of the uploaded file. This action cannot be undone.',
                 variant: 'danger',
                 confirmLabel: 'Restore',
                 cancelLabel: 'Cancel',
-                onConfirm: () => $el.submit()
-              })"
+                onConfirm: () => { confirmed = true; $el.requestSubmit(); }
+              }) }"
 				>
 					<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 					<input type="hidden" name="restore_source" value="upload"/>

--- a/internal/templates/components/settings_modal.templ
+++ b/internal/templates/components/settings_modal.templ
@@ -47,6 +47,19 @@ templ SettingsModal(p SettingsModalProps) {
 			</div>
 		</div>
 		<!--
+			In-dialog toast slot. Lives inside the <dialog> so it joins the
+			browser's top-layer stacking context and renders above the modal
+			(toasts placed in the document body are obscured by the dialog's
+			backdrop). settings_modal.js injects alert children here in
+			response to X-BB-Flash-* headers from fragment POSTs.
+		-->
+		<div
+			class="toast toast-center toast-bottom z-[60] pointer-events-none"
+			x-ref="toast"
+			aria-live="polite"
+			aria-atomic="true"
+		></div>
+		<!--
 			daisy modal-backdrop: a button-form so a backdrop click submits
 			the form (cancel), which fires the dialog's `close` event and
 			our @close listener handles the URL rewind.

--- a/static/js/admin/components/settings_modal.js
+++ b/static/js/admin/components/settings_modal.js
@@ -164,11 +164,20 @@ document.addEventListener('alpine:init', function () {
         else history.pushState({ bbSettings: tab }, '', url);
       },
 
+      // _pushPath is the multi-segment variant — used by the form-submit
+      // interceptor when the server redirects to a subpath like
+      // /settings/api-keys/{id}/created.
+      _pushPath: function (path, tab) {
+        history.pushState({ bbSettings: tab }, '', path);
+      },
+
       _onPopState: function () {
         // Read the new URL and decide whether the modal should be open.
-        var match = window.location.pathname.match(/^\/settings(?:\/([\w-]+))?\/?$/);
-        if (match) {
-          var tab = match[1] || 'account';
+        // Accept multi-segment paths (e.g. /settings/api-keys/{id}/created)
+        // so back/forward through a creation flow stays in the modal.
+        var dest = parseSettingsRedirect(window.location.href);
+        if (dest.settings) {
+          var tab = dest.tab || 'account';
           var self = this;
           if (this.currentTab !== tab) {
             this._loadTab(tab).then(function () {
@@ -187,6 +196,20 @@ document.addEventListener('alpine:init', function () {
         var self = this;
         var bodyEl = this.$refs.body || document.getElementById('bb-settings-body');
         if (!bodyEl) return Promise.reject(new Error('no settings body slot'));
+        // Defer tab GETs while a submit is in flight: the server's
+        // session flash is one-shot, and an interleaved GET would
+        // consume it before the submit's redirect GET arrives, eating
+        // the toast that belongs to the save.
+        if (self._submitInFlight) {
+          return new Promise(function (resolve) {
+            var poll = setInterval(function () {
+              if (!self._submitInFlight) {
+                clearInterval(poll);
+                resolve(self._loadTab(tab));
+              }
+            }, 50);
+          });
+        }
         // Render a lightweight loading state — daisy skeleton blocks
         // matching the section card shape.
         bodyEl.innerHTML = SKELETON_HTML;
@@ -227,6 +250,14 @@ document.addEventListener('alpine:init', function () {
         // belong to whatever page they sit on.
         var method = (form.method || 'GET').toUpperCase();
         if (method !== 'POST') return;
+        // Bail if the form's own listener already prevented the
+        // submit — Alpine's `@submit.prevent` (bb-confirm dialogs on
+        // Backups, etc.) cancels the real submit and dispatches a
+        // confirmation step that re-invokes `requestSubmit()` on the
+        // user's OK. Our listener bubbles after Alpine's; firing
+        // _submitForm here would post the form even though Alpine
+        // wanted to wait for the confirm.
+        if (e.defaultPrevented) return;
 
         e.preventDefault();
         this._submitForm(form);
@@ -246,6 +277,13 @@ document.addEventListener('alpine:init', function () {
         var reenable = function () {
           buttons.forEach(function (b) { b.disabled = false; });
         };
+
+        // Block parallel tab GETs while this submit is in flight. The
+        // server's session flash is one-shot: an interleaved
+        // `_loadTab` would consume the flash that belongs to this
+        // POST's redirect target, so the user wouldn't see the toast.
+        self._submitInFlight = true;
+        var clearInFlight = function () { self._submitInFlight = false; };
 
         return fetch(action, {
           method: 'POST',
@@ -272,6 +310,12 @@ document.addEventListener('alpine:init', function () {
           // user was on, since that's also what the server rendered
           // into the fragment.
           var targetTab = dest.tab || self.currentTab;
+          // Same-tab refresh: skip the inline-script re-eval (so the
+          // agents-tab hash-scroll IIFE doesn't snap the viewport on
+          // every save) and preserve the modal's scroll position (so
+          // the user stays next to the form they just submitted).
+          var sameTab = targetTab === self.currentTab;
+          var swapOpts = { skipInlineScripts: sameTab, preserveScroll: sameTab };
           if (!res.ok) {
             // Server returned an error fragment (validation failure,
             // 500, etc.). Surface it inside the modal — body still
@@ -281,16 +325,20 @@ document.addEventListener('alpine:init', function () {
               self._showToast('error', 'Save failed (HTTP ' + res.status + ').');
             }
             return res.text().then(function (html) {
-              return self._swapBody(html, targetTab);
+              return self._swapBody(html, targetTab, swapOpts);
             });
           }
           return res.text().then(function (html) {
-            return self._swapBody(html, targetTab).then(function () {
-              // Keep the URL bar in sync only when the server explicitly
-              // named a different tab. Bare /settings redirects leave
-              // the URL alone — the visible tab didn't change.
-              if (dest.tab && window.location.pathname !== '/settings/' + dest.tab) {
-                self._pushUrl(dest.tab, false);
+            return self._swapBody(html, targetTab, swapOpts).then(function () {
+              // Keep the URL bar in sync with the server's redirect
+              // target. We push the FULL pathname (not just
+              // /settings/<tab>) so multi-segment routes like
+              // /settings/api-keys/{id}/created survive in the address
+              // bar and back/forward navigates correctly. Bare
+              // /settings redirects leave the URL alone — the visible
+              // tab didn't change.
+              if (dest.tab && window.location.pathname !== dest.path) {
+                self._pushPath(dest.path, dest.tab);
                 self._pushed += 1;
               }
             });
@@ -298,17 +346,27 @@ document.addEventListener('alpine:init', function () {
         }).catch(function (err) {
           reenable();
           self._showToast('error', 'Save failed: ' + (err && err.message ? err.message : 'network error'));
-        });
+        }).then(clearInFlight, clearInFlight);
       },
 
       // _swapBody replaces #bb-settings-body with a freshly-fetched
       // fragment, preserving the same alpine:init re-dispatch dance
       // _loadTab used to use inline. Extracted so the form-submit path
       // gets identical script-load semantics.
-      _swapBody: function (html, tab) {
+      //
+      // opts.skipInlineScripts skips re-running inline <script> blocks
+      //   from the fragment — used on same-tab post-submit refresh so
+      //   hash-scroll IIFEs don't snap the viewport on every save.
+      // opts.preserveScroll keeps the modal's scroll position intact
+      //   across the swap — also used on same-tab refresh so the user
+      //   stays next to the form they just submitted, instead of
+      //   getting yanked back to the top of the tab.
+      _swapBody: function (html, tab, opts) {
         var self = this;
         var bodyEl = this.$refs.body || document.getElementById('bb-settings-body');
         if (!bodyEl) return Promise.reject(new Error('no settings body slot'));
+        var skipInline = !!(opts && opts.skipInlineScripts);
+        var preserveScroll = !!(opts && opts.preserveScroll);
 
         // Parse the fragment OFF-DOM so Alpine's mutation observer
         // doesn't try to instantiate x-data="avatarEditor" before the
@@ -326,22 +384,27 @@ document.addEventListener('alpine:init', function () {
         // Strip both inline and external scripts from the fragment —
         // we'll handle execution ourselves. Inline scripts inside tab
         // bodies are tiny (a few lines of immediate-effect code like
-        // hash-scroll); we re-execute them after the body is mounted.
+        // hash-scroll); we re-execute them after the body is mounted
+        // unless the caller opted out (same-tab refresh).
         var inlineSources = [];
         frag.querySelectorAll('script').forEach(function (s) {
           if (!s.hasAttribute('src')) inlineSources.push(s.textContent);
           s.parentNode.removeChild(s);
         });
 
+        var scrollWrap = bodyEl.closest('.overflow-y-auto');
+        var savedScroll = preserveScroll && scrollWrap ? scrollWrap.scrollTop : 0;
+
         return self._loadScripts(srcs).then(function () {
           bodyEl.replaceChildren(frag);
           self.currentTab = tab;
-          inlineSources.forEach(function (src) {
-            try { (0, eval)(src); } catch (e) { console.warn('settings tab inline script error:', e); }
-          });
+          if (!skipInline) {
+            inlineSources.forEach(function (src) {
+              try { (0, eval)(src); } catch (e) { console.warn('settings tab inline script error:', e); }
+            });
+          }
           self._refreshIcons();
-          var scrollWrap = bodyEl.closest('.overflow-y-auto');
-          if (scrollWrap) scrollWrap.scrollTop = 0;
+          if (scrollWrap) scrollWrap.scrollTop = preserveScroll ? savedScroll : 0;
         });
       },
 
@@ -475,20 +538,37 @@ var BB_LOADED_SCRIPTS = {};
 // an in-modal body swap and a hard navigation.
 //
 // Returns an object:
-//   { settings: true,  tab: 'sync' }   — URL is /settings/<tab>
-//   { settings: true,  tab: null    }  — URL is bare /settings (ambiguous;
-//                                        keep the current tab + URL)
-//   { settings: false }                — URL is outside the shell; the
-//                                        caller should hard-navigate.
+//   { settings: true,  tab: 'api-keys', path: '/settings/api-keys/abc/created',
+//     hash: '' }                              — inside the shell, the first
+//                                              segment maps to a rail tab.
+//   { settings: true,  tab: null,       path: '/settings', hash: '' }
+//                                            — bare /settings (ambiguous;
+//                                              caller keeps the current tab).
+//   { settings: false }                      — outside the shell; caller
+//                                              hard-navigates.
+//
+// The api-keys tab also serves /settings/oauth-clients/* (a sibling URL
+// prefix that renders the same Access page), so we map it to the same
+// rail tab. Unknown first segments fall through to {settings:false} so
+// a future /settings/<new-prefix> URL we forgot to wire here doesn't
+// silently take over an existing tab.
+var SETTINGS_SUBPATH_TAB = {
+  'oauth-clients': 'api-keys',
+};
+
 function parseSettingsRedirect(rawUrl) {
   try {
     var u = new URL(rawUrl, window.location.href);
     if (u.origin !== window.location.origin) return { settings: false };
-    var m = u.pathname.match(/^\/settings(?:\/([\w-]+))?\/?$/);
+    var m = u.pathname.match(/^\/settings(?:\/([\w-]+)(?:\/.*)?)?\/?$/);
     if (!m) return { settings: false };
-    var tab = m[1] || null;
-    if (tab && !TAB_META[tab]) return { settings: false };
-    return { settings: true, tab: tab };
+    var first = m[1] || null;
+    if (!first) {
+      return { settings: true, tab: null, path: u.pathname, hash: u.hash || '' };
+    }
+    var tab = TAB_META[first] ? first : (SETTINGS_SUBPATH_TAB[first] || null);
+    if (!tab) return { settings: false };
+    return { settings: true, tab: tab, path: u.pathname, hash: u.hash || '' };
   } catch (_) {
     return { settings: false };
   }

--- a/static/js/admin/components/settings_modal.js
+++ b/static/js/admin/components/settings_modal.js
@@ -48,6 +48,7 @@ document.addEventListener('alpine:init', function () {
             this.$nextTick(function () {
               self._showModal();
               self._refreshIcons();
+              self._consumePageFlashIntoToast();
             });
           } else {
             // No pre-rendered body — fetch it and then open.
@@ -67,6 +68,16 @@ document.addEventListener('alpine:init', function () {
         // When the user goes forward to a /settings/* URL, re-open.
         window.addEventListener('popstate', function () {
           self._onPopState();
+        });
+
+        // Intercept POST submits originating from tabs in this dialog so
+        // settings forms don't trigger a full page navigation (which
+        // would (a) render the flash banner outside the modal, (b) reset
+        // our history-rewind counter, breaking the X button). Fragment
+        // POSTs round-trip through the same `X-Settings-Fragment`
+        // protocol used for tab loads.
+        this.$el.addEventListener('submit', function (e) {
+          self._onSubmit(e);
         });
       },
 
@@ -110,20 +121,17 @@ document.addEventListener('alpine:init', function () {
         }
         // Rewind the URL pushes this instance made, so we land back on
         // the page the user was actually on. If we never pushed (cold
-        // deep-load with no prior history we own), navigate home so the
-        // user isn't stranded on a blank /settings/* URL.
+        // deep-load with no prior history we own), go home — the user
+        // explicitly tapped Close on a /settings/* URL, so dumping them
+        // on whatever happened to be one slot back in browser history
+        // (often another /settings/* page that would just re-open the
+        // modal) is confusing.
         if (this._pushed > 0) {
           var steps = this._pushed;
           this._pushed = 0;
           history.go(-steps);
         } else {
-          // Cold deep-load — if the browser has any prior history, use
-          // it; otherwise drop to /.
-          if (window.history.length > 1) {
-            history.back();
-          } else {
-            window.location.replace('/');
-          }
+          window.location.replace('/');
         }
       },
 
@@ -190,51 +198,215 @@ document.addEventListener('alpine:init', function () {
           headers: { 'X-Settings-Fragment': '1', 'Accept': 'text/html' },
         }).then(function (res) {
           if (!res.ok) throw new Error('HTTP ' + res.status);
+          // Tab GETs don't currently set X-BB-Flash-*, but it costs
+          // nothing to forward in case a future handler does.
+          self._showFlashFromHeaders(res.headers);
           return res.text();
         }).then(function (html) {
-          // Parse the fragment OFF-DOM so Alpine's mutation observer
-          // doesn't try to instantiate x-data="avatarEditor" before the
-          // tab's factory script has loaded. We pull the <script src=…>
-          // tags out, load them via <head>, and only THEN drop the
-          // (script-free) HTML into the live body where Alpine wires it
-          // up against the now-registered factories.
-          var template = document.createElement('template');
-          template.innerHTML = html;
-          var frag = template.content;
-          var srcs = [];
-          frag.querySelectorAll('script[src]').forEach(function (s) {
-            srcs.push(s.getAttribute('src'));
-          });
-          // Strip both inline and external scripts from the fragment —
-          // we'll handle execution ourselves. Inline scripts inside tab
-          // bodies are tiny (a few lines of immediate-effect code like
-          // hash-scroll); we re-execute them after the body is mounted.
-          var inlineSources = [];
-          frag.querySelectorAll('script').forEach(function (s) {
-            if (!s.hasAttribute('src')) inlineSources.push(s.textContent);
-            s.parentNode.removeChild(s);
-          });
-
-          return self._loadScripts(srcs).then(function () {
-            // Factories are registered. Safe to attach the body — when
-            // Alpine sees x-data attributes here, it will resolve them
-            // against the registered factories on the first walk.
-            bodyEl.replaceChildren(frag);
-            self.currentTab = tab;
-            // Re-run inline scripts (e.g. hash auto-scroll in
-            // agents_settings). They expect to run after the DOM exists.
-            inlineSources.forEach(function (src) {
-              try { (0, eval)(src); } catch (e) { console.warn('settings tab inline script error:', e); }
-            });
-            self._refreshIcons();
-            var scrollWrap = bodyEl.closest('.overflow-y-auto');
-            if (scrollWrap) scrollWrap.scrollTop = 0;
-          });
+          return self._swapBody(html, tab);
         }).catch(function (err) {
           bodyEl.innerHTML = '<div class="alert alert-error rounded-xl text-sm">' +
             'Could not load settings: ' + (err && err.message ? err.message : 'unknown error') +
             '</div>';
         });
+      },
+
+      // _onSubmit handles every form submit dispatched inside the
+      // dialog. Forms living in #bb-settings-body get hijacked into a
+      // fragment-POST so the modal stays open and feedback renders as
+      // an in-dialog toast instead of as a page-level banner. Forms
+      // outside the body slot (the close button's <form method="dialog">
+      // and the modal-backdrop button) are left to the browser.
+      _onSubmit: function (e) {
+        var form = e.target;
+        if (!form || form.tagName !== 'FORM') return;
+        if (form.method && form.method.toLowerCase() === 'dialog') return;
+        var bodyEl = this.$refs.body || document.getElementById('bb-settings-body');
+        if (!bodyEl || !bodyEl.contains(form)) return;
+        // Only POSTs flow through here. GET forms (search filters etc.)
+        // belong to whatever page they sit on.
+        var method = (form.method || 'GET').toUpperCase();
+        if (method !== 'POST') return;
+
+        e.preventDefault();
+        this._submitForm(form);
+      },
+
+      _submitForm: function (form) {
+        var self = this;
+        var action = form.action || window.location.href;
+        var data = new FormData(form);
+        // Disable submit buttons so a frantic double-click doesn't
+        // double-post. We re-enable on completion (success or error) —
+        // on success the buttons usually get replaced by the body swap
+        // anyway, but on the keep-current-body error path they need to
+        // come back.
+        var buttons = Array.prototype.slice.call(form.querySelectorAll('button, input[type=submit]'));
+        buttons.forEach(function (b) { b.disabled = true; });
+        var reenable = function () {
+          buttons.forEach(function (b) { b.disabled = false; });
+        };
+
+        return fetch(action, {
+          method: 'POST',
+          body: data,
+          credentials: 'same-origin',
+          // `redirect: 'follow'` (default) so the server's 303-after-POST
+          // round-trips through the GET handler, which honors the
+          // fragment header and returns just the tab body.
+          headers: { 'X-Settings-Fragment': '1', 'Accept': 'text/html' },
+        }).then(function (res) {
+          var serverToldUs = !!res.headers.get('X-BB-Flash-Message');
+          self._showFlashFromHeaders(res.headers);
+          // If the redirect target sits outside the settings shell
+          // (password change → /login, etc.), fall back to a hard
+          // navigation so the user actually lands on that page.
+          var finalUrl = res.url || action;
+          var dest = parseSettingsRedirect(finalUrl);
+          if (!dest.settings) {
+            window.location.href = finalUrl;
+            return null;
+          }
+          // Bare /settings redirects (used by Sync + Retention) are
+          // ambiguous about the tab — fall back to whichever tab the
+          // user was on, since that's also what the server rendered
+          // into the fragment.
+          var targetTab = dest.tab || self.currentTab;
+          if (!res.ok) {
+            // Server returned an error fragment (validation failure,
+            // 500, etc.). Surface it inside the modal — body still
+            // contains the form so the user can retry.
+            reenable();
+            if (!serverToldUs) {
+              self._showToast('error', 'Save failed (HTTP ' + res.status + ').');
+            }
+            return res.text().then(function (html) {
+              return self._swapBody(html, targetTab);
+            });
+          }
+          return res.text().then(function (html) {
+            return self._swapBody(html, targetTab).then(function () {
+              // Keep the URL bar in sync only when the server explicitly
+              // named a different tab. Bare /settings redirects leave
+              // the URL alone — the visible tab didn't change.
+              if (dest.tab && window.location.pathname !== '/settings/' + dest.tab) {
+                self._pushUrl(dest.tab, false);
+                self._pushed += 1;
+              }
+            });
+          });
+        }).catch(function (err) {
+          reenable();
+          self._showToast('error', 'Save failed: ' + (err && err.message ? err.message : 'network error'));
+        });
+      },
+
+      // _swapBody replaces #bb-settings-body with a freshly-fetched
+      // fragment, preserving the same alpine:init re-dispatch dance
+      // _loadTab used to use inline. Extracted so the form-submit path
+      // gets identical script-load semantics.
+      _swapBody: function (html, tab) {
+        var self = this;
+        var bodyEl = this.$refs.body || document.getElementById('bb-settings-body');
+        if (!bodyEl) return Promise.reject(new Error('no settings body slot'));
+
+        // Parse the fragment OFF-DOM so Alpine's mutation observer
+        // doesn't try to instantiate x-data="avatarEditor" before the
+        // tab's factory script has loaded. We pull the <script src=…>
+        // tags out, load them via <head>, and only THEN drop the
+        // (script-free) HTML into the live body where Alpine wires it
+        // up against the now-registered factories.
+        var template = document.createElement('template');
+        template.innerHTML = html;
+        var frag = template.content;
+        var srcs = [];
+        frag.querySelectorAll('script[src]').forEach(function (s) {
+          srcs.push(s.getAttribute('src'));
+        });
+        // Strip both inline and external scripts from the fragment —
+        // we'll handle execution ourselves. Inline scripts inside tab
+        // bodies are tiny (a few lines of immediate-effect code like
+        // hash-scroll); we re-execute them after the body is mounted.
+        var inlineSources = [];
+        frag.querySelectorAll('script').forEach(function (s) {
+          if (!s.hasAttribute('src')) inlineSources.push(s.textContent);
+          s.parentNode.removeChild(s);
+        });
+
+        return self._loadScripts(srcs).then(function () {
+          bodyEl.replaceChildren(frag);
+          self.currentTab = tab;
+          inlineSources.forEach(function (src) {
+            try { (0, eval)(src); } catch (e) { console.warn('settings tab inline script error:', e); }
+          });
+          self._refreshIcons();
+          var scrollWrap = bodyEl.closest('.overflow-y-auto');
+          if (scrollWrap) scrollWrap.scrollTop = 0;
+        });
+      },
+
+      // _showFlashFromHeaders renders a toast for the response if the
+      // server set X-BB-Flash-*. Empty / missing headers no-op. The
+      // type defaults to "info" so an empty type still surfaces, but
+      // we explicitly tolerate the success/error/warning trio.
+      _showFlashFromHeaders: function (headers) {
+        var type = headers.get('X-BB-Flash-Type') || '';
+        var raw = headers.get('X-BB-Flash-Message') || '';
+        if (!raw) return;
+        // Go's url.QueryEscape (server side) encodes spaces as `+`,
+        // which decodeURIComponent ignores — swap them to %20 first so
+        // the round-trip survives.
+        var message;
+        try { message = decodeURIComponent(raw.replace(/\+/g, '%20')); } catch (_) { message = raw; }
+        this._showToast(type, message);
+      },
+
+      // _consumePageFlashIntoToast moves the layout's flash banner
+      // (rendered inside <main> by html/template on cold deep-loads)
+      // into the in-modal toast, then hides the banner. Without this,
+      // cold-loading /settings/sync right after a redirect-with-flash
+      // would show the flash behind the modal AND we'd lose it once
+      // the modal closes.
+      _consumePageFlashIntoToast: function () {
+        var banner = document.querySelector('main [data-bb-flash]');
+        if (!banner) return;
+        var type = banner.getAttribute('data-bb-flash') || '';
+        var message = (banner.getAttribute('data-bb-flash-message') || banner.textContent || '').trim();
+        if (!message) return;
+        this._showToast(type, message);
+        banner.remove();
+      },
+
+      // _showToast mounts an alert inside the dialog's toast slot. The
+      // success toast auto-dismisses; error/warning stay until the
+      // user dismisses them.
+      _showToast: function (type, message) {
+        var slot = this.$refs.toast;
+        if (!slot) return;
+        var tone = ({
+          success: 'alert-success',
+          error:   'alert-error',
+          warning: 'alert-warning',
+        })[type] || 'alert-info';
+        // Clear any previous toast — only one shown at a time keeps the
+        // dialog uncluttered.
+        slot.replaceChildren();
+        var node = document.createElement('div');
+        node.className = 'alert ' + tone + ' alert-soft rounded-xl shadow-lg pointer-events-auto max-w-md text-sm';
+        node.setAttribute('role', type === 'error' ? 'alert' : 'status');
+        node.textContent = message;
+        slot.appendChild(node);
+        if (type !== 'error' && type !== 'warning') {
+          var t = setTimeout(function () {
+            if (node.isConnected) node.remove();
+          }, 4000);
+          node.addEventListener('click', function () {
+            clearTimeout(t);
+            node.remove();
+          });
+        } else {
+          node.addEventListener('click', function () { node.remove(); });
+        }
       },
 
       // _loadScripts loads a list of external script URLs in parallel,
@@ -297,6 +469,30 @@ var TAB_META = {
 // we don't double-fetch them on repeated tab switches. Module-scoped
 // so it survives across Alpine.data factory invocations.
 var BB_LOADED_SCRIPTS = {};
+
+// parseSettingsRedirect classifies a fetch response URL relative to the
+// settings shell. Used by the form-submit interceptor to decide between
+// an in-modal body swap and a hard navigation.
+//
+// Returns an object:
+//   { settings: true,  tab: 'sync' }   — URL is /settings/<tab>
+//   { settings: true,  tab: null    }  — URL is bare /settings (ambiguous;
+//                                        keep the current tab + URL)
+//   { settings: false }                — URL is outside the shell; the
+//                                        caller should hard-navigate.
+function parseSettingsRedirect(rawUrl) {
+  try {
+    var u = new URL(rawUrl, window.location.href);
+    if (u.origin !== window.location.origin) return { settings: false };
+    var m = u.pathname.match(/^\/settings(?:\/([\w-]+))?\/?$/);
+    if (!m) return { settings: false };
+    var tab = m[1] || null;
+    if (tab && !TAB_META[tab]) return { settings: false };
+    return { settings: true, tab: tab };
+  } catch (_) {
+    return { settings: false };
+  }
+}
 
 // Skeleton placeholder while a tab fragment is in flight — daisy
 // `skeleton` blocks shaped roughly like the section-card pattern.


### PR DESCRIPTION
## Summary

- **The bug.** Tapping **Save Schedule** (or any other save button) inside the Settings modal made the flash banner appear *behind* the modal, and the modal's X then "went back" to whatever /settings/\* page you happened to be on previously instead of dismissing.
- **Root cause.** Every form inside the modal did a vanilla `POST` → `303 redirect` → full page reload. That (1) rendered the layout's flash banner inside `<main>`, behind the open dialog, and (2) reset Alpine state so the modal's `_pushed` counter became `0` — the X button's history-rewind fell through to `history.back()`, landing the user one URL back (which was the prior /settings/\* page, re-opening the modal).
- **Fix.** Strengthen the settings modal so it owns form submission inside its body. A delegated `submit` handler on the dialog intercepts POSTs to anything under `#bb-settings-body`, posts via fetch with the existing `X-Settings-Fragment: 1` header (the server's GET handler then honours the redirect target by returning just the fragment), swaps the body in place, and surfaces the flash as a daisy toast mounted **inside** the `<dialog>` so it inherits the top-layer z-index.
- **Server side.** `renderSettingsTab` now copies the session flash into `X-BB-Flash-Type` / `X-BB-Flash-Message` response headers when serving a fragment. The Flash partial also picks up `data-bb-flash` attributes so a cold deep-load that lands on /settings/\* with a pending flash can sweep it into the in-dialog toast.
- **Cold-load X close.** When the modal has no internal history to rewind (e.g. user typed /settings/sync into the address bar) we now `replace('/')` instead of `history.back()`. The user explicitly closed Settings — bouncing them to whatever happened to be in browser history is worse than going home.
- **Cross-shell redirects.** Forms whose POST handler redirects outside the settings shell (password change → /login, wipe-data → /login) detect that the response URL isn't /settings/\* and fall back to a hard navigation, so the user actually lands on the destination.

The architecture means every existing settings form — Sync, Retention, MCP config, Backups schedule, password change, providers, agent SDK — automatically benefits without touching their handlers.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (one unrelated flake in `agent` passed on retry)
- [x] Settings modal opened from the sidebar, Sync tab: change interval, **Save Schedule** — body refreshes in place, toast "Sync settings saved." appears inside the dialog, URL stays at `/settings/sync`, X returns to the page the user came from (`/transactions` in the test).
- [x] Cold deep-load to `/settings/sync`: modal opens, Save Schedule still works inline, X navigates to `/` instead of bouncing in history.
- [x] `_pushed` counter preserved across a save (gear push + tab push = 2, save doesn't perturb it, X rewinds 2 steps).

## Screenshot

Toast pinned inside the dialog after a successful save:

<img src="https://i.img402.dev/mrvdakibj9.jpg" width="800" alt="settings modal — toast inside dialog after save">

🤖 Generated with [Claude Code](https://claude.com/claude-code)