### PR TITLE
feat(ui): skeleton loader for tags

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -794,6 +794,11 @@ templ SectionLoading() {
 				@components.ConnectionsSkeleton()
 			</div>
 		}
+		@designExample("Tags list skeleton", "Placeholder mirroring /tags — filter input, helper line, and a divided card of tag rows (chip preview, slug + optional description, usage count, overflow menu). Primitive is exposed here for future AJAX swaps and adjacent tag-centric panels (e.g. tag picker / tag-attach autocomplete); /tags is full-SSR today.") {
+			<div class="max-w-3xl">
+				@components.TagsSkeleton()
+			</div>
+		}
 		@designExample("Progress", "Indeterminate + determinate.") {
 			<div class="space-y-3 max-w-md">
 				<progress class="progress progress-primary w-full"></progress>

--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -41,6 +41,12 @@ templ Tags(p TagsProps) {
 		} else {
 			@tagsEmpty()
 		}
+		<!-- Loading skeleton for the tags list, available for any future
+		     client-side refresh / picker-preview swap. Mirrors the SSR layout
+		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		<template id="bb-tags-skeleton-template">
+			@components.TagsSkeleton()
+		</template>
 	</div>
 }
 

--- a/internal/templates/components/tags_skeleton.templ
+++ b/internal/templates/components/tags_skeleton.templ
@@ -1,0 +1,61 @@
+package components
+
+// TagsSkeleton renders a placeholder mirroring the layout of the /tags
+// page — a filter search input, the "N tags" helper line, and a divided
+// card with tag rows. Each row mirrors tagListRow: a chip-shaped pill
+// preview (natural width, capped at ~10–14rem), a slug-shaped code pill
+// + optional description line, a usage-count badge, and a trailing
+// overflow-menu slot. Sized to match the real component so a future
+// swap-in (AJAX refresh, picker preview, adjacent panel) doesn't shift
+// layout.
+//
+// /tags is a full-SSR page today; this primitive is exposed in
+// /design#loading so it's ready for the eventual AJAX swap and
+// discoverable to anyone wiring loading states for adjacent tag-centric
+// panels (e.g. the tag picker / tag-attach autocomplete).
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
+// hand-rolled `bb-skeleton*` family is being retired).
+templ TagsSkeleton() {
+	<div class="space-y-4" aria-hidden="true">
+		<!-- Filter search input -->
+		<div class="skeleton h-10 w-full sm:max-w-sm rounded-xl"></div>
+		<!-- Helper line: "N tags" -->
+		<div class="px-1">
+			<div class="skeleton h-2.5 w-20"></div>
+		</div>
+		<!-- Tag rows card. Widths vary so the skeleton reads as motion. -->
+		<div class="bb-card overflow-hidden">
+			<div class="divide-y divide-base-300/40">
+				@tagsSkeletonRow("w-24", "w-28", "w-10", true)
+				@tagsSkeletonRow("w-32", "w-20", "w-8", false)
+				@tagsSkeletonRow("w-20", "w-36", "w-12", true)
+				@tagsSkeletonRow("w-28", "w-24", "w-8", false)
+				@tagsSkeletonRow("w-16", "w-32", "w-6", false)
+				@tagsSkeletonRow("w-36", "w-16", "w-10", true)
+			</div>
+		</div>
+	</div>
+}
+
+// tagsSkeletonRow mirrors one tag row in /tags: a colored pill chip
+// preview, slug code-pill + optional description, usage-count badge,
+// and the overflow menu. Widths come from the caller so a stack of
+// rows can be varied for motion.
+templ tagsSkeletonRow(chipW string, slugW string, countW string, withDesc bool) {
+	<div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3">
+		<!-- Chip preview (rounded-full pill, matches bb-tag shape) -->
+		<div class={ "skeleton h-5 rounded-full shrink-0", chipW }></div>
+		<!-- Slug code pill + optional description -->
+		<div class="flex-1 min-w-0 space-y-1.5">
+			<div class={ "skeleton h-3 rounded-md", slugW }></div>
+			if withDesc {
+				<div class="skeleton h-2.5 w-2/3"></div>
+			}
+		</div>
+		<!-- Usage count -->
+		<div class={ "skeleton h-3 shrink-0", countW }></div>
+		<!-- Overflow menu -->
+		<div class="skeleton h-6 w-6 rounded shrink-0"></div>
+	</div>
+}


### PR DESCRIPTION
## Summary

Adds a `TagsSkeleton` templ component mirroring the layout of `/tags` so the page can swap into a loading state without shifting content.

- **New file**: `internal/templates/components/tags_skeleton.templ` — daisy `skeleton` primitives, filter input + helper line + divided card of 6 rows. Each row: rounded-full chip preview (varying widths 16–36), slug code-pill + optional description, narrow usage-count, square overflow-menu slot.
- **Live page** (`internal/templates/components/pages/tags.templ`): inert `<template id=\"bb-tags-skeleton-template\">` rendered after the SSR list so any future client-side swap can clone it.
- **Sandbox** (`internal/templates/components/pages/design_sections.templ`): new example in `SectionLoading()` for `/design#loading`.

Option-3 wiring per the established skeleton-sweep precedent (#1511 / #1512 / #1513).

## Screenshot

`/design#loading` — Tags list skeleton:

<img src=\"https://i.img402.dev/3njvpbknat.jpg\" width=\"800\" alt=\"Tags list skeleton in /design#loading\">

## Test plan

- [x] \`templ generate\` clean
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] Renders at \`/design#loading\` (Chrome DevTools MCP, 1280×900)
- [ ] No regression on \`/tags\` (inert template only — not rendered into the document flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)