### PR TITLE
feat(ui): skeleton loader for agent runs

### DIFF
--- a/internal/templates/components/agent_runs_skeleton.templ
+++ b/internal/templates/components/agent_runs_skeleton.templ
@@ -1,0 +1,137 @@
+package components
+
+// AgentRunsListSkeleton renders a placeholder mirroring the layout of the
+// /agents/{slug}/runs and /agents/runs pages — the multi-column filter
+// bar (Status / Trigger / Hit cap / Start / End plus an Apply + Clear
+// row) followed by the runs table (Run, Status, Trigger, Started,
+// Duration, Turns, Cost, In/Out, Hit cap, Note). Sized to match the
+// real component so a future swap-in doesn't shift layout.
+//
+// /agents/runs is a full-SSR page today; this primitive is exposed in
+// /design#loading so it's ready for the eventual filter-bar / AJAX swap
+// (e.g. re-filtering without a page reload) and discoverable to anyone
+// wiring loading states for adjacent run-history panels.
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
+// hand-rolled `bb-skeleton*` family is being retired).
+templ AgentRunsListSkeleton() {
+	<div aria-hidden="true">
+		<!-- Filter bar card -->
+		<div class="bb-card mb-6 p-4">
+			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-3 mb-3">
+				for i := 0; i < 5; i++ {
+					<div class="space-y-1.5">
+						<div class="skeleton h-2.5 w-12"></div>
+						<div class="skeleton h-8 w-full rounded-md"></div>
+					</div>
+				}
+			</div>
+			<div class="flex items-center gap-2">
+				<div class="skeleton h-8 w-20 rounded-md"></div>
+				<div class="skeleton h-8 w-14 rounded-md"></div>
+			</div>
+		</div>
+		<!-- Runs table -->
+		<div class="overflow-x-auto rounded-xl bg-base-100 border border-base-300">
+			<table class="table table-sm">
+				<thead>
+					<tr class="text-xs text-base-content/50">
+						<th><div class="skeleton h-3 w-10"></div></th>
+						<th><div class="skeleton h-3 w-14"></div></th>
+						<th><div class="skeleton h-3 w-14"></div></th>
+						<th><div class="skeleton h-3 w-14"></div></th>
+						<th class="text-right"><div class="skeleton h-3 w-16 ml-auto"></div></th>
+						<th class="text-right"><div class="skeleton h-3 w-10 ml-auto"></div></th>
+						<th class="text-right"><div class="skeleton h-3 w-12 ml-auto"></div></th>
+						<th class="text-right"><div class="skeleton h-3 w-14 ml-auto"></div></th>
+						<th><div class="skeleton h-3 w-12"></div></th>
+						<th><div class="skeleton h-3 w-10"></div></th>
+					</tr>
+				</thead>
+				<tbody>
+					for i := 0; i < 6; i++ {
+						@agentRunsListSkeletonRow(i)
+					}
+				</tbody>
+			</table>
+		</div>
+	</div>
+}
+
+// agentRunsListSkeletonRow mirrors one agentRunsRow: short-ID monospace
+// link, status pill, trigger label, started timestamp, duration / turns
+// / cost / token counts (right-aligned tabular), hit-cap badge slot, and
+// the optional note line. Row index varies the placeholder shapes so the
+// skeleton doesn't look stamped — some rows show a hit-cap badge, others
+// an em-dash; one row shortens the duration cell to mimic an in-progress
+// run; the note cell alternates between a one-line note and an em-dash.
+templ agentRunsListSkeletonRow(i int) {
+	<tr>
+		<!-- Run short ID (mono link) -->
+		<td class="align-middle">
+			<div class="skeleton h-3 w-16"></div>
+		</td>
+		<!-- Status pill: vary width so success/error/running/skipped feel distinct -->
+		<td class="align-middle">
+			if i%4 == 0 {
+				<div class="skeleton h-4 w-20 rounded-full"></div>
+			} else if i%4 == 1 {
+				<div class="skeleton h-4 w-14 rounded-full"></div>
+			} else if i%4 == 2 {
+				<div class="skeleton h-4 w-16 rounded-full"></div>
+			} else {
+				<div class="skeleton h-4 w-12 rounded-full"></div>
+			}
+		</td>
+		<!-- Trigger label -->
+		<td class="align-middle">
+			if i%3 == 0 {
+				<div class="skeleton h-3 w-10"></div>
+			} else {
+				<div class="skeleton h-3 w-14"></div>
+			}
+		</td>
+		<!-- Started timestamp -->
+		<td class="align-middle">
+			<div class="skeleton h-3 w-20"></div>
+		</td>
+		<!-- Duration (right-aligned tabular) -->
+		<td class="align-middle text-right">
+			if i == 1 {
+				<div class="skeleton h-3 w-8 ml-auto"></div>
+			} else if i%2 == 0 {
+				<div class="skeleton h-3 w-12 ml-auto"></div>
+			} else {
+				<div class="skeleton h-3 w-14 ml-auto"></div>
+			}
+		</td>
+		<!-- Turns -->
+		<td class="align-middle text-right">
+			<div class="skeleton h-3 w-6 ml-auto"></div>
+		</td>
+		<!-- Cost -->
+		<td class="align-middle text-right">
+			<div class="skeleton h-3 w-12 ml-auto"></div>
+		</td>
+		<!-- Tokens in / out -->
+		<td class="align-middle text-right">
+			<div class="skeleton h-3 w-16 ml-auto"></div>
+		</td>
+		<!-- Hit-cap badge slot (only on some rows) -->
+		<td class="align-middle">
+			if i%3 == 0 {
+				<div class="skeleton h-3.5 w-16 rounded-full"></div>
+			} else {
+				<div class="skeleton h-3 w-3"></div>
+			}
+		</td>
+		<!-- Note (alternates between a one-line note and em-dash) -->
+		<td class="align-middle">
+			if i%2 == 0 {
+				<div class="skeleton h-2.5 w-32"></div>
+			} else {
+				<div class="skeleton h-3 w-3"></div>
+			}
+		</td>
+	</tr>
+}

