### PR TITLE
feat(ui): skeleton loader for connections

### DIFF
--- a/internal/templates/components/connections_skeleton.templ
+++ b/internal/templates/components/connections_skeleton.templ
@@ -1,0 +1,98 @@
+package components
+
+// ConnectionsSkeleton renders a placeholder mirroring the layout of the
+// /connections page — the three-stat summary card (Net Worth / Assets /
+// Liabilities) plus a stack of connection cards (each with provider icon,
+// institution name, status badge, meta row, sync button, balance, and
+// nested account rows). Sized to match the real component so a future
+// swap-in doesn't shift layout.
+//
+// /connections is a full-SSR page today; this primitive is exposed in
+// /design#loading so it's ready for the eventual AJAX/refresh swap and
+// discoverable to anyone wiring loading states for adjacent
+// connection-centric panels.
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
+// hand-rolled `bb-skeleton*` family is being retired).
+templ ConnectionsSkeleton() {
+	<div aria-hidden="true">
+		<!-- Summary card: Net Worth / Assets / Liabilities -->
+		<div class="bb-card p-0 overflow-hidden mb-6">
+			<div class="grid grid-cols-3 divide-x divide-base-300">
+				for i := 0; i < 3; i++ {
+					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0 space-y-2">
+						<div class="skeleton h-2.5 w-16"></div>
+						<div class="skeleton h-6 sm:h-7 w-24"></div>
+					</div>
+				}
+			</div>
+		</div>
+		<!-- Connection cards -->
+		<div class="flex flex-col gap-4">
+			for i := 0; i < 4; i++ {
+				@connectionsSkeletonCard(i)
+			}
+		</div>
+	</div>
+}
+
+// connectionsSkeletonCard mirrors one connectionsCard: icon tile + name + status
+// badge + meta line on the left, sync button + balance + account count on the
+// right, and a couple of nested account rows beneath. The first card includes
+// nested account rows; subsequent ones alternate to keep the skeleton from
+// looking too uniform.
+templ connectionsSkeletonCard(i int) {
+	<div class="bb-card overflow-hidden">
+		<!-- Header row -->
+		<div class="px-4 py-3 sm:px-5 sm:py-4 flex items-center justify-between gap-2 sm:gap-4">
+			<div class="flex items-center gap-3 sm:gap-4 min-w-0 flex-1">
+				<!-- Provider icon tile (desktop only) -->
+				<div class="skeleton hidden sm:block w-10 h-10 rounded-lg shrink-0"></div>
+				<div class="min-w-0 space-y-1.5">
+					<!-- Institution name + status badge -->
+					<div class="flex items-center gap-2">
+						<div class="skeleton h-4 w-32 sm:w-40"></div>
+						<div class="skeleton h-4 w-14 rounded-full"></div>
+					</div>
+					<!-- Meta row: user · provider · last sync -->
+					<div class="flex items-center gap-2">
+						<div class="skeleton h-2.5 w-16"></div>
+						<div class="skeleton h-2.5 w-12"></div>
+						<div class="skeleton h-2.5 w-20"></div>
+					</div>
+				</div>
+			</div>
+			<!-- Right side: sync button + balance + count -->
+			<div class="flex items-center gap-1.5 sm:gap-3 shrink-0">
+				<div class="skeleton w-8 h-8 rounded-full shrink-0"></div>
+				<div class="space-y-1.5 text-right">
+					<div class="skeleton h-4 sm:h-5 w-20 ml-auto"></div>
+					<div class="skeleton h-2.5 w-14 ml-auto"></div>
+				</div>
+			</div>
+		</div>
+		<!-- Nested account rows (only on every other card to break up uniformity) -->
+		if i%2 == 0 {
+			<div class="border-t border-base-300">
+				for j := 0; j < 2; j++ {
+					@connectionsSkeletonAccountRow()
+				}
+			</div>
+		}
+	</div>
+}
+
+// connectionsSkeletonAccountRow mirrors connectionsAccountRow: a small icon
+// tile, account name + subtype/mask line, and a right-aligned balance.
+templ connectionsSkeletonAccountRow() {
+	<div class="flex items-center justify-between px-4 sm:px-5 py-3 border-b border-base-300 last:border-b-0">
+		<div class="flex items-center gap-3 min-w-0">
+			<div class="skeleton w-7 h-7 rounded-md shrink-0"></div>
+			<div class="min-w-0 space-y-1.5">
+				<div class="skeleton h-3 w-32"></div>
+				<div class="skeleton h-2.5 w-20"></div>
+			</div>
+		</div>
+		<div class="skeleton h-3.5 w-16"></div>
+	</div>
+}

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -168,6 +168,12 @@ templ Connections(p ConnectionsProps) {
 		<!-- /links tab -->
 		<!-- Create Account Link Modal -->
 		@connectionsCreateLinkModal(p)
+		<!-- Loading skeleton for the connections list, available for any future
+		     client-side refresh / pagination swap. Mirrors the SSR layout
+		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		<template id="bb-connections-skeleton-template">
+			@components.ConnectionsSkeleton()
+		</template>
 	</div>
 	<!-- /alpine x-data tabs -->
 }

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -789,6 +789,11 @@ templ SectionLoading() {
 				@components.AccountsListSkeleton()
 			</div>
 		}
+		@designExample("Connections list skeleton", "Placeholder mirroring /connections — summary stats (Net Worth / Assets / Liabilities) plus a stack of connection cards (provider icon, institution name + status badge, meta row, sync button, balance, nested account rows). Primitive is exposed here for future AJAX swaps; /connections is full-SSR today.") {
+			<div class="max-w-4xl">
+				@components.ConnectionsSkeleton()
+			</div>
+		}
 		@designExample("Progress", "Indeterminate + determinate.") {
 			<div class="space-y-3 max-w-md">
 				<progress class="progress progress-primary w-full"></progress>


### PR DESCRIPTION
## Summary

Adds `ConnectionsSkeleton` — a placeholder mirroring the `/connections` page layout, ready for any future AJAX/refresh swap.

- **Pages**: `/connections` (embedded as an inert `<template id="bb-connections-skeleton-template">` for future client-side cloning), `/design#loading` (specimen).
- **Layout match**: three-stat summary card (Net Worth / Assets / Liabilities) + a stack of 4 connection cards, each with provider-icon tile, institution name, status badge, meta row (user · provider · last sync), sync-button slot, balance, and account count. Every other card includes 2 nested account-row placeholders so the swap-in doesn't shift layout.
- **Wiring strategy**: option 3, per #1511 / #1512 — no handler restructuring. The live page is full SSR; the skeleton is rendered into a `<template>` so it's discoverable in DOM and clone-ready when a refresh/AJAX entry point lands.
- **Daisy adherence**: uses the daisy `skeleton` primitive throughout (the hand-rolled `bb-skeleton*` family is being retired per `.claude/rules/daisyui.md`).

## Screenshot

`/design#loading` — Connections list skeleton:

<img src="https://i.img402.dev/h1y2eoklb1.jpg" width="800" alt="connections list skeleton in /design#loading">

## Test plan

- [x] `templ generate` + `go build ./...` + `go vet ./...` clean
- [x] Visual check on `/design#loading` — skeleton renders 4 cards with summary stats, alternating cards include nested account rows
- [ ] `/connections` page renders the existing list unchanged (skeleton sits inside an inert `<template>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)