### PR TITLE
fix(ui): align comment-card header gray with inner border curve

### DIFF
--- a/input.css
+++ b/input.css
@@ -2670,14 +2670,19 @@
   border-radius: 0.5rem;
   overflow: visible;
 }
-/* Header bar (was the "Name commented X ago" meta line) */
+/* Header bar (was the "Name commented X ago" meta line).
+ * The card carries a 1px border + 0.5rem outer radius, so the header
+ * sits one pixel inside the curve. Match the inner curve exactly
+ * (outer radius minus border width) — using the same 0.5rem here
+ * leaves the gray fill curving inside the border arc, exposing a
+ * thin wedge of the white card background at the top corners. */
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
   background: color-mix(in srgb, var(--color-base-200) 60%, transparent);
   border-bottom: 1px solid var(--color-base-300);
   padding: 0.5rem 0.875rem;
   margin: 0;
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
+  border-top-left-radius: calc(0.5rem - 1px);
+  border-top-right-radius: calc(0.5rem - 1px);
 }
 /* Body (was the chat-bubble) */
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) .bb-comment-bubble {


### PR DESCRIPTION
## Summary
The prominent activity-timeline comment card has a 1px border + 0.5rem outer radius, so its inner curve is 7px. The header bar was using `0.5rem` for `border-top-{left,right}-radius`, matching the **outer** curve. That made the gray fill curve past the inner arc at the top corners and exposed a thin sliver of the card's white background — visible as a gap between the gray header and the card's top border.

Fix: set the header to `calc(0.5rem - 1px)` so it follows the inner curve precisely.

## Evidence

Side-by-side proof of the 1px corner mismatch and the fix:

<img src="https://i.img402.dev/jyg99bfckn.jpg" width="800" alt="before / after comparison — 8px vs 7px header radius">

Real card on `/design` after the fix (in place, no zoom):

<img src="https://i.img402.dev/blk00r4gsw.jpg" width="800" alt="comment card on /design — after">

Real card at 3× zoom, BEFORE (forced header radius back to 8px via inline style):

<img src="https://i.img402.dev/mmxdky7xol.jpg" width="800" alt="comment card 3× zoom — before">

Real card at 3× zoom, AFTER (current 7px from CSS):

<img src="https://i.img402.dev/mcfutebf3t.jpg" width="800" alt="comment card 3× zoom — after">

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Visual check on `/design` → Activity timeline → prominent variant (header `border-top-left-radius` resolves to `7px` via `getComputedStyle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)