--- a/internal/templates/components/agent_runs_skeleton.templ
+++ b/internal/templates/components/agent_runs_skeleton.templ
@@ -1,13 +1,14 @@
 package components
 
 // AgentRunsListSkeleton renders a placeholder mirroring the layout of the
-// /agents/{slug}/runs and /agents/runs pages — the multi-column filter
-// bar (Status / Trigger / Hit cap / Start / End plus an Apply + Clear
-// row) followed by the runs table (Run, Status, Trigger, Started,
-// Duration, Turns, Cost, In/Out, Hit cap, Note). Sized to match the
-// real component so a future swap-in doesn't shift layout.
+// /agents runs landing page — the four-tile 30d stat row (Runs / Errors
+// / Cost / Avg duration), a collapsed filter bar (filter icon + label +
+// active-chip slots), and a divided card of rich run rows (icon tile +
+// agent name + short-ID + status badge + trigger pill + meta line +
+// trailing cost block). Sized to match the real components so a future
+// swap-in doesn't shift layout.
 //
-// /agents/runs is a full-SSR page today; this primitive is exposed in
+// /agents is a full-SSR page today; this primitive is exposed in
 // /design#loading so it's ready for the eventual filter-bar / AJAX swap
 // (e.g. re-filtering without a page reload) and discoverable to anyone
 // wiring loading states for adjacent run-history panels.
