### PR TITLE
feat(ui): skeleton loader for rules

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -814,6 +814,11 @@ templ SectionLoading() {
 				@components.AgentRunsListSkeleton()
 			</div>
 		}
+		@designExample("Rules list skeleton", "Placeholder mirroring /rules — the count + sort-dropdown header strip and a stack of rule cards (9x9 avatar tile, name with optional Disabled/Expired/System badge, compact condition · action · hits subtitle, desktop-only pipeline-stage + last-active stats stack, and edit pencil + kebab action slots). Rows vary the badge / last-active widths so the skeleton reads as motion. Primitive is exposed here for future AJAX swaps (toggleRule / deleteRule without a full page reload); /rules is full-SSR today.") {
+			<div class="max-w-4xl">
+				@components.RulesSkeleton()
+			</div>
+		}
 		@designExample("Progress", "Indeterminate + determinate.") {
 			<div class="space-y-3 max-w-md">
 				<progress class="progress progress-primary w-full"></progress>

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -64,6 +64,13 @@ templ Rules(p RulesProps) {
 		if p.TotalPages > 1 {
 			@rulesPaginator(p)
 		}
+		<!-- Loading skeleton for the rules list, available for any future
+		     client-side refresh / pagination swap (e.g. toggleRule /
+		     deleteRule without a full page reload). Mirrors the SSR layout
+		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		<template id="bb-rules-skeleton-template">
+			@components.RulesSkeleton()
+		</template>
 	</div>
 }
 

--- a/internal/templates/components/rules_skeleton.templ
+++ b/internal/templates/components/rules_skeleton.templ
@@ -1,0 +1,88 @@
+package components
+
+// RulesSkeleton renders a placeholder mirroring the layout of the
+// /rules page — the count + sort-dropdown header strip followed by a
+// stack of rule cards (avatar + name + condition/action/hits subtitle,
+// optional pipeline-stage + last-active stats on desktop, edit pencil
+// + overflow kebab). Sized to match the real component so a future
+// swap-in doesn't shift layout.
+//
+// /rules is a full-SSR page today; this primitive is exposed in
+// /design#loading so it's ready for the eventual AJAX/refresh swap
+// (e.g. after toggleRule / deleteRule without a full page reload) and
+// discoverable to anyone wiring loading states for adjacent
+// rules-centric panels.
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
+// hand-rolled `bb-skeleton*` family is being retired).
+templ RulesSkeleton() {
+	<div aria-hidden="true">
+		<!-- Count + sort header strip (mirrors rules.templ:34-54) -->
+		<div class="flex items-center justify-between flex-wrap gap-3 mb-4 px-1">
+			<div class="skeleton h-3 w-32"></div>
+			<div class="skeleton h-6 w-40 rounded-md"></div>
+		</div>
+		<!-- Rule cards -->
+		<div class="space-y-3">
+			for i := 0; i < 6; i++ {
+				@rulesSkeletonRow(i)
+			}
+		</div>
+	</div>
+}
+
+// rulesSkeletonRow mirrors one rulesRow: a 9x9 avatar tile on the left,
+// the name + optional badges row + the compact condition/action/hits
+// subtitle in the middle, the desktop-only priority + last-active stats
+// stack on the right, and the edit pencil + kebab slot at the end.
+// Row index varies the placeholder shapes so the skeleton doesn't look
+// stamped — some rows render a "Disabled"/"Expired"/"System" badge, the
+// last row mimics a rule that has never matched (no last-active line).
+templ rulesSkeletonRow(i int) {
+	<div class="bb-card p-0 relative">
+		<div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-4 sm:py-5">
+			<!-- Avatar (rulesAvatar — 9x9 rounded tile) -->
+			<div class="flex-shrink-0">
+				<div class="skeleton w-9 h-9 rounded-xl"></div>
+			</div>
+			<!-- Main info: name + badges + subtitle -->
+			<div class="flex-1 min-w-0 space-y-1.5">
+				<div class="flex items-center gap-2 flex-wrap">
+					<div class="skeleton h-3.5 w-40 sm:w-56"></div>
+					if i%3 == 0 {
+						<div class="skeleton hidden sm:block h-3.5 w-14 rounded-full"></div>
+					}
+				</div>
+				<!-- Condition · action · hits subtitle -->
+				<div class="flex items-center gap-2">
+					<div class="skeleton h-2.5 w-16"></div>
+					<div class="skeleton h-2.5 w-1 rounded-full"></div>
+					<div class="skeleton h-2.5 w-20"></div>
+					<div class="skeleton h-2.5 w-1 rounded-full"></div>
+					<div class="skeleton h-2.5 w-12"></div>
+				</div>
+			</div>
+			<!-- Right-side stats (desktop+): pipeline stage + last active -->
+			<div class="hidden lg:flex items-center gap-4 flex-shrink-0">
+				<div class="w-12 text-center space-y-1">
+					<div class="skeleton h-3.5 w-6 mx-auto"></div>
+					<div class="skeleton h-2.5 w-10 mx-auto"></div>
+				</div>
+				<div class="w-20 text-center space-y-1">
+					if i == 5 {
+						<div class="skeleton h-3 w-4 mx-auto"></div>
+						<div class="skeleton h-2.5 w-14 mx-auto"></div>
+					} else {
+						<div class="skeleton h-3 w-16 mx-auto"></div>
+						<div class="skeleton h-2.5 w-14 mx-auto"></div>
+					}
+				</div>
+			</div>
+			<!-- Actions: edit pencil + kebab -->
+			<div class="flex items-center justify-end gap-0.5 flex-shrink-0">
+				<div class="skeleton h-6 w-6 rounded-md"></div>
+				<div class="skeleton h-6 w-6 rounded-md"></div>
+			</div>
+		</div>
+	</div>
+}


### PR DESCRIPTION
Add a daisy-skeleton placeholder for `/rules` so the page is ready for a future AJAX swap (toggle/delete without a full reload) and so a representative variant lands in the design sandbox under Loading & skeletons.

## What ships

- New component: `internal/templates/components/rules_skeleton.templ` (`RulesSkeleton`).
- Live page wiring: inert `<template id=\"bb-rules-skeleton-template\">` appended to the root container in `internal/templates/components/pages/rules.templ` — does not affect SSR output.
- Sandbox surface: added a `Rules list skeleton` example to `SectionLoading()` in `internal/templates/components/pages/design_sections.templ`.

## Mirrors the real layout

- Count + sort-dropdown header strip.
- 6 rule cards, each with: 9x9 avatar tile, name line (optional Disabled/Expired/System badge on every 3rd row), compact condition · action · hits subtitle with separator dots, desktop-only pipeline-stage + last-active stats stack, and edit pencil + kebab action slots.
- Last row mimics a rule that has never matched (narrower last-active line) so the stack reads as motion.

## Wiring strategy

Option 3 (per the established skeleton-loader sprint pattern from #1511–#1515): sibling `<name>_skeleton.templ` + inert `<template id=\"bb-rules-skeleton-template\">` on the live page + example added to `SectionLoading()`. Uses the daisy `skeleton` primitive throughout (the hand-rolled `bb-skeleton*` family is being retired per `.claude/rules/daisyui.md`).

## Screenshot

`/design#loading` — Rules list skeleton section:

<img src=\"https://i.img402.dev/41f4qxckq0.jpg\" width=\"800\" alt=\"/design#loading — Rules list skeleton\">

## Test plan

- [ ] Visit `/design#loading` and verify the new \"Rules list skeleton\" example renders.
- [ ] Visit `/rules` and confirm normal SSR output is unchanged (the inert `<template>` doesn't render).
- [ ] DOM check: `document.getElementById('bb-rules-skeleton-template')` is a `<template>` on `/rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)