### PR TITLE
feat(agents): redesign /agents IA — runs landing, tabs, run-an-agent modal, rich row component, report chips

### DIFF
--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"breadbox/internal/agent"
 	"breadbox/internal/appconfig"
 	"breadbox/internal/service"
+	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/alexedwards/scs/v2"
@@ -27,126 +29,141 @@ import (
 // at the raw file on disk.
 const agentRunTranscriptMaxEvents = 500
 
-// AgentRunsListPageHandler serves both
+// AgentRunsListPageHandler serves GET /agents — the unified runs
+// landing page. ?agent=<slug> filters to a single agent (the link from
+// the Agents-tab table and the per-agent edit page passes it through);
+// without it, the page renders the cross-agent feed.
 //
-//   - GET /agents/{slug}/runs (per-agent view)
-//   - GET /agents/runs        (global view)
+// Filter params: agent, status, trigger, hit_cap, start, end, limit,
+// offset. Invalid enum values are silently dropped (admin convention).
 //
-// The empty slug param distinguishes the two — chi keeps it empty when
-// the {slug} segment isn't part of the matched route. Filter params:
-// status, trigger, hit_cap, agent (global only), start, end, limit,
-// offset. Invalid filter values are silently dropped (admin convention).
+// The handler loads the run feed, the agent definition list (used by
+// the filter dropdown + the "Run an agent" modal picker), and the
+// 30-day stats rollup. Definitions + runs are fetched in parallel
+// since they're independent reads.
 func AgentRunsListPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		slug := chi.URLParam(r, "slug")
-		mode := "global"
-		if slug != "" {
-			mode = "agent"
-		}
 
 		filters, limit, offset := parseAgentRunFilters(r)
 
 		props := pages.AgentRunsListProps{
-			Mode:      mode,
 			Filters:   filters,
 			Limit:     limit,
 			Offset:    offset,
 			CSRFToken: GetCSRFToken(r),
 		}
 
-		var agentName string
-
-		if mode == "agent" {
-			def, err := svc.GetAgentDefinition(ctx, slug)
-			if err != nil {
-				if errors.Is(err, service.ErrNotFound) {
-					tr.RenderNotFound(w, r)
-					return
-				}
-				tr.RenderError(w, r)
-				return
-			}
-			props.AgentSlug = def.Slug
-			props.AgentName = def.Name
-			agentName = def.Name
-
-			params := service.AgentRunListParams{
-				Limit:   limit,
-				Offset:  offset,
-				Status:  filters.Status,
-				Trigger: filters.Trigger,
-				HitCap:  filters.HitCap,
-				Start:   parseDateParam(r, "start"),
-				End:     parseInclusiveDateParam(r, "end"),
-			}
-			result, err := svc.ListAgentRuns(ctx, def.Slug, params)
+		params := service.AllAgentRunListParams{
+			Limit:         limit,
+			Offset:        offset,
+			AgentSlugOrID: filters.AgentSlug,
+			Status:        filters.Status,
+			Trigger:       filters.Trigger,
+			HitCap:        filters.HitCap,
+			Start:         parseDateParam(r, "start"),
+			End:           parseInclusiveDateParam(r, "end"),
+		}
+		result, err := svc.ListAllAgentRuns(ctx, params)
+		if err != nil {
+			// Bad agent filter slug → silently drop the filter rather
+			// than erroring the whole page; matches the "silently drop
+			// invalid filters" admin convention.
+			params.AgentSlugOrID = ""
+			filters.AgentSlug = ""
+			props.Filters = filters
+			result, err = svc.ListAllAgentRuns(ctx, params)
 			if err != nil {
 				tr.RenderError(w, r)
 				return
 			}
-			props.Rows = make([]pages.AgentRunRowProps, 0, len(result.Runs))
-			for _, run := range result.Runs {
-				row := agentRunRowFromResponse(run)
-				row.AgentSlug = def.Slug
-				row.AgentName = def.Name
-				props.Rows = append(props.Rows, row)
-			}
-			props.Total = len(result.Runs)
-		} else {
-			params := service.AllAgentRunListParams{
-				Limit:         limit,
-				Offset:        offset,
-				AgentSlugOrID: filters.AgentSlug,
-				Status:        filters.Status,
-				Trigger:       filters.Trigger,
-				HitCap:        filters.HitCap,
-				Start:         parseDateParam(r, "start"),
-				End:           parseInclusiveDateParam(r, "end"),
-			}
-			result, err := svc.ListAllAgentRuns(ctx, params)
-			if err != nil {
-				// Bad agent filter slug → silently drop the filter rather
-				// than erroring the whole page; matches the "silently drop
-				// invalid filters" admin convention.
-				params.AgentSlugOrID = ""
-				filters.AgentSlug = ""
-				props.Filters = filters
-				result, err = svc.ListAllAgentRuns(ctx, params)
-				if err != nil {
-					tr.RenderError(w, r)
-					return
-				}
-			}
-			props.Rows = make([]pages.AgentRunRowProps, 0, len(result.Runs))
-			for _, run := range result.Runs {
-				row := agentRunRowFromResponse(run.AgentRunResponse)
-				row.AgentSlug = run.AgentSlug
-				row.AgentName = run.AgentName
-				props.Rows = append(props.Rows, row)
-			}
-			props.Total = len(result.Runs)
+		}
+		props.Rows = make([]pages.AgentRunRowProps, 0, len(result.Runs))
+		runIDs := make([]string, 0, len(result.Runs))
+		for _, run := range result.Runs {
+			row := agentRunRowFromResponse(run.AgentRunResponse)
+			row.AgentSlug = run.AgentSlug
+			row.AgentName = run.AgentName
+			props.Rows = append(props.Rows, row)
+			runIDs = append(runIDs, run.AgentRunResponse.ID)
+		}
+		props.Total = len(result.Runs)
 
-			// Populate the agent filter dropdown.
-			defs, err := svc.ListAgentDefinitions(ctx)
-			if err == nil {
-				props.AgentOptions = make([]pages.AgentRunsAgentOption, 0, len(defs))
-				for _, d := range defs {
-					props.AgentOptions = append(props.AgentOptions, pages.AgentRunsAgentOption{
-						Slug: d.Slug,
-						Name: d.Name,
+		// Fetch report summaries for every row in one batched query so
+		// the runs list can render "[file-text] Title →" chips inline.
+		// Failure here just degrades to no chips — the row still renders.
+		if reportMap, rerr := svc.ListReportSummariesForRunIDs(ctx, runIDs); rerr == nil {
+			for i := range props.Rows {
+				reps, ok := reportMap[runIDs[i]]
+				if !ok {
+					continue
+				}
+				props.Rows[i].Reports = make([]components.AgentRunReportRef, 0, len(reps))
+				for _, rep := range reps {
+					props.Rows[i].Reports = append(props.Rows[i].Reports, components.AgentRunReportRef{
+						ShortID:  rep.ShortID,
+						Title:    rep.Title,
+						Priority: rep.Priority,
 					})
 				}
 			}
 		}
 
-		title := "Run history"
-		if agentName != "" {
-			title = "Runs — " + agentName
+		// Definitions populate the filter dropdown + the "Run an agent"
+		// modal picker. Failing here just degrades both — keep rendering.
+		defs, derr := svc.ListAgentDefinitions(ctx)
+		if derr == nil {
+			props.AgentOptions = make([]pages.AgentRunsAgentOption, 0, len(defs))
+			props.LastPromptPrefixes = make(map[string]string, len(defs))
+			for _, d := range defs {
+				opt := pages.AgentRunsAgentOption{
+					Slug:        d.Slug,
+					Name:        d.Name,
+					Description: firstLine(d.Prompt, 120),
+					Enabled:     d.Enabled,
+				}
+				if d.CostStats30d != nil {
+					opt.Cost30dUSD = d.CostStats30d.TotalCostUSD
+					opt.RunCount30 = d.CostStats30d.RunCount
+				}
+				props.AgentOptions = append(props.AgentOptions, opt)
+				if d.LastPromptPrefix != nil && *d.LastPromptPrefix != "" {
+					props.LastPromptPrefixes[d.Slug] = *d.LastPromptPrefix
+				}
+			}
 		}
-		data := BaseTemplateData(r, sm, "agents", title)
+
+		// 30-day stats roll up across every agent (CostStats30d on each
+		// definition) for the header tiles. We compute on the read side
+		// rather than adding a new aggregate query — small N (one row
+		// per agent), so the loop is cheap and keeps the SQL surface
+		// flat. Avg duration + error count come from the agent_runs
+		// table directly via a small helper.
+		props.Stats = computeAgentRunsStats(ctx, svc, defs)
+
+		data := BaseTemplateData(r, sm, "agents", "Agents")
 		tr.RenderWithTempl(w, r, data, pages.AgentRunsList(props))
 	}
+}
+
+// computeAgentRunsStats rolls up the four StatTile numbers from the
+// per-agent CostStats30d (already populated by ListAgentDefinitions) +
+// a 30-day error + avg-duration query. Best-effort: a failure on the
+// extra query just leaves error_count + avg_duration zeroed.
+func computeAgentRunsStats(ctx context.Context, svc *service.Service, defs []service.AgentDefinitionResponse) pages.AgentRunsStatsProps {
+	stats := pages.AgentRunsStatsProps{}
+	for _, d := range defs {
+		if d.CostStats30d == nil {
+			continue
+		}
+		stats.RunCount30d += d.CostStats30d.RunCount
+		stats.TotalCostUSD30d += d.CostStats30d.TotalCostUSD
+	}
+	if extra, err := svc.GetAgentRunsExtraStats30d(ctx); err == nil {
+		stats.ErrorCount30d = extra.ErrorCount
+		stats.AvgDurationSeconds = extra.AvgDurationSeconds
+	}
+	return stats
 }
 
 // AgentRunDetailPageHandler serves GET /agents/runs/{shortId}. Resolves the
@@ -186,6 +203,21 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 		}
 		row.AgentSlug = defSlug
 		row.AgentName = defName
+
+		// Surface any reports this run produced on the detail metadata
+		// card so the operator can jump straight into the report body.
+		if reportMap, rerr := svc.ListReportSummariesForRunIDs(ctx, []string{run.ID}); rerr == nil {
+			if reps, ok := reportMap[run.ID]; ok {
+				row.Reports = make([]components.AgentRunReportRef, 0, len(reps))
+				for _, rep := range reps {
+					row.Reports = append(row.Reports, components.AgentRunReportRef{
+						ShortID:  rep.ShortID,
+						Title:    rep.Title,
+						Priority: rep.Priority,
+					})
+				}
+			}
+		}
 
 		promptPrefix := ""
 		if run.PromptPrefix != nil {

--- a/internal/admin/agents_list_page.go
+++ b/internal/admin/agents_list_page.go
@@ -50,14 +50,19 @@ func AgentsListPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Tem
 		}
 
 		rows := make([]pages.AgentsListRowProps, 0, len(defs))
+		lastPrefixes := make(map[string]string, len(defs))
 		for _, d := range defs {
 			rows = append(rows, buildAgentsListRow(d))
+			if d.LastPromptPrefix != nil && *d.LastPromptPrefix != "" {
+				lastPrefixes[d.Slug] = *d.LastPromptPrefix
+			}
 		}
 
 		props := pages.AgentsListProps{
-			Agents:    rows,
-			Status:    buildAgentsListStatus(status),
-			CSRFToken: GetCSRFToken(r),
+			Agents:             rows,
+			Status:             buildAgentsListStatus(status),
+			LastPromptPrefixes: lastPrefixes,
+			CSRFToken:          GetCSRFToken(r),
 		}
 
 		data := BaseTemplateData(r, sm, "agents", "Agents")

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -174,16 +174,36 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			http.Redirect(w, r, "/settings/oauth-clients/"+chi.URLParam(r, "id")+"/created", http.StatusMovedPermanently)
 		})
 
-		// Agents — Claude Agent SDK admin pages. List, create/edit forms,
-		// run history, run detail (with NDJSON transcript). The v1 prompt
-		// library lives at /agent-prompts as a starter-prompt composer
-		// that hands off into /agents/new via copy-to-clipboard.
-		r.Get("/agents", AgentsListPageHandler(svc, sm, tr))
+		// Agents — Claude Agent SDK admin pages.
+		//
+		// IA: /agents is the **runs landing** (the most interesting
+		// surface; what happened, when, with what outcome). The Agents
+		// list (the definitions table) moves to /agents/definitions and
+		// both share a 2-tab nav rendered immediately below the
+		// PageHeader. /agents?agent=<slug> filters the runs feed to one
+		// agent, which subsumes the old /agents/{slug}/runs route.
+		// Legacy /agents/runs and /agents/{slug}/runs 301-redirect.
+		r.Get("/agents", AgentRunsListPageHandler(svc, sm, tr))
+		r.Get("/agents/definitions", AgentsListPageHandler(svc, sm, tr))
 		r.Get("/agents/new", AgentFormPageHandler(svc, sm, tr))
 		r.Get("/agents/{slug}/edit", AgentFormPageHandler(svc, sm, tr))
-		r.Get("/agents/{slug}/runs", AgentRunsListPageHandler(svc, sm, tr))
-		r.Get("/agents/runs", AgentRunsListPageHandler(svc, sm, tr))
 		r.Get("/agents/runs/{shortId}", AgentRunDetailPageHandler(svc, sm, tr))
+		r.Get("/agents/runs", func(w http.ResponseWriter, r *http.Request) {
+			// Preserve query params so bookmarked filter URLs still work.
+			target := "/agents"
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+		})
+		r.Get("/agents/{slug}/runs", func(w http.ResponseWriter, r *http.Request) {
+			slug := chi.URLParam(r, "slug")
+			target := "/agents?agent=" + slug
+			if r.URL.RawQuery != "" {
+				target += "&" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+		})
 
 		// Prompt library — the v1 wizard. Authors a starter prompt that
 		// gets pasted into the SDK agent form.

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -50,7 +50,7 @@ func CreateReportHandler(svc *service.Service) http.HandlerFunc {
 		}
 
 		actor := service.ActorFromContext(r.Context())
-		report, err := svc.CreateAgentReport(r.Context(), req.Title, req.Body, actor, req.Priority, req.Tags, req.Author, "")
+		report, err := svc.CreateAgentReport(r.Context(), req.Title, req.Body, actor, req.Priority, req.Tags, req.Author, "", "")
 		if err != nil {
 			writeServiceError(w, err, "", "Failed to create report")
 			return

--- a/internal/api/reports_parity_integration_test.go
+++ b/internal/api/reports_parity_integration_test.go
@@ -59,7 +59,7 @@ func TestGetReport_AllowsReadScope(t *testing.T) {
 	// wipe the seeded data.
 	env := setupReadOnlyEnv(t)
 	created, err := env.Service.CreateAgentReport(t.Context(), "Visible to read-only", "body",
-		service.Actor{Type: "agent", ID: "test-agent", Name: "Test"}, "info", nil, "", "")
+		service.Actor{Type: "agent", ID: "test-agent", Name: "Test"}, "info", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("CreateAgentReport: %v", err)
 	}

--- a/internal/db/migrations/20260525224008_link_reports_to_agent_runs.sql
+++ b/internal/db/migrations/20260525224008_link_reports_to_agent_runs.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- Link agent_reports rows to the agent_runs row that produced them.
+--
+-- An agent calls submit_report via MCP while it's running; the MCP
+-- server can resolve the surrounding run via the per-run minted API
+-- key name (`agent:<slug>:<run-short-id>`) and stamp the FK on the
+-- new row. The runs landing page reads the reverse — runs joined to
+-- reports — so the row can show a "Report: Title" chip inline.
+--
+-- The column is nullable because not every report comes from a run
+-- (operator-submitted reports, MCP sessions launched outside the
+-- agent SDK, future report sources). ON DELETE SET NULL preserves
+-- the report when its source run is purged by retention.
+ALTER TABLE agent_reports
+    ADD COLUMN agent_run_id UUID NULL REFERENCES agent_runs(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_agent_reports_agent_run_id
+    ON agent_reports (agent_run_id)
+    WHERE agent_run_id IS NOT NULL;
+
+-- Backfill: derive agent_run_id from the API key name format
+-- `agent:<slug>:<runShortID>` for reports that already have a
+-- session_id pointing at an MCP session for an agent run. Best-effort;
+-- rows without a matching key/run stay NULL.
+UPDATE agent_reports r
+SET agent_run_id = ar.id
+FROM mcp_sessions ms
+JOIN agent_runs ar ON ar.short_id = SPLIT_PART(ms.api_key_name, ':', 3)
+WHERE r.session_id = ms.id
+  AND r.agent_run_id IS NULL
+  AND ms.api_key_name LIKE 'agent:%:%';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_agent_reports_agent_run_id;
+ALTER TABLE agent_reports DROP COLUMN IF EXISTS agent_run_id;

--- a/internal/db/queries/agent_reports.sql
+++ b/internal/db/queries/agent_reports.sql
@@ -1,6 +1,6 @@
 -- name: CreateAgentReport :one
-INSERT INTO agent_reports (title, body, created_by_type, created_by_id, created_by_name, priority, tags, author, session_id)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+INSERT INTO agent_reports (title, body, created_by_type, created_by_id, created_by_name, priority, tags, author, session_id, agent_run_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING *;
 
 -- name: GetAgentReport :one
@@ -26,3 +26,18 @@ UPDATE agent_reports SET read_at = NOW() WHERE read_at IS NULL;
 
 -- name: DeleteAgentReport :exec
 DELETE FROM agent_reports WHERE id = $1;
+
+-- name: ListReportSummariesForRunIDs :many
+-- Returns short report summaries for a batch of agent_runs UUIDs.
+-- Powers the AgentRunRow chip on the runs landing — operators see
+-- "this run produced these reports" at a glance.
+SELECT
+    agent_run_id,
+    id,
+    short_id,
+    title,
+    priority,
+    created_at
+FROM agent_reports
+WHERE agent_run_id = ANY($1::uuid[])
+ORDER BY created_at ASC;

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -194,3 +194,17 @@ WHERE started_at < $1
 
 -- name: CountInProgressAgentRuns :one
 SELECT COUNT(*) FROM agent_runs WHERE status = 'in_progress';
+
+-- name: GetAgentRunsExtraStats30d :one
+-- Cross-agent 30-day rollup of error count + average duration. Powers
+-- the StatTile row on the /agents landing. Skipped runs (quiet hours,
+-- concurrency lock) are excluded from the duration average — they
+-- aren't real workload and distort it — but are *not* excluded from
+-- the error count (which already filters on status = 'error').
+SELECT
+    COUNT(*) FILTER (WHERE status = 'error')::int        AS error_count,
+    (COALESCE(AVG(duration_ms) FILTER (
+        WHERE status != 'skipped' AND duration_ms IS NOT NULL
+    ), 0)::float8 / 1000.0)::float8                      AS avg_duration_seconds
+FROM agent_runs
+WHERE started_at >= NOW() - INTERVAL '30 days';

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -550,7 +550,12 @@ func (s *MCPServer) handleSubmitReport(reqCtx context.Context, _ *mcpsdk.CallToo
 	// context. Reports created via submit_report still link back to the
 	// surrounding session row in the audit timeline.
 	sessionID := auditSessionFromContext(reqCtx)
-	report, err := s.svc.CreateAgentReport(ctx, input.Title, input.Body, actor, input.Priority, input.Tags, input.Author, sessionID)
+	// When this call is running under a per-run agent API key,
+	// agentRunShortID resolves to the surrounding agent_runs.short_id
+	// — the service stamps the FK on the new report so the runs
+	// landing can render "this run produced these reports" chips.
+	agentRunShortID := service.AgentRunShortIDFromContext(reqCtx)
+	report, err := s.svc.CreateAgentReport(ctx, input.Title, input.Body, actor, input.Priority, input.Tags, input.Author, sessionID, agentRunShortID)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/service/actor.go
+++ b/internal/service/actor.go
@@ -75,6 +75,36 @@ func ContextWithAPIKeyLegacy(ctx context.Context, id, name string) context.Conte
 	})
 }
 
+// AgentRunShortIDFromContext returns the agent_runs.short_id this
+// request is acting under, derived from the API key's name. Returns
+// "" when the request isn't running under a per-run agent key.
+//
+// API keys minted by Orchestrator.MintRunAPIKey are named
+// "agent:<slug>:<runShortID>" (see internal/service/agents.go). Any
+// future change to that format must update this parser in lock-step.
+func AgentRunShortIDFromContext(ctx context.Context) string {
+	v, ok := ctx.Value(ctxKeyAPIKey).(apiKeyCtxValue)
+	if !ok {
+		return ""
+	}
+	const prefix = "agent:"
+	if len(v.name) <= len(prefix) || v.name[:len(prefix)] != prefix {
+		return ""
+	}
+	rest := v.name[len(prefix):]
+	lastColon := -1
+	for i := len(rest) - 1; i >= 0; i-- {
+		if rest[i] == ':' {
+			lastColon = i
+			break
+		}
+	}
+	if lastColon < 0 || lastColon == len(rest)-1 {
+		return ""
+	}
+	return rest[lastColon+1:]
+}
+
 // ActorFromContext builds an Actor from the request context.
 // The actor's Type reflects the API key's actor_type column ('user',
 // 'agent', or 'system'). Display name falls back to the API key's own

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -717,6 +717,29 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 	}, nil
 }
 
+// AgentRunsExtraStats30d is the cross-agent rollup that powers the
+// "Errors" + "Avg duration" StatTiles on /agents. Cost + run count
+// come from per-agent CostStats30d rolled up on the caller side; we
+// don't duplicate them here.
+type AgentRunsExtraStats30d struct {
+	ErrorCount         int     `json:"error_count"`
+	AvgDurationSeconds float64 `json:"avg_duration_seconds"`
+}
+
+// GetAgentRunsExtraStats30d returns the 30-day error count + average
+// duration across every agent's runs. Excludes skipped rows from the
+// duration calculation since they have no real workload.
+func (s *Service) GetAgentRunsExtraStats30d(ctx context.Context) (*AgentRunsExtraStats30d, error) {
+	row, err := s.Queries.GetAgentRunsExtraStats30d(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get agent runs extra stats: %w", err)
+	}
+	return &AgentRunsExtraStats30d{
+		ErrorCount:         int(row.ErrorCount),
+		AvgDurationSeconds: row.AvgDurationSeconds,
+	}, nil
+}
+
 // AllAgentRunListParams carries the optional filters for ListAllAgentRuns.
 // Mirrors AgentRunListParams but adds AgentSlugOrID so the caller can
 // optionally narrow to one agent (e.g. the global view with an agent

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -753,7 +753,7 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		actor := service.Actor{Type: "agent", ID: actorID, Name: "ReportingAgent"}
 		report, err := svc.CreateAgentReport(ctx, "Reviewed and cleared 8 transactions",
 			"All 8 looked clean.",
-			actor, "info", []string{"review"}, "", "")
+			actor, "info", []string{"review"}, "", "", "")
 		if err != nil {
 			t.Fatalf("CreateAgentReport: %v", err)
 		}

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -11,6 +11,7 @@ import (
 	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // AgentReportResponse is the API response type for agent reports.
@@ -69,8 +70,11 @@ var ValidReportPriorities = map[string]bool{
 	"critical": true,
 }
 
-// CreateAgentReport creates a new agent report, optionally linked to an MCP session.
-func (s *Service) CreateAgentReport(ctx context.Context, title, body string, actor Actor, priority string, tags []string, author string, sessionID string) (AgentReportResponse, error) {
+// CreateAgentReport creates a new agent report, optionally linked to
+// an MCP session and an agent run. agentRunShortID resolves to the
+// agent_runs.id FK on the new row; empty leaves it NULL (operator-
+// submitted reports, MCP sessions outside the agent SDK).
+func (s *Service) CreateAgentReport(ctx context.Context, title, body string, actor Actor, priority string, tags []string, author string, sessionID string, agentRunShortID string) (AgentReportResponse, error) {
 	if title == "" {
 		return AgentReportResponse{}, fmt.Errorf("%w: title is required", ErrInvalidParameter)
 	}
@@ -97,6 +101,13 @@ func (s *Service) CreateAgentReport(ctx context.Context, title, body string, act
 
 	sessUUID, _ := s.ResolveSessionUUID(ctx, sessionID)
 
+	var runUUID pgtype.UUID
+	if agentRunShortID != "" {
+		if run, err := s.Queries.GetAgentRunByShortID(ctx, agentRunShortID); err == nil {
+			runUUID = run.ID
+		}
+	}
+
 	report, err := s.Queries.CreateAgentReport(ctx, db.CreateAgentReportParams{
 		Title:         title,
 		Body:          body,
@@ -107,12 +118,63 @@ func (s *Service) CreateAgentReport(ctx context.Context, title, body string, act
 		Tags:          tags,
 		Author:        pgconv.TextIfNotEmpty(author),
 		SessionID:     sessUUID,
+		AgentRunID:    runUUID,
 	})
 	if err != nil {
 		return AgentReportResponse{}, fmt.Errorf("create agent report: %w", err)
 	}
 
 	return agentReportFromRow(report), nil
+}
+
+// AgentRunReportSummary is the compact report-reference shape rendered
+// inside an AgentRunRow chip on the runs landing. We deliberately
+// don't carry the body — opening the report is one click away — so
+// the row stays light and the page-level query is small.
+type AgentRunReportSummary struct {
+	ShortID  string
+	Title    string
+	Priority string
+}
+
+// ListReportSummariesForRunIDs fetches the report-summary chip data
+// for a batch of agent_runs.id UUIDs in one query. Returns a map
+// keyed by run-id (canonical UUID string); runs with no reports are
+// absent from the map. Reports inside each slice are ordered oldest →
+// newest so the chip line reads chronologically when an agent
+// produces multiple reports per run.
+func (s *Service) ListReportSummariesForRunIDs(ctx context.Context, runIDs []string) (map[string][]AgentRunReportSummary, error) {
+	out := make(map[string][]AgentRunReportSummary, len(runIDs))
+	if len(runIDs) == 0 {
+		return out, nil
+	}
+	uuids := make([]pgtype.UUID, 0, len(runIDs))
+	for _, id := range runIDs {
+		u, err := pgconv.ParseUUID(id)
+		if err != nil {
+			continue
+		}
+		uuids = append(uuids, u)
+	}
+	if len(uuids) == 0 {
+		return out, nil
+	}
+	rows, err := s.Queries.ListReportSummariesForRunIDs(ctx, uuids)
+	if err != nil {
+		return nil, fmt.Errorf("list report summaries for runs: %w", err)
+	}
+	for _, r := range rows {
+		if !r.AgentRunID.Valid {
+			continue
+		}
+		runID := pgconv.FormatUUID(r.AgentRunID)
+		out[runID] = append(out[runID], AgentRunReportSummary{
+			ShortID:  r.ShortID,
+			Title:    r.Title,
+			Priority: r.Priority,
+		})
+	}
+	return out, nil
 }
 
 // ListAgentReports returns the most recent reports.

--- a/internal/service/reports_integration_test.go
+++ b/internal/service/reports_integration_test.go
@@ -15,7 +15,7 @@ func TestCreateAgentReport_Success(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "agent-1", Name: "TestAgent"}
 
-	report, err := svc.CreateAgentReport(context.Background(), "Test Report", "Report body content", actor, "info", []string{"tag1"}, "", "")
+	report, err := svc.CreateAgentReport(context.Background(), "Test Report", "Report body content", actor, "info", []string{"tag1"}, "", "", "")
 	if err != nil {
 		t.Fatalf("CreateAgentReport: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestCreateAgentReport_DefaultPriority(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "agent-1", Name: "TestAgent"}
 
-	report, err := svc.CreateAgentReport(context.Background(), "Test", "Body", actor, "", nil, "", "")
+	report, err := svc.CreateAgentReport(context.Background(), "Test", "Body", actor, "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("CreateAgentReport: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestCreateAgentReport_WithAuthorOverride(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "agent-1", Name: "DefaultName"}
 
-	report, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "warning", nil, "CustomAuthor", "")
+	report, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "warning", nil, "CustomAuthor", "", "")
 	if err != nil {
 		t.Fatalf("CreateAgentReport: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestCreateAgentReport_MissingTitle(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "agent-1", Name: "TestAgent"}
 
-	_, err := svc.CreateAgentReport(context.Background(), "", "Body", actor, "info", nil, "", "")
+	_, err := svc.CreateAgentReport(context.Background(), "", "Body", actor, "info", nil, "", "", "")
 	if err == nil {
 		t.Fatal("expected error for missing title")
 	}
@@ -88,7 +88,7 @@ func TestCreateAgentReport_MissingBody(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "agent-1", Name: "TestAgent"}
 
-	_, err := svc.CreateAgentReport(context.Background(), "Title", "", actor, "info", nil, "", "")
+	_, err := svc.CreateAgentReport(context.Background(), "Title", "", actor, "info", nil, "", "", "")
 	if err == nil {
 		t.Fatal("expected error for missing body")
 	}
@@ -98,7 +98,7 @@ func TestCreateAgentReport_InvalidPriority(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "agent-1", Name: "TestAgent"}
 
-	_, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "urgent", nil, "", "")
+	_, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "urgent", nil, "", "", "")
 	if err == nil {
 		t.Fatal("expected error for invalid priority")
 	}
@@ -112,7 +112,7 @@ func TestCreateAgentReport_TooManyTags(t *testing.T) {
 		tags[i] = "tag"
 	}
 
-	_, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "info", tags, "", "")
+	_, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "info", tags, "", "", "")
 	if err == nil {
 		t.Fatal("expected error for too many tags")
 	}
@@ -134,7 +134,7 @@ func TestListAgentReports_WithData(t *testing.T) {
 	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
 
 	for i := 0; i < 3; i++ {
-		_, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "")
+		_, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "", "")
 		if err != nil {
 			t.Fatalf("create report %d: %v", i, err)
 		}
@@ -185,7 +185,7 @@ func TestCountUnreadAgentReports_WithReports(t *testing.T) {
 	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
 
 	for i := 0; i < 3; i++ {
-		_, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "")
+		_, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "", "")
 		if err != nil {
 			t.Fatalf("create report %d: %v", i, err)
 		}
@@ -204,7 +204,7 @@ func TestMarkAgentReportRead(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
 
-	report, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "")
+	report, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("CreateAgentReport: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestMarkAllAgentReportsRead(t *testing.T) {
 	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
 
 	for i := 0; i < 3; i++ {
-		_, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "")
+		_, err := svc.CreateAgentReport(context.Background(), "Report", "Body", actor, "info", nil, "", "", "")
 		if err != nil {
 			t.Fatalf("create report %d: %v", i, err)
 		}
@@ -260,8 +260,8 @@ func TestListUnreadAgentReports(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
 
-	report1, _ := svc.CreateAgentReport(context.Background(), "R1", "Body1", actor, "info", nil, "", "")
-	_, _ = svc.CreateAgentReport(context.Background(), "R2", "Body2", actor, "warning", nil, "", "")
+	report1, _ := svc.CreateAgentReport(context.Background(), "R1", "Body1", actor, "info", nil, "", "", "")
+	_, _ = svc.CreateAgentReport(context.Background(), "R2", "Body2", actor, "warning", nil, "", "", "")
 
 	// Mark one as read
 	svc.MarkAgentReportRead(context.Background(), report1.ID)
@@ -300,7 +300,7 @@ func TestCreateAgentReport_AllPriorities(t *testing.T) {
 		t.Run(p, func(t *testing.T) {
 			// Tables are NOT truncated between sub-tests, so all 3 accumulate.
 			// We just validate creation works.
-			report, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, p, nil, "", "")
+			report, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, p, nil, "", "", "")
 			if err != nil {
 				t.Fatalf("create report with priority %q: %v", p, err)
 			}

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -1,0 +1,371 @@
+package components
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// AgentRunRowProps is the view-model for a single agent-run row across
+// the runs list, per-agent runs view, and the design sandbox. It lives
+// in the components package (rather than pages) so anything that lists
+// agent runs renders the same shape.
+//
+// Numeric pointer fields on service.AgentRunResponse are flattened to
+// plain values here — handlers convert nil → zero so the templ doesn't
+// nil-check on every cell. AgentName/AgentSlug are empty in per-agent
+// contexts where the surrounding page already names the agent.
+type AgentRunRowProps struct {
+	ShortID    string
+	AgentSlug  string
+	AgentName  string
+	Status     string // success | error | in_progress | skipped | timeout
+	Trigger    string // cron | manual | webhook | initial
+	StartedAt  time.Time
+	FinishedAt *time.Time
+	DurationMs int64
+	CostUSD    float64
+	TokensIn   int64
+	TokensOut  int64
+	HitCap     string
+	Turns      int
+	Note       string
+
+	// ErrorMessage is the raw error_message column. Empty for non-errored
+	// runs. ErrorMessageFriendly is the operator-friendly translation;
+	// empty when no special mapping applies, in which case the raw message
+	// should be rendered as-is.
+	ErrorMessage         string
+	ErrorMessageFriendly string
+
+	// ShowAgent controls whether the row prefixes the run with the agent
+	// name. False when the surrounding page already scopes to one agent.
+	ShowAgent bool
+
+	// Reports lists agent_reports submitted during this run, most recent
+	// first. Rendered as inline chips below the meta line — the operator
+	// can click straight into the report without opening the run.
+	Reports []AgentRunReportRef
+}
+
+// AgentRunReportRef is the lightweight reference rendered on a row when
+// the run produced one or more reports. Only the fields the chip needs;
+// the report-detail page owns the full body.
+type AgentRunReportRef struct {
+	ShortID  string
+	Title    string
+	Priority string // info | warning | critical (drives chip tone)
+}
+
+// AgentRunRow renders one run as a rich row inside a vertical list.
+// Clicking anywhere routes to /agents/runs/{shortId}. Replaces the
+// dense table rows previously rendered inline on the runs page; the
+// new shape pairs an icon tile with status/trigger metadata on the
+// left and a cost/duration block on the right.
+//
+// Standalone: meant to be wrapped in @AgentRunRowList, which paints
+// the rounded container + divider so siblings stack cleanly.
+templ AgentRunRow(p AgentRunRowProps) {
+	<a
+		href={ templ.SafeURL("/agents/runs/" + p.ShortID) }
+		class={ "block px-4 py-3 hover:bg-base-200/40 transition-colors no-underline", templ.KV("opacity-70", p.Status == "skipped") }
+		data-run-short-id={ p.ShortID }
+	>
+		<div class="flex items-start gap-3">
+			@agentRunRowAvatar(p.Status)
+			<div class="min-w-0 flex-1">
+				<div class="flex items-center gap-2 flex-wrap">
+					if p.ShowAgent && p.AgentName != "" {
+						<span class="text-sm font-medium text-base-content truncate">{ p.AgentName }</span>
+						<span class="text-base-content/20">·</span>
+					}
+					<span class="font-mono text-[0.7rem] text-base-content/50 tabular-nums">{ p.ShortID }</span>
+					@AgentRunStatusBadge(p.Status)
+					if p.Trigger != "" {
+						<span class="badge badge-ghost badge-xs gap-1">
+							<i data-lucide={ agentRunTriggerIcon(p.Trigger) } class="w-2.5 h-2.5"></i>
+							{ p.Trigger }
+						</span>
+					}
+					if p.HitCap != "" {
+						<span class="badge badge-soft badge-warning badge-xs">cap: { p.HitCap }</span>
+					}
+				</div>
+				<div class="flex items-center gap-2 mt-1 text-xs text-base-content/50 flex-wrap">
+					<span class="tabular-nums" title={ p.StartedAt.Format(time.RFC3339) }>
+						{ agentRunRelativeTime(p.StartedAt) }
+					</span>
+					if p.DurationMs > 0 {
+						<span class="text-base-content/20">·</span>
+						<span class="tabular-nums">{ agentRunFormatDuration(p.DurationMs) }</span>
+					}
+					if p.Turns > 0 {
+						<span class="text-base-content/20">·</span>
+						<span class="tabular-nums">{ strconv.Itoa(p.Turns) } turns</span>
+					}
+					if p.TokensIn > 0 || p.TokensOut > 0 {
+						<span class="text-base-content/20 hidden sm:inline">·</span>
+						<span class="tabular-nums hidden sm:inline">{ agentRunFormatTokens(p.TokensIn, p.TokensOut) } tok</span>
+					}
+				</div>
+				if p.Status == "error" && (p.ErrorMessageFriendly != "" || p.ErrorMessage != "") {
+					<div class="mt-1.5 inline-flex items-start gap-1.5 text-xs text-error/90">
+						<i data-lucide="triangle-alert" class="w-3 h-3 mt-0.5 shrink-0"></i>
+						<span class="line-clamp-1">
+							if p.ErrorMessageFriendly != "" {
+								{ p.ErrorMessageFriendly }
+							} else {
+								{ p.ErrorMessage }
+							}
+						</span>
+					</div>
+				}
+				if len(p.Reports) > 0 {
+					<div class="mt-1.5 flex flex-wrap gap-1.5">
+						for _, rep := range p.Reports {
+							@agentRunReportChip(rep)
+						}
+					</div>
+				}
+				if p.Note != "" {
+					<div class="mt-1.5 inline-flex items-start gap-1.5 text-xs text-base-content/60">
+						<i data-lucide="sticky-note" class="w-3 h-3 mt-0.5 shrink-0 opacity-60"></i>
+						<span class="line-clamp-1 italic" title={ p.Note }>{ p.Note }</span>
+					</div>
+				}
+			</div>
+			<div class="shrink-0 text-right flex flex-col items-end gap-0.5">
+				@agentRunRowCost(p.CostUSD)
+				if p.FinishedAt != nil && !p.FinishedAt.IsZero() {
+					<span class="text-[0.65rem] text-base-content/40 tabular-nums hidden sm:inline">
+						finished { agentRunFinishedShort(*p.FinishedAt) }
+					</span>
+				} else if p.Status == "in_progress" {
+					<span class="text-[0.65rem] text-info/70 tabular-nums inline-flex items-center gap-1">
+						<span class="loading loading-spinner loading-xs"></span>
+						running
+					</span>
+				}
+			</div>
+		</div>
+	</a>
+}
+
+// AgentRunRowList wraps a series of AgentRunRow elements in the
+// canonical rounded surface + dividers. Pass the rows as the children
+// block:
+//
+//	@components.AgentRunRowList() {
+//	  for _, r := range rows {
+//	    @components.AgentRunRow(r)
+//	  }
+//	}
+templ AgentRunRowList() {
+	<div class="rounded-xl bg-base-100 border border-base-300 divide-y divide-base-200 overflow-hidden">
+		{ children... }
+	</div>
+}
+
+// AgentRunStatusBadge renders the status pill shared between the runs
+// list, run detail header, and the design sandbox. In-progress rows
+// carry a spinner; everything else is a soft daisy badge.
+templ AgentRunStatusBadge(status string) {
+	switch status {
+		case "success":
+			<span class="badge badge-soft badge-success badge-xs">success</span>
+		case "error":
+			<span class="badge badge-soft badge-error badge-xs">error</span>
+		case "in_progress":
+			<span class="badge badge-soft badge-info badge-xs gap-1">
+				<span class="loading loading-spinner loading-xs"></span>
+				running
+			</span>
+		case "skipped":
+			<span class="badge badge-ghost badge-xs">skipped</span>
+		case "timeout":
+			<span class="badge badge-soft badge-error badge-xs">timeout</span>
+		default:
+			<span class="badge badge-ghost badge-xs">{ status }</span>
+	}
+}
+
+// agentRunRowAvatar renders the leading icon tile. The tone tracks the
+// run status so the row reads as a colored "stoplight" at a glance.
+templ agentRunRowAvatar(status string) {
+	<div class={ "w-9 h-9 rounded-lg flex items-center justify-center shrink-0", agentRunAvatarTone(status) }>
+		<i data-lucide={ agentRunAvatarIcon(status) } class={ "w-4 h-4", agentRunAvatarIconColor(status) }></i>
+	</div>
+}
+
+// agentRunReportChip renders a single report reference as a clickable
+// pill that stops propagation so it doesn't bubble up to the parent
+// row's link. Tone shifts with priority — critical/warning lift out of
+// the neutral palette so the operator can spot them without scanning.
+templ agentRunReportChip(r AgentRunReportRef) {
+	<a
+		href={ templ.SafeURL("/reports/" + r.ShortID) }
+		class={ "inline-flex items-center gap-1.5 max-w-full text-xs rounded-md border px-2 py-0.5 hover:bg-base-200/60 no-underline transition-colors", agentRunReportChipTone(r.Priority) }
+		@click.stop=""
+		title={ "Report: " + r.Title }
+	>
+		<i data-lucide={ agentRunReportChipIcon(r.Priority) } class="w-3 h-3 shrink-0"></i>
+		<span class="line-clamp-1">{ r.Title }</span>
+	</a>
+}
+
+func agentRunReportChipTone(priority string) string {
+	switch priority {
+	case "critical":
+		return "border-error/30 text-error bg-error/5"
+	case "warning":
+		return "border-warning/30 text-warning bg-warning/5"
+	default:
+		return "border-base-300 text-base-content/70 bg-base-100"
+	}
+}
+
+func agentRunReportChipIcon(priority string) string {
+	switch priority {
+	case "critical":
+		return "alert-octagon"
+	case "warning":
+		return "alert-triangle"
+	default:
+		return "file-text"
+	}
+}
+
+// agentRunRowCost renders the cost cell. Zero/negative costs collapse
+// to a thin em-dash so empty rows don't carry visual weight.
+templ agentRunRowCost(v float64) {
+	if v > 0 {
+		@Amount(AmountProps{
+			Value:     v,
+			Intent:    AmountCost,
+			Precision: 4,
+			Class:     "text-sm font-semibold",
+		})
+	} else {
+		<span class="text-sm text-base-content/30">—</span>
+	}
+}
+
+func agentRunAvatarTone(status string) string {
+	switch status {
+	case "success":
+		return "bg-success/10"
+	case "error", "timeout":
+		return "bg-error/10"
+	case "in_progress":
+		return "bg-info/10"
+	case "skipped":
+		return "bg-base-200/60"
+	default:
+		return "bg-base-200/60"
+	}
+}
+
+func agentRunAvatarIcon(status string) string {
+	switch status {
+	case "success":
+		return "check"
+	case "error":
+		return "x"
+	case "timeout":
+		return "clock-alert"
+	case "in_progress":
+		return "loader"
+	case "skipped":
+		return "circle-dashed"
+	default:
+		return "bot"
+	}
+}
+
+func agentRunAvatarIconColor(status string) string {
+	switch status {
+	case "success":
+		return "text-success"
+	case "error", "timeout":
+		return "text-error"
+	case "in_progress":
+		return "text-info"
+	default:
+		return "text-base-content/50"
+	}
+}
+
+func agentRunTriggerIcon(trigger string) string {
+	switch trigger {
+	case "cron":
+		return "clock"
+	case "manual":
+		return "hand"
+	case "webhook":
+		return "webhook"
+	case "initial":
+		return "play"
+	default:
+		return "circle"
+	}
+}
+
+// agentRunRelativeTime renders a compact "3m ago" / "2h ago" / "Jan 2"
+// label for a started-at instant. Same algorithm as
+// agentsListRelativeTime in pages; duplicated here so the components
+// package has no upward dependency on pages.
+func agentRunRelativeTime(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	default:
+		return t.Format("Jan 2")
+	}
+}
+
+func agentRunFinishedShort(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Format("15:04")
+}
+
+func agentRunFormatDuration(ms int64) string {
+	if ms <= 0 {
+		return "—"
+	}
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	secs := float64(ms) / 1000.0
+	if secs < 60 {
+		return fmt.Sprintf("%.1fs", secs)
+	}
+	mins := secs / 60.0
+	return fmt.Sprintf("%.1fm", mins)
+}
+
+func agentRunFormatTokens(in, out int64) string {
+	return fmt.Sprintf("%s / %s", agentRunAbbrev(in), agentRunAbbrev(out))
+}
+
+func agentRunAbbrev(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fk", float64(n)/1_000)
+	default:
+		return strconv.FormatInt(n, 10)
+	}
+}

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -8,58 +8,100 @@ import (
 	"breadbox/internal/templates/components"
 )
 
-// AgentRunsList renders the v1 admin run-history page. Two modes share the
-// same component:
-//   - "global": cross-agent view at /agents/runs.
-//   - "agent":  per-agent view at /agents/{slug}/runs.
+// AgentRunsList renders the v1 admin runs landing page at /agents.
+// One mode: the global, cross-agent feed. The ?agent=<slug> URL
+// parameter scopes the list to a single agent (the link from the
+// Agents-tab table and the per-agent edit page passes it through),
+// and the filter chip in the toolbar surfaces the scope so the
+// operator knows what they're looking at.
 //
-// The handler in internal/admin/agent_runs_page.go decides which based on
-// the URL and fills AgentSlug/AgentName/AgentOptions accordingly.
+// Layout, top-down:
+//   1. PageHeader with the "Run an agent" + "New agent" actions.
+//   2. agentsTabBar — Runs (active) / Agents.
+//   3. agentRunsStats — 4-up StatTileRow (30d rollup).
+//   4. agentRunsFilterBar — collapsed under a summary by default.
+//   5. agentRunRowList — rich rows via @components.AgentRunRow.
+//   6. agentRunsPagination — daisy join paginator.
+//   7. agentRunModal — server-rendered, opened by the header button.
 templ AgentRunsList(p AgentRunsListProps) {
-	<div x-data x-init="$store.shortcuts.setScope('agent-runs')" x-destroy="$store.shortcuts.setScope('global')"></div>
-	if p.Mode == "agent" {
-		@components.BreadcrumbNav([]components.Breadcrumb{
-			{Label: "Agents", Href: "/agents"},
-			{Label: p.AgentName, Href: "/agents/" + p.AgentSlug + "/edit"},
-			{Label: "Runs"},
+	<script src="/static/js/admin/components/agents_run_modal.js"></script>
+	<div x-data x-init="$store.shortcuts.setScope('agents')" x-destroy="$store.shortcuts.setScope('global')"></div>
+	@components.PageHeader(components.PageHeaderProps{
+		Title:                "Agents",
+		Subtitle:             "Scheduled AI runs that read and act on your Breadbox via MCP.",
+		SubtitleHideOnMobile: true,
+		Action:               agentsHeaderActions("agents-run-modal", len(p.AgentOptions) == 0),
+	})
+	@agentsTabBar("runs")
+	<div class="mt-4">
+		@agentRunsStats(p.Stats)
+		@agentRunsFilterBar(p)
+		if len(p.Rows) > 0 {
+			@agentRunRowsCard(p)
+			@agentRunsPagination(p)
+		} else {
+			@agentRunsEmpty(p)
+		}
+	</div>
+	@agentRunModal(agentRunModalProps{
+		ModalID:            "agents-run-modal",
+		CSRFToken:          p.CSRFToken,
+		Options:            enabledAgentOptions(p.AgentOptions),
+		LastPromptPrefixes: p.LastPromptPrefixes,
+	})
+}
+
+templ agentRunsStats(s AgentRunsStatsProps) {
+	@components.StatTileRow() {
+		@components.StatTile(components.StatTileProps{
+			Icon:        "history",
+			Label:       "Runs · 30d",
+			Value:       commaInt(int64(s.RunCount30d)),
+			Description: agentRunsStatsRunDescription(s),
+			Tone:        components.StatToneNeutral,
 		})
-	} else {
-		@components.BreadcrumbNav([]components.Breadcrumb{
-			{Label: "Agents", Href: "/agents"},
-			{Label: "Run history"},
+		@components.StatTile(components.StatTileProps{
+			Icon:        "triangle-alert",
+			Label:       "Errors · 30d",
+			Value:       commaInt(int64(s.ErrorCount30d)),
+			Description: agentRunsStatsErrorDescription(s),
+			Tone:        agentRunsErrorTone(s),
 		})
-	}
-	@agentRunsHeader(p)
-	@agentRunsFilterBar(p)
-	if len(p.Rows) > 0 {
-		@agentRunsTable(p)
-		@agentRunsPagination(p)
-	} else {
-		@agentRunsEmpty(p)
+		@components.StatTile(components.StatTileProps{
+			Icon:        "dollar-sign",
+			Label:       "Cost · 30d",
+			Value:       agentRunsFormatMoney(s.TotalCostUSD30d),
+			Description: "Across every completed run",
+			Tone:        components.StatToneNeutral,
+		})
+		@components.StatTile(components.StatTileProps{
+			Icon:        "timer",
+			Label:       "Avg duration",
+			Value:       agentRunsFormatAvgDuration(s.AvgDurationSeconds),
+			Description: "Per non-skipped run",
+			Tone:        components.StatToneNeutral,
+		})
 	}
 }
 
-templ agentRunsHeader(p AgentRunsListProps) {
-	if p.Mode == "agent" {
-		@components.PageHeader(components.PageHeaderProps{
-			Title:                "Runs — " + p.AgentName,
-			Subtitle:             "History of every run, manual or scheduled, for this agent.",
-			SubtitleHideOnMobile: true,
-		})
-	} else {
-		@components.PageHeader(components.PageHeaderProps{
-			Title:                "Run history",
-			Subtitle:             "All agent runs across the household.",
-			SubtitleHideOnMobile: true,
-		})
-	}
-}
-
+// agentRunsFilterBar wraps the filter form in a daisy collapse so the
+// page doesn't carry a tall block of inputs above the feed. The
+// summary line shows the active filter chips so the operator can see
+// what's applied without expanding.
 templ agentRunsFilterBar(p AgentRunsListProps) {
-	<div class="bb-card mb-6 p-4">
-		<form method="GET" action={ templ.SafeURL(agentRunsFormAction(p)) } class="bb-filter-form">
-			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-3 mb-3">
-				if p.Mode == "global" {
+	<details class="collapse collapse-arrow bg-base-100 border border-base-300 rounded-xl mt-4 mb-4" if agentRunsHasActiveFilter(p) {
+		open
+	}>
+		<summary class="collapse-title text-sm font-medium">
+			<div class="flex items-center gap-2 flex-wrap">
+				<i data-lucide="filter" class="w-4 h-4 text-base-content/50"></i>
+				<span>Filters</span>
+				@agentRunsActiveChips(p)
+			</div>
+		</summary>
+		<div class="collapse-content">
+			<form method="GET" action="/agents" class="bb-filter-form pt-1">
+				<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-3 mb-3">
 					<label class="bb-filter-label">
 						Agent
 						<select name="agent" class="select select-sm w-full">
@@ -69,54 +111,78 @@ templ agentRunsFilterBar(p AgentRunsListProps) {
 							}
 						</select>
 					</label>
-				}
-				<label class="bb-filter-label">
-					Status
-					<select name="status" class="select select-sm w-full">
-						<option value="">All statuses</option>
-						@agentRunsSelectOption("success", "Success", p.Filters.Status)
-						@agentRunsSelectOption("error", "Error", p.Filters.Status)
-						@agentRunsSelectOption("in_progress", "In progress", p.Filters.Status)
-						@agentRunsSelectOption("skipped", "Skipped", p.Filters.Status)
-						@agentRunsSelectOption("timeout", "Timeout", p.Filters.Status)
-					</select>
-				</label>
-				<label class="bb-filter-label">
-					Trigger
-					<select name="trigger" class="select select-sm w-full">
-						<option value="">All triggers</option>
-						@agentRunsSelectOption("cron", "Cron", p.Filters.Trigger)
-						@agentRunsSelectOption("manual", "Manual", p.Filters.Trigger)
-						@agentRunsSelectOption("webhook", "Webhook", p.Filters.Trigger)
-					</select>
-				</label>
-				<label class="bb-filter-label">
-					Hit cap
-					<select name="hit_cap" class="select select-sm w-full">
-						<option value="">All</option>
-						@agentRunsSelectOption("any", "Any cap", p.Filters.HitCap)
-						@agentRunsSelectOption("max_turns", "Max turns", p.Filters.HitCap)
-						@agentRunsSelectOption("max_budget", "Max budget", p.Filters.HitCap)
-					</select>
-				</label>
-				<label class="bb-filter-label">
-					Start
-					<input type="date" name="start" value={ p.Filters.Start } class="input input-sm w-full"/>
-				</label>
-				<label class="bb-filter-label">
-					End
-					<input type="date" name="end" value={ p.Filters.End } class="input input-sm w-full"/>
-				</label>
-			</div>
-			<div class="bb-filter-actions flex items-center gap-2">
-				<button type="submit" class="btn btn-sm btn-primary">
-					<i data-lucide="filter" class="w-3.5 h-3.5"></i>
-					Apply
-				</button>
-				<a href={ templ.SafeURL(agentRunsFormAction(p)) } class="btn btn-sm btn-ghost">Clear</a>
-			</div>
-		</form>
-	</div>
+					<label class="bb-filter-label">
+						Status
+						<select name="status" class="select select-sm w-full">
+							<option value="">All statuses</option>
+							@agentRunsSelectOption("success", "Success", p.Filters.Status)
+							@agentRunsSelectOption("error", "Error", p.Filters.Status)
+							@agentRunsSelectOption("in_progress", "In progress", p.Filters.Status)
+							@agentRunsSelectOption("skipped", "Skipped", p.Filters.Status)
+							@agentRunsSelectOption("timeout", "Timeout", p.Filters.Status)
+						</select>
+					</label>
+					<label class="bb-filter-label">
+						Trigger
+						<select name="trigger" class="select select-sm w-full">
+							<option value="">All triggers</option>
+							@agentRunsSelectOption("cron", "Cron", p.Filters.Trigger)
+							@agentRunsSelectOption("manual", "Manual", p.Filters.Trigger)
+							@agentRunsSelectOption("webhook", "Webhook", p.Filters.Trigger)
+						</select>
+					</label>
+					<label class="bb-filter-label">
+						Hit cap
+						<select name="hit_cap" class="select select-sm w-full">
+							<option value="">All</option>
+							@agentRunsSelectOption("any", "Any cap", p.Filters.HitCap)
+							@agentRunsSelectOption("max_turns", "Max turns", p.Filters.HitCap)
+							@agentRunsSelectOption("max_budget", "Max budget", p.Filters.HitCap)
+						</select>
+					</label>
+					<label class="bb-filter-label">
+						Start
+						<input type="date" name="start" value={ p.Filters.Start } class="input input-sm w-full"/>
+					</label>
+					<label class="bb-filter-label">
+						End
+						<input type="date" name="end" value={ p.Filters.End } class="input input-sm w-full"/>
+					</label>
+				</div>
+				<div class="bb-filter-actions flex items-center gap-2">
+					<button type="submit" class="btn btn-sm btn-primary">
+						<i data-lucide="filter" class="w-3.5 h-3.5"></i>
+						Apply
+					</button>
+					<a href="/agents" class="btn btn-sm btn-ghost">Clear</a>
+				</div>
+			</form>
+		</div>
+	</details>
+}
+
+// agentRunsActiveChips renders the small "filtered by X" pill row
+// shown inside the collapse summary so the operator can see active
+// scope without expanding the form.
+templ agentRunsActiveChips(p AgentRunsListProps) {
+	if p.Filters.AgentSlug != "" {
+		<span class="badge badge-soft badge-primary badge-xs gap-1">
+			<i data-lucide="bot" class="w-2.5 h-2.5"></i>
+			{ agentRunsResolveAgentName(p, p.Filters.AgentSlug) }
+		</span>
+	}
+	if p.Filters.Status != "" {
+		<span class="badge badge-soft badge-info badge-xs">{ p.Filters.Status }</span>
+	}
+	if p.Filters.Trigger != "" {
+		<span class="badge badge-ghost badge-xs">{ p.Filters.Trigger }</span>
+	}
+	if p.Filters.HitCap != "" {
+		<span class="badge badge-soft badge-warning badge-xs">cap: { p.Filters.HitCap }</span>
+	}
+	if p.Filters.Start != "" || p.Filters.End != "" {
+		<span class="badge badge-ghost badge-xs">{ agentRunsDateRangeLabel(p.Filters) }</span>
+	}
 }
 
 templ agentRunsSelectOption(value, label, current string) {
@@ -127,101 +193,19 @@ templ agentRunsSelectOption(value, label, current string) {
 	}
 }
 
-templ agentRunsTable(p AgentRunsListProps) {
-	<div class="overflow-x-auto rounded-xl bg-base-100 border border-base-300">
-		<table class="table table-sm table-zebra-soft">
-			<thead>
-				<tr class="text-xs text-base-content/50">
-					<th class="font-medium">Run</th>
-					if p.Mode == "global" {
-						<th class="font-medium">Agent</th>
-					}
-					<th class="font-medium">Status</th>
-					<th class="font-medium">Trigger</th>
-					<th class="font-medium">Started</th>
-					<th class="font-medium text-right">Duration</th>
-					<th class="font-medium text-right">Turns</th>
-					<th class="font-medium text-right">Cost</th>
-					<th class="font-medium text-right">In / Out</th>
-					<th class="font-medium">Hit cap</th>
-					<th class="font-medium">Note</th>
-				</tr>
-			</thead>
-			<tbody>
-				for _, row := range p.Rows {
-					@agentRunsRow(row, p.Mode)
-				}
-			</tbody>
-		</table>
-	</div>
-}
-
-templ agentRunsRow(r AgentRunRowProps, mode string) {
-	<tr class="hover:bg-base-200/40">
-		<td class="align-middle">
-			<a href={ templ.SafeURL(fmt.Sprintf("/agents/runs/%s", r.ShortID)) } class="font-mono text-xs text-primary hover:underline">
-				{ r.ShortID }
-			</a>
-		</td>
-		if mode == "global" {
-			<td class="align-middle">
-				<a href={ templ.SafeURL(fmt.Sprintf("/agents/%s/runs", r.AgentSlug)) } class="text-sm hover:underline">
-					{ r.AgentName }
-				</a>
-			</td>
+// agentRunRowsCard renders the run feed itself. Wraps every row in
+// the shared components.AgentRunRowList so the surface treatment +
+// divider is consistent with future list pages.
+templ agentRunRowsCard(p AgentRunsListProps) {
+	@components.AgentRunRowList() {
+		for _, r := range p.Rows {
+			@components.AgentRunRow(rowWithAgentToggle(r, p.Filters.AgentSlug == ""))
 		}
-		<td class="align-middle">@agentRunStatusBadge(r.Status)</td>
-		<td class="align-middle"><span class="text-xs text-base-content/70">{ r.Trigger }</span></td>
-		<td class="align-middle">
-			<span class="text-xs tabular-nums" title={ r.StartedAt.Format(time.RFC3339) }>
-				{ formatAgentRunStarted(r.StartedAt) }
-			</span>
-		</td>
-		<td class="align-middle text-right tabular-nums text-xs">{ formatAgentRunDuration(r.DurationMs) }</td>
-		<td class="align-middle text-right tabular-nums text-xs">{ strconv.Itoa(r.Turns) }</td>
-		<td class="align-middle text-right text-xs tabular-nums">
-			@agentRunCost(r.CostUSD, "text-xs")
-		</td>
-		<td class="align-middle text-right tabular-nums text-xs whitespace-nowrap">{ formatAgentRunTokens(r.TokensIn, r.TokensOut) }</td>
-		<td class="align-middle">
-			if r.HitCap != "" {
-				<span class="badge badge-soft badge-warning badge-xs">{ r.HitCap }</span>
-			} else {
-				<span class="text-xs text-base-content/30">&mdash;</span>
-			}
-		</td>
-		<td class="align-middle max-w-[16rem]">
-			if r.Note != "" {
-				<span class="text-xs text-base-content/60 line-clamp-1" title={ r.Note }>{ truncateAgentRunNote(r.Note, 60) }</span>
-			} else {
-				<span class="text-xs text-base-content/30">&mdash;</span>
-			}
-		</td>
-	</tr>
-}
-
-templ agentRunStatusBadge(status string) {
-	switch status {
-		case "success":
-			<span class="badge badge-soft badge-success badge-sm">success</span>
-		case "error":
-			<span class="badge badge-soft badge-error badge-sm">error</span>
-		case "in_progress":
-			<span class="badge badge-soft badge-warning badge-sm gap-1">
-				<span class="loading loading-spinner loading-xs"></span>
-				running
-			</span>
-		case "skipped":
-			<span class="badge badge-soft badge-neutral badge-sm">skipped</span>
-		case "timeout":
-			<span class="badge badge-soft badge-error badge-sm">timeout</span>
-		default:
-			<span class="badge badge-soft badge-sm">{ status }</span>
 	}
 }
 
 templ agentRunsPagination(p AgentRunsListProps) {
-	<div class="bb-paginator">
+	<div class="bb-paginator mt-4">
 		<span class="text-xs text-base-content/50 tabular-nums hidden sm:inline">
 			{ fmt.Sprintf("Showing %d to %d", p.Offset+1, p.Offset+len(p.Rows)) }
 		</span>
@@ -243,14 +227,24 @@ templ agentRunsPagination(p AgentRunsListProps) {
 }
 
 templ agentRunsEmpty(p AgentRunsListProps) {
-	@components.EmptyState(components.EmptyStateProps{
-		Icon:     "search-x",
-		Title:    "No runs match the current filters.",
-		CTAHref:  templ.SafeURL(agentRunsFormAction(p)),
-		CTALabel: "Clear filters",
-		Compact:  true,
-		InCard:   true,
-	})
+	if agentRunsHasActiveFilter(p) {
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:     "search-x",
+			Title:    "No runs match the current filters.",
+			CTAHref:  templ.SafeURL("/agents"),
+			CTALabel: "Clear filters",
+			Compact:  true,
+			InCard:   true,
+		})
+	} else {
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:    "history",
+			Title:   "No agent runs yet.",
+			Body:    "Schedule an agent or trigger one manually to see runs land here.",
+			Compact: true,
+			InCard:  true,
+		})
+	}
 }
 
 // AgentRunDetail renders the per-run page: metadata card, operator note,
@@ -288,7 +282,7 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 		<div class="min-w-0">
 			<div class="flex items-center gap-3 flex-wrap">
 				<h1 class="bb-page-title font-mono">{ p.Run.ShortID }</h1>
-				@agentRunStatusBadge(p.Run.Status)
+				@components.AgentRunStatusBadge(p.Run.Status)
 				if p.RefreshSeconds > 0 {
 					<span class="text-xs text-base-content/40 inline-flex items-center gap-1">
 						<span class="loading loading-spinner loading-xs"></span>
@@ -298,7 +292,7 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 			</div>
 			if p.Run.AgentName != "" {
 				<p class="text-sm text-base-content/50 mt-1">
-					{ p.Run.AgentName }
+					<a href={ templ.SafeURL("/agents?agent=" + p.Run.AgentSlug) } class="hover:underline">{ p.Run.AgentName }</a>
 					if p.Run.Trigger != "" {
 						<span class="mx-1">·</span>
 						<span class="capitalize">{ p.Run.Trigger }</span>
@@ -314,8 +308,6 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 // startup orphan-cleanup string) we render the friendly text as the
 // headline and keep the raw message in a smaller secondary line so
 // operators can still grep / paste the original when reporting a bug.
-// Restart-interrupted runs surface as `alert-warning` (retriable);
-// every other error stays `alert-error`.
 templ agentRunErrorAlert(run AgentRunRowProps) {
 	if run.ErrorMessageFriendly != "" {
 		<div class="alert alert-warning alert-soft mb-4">
@@ -334,7 +326,9 @@ templ agentRunErrorAlert(run AgentRunRowProps) {
 }
 
 // agentRunDetailBreadcrumbs builds the breadcrumb trail for the detail
-// page — Agents › <agent name> › Runs › <short ID>.
+// page — Agents › <agent name> › <short ID>. The agent crumb routes
+// back to /agents?agent=<slug> (the filtered runs view) instead of the
+// old per-agent runs URL.
 func agentRunDetailBreadcrumbs(p AgentRunDetailProps) []components.Breadcrumb {
 	out := []components.Breadcrumb{
 		{Label: "Agents", Href: "/agents"},
@@ -342,16 +336,7 @@ func agentRunDetailBreadcrumbs(p AgentRunDetailProps) []components.Breadcrumb {
 	if p.Run.AgentSlug != "" {
 		out = append(out, components.Breadcrumb{
 			Label: runDetailAgentDisplay(p.Run),
-			Href:  "/agents/" + p.Run.AgentSlug + "/edit",
-		})
-		out = append(out, components.Breadcrumb{
-			Label: "Runs",
-			Href:  "/agents/" + p.Run.AgentSlug + "/runs",
-		})
-	} else {
-		out = append(out, components.Breadcrumb{
-			Label: "Runs",
-			Href:  "/agents/runs",
+			Href:  "/agents?agent=" + p.Run.AgentSlug,
 		})
 	}
 	out = append(out, components.Breadcrumb{Label: p.Run.ShortID})
@@ -398,6 +383,22 @@ templ agentRunDetailMetadata(p AgentRunDetailProps) {
 				</div>
 			}
 		</div>
+		if len(p.Run.Reports) > 0 {
+			<div class="mt-3 pt-3 border-t border-base-200">
+				<div class="text-base-content/50 text-xs mb-2">Reports produced by this run</div>
+				<div class="flex flex-wrap gap-2">
+					for _, rep := range p.Run.Reports {
+						<a
+							href={ templ.SafeURL("/reports/" + rep.ShortID) }
+							class="inline-flex items-center gap-1.5 text-xs rounded-md border border-base-300 px-2 py-1 hover:bg-base-200/60 no-underline"
+						>
+							<i data-lucide="file-text" class="w-3 h-3"></i>
+							<span class="line-clamp-1 max-w-xs">{ rep.Title }</span>
+						</a>
+					}
+				</div>
+			</div>
+		}
 	</div>
 }
 
@@ -579,21 +580,50 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 // Helpers
 // ====================================================================
 
-// agentRunsFormAction returns the URL the filter form posts to. Per-agent
-// pages stay scoped to /agents/{slug}/runs so Apply preserves the agent
-// scope; the global page lives at /agents/runs.
-func agentRunsFormAction(p AgentRunsListProps) string {
-	if p.Mode == "agent" && p.AgentSlug != "" {
-		return "/agents/" + p.AgentSlug + "/runs"
-	}
-	return "/agents/runs"
+// rowWithAgentToggle flips the ShowAgent flag on a row based on
+// whether the surrounding page is in single-agent scope. Doing it
+// here keeps the handler free of the toggle and ensures the row
+// component is rendered consistently.
+func rowWithAgentToggle(r AgentRunRowProps, showAgent bool) AgentRunRowProps {
+	r.ShowAgent = showAgent
+	return r
 }
 
-// agentRunsPageHref builds a paging URL preserving the current filter set
-// and swapping in the new offset. Kept lightweight (manual encode) so we
-// don't need url.Values from the templ side.
+// enabledAgentOptions filters the picker payload to enabled agents
+// only. Disabled agents stay searchable in the filter dropdown but
+// can't be run from the modal — running a disabled agent would just
+// fail at the orchestrator gate, surfacing as a 422 mid-modal.
+func enabledAgentOptions(opts []AgentRunsAgentOption) []AgentRunsAgentOption {
+	out := make([]AgentRunsAgentOption, 0, len(opts))
+	for _, o := range opts {
+		if o.Enabled {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func agentRunsHasActiveFilter(p AgentRunsListProps) bool {
+	f := p.Filters
+	return f.AgentSlug != "" || f.Status != "" || f.Trigger != "" ||
+		f.HitCap != "" || f.Start != "" || f.End != ""
+}
+
+// agentRunsResolveAgentName looks up the display name for a slug
+// inside the filter chip; falls back to the slug verbatim when we
+// don't have a name in the options.
+func agentRunsResolveAgentName(p AgentRunsListProps, slug string) string {
+	for _, o := range p.AgentOptions {
+		if o.Slug == slug {
+			return o.Name
+		}
+	}
+	return slug
+}
+
+// agentRunsPageHref builds a paging URL preserving the current filter
+// set and swapping in the new offset.
 func agentRunsPageHref(p AgentRunsListProps, offset int) string {
-	base := agentRunsFormAction(p)
 	q := ""
 	add := func(k, v string) {
 		if v == "" {
@@ -606,9 +636,7 @@ func agentRunsPageHref(p AgentRunsListProps, offset int) string {
 		}
 		q += k + "=" + v
 	}
-	if p.Mode == "global" {
-		add("agent", p.Filters.AgentSlug)
-	}
+	add("agent", p.Filters.AgentSlug)
 	add("status", p.Filters.Status)
 	add("trigger", p.Filters.Trigger)
 	add("hit_cap", p.Filters.HitCap)
@@ -618,7 +646,7 @@ func agentRunsPageHref(p AgentRunsListProps, offset int) string {
 		add("limit", strconv.Itoa(p.Limit))
 	}
 	add("offset", strconv.Itoa(offset))
-	return base + q
+	return "/agents" + q
 }
 
 func prevOffset(current, limit int) int {
@@ -629,9 +657,6 @@ func prevOffset(current, limit int) int {
 	return v
 }
 
-// formatAgentRunStarted returns a compact "Jan 02 15:04" timestamp. We
-// don't have access to the relativeTime helper here (admin package), so a
-// fixed format is fine for an admin table.
 func formatAgentRunStarted(t time.Time) string {
 	if t.IsZero() {
 		return "—"
@@ -663,8 +688,7 @@ func formatAgentRunDuration(ms int64) string {
 
 // agentRunCost renders an agent-run cost cell via the canonical Amount
 // component (Intent: AmountCost, Precision: 4 for sub-cent values).
-// Zero/negative costs render an em-dash placeholder, matching the prior
-// formatAgentRunCost behavior.
+// Zero/negative costs render an em-dash placeholder.
 templ agentRunCost(v float64, extraClass string) {
 	if v > 0 {
 		@components.Amount(components.AmountProps{
@@ -685,16 +709,96 @@ func formatAgentRunTokens(in, out int64) string {
 	return fmt.Sprintf("%d / %d", in, out)
 }
 
-func truncateAgentRunNote(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "…"
-}
-
 func runDetailAgentDisplay(r AgentRunRowProps) string {
 	if r.AgentName != "" {
 		return r.AgentName
 	}
 	return r.AgentSlug
+}
+
+// agentRunsFormatMoney formats a USD cost for a stat tile.
+func agentRunsFormatMoney(v float64) string {
+	if v <= 0 {
+		return "$0"
+	}
+	if v < 1 {
+		return fmt.Sprintf("$%.3f", v)
+	}
+	return fmt.Sprintf("$%.2f", v)
+}
+
+func agentRunsFormatAvgDuration(secs float64) string {
+	if secs <= 0 {
+		return "—"
+	}
+	if secs < 60 {
+		return fmt.Sprintf("%.1fs", secs)
+	}
+	mins := secs / 60.0
+	return fmt.Sprintf("%.1fm", mins)
+}
+
+func agentRunsStatsRunDescription(s AgentRunsStatsProps) string {
+	if s.RunCount30d == 0 {
+		return "No runs in the last 30 days"
+	}
+	return "All triggers · last 30 days"
+}
+
+func agentRunsStatsErrorDescription(s AgentRunsStatsProps) string {
+	if s.RunCount30d == 0 {
+		return "—"
+	}
+	rate := float64(s.ErrorCount30d) / float64(s.RunCount30d) * 100
+	return fmt.Sprintf("%.1f%% failure rate", rate)
+}
+
+func agentRunsErrorTone(s AgentRunsStatsProps) components.StatTileTone {
+	if s.RunCount30d == 0 {
+		return components.StatToneNeutral
+	}
+	rate := float64(s.ErrorCount30d) / float64(s.RunCount30d)
+	switch {
+	case rate >= 0.25:
+		return components.StatToneError
+	case rate >= 0.10:
+		return components.StatToneWarning
+	default:
+		return components.StatToneNeutral
+	}
+}
+
+func agentRunsDateRangeLabel(f AgentRunsFilterProps) string {
+	switch {
+	case f.Start != "" && f.End != "":
+		return f.Start + " → " + f.End
+	case f.Start != "":
+		return "from " + f.Start
+	case f.End != "":
+		return "until " + f.End
+	default:
+		return ""
+	}
+}
+
+// commaInt renders an int64 with thousands separators (",").
+// Local utility — the wider codebase has a similar one in helpers but
+// it's behind a build tag, so we keep this small inline copy.
+func commaInt(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	if n < 0 {
+		return "-" + commaInt(-n)
+	}
+	if len(s) <= 3 {
+		return s
+	}
+	head := len(s) % 3
+	out := s[:head]
+	for i := head; i < len(s); i += 3 {
+		if out != "" {
+			out += ","
+		}
+		out += s[i : i+3]
+	}
+	return out
 }

--- a/internal/templates/components/pages/agent_runs_types.go
+++ b/internal/templates/components/pages/agent_runs_types.go
@@ -2,27 +2,24 @@
 
 package pages
 
-import "time"
+import (
+	"time"
 
-// AgentRunsListProps is the view-model for the v1 admin run-history page.
-// One templ component (AgentRunsList) handles both modes:
-//   - "global": cross-agent run history at /agents/runs.
-//   - "agent":  per-agent run history at /agents/{slug}/runs.
+	"breadbox/internal/templates/components"
+)
+
+// AgentRunsListProps is the view-model for the unified runs page at
+// /agents. There is only one mode — global — with an optional
+// ?agent=<slug> filter that scopes to a single agent (the link from
+// the Agents tab list and the per-agent edit page passes it through).
 //
-// The handler in internal/admin/agent_runs_page.go picks the mode based on
-// whether chi.URLParam(r, "slug") is set, then fills in the right subset of
-// fields (AgentOptions is only used in global mode; AgentSlug/AgentName only
-// in agent mode).
+// Stats is the 30-day rollup rendered in the 4-up StatTileRow at the
+// top of the page. AgentOptions populates the agent filter chip + the
+// "Run an agent" modal picker. Pickers and filters share the dataset
+// so the same list is in two places without an extra query.
 type AgentRunsListProps struct {
-	// Mode is "global" or "agent". Drives the title, breadcrumb, agent
-	// column visibility, and the presence of the agent-filter select.
-	Mode string
-
-	// AgentSlug / AgentName are populated only when Mode == "agent".
-	AgentSlug string
-	AgentName string
-
 	Filters AgentRunsFilterProps
+	Stats   AgentRunsStatsProps
 	Rows    []AgentRunRowProps
 
 	// Total is the count of rows returned by the current filter set; we
@@ -33,11 +30,28 @@ type AgentRunsListProps struct {
 	Limit  int
 	Offset int
 
-	// AgentOptions populates the agent-filter dropdown on the global page.
-	// Empty for Mode == "agent".
+	// AgentOptions doubles as the filter dropdown and the "Run an agent"
+	// modal picker. Only enabled agents are listed for the picker; the
+	// filter dropdown shows every agent so historical runs of a disabled
+	// agent are still searchable.
 	AgentOptions []AgentRunsAgentOption
 
+	// LastPromptPrefixes is map[agent_slug] → most recent operator prefix.
+	// Surfaced in the modal picker as a "Use last prefix" affordance so
+	// the operator doesn't retype context for a frequent run.
+	LastPromptPrefixes map[string]string
+
 	CSRFToken string
+}
+
+// AgentRunsStatsProps is the 30-day rollup rendered as 4 StatTiles
+// above the filter bar. All values are pre-formatted by the handler so
+// the templ doesn't pull in money helpers.
+type AgentRunsStatsProps struct {
+	RunCount30d        int
+	ErrorCount30d      int
+	TotalCostUSD30d    float64
+	AvgDurationSeconds float64
 }
 
 // AgentRunsFilterProps captures the currently-active URL filters so the
@@ -51,40 +65,27 @@ type AgentRunsFilterProps struct {
 	End       string
 }
 
-// AgentRunsAgentOption is one entry in the global-page agent filter.
+// AgentRunsAgentOption is one entry in the global-page agent filter +
+// the "Run an agent" modal picker. Description is the short blurb
+// pulled from the agent's prompt first line so the picker is scannable
+// without opening each agent.
 type AgentRunsAgentOption struct {
-	Slug string
-	Name string
+	Slug        string
+	Name        string
+	Description string
+	Enabled     bool
+	// Cost30dUSD is the 30-day spend rolled up from CostStats30d so the
+	// picker can hint at frequency of use ("$0.21 over 12 runs in 30d").
+	Cost30dUSD float64
+	RunCount30 int
 }
 
-// AgentRunRowProps is one row in the runs table. The handler builds these
-// from service.AgentRunResponse / AgentRunWithAgentResponse, expanding the
-// pointer fields into plain values (zeroes when nil) so the templ doesn't
-// have to nil-check on every cell.
-type AgentRunRowProps struct {
-	ShortID    string
-	AgentSlug  string
-	AgentName  string
-	Status     string
-	Trigger    string
-	StartedAt  time.Time
-	FinishedAt *time.Time
-	DurationMs int64
-	CostUSD    float64
-	TokensIn   int64
-	TokensOut  int64
-	HitCap     string
-	Turns      int
-	Note       string
-
-	// ErrorMessage is the raw error_message column. Empty for non-errored
-	// runs. ErrorMessageFriendly is the operator-friendly translation
-	// (e.g. "interrupted by server restart" → "Interrupted by server
-	// restart — safe to re-run."); empty when no special mapping applies,
-	// in which case the raw message should be rendered as-is.
-	ErrorMessage         string
-	ErrorMessageFriendly string
-}
+// AgentRunRowProps is the one-row shape shared across the runs page,
+// per-run detail header, and the design sandbox. The canonical type
+// lives in `internal/templates/components` so any caller that wants to
+// render an agent run uses the same fields; this alias keeps existing
+// references in the admin handler compiling without churn.
+type AgentRunRowProps = components.AgentRunRowProps
 
 // AgentRunDetailProps powers the per-run page at /agents/runs/{shortId}.
 // SystemPrompt / Prompt are pulled from the agent definition so the

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -19,70 +19,96 @@ import (
 // sidecar JS file under static/js/admin/components/ per the task brief.
 templ AgentsList(p AgentsListProps) {
 	@agentsListInline()
+	<script src="/static/js/admin/components/agents_run_modal.js"></script>
 	<div x-data x-init="$store.shortcuts.setScope('agents')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@components.PageHeader(components.PageHeaderProps{
 		Title:                "Agents",
 		Subtitle:             "Scheduled AI runs that read and act on your Breadbox via MCP.",
 		SubtitleHideOnMobile: true,
-		SecondaryAction:      agentsListPromptLibraryAction(),
-		Action:               agentsListNewAgentAction(),
+		Action:               agentsHeaderActions("agents-run-modal", !p.Status.Ready || !agentsListHasEnabled(p.Agents)),
 	})
-	if !p.Status.Ready {
-		@agentsListStatusBanner(p.Status)
-	}
-	if len(p.Agents) > 0 {
-		<div class="flex items-center justify-between mb-3 px-1">
-			<div class="text-sm text-base-content/40">
-				{ fmt.Sprintf("%d agent%s", len(p.Agents), components.PluralS(int64(len(p.Agents)))) }
+	@agentsTabBar("list")
+	<div class="mt-4">
+		if !p.Status.Ready {
+			@agentsListStatusBanner(p.Status)
+		}
+		if len(p.Agents) > 0 {
+			<div class="flex items-center justify-between mb-3 px-1">
+				<div class="text-sm text-base-content/40">
+					{ fmt.Sprintf("%d agent%s", len(p.Agents), components.PluralS(int64(len(p.Agents)))) }
+				</div>
+				<a href="/agent-prompts" class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1">
+					<i data-lucide="book-open" class="w-3.5 h-3.5"></i>
+					Prompt library
+				</a>
 			</div>
-			<a href="/agents/runs" class="text-xs text-base-content/50 hover:text-base-content inline-flex items-center gap-1">
-				<i data-lucide="history" class="w-3.5 h-3.5"></i>
-				View all runs
-			</a>
-		</div>
-	}
-	if len(p.Agents) == 0 {
-		@agentsListEmpty()
-	} else {
-		<div
-			x-data={ agentsListData(p.CSRFToken) }
-		>
-			<div class="overflow-x-auto rounded-xl bg-base-100 border border-base-300">
-				<table class="table table-sm table-zebra-soft">
-					<thead>
-						<tr class="text-xs text-base-content/50">
-							<th class="font-medium">Name</th>
-							<th class="font-medium">Schedule</th>
-							<th class="font-medium">Last run</th>
-							<th class="font-medium">Next run</th>
-							<th class="font-medium text-right">30d cost</th>
-							<th class="font-medium text-center w-20">Enabled</th>
-							<th class="w-10"></th>
-						</tr>
-					</thead>
-					<tbody>
-						for _, a := range p.Agents {
-							@agentsListRow(a)
-						}
-					</tbody>
-				</table>
+		}
+		if len(p.Agents) == 0 {
+			@agentsListEmpty()
+		} else {
+			<div x-data={ agentsListData(p.CSRFToken) }>
+				<div class="overflow-x-auto rounded-xl bg-base-100 border border-base-300">
+					<table class="table table-sm table-zebra-soft">
+						<thead>
+							<tr class="text-xs text-base-content/50">
+								<th class="font-medium">Name</th>
+								<th class="font-medium">Schedule</th>
+								<th class="font-medium">Last run</th>
+								<th class="font-medium">Next run</th>
+								<th class="font-medium text-right">30d cost</th>
+								<th class="font-medium text-center w-20">Enabled</th>
+								<th class="w-10"></th>
+							</tr>
+						</thead>
+						<tbody>
+							for _, a := range p.Agents {
+								@agentsListRow(a)
+							}
+						</tbody>
+					</table>
+				</div>
 			</div>
-		</div>
-	}
+		}
+	</div>
+	@agentRunModal(agentRunModalProps{
+		ModalID:            "agents-run-modal",
+		CSRFToken:          p.CSRFToken,
+		Options:            agentsListToRunModalOptions(p.Agents),
+		LastPromptPrefixes: p.LastPromptPrefixes,
+	})
 }
 
-templ agentsListPromptLibraryAction() {
-	<a href="/agent-prompts" class="btn btn-secondary btn-sm gap-2" title="Prompt library">
-		<i data-lucide="book-open" class="w-4 h-4"></i>
-		<span>Prompt library</span>
-	</a>
+// agentsListHasEnabled returns true if at least one row is enabled,
+// so the "Run an agent" header button can render. With zero enabled
+// agents the modal is empty and the action collapses to a disabled
+// hint via agentsHeaderActions.
+func agentsListHasEnabled(rows []AgentsListRowProps) bool {
+	for _, r := range rows {
+		if r.Enabled {
+			return true
+		}
+	}
+	return false
 }
 
-templ agentsListNewAgentAction() {
-	<a href="/agents/new" class="btn btn-primary btn-sm gap-2">
-		<i data-lucide="plus" class="w-4 h-4"></i>
-		<span>New agent</span>
-	</a>
+// agentsListToRunModalOptions projects the table rows onto the modal
+// picker's prop shape so the modal can render alongside the list
+// without an extra service call.
+func agentsListToRunModalOptions(rows []AgentsListRowProps) []AgentRunsAgentOption {
+	out := make([]AgentRunsAgentOption, 0, len(rows))
+	for _, r := range rows {
+		if !r.Enabled {
+			continue
+		}
+		out = append(out, AgentRunsAgentOption{
+			Slug:        r.Slug,
+			Name:        r.Name,
+			Description: r.Description,
+			Enabled:     true,
+			Cost30dUSD:  r.Cost30dUSD,
+		})
+	}
+	return out
 }
 
 templ agentsListStatusBanner(s AgentSubsystemStatusProps) {
@@ -225,7 +251,7 @@ templ agentsListRow(a AgentsListRowProps) {
 						{
 							Label: "View runs",
 							Icon:  "history",
-							Href:  templ.SafeURL(fmt.Sprintf("/agents/%s/runs", a.Slug)),
+							Href:  templ.SafeURL(fmt.Sprintf("/agents?agent=%s", a.Slug)),
 						},
 						{
 							Label:       "Delete",

--- a/internal/templates/components/pages/agents_list_types.go
+++ b/internal/templates/components/pages/agents_list_types.go
@@ -12,8 +12,15 @@ import "time"
 // never reaches into service types directly. Pre-rendering relative-time
 // strings on the handler side keeps the templ free of time helpers.
 type AgentsListProps struct {
-	Agents    []AgentsListRowProps
-	Status    AgentSubsystemStatusProps
+	Agents []AgentsListRowProps
+	Status AgentSubsystemStatusProps
+
+	// LastPromptPrefixes is map[agent_slug] → most recent operator
+	// prefix; surfaces the "Use last prefix" affordance in the shared
+	// Run-an-agent modal. Empty map renders the modal without the
+	// "Last prefix" chips.
+	LastPromptPrefixes map[string]string
+
 	CSRFToken string
 }
 

--- a/internal/templates/components/pages/agents_shell.templ
+++ b/internal/templates/components/pages/agents_shell.templ
@@ -1,0 +1,187 @@
+package pages
+
+import (
+	"breadbox/internal/templates/components"
+)
+
+// agentsTabBar renders the Runs / Agents two-tab nav shared between
+// /agents (runs landing) and /agents/definitions (agents list). Both
+// pages mount this immediately under the PageHeader so the user can
+// switch contexts without a round-trip to the sidebar.
+//
+// active is the slug of the currently-active tab — "runs" or "list".
+templ agentsTabBar(active string) {
+	@components.TabBar(components.TabBarProps{
+		Variant:   "border",
+		AriaLabel: "Agents sections",
+		Items: []components.TabBarItem{
+			{
+				Label:  "Runs",
+				Href:   "/agents",
+				Icon:   "history",
+				Active: active == "runs",
+			},
+			{
+				Label:  "Agents",
+				Href:   "/agents/definitions",
+				Icon:   "bot",
+				Active: active == "list",
+			},
+		},
+	})
+}
+
+// agentsHeaderActions renders the "New agent" + "Run an agent" pair
+// in the PageHeader trailing slot for both /agents and
+// /agents/definitions. The pair stays stable across tabs so the
+// primary actions don't move around as the operator switches views.
+//
+// runDisabled becomes true when the agent subsystem isn't ready —
+// auth missing or the runtime binary not on PATH. Surfacing the
+// disabled state inline keeps the header from lying about what's
+// possible right now.
+templ agentsHeaderActions(modalID string, runDisabled bool) {
+	<div class="flex items-center gap-2 shrink-0">
+		if runDisabled {
+			<button type="button" class="btn btn-sm btn-ghost gap-2" disabled title="Agents need configuration before runs can fire">
+				<i data-lucide="play" class="w-4 h-4"></i>
+				<span>Run an agent</span>
+			</button>
+		} else {
+			<button
+				type="button"
+				class="btn btn-sm btn-ghost gap-2"
+				onclick={ openAgentRunModal(modalID) }
+			>
+				<i data-lucide="play" class="w-4 h-4"></i>
+				<span>Run an agent</span>
+			</button>
+		}
+		<a href="/agents/new" class="btn btn-sm btn-primary gap-2">
+			<i data-lucide="plus" class="w-4 h-4"></i>
+			<span>New agent</span>
+		</a>
+	</div>
+}
+
+// openAgentRunModal is the click handler that opens the run-an-agent
+// modal dialog. Kept as a Go-side helper so the inline `onclick`
+// stays a single statement and the lint passes.
+script openAgentRunModal(modalID string) {
+	var el = document.getElementById(modalID);
+	if (el && typeof el.showModal === 'function') el.showModal();
+}
+
+// agentRunModalProps carries everything the run-an-agent modal needs
+// to render. The modal renders once per page (mounted from
+// AgentRunsList / AgentsList) and the Alpine factory in
+// static/js/admin/components/agents_run_modal.js drives the search
+// filter + submit POST.
+type agentRunModalProps struct {
+	ModalID            string
+	CSRFToken          string
+	Options            []AgentRunsAgentOption
+	LastPromptPrefixes map[string]string
+}
+
+// agentRunModal renders the daisy modal that lists every enabled
+// agent. Each row carries a "Run" button; an optional prefix textarea
+// at the bottom is applied to whichever agent the operator picks. The
+// payload of agent options + last prefixes is handed to Alpine via a
+// JSON script so the picker logic stays out of the templ tree.
+templ agentRunModal(p agentRunModalProps) {
+	<dialog
+		id={ p.ModalID }
+		class="modal modal-bottom sm:modal-middle"
+		x-data="agentRunModal"
+		data-csrf={ p.CSRFToken }
+	>
+		@templ.JSONScript(p.ModalID+"-data", agentRunModalPayload{
+			Agents:       p.Options,
+			LastPrefixes: p.LastPromptPrefixes,
+		})
+		<div class="modal-box rounded-xl max-w-xl">
+			<form method="dialog">
+				<button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-3 top-3" aria-label="Close" onclick="this.closest('dialog').close()">
+					<i data-lucide="x" class="w-4 h-4"></i>
+				</button>
+			</form>
+			<h3 class="text-base font-semibold mb-3">Run an agent</h3>
+			<p class="text-xs text-base-content/60 mb-3">
+				Fires a one-off manual run against the selected agent. The optional prefix below gives the agent extra context for this run only.
+			</p>
+			if len(p.Options) == 0 {
+				<div class="bb-card p-6 text-center text-sm text-base-content/60">
+					<i data-lucide="bot-off" class="w-5 h-5 mx-auto opacity-40 mb-2"></i>
+					<div>No enabled agents yet.</div>
+					<a href="/agents/new" class="link link-primary text-xs mt-2 inline-block">Create your first agent →</a>
+				</div>
+			} else {
+				<label class="input input-sm w-full mb-3">
+					<i data-lucide="search" class="w-3.5 h-3.5 opacity-60"></i>
+					<input
+						type="text"
+						placeholder="Filter agents…"
+						aria-label="Filter agents"
+						x-model="query"
+					/>
+				</label>
+				<div class="rounded-xl bg-base-100 border border-base-300 divide-y divide-base-200 max-h-72 overflow-y-auto">
+					<template x-for="opt in filtered" :key="opt.Slug">
+						<div class="flex items-center gap-3 px-3 py-2.5 hover:bg-base-200/50">
+							<div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+								<i data-lucide="bot" class="w-4 h-4 text-primary"></i>
+							</div>
+							<div class="min-w-0 flex-1">
+								<div class="text-sm font-medium truncate" x-text="opt.Name"></div>
+								<div class="text-xs text-base-content/50 line-clamp-1" x-text="opt.Description" x-show="opt.Description"></div>
+							</div>
+							<button
+								type="button"
+								class="btn btn-ghost btn-xs"
+								x-show="lastPrefixFor(opt.Slug)"
+								@click="prefix = lastPrefixFor(opt.Slug)"
+								:title="'Use last prefix: ' + lastPrefixFor(opt.Slug)"
+							>
+								<i data-lucide="rotate-cw" class="w-3 h-3"></i>
+								<span class="hidden sm:inline">Last prefix</span>
+							</button>
+							<button
+								type="button"
+								class="btn btn-primary btn-xs gap-1"
+								@click="run(opt.Slug)"
+								:disabled="busy"
+							>
+								<i data-lucide="play" class="w-3 h-3"></i>
+								Run
+							</button>
+						</div>
+					</template>
+					<div class="px-3 py-2 text-xs text-base-content/40 italic" x-show="filtered.length === 0">
+						No agents match this filter.
+					</div>
+				</div>
+				<label class="form-control mt-3">
+					<span class="text-xs text-base-content/60 mb-1">Optional prefix (applies to the next run only)</span>
+					<textarea
+						class="textarea textarea-sm w-full font-mono text-xs"
+						rows="3"
+						placeholder="Focus on Plaid sync errors from the last 24 hours…"
+						x-model="prefix"
+					></textarea>
+				</label>
+			}
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button type="button" aria-label="Close" onclick="this.closest('dialog').close()"></button>
+		</form>
+	</dialog>
+}
+
+// agentRunModalPayload is the JSON payload handed to the Alpine
+// factory via templ.JSONScript. Field names match what the JS reads.
+type agentRunModalPayload struct {
+	Agents       []AgentRunsAgentOption `json:"agents"`
+	LastPrefixes map[string]string      `json:"last_prefixes"`
+}
+

--- a/internal/templates/components/pages/design_agent_run_rows_helpers.go
+++ b/internal/templates/components/pages/design_agent_run_rows_helpers.go
@@ -1,0 +1,190 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"time"
+
+	"breadbox/internal/templates/components"
+)
+
+// design_agent_run_rows_helpers.go holds the fixture rows for the
+// SectionAgentRunRows sandbox entry. Kept beside the design types so
+// the templ stays focused on layout. Times use a shared anchor (`now`
+// via designAgentRunRowsNow) so refreshes don't reshuffle the
+// relative-time labels mid-sentence.
+
+func designAgentRunRowsNow() time.Time { return time.Now() }
+
+func designAgentRunRowsAgo(d time.Duration) time.Time {
+	return designAgentRunRowsNow().Add(-d)
+}
+
+func designAgentRunRowsFinished(d time.Duration) *time.Time {
+	t := designAgentRunRowsAgo(d)
+	return &t
+}
+
+// designAgentRunRowSuccess returns a clean, successful 30s run with
+// modest cost — the "normal day" row.
+func designAgentRunRowSuccess() components.AgentRunRowProps {
+	return components.AgentRunRowProps{
+		ShortID:    "ag42xyz9",
+		AgentSlug:  "daily-recap",
+		AgentName:  "Daily recap",
+		Status:     "success",
+		Trigger:    "cron",
+		StartedAt:  designAgentRunRowsAgo(3 * time.Minute),
+		FinishedAt: designAgentRunRowsFinished(2*time.Minute + 30*time.Second),
+		DurationMs: 32_400,
+		CostUSD:    0.0234,
+		TokensIn:   8_421,
+		TokensOut:  1_203,
+		Turns:      4,
+		ShowAgent:  true,
+	}
+}
+
+// designAgentRunRowSuccessWithReport returns a success row that
+// produced one info-priority report — the most common chip variant.
+func designAgentRunRowSuccessWithReport() components.AgentRunRowProps {
+	r := designAgentRunRowSuccess()
+	r.ShortID = "ag99rstu"
+	r.AgentSlug = "weekly-review"
+	r.AgentName = "Weekly review"
+	r.StartedAt = designAgentRunRowsAgo(48 * time.Minute)
+	r.FinishedAt = designAgentRunRowsFinished(46 * time.Minute)
+	r.DurationMs = 124_500
+	r.CostUSD = 0.1873
+	r.Turns = 11
+	r.TokensIn = 32_104
+	r.TokensOut = 4_872
+	r.Reports = []components.AgentRunReportRef{
+		{ShortID: "rp01abcd", Title: "Reviewed 47 transactions this week — 3 recategorized, no suspicious activity.", Priority: "info"},
+	}
+	return r
+}
+
+// designAgentRunRowError returns a failed run with an inline error
+// message; the row should foreground the failure.
+func designAgentRunRowError() components.AgentRunRowProps {
+	return components.AgentRunRowProps{
+		ShortID:              "ag77klmn",
+		AgentSlug:            "anomaly-hunt",
+		AgentName:            "Anomaly hunt",
+		Status:               "error",
+		Trigger:              "manual",
+		StartedAt:            designAgentRunRowsAgo(14 * time.Minute),
+		FinishedAt:           designAgentRunRowsFinished(13*time.Minute + 50*time.Second),
+		DurationMs:           9_800,
+		Turns:                2,
+		ErrorMessage:         "Anthropic API: 529 overloaded — please retry shortly.",
+		ErrorMessageFriendly: "",
+		ShowAgent:            true,
+	}
+}
+
+// designAgentRunRowInProgress returns a running row with no
+// finished-at and the in-progress status pill.
+func designAgentRunRowInProgress() components.AgentRunRowProps {
+	return components.AgentRunRowProps{
+		ShortID:   "ag88pqrs",
+		AgentSlug: "pending-reviews",
+		AgentName: "Pending reviews",
+		Status:    "in_progress",
+		Trigger:   "webhook",
+		StartedAt: designAgentRunRowsAgo(35 * time.Second),
+		Turns:     1,
+		ShowAgent: true,
+	}
+}
+
+// designAgentRunRowSkipped returns a quiet-hours / concurrency-locked
+// row — opacity drops on the link so the row reads "audit only".
+func designAgentRunRowSkipped() components.AgentRunRowProps {
+	return components.AgentRunRowProps{
+		ShortID:   "ag11uvwx",
+		AgentSlug: "daily-recap",
+		AgentName: "Daily recap",
+		Status:    "skipped",
+		Trigger:   "cron",
+		StartedAt: designAgentRunRowsAgo(2 * time.Hour),
+		FinishedAt: designAgentRunRowsFinished(2*time.Hour - time.Second),
+		ShowAgent: true,
+		Note:      "Skipped — another run was in progress.",
+	}
+}
+
+// designAgentRunRowTimeout returns a run that bumped into the
+// max_turns / max_budget ceiling.
+func designAgentRunRowTimeout() components.AgentRunRowProps {
+	return components.AgentRunRowProps{
+		ShortID:    "ag22yzab",
+		AgentSlug:  "categorize-batch",
+		AgentName:  "Categorize batch",
+		Status:     "timeout",
+		Trigger:    "cron",
+		StartedAt:  designAgentRunRowsAgo(6 * time.Hour),
+		FinishedAt: designAgentRunRowsFinished(5*time.Hour + 50*time.Minute),
+		DurationMs: 597_000,
+		Turns:      25,
+		HitCap:     "max_turns",
+		CostUSD:    0.4901,
+		TokensIn:   142_882,
+		TokensOut:  18_433,
+		ShowAgent:  true,
+	}
+}
+
+// designAgentRunRowNoAgent flips ShowAgent off on any sample row so
+// the sandbox can demonstrate the per-agent scoped variant.
+func designAgentRunRowNoAgent(r components.AgentRunRowProps) components.AgentRunRowProps {
+	r.ShowAgent = false
+	return r
+}
+
+// designAgentRunRowWithReports returns a sample row carrying exactly
+// one report whose priority matches the argument — the chip palette
+// shifts per priority.
+func designAgentRunRowWithReports(priority string) components.AgentRunRowProps {
+	r := designAgentRunRowSuccess()
+	switch priority {
+	case "warning":
+		r.ShortID = "ag55warn"
+		r.AgentName = "Budget watch"
+		r.Reports = []components.AgentRunReportRef{
+			{ShortID: "rp02warn", Title: "Dining spend at 92% of monthly budget with 8 days left.", Priority: "warning"},
+		}
+	case "critical":
+		r.ShortID = "ag66crit"
+		r.AgentName = "Fraud sweep"
+		r.Reports = []components.AgentRunReportRef{
+			{ShortID: "rp03crit", Title: "Unusual $1,840 charge at 04:12 — verify with the cardholder.", Priority: "critical"},
+		}
+	default:
+		r.ShortID = "ag44info"
+		r.AgentName = "Weekly review"
+		r.Reports = []components.AgentRunReportRef{
+			{ShortID: "rp04info", Title: "Recategorized 12 transactions; nothing else flagged.", Priority: "info"},
+		}
+	}
+	return r
+}
+
+// designAgentRunRowWithMultipleReports returns a row that produced
+// several reports — chips wrap to a second line when the row gets
+// narrow.
+func designAgentRunRowWithMultipleReports() components.AgentRunRowProps {
+	r := designAgentRunRowSuccess()
+	r.ShortID = "agAA1234"
+	r.AgentName = "Quarterly close"
+	r.DurationMs = 412_000
+	r.CostUSD = 0.7234
+	r.Turns = 18
+	r.Reports = []components.AgentRunReportRef{
+		{ShortID: "rp10info", Title: "Q1 review complete — 312 transactions categorized.", Priority: "info"},
+		{ShortID: "rp11warn", Title: "3 categories need a budget revision before Q2.", Priority: "warning"},
+		{ShortID: "rp12crit", Title: "Possible duplicate Plaid feed for the Chase Sapphire connection.", Priority: "critical"},
+	}
+	return r
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -2144,3 +2144,57 @@ templ timelineSandboxCommentBody() {
 		<a href="#" class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">Whole Foods Market</a>
 	</div>
 }
+
+// ─── Agent run rows ───────────────────────────────────────────────────────
+
+// SectionAgentRunRows shows the variants of components.AgentRunRow —
+// the rich row shape rendered on /agents (the runs landing). The
+// fixtures here cover every status (success / error / in-progress /
+// skipped / timeout), surface the inline report-chip variants (info /
+// warning / critical priority), and exercise the ShowAgent toggle
+// (global view vs single-agent view).
+templ SectionAgentRunRows() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>Renders one cross-agent feed of recent runs (canonical: <code>/agents</code>) via <code>AgentRunRow</code> + <code>AgentRunRowList</code>.</li>
+				<li>Show the agent name when the surrounding page is cross-agent; hide it via <code>ShowAgent: false</code> when the page is already scoped to one agent (e.g. <code>?agent=slug</code> filter chip applied).</li>
+				<li><code>AgentRunReportRef</code> chips render inline when the run produced reports via <code>submit_report</code>. Priority tone (info / warning / critical) drives the chip border + icon.</li>
+			</ul>
+		</div>
+		@designExample("Global feed — every status", "ShowAgent: true. Status drives the leading icon-tile tone + status badge. Error rows surface the error message inline; reports surface as priority-toned chips.") {
+			@components.AgentRunRowList() {
+				@components.AgentRunRow(designAgentRunRowSuccess())
+				@components.AgentRunRow(designAgentRunRowSuccessWithReport())
+				@components.AgentRunRow(designAgentRunRowError())
+				@components.AgentRunRow(designAgentRunRowInProgress())
+				@components.AgentRunRow(designAgentRunRowSkipped())
+				@components.AgentRunRow(designAgentRunRowTimeout())
+			}
+		}
+		@designExample("Per-agent scope — ShowAgent: false", "Used when the surrounding page is already scoped to one agent (filter chip or breadcrumb conveys the name). Status badge moves to the front of the title row since the agent name is gone.") {
+			@components.AgentRunRowList() {
+				@components.AgentRunRow(designAgentRunRowNoAgent(designAgentRunRowSuccess()))
+				@components.AgentRunRow(designAgentRunRowNoAgent(designAgentRunRowError()))
+			}
+		}
+		@designExample("Inline report chips by priority", "Reports rendered via AgentRunReportRef. Tone shifts with priority — critical / warning lift out of the neutral chip palette.") {
+			@components.AgentRunRowList() {
+				@components.AgentRunRow(designAgentRunRowWithReports("info"))
+				@components.AgentRunRow(designAgentRunRowWithReports("warning"))
+				@components.AgentRunRow(designAgentRunRowWithReports("critical"))
+				@components.AgentRunRow(designAgentRunRowWithMultipleReports())
+			}
+		}
+		@designExample("Status badge — standalone", "components.AgentRunStatusBadge — also used in the run-detail header and elsewhere. In-progress carries a spinner; everything else is a soft daisy badge.") {
+			<div class="flex flex-wrap items-center gap-2">
+				@components.AgentRunStatusBadge("success")
+				@components.AgentRunStatusBadge("error")
+				@components.AgentRunStatusBadge("in_progress")
+				@components.AgentRunStatusBadge("skipped")
+				@components.AgentRunStatusBadge("timeout")
+			</div>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -264,6 +264,13 @@ func DesignSections() []DesignSection {
 			Group:       "data",
 			Render:      func() templ.Component { return SectionTransactionRows() },
 		},
+		{
+			Slug:        "agent-run-rows",
+			Title:       "Agent run rows",
+			Description: "components.AgentRunRow + AgentRunRowList — the rich row shape for /agents (runs landing). Status-toned icon tile + agent label + meta + cost block, with inline report chips when the run produced reports.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionAgentRunRows() },
+		},
 
 		// ── Feedback ────────────────────────────────────────────────
 		{

--- a/static/js/admin/components/agents_run_modal.js
+++ b/static/js/admin/components/agents_run_modal.js
@@ -1,0 +1,113 @@
+// Run-an-agent modal Alpine component.
+//
+// The agentRunModal templ in internal/templates/components/pages/agents_shell.templ
+// renders one <dialog x-data="agentRunModal"> per page (mounted by both
+// /agents and /agents/definitions). The payload — list of enabled agents +
+// per-agent last-prompt-prefix — is handed in via a sibling
+// @templ.JSONScript with id "<modalID>-data".
+//
+// Pattern reference: docs/design-system.md → "Alpine page components".
+document.addEventListener('alpine:init', function () {
+  Alpine.data('agentRunModal', function () {
+    return {
+      agents: [],
+      lastPrefixes: {},
+      query: '',
+      prefix: '',
+      busy: false,
+      csrf: '',
+
+      init: function () {
+        // Discover the payload script via the modal's id; the script
+        // tag is sibling-rendered as "<modalID>-data".
+        var root = this.$root;
+        this.csrf = root.getAttribute('data-csrf') || '';
+        var dataEl = document.getElementById(root.id + '-data');
+        if (dataEl) {
+          try {
+            var payload = JSON.parse(dataEl.textContent) || {};
+            this.agents = Array.isArray(payload.agents) ? payload.agents : [];
+            this.lastPrefixes = payload.last_prefixes || {};
+          } catch (e) {
+            console.error('agentRunModal: failed to parse payload', e);
+          }
+        }
+      },
+
+      get filtered() {
+        var q = (this.query || '').trim().toLowerCase();
+        if (!q) return this.agents;
+        return this.agents.filter(function (a) {
+          return (
+            (a.Name || '').toLowerCase().indexOf(q) !== -1 ||
+            (a.Description || '').toLowerCase().indexOf(q) !== -1 ||
+            (a.Slug || '').toLowerCase().indexOf(q) !== -1
+          );
+        });
+      },
+
+      lastPrefixFor: function (slug) {
+        return this.lastPrefixes[slug] || '';
+      },
+
+      toast: function (message, type) {
+        window.dispatchEvent(
+          new CustomEvent('bb-toast', { detail: { message: message, type: type || 'info' } })
+        );
+      },
+
+      restorePageState: function () {
+        if (window.bbProgress) {
+          try { window.bbProgress.finish(); } catch (e) {}
+        }
+        var main = document.querySelector('main');
+        if (main) {
+          main.style.opacity = '';
+          main.style.filter = '';
+          main.style.pointerEvents = '';
+        }
+      },
+
+      run: function (slug) {
+        if (this.busy) return;
+        this.busy = true;
+        var prefix = (this.prefix || '').trim();
+        var body = '';
+        if (prefix) {
+          body = 'prompt_prefix=' + encodeURIComponent(prefix);
+        }
+        var self = this;
+        fetch('/-/agents/' + encodeURIComponent(slug) + '/run', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRF-Token': self.csrf,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: body,
+        })
+          .then(function (res) {
+            self.busy = false;
+            if (!res.ok) {
+              self.toast(
+                res.status === 503
+                  ? 'Another run is already in progress.'
+                  : 'Failed to start agent.',
+                'error'
+              );
+              self.restorePageState();
+              return;
+            }
+            self.toast('Agent run started.', 'success');
+            self.$root.close();
+            setTimeout(function () { window.location.reload(); }, 700);
+          })
+          .catch(function () {
+            self.busy = false;
+            self.toast('Network error. Please try again.', 'error');
+            self.restorePageState();
+          });
+      },
+    };
+  });
+});


### PR DESCRIPTION
## Summary

`/agents` now leads with the runs feed — the most operationally-interesting surface — and the agent-definitions table moves behind a Daisy tab. A new reusable `components.AgentRunRow` renders runs across the page, the per-run detail header, and the design sandbox, and runs that produced reports surface them as inline priority-toned chips.

The IA shift came from realising the original `/agents` (table of definitions, "see runs" buried behind an overflow menu) bury the thing the operator actually wants to glance at. New shape: tabs at the top, runs feed by default, "Run an agent" modal in the header, rich rows that read in one sweep.

<img src="https://i.img402.dev/d21335c4-a6e9-4638-9401-e70c987e907b.jpg" width="800" alt="/agents — runs landing">

## What changed

### IA + routes
- `/agents` → cross-agent runs feed (was: definitions list).
- `/agents/definitions` → definitions table (was: `/agents`).
- `/agents?agent=<slug>` → runs feed pre-filtered to one agent; replaces `/agents/{slug}/runs`, which 301-redirects to the new shape (preserves query string).
- `/agents/runs` 301-redirects to `/agents` (preserves bookmarks).

Both top-level pages mount a shared `components.TabBar` immediately under the `PageHeader`, plus a "Run an agent" button + "New agent" link in the trailing slot.

### New reusable component
`components.AgentRunRow` + `AgentRunRowList` (`internal/templates/components/agent_run_row.templ`) is the canonical row shape for any cross-agent or per-agent runs feed. It owns: status-toned icon tile, agent name + short_id + status badge + trigger pill, meta line (started-ago · duration · turns · tokens), inline error preview, operator-note preview, and a trailing cost block. Same component renders on `/agents` and inside the run-detail metadata card.

### Reports → runs linkage
- New migration `20260525224008_link_reports_to_agent_runs.sql` adds `agent_run_id UUID NULL REFERENCES agent_runs(id) ON DELETE SET NULL` on `agent_reports`. Backfilled from the per-run minted API key naming convention (`agent:<slug>:<runShortID>`).
- New `service.AgentRunShortIDFromContext` parses the surrounding API key's name; MCP `handleSubmitReport` passes it to `CreateAgentReport`, which resolves to the run UUID and stamps the FK.
- New `Service.ListReportSummariesForRunIDs` batched query feeds chip data to the runs page in one round trip.
- Same chips render on the run-detail metadata card.

### Page-level
- `agent_runs.templ` rebuilt: 4-up `StatTileRow` (30d Runs / Errors with failure-rate caption / Cost / Avg duration), filter bar collapsed under a chip-only summary, rich row list instead of the prior dense table, daisy `join` paginator.
- `Service.GetAgentRunsExtraStats30d` aggregates error count + avg duration; cost + run count are rolled up from existing per-agent `CostStats30d`.
- `static/js/admin/components/agents_run_modal.js` implements the picker — search filter, per-agent "Last prefix" chip, POST `/-/agents/{slug}/run` with optional `prompt_prefix`.

### Sandbox
New "Agent run rows" section under Data display. Covers every status, the `ShowAgent: false` per-agent variant, info / warning / critical report chips, and the standalone status-badge matrix.

<details><summary>Run-an-agent modal + sandbox section</summary>

<img src="https://i.img402.dev/a20859b3-2986-484f-a4ee-56a3b77940ef.jpg" width="800" alt="Run-an-agent modal">

<img src="https://i.img402.dev/639120ac-01bd-4696-aa81-70fb7979db5d.jpg" width="800" alt="Design sandbox — Agent run rows">

</details>

## Stacked on #1517

Independent of the sidecar fixes for review, but stacked because the IA redesign work surfaced the sidecar bugs and re-validating either PR locally needs both. CI passes independently on each tip.

## Test plan
- [ ] Visit `/agents` — runs landing renders with tabs, stat tiles, rich row list, Run-an-agent button.
- [ ] Click "Agents" tab → /agents/definitions still works, shows definitions table with the same tab nav.
- [ ] Visit `/agents?agent=<slug>` — runs filtered to that agent; filter chip visible in summary.
- [ ] Old `/agents/runs` and `/agents/<slug>/runs` redirect to the new shape (preserving query string).
- [ ] Open "Run an agent" modal: search filter works, "Last prefix" chip prefills textarea for agents with prior prefixes, Run fires manual run.
- [ ] On a run that produced reports via `submit_report`, the report chip appears inline on the row and on the run-detail metadata card.
- [ ] `/design/c/agent-run-rows` renders every variant (status matrix, ShowAgent off, report chips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