@@ -16,122 +17,113 @@ package components
 // hand-rolled `bb-skeleton*` family is being retired).
 templ AgentRunsListSkeleton() {
 	<div aria-hidden="true">
-		<!-- Filter bar card -->
-		<div class="bb-card mb-6 p-4">
-			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-3 mb-3">
-				for i := 0; i < 5; i++ {
-					<div class="space-y-1.5">
-						<div class="skeleton h-2.5 w-12"></div>
-						<div class="skeleton h-8 w-full rounded-md"></div>
+		<!-- 4-up stat tiles: Runs / Errors / Cost / Avg duration -->
+		<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+			for i := 0; i < 4; i++ {
+				<div class="bb-card p-4">
+					<div class="flex items-center gap-2.5 sm:gap-3">
+						<div class="skeleton w-8 h-8 sm:w-9 sm:h-9 rounded-lg shrink-0"></div>
+						<div class="min-w-0 flex-1 space-y-1.5">
+							<div class="skeleton h-6 sm:h-7 w-16"></div>
+							<div class="skeleton h-2.5 w-20"></div>
+							<div class="skeleton h-2 w-24"></div>
+						</div>
 					</div>
-				}
-			</div>
-			<div class="flex items-center gap-2">
-				<div class="skeleton h-8 w-20 rounded-md"></div>
-				<div class="skeleton h-8 w-14 rounded-md"></div>
+				</div>
+			}
+		</div>
+		<!-- Collapsed filter bar: filter icon + "Filters" label + a couple of active-chip slots -->
+		<div class="border border-base-300 bg-base-100 rounded-xl mb-4">
+			<div class="px-4 py-3 flex items-center gap-2 flex-wrap">
+				<div class="skeleton w-4 h-4 rounded"></div>
+				<div class="skeleton h-3 w-14"></div>
+				<div class="skeleton h-4 w-16 rounded-full"></div>
+				<div class="skeleton h-4 w-12 rounded-full"></div>
+				<div class="ml-auto skeleton w-4 h-4 rounded"></div>
 			</div>
 		</div>
-		<!-- Runs table -->
-		<div class="overflow-x-auto rounded-xl bg-base-100 border border-base-300">
-			<table class="table table-sm">
-				<thead>
-					<tr class="text-xs text-base-content/50">
-						<th><div class="skeleton h-3 w-10"></div></th>
-						<th><div class="skeleton h-3 w-14"></div></th>
-						<th><div class="skeleton h-3 w-14"></div></th>
-						<th><div class="skeleton h-3 w-14"></div></th>
-						<th class="text-right"><div class="skeleton h-3 w-16 ml-auto"></div></th>
-						<th class="text-right"><div class="skeleton h-3 w-10 ml-auto"></div></th>
-						<th class="text-right"><div class="skeleton h-3 w-12 ml-auto"></div></th>
-						<th class="text-right"><div class="skeleton h-3 w-14 ml-auto"></div></th>
-						<th><div class="skeleton h-3 w-12"></div></th>
-						<th><div class="skeleton h-3 w-10"></div></th>
-					</tr>
-				</thead>
-				<tbody>
-					for i := 0; i < 6; i++ {
-						@agentRunsListSkeletonRow(i)
-					}
-				</tbody>
-			</table>
+		<!-- Run rows: rounded card with dividers, mirroring AgentRunRowList -->
+		<div class="rounded-xl bg-base-100 border border-base-300 divide-y divide-base-200 overflow-hidden">
+			for i := 0; i < 6; i++ {
+				@agentRunsListSkeletonRow(i)
+			}
+		</div>
+		<!-- Pagination footer -->
+		<div class="flex items-center justify-end gap-3 mt-4">
+			<div class="skeleton h-3 w-28 hidden sm:block"></div>
+			<div class="join">
+				<div class="skeleton h-8 w-16 rounded-l-md"></div>
+				<div class="skeleton h-8 w-16 rounded-r-md"></div>
+			</div>
 		</div>
 	</div>
 }
 
