### PR TITLE
feat(ui): skeleton loader for accounts list

### DIFF
--- a/internal/templates/components/accounts_list_skeleton.templ
+++ b/internal/templates/components/accounts_list_skeleton.templ
@@ -1,0 +1,95 @@
+package components
+
+// AccountsListSkeleton renders a placeholder mirroring the layout of the
+// /accounts page — the three-stat summary card (Net Worth / Assets /
+// Liabilities) plus the sortable account table. Sized to match the
+// real component so a swap-in (current or future) doesn't shift layout.
+//
+// /accounts is a full-SSR page today; this primitive is exposed in
+// /design#loading so it's ready for the eventual AJAX/paginated swap
+// and discoverable to anyone wiring loading states for adjacent
+// account-centric panels.
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
+// hand-rolled `bb-skeleton*` family is being retired).
+templ AccountsListSkeleton() {
+	<div aria-hidden="true">
+		<!-- Summary card: Net Worth / Assets / Liabilities -->
+		<div class="bb-card p-0 overflow-hidden mb-6">
+			<div class="grid grid-cols-3 divide-x divide-base-300">
+				for i := 0; i < 3; i++ {
+					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0 space-y-2">
+						<div class="skeleton h-2.5 w-16"></div>
+						<div class="skeleton h-6 sm:h-7 w-24"></div>
+					</div>
+				}
+			</div>
+		</div>
+		<!-- Filter search input -->
+		<div class="skeleton h-10 w-full sm:max-w-sm rounded-xl mb-4"></div>
+		<!-- Accounts table -->
+		<div class="bb-card overflow-hidden">
+			<div class="overflow-x-auto">
+				<table class="table table-sm">
+					<thead class="text-xs text-base-content/60">
+						<tr>
+							<th class="min-w-[12rem]"><div class="skeleton h-3 w-16"></div></th>
+							<th class="hidden md:table-cell"><div class="skeleton h-3 w-20"></div></th>
+							<th class="hidden lg:table-cell"><div class="skeleton h-3 w-12"></div></th>
+							<th class="hidden lg:table-cell"><div class="skeleton h-3 w-14"></div></th>
+							<th class="text-right"><div class="skeleton h-3 w-16 ml-auto"></div></th>
+							<th class="w-8"></th>
+						</tr>
+					</thead>
+					<tbody>
+						for i := 0; i < 6; i++ {
+							@accountsListSkeletonRow()
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+}
+
+// accountsListSkeletonRow mirrors one accountsListRow: icon tile + name/meta
+// stack, optional desktop-only institution/type/owner cells, right-aligned
+// balance, overflow-menu slot. Widths line up with real-row content so the
+// swap-in doesn't shift the page.
+templ accountsListSkeletonRow() {
+	<tr>
+		<!-- Account name + icon -->
+		<td>
+			<div class="flex items-center gap-3">
+				<div class="skeleton w-8 h-8 rounded-md shrink-0"></div>
+				<div class="min-w-0 space-y-1.5">
+					<div class="skeleton h-3 w-32"></div>
+					<div class="skeleton h-2.5 w-20 md:hidden"></div>
+				</div>
+			</div>
+		</td>
+		<!-- Institution (md+) -->
+		<td class="hidden md:table-cell">
+			<div class="skeleton h-3 w-28"></div>
+		</td>
+		<!-- Type (lg+) -->
+		<td class="hidden lg:table-cell">
+			<div class="skeleton h-3 w-16"></div>
+		</td>
+		<!-- Owner (lg+) -->
+		<td class="hidden lg:table-cell">
+			<div class="flex items-center gap-1.5">
+				<div class="skeleton w-5 h-5 rounded-full shrink-0"></div>
+				<div class="skeleton h-3 w-14"></div>
+			</div>
+		</td>
+		<!-- Balance -->
+		<td class="text-right">
+			<div class="skeleton h-3.5 w-20 ml-auto"></div>
+		</td>
+		<!-- Overflow menu slot -->
+		<td class="text-right">
+			<div class="skeleton h-6 w-6 ml-auto"></div>
+		</td>
+	</tr>
+}

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -97,6 +97,12 @@ templ AccountsList(p AccountsListProps) {
 				})
 			}
 		</div>
+		<!-- Loading skeleton for the accounts list, available for any future
+		     client-side refresh / pagination swap. Mirrors the SSR layout
+		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		<template id="bb-accounts-list-skeleton-template">
+			@components.AccountsListSkeleton()
+		</template>
 	</div>
 	<script>
 		document.addEventListener('DOMContentLoaded', function() { lucide.createIcons(); });

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -784,6 +784,11 @@ templ SectionLoading() {
 				@components.TxResultsSkeleton()
 			</div>
 		}
+		@designExample("Accounts list skeleton", "Placeholder mirroring /accounts — summary stats (Net Worth / Assets / Liabilities), filter input, and the sortable table. Primitive is exposed here for future AJAX swaps and adjacent account panels; /accounts is full-SSR today.") {
+			<div class="max-w-4xl">
+				@components.AccountsListSkeleton()
+			</div>
+		}
 		@designExample("Progress", "Indeterminate + determinate.") {
 			<div class="space-y-3 max-w-md">
 				<progress class="progress progress-primary w-full"></progress>


### PR DESCRIPTION
## Summary

- Adds `AccountsListSkeleton` — a daisy-`skeleton`-based placeholder mirroring the /accounts layout (Net Worth / Assets / Liabilities summary card, filter input, and the sortable table with icon tile + name, institution, type, owner avatar + name, balance, overflow-menu slot).
- Mirrors the SSR row layout exactly (responsive `hidden md:` / `hidden lg:` modifiers preserved) so any future swap-in lands without layout shift.
- Exposes the primitive at `/design#loading` so it's discoverable next to `TxResultsSkeleton` (PR #1511), following the same pattern.
- Embeds the skeleton as a `<template id=\"bb-accounts-list-skeleton-template\">` on the live `/accounts` page — inert today, available for client-side cloning when /accounts gains an AJAX refresh or pagination.

## Wiring strategy

**Option 3** — register the primitive and expose it in the design sandbox. `/accounts` is full-SSR with no AJAX swap (Alpine only sorts/filters in-place), so options 1 (handler restructure to AJAX-load the table) and 2 (HTMX `hx-trigger=\"load\"`) would be over-budget for a per-page iteration in a codebase that doesn't use HTMX. The `<template>` embed mirrors PR #1511's pattern: the skeleton ships alongside the page so a future client-side feature (refresh balances, pagination, filter-by-user AJAX) can clone it without another round-trip through the design system.

## Screenshot

<img src=\"https://i.img402.dev/8qqw280ymg.jpg\" width=\"800\" alt=\"/design#loading — Accounts list skeleton\">

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`templ generate\` + \`templ fmt\` clean
- [x] \`/design#loading\` renders the skeleton with summary card + filter input + 6-row table (screenshot above)
- [x] \`/accounts\` still renders normally; the embedded \`<template>\` is inert
- [ ] Reviewer: visual sanity-check on the design sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)