### PR TITLE
refactor(design): consolidate sidebar avatar + settings into user menu

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -96,55 +96,27 @@ templ Nav(p NavProps) {
 				</a>
 			}
 		}
-		<div class="bb-sidebar-section">Resources</div>
 		if p.IsEditor {
+			<div class="bb-sidebar-section">Resources</div>
 			<a href="/agents" class={ "bb-sidebar-link", navActive(p.CurrentPage, "agents") }>
 				<i data-lucide="bot-message-square"></i>
 				<span>Agents</span>
 				<i data-lucide="sparkles" class="bb-sidebar-sparkle ml-auto !text-amber-400"></i>
 			</a>
 		}
-		@navExternalLink("https://docs.breadbox.sh", "book-open", "Documentation")
-		@navExternalLink("https://github.com/canalesb93/breadbox", "github", "GitHub")
 	</nav>
-	<!--
-		Footer entrypoint to the Settings modal. The clickable card opens
-		the modal at the Account tab; the trailing gear button opens it
-		at whatever tab the user last visited (or Account if none).
-		Settings has no top-level sidebar entry anymore — this card is
-		the only entry point.
-	-->
 	<div class="mt-auto pt-3 border-t border-base-300 px-2">
-		<div class="flex items-center gap-1">
-			<button
-				type="button"
-				class={ "flex-1 flex items-center gap-2.5 py-2.5 px-2.5 rounded-lg no-underline transition-colors hover:bg-base-200/70 text-left", navActive(p.CurrentPage, "account") }
-				title="Open settings"
-				aria-label="Open settings"
-				x-data
-				@click="$dispatch('open-settings', { tab: 'account' })"
-			>
-				if p.HasLinkedUser {
-					<img src={ navAvatar(p.SessionUserID, p.SessionAvatarVersion) } alt="" class="bb-sidebar-profile-avatar shrink-0"/>
-				} else {
-					<i data-lucide="user-circle" class="w-6 h-6 text-base-content/40 shrink-0"></i>
-				}
-				<div class="flex-1 min-w-0">
-					<div class="bb-sidebar-profile-name">{ navDisplayName(p.UserName, p.AdminUsername) }</div>
-					<div class="bb-sidebar-profile-role">{ p.RoleDisplay }</div>
-				</div>
-			</button>
-			<button
-				type="button"
-				class="shrink-0 p-2 rounded-lg text-base-content/40 hover:text-base-content hover:bg-base-200/70 transition-colors"
-				title="Settings"
-				aria-label="Open settings"
-				x-data
-				@click="$dispatch('open-settings', { tab: 'account' })"
-			>
-				<i data-lucide="settings" class="w-4 h-4"></i>
-			</button>
-		</div>
+		@SidebarUserMenu(SidebarUserMenuProps{
+			CurrentPage:          p.CurrentPage,
+			IsEditor:             p.IsEditor,
+			HasLinkedUser:        p.HasLinkedUser,
+			SessionUserID:        p.SessionUserID,
+			SessionAvatarVersion: p.SessionAvatarVersion,
+			AdminUsername:        p.AdminUsername,
+			UserName:             p.UserName,
+			RoleDisplay:          p.RoleDisplay,
+			CSRFToken:            p.CSRFToken,
+		})
 	</div>
 }
 

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1136,6 +1136,55 @@ templ SectionOverflowMenu() {
 	</div>
 }
 
