### PR TITLE
feat(ui): rename Settings>Sync to General, fold Security into System

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -367,8 +367,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/backups", redirectGET("/settings/backups"))
 
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
-		r.Get("/settings/sync", SettingsGetHandler(a, sm, tr))
-		r.Get("/settings/security", SecuritySettingsHandler(a, sm, tr))
+		r.Get("/settings/general", SettingsGetHandler(a, sm, tr))
+		r.Get("/settings/sync", redirectGET("/settings/general"))
+		r.Get("/settings/security", redirectGET("/settings/system"))
 		r.Get("/settings/system", SystemSettingsHandler(a, sm, tr))
 		r.Get("/settings/help", HelpSettingsHandler(a, sm, tr))
 		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -33,7 +33,7 @@ func formatNextSync(nextRun time.Time) string {
 }
 
 // buildSettingsProps assembles the typed SettingsProps shared by every
-// /settings/* General-family tab (Sync, Security, System, Help). Each
+// /settings/* General-family tab (General, System, Help). Each
 // tab handler builds full props (cheap — a few DB lookups + version
 // check) and renders only the section it owns.
 func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[string]any) {
@@ -90,30 +90,21 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 	return props, data
 }
 
-// SettingsGetHandler serves GET /settings — the Sync tab is the default
-// landing for the Settings entry. /settings/sync renders the same.
+// SettingsGetHandler serves GET /settings — the General tab is the
+// default landing for the Settings entry. /settings/general renders
+// the same.
 func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		props, data := buildSettingsProps(a, r)
-		data["PageTitle"] = "Sync"
-		data["CurrentPage"] = "sync"
+		data["PageTitle"] = "General"
+		data["CurrentPage"] = "general"
 		data["Flash"] = GetFlash(r.Context(), sm)
-		renderSettingsTab(tr, w, r, data, pages.SettingsTabSync, pages.SettingsSync(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabGeneral, pages.SettingsGeneral(props))
 	}
 }
 
-// SecuritySettingsHandler serves GET /settings/security.
-func SecuritySettingsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		props, data := buildSettingsProps(a, r)
-		data["PageTitle"] = "Security"
-		data["CurrentPage"] = "security"
-		data["Flash"] = GetFlash(r.Context(), sm)
-		renderSettingsTab(tr, w, r, data, pages.SettingsTabSecurity, pages.SettingsSecurity(props))
-	}
-}
-
-// SystemSettingsHandler serves GET /settings/system.
+// SystemSettingsHandler serves GET /settings/system — combines security
+// (encryption key) and runtime/version info on a single tab.
 func SystemSettingsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		props, data := buildSettingsProps(a, r)
@@ -217,7 +208,7 @@ func SettingsAvatarStylePostHandler(a *app.App, sm *scs.SessionManager) http.Han
 
 		style := strings.TrimSpace(r.FormValue("avatar_style"))
 		if !avatar.IsValidStyle(style) {
-			FlashRedirect(w, r, sm, "error", "Invalid avatar style.", "/settings/system")
+			FlashRedirect(w, r, sm, "error", "Invalid avatar style.", "/settings/general")
 			return
 		}
 
@@ -226,13 +217,13 @@ func SettingsAvatarStylePostHandler(a *app.App, sm *scs.SessionManager) http.Han
 			Value: pgconv.Text(style),
 		}); err != nil {
 			a.Logger.Error("save avatar style", "error", err)
-			FlashRedirect(w, r, sm, "error", "Failed to save avatar style.", "/settings/system")
+			FlashRedirect(w, r, sm, "error", "Failed to save avatar style.", "/settings/general")
 			return
 		}
 		avatar.SetStyle(style)
 
 		SetFlash(ctx, sm, "success", "Avatar style updated.")
-		http.Redirect(w, r, "/settings/system", http.StatusSeeOther)
+		http.Redirect(w, r, "/settings/general", http.StatusSeeOther)
 	}
 }
 

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -7,48 +7,37 @@ import (
 	"breadbox/internal/templates/components"
 )
 
