### PR TITLE
fix(nav): drop sparkle accent from Agents sidebar link

### DIFF
--- a/input.css
+++ b/input.css
@@ -540,20 +540,6 @@
     to { transform: rotate(360deg); }
   }
 
-  /* ── Sparkle accent for highlighted sidebar links (e.g. Agent Prompts) ── */
-  /* Trailing sparkle icon — overrides the generic icon rule above so it
-     gets its own size, accent colour, and a gentle pulse to draw the eye. */
-  .bb-sidebar-link .bb-sidebar-sparkle,
-  .bb-sidebar-link .bb-sidebar-sparkle svg {
-    @apply w-3.5 h-3.5 opacity-90;
-  }
-  .bb-sidebar-link:hover .bb-sidebar-sparkle,
-  .bb-sidebar-link:hover .bb-sidebar-sparkle svg,
-  .bb-sidebar-link--active .bb-sidebar-sparkle,
-  .bb-sidebar-link--active .bb-sidebar-sparkle svg {
-    @apply opacity-100;
-  }
-
   /* ── External-link arrow (Documentation / GitHub buttons) ── */
   /* Always visible on mobile (no hover affordance there), hidden by
      default and faded in on hover at lg+. Kept inside the

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -101,7 +101,6 @@ templ Nav(p NavProps) {
 			<a href="/agents" class={ "bb-sidebar-link", navActive(p.CurrentPage, "agents") }>
 				<i data-lucide="bot-message-square"></i>
 				<span>Agents</span>
-				<i data-lucide="sparkles" class="bb-sidebar-sparkle ml-auto !text-amber-400"></i>
 			</a>
 		}
 		@navExternalLink("https://docs.breadbox.sh", "book-open", "Documentation")


### PR DESCRIPTION
## Summary
- Removes the trailing `sparkles` Lucide icon from the **Agents** sidebar link, which collided with the prefetch spinner and produced a stacked/glitched render.
- Also drops the now-unused `.bb-sidebar-sparkle` CSS block in `input.css`.

<img src="https://i.img402.dev/9hdcijs3f1.jpg" width="800" alt="Sidebar — Agents link without sparkle">

## Test plan
- [x] `templ generate` + `go build ./...` clean
- [x] Verified visually on `localhost:8085` — Agents link renders bot icon + label, no sparkle
- [x] `getComputedStyle` / DOM inspection confirms no `bb-sidebar-sparkle` node remains