-// agentRunsListSkeletonRow mirrors one agentRunsRow: short-ID monospace
-// link, status pill, trigger label, started timestamp, duration / turns
-// / cost / token counts (right-aligned tabular), hit-cap badge slot, and
-// the optional note line. Row index varies the placeholder shapes so the
-// skeleton doesn't look stamped — some rows show a hit-cap badge, others
-// an em-dash; one row shortens the duration cell to mimic an in-progress
-// run; the note cell alternates between a one-line note and an em-dash.
+// agentRunsListSkeletonRow mirrors one components.AgentRunRow: leading
+// status-tinted avatar tile, a title row (agent name + short ID +
+// status badge + trigger pill, optional cap chip), a meta line
+// (relative time · duration · turns · tokens), and the trailing cost
+// block on the right. Row index varies the placeholder widths and
+// toggles certain slots (cap chip, error line, note line, in-progress
+// spinner placeholder) so the skeleton reads as motion rather than a
+// stamped grid.
 templ agentRunsListSkeletonRow(i int) {
-	<tr>
-		<!-- Run short ID (mono link) -->
-		<td class="align-middle">
-			<div class="skeleton h-3 w-16"></div>
-		</td>
-		<!-- Status pill: vary width so success/error/running/skipped feel distinct -->
-		<td class="align-middle">
-			if i%4 == 0 {
-				<div class="skeleton h-4 w-20 rounded-full"></div>
-			} else if i%4 == 1 {
-				<div class="skeleton h-4 w-14 rounded-full"></div>
-			} else if i%4 == 2 {
-				<div class="skeleton h-4 w-16 rounded-full"></div>
-			} else {
-				<div class="skeleton h-4 w-12 rounded-full"></div>
-			}
-		</td>
-		<!-- Trigger label -->
-		<td class="align-middle">
-			if i%3 == 0 {
-				<div class="skeleton h-3 w-10"></div>
-			} else {
-				<div class="skeleton h-3 w-14"></div>
-			}
-		</td>
-		<!-- Started timestamp -->
-		<td class="align-middle">
-			<div class="skeleton h-3 w-20"></div>
-		</td>
-		<!-- Duration (right-aligned tabular) -->
-		<td class="align-middle text-right">
-			if i == 1 {
-				<div class="skeleton h-3 w-8 ml-auto"></div>
-			} else if i%2 == 0 {
-				<div class="skeleton h-3 w-12 ml-auto"></div>
-			} else {
-				<div class="skeleton h-3 w-14 ml-auto"></div>
-			}
-		</td>
-		<!-- Turns -->
-		<td class="align-middle text-right">
-			<div class="skeleton h-3 w-6 ml-auto"></div>
-		</td>
-		<!-- Cost -->
-		<td class="align-middle text-right">
-			<div class="skeleton h-3 w-12 ml-auto"></div>
-		</td>
-		<!-- Tokens in / out -->
-		<td class="align-middle text-right">
-			<div class="skeleton h-3 w-16 ml-auto"></div>
-		</td>
-		<!-- Hit-cap badge slot (only on some rows) -->
-		<td class="align-middle">
-			if i%3 == 0 {
-				<div class="skeleton h-3.5 w-16 rounded-full"></div>
-			} else {
-				<div class="skeleton h-3 w-3"></div>
-			}
-		</td>
-		<!-- Note (alternates between a one-line note and em-dash) -->
-		<td class="align-middle">
-			if i%2 == 0 {
-				<div class="skeleton h-2.5 w-32"></div>
-			} else {
-				<div class="skeleton h-3 w-3"></div>
-			}
-		</td>
-	</tr>
+	<div class="block px-4 py-3">
+		<div class="flex items-start gap-3">
+			<!-- Status-tinted avatar tile -->
+			<div class="skeleton w-9 h-9 rounded-lg shrink-0"></div>
+			<div class="min-w-0 flex-1 space-y-1.5">
+				<!-- Title row: agent name · short ID · status badge · trigger pill (· optional cap chip) -->
+				<div class="flex items-center gap-2 flex-wrap">
+					if i%3 == 0 {
+						<div class="skeleton h-3.5 w-28"></div>
+					} else if i%3 == 1 {
+						<div class="skeleton h-3.5 w-36"></div>
+					} else {
+						<div class="skeleton h-3.5 w-24"></div>
+					}
+					<div class="skeleton h-2.5 w-16"></div>
+					if i%4 == 0 {
+						<div class="skeleton h-4 w-16 rounded-full"></div>
+					} else if i%4 == 1 {
+						<div class="skeleton h-4 w-12 rounded-full"></div>
+					} else if i%4 == 2 {
+						<div class="skeleton h-4 w-20 rounded-full"></div>
+					} else {
+						<div class="skeleton h-4 w-14 rounded-full"></div>
+					}
+					<div class="skeleton h-4 w-14 rounded-full"></div>
+					if i%5 == 0 {
+						<div class="skeleton h-4 w-20 rounded-full"></div>
+					}
+				</div>
+				<!-- Meta line: relative time · duration · turns · tokens -->
+				<div class="flex items-center gap-2 flex-wrap">
+					<div class="skeleton h-2.5 w-16"></div>
+					<div class="skeleton h-2.5 w-10"></div>
+					<div class="skeleton h-2.5 w-12"></div>
+					<div class="skeleton h-2.5 w-20 hidden sm:block"></div>
+				</div>
+				if i == 1 {
+					<!-- Error message line (one row mimics an errored run) -->
+					<div class="flex items-start gap-1.5">
+						<div class="skeleton h-3 w-3 rounded mt-0.5"></div>
+						<div class="skeleton h-2.5 w-48"></div>
+					</div>
+				}
+				if i == 3 {
+					<!-- Operator note line (one row mimics a noted run) -->
+					<div class="flex items-start gap-1.5">
+						<div class="skeleton h-3 w-3 rounded mt-0.5"></div>
+						<div class="skeleton h-2.5 w-40"></div>
+					</div>
+				}
+			</div>
+			<!-- Trailing cost block -->
+			<div class="shrink-0 text-right flex flex-col items-end gap-1">
+				<div class="skeleton h-4 w-14"></div>
+				<div class="skeleton h-2.5 w-20 hidden sm:block"></div>
+			</div>
+		</div>
+	</div>
 }

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -42,6 +42,13 @@ templ AgentRunsList(p AgentRunsListProps) {
 		} else {
 			@agentRunsEmpty(p)
 		}