-// SettingsSync renders the Sync tab — schedule + retention. Lands at
-// both /settings (the default Settings entry) and /settings/sync.
-templ SettingsSync(p SettingsProps) {
+// SettingsGeneral renders the General tab — sync schedule, log retention,
+// and the user-avatar style picker. Lands at both /settings (the default
+// Settings entry) and /settings/general.
+templ SettingsGeneral(p SettingsProps) {
 	<script src="/static/js/admin/components/settings.js"></script>
 	<div x-data x-init="$store.shortcuts.setScope('settings')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div class="max-w-2xl">
 		@settingsTabHeader(settingsTabHeaderProps{
-			Title:    "Sync",
-			Subtitle: "Schedule and log retention",
+			Title:    "General",
+			Subtitle: "Schedule, log retention, and avatars",
 		})
 		<div class="grid gap-6">
 			@settingsSyncSchedule(p)
 			@settingsSyncRetention(p)
+			@settingsAvatarStyleCard(p)
 		</div>
 	</div>
 }
 
-// SettingsSecurity renders the Security tab — encryption key status +
-// pointer to Account for password changes.
-templ SettingsSecurity(p SettingsProps) {
-	<div class="max-w-2xl">
-		@settingsTabHeader(settingsTabHeaderProps{
-			Title:    "Security",
-			Subtitle: "Encryption key status",
-		})
-		<div class="grid gap-6">
-			@settingsSecurityCardFlat(p)
-		</div>
-	</div>
-}
-
-// SettingsSystem renders the System tab — version info + update badge
-// + the user-avatar style picker.
+// SettingsSystem renders the System tab — encryption key status,
+// version info, and runtime details. Security folds in here so the
+// admin has one stop for "this server's posture."
 templ SettingsSystem(p SettingsProps) {
 	<div class="max-w-2xl">
 		@settingsTabHeader(settingsTabHeaderProps{
 			Title:    "System",
-			Subtitle: "Version and runtime information",
+			Subtitle: "Security and runtime information",
 		})
 		<div class="grid gap-6">
+			@settingsSecurityCardFlat(p)
 			@settingsSystemCard(p)
-			@settingsAvatarStyleCard(p)
 		</div>
 	</div>
 }
@@ -264,7 +253,7 @@ templ settingsSystemCard(p SettingsProps) {
 }
 
 // settingsAvatarStyleCard renders the DiceBear style picker on the
-// System tab. The select submits via POST /settings/avatar-style;
+// General tab. The select submits via POST /settings/avatar-style;
 // the live preview is driven by Alpine and points at
 // api.dicebear.com so the user can compare styles without
 // reloading the server-rendered identicons.
@@ -369,7 +358,7 @@ func encryptionStatus(has bool) string {
 }
 
 // ---------------------------------------------------------------------
-// Flat (non-accordion) templs used by the new SettingsSync/Security/Help
+// Flat (non-accordion) templs used by the new SettingsGeneral/System/Help
 // tab pages. Each renders the same content the legacy accordion cards
 // did, but without the expand/collapse chrome — a tab page IS the
 // disclosure now.

--- a/internal/templates/components/pages/settings_tabs.go
+++ b/internal/templates/components/pages/settings_tabs.go
@@ -16,8 +16,7 @@ import "breadbox/internal/templates/components"
 //     page, hung off the sidebar's System section.
 const (
 	SettingsTabAccount   = components.SettingsModalTabAccount
-	SettingsTabSync      = components.SettingsModalTabSync
-	SettingsTabSecurity  = components.SettingsModalTabSecurity
+	SettingsTabGeneral   = components.SettingsModalTabGeneral
 	SettingsTabSystem    = components.SettingsModalTabSystem
 	SettingsTabProviders = components.SettingsModalTabProviders
 	SettingsTabAgents    = components.SettingsModalTabAgents

--- a/internal/templates/components/settings_modal.templ
+++ b/internal/templates/components/settings_modal.templ
@@ -127,8 +127,7 @@ templ settingsModalDesktopRail(p SettingsModalProps) {
 templ settingsModalRailItems(p SettingsModalProps, mobile bool) {
 	@settingsModalRailItem(SettingsModalTabAccount, "user-cog", "Account", mobile)
 	if p.IsAdmin {
-		@settingsModalRailItem(SettingsModalTabSync, "refresh-cw", "Sync", mobile)
-		@settingsModalRailItem(SettingsModalTabSecurity, "shield", "Security", mobile)
+		@settingsModalRailItem(SettingsModalTabGeneral, "sliders-horizontal", "General", mobile)
 		@settingsModalRailItem(SettingsModalTabSystem, "cpu", "System", mobile)
 		@settingsModalRailItem(SettingsModalTabProviders, "plug", "Providers", mobile)
 		@settingsModalRailItem(SettingsModalTabAgents, "sparkles", "Agents", mobile)

--- a/internal/templates/components/settings_modal_types.go
+++ b/internal/templates/components/settings_modal_types.go
@@ -47,11 +47,11 @@ type SettingsModalProps struct {
 
 // SettingsModalTab identifiers — mirror the old SettingsLayout constants
 // minus Profile (merged into Account) and Household (promoted to its own
-// top-level page).
+// top-level page). Security folds into System, and the legacy Sync tab
+// became General (general settings: schedule, retention, avatars).
 const (
 	SettingsModalTabAccount   = "account"
-	SettingsModalTabSync      = "sync"
-	SettingsModalTabSecurity  = "security"
+	SettingsModalTabGeneral   = "general"
 	SettingsModalTabSystem    = "system"
 	SettingsModalTabProviders = "providers"
 	SettingsModalTabAgents    = "agents"

--- a/static/js/admin/components/settings_modal.js
+++ b/static/js/admin/components/settings_modal.js
@@ -427,7 +427,7 @@ document.addEventListener('alpine:init', function () {
       // _consumePageFlashIntoToast moves the layout's flash banner
       // (rendered inside <main> by html/template on cold deep-loads)
       // into the in-modal toast, then hides the banner. Without this,
-      // cold-loading /settings/sync right after a redirect-with-flash
+      // cold-loading /settings/general right after a redirect-with-flash
       // would show the flash behind the modal AND we'd lose it once
       // the modal closes.
       _consumePageFlashIntoToast: function () {
@@ -517,8 +517,7 @@ document.addEventListener('alpine:init', function () {
 // summary can render the active label/icon without a server round-trip.
 var TAB_META = {
   'account':   { label: 'Account',   icon: 'user-cog' },
-  'sync':      { label: 'Sync',      icon: 'refresh-cw' },
-  'security':  { label: 'Security',  icon: 'shield' },
+  'general':   { label: 'General',   icon: 'sliders-horizontal' },
   'system':    { label: 'System',    icon: 'cpu' },
   'providers': { label: 'Providers', icon: 'plug' },
   'agents':    { label: 'Agents',    icon: 'sparkles' },


### PR DESCRIPTION
## Summary

- Rename Settings → **Sync** to **General**: hosts schedule, log retention, and the user-avatar style picker (moved from System).
- Fold **Security** into **System**: encryption-key card now sits beside version/runtime info — one stop for "this server's posture."
- Old URLs redirect: `/settings/sync` → `/settings/general`, `/settings/security` → `/settings/system`.
- Rail icon for General is `sliders-horizontal`; JS tab metadata moves in lockstep.

## Screenshots

### General tab — top (schedule + log retention)

<img src="https://i.img402.dev/cidyh8tuai.jpg" width="800" alt="Settings → General — top of tab">

### General tab — bottom (User Avatars moved here)

<img src="https://i.img402.dev/pb88s871hk.jpg" width="800" alt="Settings → General — User Avatars card">

### System tab (Security folded in)

<img src="https://i.img402.dev/ouwdcqy7y4.jpg" width="800" alt="Settings → System — Encryption Key + System">

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] `/settings` lands on the new General tab
- [x] `/settings/sync` → 303 → `/settings/general`
- [x] `/settings/security` → 303 → `/settings/system`
- [x] Avatar style POST redirects back to `/settings/general`
- [x] System tab renders Encryption Key + System info

🤖 Generated with [Claude Code](https://claude.com/claude-code)
