### PR TITLE
feat(agents): label tool_result rows with their tool name + system event tier

### DIFF
--- a/input.css
+++ b/input.css
@@ -3308,3 +3308,18 @@
 /* Thread within the run page surface: a single shared list rhythm for
  * the inner <ul class="bb-chat-thread">. */
 .bb-run-thread { display: block; }
+
+/* Run-detail "system" event row — subtle informational tier that
+ * sits below the chat thread visually. Used for SDK init messages,
+ * cost_cap_hit notifications, and anything else the operator wants
+ * to know happened but didn't author themselves. Pairs with the
+ * pages.agentRunTranscriptEvent "system" case. */
+.bb-system-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.5rem;
+  background: color-mix(in oklch, var(--color-base-200) 35%, transparent);
+  border: 1px dashed color-mix(in oklch, var(--color-base-300) 60%, transparent);
+}

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -472,9 +472,10 @@ func classifyTranscriptEvent(obj map[string]any, raw string) pages.TranscriptEve
 		// see "no text content" for the tool-only assistant message.
 		// We could iterate content[] for tool_use too, but the
 		// constraint says "don't gold-plate" — grouping is non-trivial.
-		if toolUse, name, input := firstToolUseBlock(obj); toolUse {
+		if toolUse, id, name, input := firstToolUseBlock(obj); toolUse {
 			ev.Type = "tool_use"
 			ev.ToolName = name
+			ev.ToolUseID = id
 			ev.ToolInputJSON = input
 		}
 	case "user_message":
@@ -483,8 +484,9 @@ func classifyTranscriptEvent(obj map[string]any, raw string) pages.TranscriptEve
 		// A user_message often carries tool_result blocks. Surface the
 		// first one as a tool_result event if there is one; otherwise
 		// fall back to user text.
-		if hasResult, resultJSON := firstToolResultBlock(obj); hasResult {
+		if hasResult, id, resultJSON := firstToolResultBlock(obj); hasResult {
 			ev.Type = "tool_result"
+			ev.ToolUseID = id
 			ev.ToolResultJSON = resultJSON
 		} else {
 			ev.Text = extractMessageText(obj)
@@ -493,6 +495,7 @@ func classifyTranscriptEvent(obj map[string]any, raw string) pages.TranscriptEve
 		ev.Type = "tool_use"
 		if data, ok := obj["data"].(map[string]any); ok {
 			ev.ToolName, _ = data["name"].(string)
+			ev.ToolUseID, _ = data["id"].(string)
 			if input, ok := data["input"]; ok {
 				if b, err := json.MarshalIndent(input, "", "  "); err == nil {
 					ev.ToolInputJSON = string(b)
@@ -502,6 +505,7 @@ func classifyTranscriptEvent(obj map[string]any, raw string) pages.TranscriptEve
 	case "tool_result":
 		ev.Type = "tool_result"
 		if data, ok := obj["data"].(map[string]any); ok {
+			ev.ToolUseID, _ = data["tool_use_id"].(string)
 			if content, ok := data["content"]; ok {
 				if b, err := json.MarshalIndent(content, "", "  "); err == nil {
 					ev.ToolResultJSON = string(b)
@@ -569,18 +573,18 @@ func extractMessageText(obj map[string]any) string {
 	return out
 }
 
-func firstToolUseBlock(obj map[string]any) (found bool, name, inputJSON string) {
+func firstToolUseBlock(obj map[string]any) (found bool, id, name, inputJSON string) {
 	data, ok := obj["data"].(map[string]any)
 	if !ok {
-		return false, "", ""
+		return false, "", "", ""
 	}
 	msg, ok := data["message"].(map[string]any)
 	if !ok {
-		return false, "", ""
+		return false, "", "", ""
 	}
 	content, ok := msg["content"].([]any)
 	if !ok {
-		return false, "", ""
+		return false, "", "", ""
 	}
 	for _, block := range content {
 		bm, ok := block.(map[string]any)
@@ -589,26 +593,27 @@ func firstToolUseBlock(obj map[string]any) (found bool, name, inputJSON string) 
 		}
 		if t, _ := bm["type"].(string); t == "tool_use" {
 			n, _ := bm["name"].(string)
+			tid, _ := bm["id"].(string)
 			input := bm["input"]
 			b, _ := json.MarshalIndent(input, "", "  ")
-			return true, n, string(b)
+			return true, tid, n, string(b)
 		}
 	}
-	return false, "", ""
+	return false, "", "", ""
 }
 
-func firstToolResultBlock(obj map[string]any) (found bool, contentJSON string) {
+func firstToolResultBlock(obj map[string]any) (found bool, id, contentJSON string) {
 	data, ok := obj["data"].(map[string]any)
 	if !ok {
-		return false, ""
+		return false, "", ""
 	}
 	msg, ok := data["message"].(map[string]any)
 	if !ok {
-		return false, ""
+		return false, "", ""
 	}
 	content, ok := msg["content"].([]any)
 	if !ok {
-		return false, ""
+		return false, "", ""
 	}
 	for _, block := range content {
 		bm, ok := block.(map[string]any)
@@ -616,12 +621,13 @@ func firstToolResultBlock(obj map[string]any) (found bool, contentJSON string) {
 			continue
 		}
 		if t, _ := bm["type"].(string); t == "tool_result" {
+			tid, _ := bm["tool_use_id"].(string)
 			inner := bm["content"]
 			b, _ := json.MarshalIndent(inner, "", "  ")
-			return true, string(b)
+			return true, tid, string(b)
 		}
 	}
-	return false, ""
+	return false, "", ""
 }
 
 func readFloat(m map[string]any, k string) float64 {

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -334,6 +334,9 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 					<summary class="bb-tool__summary">
 						<div class="bb-tool__icon bb-tool__icon--result"><i data-lucide="check-check" class="w-3.5 h-3.5"></i></div>
 						<span class="bb-tool__label">Tool result</span>
+						if ev.ToolName != "" {
+							<span class="bb-tool__name font-mono">{ agentRunToolDisplay(ev.ToolName) }</span>
+						}
 						if !ev.Timestamp.IsZero() {
 							<time class="bb-tool__time" datetime={ ev.Timestamp.Format(time.RFC3339) }>{ ev.Timestamp.Format("15:04:05") }</time>
 						}
@@ -347,6 +350,19 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 						}
 					</div>
 				</details>
+			</li>
+		case "system":
+			<li class="bb-system-row">
+				<i data-lucide="info" class="w-3.5 h-3.5 flex-shrink-0 mt-0.5 text-base-content/50"></i>
+				<div class="min-w-0">
+					<div class="text-[0.65rem] uppercase tracking-wider text-base-content/50">System</div>
+					if ev.Text != "" {
+						<div class="text-xs text-base-content/70 mt-0.5 whitespace-pre-wrap break-words">{ ev.Text }</div>
+					}
+					if !ev.Timestamp.IsZero() {
+						<time class="text-[0.65rem] text-base-content/40 tabular-nums" datetime={ ev.Timestamp.Format(time.RFC3339) }>{ ev.Timestamp.Format("15:04:05") }</time>
+					}
+				</div>
 			</li>
 		case "result":
 			<li class="bb-run-summary">

--- a/internal/templates/components/pages/agent_runs_helpers.go
+++ b/internal/templates/components/pages/agent_runs_helpers.go
@@ -35,23 +35,46 @@ var AgentRunFriendlyErrorMappings = []agentRunErrorMapping{
 }
 
 // FilterTranscriptForDisplay drops events that are present in the
-// NDJSON file but add no signal to the rendered transcript. Currently
-// just `result` events where every numeric field is zero: the SDK
-// sometimes emits an init-shaped result envelope before the actual
-// usage payload, and rendering both as "Final result" bubbles is
-// confusing (the operator sees a row of zeros followed by the real one).
+// NDJSON file but add no signal to the rendered transcript, AND
+// enriches tool_result events with the name of the tool_use they're
+// answering. Two responsibilities in one pass because both touch
+// every event and the live endpoint + the initial render must agree
+// on the result either way.
+//
+// Filtering: `result` events where every numeric field is zero. The
+// Claude Agent SDK sometimes emits an init-shaped result envelope
+// before the actual usage payload, and rendering both as "Final
+// result" bubbles is confusing.
+//
+// Enrichment: builds an id->name index from tool_use events and
+// writes the tool name onto every tool_result whose ToolUseID
+// matches. The chat-thread row then reads "tool result —
+// query_transactions" instead of an anonymous "tool result".
 //
 // Callers: the initial server render and the /-/agents/runs/{id}/live
-// poll endpoint — both feed events through here so the live patch
-// matches what the operator already saw on first paint.
+// poll endpoint.
 func FilterTranscriptForDisplay(events []TranscriptEvent) []TranscriptEvent {
 	if len(events) == 0 {
 		return events
 	}
+	// Pass 1: build the id->name index across the whole slice.
+	toolNames := make(map[string]string, 8)
+	for _, ev := range events {
+		if ev.Type == "tool_use" && ev.ToolUseID != "" && ev.ToolName != "" {
+			toolNames[ev.ToolUseID] = ev.ToolName
+		}
+	}
+
+	// Pass 2: filter + enrich.
 	out := make([]TranscriptEvent, 0, len(events))
 	for _, ev := range events {
 		if ev.Type == "result" && resultEventIsEmpty(ev) {
 			continue
+		}
+		if ev.Type == "tool_result" && ev.ToolName == "" && ev.ToolUseID != "" {
+			if name, ok := toolNames[ev.ToolUseID]; ok {
+				ev.ToolName = name
+			}
 		}
 		out = append(out, ev)
 	}

--- a/internal/templates/components/pages/agent_runs_helpers_test.go
+++ b/internal/templates/components/pages/agent_runs_helpers_test.go
@@ -47,3 +47,37 @@ func TestFilterTranscriptForDisplay_KeepsResultWithJustCacheData(t *testing.T) {
 		t.Fatalf("expected result with cache_read preserved, got %+v", out)
 	}
 }
+
+func TestFilterTranscriptForDisplay_EnrichesToolResultWithName(t *testing.T) {
+	in := []TranscriptEvent{
+		{Type: "tool_use", ToolUseID: "toolu_a", ToolName: "query_transactions"},
+		{Type: "tool_use", ToolUseID: "toolu_b", ToolName: "list_categories"},
+		{Type: "tool_result", ToolUseID: "toolu_a", ToolResultJSON: `{"count": 47}`},
+		{Type: "tool_result", ToolUseID: "toolu_b", ToolResultJSON: `[]`},
+	}
+	out := FilterTranscriptForDisplay(in)
+	if len(out) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(out))
+	}
+	if out[2].ToolName != "query_transactions" {
+		t.Errorf("expected first tool_result enriched with query_transactions, got %q", out[2].ToolName)
+	}
+	if out[3].ToolName != "list_categories" {
+		t.Errorf("expected second tool_result enriched with list_categories, got %q", out[3].ToolName)
+	}
+}
+
+func TestFilterTranscriptForDisplay_LeavesOrphanToolResultAlone(t *testing.T) {
+	// A tool_result whose ToolUseID has no matching tool_use should keep
+	// an empty ToolName. The renderer drops the name pill in that case.
+	in := []TranscriptEvent{
+		{Type: "tool_result", ToolUseID: "toolu_unknown"},
+	}
+	out := FilterTranscriptForDisplay(in)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(out))
+	}
+	if out[0].ToolName != "" {
+		t.Errorf("expected empty ToolName for orphan tool_result, got %q", out[0].ToolName)
+	}
+}

--- a/internal/templates/components/pages/agent_runs_types.go
+++ b/internal/templates/components/pages/agent_runs_types.go
@@ -152,6 +152,15 @@ type TranscriptEvent struct {
 	ToolInputJSON  string
 	ToolResultJSON string
 
+	// ToolUseID is the SDK-assigned correlation ID. tool_use events
+	// carry their own ID; tool_result events carry the ID of the
+	// tool_use they're answering. The enrichment pass in
+	// FilterTranscriptForDisplay writes the tool's name onto every
+	// tool_result whose ToolUseID matches a known tool_use, so the
+	// rendered row can read "tool result — query_transactions" instead
+	// of an anonymous "tool result".
+	ToolUseID string
+
 	// CostUSD / token counts are populated for type=="result".
 	CostUSD     float64
 	TokensIn    int64

--- a/internal/templates/components/pages/design_agent_run_chat.templ
+++ b/internal/templates/components/pages/design_agent_run_chat.templ
@@ -182,12 +182,22 @@ templ SectionAgentRunChat() {
 		}
 		@designExample(
 			"Tool call + result rows",
-			"Tool events render as compact rows that expand into the JSONViewer. We strip the `mcp__breadbox__` prefix from tool names so the row stays readable. Color tone: blue tile for `tool_use`, green for `tool_result`.",
+			"Tool events render as compact rows that expand into the JSONViewer. We strip the `mcp__breadbox__` prefix from tool names so the row stays readable. Tool results inherit the name of the tool_use they're answering (via tool_use_id) so the operator can pair them at a glance. Color tone: blue tile for `tool_use`, green for `tool_result`.",
 		) {
 			<div class="bb-card p-4 max-w-2xl">
 				<ul class="bb-chat-thread">
 					@agentRunTranscriptEvent(designChatToolUseEvent(), 0)
 					@agentRunTranscriptEvent(designChatToolResultEvent(), 1)
+				</ul>
+			</div>
+		}
+		@designExample(
+			"System events",
+			"SDK init messages, cost_cap_hit, and other non-conversational events render as a subtle row beneath the chat thread. Dashed border + neutral icon to keep them out of the way.",
+		) {
+			<div class="bb-card p-4 max-w-2xl">
+				<ul class="bb-chat-thread">
+					@agentRunTranscriptEvent(designChatSystemEvent(), 0)
 				</ul>
 			</div>
 		}
@@ -230,6 +240,7 @@ func designChatToolUseEvent() TranscriptEvent {
 	return TranscriptEvent{
 		Type:          "tool_use",
 		ToolName:      "mcp__breadbox__query_transactions",
+		ToolUseID:     "toolu_demo_01",
 		ToolInputJSON: `{"start": "2026-04-25", "limit": 100, "categories": ["groceries", "subscriptions"]}`,
 		Timestamp:     time.Now().Add(-2 * time.Minute),
 	}
@@ -238,8 +249,18 @@ func designChatToolUseEvent() TranscriptEvent {
 func designChatToolResultEvent() TranscriptEvent {
 	return TranscriptEvent{
 		Type:           "tool_result",
+		ToolName:       "mcp__breadbox__query_transactions",
+		ToolUseID:      "toolu_demo_01",
 		ToolResultJSON: `{"count": 47, "sample": [{"merchant": "Whole Foods", "amount": 42.18}, {"merchant": "Spotify", "amount": 9.99}], "has_more": true}`,
 		Timestamp:      time.Now().Add(-1*time.Minute - 50*time.Second),
+	}
+}
+
+func designChatSystemEvent() TranscriptEvent {
+	return TranscriptEvent{
+		Type:      "system",
+		Text:      "Cost cap reached: stopping after 5 turns. Remaining budget: $0.00.",
+		Timestamp: time.Now().Add(-30 * time.Second),
 	}
 }
 


### PR DESCRIPTION
## Summary

Two scoped run-detail improvements on top of [#1536](https://github.com/canalesb93/breadbox/pull/1536):

- **Tool results show their tool name.** The Agent SDK ships a `tool_use_id` on every `tool_use` block and echoes it on the matching `tool_result` block; we thread it through the `TranscriptEvent` shape and `FilterTranscriptForDisplay` enriches each `tool_result` with the matching name. The chat-thread row reads "TOOL RESULT — `query_transactions`" instead of an anonymous "TOOL RESULT" — important because the SDK can return results out-of-order when a turn issues multiple parallel tool calls (visible in the screenshot below: on a real run, the first `query_transactions` result lands before the `get_overview` result).
- **Dedicated `system` transcript event tier.** The classifier already maps SDK `system` / `cost_cap_hit` events to `TranscriptEvent.Type="system"`, but the templ had no matching case so they fell into the "raw event" default. New row renders a subtle dashed-border block with an info icon, the message text, and a timestamp.

## Screenshot — tool result rows now name their tool

<img src="https://i.img402.dev/6bcvsp4mxv.jpg" width="800" alt="Tool call + result rows showing matched tool names">

## Test plan

- [x] `go test ./...` clean — new `agent_runs_helpers_test.go` cases cover happy-path enrichment (two parallel tool_use + tool_result, names threaded) and the orphan `tool_result` case (unknown ToolUseID → ToolName stays empty so the renderer drops the pill).
- [x] Sandbox: `/design/c/agent-run-chat` picks up a new "System events" example; the tool-pair example wires through ToolUseID end-to-end.
- [x] Verified on `/agents/runs/dGHbZfr6`: every `TOOL RESULT` row in a 4-call run now shows its tool name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