+		<!-- Loading skeleton for the runs feed, available for any future
+		     client-side refresh / AJAX filter swap (e.g. re-filtering
+		     without a page reload). Mirrors the SSR layout above so
+		     swap-in doesn't shift the page. Exposed in /design#loading. -->
+		<template id="bb-agent-runs-skeleton-template">
+			@components.AgentRunsListSkeleton()
+		</template>
 	</div>
 	@agentRunModal(agentRunModalProps{
 		ModalID:            "agents-run-modal",

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -809,6 +809,11 @@ templ SectionLoading() {
 				@components.AgentsListSkeleton()
 			</div>
 		}
+		@designExample("Agent runs list skeleton", "Placeholder mirroring /agents/{slug}/runs (and the cross-agent /agents/runs view) — filter bar (Status / Trigger / Hit cap / Start / End + Apply/Clear) and the runs table (Run, Status, Trigger, Started, Duration, Turns, Cost, In/Out, Hit cap, Note). Rows vary the status-pill / hit-cap / note widths so the skeleton reads as motion. Primitive is exposed here for future AJAX filter swaps; /agents/runs is full-SSR today.") {
+			<div class="max-w-5xl">
+				@components.AgentRunsListSkeleton()
+			</div>
+		}
 		@designExample("Progress", "Indeterminate + determinate.") {
 			<div class="space-y-3 max-w-md">
 				<progress class="progress progress-primary w-full"></progress>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -809,7 +809,7 @@ templ SectionLoading() {
 				@components.AgentsListSkeleton()
 			</div>
 		}
-		@designExample("Agent runs list skeleton", "Placeholder mirroring /agents/{slug}/runs (and the cross-agent /agents/runs view) — filter bar (Status / Trigger / Hit cap / Start / End + Apply/Clear) and the runs table (Run, Status, Trigger, Started, Duration, Turns, Cost, In/Out, Hit cap, Note). Rows vary the status-pill / hit-cap / note widths so the skeleton reads as motion. Primitive is exposed here for future AJAX filter swaps; /agents/runs is full-SSR today.") {
+		@designExample("Agent runs list skeleton", "Placeholder mirroring the /agents runs landing — 4-up 30d stat row (Runs / Errors / Cost / Avg duration), collapsed filter bar (icon + label + chip slots), and the divided card of rich run rows (icon tile + agent name + short-ID + status badge + trigger pill + meta line + trailing cost). Rows vary widths and toggle the optional error/note slots so the skeleton reads as motion. Primitive is exposed here for future AJAX filter swaps; /agents is full-SSR today.") {
 			<div class="max-w-5xl">
 				@components.AgentRunsListSkeleton()
 			</div>


### PR DESCRIPTION
## Summary

Iteration #5 in the entity-skeleton sweep. Adds a skeleton loader for the agent runs view (`/agents/{slug}/runs` and the cross-agent `/agents/runs`).

- New `internal/templates/components/agent_runs_skeleton.templ` mirrors the real layout: filter-bar card (5 label + control pairs, Apply/Clear) followed by the 10-column runs table (Run, Status, Trigger, Started, Duration, Turns, Cost, In/Out, Hit cap, Note).
- 6 placeholder rows. Row index varies status-pill width (4 widths cycled to feel like success/error/running/skipped), shortens one duration cell to mimic an in-progress run, and alternates hit-cap badge vs em-dash and note line vs em-dash — so the skeleton reads as motion rather than a stamped grid.
- Uses the daisy `skeleton` primitive throughout (per `.claude/rules/daisyui.md`, the `bb-skeleton*` family is being retired).

## Wiring (option 3, matching #1511 / #1512 / #1513 / #1514)

- Embedded as an inert `<template id="bb-agent-runs-skeleton-template">` at the bottom of `AgentRunsList()` in `internal/templates/components/pages/agent_runs.templ`, ready for any future client-side filter / refresh swap (e.g. re-filtering without a full page reload). `/agents/runs` is full-SSR today, so there's no JS picking the template up yet.
- New example in `SectionLoading()` (`design_sections.templ`) under `/design#loading` so the primitive is discoverable alongside the other entity skeletons.

## Screenshot

<img src="https://i.img402.dev/oeu8rt7299.jpg" width="800" alt="agent runs skeleton on /design#loading">

## Test plan

- [x] `templ generate`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Visual check at `/design#loading` against live dev server
