### PR TITLE
feat(ui): move Agents to top of Manage sidebar section

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -68,6 +68,12 @@ templ Nav(p NavProps) {
 			</a>
 		}
 		<div class="bb-sidebar-section">Manage</div>
+		if p.IsEditor {
+			<a href="/agents" class={ "bb-sidebar-link", navActive(p.CurrentPage, "agents") }>
+				<i data-lucide="bot-message-square"></i>
+				<span>Agents</span>
+			</a>
+		}
 		if p.IsAdmin {
 			<a href="/rules" class={ "bb-sidebar-link", navActive(p.CurrentPage, "rules") }>
 				<i data-lucide="zap"></i> Rules
@@ -98,13 +104,6 @@ templ Nav(p NavProps) {
 					<i data-lucide="scroll-text"></i> Logs
 				</a>
 			}
-		}
-		if p.IsEditor {
-			<div class="bb-sidebar-section">Resources</div>
-			<a href="/agents" class={ "bb-sidebar-link", navActive(p.CurrentPage, "agents") }>
-				<i data-lucide="bot-message-square"></i>
-				<span>Agents</span>
-			</a>
 		}
 	</nav>
 	<div class="mt-auto pt-3 border-t border-base-300 px-2">


### PR DESCRIPTION
## Summary

- Move the Agents sidebar link to the top of the **Manage** section (above Rules, Categories, Tags).
- Drop the standalone **Resources** section heading — it only held Agents.

## Screenshot

<img src="https://i.img402.dev/9b95fbjngy.jpg" width="800" alt="sidebar — Agents at top of Manage">

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/templates/...` green
- [x] Logged in locally; sidebar order is `Manage → Agents → Rules → Categories → Tags`, Resources heading gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
