### PR TITLE
fix(ui): drop redundant error chips when banner conveys the same signal

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -271,6 +271,64 @@ The canonical pattern for create/edit/settings forms. A sectioned card with a co
 - **No back link inside `.bb-page-header`.** The breadcrumb above the header is the sole back affordance — see the [Page Header](#page-header-bb-page-header) section above. The Cancel button in the bottom action row is the only secondary navigation the form needs.
 - For destructive operations, add a **separate** `bb-card bb-danger-card` below — never mix the save action with the delete action in one card.
 
+### Error surfacing — banner vs badge
+
+Errors and warnings should appear in **exactly one place** per page. When the same error is communicated as both a badge in the entity header *and* an alert banner below, the banner always wins — drop the badge.
+
+**Pick one surface per condition:**
+
+| Condition | Use |
+|---|---|
+| Error has a **message + action** the user must take (reauth, fix-it button, "view details") | **Banner / alert card** — full-width, prominent, contains the action |
+| Error is a **transient state on a list row** with no per-row action | **Badge** — compact, scannable across many rows |
+| Entity is in a **neutral state** (Active, Paused, Stale, Manual trigger) | **Badge** — these are state indicators, not duplicates of an error message |
+
+**Decision rule (canonical):**
+
+> If a banner or alert card on this page surfaces an error or required action, the entity header (or row header) must **not** also render a chip for that same condition. The banner carries the message; the chip would be a second copy of the same signal.
+
+Neutral metadata badges (`Paused`, `Stale`, trigger label, `Manual`, etc.) are **orthogonal** to the error and stay regardless of whether a banner is present — they communicate different facts.
+
+**Implementation pattern.** Compute a `hasErrorBanner` predicate from the same conditions the banner uses, then gate the status chip on `!hasErrorBanner`. Example from `connection_detail.templ`:
+
+```go
+// connDetailHasErrorBanner mirrors the two banner conditions above the
+// EntityHeader (reauth-required + 3+ consecutive failures). The status
+// chips inside connDetailBadges read this so they don't duplicate the
+// same signal as an inline pill.
+func connDetailHasErrorBanner(p ConnectionDetailProps) bool {
+    if p.Status == "error" || p.Status == "pending_reauth" {
+        return true
+    }
+    if p.ConsecutiveFailures >= 3 {
+        return true
+    }
+    return false
+}
+```
+
+```templ
+templ connDetailBadges(p ConnectionDetailProps) {
+    if !connDetailHasErrorBanner(p) {
+        // status / sync-error chip — suppressed when a banner is canonical
+        @templ.Raw(components.StatusBadge(p.Status))
+    }
+    if p.Paused {
+        <span class="badge badge-ghost badge-sm">Paused</span>  <!-- orthogonal: always shown -->
+    }
+}
+```
+
+**What this fixes.** Before the consolidation, `/connections/{id}` rendered a full red banner ("This connection needs re-authentication" + Re-authenticate button) AND a `Reauth` chip beside the title, and `/sync-logs/{id}` rendered a "warning" chip beside the title AND a Warning detail card below. Both were two visual carriers of the same fact. After: banner wins, chip disappears.
+
+**Anti-patterns to avoid:**
+
+- A status chip + alert banner saying the same thing on the same page.
+- A "Sync Error" hover-tooltip chip when the row already has a banner below explaining the same error.
+- Stacking a header chip on top of a row-level error banner inside the same card.
+
+When in doubt: **delete the chip, keep the banner**. The banner has the message + the action; the chip is just a colored label of the same fact.
+
 
 ## 3. Form patterns
 

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -114,25 +114,45 @@ func connDetailIconTone(provider string) components.IconTone {
 	}
 }
 
