### PR TITLE
feat(agents): "Tools used" sidebar card + "Jump to result" anchor

### DIFF
--- a/input.css
+++ b/input.css
@@ -3323,3 +3323,15 @@
   background: color-mix(in oklch, var(--color-base-200) 35%, transparent);
   border: 1px dashed color-mix(in oklch, var(--color-base-300) 60%, transparent);
 }
+
+/* "Jump to result" target flash — a brief primary-tinted halo when the
+ * sticky-header button scrolls the run summary into view, so the eye
+ * catches where the page jumped to. */
+.bb-run-summary--flash {
+  animation: bb-run-summary-flash 1.2s ease-out;
+}
+@keyframes bb-run-summary-flash {
+  0%   { box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-primary) 60%, transparent); }
+  20%  { box-shadow: 0 0 0 6px color-mix(in oklch, var(--color-primary) 30%, transparent); }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -56,6 +56,7 @@ templ AgentRunDetail(p AgentRunDetailProps) {
 			</section>
 			<aside class="space-y-4">
 				@agentRunStatsCard(p)
+				@agentRunToolsCard(p)
 				@agentRunNoteCard(p)
 				if len(p.Run.Reports) > 0 {
 					@agentRunReportsCard(p)
@@ -119,6 +120,17 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 			</div>
 		</div>
 		<div class="bb-run-header__actions">
+			if TranscriptHasResultEvent(p.Transcript) {
+				<button
+					type="button"
+					class="btn btn-sm btn-ghost gap-2"
+					title="Jump to the run's final result bubble"
+					@click="jumpToResult()"
+				>
+					<i data-lucide="flag-triangle-right" class="w-4 h-4"></i>
+					Jump to result
+				</button>
+			}
 			if p.Run.AgentSlug != "" {
 				<a
 					href={ templ.SafeURL("/agents?agent=" + p.Run.AgentSlug + "&run=1") }
@@ -540,6 +552,29 @@ templ agentRunNoteCard(p AgentRunDetailProps) {
 			</div>
 		</form>
 	</div>
+}
+
+// agentRunToolsCard surfaces the per-tool call counts for the run.
+// Helps the operator answer "which tools did this agent lean on?"
+// without scrolling the transcript. Hidden entirely when the run made
+// no tool calls (a pure-conversation agent).
+templ agentRunToolsCard(p AgentRunDetailProps) {
+	if usage := ComputeToolUsage(p.Transcript); len(usage) > 0 {
+		<div class="bb-card p-4">
+			<h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-2 flex items-center gap-1.5">
+				<i data-lucide="wrench" class="w-3 h-3"></i>
+				Tools used
+			</h3>
+			<ul class="space-y-1">
+				for _, t := range usage {
+					<li class="flex items-baseline justify-between gap-2 text-sm">
+						<span class="font-mono text-xs text-base-content/80 truncate">{ t.Name }</span>
+						<span class="badge badge-ghost badge-xs tabular-nums">{ strconv.Itoa(t.Count) }</span>
+					</li>
+				}
+			</ul>
+		</div>
+	}
 }
 
 templ agentRunReportsCard(p AgentRunDetailProps) {

--- a/internal/templates/components/pages/agent_runs_helpers.go
+++ b/internal/templates/components/pages/agent_runs_helpers.go
@@ -88,3 +88,77 @@ func resultEventIsEmpty(ev TranscriptEvent) bool {
 		ev.CacheRead == 0 &&
 		ev.CacheWrite == 0
 }
+
+// ToolUsageEntry is one row in the sidebar's "Tools used" breakdown:
+// the stripped tool name (no mcp__breadbox__ prefix) and how many
+// times this run invoked it.
+type ToolUsageEntry struct {
+	Name  string
+	Count int
+}
+
+// ComputeToolUsage walks the transcript and returns per-tool call
+// counts, sorted by count DESC then by name ASC. Drives the sidebar's
+// "Tools used" card. We count tool_use events (not tool_result) so a
+// run that issued a call but never got a result still shows up — the
+// operator probably wants to see the call attempt.
+func ComputeToolUsage(events []TranscriptEvent) []ToolUsageEntry {
+	if len(events) == 0 {
+		return nil
+	}
+	counts := make(map[string]int, 8)
+	for _, ev := range events {
+		if ev.Type != "tool_use" {
+			continue
+		}
+		name := stripMCPPrefix(ev.ToolName)
+		if name == "" {
+			continue
+		}
+		counts[name]++
+	}
+	out := make([]ToolUsageEntry, 0, len(counts))
+	for name, c := range counts {
+		out = append(out, ToolUsageEntry{Name: name, Count: c})
+	}
+	// Sort: count DESC, then name ASC.
+	sortToolUsage(out)
+	return out
+}
+
+func sortToolUsage(s []ToolUsageEntry) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0; j-- {
+			a, b := s[j-1], s[j]
+			if a.Count > b.Count || (a.Count == b.Count && a.Name <= b.Name) {
+				break
+			}
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// stripMCPPrefix is the canonical mirror of the templ's
+// agentRunToolDisplay helper, lifted out here so non-templ code (the
+// usage rollup) doesn't need to duplicate the constant. Kept private
+// because callers should never need to know about the prefix
+// convention.
+func stripMCPPrefix(name string) string {
+	const mcp = "mcp__breadbox__"
+	if len(name) > len(mcp) && name[:len(mcp)] == mcp {
+		return name[len(mcp):]
+	}
+	return name
+}
+
+// TranscriptHasResultEvent reports whether the transcript contains a
+// (non-empty) `result` event — used by the sticky header to decide
+// whether to render the "Jump to result" anchor button.
+func TranscriptHasResultEvent(events []TranscriptEvent) bool {
+	for _, ev := range events {
+		if ev.Type == "result" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/templates/components/pages/agent_runs_helpers_test.go
+++ b/internal/templates/components/pages/agent_runs_helpers_test.go
@@ -67,6 +67,51 @@ func TestFilterTranscriptForDisplay_EnrichesToolResultWithName(t *testing.T) {
 	}
 }
 
+func TestComputeToolUsage(t *testing.T) {
+	in := []TranscriptEvent{
+		{Type: "tool_use", ToolName: "mcp__breadbox__query_transactions"},
+		{Type: "tool_use", ToolName: "mcp__breadbox__query_transactions"},
+		{Type: "tool_use", ToolName: "mcp__breadbox__list_categories"},
+		{Type: "tool_result", ToolName: "mcp__breadbox__query_transactions"}, // not counted
+		{Type: "assistant", Text: "hi"},
+		{Type: "tool_use", ToolName: "Bash"}, // non-mcp tool, kept as-is
+	}
+	got := ComputeToolUsage(in)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 unique tools, got %d: %+v", len(got), got)
+	}
+	// First entry: query_transactions, 2 calls.
+	if got[0].Name != "query_transactions" || got[0].Count != 2 {
+		t.Errorf("expected query_transactions=2 first, got %+v", got[0])
+	}
+	// Tie-break — name ASC among count=1 entries: Bash < list_categories.
+	if got[1].Name != "Bash" || got[1].Count != 1 {
+		t.Errorf("expected Bash=1 second, got %+v", got[1])
+	}
+	if got[2].Name != "list_categories" || got[2].Count != 1 {
+		t.Errorf("expected list_categories=1 third, got %+v", got[2])
+	}
+}
+
+func TestTranscriptHasResultEvent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []TranscriptEvent
+		want bool
+	}{
+		{"empty", nil, false},
+		{"no result", []TranscriptEvent{{Type: "assistant"}, {Type: "tool_use"}}, false},
+		{"has result", []TranscriptEvent{{Type: "assistant"}, {Type: "result", CostUSD: 0.01}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := TranscriptHasResultEvent(c.in); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestFilterTranscriptForDisplay_LeavesOrphanToolResultAlone(t *testing.T) {
 	// A tool_result whose ToolUseID has no matching tool_use should keep
 	// an empty ToolName. The renderer drops the name pill in that case.

--- a/static/js/admin/components/agent_run_detail.js
+++ b/static/js/admin/components/agent_run_detail.js
@@ -211,6 +211,23 @@ document.addEventListener('alpine:init', function () {
           else d.removeAttribute('open');
         }, this);
       },
+
+      // jumpToResult scrolls the page so the run's "Final result"
+      // bubble lands at the top of the viewport (with a little
+      // breathing room for the sticky header). For long transcripts
+      // this is the single most-requested affordance — "skip to the
+      // bottom line." We pick the LAST .bb-run-summary because some
+      // transcripts have two result events and we already drop the
+      // zero-valued one, but defence-in-depth is cheap.
+      jumpToResult: function () {
+        var nodes = this.$el.querySelectorAll('.bb-run-summary');
+        if (!nodes.length) return;
+        var target = nodes[nodes.length - 1];
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        // Brief highlight pulse so the eye catches where we landed.
+        target.classList.add('bb-run-summary--flash');
+        setTimeout(function () { target.classList.remove('bb-run-summary--flash'); }, 1200);
+      },
     };
   });
 


### PR DESCRIPTION
## Summary

Two scoped polish items on top of [#1537](https://github.com/canalesb93/breadbox/pull/1537) for scanning long transcripts:

- **"Tools used" sidebar card** — per-tool call counts, sorted by count DESC then name ASC. Strips the `mcp__breadbox__` prefix so the list reads cleanly. Hidden on pure-conversation runs (no `tool_use` events). New helper `ComputeToolUsage` lives next to `FilterTranscriptForDisplay` so any caller that already has the parsed events can build the rollup without re-parsing.
- **"Jump to result" sticky-header button** — for transcripts that contain a `result` event. Scrolls the final result bubble into view and flashes a primary-tinted halo so the eye catches where the page landed. Hidden when there's no result event to jump to (gated by `TranscriptHasResultEvent`).

## Screenshot — sidebar Tools used card + Jump-to-result button

<img src="https://i.img402.dev/tohy01hd4n.jpg" width="800" alt="Run detail with Tools used sidebar and Jump-to-result button">

## Test plan

- [x] `go test ./...` clean — `ComputeToolUsage` covers count + sort tie-break behaviour and the non-mcp tool case (Bash kept verbatim). `TranscriptHasResultEvent` has empty / no-result / has-result cases.
- [x] Verified on `/agents/runs/dGHbZfr6` (4 tool_use events, 1 result): sidebar shows all 4 tools at count 1; "Jump to result" scrolls + flashes the final result bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
