### PR TITLE
fix(ui): swap remaining "Sync Error" pills for daisy badges

### DIFF
--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -122,7 +122,7 @@ templ connDetailBadges(p ConnectionDetailProps) {
 	if !connDetailHasErrorBanner(p) {
 		if p.LastSyncStatus == "error" && p.Status == "active" {
 			<span class="relative group/err">
-				<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+				<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 				if p.LastSyncErrorMessageValid {
 					<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
 						<span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -226,7 +226,7 @@ templ connectionsCard(c ConnectionsRow) {
 						} else if !c.ErrorMessageValid {
 							if c.LastSyncStatus == "error" && c.Status == "active" {
 								<span class="relative group/err shrink-0">
-									<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+									<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 									if c.LastSyncErrorMessage != "" {
 										<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
 											<span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>


### PR DESCRIPTION
## Summary

Follow-up to #1533. After consolidating the redundant error chips, the *surviving* "Sync Error" chips in `connections.templ` and `connection_detail.templ` were still hand-rolled rounded-full pills — exactly the anti-pattern called out in `.claude/rules/daisyui.md`:

> Hand-rolled rounded-full chips that bypass `badge`. Several sites use `inline-flex … rounded-full bg-{tone}/10 text-{tone}` — use `badge badge-soft badge-{tone}`.

Swap both to `badge badge-soft badge-error badge-sm`, matching the size the `StatusBadge` helper already uses in the same rows. The hover-tooltip wrapper still wraps the daisy badge — only the inner pill markup changes.

```diff
-<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
```

## After

Connections list. Each row that has a sync error but no banner now uses the standard daisy badge — same size and weight as `StatusBadge`'s `Active` / `Disconnected` / `Reauth Needed` chips, so cross-row alignment is consistent.

<img src="https://i.img402.dev/46tgens422.jpg" width="800" alt="connections list with daisy badge Sync Error chips">

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (after `make sqlc` to refresh stale generated code)
- [x] `templ generate` clean
- [x] Visually validated `/connections` — three Sync Error chips render with consistent size/tone
- [ ] Reviewer: confirm the hover tooltip still works as before on the daisy-badge variant

## Follow-ups not in this PR

- `feed.templ` per-report `Critical` / `Warning` chips alongside the same-row alert blocks — same redundancy class as #1533, different page.
- `account_detail.templ` connection-status badges in the page header — check for banner-redundancy after the parent connection's reauth banner.
- Bespoke `Stale` pill in `connections.templ` (line ~221) is also hand-rolled — same anti-pattern, deferred for scope clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
