### PR TITLE
feat(agents): sticky run-detail header, dedupe zero-result, auto-scroll on live

### DIFF
--- a/input.css
+++ b/input.css
@@ -3065,10 +3065,20 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.5rem 0;
-  margin-bottom: 1rem;
+  padding: 0.5rem 0.25rem;
+  margin: 0 -0.25rem 1rem -0.25rem;
   border-bottom: 1px solid color-mix(in oklch, var(--color-base-300) 60%, transparent);
   flex-wrap: wrap;
+
+  /* Sticky to the top of the scroll container so the agent name +
+   * status badge + duration ticker remain accessible while the
+   * operator scrolls through a long transcript. */
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: color-mix(in oklch, var(--color-base-100) 92%, transparent);
+  backdrop-filter: saturate(140%) blur(6px);
+  -webkit-backdrop-filter: saturate(140%) blur(6px);
 }
 .bb-run-header__lead {
   display: flex;

--- a/internal/admin/agent_run_live.go
+++ b/internal/admin/agent_run_live.go
@@ -99,6 +99,9 @@ func AgentRunLiveHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 		var truncated bool
 		if path != "" {
 			events, truncated, _ = parseTranscriptFile(path, agentRunTranscriptMaxEvents)
+			// Match the initial server render — drop zero-valued result
+			// envelopes so the live patch doesn't reintroduce them.
+			events = pages.FilterTranscriptForDisplay(events)
 		}
 
 		props := pages.AgentRunDetailProps{

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -267,7 +267,11 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 					props.Error = "Transcript file not available: " + perr.Error()
 				}
 			} else {
-				props.Transcript = events
+				// Drop empty `result` envelopes (zero cost + zero tokens
+				// across the board) — the SDK occasionally emits one
+				// before the real usage payload and rendering both as
+				// "Final result" bubbles is confusing.
+				props.Transcript = pages.FilterTranscriptForDisplay(events)
 				props.Truncated = truncated
 			}
 		}

--- a/internal/templates/components/pages/agent_runs_helpers.go
+++ b/internal/templates/components/pages/agent_runs_helpers.go
@@ -33,3 +33,35 @@ var AgentRunFriendlyErrorMappings = []agentRunErrorMapping{
 		message: "Interrupted by a server restart — safe to re-run.",
 	},
 }