+// ─── Sidebar user menu ─────────────────────────────────────────────────
+
+templ SectionSidebarUserMenu() {
+	<div class="flex flex-col gap-6">
+		@designExample("Linked household member (editor)", "Avatar comes from the linked household user. Editor role unlocks the `/design` shortcut. Click the trigger to open the popover — Settings, the external links, and the destructive Sign out (below an `<hr>`) live inside.") {
+			<div class="bb-card w-[15rem] p-2">
+				@components.SidebarUserMenu(components.SidebarUserMenuProps{
+					CurrentPage:          "transactions",
+					IsEditor:             true,
+					HasLinkedUser:        true,
+					SessionUserID:        "demo-user",
+					SessionAvatarVersion: "1",
+					AdminUsername:        "ricardo@example.com",
+					UserName:             "Ricardo",
+					RoleDisplay:          "Admin",
+					CSRFToken:            "demo-csrf",
+				})
+			</div>
+		}
+		@designExample("Unlinked admin (email only)", "Without a household link the trigger renders a generic user-circle icon and falls back to the auth username (typically the email).") {
+			<div class="bb-card w-[15rem] p-2">
+				@components.SidebarUserMenu(components.SidebarUserMenuProps{
+					CurrentPage:   "feed",
+					IsEditor:      true,
+					HasLinkedUser: false,
+					AdminUsername: "admin@example.com",
+					RoleDisplay:   "Editor",
+					CSRFToken:     "demo-csrf",
+				})
+			</div>
+		}
+		@designExample("Viewer role (no design shortcut)", "Non-editor roles don't see the `/design` shortcut — it's gated behind `IsEditor`. Same identity surface otherwise.") {
+			<div class="bb-card w-[15rem] p-2">
+				@components.SidebarUserMenu(components.SidebarUserMenuProps{
+					CurrentPage:          "reports",
+					IsEditor:             false,
+					HasLinkedUser:        true,
+					SessionUserID:        "demo-viewer",
+					SessionAvatarVersion: "1",
+					AdminUsername:        "guest@example.com",
+					UserName:             "Guest",
+					RoleDisplay:          "Viewer",
+					CSRFToken:            "demo-csrf",
+				})
+			</div>
+		}
+	</div>
+}
+
 // ─── Section header ────────────────────────────────────────────────────
 
 templ SectionSectionHeader() {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -190,6 +190,13 @@ func DesignSections() []DesignSection {
 			Group:       "navigation",
 			Render:      func() templ.Component { return SectionOverflowMenu() },
 		},
+		{
+			Slug:        "sidebar-user-menu",
+			Title:       "Sidebar user menu",
+			Description: "Consolidated identity + actions popover at the bottom of the sidebar. Trigger shows avatar + display name + role; popover holds Settings, Documentation, GitHub, an editor-only /design shortcut, and a destructive Sign out below an <hr> separator. Use components.SidebarUserMenu.",
+			Group:       "navigation",
+			Render:      func() templ.Component { return SectionSidebarUserMenu() },
+		},
 
 		// ── Forms ───────────────────────────────────────────────────
 		{

--- a/internal/templates/components/sidebar_user_menu.templ
+++ b/internal/templates/components/sidebar_user_menu.templ
@@ -1,0 +1,119 @@
+package components
+
+import (
+	"strconv"
+	"sync/atomic"
+)
+
+// SidebarUserMenuProps drives the consolidated identity + actions
+// popover at the bottom of the sidebar rail.
+//
+// Trigger: avatar + display name + role + chevron.
+// Popover: Settings / Documentation / GitHub / (Design system if editor)
+// / Sign out.
+type SidebarUserMenuProps struct {
+	CurrentPage string
+
+	IsEditor bool
+
+	HasLinkedUser        bool
+	SessionUserID        string
+	SessionAvatarVersion string
+	AdminUsername        string
+	UserName             string
+	RoleDisplay          string
+
+	CSRFToken string
+}
+
+var sidebarUserMenuSeq atomic.Uint64
+
+func nextSidebarUserMenuID() string {
+	return strconv.FormatUint(sidebarUserMenuSeq.Add(1), 10)
+}
+
+templ SidebarUserMenu(p SidebarUserMenuProps) {
+	{{ uid := nextSidebarUserMenuID() }}
+	{{ popoverID := "sum-" + uid }}
+	{{ anchorName := "--sum-anchor-" + uid }}
+	{{ logoutFormID := popoverID + "-logout" }}
+	<button
+		type="button"
+		popovertarget={ popoverID }
+		class={ "w-full flex items-center gap-2.5 py-2.5 px-2.5 rounded-lg no-underline transition-colors hover:bg-base-200/70 text-left", navActive(p.CurrentPage, "account") }
+		aria-label="Open user menu"
+		style={ "anchor-name:" + anchorName }
+	>
+		if p.HasLinkedUser {
+			<img src={ navAvatar(p.SessionUserID, p.SessionAvatarVersion) } alt="" class="bb-sidebar-profile-avatar shrink-0"/>
+		} else {
+			<i data-lucide="user-circle" class="w-6 h-6 text-base-content/40 shrink-0"></i>
+		}
+		<div class="flex-1 min-w-0">
+			<div class="bb-sidebar-profile-name">{ navDisplayName(p.UserName, p.AdminUsername) }</div>
+			<div class="bb-sidebar-profile-role">{ p.RoleDisplay }</div>
+		</div>
+		<i data-lucide="chevrons-up-down" class="w-4 h-4 text-base-content/40 shrink-0"></i>
+	</button>
+	<ul
+		id={ popoverID }
+		popover="auto"
+		class="dropdown dropdown-top dropdown-start menu bg-base-100 rounded-xl shadow-lg border border-base-300 w-56 p-1"
+		style={ "position-anchor:" + anchorName }
+	>
+		<li>
+			<button
+				type="button"
+				x-data
+				@click="$dispatch('open-settings', { tab: 'account' }); $el.closest('[popover]')?.hidePopover()"
+			>
+				<i data-lucide="settings" class="w-3.5 h-3.5"></i>
+				<span class="flex-1">Settings</span>
+			</button>
+		</li>
+		<li>
+			<a
+				href="https://docs.breadbox.sh"
+				target="_blank"
+				rel="noopener noreferrer"
+				@click="$el.closest('[popover]')?.hidePopover()"
+			>
+				<i data-lucide="book-open" class="w-3.5 h-3.5"></i>
+				<span class="flex-1">Documentation</span>
+				<i data-lucide="square-arrow-out-up-right" class="w-3 h-3 opacity-50"></i>
+			</a>
+		</li>
+		<li>
+			<a
+				href="https://github.com/canalesb93/breadbox"
+				target="_blank"
+				rel="noopener noreferrer"
+				@click="$el.closest('[popover]')?.hidePopover()"
+			>
+				<i data-lucide="github" class="w-3.5 h-3.5"></i>
+				<span class="flex-1">GitHub</span>
+				<i data-lucide="square-arrow-out-up-right" class="w-3 h-3 opacity-50"></i>
+			</a>
+		</li>
+		if p.IsEditor {
+			<li>
+				<a href="/design" @click="$el.closest('[popover]')?.hidePopover()">
+					<i data-lucide="palette" class="w-3.5 h-3.5"></i>
+					<span class="flex-1">Design system</span>
+				</a>
+			</li>
+		}
+		<hr class="border-base-300 my-1 mx-2"/>
+		<li>
+			<button type="submit" form={ logoutFormID } class="text-error">
+				<i data-lucide="log-out" class="w-3.5 h-3.5"></i>
+				<span class="flex-1">Sign out</span>
+			</button>
+		</li>
+	</ul>
+	<form id={ logoutFormID } method="POST" action="/logout" class="hidden">
+		if p.CSRFToken != "" {
+			<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+		}
+	</form>
+}


### PR DESCRIPTION
## Summary

- Replaces the split sidebar footer (avatar button + gear button — both opened the same modal) with a single popover trigger. The popover hosts **Settings**, **Documentation**, **GitHub**, an editor-only **Design system** shortcut to `/design`, and a destructive **Sign out** below an `<hr>` separator.
- Documentation + GitHub were the only items pinned into the sidebar Resources section for non-editors, so that section now renders only for editors (just Agents).
- Sign out is a daisy `menu` item linked to a sibling hidden `<form>` via the standard HTML `form="…"` attribute, so it inherits daisy hover/focus styling without a bespoke button shape. CSRF token threaded through `NavProps.CSRFToken`.
- Shipped as a proper `components.SidebarUserMenu` with a `/design/c/sidebar-user-menu` sandbox section (three variants — linked editor / unlinked admin / viewer).

## Screenshots

<table>
  <tr><th>Light, popover open</th><th>Dark, popover open</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ydy2lig3pd.jpg" width="400" alt="sidebar user menu — light, open"></td>
    <td><img src="https://i.img402.dev/f9lyfpvh06.jpg" width="400" alt="sidebar user menu — dark, open"></td>
  </tr>
</table>

Design sandbox at `/design/c/sidebar-user-menu`:

<img src="https://i.img402.dev/k43xe63mmu.jpg" width="800" alt="sandbox variants — linked editor, unlinked admin, viewer">

Mobile (390×844), drawer + popover open:

<img src="https://i.img402.dev/1ly3nd3w3d.jpg" width="320" alt="sidebar user menu — mobile">

## Test plan

- [ ] Sidebar avatar button opens the popover; Settings still dispatches `open-settings`
- [ ] Documentation + GitHub open in new tabs and the popover closes
- [ ] Design system link visible for editors only; navigates to `/design`
- [ ] Sign out POSTs to `/logout` with the session CSRF token
- [ ] `/design/c/sidebar-user-menu` renders all three sandbox variants without overlap
- [ ] No `bb-sum-*` orphan classes in `input.css`, no orphan `sidebar_user_menu.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