-// connDetailBadges renders the inline status chips next to the title:
-// the StatusBadge (or sync-error hover tooltip), plus a Paused badge.
+// connDetailBadges renders the inline status chips next to the title.
+//
+// Error-surfacing rule: when one of the page-level banners renders
+// above the header (reauth-required or consecutive-failures), suppress
+// the status / sync-error chip here — the banner is canonical. Neutral
+// metadata (Paused) is kept because it's orthogonal to the error.
 templ connDetailBadges(p ConnectionDetailProps) {
-	if p.LastSyncStatus == "error" && p.Status == "active" {
-		<span class="relative group/err">
-			<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
-			if p.LastSyncErrorMessageValid {
-				<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-					<span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
-					<span class="text-base-content/70">{ p.LastSyncErrorMessageString }</span>
-				</span>
-			}
-		</span>
-	} else {
-		@templ.Raw(components.StatusBadge(p.Status))
+	if !connDetailHasErrorBanner(p) {
+		if p.LastSyncStatus == "error" && p.Status == "active" {
+			<span class="relative group/err">
+				<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+				if p.LastSyncErrorMessageValid {
+					<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
+						<span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
+						<span class="text-base-content/70">{ p.LastSyncErrorMessageString }</span>
+					</span>
+				}
+			</span>
+		} else {
+			@templ.Raw(components.StatusBadge(p.Status))
+		}
 	}
 	if p.Paused {
 		<span class="badge badge-ghost badge-sm">Paused</span>
 	}
+}
+
+// connDetailHasErrorBanner mirrors the two banner conditions above the
+// EntityHeader: needs-reauth (status error or pending_reauth) and the
+// 3+ consecutive failures warning. Used by connDetailBadges to avoid
+// duplicating the same signal as an inline chip.
+func connDetailHasErrorBanner(p ConnectionDetailProps) bool {
+	if p.Status == "error" || p.Status == "pending_reauth" {
+		return true
+	}
+	if p.ConsecutiveFailures >= 3 {
+		return true
+	}
+	return false
 }
 
 // connDetailMeta renders the bullet-separated meta line: provider,

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -214,23 +214,29 @@ templ connectionsCard(c ConnectionsRow) {
 					}
 				</div>
 				<div class="min-w-0">
-					<!-- Name + status badge row -->
+					<!-- Name + status badge row.
+					     Error-surfacing rule: when the connection-error banner renders
+					     below (c.ErrorMessageValid), suppress the status / sync-error
+					     chip here — the banner is canonical. Neutral badges (Stale,
+					     Paused) remain because they're orthogonal signals. -->
 					<div class="flex items-center gap-2 flex-wrap">
 						<h3 class="font-semibold text-sm sm:text-base group-hover:text-primary transition-colors truncate max-w-[8rem] xs:max-w-[10rem] sm:max-w-none">{ c.InstitutionName }</h3>
 						if c.IsStale {
 							<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning shrink-0">Stale</span>
-						} else if c.LastSyncStatus == "error" && c.Status == "active" {
-							<span class="relative group/err shrink-0">
-								<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
-								if c.LastSyncErrorMessage != "" {
-									<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-										<span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
-										<span class="text-base-content/70">{ c.LastSyncErrorMessage }</span>
-									</span>
-								}
-							</span>
-						} else {
-							@templ.Raw(components.StatusBadge(c.Status))
+						} else if !c.ErrorMessageValid {
+							if c.LastSyncStatus == "error" && c.Status == "active" {
+								<span class="relative group/err shrink-0">
+									<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+									if c.LastSyncErrorMessage != "" {
+										<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
+											<span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
+											<span class="text-base-content/70">{ c.LastSyncErrorMessage }</span>
+										</span>
+									}
+								</span>
+							} else {
+								@templ.Raw(components.StatusBadge(c.Status))
+							}
 						}
 						if c.Paused {
 							<span class="badge badge-ghost badge-xs shrink-0">Paused</span>

--- a/internal/templates/components/pages/sync_log_detail.templ
+++ b/internal/templates/components/pages/sync_log_detail.templ
@@ -204,14 +204,16 @@ func syncDetailIconTone(status string) components.IconTone {
 	}
 }
 
+// syncDetailBadges renders the inline status chips next to the title.
+//
+// Error-surfacing rule: the Warning Card and Error Details Card below
+// are canonical for their respective messages — we no longer render a
+// "warning" chip here in addition. The trigger badge stays (orthogonal
+// metadata) and the SyncBadge stays (state indicator, not a duplicate
+// of the message).
 templ syncDetailBadges(p SyncLogDetailProps) {
 	<span class="badge badge-ghost badge-sm">{ p.Log.Trigger }</span>
 	@templ.Raw(components.SyncBadge(p.Log.Status))
-	if p.Log.WarningMessage != "" {
-		<span class="badge badge-warning badge-sm gap-1">
-			<i data-lucide="alert-triangle" class="w-3 h-3"></i>warning
-		</span>
-	}
 }
 
 templ syncDetailMeta(p SyncLogDetailProps) {


### PR DESCRIPTION
## Summary

- Stops stacking an error/warning chip in the entity header when a banner or detail card on the same page already carries that message. Hits `/connections`, `/connections/{id}`, and `/sync-logs/{id}`.
- Adds an "Error surfacing — banner vs badge" pattern to `docs/design-system.md` so future pages have a written rule: banner wins, drop the redundant chip; neutral metadata badges (`Paused`, `Stale`, trigger) stay because they're orthogonal.
- `connection_detail.templ` gets a small `connDetailHasErrorBanner` predicate so the chip-gating mirrors the banner-gating instead of diverging.

## Before / after — `/connections/{id}` with consecutive-failure banner

The orange "This connection has failed 3 syncs in a row" banner already carries the message + the implicit pointer to the sync history. The "Sync Error" pill beside the title was a second copy of the same fact.

<table>
  <tr><th>Before — banner + redundant "Sync Error" pill</th><th>After — banner only</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/7ii3sdadxy.jpg" width="430" alt="connection detail before — Sync Error pill next to title plus banner"></td>
    <td><img src="https://i.img402.dev/1ispr489wt.jpg" width="430" alt="connection detail after — banner only, no chip"></td>
  </tr>
</table>

The same predicate also covers the `pending_reauth` / `error` reauth banner — when that banner renders, the `Reauth` / `Error` status pill in the header is suppressed.

## Other pages touched

- **`/connections`** — when a connection card renders the inline reauth-required / `View Details` banner (`c.ErrorMessageValid`), the status pill (`Reauth`, `Error`, `Sync Error`) in that card's header is suppressed. `Stale` and `Paused` are unchanged.
- **`/sync-logs/{id}`** — the standalone "warning" chip (icon + literal word "warning") next to the title is removed. The `Warning` detail card below has the message. The trigger badge (`cron`/`manual`) and `SyncBadge` (status state indicator) stay — neither duplicates the card.

## Pattern (now in `docs/design-system.md` §2)

> If a banner or alert card on this page surfaces an error or required action, the entity header must **not** also render a chip for that same condition. Neutral metadata badges (Paused, Stale, trigger label) are orthogonal and stay.

Implementation tip: compute a `hasErrorBanner` predicate from the same conditions the banner uses, then gate the chip on `!hasErrorBanner` so the two surfaces can't drift apart.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `templ generate` clean (3 templ files updated)
- [x] Visually validated `/connections/{id}` with `ConsecutiveFailures >= 3` — banner remains, "Sync Error" pill removed (see screenshots above)
- [ ] Reviewer: confirm `/connections` list still shows status pill for cards **without** a banner (active/disconnected/sync-only-error cases)
- [ ] Reviewer: confirm `/sync-logs/{id}` with a populated `warning_message` (no seed fixture available locally) still shows the Warning card, with no `warning` chip in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
