### PR TITLE
fix(ui): make TxRowFeed hover visible on prominent-timeline surface

### DIFF
--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -42,7 +42,7 @@ type TxRowFeedProps struct {
 templ TxRowFeed(p TxRowFeedProps) {
 	<a
 		href={ templ.SafeURL("/transactions/" + p.ShortID) }
-		class="bb-tx-row-feed flex items-center gap-2 py-1 px-1 -mx-1 rounded-md hover:bg-base-200/70 focus-visible:bg-base-200/70 focus-visible:outline-none transition-colors duration-150 no-underline"
+		class="bb-tx-row-feed flex items-center gap-2 py-1 px-1 -mx-1 rounded-md hover:bg-base-content/5 focus-visible:bg-base-content/5 focus-visible:outline-none transition-colors duration-150 no-underline"
 	>
 		<!-- Category avatar — mirrors TxRowCompact so the feed's coloured
 		     circle reads identically to the /transactions list. -->


### PR DESCRIPTION
## Summary

`TxRowFeed` had `hover:bg-base-200/70`, which is invisible against the `/feed` page's prominent-timeline rail — that variant shifts the surface to `base-200` (see `input.css:2597`), so a `base-200/70` hover blends into the parent. The hover read fine in the `/design` sandbox because the example sits on `bg-base-100`, which is why the visual diverged between the two surfaces.

Swap to `hover:bg-base-content/5` (and the matching `focus-visible`). It's a foreground tint, so it lifts visibly on any base surface in either theme without re-introducing a per-surface override.

## Test plan

- [x] `go build ./...` clean
- [x] Validated `/feed` in a real browser — hover now visible on the prominent timeline rail
- [x] Verified `/design` sandbox still shows the hover (no regression on the `base-100` surface)

## Screenshots

`/feed` — hovering "The Home Depot" row (background lifts to a subtle gray):

<img src="https://i.img402.dev/kv1lvj6z7p.jpg" width="800" alt="/feed — TxRowFeed hover on prominent timeline">

`/design` sandbox — hovering the "Wholefds New York 12345" row (regression check, still reads):

<img src="https://i.img402.dev/vdc0uipx91.jpg" width="800" alt="/design — TxRowFeed hover in sandbox">