+
+// FilterTranscriptForDisplay drops events that are present in the
+// NDJSON file but add no signal to the rendered transcript. Currently
+// just `result` events where every numeric field is zero: the SDK
+// sometimes emits an init-shaped result envelope before the actual
+// usage payload, and rendering both as "Final result" bubbles is
+// confusing (the operator sees a row of zeros followed by the real one).
+//
+// Callers: the initial server render and the /-/agents/runs/{id}/live
+// poll endpoint — both feed events through here so the live patch
+// matches what the operator already saw on first paint.
+func FilterTranscriptForDisplay(events []TranscriptEvent) []TranscriptEvent {
+	if len(events) == 0 {
+		return events
+	}
+	out := make([]TranscriptEvent, 0, len(events))
+	for _, ev := range events {
+		if ev.Type == "result" && resultEventIsEmpty(ev) {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+func resultEventIsEmpty(ev TranscriptEvent) bool {
+	return ev.CostUSD == 0 &&
+		ev.TokensIn == 0 &&
+		ev.TokensOut == 0 &&
+		ev.CacheRead == 0 &&
+		ev.CacheWrite == 0
+}

--- a/internal/templates/components/pages/agent_runs_helpers_test.go
+++ b/internal/templates/components/pages/agent_runs_helpers_test.go
@@ -1,0 +1,49 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+func TestFilterTranscriptForDisplay_DropsEmptyResult(t *testing.T) {
+	in := []TranscriptEvent{
+		{Type: "assistant", Text: "hello"},
+		{Type: "result"}, // zero everywhere → drop
+		{Type: "assistant", Text: "world"},
+		{Type: "result", CostUSD: 0.05, TokensIn: 12, TokensOut: 4},
+	}
+	out := FilterTranscriptForDisplay(in)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 events after filter, got %d: %+v", len(out), out)
+	}
+	if out[0].Type != "assistant" || out[0].Text != "hello" {
+		t.Errorf("expected first assistant event preserved, got %+v", out[0])
+	}
+	if out[1].Type != "assistant" || out[1].Text != "world" {
+		t.Errorf("expected second assistant event preserved, got %+v", out[1])
+	}
+	if out[2].Type != "result" || out[2].CostUSD == 0 {
+		t.Errorf("expected non-empty result preserved, got %+v", out[2])
+	}
+}
+
+func TestFilterTranscriptForDisplay_KeepsNonResult(t *testing.T) {
+	in := []TranscriptEvent{
+		{Type: "tool_use", ToolName: "x"},
+		{Type: "tool_result"},
+		{Type: "error", Text: "oops"},
+	}
+	out := FilterTranscriptForDisplay(in)
+	if len(out) != len(in) {
+		t.Fatalf("expected no filtering on non-result events, got %d / %d", len(out), len(in))
+	}
+}
+
+func TestFilterTranscriptForDisplay_KeepsResultWithJustCacheData(t *testing.T) {
+	// A result event that only carries cache stats (no cost, no input/output
+	// tokens) is still meaningful — surface it.
+	in := []TranscriptEvent{{Type: "result", CacheRead: 100}}
+	out := FilterTranscriptForDisplay(in)
+	if len(out) != 1 {
+		t.Fatalf("expected result with cache_read preserved, got %+v", out)
+	}
+}

--- a/static/js/admin/components/agent_run_detail.js
+++ b/static/js/admin/components/agent_run_detail.js
@@ -61,6 +61,30 @@ document.addEventListener('alpine:init', function () {
         if (this.pollSeconds > 0 && this.status === 'in_progress') {
           var self2 = this;
           this.pollTimer = setTimeout(function () { self2.poll(); }, this.pollSeconds * 1000);
+          // For long in_progress runs the operator usually wants to
+          // see what just happened — anchor the view at the bottom
+          // of the thread on first paint.
+          this.$nextTick(function () { self2.scrollThreadToBottom(false); });
+        }
+      },
+
+      // scrollThreadToBottom snaps the chat thread to its last event.
+      // We only run this for in_progress runs — a finished run should
+      // open at the top so the operator reads the conversation in
+      // order. `smooth` toggles the scroll-behaviour: false for the
+      // initial anchor (the operator hasn't moved yet), true after a
+      // live-poll patch (so they notice new content land).
+      scrollThreadToBottom: function (smooth) {
+        var thread = this.$refs.thread;
+        if (!thread) return;
+        // We may be scrolling either the inner thread element (when it
+        // has its own overflow) or the window (when the page itself
+        // grows). Try the inner element first.
+        try {
+          thread.scrollIntoView({ block: 'end', behavior: smooth ? 'smooth' : 'auto' });
+        } catch (e) {
+          // older browsers — fall back to a manual offset
+          window.scrollTo(0, document.body.scrollHeight);
         }
       },
 
@@ -111,6 +135,11 @@ document.addEventListener('alpine:init', function () {
       // round-trip individual events.
       applyLive: function (body) {
         if (!body) return;
+        var prevEventCount = -1;
+        if (this.$refs.eventCount) {
+          var m = (this.$refs.eventCount.textContent || '').match(/(\d+)/);
+          if (m) prevEventCount = parseInt(m[1], 10);
+        }
         if (typeof body.transcriptHTML === 'string') {
           var threadEl = this.$refs.thread;
           if (threadEl) {
@@ -118,6 +147,19 @@ document.addEventListener('alpine:init', function () {
             // Re-init lucide icons for any newly-injected <i data-lucide>.
             if (window.lucide && typeof window.lucide.createIcons === 'function') {
               window.lucide.createIcons();
+            }
+            // If new events landed AND the run is still in_progress,
+            // smoothly scroll the thread so the operator sees them
+            // arrive. We skip this on a no-op patch (same event count)
+            // so reading from above the fold doesn't get yanked down.
+            if (
+              this.status === 'in_progress' &&
+              typeof body.eventCount === 'number' &&
+              prevEventCount >= 0 &&
+              body.eventCount > prevEventCount
+            ) {
+              var self = this;
+              this.$nextTick(function () { self.scrollThreadToBottom(true); });
             }
           }
         }


### PR DESCRIPTION
## Summary

Three polish items on top of [#1534](https://github.com/canalesb93/breadbox/pull/1534):

- **`.bb-run-header` is sticky** — `position: sticky; top: 0` + translucent blur. Agent name, status, copyable shortid, and the live duration ticker stay reachable while the operator scrolls a long transcript.
- **Drop empty `result` events** — the SDK emits a pre-result envelope (all-zero cost / tokens / cache) before the real usage payload. Rendering both as "Final result" bubbles was confusing. The new `FilterTranscriptForDisplay` helper is shared by both the initial render and the `/-/agents/runs/{id}/live` poll endpoint so the two agree.
- **Auto-scroll on live updates** — `in_progress` runs anchor to the bottom of the transcript on first paint, and smooth-scroll to the bottom when the live poll appends new events. No-op patches (same event count) don't scroll, so reading from above the fold isn't yanked down.

## Screenshot — sticky header in action

<img src="https://i.img402.dev/1mzdd50jix.jpg" width="800" alt="Sticky header pinned while the page is scrolled into the transcript">

## Test plan

- [x] `go test ./...` clean — new `agent_runs_helpers_test.go` covers the filter (drops zero-result, keeps non-result, keeps cache-only result).
- [x] Verified on `/agents/runs/dGHbZfr6`: header pinned while scrolling, exactly one Final Result bubble (was two), no regressions on the chat thread.
- [x] Live endpoint applies the same filter, so a poll patch can't reintroduce the suppressed event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
