### PR TITLE
feat(ui): skeleton loader for categories

### DIFF
--- a/internal/templates/components/categories_skeleton.templ
+++ b/internal/templates/components/categories_skeleton.templ
@@ -1,0 +1,87 @@
+package components
+
+// CategoriesSkeleton renders a placeholder mirroring the layout of the
+// /categories page — a filter search input, the "N top-level categories"
+// helper line, and a divided card with parent rows plus a few expanded
+// subcategory groups underneath. Sized to match the real component so a
+// future swap-in (AJAX refresh, picker preview, adjacent panel) doesn't
+// shift layout.
+//
+// /categories is a full-SSR page today; this primitive is exposed in
+// /design#loading so it's ready for the eventual AJAX swap and
+// discoverable to anyone wiring loading states for adjacent
+// category-centric panels (e.g. the category picker).
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
+// hand-rolled `bb-skeleton*` family is being retired).
+templ CategoriesSkeleton() {
+	<div class="space-y-4" aria-hidden="true">
+		<!-- Filter search input -->
+		<div class="skeleton h-10 w-full sm:max-w-sm rounded-xl"></div>
+		<!-- Helper line: "N top-level categories" -->
+		<div class="px-1">
+			<div class="skeleton h-2.5 w-32"></div>
+		</div>
+		<!-- Categories list card -->
+		<div class="bb-card overflow-hidden">
+			<div class="divide-y divide-base-300/40">
+				@categoriesSkeletonParent(true, 3)
+				@categoriesSkeletonParent(false, 0)
+				@categoriesSkeletonParent(true, 2)
+				@categoriesSkeletonParent(false, 0)
+				@categoriesSkeletonParent(false, 0)
+			</div>
+		</div>
+	</div>
+}
+
+// categoriesSkeletonParent mirrors one top-level category row: large icon
+// tile + chevron + display name + optional child-count badge + overflow
+// menu. When `childCount > 0`, a sub-list of indented child rows is
+// rendered below it to match the expanded state.
+templ categoriesSkeletonParent(expanded bool, childCount int) {
+	<div>
+		<!-- Parent row -->
+		<div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3">
+			<!-- Large icon tile -->
+			<div class="skeleton w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"></div>
+			<div class="flex items-center gap-2 min-w-0 flex-1">
+				<!-- Chevron placeholder -->
+				<div class="skeleton w-3.5 h-3.5 rounded shrink-0"></div>
+				<!-- Display name -->
+				<div class="skeleton h-3.5 w-40 sm:w-48"></div>
+				if childCount > 0 {
+					<!-- Child-count pill -->
+					<div class="skeleton h-4 w-6 rounded-full shrink-0"></div>
+				}
+			</div>
+			<!-- Overflow menu -->
+			<div class="skeleton h-6 w-6 rounded shrink-0"></div>
+		</div>
+		if expanded && childCount > 0 {
+			<!-- Expanded subcategory list -->
+			<div class="border-t border-base-300/30 bg-base-200/20">
+				for i := 0; i < childCount; i++ {
+					@categoriesSkeletonChild()
+				}
+			</div>
+		}
+	</div>
+}
+
+// categoriesSkeletonChild mirrors one subcategory row: indented padding,
+// small icon tile, display name, and trailing overflow-menu slot. Width
+// of the name placeholder is narrower than the parent so the skeleton
+// reads as a real hierarchy at a glance.
+templ categoriesSkeletonChild() {
+	<div class="flex items-center gap-3 sm:gap-4 pl-10 sm:pl-14 pr-4 sm:pr-5 py-2.5">
+		<!-- Small icon tile -->
+		<div class="skeleton w-7 h-7 sm:w-8 sm:h-8 rounded-lg shrink-0"></div>
+		<div class="flex items-center gap-2 min-w-0 flex-1">
+			<!-- Subcategory name (narrower than parent) -->
+			<div class="skeleton h-3 w-28 sm:w-36"></div>
+		</div>
+		<!-- Overflow menu -->
+		<div class="skeleton h-6 w-6 rounded shrink-0"></div>
+	</div>
+}

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -58,6 +58,12 @@ templ Categories(p CategoriesProps) {
 		} else {
 			@categoriesEmpty()
 		}
+		<!-- Loading skeleton for the categories list, available for any future
+		     client-side refresh / picker-preview swap. Mirrors the SSR layout
+		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		<template id="bb-categories-skeleton-template">
+			@components.CategoriesSkeleton()
+		</template>
 	</div>
 	@deleteCategoryModal()
 	<script>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -799,6 +799,11 @@ templ SectionLoading() {
 				@components.TagsSkeleton()
 			</div>
 		}
+		@designExample("Categories skeleton", "Placeholder mirroring /categories — filter input, helper line, and a divided card with parent rows plus expanded subcategory groups. Primitive is exposed here for future AJAX swaps and adjacent category-centric panels (e.g. category picker); /categories is full-SSR today.") {
+			<div class="max-w-3xl">
+				@components.CategoriesSkeleton()
+			</div>
+		}
 		@designExample("Progress", "Indeterminate + determinate.") {
 			<div class="space-y-3 max-w-md">
 				<progress class="progress progress-primary w-full"></progress>


### PR DESCRIPTION
## Summary

- Add `CategoriesSkeleton` mirroring the `/categories` layout — filter input, helper line, and a divided card with parent rows plus expanded subcategory groups (large icon tile + chevron + name + child-count pill + overflow-menu slot for parents; indented, narrower-name rows for children).
- Wiring (option-3 per #1511/#1512/#1513): inert `<template id="bb-categories-skeleton-template">` on the live `/categories` page and a new example in `SectionLoading()` on `/design#loading`. `/categories` is full-SSR today; primitive ships now so an eventual AJAX/picker-preview swap (or adjacent category-centric panel) has a daisy-skeleton-based placeholder ready.
- Uses the daisy `skeleton` primitive per `.claude/rules/daisyui.md` (the hand-rolled `bb-skeleton*` family is being retired).

## Screenshot

<img src="https://i.img402.dev/xhh4cu3xad.jpg" width="800" alt="/design#loading — Categories skeleton">

## Test plan

- [x] `templ generate`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Visually verified at `/design#loading` (Chrome DevTools MCP, 1280x900)

🤖 Generated with [Claude Code](https://claude.com/claude-code)