### PR TITLE
feat(ui): page-level skeleton loader for /transactions

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -784,6 +784,11 @@ templ SectionLoading() {
 				@components.TxResultsSkeleton()
 			</div>
 		}
+		@designExample("Transactions page skeleton", "Placeholder mirroring /transactions content area — search + filter-toggle row, results toolbar (select / view-mode / kbd hints), and the results region (delegated to TxResultsSkeleton). Primitive is exposed here for future AJAX swaps (paginator / view-mode change without a page reload); /transactions is full-SSR today.") {
+			<div x-data x-init="if (window.Alpine && Alpine.store && !Alpine.store('txView')) Alpine.store('txView', { mode: 'grouped', setMode(m) { this.mode = m; } })" class="max-w-4xl">
+				@components.TransactionsSkeleton()
+			</div>
+		}
 		@designExample("Accounts list skeleton", "Placeholder mirroring /accounts — summary stats (Net Worth / Assets / Liabilities), filter input, and the sortable table. Primitive is exposed here for future AJAX swaps and adjacent account panels; /accounts is full-SSR today.") {
 			<div class="max-w-4xl">
 				@components.AccountsListSkeleton()

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -59,6 +59,14 @@ templ Transactions(p TransactionsProps) {
 	} else {
 		@txEmptyState(p)
 	}
+	<!-- Page-level skeleton for /transactions, available for any future
+	     client-side refresh / AJAX swap (e.g. paginator / view-mode change
+	     without a page reload). Mirrors the SSR content area above
+	     (search + filter-toggle row, results toolbar, results region) so
+	     swap-in doesn't shift the page. Exposed in /design#loading. -->
+	<template id="bb-transactions-skeleton-template">
+		@components.TransactionsSkeleton()
+	</template>
 	<!-- Floating bulk action bar is created via JS in <body> to avoid parent transform breaking position:fixed -->
 	if p.IsReviewQueue() {
 		@txReviewQueueShortcuts()

--- a/internal/templates/components/transactions_skeleton.templ
+++ b/internal/templates/components/transactions_skeleton.templ
@@ -1,0 +1,45 @@
+package components
+
+// TransactionsSkeleton renders a placeholder mirroring the /transactions
+// page content area — the search + filter-toggle row, the results
+// toolbar (select / view mode / kbd hints), and the results region
+// (delegated to TxResultsSkeleton so grouped/list both match the real
+// layout).
+//
+// /transactions is full-SSR today; this primitive is exposed in
+// /design#loading so it's ready for the eventual AJAX/refresh swap
+// (e.g. paginator / view-mode change without a page reload) and
+// discoverable to anyone wiring loading states for adjacent
+// transaction surfaces.
+//
+// The PageHeader is intentionally NOT included — mirrors the
+// agents/categories/etc. convention where the header stays live
+// across swaps and only the dynamic content area is replaced.
+//
+// Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md,
+// the hand-rolled `bb-skeleton*` family is being retired).
+templ TransactionsSkeleton() {
+	<div aria-hidden="true">
+		<!-- Search + filter-toggle row (mirrors txFilters collapsed state) -->
+		<div class="mb-6">
+			<div class="flex items-center gap-3">
+				<div class="skeleton h-10 flex-1 rounded-lg"></div>
+				<div class="skeleton h-10 w-28 shrink-0 rounded-lg"></div>
+			</div>
+		</div>
+		<!-- Results toolbar (mirrors txResultsShell toolbar) -->
+		<div class="flex items-center gap-3 px-2 pb-2">
+			<div class="skeleton h-6 w-16 rounded-md"></div>
+			<div class="skeleton h-6 w-32 rounded-md"></div>
+			<div class="flex-1"></div>
+			<div class="hidden sm:flex items-center gap-3">
+				for i := 0; i < 5; i++ {
+					<div class="skeleton h-3 w-12"></div>
+				}
+			</div>
+		</div>
+		<!-- Results region — delegates to the existing TxResultsSkeleton
+		     so the grouped/list view-mode branches stay in one place. -->
+		@TxResultsSkeleton()
+	</div>
+}


### PR DESCRIPTION
## Summary

Page-level skeleton for the `/transactions` surface, continuing the per-surface rollout (#1511 tx-results swap, #1512 accounts, #1513 connections, #1514 agents-list, #1520 categories, #1521 tags, plus rules / reports / agent-runs).

- New `components.TransactionsSkeleton()` in `internal/templates/components/transactions_skeleton.templ`
- Mirrors the `/transactions` content area — search + filter-toggle row, results toolbar (select toggle / view-mode toggle / kbd hints), and the results region (delegated to the existing `TxResultsSkeleton` so the grouped/list view-mode branches stay in one place)
- Wired as an inert `<template id="bb-transactions-skeleton-template">` on `/transactions` for future AJAX swaps (paginator / view-mode change without a full page reload) so swap-in doesn't shift the page
- Showcased in `/design#loading` under "Transactions page skeleton"
- Daisy `skeleton` primitive throughout, no `bb-skeleton*` (per `.claude/rules/daisyui.md`)

The `PageHeader` is intentionally omitted — matches the agents/categories convention where the header stays live across swaps and only the dynamic content area is replaced.

<img src="https://i.img402.dev/p8yg3lwqfp.jpg" width="800" alt="Transactions page skeleton in /design#loading">

## Test plan

- [x] `templ generate && go build ./... && go vet ./...` clean
- [x] `go test ./internal/templates/...` green (incl. `scripts_lint_test.go`)
- [x] `/design#loading` renders the new "Transactions page skeleton" example
- [x] `/transactions` continues to render normally; embedded `<template>` is inert (verified: 9 visible skeleton nodes in the cloned content — the grouped/list view nodes live inside Alpine `<template x-if>` and expand on use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)