### PR TITLE
feat(avatars): consolidate via components.UserAvatar + multi-style infra

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -27,20 +27,32 @@ const maxAvatarUploadSize = 5 << 20 // 5 MB
 // AvatarHandler serves GET /avatars/{id} — returns uploaded image or generated SVG.
 // Looks up the user by UUID. If not found, generates a pattern from the raw ID string
 // (covers unlinked admin accounts whose session falls back to account UUID).
+//
+// Query params:
+//
+//	?type=user|agent — picks which configured DiceBear style to use.
+//	                   Default "user". Agent identicons use a separate
+//	                   style (default "bottts") so agent activity reads
+//	                   as obviously non-human.
+//	?size=N          — requested pixel size; clamped to [32, 512].
+//	                   Passed through to DiceBear so big tiles fetch
+//	                   crisper SVGs and small tiles fetch lighter ones.
 func AvatarHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := clampSeed(chi.URLParam(r, "id"))
+		actor := parseActorType(r)
+		size := parseAvatarSize(r)
 
 		uid, err := resolveUUID(idStr)
 		if err != nil {
-			serveGeneratedAvatar(w, r, idStr, "")
+			serveGeneratedAvatarForActor(w, r, idStr, actor, size)
 			return
 		}
 
 		row, err := a.Queries.GetUserAvatar(r.Context(), uid)
 		if err != nil {
 			// Not a user — generate a stable pattern from the raw ID.
-			serveGeneratedAvatar(w, r, idStr, "")
+			serveGeneratedAvatarForActor(w, r, idStr, actor, size)
 			return
 		}
 
@@ -53,8 +65,42 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 		if row.AvatarSeed.Valid && row.AvatarSeed.String != "" {
 			seed = row.AvatarSeed.String
 		}
-		serveGeneratedAvatar(w, r, seed, "")
+		serveGeneratedAvatarForActor(w, r, seed, actor, size)
 	}
+}
+
+// parseActorType reads the `?type=` query param and normalises it
+// into an avatar.ActorType. Anything other than "agent" falls back
+// to ActorUser — the safer default because the previous single-style
+// behavior was user-side.
+func parseActorType(r *http.Request) avatar.ActorType {
+	if r.URL.Query().Get("type") == string(avatar.ActorAgent) {
+		return avatar.ActorAgent
+	}
+	return avatar.ActorUser
+}
+
+// parseAvatarSize reads the `?size=` query param and clamps it into
+// the supported range. Returns 256 (the legacy default) when the
+// param is missing or invalid. Bounded to [32, 512] so an attacker
+// can't fan out cache entries by spamming arbitrary sizes — the
+// component-side enum only emits 16, 20, 24, 32, 40, 48, 56, 256.
+func parseAvatarSize(r *http.Request) int {
+	raw := r.URL.Query().Get("size")
+	if raw == "" {
+		return 256
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 256
+	}
+	if n < 32 {
+		return 32
+	}
+	if n > 512 {
+		return 512
+	}
+	return n
 }
 
 // clampSeed bounds an attacker-supplied path segment to MaxSeedLength
@@ -91,7 +137,7 @@ func AvatarPreviewHandler() http.HandlerFunc {
 			http.Error(w, "invalid style", http.StatusBadRequest)
 			return
 		}
-		serveGeneratedAvatar(w, r, seed, styleOverride)
+		serveGeneratedAvatar(w, r, seed, styleOverride, parseAvatarSize(r))
 	}
 }
 
@@ -107,9 +153,10 @@ func serveUploadedAvatar(w http.ResponseWriter, r *http.Request, data []byte, co
 	w.Write(data)
 }
 
-// serveGeneratedAvatar renders a DiceBear SVG. styleOverride is used
-// by the settings preview tiles to render each style on demand;
-// empty string falls back to the global Style().
+// serveGeneratedAvatar renders a DiceBear SVG with an explicit style
+// override + size. Used by the settings preview tiles to render each
+// style on demand; empty styleOverride falls back to the configured
+// user style.
 //
 // Cache-Control is intentionally shorter than the uploaded-avatar
 // path: generated SVGs flip when the operator changes the style and
@@ -117,8 +164,25 @@ func serveUploadedAvatar(w http.ResponseWriter, r *http.Request, data []byte, co
 // outage. 1h fresh + must-revalidate keeps the bytes hot for normal
 // traffic but lets a recovery propagate within the hour instead of
 // pinning the placeholder for a full day.
-func serveGeneratedAvatar(w http.ResponseWriter, r *http.Request, seed, styleOverride string) {
-	svg := avatar.GenerateSVGStyled(seed, 256, styleOverride)
+func serveGeneratedAvatar(w http.ResponseWriter, r *http.Request, seed, styleOverride string, size int) {
+	svg := avatar.GenerateSVGStyled(seed, size, styleOverride)
+	writeAvatarSVG(w, r, svg)
+}
+
+// serveGeneratedAvatarForActor is the actor-typed variant — the URL
+// carried `?type=user|agent` so we look up the right configured
+// style rather than passing a literal slug. Threaded through from
+// /avatars/{id} where the styleOverride knob isn't exposed.
+func serveGeneratedAvatarForActor(w http.ResponseWriter, r *http.Request, seed string, actor avatar.ActorType, size int) {
+	svg := avatar.GenerateSVGForActor(seed, size, actor)
+	writeAvatarSVG(w, r, svg)
+}
+
+// writeAvatarSVG owns the ETag + Cache-Control headers shared by both
+// serve paths. Lives separately so adding a new render path (e.g. a
+// signed-URL variant in the future) doesn't accidentally diverge the
+// cache contract.
+func writeAvatarSVG(w http.ResponseWriter, r *http.Request, svg []byte) {
 	etag := fmt.Sprintf(`"%x"`, sha256.Sum256(svg))
 	if r.Header.Get("If-None-Match") == etag {
 		w.WriteHeader(http.StatusNotModified)

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -51,7 +51,14 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 	retentionDays, _ := a.Service.GetSyncLogRetentionDays(ctx)
 	syncLogCount, _ := a.Service.CountSyncLogs(ctx)
 	onboardingDismissed := appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false)
-	avatarStyle := appconfig.String(ctx, a.Queries, appconfig.KeyAvatarStyle, avatar.DefaultStyle)
+	// User style: prefer the new per-actor key; fall back to the
+	// legacy single-key for deployments that haven't migrated yet so
+	// the System tab still shows the operator's prior choice.
+	userAvatarStyle := appconfig.String(ctx, a.Queries, appconfig.KeyAvatarUserStyle, "")
+	if userAvatarStyle == "" {
+		userAvatarStyle = appconfig.String(ctx, a.Queries, appconfig.KeyAvatarStyle, avatar.DefaultUserStyle)
+	}
+	agentAvatarStyle := appconfig.String(ctx, a.Queries, appconfig.KeyAvatarAgentStyle, avatar.DefaultAgentStyle)
 
 	nextSyncTime := ""
 	if a.Scheduler != nil {
@@ -72,7 +79,8 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		OnboardingDismissed:  onboardingDismissed,
 		NextSyncTime:         nextSyncTime,
 		ConfigSources:        a.Config.ConfigSources,
-		AvatarStyle:          avatarStyle,
+		AvatarUserStyle:      userAvatarStyle,
+		AvatarAgentStyle:     agentAvatarStyle,
 		AvatarStyles:         avatar.AvailableStyles,
 	}
 	if a.VersionChecker != nil {
@@ -199,9 +207,10 @@ func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.Handl
 }
 
 // SettingsAvatarStylePostHandler serves POST /settings/avatar-style.
-// Persists the operator-picked DiceBear style into app_config and
-// updates the in-process default so the next /avatars/{id} render
-// uses it. Uploaded avatars are untouched.
+// Routes by the `actor` form field: "user" (default) persists into
+// KeyAvatarUserStyle, "agent" into KeyAvatarAgentStyle. Updates the
+// in-process default so the next /avatars/{id} render uses it.
+// Uploaded avatars are untouched.
 func SettingsAvatarStylePostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -212,17 +221,40 @@ func SettingsAvatarStylePostHandler(a *app.App, sm *scs.SessionManager) http.Han
 			return
 		}
 
+		actor := strings.TrimSpace(r.FormValue("actor"))
+		if actor == "" {
+			actor = "user"
+		}
+		var (
+			key       string
+			applyFunc func(string)
+			label     string
+		)
+		switch actor {
+		case "agent":
+			key = appconfig.KeyAvatarAgentStyle
+			applyFunc = avatar.SetAgentStyle
+			label = "Agent avatar style"
+		case "user":
+			key = appconfig.KeyAvatarUserStyle
+			applyFunc = avatar.SetUserStyle
+			label = "User avatar style"
+		default:
+			FlashRedirect(w, r, sm, "error", "Invalid actor type.", "/settings/system")
+			return
+		}
+
 		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
-			Key:   appconfig.KeyAvatarStyle,
+			Key:   key,
 			Value: pgconv.Text(style),
 		}); err != nil {
-			a.Logger.Error("save avatar style", "error", err)
+			a.Logger.Error("save avatar style", "error", err, "actor", actor)
 			FlashRedirect(w, r, sm, "error", "Failed to save avatar style.", "/settings/general")
 			return
 		}
-		avatar.SetStyle(style)
+		applyFunc(style)
 
-		SetFlash(ctx, sm, "success", "Avatar style updated.")
+		SetFlash(ctx, sm, "success", label+" updated.")
 		http.Redirect(w, r, "/settings/general", http.StatusSeeOther)
 	}
 }

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -86,6 +86,13 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.KbdCombo(keys...), nil
 	},
+	"UserAvatar": func(data any) (templ.Component, error) {
+		p, ok := data.(components.UserAvatarProps)
+		if !ok {
+			return nil, fmt.Errorf("UserAvatar: want components.UserAvatarProps, got %T", data)
+		}
+		return components.UserAvatar(p), nil
+	},
 	"SettingsModal": func(data any) (templ.Component, error) {
 		m, ok := data.(map[string]any)
 		if !ok {
@@ -262,6 +269,21 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			// (e.g. `{{renderComponent "KbdCombo" (strs "cmd" "k")}}`).
 			"strs":            func(vals ...string) []string { return vals },
 			"renderComponent": renderTemplComponent,
+			// userAvatarProps constructs a UserAvatarProps from the
+			// BaseTemplateData fields html/template partials carry,
+			// for use through renderComponent. Kept inline so the
+			// mobile-navbar trigger in base.html stays a one-liner
+			// rather than a bespoke partial. size is the literal
+			// UserAvatarSize slug ("md" / "lg" / etc).
+			"userAvatarProps": func(id, version, name, size string) components.UserAvatarProps {
+				return components.UserAvatarProps{
+					ID:         id,
+					Version:    version,
+					Name:       name,
+					Size:       components.UserAvatarSize(size),
+					Decorative: true,
+				}
+			},
 		},
 	}
 	if err := tr.parseTemplates(); err != nil {

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -4,10 +4,10 @@ package admin
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"net/http"
 	"net/mail"
+	"strconv"
 	"strings"
 
 	"breadbox/internal/app"
@@ -216,7 +216,7 @@ func buildUsersProps(in usersListInput) pages.UsersProps {
 			Name:            eu.Name,
 			Email:           pgconv.TextOr(eu.Email, ""),
 			HasEmail:        eu.Email.Valid,
-			AvatarURL:       usersAvatarURL(uid, eu.UpdatedAt),
+			AvatarVersion:   usersAvatarVersion(eu.UpdatedAt),
 			AccountCount:    eu.AccountCount,
 			ConnectionCount: eu.ConnectionCount,
 		}
@@ -253,19 +253,15 @@ func buildUsersProps(in usersListInput) pages.UsersProps {
 	return props
 }
 
-// usersAvatarURL builds the per-user avatar URL with a cache-busting `v`
-// query param keyed on UpdatedAt. Mirrors the funcMap "avatarURL" helper
-// in admin/templates.go for the (UUID, Timestamptz) call shape used by
-// the prior users.html template.
-func usersAvatarURL(formattedID string, updatedAt pgtype.Timestamptz) string {
-	if formattedID == "" {
-		return "/avatars/unknown"
+// usersAvatarVersion returns the per-user cache-bust suffix (the
+// updated_at unix timestamp as a string) for components.UserAvatar's
+// Version prop. URL construction itself lives inside the shared
+// component (components.AvatarURLWith) so all callers stay aligned.
+func usersAvatarVersion(updatedAt pgtype.Timestamptz) string {
+	if !updatedAt.Valid {
+		return ""
 	}
-	base := "/avatars/" + formattedID
-	if updatedAt.Valid {
-		base += fmt.Sprintf("?v=%d", updatedAt.Time.Unix())
-	}
-	return base
+	return strconv.FormatInt(updatedAt.Time.Unix(), 10)
 }
 
 // NewUserHandler serves GET /admin/users/new.

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -46,11 +46,25 @@ const (
 	// `breadbox reveal-key` shell command.
 	KeyEncryptionKeyAcknowledgedAt = "setup.encryption_key_acknowledged_at"
 
-	// KeyAvatarStyle is the DiceBear style slug used for auto-generated
-	// user identicons (https://www.dicebear.com). Operators can change
-	// the style from Settings → System. Uploaded avatars are unaffected.
-	// Default: "shapes" (set in internal/avatar).
+	// KeyAvatarStyle is the legacy single-style key. New code reads
+	// KeyAvatarUserStyle for user avatars and KeyAvatarAgentStyle for
+	// agent avatars; this key is retained for back-compat — the
+	// startup loader copies it into KeyAvatarUserStyle when the latter
+	// is unset so existing deployments keep their configured style.
+	//
+	// Deprecated: use KeyAvatarUserStyle.
 	KeyAvatarStyle = "avatar.dicebear_style"
+
+	// KeyAvatarUserStyle is the DiceBear style slug used for user
+	// identicons. Operators pick it from Settings → System.
+	// Default: "shapes" (set in internal/avatar).
+	KeyAvatarUserStyle = "avatar.dicebear_style_user"
+
+	// KeyAvatarAgentStyle is the DiceBear style slug used for agent
+	// identicons. Agents render distinct avatars from users so an
+	// AI-authored activity row reads unambiguously against a human
+	// one. Default: "bottts" (robot-style identicons).
+	KeyAvatarAgentStyle = "avatar.dicebear_style_agent"
 )
 
 // AuthMode values for KeyAgentAuthMode.

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -1,11 +1,19 @@
-// Package avatar fetches user identicons from the DiceBear HTTP API
-// (https://www.dicebear.com) and processes uploaded image files.
+// Package avatar fetches user/agent identicons from the DiceBear HTTP
+// API (https://www.dicebear.com) and processes uploaded image files.
 //
-// The current DiceBear style is stored in app_config under
-// avatar.dicebear_style and pushed into the package via SetStyle at
-// server startup and from the settings POST handler. GenerateSVG
-// caches fetched SVGs in-process keyed by (style, seed, size) so a
-// warm server serves identicons without round-tripping to DiceBear.
+// The package tracks two DiceBear styles — one for human users
+// (avatar.dicebear_style_user, default "shapes") and one for AI
+// agents (avatar.dicebear_style_agent, default "bottts") — so a
+// human-authored activity row reads unambiguously against an
+// agent-authored one. Both values live in app_config and are pushed
+// into the package via SetUserStyle / SetAgentStyle at server
+// startup and from the Settings → System POST handlers. The legacy
+// avatar.dicebear_style key remains a back-compat alias that the
+// startup loader copies into the user-style slot.
+//
+// GenerateSVG caches fetched SVGs in-process keyed by (style, seed,
+// size) so a warm server serves identicons without round-tripping to
+// DiceBear.
 package avatar
 
 import (
@@ -23,9 +31,20 @@ import (
 )
 
 const (
-	// DefaultStyle is used when no app_config value is set. "shapes"
-	// keeps the previous abstract-geometric aesthetic.
+	// DefaultStyle is the fallback when no app_config value is set
+	// for the user identicon style. "shapes" keeps the previous
+	// abstract-geometric aesthetic. Retained as the legacy alias.
 	DefaultStyle = "shapes"
+
+	// DefaultUserStyle is the fallback for user identicons. Same as
+	// DefaultStyle; the alias exists so the per-actor accessors stay
+	// symmetrical with DefaultAgentStyle.
+	DefaultUserStyle = "shapes"
+
+	// DefaultAgentStyle is the fallback for agent identicons. "bottts"
+	// is DiceBear's canonical robot style — agents read as obviously
+	// non-human against the user fallback aesthetic.
+	DefaultAgentStyle = "bottts"
 
 	// DefaultAPIBaseURL is the DiceBear v9 HTTP API root. Tests
 	// override this via SetAPIBaseURL.
@@ -50,37 +69,98 @@ const (
 )
 
 var (
-	styleAtomic  atomic.Value // string
-	baseURL      atomic.Value // string
-	defaultHTTPC = &http.Client{Timeout: httpTimeout}
-	httpClient   atomic.Value // *http.Client — overridable in tests
-	cache        sync.Map     // string -> []byte
-	cacheCount   atomic.Int64 // entries currently in cache; bounded by maxCacheEntries
+	userStyleAtomic  atomic.Value // string — DiceBear style for users
+	agentStyleAtomic atomic.Value // string — DiceBear style for agents
+	baseURL          atomic.Value // string
+	defaultHTTPC     = &http.Client{Timeout: httpTimeout}
+	httpClient       atomic.Value // *http.Client — overridable in tests
+	cache            sync.Map     // string -> []byte
+	cacheCount       atomic.Int64 // entries currently in cache; bounded by maxCacheEntries
 )
 
 func init() {
-	styleAtomic.Store(DefaultStyle)
+	userStyleAtomic.Store(DefaultUserStyle)
+	agentStyleAtomic.Store(DefaultAgentStyle)
 	baseURL.Store(DefaultAPIBaseURL)
 	httpClient.Store(defaultHTTPC)
 }
 
-// SetStyle overrides the DiceBear style at runtime. Call from server
-// startup (with the value loaded from app_config) and from the
-// settings POST handler when the operator changes the style.
-func SetStyle(s string) {
+// SetUserStyle overrides the DiceBear style used for user identicons.
+// Call from server startup (with the value loaded from
+// app_config[avatar.dicebear_style_user]) and from the settings POST
+// handler when the operator changes the style.
+func SetUserStyle(s string) {
 	if s == "" {
-		s = DefaultStyle
+		s = DefaultUserStyle
 	}
-	styleAtomic.Store(s)
+	userStyleAtomic.Store(s)
 }
 
-// Style returns the currently configured DiceBear style.
-func Style() string {
-	v, _ := styleAtomic.Load().(string)
+// SetAgentStyle overrides the DiceBear style used for agent
+// identicons. Call from server startup
+// (app_config[avatar.dicebear_style_agent]) and from the settings
+// POST handler when the operator changes the style.
+func SetAgentStyle(s string) {
+	if s == "" {
+		s = DefaultAgentStyle
+	}
+	agentStyleAtomic.Store(s)
+}
+
+// SetStyle sets the legacy single-style key. Routes to SetUserStyle
+// so existing callers (older startup code, legacy POST handlers) keep
+// working without breaking the user/agent split.
+//
+// Deprecated: use SetUserStyle.
+func SetStyle(s string) { SetUserStyle(s) }
+
+// UserStyle returns the currently configured DiceBear style for
+// users.
+func UserStyle() string {
+	v, _ := userStyleAtomic.Load().(string)
 	if v == "" {
-		return DefaultStyle
+		return DefaultUserStyle
 	}
 	return v
+}
+
+// AgentStyle returns the currently configured DiceBear style for
+// agents.
+func AgentStyle() string {
+	v, _ := agentStyleAtomic.Load().(string)
+	if v == "" {
+		return DefaultAgentStyle
+	}
+	return v
+}
+
+// Style returns the legacy single style. Routes to UserStyle so old
+// callers keep returning the human-side value (which is what they
+// rendered before the user/agent split).
+//
+// Deprecated: use UserStyle or StyleForActor.
+func Style() string { return UserStyle() }
+
+// ActorType is the discriminator for which DiceBear style to use.
+// Empty + invalid values resolve to ActorUser.
+type ActorType string
+
+const (
+	ActorUser  ActorType = "user"
+	ActorAgent ActorType = "agent"
+)
+
+// StyleForActor returns the configured DiceBear style for the given
+// actor type. Empty / unknown actor types fall back to the user
+// style — the safer default since the legacy avatar render path was
+// human-side.
+func StyleForActor(t ActorType) string {
+	switch t {
+	case ActorAgent:
+		return AgentStyle()
+	default:
+		return UserStyle()
+	}
 }
 
 // SetAPIBaseURL overrides the DiceBear API base URL. Test-only entry
@@ -112,7 +192,9 @@ func ResetCache() {
 }
 
 // GenerateSVG fetches a DiceBear avatar SVG for the given seed using
-// the global style (or per-call override via GenerateSVGStyled).
+// the user-side global style. For agent-side renders or per-call
+// overrides use GenerateSVGStyled or GenerateSVGForActor.
+//
 // Cached in memory keyed by (style, size, seed); cache is hard-
 // capped at maxCacheEntries so adversarial unauthenticated traffic
 // to /avatars/preview/{seed} can't OOM the process. On upstream
@@ -125,13 +207,22 @@ func GenerateSVG(seed string, size int) []byte {
 	return GenerateSVGStyled(seed, size, "")
 }
 
+// GenerateSVGForActor is GenerateSVG with an actor-type selector
+// instead of an explicit style. Used by /avatars/{id} when the
+// handler resolves an ID to a user vs agent and wants the right
+// configured style without hardcoding the slug.
+func GenerateSVGForActor(seed string, size int, actor ActorType) []byte {
+	return GenerateSVGStyled(seed, size, StyleForActor(actor))
+}
+
 // GenerateSVGStyled is GenerateSVG with a per-call style override.
 // Used by the settings-page preview tiles so the operator can see
-// each style before saving without flipping the global.
+// each style before saving without flipping the global, and by
+// GenerateSVGForActor to route by actor type.
 func GenerateSVGStyled(seed string, size int, styleOverride string) []byte {
 	st := styleOverride
 	if st == "" {
-		st = Style()
+		st = UserStyle()
 	}
 	key := cacheKey(st, size, seed)
 	if v, ok := cache.Load(key); ok {

--- a/internal/avatar/avatar_test.go
+++ b/internal/avatar/avatar_test.go
@@ -22,7 +22,7 @@ func withDiceBearMock(t *testing.T, handler http.HandlerFunc) func() {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	prevBase, _ := baseURL.Load().(string)
-	prevStyle, _ := styleAtomic.Load().(string)
+	prevStyle, _ := userStyleAtomic.Load().(string)
 	SetAPIBaseURL(srv.URL)
 	ResetCache()
 	return func() {
@@ -217,7 +217,7 @@ func TestGenerateSVGStyled_OverridesGlobal(t *testing.T) {
 }
 
 func TestSetStyle_DefaultOnEmpty(t *testing.T) {
-	prev, _ := styleAtomic.Load().(string)
+	prev, _ := userStyleAtomic.Load().(string)
 	defer SetStyle(prev)
 
 	SetStyle("")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -114,10 +114,19 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 		logger.Info("cleaned up orphaned sync logs", "count", n)
 	}
 
-	// Push the operator-picked DiceBear style into the avatar package so
-	// /avatars/{id} renders match the Settings → System choice without a
-	// per-request DB lookup.
-	avatar.SetStyle(appconfig.String(ctx, a.Queries, appconfig.KeyAvatarStyle, avatar.DefaultStyle))
+	// Push the operator-picked DiceBear styles into the avatar package
+	// so /avatars/{id} renders match the Settings → System choices
+	// without a per-request DB lookup. Two styles: one for human users,
+	// one for AI agents. The legacy single-key `avatar.dicebear_style`
+	// remains a back-compat alias — when the user-specific key is
+	// unset we fall through to it so existing deployments keep their
+	// configured style.
+	userStyle := appconfig.String(ctx, a.Queries, appconfig.KeyAvatarUserStyle, "")
+	if userStyle == "" {
+		userStyle = appconfig.String(ctx, a.Queries, appconfig.KeyAvatarStyle, avatar.DefaultUserStyle)
+	}
+	avatar.SetUserStyle(userStyle)
+	avatar.SetAgentStyle(appconfig.String(ctx, a.Queries, appconfig.KeyAvatarAgentStyle, avatar.DefaultAgentStyle))
 
 	syncTimeout := time.Duration(cfg.SyncTimeoutSeconds) * time.Second
 	scheduler := sync.NewScheduler(a.SyncEngine, a.Queries, logger, syncTimeout)

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -148,14 +148,6 @@ func navActive(current, page string) string {
 	return ""
 }
 
-func navAvatar(id, version string) string {
-	base := avatarURL(id)
-	if version != "" {
-		return base + "?v=" + version
-	}
-	return base
-}
-
 // navDisplayName picks the friendliest available name for the sidebar
 // footer: linked household-member name first (e.g. "Ricardo"), then the
 // auth_accounts.username (often an email), then a generic "Admin".

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -2443,3 +2443,243 @@ templ SectionCommandPalette() {
 		}
 	</div>
 }
+
+// ─── User avatar ───────────────────────────────────────────────────────
+
+templ SectionUserAvatar() {
+	<div class="flex flex-col gap-6">
+		@designExample("Size scale", "Seven sizes cover every surface that renders a person/agent identity. Pick the one that matches the call site, not the largest that fits. The component threads the pixel size through to /avatars/{id}?size=N so the backend fetches a pre-sized SVG.") {
+			<div class="flex flex-wrap items-end gap-6">
+				@designUserAvatarSwatch("xs · 16px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarXS})
+				@designUserAvatarSwatch("sm · 20px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarSm})
+				@designUserAvatarSwatch("md · 24px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarMd})
+				@designUserAvatarSwatch("lg · 32px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarLg})
+				@designUserAvatarSwatch("xl · 40px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarXL})
+				@designUserAvatarSwatch("2xl · 48px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatar2XL})
+				@designUserAvatarSwatch("3xl · 56px", components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatar3XL})
+			</div>
+		}
+		@designExample("Image — backed by /avatars/{id}", "ID flows through components.AvatarURL(id, version). Pass Version (the user's updated_at unix timestamp) to bust the browser cache after the operator uploads a new photo or regenerates the seed.") {
+			<div class="flex flex-wrap items-center gap-4">
+				@components.UserAvatar(components.UserAvatarProps{ID: "alice-uuid", Name: "Alice Adams", Size: components.UserAvatarLg})
+				@components.UserAvatar(components.UserAvatarProps{ID: "bob-uuid", Name: "Bob Bennett", Size: components.UserAvatarLg})
+				@components.UserAvatar(components.UserAvatarProps{ID: "casey-uuid", Name: "Casey Cole", Size: components.UserAvatarLg})
+				@components.UserAvatar(components.UserAvatarProps{ID: "drew-uuid", Name: "Drew Dawson", Size: components.UserAvatarLg, Version: "1735776000"})
+			</div>
+		}
+		@designExample("Agents — dual style + bot fallback", "IsAgent has two render paths. With an ID set, the URL routes through ?type=agent and the server picks the configured agent DiceBear style (default \"bottts\") — distinct from the user style so agent activity reads as obviously non-human. With no ID, the bot-tile fallback fires.") {
+			<div class="flex flex-col gap-4">
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Agent identicon (ID + IsAgent)</span>
+					@components.UserAvatar(components.UserAvatarProps{ID: "agent-cat", Name: "Categorizer", IsAgent: true, Size: components.UserAvatarMd})
+					@components.UserAvatar(components.UserAvatarProps{ID: "agent-cat", Name: "Categorizer", IsAgent: true, Size: components.UserAvatarLg})
+					@components.UserAvatar(components.UserAvatarProps{ID: "agent-cat", Name: "Categorizer", IsAgent: true, Size: components.UserAvatarXL})
+					@components.UserAvatar(components.UserAvatarProps{ID: "agent-cat", Name: "Categorizer", IsAgent: true, Size: components.UserAvatar2XL})
+					@components.UserAvatar(components.UserAvatarProps{ID: "agent-aud", Name: "Auditor", IsAgent: true, Size: components.UserAvatar2XL})
+					@components.UserAvatar(components.UserAvatarProps{ID: "agent-rev", Name: "Reviewer", IsAgent: true, Size: components.UserAvatar2XL})
+				</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Bot fallback (IsAgent only)</span>
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarXS})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarSm})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarMd})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarLg})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarXL})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatar2XL})
+				</div>
+			</div>
+		}
+		@designExample("Letter fallback — no ID, no IsAgent", "First initial when the name is a single word; first + last initials when it has two or more (\"Alice Canales\" → \"AC\"). The xs / sm sizes always render a single letter to keep the 16–20px tile from crowding. Falls to \"?\" when Name is empty too.") {
+			<div class="flex flex-col gap-4">
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Two-word name</span>
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice Canales", Size: components.UserAvatarXS})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice Canales", Size: components.UserAvatarSm})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice Canales", Size: components.UserAvatarMd})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice Canales", Size: components.UserAvatarLg})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice Canales", Size: components.UserAvatarXL})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice Canales", Size: components.UserAvatar2XL})
+				</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Single-word name</span>
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice", Size: components.UserAvatarXS})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice", Size: components.UserAvatarSm})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice", Size: components.UserAvatarMd})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice", Size: components.UserAvatarLg})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice", Size: components.UserAvatarXL})
+					@components.UserAvatar(components.UserAvatarProps{Name: "Alice", Size: components.UserAvatar2XL})
+				</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Empty (renders "?")</span>
+					@components.UserAvatar(components.UserAvatarProps{Name: "", Size: components.UserAvatarMd})
+					@components.UserAvatar(components.UserAvatarProps{Name: "", Size: components.UserAvatarLg})
+					@components.UserAvatar(components.UserAvatarProps{Name: "", Size: components.UserAvatarXL})
+				</div>
+			</div>
+		}
+		@designExample("Ring — timeline rail tile (Ring: true)", "Adds the 4px ring-base-100 chrome that threads the avatar through the activity-timeline rail. The bb-timeline-prominent variant CSS remaps the ring colour to base-200 so the same tile works against either a card or a page surface.") {
+			<div class="bb-card p-5 max-w-md">
+				<ol class="relative pl-4">
+					<span class="absolute left-[28px] top-2 bottom-2 w-px bg-base-200" aria-hidden="true"></span>
+					<li class="relative flex items-start gap-3 py-2.5">
+						<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
+							@components.UserAvatar(components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarMd, Ring: true})
+						</div>
+						<div class="flex-1 min-w-0 text-sm">
+							<div class="flex items-center gap-1.5">
+								<strong class="font-semibold">Alice</strong>
+								<span class="text-base-content/55">commented</span>
+								<span class="text-base-content/40">· 5 minutes ago</span>
+							</div>
+							<div class="text-base-content/70 mt-1">Got the receipt for this — tagging as business.</div>
+						</div>
+					</li>
+					<li class="relative flex items-start gap-3 py-2.5">
+						<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
+							@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarMd, Ring: true})
+						</div>
+						<div class="flex-1 min-w-0 text-sm">
+							<div class="flex items-center gap-1.5">
+								<strong class="font-semibold">Categorizer</strong>
+								<span class="text-base-content/55">applied rule · 2 hours ago</span>
+							</div>
+						</div>
+					</li>
+				</ol>
+			</div>
+		}
+		@designExample("Inline — in-text actor reference (Inline: true)", "Switches the wrapper to inline-flex + align-text-bottom so the avatar sits on the same baseline as the surrounding text run. Pair with Size XS for system-row sentences and comment meta lines; Size Sm reads bigger and works in headline copy. Used by components.TimelineActorInline on /feed and /transactions/{id}.") {
+			<div class="flex flex-col gap-2 text-sm leading-6">
+				<div>
+					@components.UserAvatar(components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarXS, Inline: true, Class: "mr-1"})
+					<strong class="font-semibold">Alice</strong>
+					<span class="text-base-content/65">commented on</span>
+					<a href="#" class="font-semibold hover:text-primary">Whole Foods</a>
+				</div>
+				<div>
+					@components.UserAvatar(components.UserAvatarProps{Name: "Categorizer", IsAgent: true, Size: components.UserAvatarXS, Inline: true, Class: "mr-1"})
+					<strong class="font-semibold">Categorizer</strong>
+					<span class="text-base-content/65">applied rule on Whole Foods</span>
+				</div>
+			</div>
+		}
+		@designExample("Tx owner badge — bespoke geometry", "The 14px corner badge that sits on a transaction row's category avatar uses its own `.bb-tx-owner-badge` class (w-3.5 h-3.5 + absolute + row-tinted box-shadow). It's the documented exception to the size scale; the rest of the avatar markup (img / letter fallback) still flows through the standard helpers so URL construction stays centralized.") {
+			<div class="bb-card p-4 flex flex-wrap gap-6">
+				<div class="flex items-center gap-3">
+					<div class="relative shrink-0">
+						<div class="bb-tx-avatar" style={ components.TxAvatarColorStyle(designSampleColor()) }>
+							<i data-lucide="shopping-cart" class="w-4 h-4"></i>
+						</div>
+						<img src={ components.AvatarURL("alice-uuid", "") } alt="" class="bb-tx-owner-badge" title="Alice"/>
+					</div>
+					<div class="text-sm">
+						<div class="font-medium">Whole Foods</div>
+						<div class="text-xs text-base-content/50">Alice paid · 2 days ago</div>
+					</div>
+				</div>
+				<div class="flex items-center gap-3">
+					<div class="relative shrink-0">
+						<div class="bb-tx-avatar" style={ components.TxAvatarColorStyle(designSampleColor()) }>
+							<i data-lucide="shopping-cart" class="w-4 h-4"></i>
+						</div>
+						<span class="bb-tx-owner-badge bb-tx-owner-badge--letter" title="Drew">
+							<span>D</span>
+						</span>
+					</div>
+					<div class="text-sm">
+						<div class="font-medium">Costco</div>
+						<div class="text-xs text-base-content/50">Drew paid · 4 days ago</div>
+					</div>
+				</div>
+			</div>
+		}
+		@designExample("Sidebar profile — live call site", "The sidebar's account trigger renders UserAvatar at Size Lg with Class \"bb-sidebar-profile-avatar\" so the opacity transition on hover stays attached to the inner img. The wrapper handles size, shape, and the letter fallback for not-yet-linked accounts.") {
+			<div class="bb-card p-3 max-w-sm flex items-center gap-2.5">
+				@components.UserAvatar(components.UserAvatarProps{
+					ID:      "alice-uuid",
+					Name:    "Alice",
+					Size:    components.UserAvatarLg,
+					Class:   "bb-sidebar-profile-avatar",
+					Version: "1735776000",
+				})
+				<div class="flex-1 min-w-0">
+					<div class="bb-sidebar-profile-name">Alice Adams</div>
+					<div class="bb-sidebar-profile-role">Admin</div>
+				</div>
+				<i data-lucide="settings" class="w-4 h-4 text-base-content/40 shrink-0"></i>
+			</div>
+		}
+		@designExample("Loading / Lazy / Decorative", "Three independent state flags. Loading swaps in a skeleton circle while waiting for an actor to resolve (optimistic inserts, async hydration). Lazy adds loading=\"lazy\" for below-the-fold avatars. Decorative emits alt=\"\" when the surrounding context already names the actor — almost every timeline call site sets this.") {
+			<div class="flex flex-col gap-4 text-sm">
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Loading</span>
+					@components.UserAvatar(components.UserAvatarProps{Size: components.UserAvatarSm, Loading: true})
+					@components.UserAvatar(components.UserAvatarProps{Size: components.UserAvatarMd, Loading: true})
+					@components.UserAvatar(components.UserAvatarProps{Size: components.UserAvatarLg, Loading: true})
+					@components.UserAvatar(components.UserAvatarProps{Size: components.UserAvatarXL, Loading: true})
+					@components.UserAvatar(components.UserAvatarProps{Size: components.UserAvatar2XL, Loading: true})
+				</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<span class="text-xs text-base-content/40 w-32">Lazy + Decorative</span>
+					@components.UserAvatar(components.UserAvatarProps{ID: "alice-uuid", Name: "Alice", Size: components.UserAvatarLg, Lazy: true, Decorative: true})
+					<code class="text-xs text-base-content/50">→ &lt;img loading="lazy" alt=""&gt;</code>
+				</div>
+			</div>
+		}
+		@designExample("URL helpers — single source of truth", "Every server-rendered avatar URL flows through one of three helpers. AvatarURL is user-side; AgentAvatarURL appends ?type=agent so the server picks the agent style; AvatarURLWith threads size + actor + version in one shot for the component-side renderer.") {
+			<div class="flex flex-col gap-2 text-xs font-mono">
+				<div class="flex items-center gap-3">
+					<span class="text-base-content/40 w-64">AvatarURL("alice", "1735776000")</span>
+					<code class="px-2 py-1 rounded bg-base-200">{ components.AvatarURL("alice", "1735776000") }</code>
+				</div>
+				<div class="flex items-center gap-3">
+					<span class="text-base-content/40 w-64">AgentAvatarURL("cat", "1735776000")</span>
+					<code class="px-2 py-1 rounded bg-base-200">{ components.AgentAvatarURL("cat", "1735776000") }</code>
+				</div>
+				<div class="flex items-center gap-3">
+					<span class="text-base-content/40 w-64">AvatarURLWith("a", "v1", "user", 32)</span>
+					<code class="px-2 py-1 rounded bg-base-200">{ components.AvatarURLWith("a", "v1", "user", 32) }</code>
+				</div>
+				<div class="flex items-center gap-3">
+					<span class="text-base-content/40 w-64">AvatarURL("", "")</span>
+					<code class="px-2 py-1 rounded bg-base-200">{ components.AvatarURL("", "") }</code>
+				</div>
+			</div>
+		}
+		@designExample("Alpine-bound previews — settings + user form", "Three surfaces drive the avatar src from Alpine state instead of a server-rendered ID: the settings → System User-style picker (alice/bob/casey/drew seeds), the matching Agent-style picker (categorizer/auditor/reviewer/scout seeds), and the user-form create/edit (avatar seed shuffles client-side until the user saves). They use plain <img :src=\"…\"> bindings against the /avatars/preview proxy rather than UserAvatar so the dynamic binding stays trivial.") {
+			<div class="flex flex-col gap-3">
+				<div class="flex items-center gap-2">
+					<span class="text-xs text-base-content/40 w-24">User seeds</span>
+					for _, seed := range []string{"alice", "bob", "casey", "drew"} {
+						<img class="w-10 h-10 rounded-full bg-base-200" alt={ "Preview " + seed } src={ "/avatars/preview/" + seed }/>
+					}
+				</div>
+				<div class="flex items-center gap-2">
+					<span class="text-xs text-base-content/40 w-24">Agent seeds</span>
+					for _, seed := range []string{"categorizer", "auditor", "reviewer", "scout"} {
+						<img class="w-10 h-10 rounded-full bg-base-200" alt={ "Preview " + seed } src={ "/avatars/preview/" + seed + "?style=bottts" }/>
+					}
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// designUserAvatarSwatch renders one entry in the size-scale demo: a
+// label + the avatar at that size. The bottom-aligned flex layout makes
+// every size visually anchor to the same baseline so the scale reads
+// at a glance.
+templ designUserAvatarSwatch(label string, p components.UserAvatarProps) {
+	<div class="flex flex-col items-center gap-2">
+		@components.UserAvatar(p)
+		<code class="text-[0.65rem] text-base-content/50 font-mono">{ label }</code>
+	</div>
+}
+
+// designSampleColor returns a stable demo category color for the
+// tx-owner-badge example. The colored circle behind the corner badge
+// is decorative — value picked so the badge contrast reads clearly.
+func designSampleColor() *string {
+	c := "#f97316"
+	return &c
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -265,6 +265,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionAmounts() },
 		},
 		{
+			Slug:        "user-avatar",
+			Title:       "User avatar",
+			Description: "components.UserAvatar — the shared identity badge used by the sidebar profile, transaction owner badge, activity-timeline rail tile + inline actor, and settings preview. Backed by the DiceBear /avatars/{id} endpoint with components.AvatarURL as the single source of truth for URL construction.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionUserAvatar() },
+		},
+		{
 			Slug:        "transaction-rows",
 			Title:       "Transaction rows",
 			Description: "TxRow / TxRowCompact / TxRowFeed and their building blocks (bb-tx-avatar, bb-tx-owner-badge, bb-tx-amount). The same avatar + amount shapes carry across every surface that lists transactions.",

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -412,20 +412,23 @@ templ feedReportTile(priority string) {
 
 // feedActorTile is the avatar tile used for actor-driven rows
 // (agent_session, bulk_action). Mirrors the per-tx timeline avatar tile so
-// the same person looks identical on both surfaces. We pass a single 24px
-// tile through the rail's ring-4 ring-base-200 scaffolding.
+// the same person looks identical on both surfaces. The shared
+// UserAvatar primitive owns the tile shape; `bb-timeline-prominent`
+// remaps ring-base-100 → ring-base-200 via CSS so the feed surface
+// keeps its page-background-tinted ring without duplicating the rule
+// at the call site. Decorative=true: the actor's name is already
+// announced in the surrounding row sentence.
 templ feedActorTile(actorType, actorID, version, name string) {
-	if actorType == "user" && actorID != "" {
-		<img src={ feedAvatarURL(actorID, version) } alt={ name + " avatar" } class="w-6 h-6 rounded-full object-cover border border-base-300 ring-4 ring-base-200" title={ name }/>
-	} else if actorType == "agent" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/12 border border-base-300 ring-4 ring-base-200" aria-hidden="true" title={ name }>
-			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
-		</span>
-	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-200" aria-hidden="true" title={ name }>
-			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ feedFirstChar(name) }</span>
-		</span>
-	}
+	@components.UserAvatar(components.UserAvatarProps{
+		Name:       name,
+		ID:         actorID,
+		Version:    version,
+		IsAgent:    actorType == "agent",
+		Size:       components.UserAvatarMd,
+		Ring:       true,
+		Decorative: true,
+		Lazy:       true,
+	})
 }
 
 // ── Row body templates ────────────────────────────────────────────────────
@@ -796,15 +799,22 @@ func feedCommentPeek(body string) string {
 }
 
 // feedCommentActor builds the shared TimelineActor for a feed comment so
-// the inline-actor renderer can do its job uniformly. Users get an avatar
-// URL (or fall through to initials when the ID is missing); agents get the
-// bot fallback; system actors render as just the name (no glyph).
+// the inline-actor renderer can do its job uniformly. UserID + Version
+// flow straight through to UserAvatar which builds the URL. Users +
+// agents both render a DiceBear identicon when they carry an ID (the
+// agent style is configured separately in Settings → System); agents
+// without an ID fall through to the bot tile; pure system actors
+// render as just the bold name.
 func feedCommentActor(c *FeedComment) components.TimelineActor {
 	a := components.TimelineActor{Name: feedActorDisplay(c.ActorName, c.ActorType)}
-	if c.ActorType == "user" && c.ActorID != "" {
-		a.AvatarURL = feedAvatarURL(c.ActorID, c.ActorAvatarVersion)
-	} else if c.ActorType == "agent" {
+	switch c.ActorType {
+	case "user":
+		a.UserID = c.ActorID
+		a.Version = c.ActorAvatarVersion
+	case "agent":
 		a.IsAgent = true
+		a.UserID = c.ActorID
+		a.Version = c.ActorAvatarVersion
 	}
 	return a
 }
@@ -867,13 +877,6 @@ templ feedTxRefList(samples []FeedTransactionRef, additional int) {
 
 // ── String helpers ────────────────────────────────────────────────────────
 
-func feedAvatarURL(id, version string) string {
-	base := "/avatars/" + id
-	if version != "" {
-		return base + "?v=" + version
-	}
-	return base
-}
 
 func feedActorDisplay(name, actorType string) string {
 	if name != "" {
@@ -1012,13 +1015,6 @@ func feedNonEmpty(a, fallback string) string {
 		return a
 	}
 	return fallback
-}
-
-func feedFirstChar(s string) string {
-	for _, r := range s {
-		return string(r)
-	}
-	return ""
 }
 
 func feedSyncDotClass(status string) string {

--- a/internal/templates/components/pages/feed_comment_test.go
+++ b/internal/templates/components/pages/feed_comment_test.go
@@ -68,8 +68,15 @@ func TestFeedCommentRowUsesSharedCommentTile(t *testing.T) {
 				// Rail tile is the shared message-square, not an avatar.
 				`data-lucide="message-square"`,
 				// Inline avatar uses the 16px treatment from
-				// TimelineActorInline.
-				`inline-block w-4 h-4 rounded-full object-cover border border-base-300 align-text-bottom`,
+				// TimelineActorInline — now rendered via the shared
+				// UserAvatar component (Size XS + Inline + Class="mr-1").
+				`w-4 h-4`,
+				`align-text-bottom`,
+				`/avatars/user-abc`,
+				// XS-sized avatars thread ?size=16 through to the
+				// backend so DiceBear returns a smaller SVG payload.
+				`size=16`,
+				`v=v1`,
 				// Bold actor name + verb.
 				`Alice`,
 				`commented on`,
@@ -97,7 +104,10 @@ func TestFeedCommentRowUsesSharedCommentTile(t *testing.T) {
 				`data-lucide="message-square"`,
 				// Inline bot tile, 16px (w-4 h-4) — distinct from the
 				// 24px (w-6 h-6) rail tile that used to be there.
-				`inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10`,
+				// Rendered by UserAvatar's IsAgent branch.
+				`w-4 h-4`,
+				`bg-primary/10`,
+				`data-lucide="bot"`,
 				`Categorizer`,
 				`commented on`,
 			},
@@ -146,12 +156,21 @@ func TestFeedAndTxDetailShareInlineActor(t *testing.T) {
 		{
 			name: "user_with_avatar",
 			actor: components.TimelineActor{
-				Name:      "Alice",
-				AvatarURL: "/avatars/user-abc?v=v1",
+				Name:    "Alice",
+				UserID:  "user-abc",
+				Version: "v1",
 			},
 			mustHave: []string{
-				`<img src="/avatars/user-abc?v=v1"`,
-				`inline-block w-4 h-4 rounded-full object-cover border border-base-300 align-text-bottom mr-1`,
+				// URL is built by UserAvatar from UserID + Version,
+				// with ?size=16 threaded through for the XS variant.
+				`/avatars/user-abc`,
+				`v=v1`,
+				`size=16`,
+				// Inline 16px treatment now flows through UserAvatar
+				// (Size XS + Inline + Class="mr-1").
+				`w-4 h-4`,
+				`align-text-bottom`,
+				`mr-1`,
 				`<strong class="font-semibold text-base-content">Alice</strong>`,
 			},
 		},

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"breadbox/internal/avatar"
 	"breadbox/internal/templates/components"
 )
 
@@ -252,28 +253,72 @@ templ settingsSystemCard(p SettingsProps) {
 	</div>
 }
 
-// settingsAvatarStyleCard renders the DiceBear style picker on the
-// General tab. The select submits via POST /settings/avatar-style;
-// the live preview is driven by Alpine and points at
-// api.dicebear.com so the user can compare styles without
-// reloading the server-rendered identicons.
+// settingsAvatarStyleCard renders the DiceBear style pickers on the
+// General tab — one for human users, one for AI agents. Each form
+// posts to /settings/avatar-style with its `actor` field set; the
+// live preview is driven by Alpine and routes through the
+// /avatars/preview proxy so both pickers warm the same in-memory
+// cache /avatars/{id} reads from.
 templ settingsAvatarStyleCard(p SettingsProps) {
-	<div class="bb-card p-5" x-data="{ style: $el.dataset.style }" data-style={ p.AvatarStyle }>
+	<div class="flex flex-col gap-5">
+		@settingsAvatarStylePicker(settingsAvatarPickerProps{
+			Actor:        "user",
+			Title:        "User Avatars",
+			Description:  "DiceBear style for human-member identicons — uploaded avatars are unaffected.",
+			Icon:         "user-circle",
+			CurrentStyle: p.AvatarUserStyle,
+			Seeds:        userPreviewSeeds(),
+			CSRFToken:    p.CSRFToken,
+			Styles:       p.AvatarStyles,
+		})
+		@settingsAvatarStylePicker(settingsAvatarPickerProps{
+			Actor:        "agent",
+			Title:        "Agent Avatars",
+			Description:  "DiceBear style for AI agents — distinct from the user style so agent-authored activity reads as obviously non-human.",
+			Icon:         "bot",
+			CurrentStyle: p.AvatarAgentStyle,
+			Seeds:        agentPreviewSeeds(),
+			CSRFToken:    p.CSRFToken,
+			Styles:       p.AvatarStyles,
+		})
+	</div>
+}
+
+// settingsAvatarPickerProps captures one picker card's render inputs.
+// Used by settingsAvatarStylePicker so the two cards (user + agent)
+// share markup but differ in actor key, copy, and preview seeds.
+type settingsAvatarPickerProps struct {
+	Actor        string // "user" or "agent" — flows into the form's hidden field
+	Title        string
+	Description  string
+	Icon         string // lucide icon name for the card header tile
+	CurrentStyle string
+	Seeds        []string // four sample seeds for the live preview row
+	CSRFToken    string
+	Styles       []avatar.StyleOption
+}
+
+// settingsAvatarStylePicker renders one picker card. Self-contained
+// x-data scope: the select drives the four preview tiles through the
+// /avatars/preview proxy on every change, no submit needed.
+templ settingsAvatarStylePicker(p settingsAvatarPickerProps) {
+	<div class="bb-card p-5" x-data="{ style: $el.dataset.style }" data-style={ p.CurrentStyle }>
 		<div class="bb-icon-header">
 			<div class="bb-icon-header__tile bg-base-200/60">
-				<i data-lucide="user-circle" class="w-4 h-4 text-base-content opacity-60"></i>
+				<i data-lucide={ p.Icon } class="w-4 h-4 text-base-content opacity-60"></i>
 			</div>
 			<div class="bb-icon-header__text">
-				<h2 class="text-sm font-semibold">User Avatars</h2>
-				<p class="text-xs text-base-content/45">DiceBear style for auto-generated identicons — uploaded avatars are unaffected</p>
+				<h2 class="text-sm font-semibold">{ p.Title }</h2>
+				<p class="text-xs text-base-content/45">{ p.Description }</p>
 			</div>
 		</div>
 		<form method="POST" action="/settings/avatar-style">
 			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
-			<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="avatar_style">Style</label>
-			<select id="avatar_style" name="avatar_style" class="select select-sm w-full max-w-sm bg-base-200" x-model="style">
-				for _, opt := range p.AvatarStyles {
-					if opt.ID == p.AvatarStyle {
+			<input type="hidden" name="actor" value={ p.Actor }/>
+			<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for={ "avatar_style_" + p.Actor }>Style</label>
+			<select id={ "avatar_style_" + p.Actor } name="avatar_style" class="select select-sm w-full max-w-sm bg-base-200" x-model="style">
+				for _, opt := range p.Styles {
+					if opt.ID == p.CurrentStyle {
 						<option value={ opt.ID } selected>{ opt.Label }</option>
 					} else {
 						<option value={ opt.ID }>{ opt.Label }</option>
@@ -283,7 +328,7 @@ templ settingsAvatarStyleCard(p SettingsProps) {
 			<div class="mt-4 flex items-center gap-3">
 				<span class="text-xs text-base-content/40">Preview</span>
 				<div class="flex items-center gap-2">
-					for _, seed := range []string{"alice", "bob", "casey", "drew"} {
+					for _, seed := range p.Seeds {
 						<img
 							class="w-10 h-10 rounded-full bg-base-200"
 							alt={ "Preview " + seed }

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -18,6 +18,20 @@ func avatarPreviewExpr(seed string) string {
 	return "'/avatars/preview/" + seed + "?style=' + encodeURIComponent(style)"
 }
 
+// agentPreviewSeeds is the canonical seed list for the Agent style
+// picker preview tiles. Distinct from the user list (alice / bob /
+// casey / drew) so an operator comparing the two cards reads them as
+// different actor categories at a glance.
+func agentPreviewSeeds() []string {
+	return []string{"categorizer", "auditor", "reviewer", "scout"}
+}
+
+// userPreviewSeeds is the seed list for the User style picker tiles.
+// Held here so the two pickers stay symmetrical when one is extended.
+func userPreviewSeeds() []string {
+	return []string{"alice", "bob", "casey", "drew"}
+}
+
 // SettingsProps mirrors the field set the old settings.html read off the layout
 // data map. Kept flat so admin/settings.go can copy fields one-to-one.
 type SettingsProps struct {
@@ -42,8 +56,11 @@ type SettingsProps struct {
 	LatestVersion   string
 	LatestURL       string
 
-	// Avatar style — DiceBear slug used for auto-generated user identicons.
-	// AvatarStyles drives the dropdown options.
-	AvatarStyle  string
-	AvatarStyles []avatar.StyleOption
+	// Avatar styles — DiceBear slugs used for auto-generated
+	// identicons. AvatarUserStyle drives human users; AvatarAgentStyle
+	// drives AI agents. AvatarStyles is the shared catalog of options
+	// for both dropdowns.
+	AvatarUserStyle  string
+	AvatarAgentStyle string
+	AvatarStyles     []avatar.StyleOption
 }

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -496,13 +496,23 @@ templ txdActorInline(e service.ActivityEntry) {
 }
 
 // txdActor adapts a system-event ActivityEntry into the shared
-// TimelineActor shape used by `TimelineActorInline`.
+// TimelineActor shape used by `TimelineActorInline`. UserID +
+// Version are passed straight through — UserAvatar builds the
+// URL on the render side via components.AvatarURLWith.
 func txdActor(e service.ActivityEntry) components.TimelineActor {
 	a := components.TimelineActor{Name: e.ActorName}
-	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
-		a.AvatarURL = avatarURLStr(*e.ActorID, e.ActorAvatarVersion)
-	} else if e.ActorType == "agent" {
+	switch e.ActorType {
+	case "user":
+		if e.ActorID != nil {
+			a.UserID = *e.ActorID
+		}
+		a.Version = e.ActorAvatarVersion
+	case "agent":
 		a.IsAgent = true
+		if e.ActorID != nil {
+			a.UserID = *e.ActorID
+			a.Version = e.ActorAvatarVersion
+		}
 	}
 	return a
 }
@@ -626,14 +636,23 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 
 // txdCommentActor adapts a comment ActivityEntry into the shared
 // TimelineActor shape so `TimelineActorInline` can render its 16px
-// avatar. Users get an image URL; agents get the bot fallback; system
-// actors render as just the bold name.
+// avatar. Users get an image URL; agents get an agent-styled
+// identicon when they carry an ID and the bot fallback otherwise;
+// system actors render as just the bold name.
 func txdCommentActor(e service.ActivityEntry) components.TimelineActor {
 	a := components.TimelineActor{Name: e.ActorName}
-	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
-		a.AvatarURL = avatarURLStr(*e.ActorID, e.ActorAvatarVersion)
-	} else if e.ActorType == "agent" {
+	switch e.ActorType {
+	case "user":
+		if e.ActorID != nil {
+			a.UserID = *e.ActorID
+		}
+		a.Version = e.ActorAvatarVersion
+	case "agent":
 		a.IsAgent = true
+		if e.ActorID != nil {
+			a.UserID = *e.ActorID
+			a.Version = e.ActorAvatarVersion
+		}
 	}
 	return a
 }
@@ -990,19 +1009,6 @@ func relativeTimeStrAt(s string, now time.Time) string {
 	return timefmt.RelativeRFC3339At(s, now)
 }
 
-// avatarURLStr mirrors the admin "avatarURL" funcMap for the (user_id,
-// version) overload the activity timeline uses — second arg is a
-// stringified unix timestamp for cache-busting after avatar uploads.
-func avatarURLStr(id, version string) string {
-	if id == "" {
-		return "/avatars/unknown"
-	}
-	url := "/avatars/" + id
-	if version != "" {
-		url += "?v=" + version
-	}
-	return url
-}
 
 // txdCategoryInitial returns the current category UUID for the picker's
 // data-initial attribute, or an empty string when the transaction has no

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -136,7 +136,14 @@ templ usersMemberCard(u UsersEnrichedRow) {
 		<div class="p-4 sm:p-6 pb-4">
 			<div class="flex items-center justify-between gap-3">
 				<div class="flex items-center gap-4 min-w-0">
-					<img src={ u.AvatarURL } alt="" class="w-12 h-12 rounded-full object-cover shrink-0"/>
+					@components.UserAvatar(components.UserAvatarProps{
+						ID:         u.ID,
+						Name:       u.Name,
+						Version:    u.AvatarVersion,
+						Size:       components.UserAvatar2XL,
+						Decorative: true,
+						Class:      "shrink-0",
+					})
 					<div>
 						<div class="flex items-center gap-2 flex-wrap">
 							<h3 class="font-semibold text-base">{ u.Name }</h3>

--- a/internal/templates/components/pages/users_types.go
+++ b/internal/templates/components/pages/users_types.go
@@ -29,7 +29,7 @@ type UsersEnrichedRow struct {
 	Name              string
 	Email             string
 	HasEmail          bool
-	AvatarURL         string // already-built /avatars/<id>?v=<unix>
+	AvatarVersion     string // updated_at unix timestamp; threaded through UserAvatar's Version prop
 	AccountCount      int
 	ConnectionCount   int64
 	HasCreatedAt      bool

--- a/internal/templates/components/sidebar_user_menu.templ
+++ b/internal/templates/components/sidebar_user_menu.templ
@@ -45,7 +45,14 @@ templ SidebarUserMenu(p SidebarUserMenuProps) {
 		style={ "anchor-name:" + anchorName }
 	>
 		if p.HasLinkedUser {
-			<img src={ navAvatar(p.SessionUserID, p.SessionAvatarVersion) } alt="" class="bb-sidebar-profile-avatar shrink-0"/>
+			@UserAvatar(UserAvatarProps{
+				ID:         p.SessionUserID,
+				Name:       navDisplayName(p.UserName, p.AdminUsername),
+				Version:    p.SessionAvatarVersion,
+				Size:       UserAvatarLg,
+				Class:      "bb-sidebar-profile-avatar",
+				Decorative: true,
+			})
 		} else {
 			<i data-lucide="user-circle" class="w-6 h-6 text-base-content/40 shrink-0"></i>
 		}

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -73,12 +73,17 @@ type TimelineRowProps struct {
 	Now       time.Time // Request-level now anchor threaded through to the relative-time helper so day-bucket labels and per-row timestamps can never disagree across midnight. Zero → render-time time.Now() fallback.
 }
 
-// TimelineActor is reused inside comment rows.
+// TimelineActor is reused inside comment rows. UserID + Version
+// drive the avatar URL through the shared components.AvatarURL
+// helper — no caller-side URL stringing. IsAgent flips both the
+// avatar style (when UserID is set) and the fallback render
+// (bot tile when UserID is empty).
 type TimelineActor struct {
-	Name      string
-	AvatarURL string // When set, an <img> avatar is used. Falls back to initials/bot tile.
-	IsAgent   bool   // When true, renders the bot-tile fallback instead of initials.
-	HRef      string // Optional link target wrapping the actor name.
+	Name    string
+	UserID  string // users.id / agent_definitions.id; empty + non-agent → letter fallback
+	Version string // avatar-version cache-buster (avatar_v on session, ActorAvatarVersion on activity rows)
+	IsAgent bool   // routes the avatar URL to ?type=agent and triggers the bot fallback when UserID is empty
+	HRef    string // Optional link target wrapping the actor name.
 }
 
 // Timeline renders the section wrapper (header + rail + ordered list). The
@@ -328,18 +333,25 @@ templ TimelineEmpty(message string) {
 }
 
 // timelineCommentAvatar renders the 24px avatar tile for a comment row.
+// Delegates to UserAvatar with Ring=true so the same primitive renders
+// the sidebar profile, the cmdk row, and this rail tile — the tile
+// chrome (4px ring against base-100) comes from the Ring flag.
+//
+// When UserID is set the URL flows through components.AvatarURL with
+// the right actor-type query param (?type=agent for agents). When
+// UserID is empty + IsAgent fires the bot-tile fallback; otherwise
+// the letter-initials fallback.
 templ timelineCommentAvatar(actor TimelineActor) {
-	if actor.AvatarURL != "" {
-		<img src={ actor.AvatarURL } alt={ actor.Name + " avatar" } class="w-6 h-6 rounded-full object-cover border border-base-300 ring-4 ring-base-100" title={ actor.Name }/>
-	} else if actor.IsAgent {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 border border-base-300 ring-4 ring-base-100" aria-hidden="true" title={ actor.Name }>
-			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
-		</span>
-	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true" title={ actor.Name }>
-			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ firstChar(actor.Name) }</span>
-		</span>
-	}
+	@UserAvatar(UserAvatarProps{
+		Name:       actor.Name,
+		ID:         actor.UserID,
+		Version:    actor.Version,
+		IsAgent:    actor.IsAgent,
+		Size:       UserAvatarMd,
+		Ring:       true,
+		Decorative: true,
+		Lazy:       true,
+	})
 }
 
 // TimelineCommentTile renders the 24px rail tile for a comment row — the
@@ -370,12 +382,18 @@ templ TimelineCommentTile() {
 // avatar slot uses `align-text-bottom` so the baseline lines up with the
 // surrounding `leading-6` text, and `mr-1` reproduces the legacy spacing.
 templ TimelineActorInline(actor TimelineActor) {
-	if actor.AvatarURL != "" {
-		<img src={ actor.AvatarURL } alt="" class="inline-block w-4 h-4 rounded-full object-cover border border-base-300 align-text-bottom mr-1" aria-hidden="true"/>
-	} else if actor.IsAgent {
-		<span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 border border-base-300 align-text-bottom mr-1" aria-hidden="true">
-			<i data-lucide="bot" class="w-2.5 h-2.5 text-primary"></i>
-		</span>
+	if actor.UserID != "" || actor.IsAgent {
+		@UserAvatar(UserAvatarProps{
+			Name:       actor.Name,
+			ID:         actor.UserID,
+			Version:    actor.Version,
+			IsAgent:    actor.IsAgent,
+			Size:       UserAvatarXS,
+			Inline:     true,
+			Class:      "mr-1",
+			Decorative: true,
+			Lazy:       true,
+		})
 	}
 	if actor.Name != "" {
 		if actor.HRef != "" {

--- a/internal/templates/components/tx_row_atoms.templ
+++ b/internal/templates/components/tx_row_atoms.templ
@@ -56,7 +56,7 @@ templ TxAvatar(p TxAvatarProps) {
 		}
 		if p.OwnerName != "" {
 			if p.OwnerID != nil {
-				<img src={ avatarURL(deref(p.OwnerID)) } alt="" class="bb-tx-owner-badge" title={ p.OwnerName }/>
+				<img src={ AvatarURL(deref(p.OwnerID), "") } alt="" class="bb-tx-owner-badge" title={ p.OwnerName } loading="lazy" decoding="async"/>
 			} else {
 				<span class="bb-tx-owner-badge bb-tx-owner-badge--letter" title={ p.OwnerName }>
 					<span>{ firstChar(p.OwnerName) }</span>

--- a/internal/templates/components/user_avatar.go
+++ b/internal/templates/components/user_avatar.go
@@ -1,0 +1,427 @@
+//go:build !headless && !lite
+
+package components
+
+import (
+	"net/url"
+	"strings"
+)
+
+// UserAvatarSize controls the avatar's outer w/h and the inner glyph
+// (letter fallback / bot tile icon) sizing. Seven sizes cover every
+// surface that renders a person/agent identity in the admin UI; pick
+// the one that matches the call site, not the largest that "fits".
+//
+//	UserAvatarXS  — 16px, inline inside text (TimelineActorInline).
+//	UserAvatarSm  — 20px, list-row + small overflow badges.
+//	UserAvatarMd  — 24px, timeline comment rail tile, cmdk rows.
+//	UserAvatarLg  — 32px, sidebar profile.
+//	UserAvatarXL  — 40px, settings style picker + user-form edit.
+//	UserAvatar2XL — 48px, household member card.
+//	UserAvatar3XL — 56px, user-form create + large detail headers.
+type UserAvatarSize string
+
+const (
+	UserAvatarXS  UserAvatarSize = "xs"
+	UserAvatarSm  UserAvatarSize = "sm"
+	UserAvatarMd  UserAvatarSize = "md"
+	UserAvatarLg  UserAvatarSize = "lg"
+	UserAvatarXL  UserAvatarSize = "xl"
+	UserAvatar2XL UserAvatarSize = "2xl"
+	UserAvatar3XL UserAvatarSize = "3xl"
+)
+
+// UserAvatarProps is the prop bag for the UserAvatar component. Empty
+// fields collapse cleanly: no ID + no IsAgent renders the letter
+// fallback; empty Version skips the ?v= cache-buster; empty Class
+// keeps just the size + shape classes.
+type UserAvatarProps struct {
+	// ID is the users.id / short_id used to fetch the DiceBear-backed
+	// /avatars/{id} SVG. Empty falls through to the letter or bot
+	// fallback (depending on IsAgent).
+	ID string
+	// Name drives the tooltip (`title`), alt text, and the letter
+	// fallback glyph (first A–Z / 0–9 char). Required for accessibility
+	// when ID is set; "?" is rendered when both are missing.
+	Name string
+	// Version is the cache-bust suffix appended to the URL as `?v=`.
+	// Pass the user's updated_at unix timestamp; empty skips the param.
+	Version string
+	// Size selects one of the size variants. Empty + non-empty Class
+	// lets the caller provide bespoke sizing (bb-tx-owner-badge is
+	// the canonical exception).
+	Size UserAvatarSize
+	// IsAgent flags the actor as an AI agent. When ID is set the URL
+	// is routed via ?type=agent so the configured agent DiceBear
+	// style is used. When ID is empty, IsAgent triggers the bot-tile
+	// fallback (lucide "bot" icon over a primary tint).
+	IsAgent bool
+	// Ring adds the `ring-4 ring-base-100` border that lets the avatar
+	// thread through the timeline rail. Defaults off.
+	Ring bool
+	// Inline switches the wrapper from `flex` to `inline-block` /
+	// `inline-flex` so the avatar can sit on a baseline inside a text
+	// run (TimelineActorInline). Adds `align-text-bottom`.
+	Inline bool
+	// Class is appended to the outer wrapper. Used for one-off
+	// positioning (e.g. "bb-tx-owner-badge" — which carries its own
+	// w/h, rounded-full, absolute, and shadow) and for `shrink-0`.
+	Class string
+	// Title overrides the tooltip text. Defaults to Name when empty.
+	Title string
+	// SrcOverride bypasses ID-based URL construction. Used by sandbox
+	// previews and any caller that already has a fully-resolved URL
+	// (e.g. the settings preview proxy path). When empty, the URL is
+	// built from ID + Version + IsAgent.
+	SrcOverride string
+	// Decorative marks the avatar as purely decorative — the
+	// surrounding context already names the actor (typical inside
+	// timeline rows). Renders `alt=""` so assistive tech doesn't
+	// double-announce the name. Defaults off; new call sites should
+	// set this when the next sibling is a `<strong>actor name</strong>`.
+	Decorative bool
+	// Lazy enables native browser lazy-loading on the inner <img>.
+	// Use for below-the-fold avatars (long member lists, deep
+	// comment threads). Skip for above-the-fold renders so the user
+	// doesn't watch them pop in.
+	Lazy bool
+	// Loading renders a skeleton circle in place of the image.
+	// Useful for hydration flicker on optimistic inserts and for
+	// async-loaded actor rows. Wins over all other render branches.
+	Loading bool
+}
+
+// AvatarURL is the single source of truth for a user-side avatar URL.
+// id is the users.id (or short_id); version is the session's avatar_v
+// cache-buster (typically the user's updated_at unix timestamp).
+// Empty id returns the unknown-avatar fallback.
+//
+// For agent avatars, call AgentAvatarURL — it appends ?type=agent so
+// the server picks the configured agent DiceBear style. For sized
+// renders, call AvatarURLWith — it threads the size + actor type
+// through in one shot.
+//
+// Mirrors the lowercased `avatarURL` helper above so templ-generated
+// code (which calls the bare identifier) and external Go callers
+// share a definition.
+func AvatarURL(id, version string) string {
+	return AvatarURLWith(id, version, "user", 0)
+}
+
+// AgentAvatarURL is AvatarURL for AI agents — appends ?type=agent so
+// the server resolves the configured agent style instead of the
+// user style. Pair with the agent's ID + version the same way.
+func AgentAvatarURL(id, version string) string {
+	return AvatarURLWith(id, version, "agent", 0)
+}
+
+// AvatarURLWith builds an avatar URL with explicit actor type +
+// pixel size. Empty actor → user. Size 0 → omit the `?size=` param
+// (server falls back to its 256px default). Most callers should use
+// AvatarURL / AgentAvatarURL; this is the single-knob version used
+// by the component when threading the size enum through.
+func AvatarURLWith(id, version, actor string, size int) string {
+	if id == "" {
+		return "/avatars/unknown"
+	}
+	u := "/avatars/" + id
+	params := url.Values{}
+	if version != "" {
+		params.Set("v", version)
+	}
+	if actor == "agent" {
+		params.Set("type", "agent")
+	}
+	if size > 0 {
+		params.Set("size", itoaPositive(size))
+	}
+	if len(params) == 0 {
+		return u
+	}
+	return u + "?" + params.Encode()
+}
+
+// itoaPositive is a tiny strconv-free integer formatter that handles
+// the positive-only avatar size values without pulling strconv into
+// the templ generated code. Sizes are bounded at the call site
+// (UserAvatarSize → 16..56) so we don't need the full conversion.
+func itoaPositive(n int) string {
+	if n <= 0 {
+		return "0"
+	}
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	var buf [4]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// userAvatarTitle returns the tooltip text for a given UserAvatarProps,
+// preferring an explicit Title override, then Name, then empty.
+func userAvatarTitle(p UserAvatarProps) string {
+	if p.Title != "" {
+		return p.Title
+	}
+	return p.Name
+}
+
+// userAvatarAlt returns the alt text. When the avatar is marked
+// decorative (the surrounding context already names the actor) we
+// emit alt="" so screen readers don't double-announce; otherwise
+// "<Name> avatar". Letter / bot fallbacks always have alt="" — the
+// inner span carries its own aria-hidden treatment.
+func userAvatarAlt(p UserAvatarProps) string {
+	if p.Decorative || p.Name == "" {
+		return ""
+	}
+	return p.Name + " avatar"
+}
+
+// userAvatarSrc returns the image src for the props, applying the
+// SrcOverride escape hatch first, then routing by actor type.
+func userAvatarSrc(p UserAvatarProps) string {
+	if p.SrcOverride != "" {
+		return p.SrcOverride
+	}
+	actor := "user"
+	if p.IsAgent {
+		actor = "agent"
+	}
+	return AvatarURLWith(p.ID, p.Version, actor, userAvatarPixelSize(p.Size))
+}
+
+// userAvatarLoadingAttr returns "lazy" when the prop opts in,
+// otherwise "". Used as the `loading` attribute on the inner <img>.
+func userAvatarLoadingAttr(p UserAvatarProps) string {
+	if p.Lazy {
+		return "lazy"
+	}
+	return ""
+}
+
+// userAvatarPixelSize maps a Size variant to its rendered pixel
+// dimension. Threaded through to ?size= so the backend fetches a
+// pre-sized SVG. Returns 0 when no size is set so callers fall back
+// to the server's 256px default.
+func userAvatarPixelSize(s UserAvatarSize) int {
+	switch s {
+	case UserAvatarXS:
+		return 16
+	case UserAvatarSm:
+		return 20
+	case UserAvatarMd:
+		return 24
+	case UserAvatarLg:
+		return 32
+	case UserAvatarXL:
+		return 40
+	case UserAvatar2XL:
+		return 48
+	case UserAvatar3XL:
+		return 56
+	}
+	return 0
+}
+
+// userAvatarHasImage reports whether the component should render an
+// <img> path versus a fallback (letter or bot tile). When SrcOverride
+// is set we always render an image; otherwise only when ID is set.
+func userAvatarHasImage(p UserAvatarProps) bool {
+	if p.IsAgent {
+		return false
+	}
+	return p.SrcOverride != "" || p.ID != ""
+}
+
+// userAvatarWrapperClass composes the outer wrapper classes for a
+// UserAvatar render. Inline + Ring + Class + Size all contribute. When
+// Size is empty (caller-supplied sizing via Class) we still emit a
+// `rounded-full` so callers don't have to repeat it.
+func userAvatarWrapperClass(p UserAvatarProps) string {
+	parts := []string{}
+	switch {
+	case p.Inline:
+		parts = append(parts, "inline-flex items-center justify-center align-text-bottom shrink-0")
+	default:
+		parts = append(parts, "inline-flex items-center justify-center shrink-0")
+	}
+	parts = append(parts, "rounded-full overflow-hidden")
+	if size := userAvatarSizeClass(p.Size); size != "" {
+		parts = append(parts, size)
+	}
+	if p.Ring {
+		parts = append(parts, "ring-4 ring-base-100")
+	}
+	if p.Class != "" {
+		parts = append(parts, p.Class)
+	}
+	return joinClasses(parts)
+}
+
+// userAvatarSizeClass returns the w/h tailwind utility pair for a
+// given Size value, or "" when Size is empty (caller-controlled).
+func userAvatarSizeClass(s UserAvatarSize) string {
+	switch s {
+	case UserAvatarXS:
+		return "w-4 h-4"
+	case UserAvatarSm:
+		return "w-5 h-5"
+	case UserAvatarMd:
+		return "w-6 h-6"
+	case UserAvatarLg:
+		return "w-8 h-8"
+	case UserAvatarXL:
+		return "w-10 h-10"
+	case UserAvatar2XL:
+		return "w-12 h-12"
+	case UserAvatar3XL:
+		return "w-14 h-14"
+	}
+	return ""
+}
+
+// userAvatarImgClass returns the inner <img>'s classes. The img fills
+// the wrapper (`w-full h-full object-cover`); the wrapper handles
+// shape + ring. A subtle border keeps photos from blending into the
+// page surface.
+func userAvatarImgClass(p UserAvatarProps) string {
+	return "w-full h-full object-cover bg-base-200"
+}
+
+// userAvatarFallbackClass returns the classes for the letter-fallback
+// wrapper. Daisy `primary/10` tint + `text-primary/80` glyph mirrors
+// the legacy `.bb-tx-owner-badge--letter` look at the larger sizes.
+func userAvatarFallbackClass(p UserAvatarProps) string {
+	return "w-full h-full flex items-center justify-center bg-base-200 text-base-content/60"
+}
+
+// userAvatarAgentClass returns the classes for the bot-tile fallback.
+// `bg-primary/10` + `text-primary` matches the legacy timeline agent
+// avatar treatment.
+func userAvatarAgentClass(p UserAvatarProps) string {
+	return "w-full h-full flex items-center justify-center bg-primary/10 text-primary"
+}
+
+// userAvatarLetterClass returns the size-aware text classes for the
+// letter fallback glyph. Smaller sizes need tighter font + leading so
+// the character fits without overflowing the tile. Two-letter renders
+// (md+) trim the font by one step so "AC" doesn't visually crowd the
+// tile vs a single "A".
+func userAvatarLetterClass(s UserAvatarSize, twoLetters bool) string {
+	switch s {
+	case UserAvatarXS:
+		return "text-[0.5rem] font-semibold leading-none"
+	case UserAvatarSm:
+		return "text-[0.625rem] font-semibold leading-none"
+	case UserAvatarMd:
+		if twoLetters {
+			return "text-[8px] font-semibold leading-none tracking-tighter"
+		}
+		return "text-[10px] font-semibold leading-none"
+	case UserAvatarLg:
+		if twoLetters {
+			return "text-[11px] font-semibold leading-none tracking-tight"
+		}
+		return "text-xs font-semibold leading-none"
+	case UserAvatarXL:
+		if twoLetters {
+			return "text-[13px] font-semibold leading-none tracking-tight"
+		}
+		return "text-sm font-semibold leading-none"
+	case UserAvatar2XL:
+		if twoLetters {
+			return "text-sm font-semibold leading-none"
+		}
+		return "text-base font-semibold leading-none"
+	case UserAvatar3XL:
+		if twoLetters {
+			return "text-base font-semibold leading-none"
+		}
+		return "text-lg font-semibold leading-none"
+	}
+	return "text-xs font-semibold leading-none"
+}
+
+// userAvatarLetters returns the glyph(s) for a letter-fallback render.
+// Mirrors the GitHub/Gravatar-style "two initials when available"
+// convention used by most identity chips:
+//
+//	"Alice Canales"          → "AC"
+//	"alice"                  → "A"
+//	"Alice von Canales"      → "AC"  (first + last word's initial)
+//	"AC"                     → "AC"
+//	""                       → "?"
+//
+// For the smallest sizes (xs / sm), two letters would visually crowd
+// the 16–20px tile, so we collapse back to a single initial. Sizes
+// md+ get the full two-letter treatment.
+func userAvatarLetters(name string, size UserAvatarSize) string {
+	first := firstChar(name)
+	if first == "?" {
+		return "?"
+	}
+	if size == UserAvatarXS || size == UserAvatarSm {
+		return first
+	}
+	words := strings.Fields(name)
+	if len(words) >= 2 {
+		last := firstChar(words[len(words)-1])
+		if last != "?" && last != first {
+			return first + last
+		}
+	}
+	return first
+}
+
+// userAvatarTwoLetters reports whether the letter fallback for a
+// given (name, size) will render two characters. Mirrors the
+// userAvatarLetters branching so the font-size helper can pick the
+// crowded-two-letters variant without re-parsing the name.
+func userAvatarTwoLetters(name string, size UserAvatarSize) bool {
+	return len(userAvatarLetters(name, size)) > 1
+}
+
+// userAvatarBotIconClass returns the size-aware lucide icon size for
+// the bot fallback tile. Matches the surrounding tile width so the
+// glyph reads as a filled icon, not a tiny mark on a large field.
+func userAvatarBotIconClass(s UserAvatarSize) string {
+	switch s {
+	case UserAvatarXS:
+		return "w-2.5 h-2.5"
+	case UserAvatarSm:
+		return "w-3 h-3"
+	case UserAvatarMd:
+		return "w-3 h-3"
+	case UserAvatarLg:
+		return "w-4 h-4"
+	case UserAvatarXL:
+		return "w-5 h-5"
+	case UserAvatar2XL:
+		return "w-6 h-6"
+	case UserAvatar3XL:
+		return "w-7 h-7"
+	}
+	return "w-4 h-4"
+}
+
+// joinClasses concatenates a list of class strings with single spaces,
+// dropping empty entries so the rendered class attribute stays tight.
+func joinClasses(parts []string) string {
+	out := ""
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if out != "" {
+			out += " "
+		}
+		out += p
+	}
+	return out
+}

--- a/internal/templates/components/user_avatar.templ
+++ b/internal/templates/components/user_avatar.templ
@@ -1,0 +1,58 @@
+package components
+
+// UserAvatar renders a person/agent identity badge — the shared
+// shape used by the sidebar profile, transaction owner badges, the
+// activity timeline (rail tile + inline actor), settings preview
+// tiles, and the user-form preview. Built on the DiceBear-backed
+// `/avatars/{id}` endpoint (see internal/avatar).
+//
+// Three render paths:
+//
+//   - <img> when ID (or SrcOverride) is set and the actor is a user.
+//     URL is built via AvatarURL(id, version); version is the
+//     session avatar_v cache-buster.
+//   - Bot tile when IsAgent is true — `bg-primary/10` ring with a
+//     lucide "bot" glyph sized to the variant.
+//   - Letter fallback when neither ID nor IsAgent is set — first
+//     A–Z / 0–9 char of Name, or "?" if Name is empty too.
+//
+// Pick a Size from the UserAvatarSize palette unless your caller has
+// genuinely bespoke sizing — `bb-tx-owner-badge` is the documented
+// exception (14px + absolute + box-shadow + per-row tinting). In
+// that case pass Size="" + Class="bb-tx-owner-badge"; the component
+// emits the inner glyph and lets the class drive everything else.
+//
+// Title overrides the tooltip + alt text; defaults to Name. Use
+// Ring + Inline to opt into the timeline-rail and inline-in-text
+// treatments respectively (see TimelineCommentRow / TimelineActorInline
+// for the call sites).
+templ UserAvatar(p UserAvatarProps) {
+	<span
+		class={ userAvatarWrapperClass(p) }
+		if t := userAvatarTitle(p); t != "" && !p.Loading {
+			title={ t }
+		}
+	>
+		if p.Loading {
+			<span class="skeleton w-full h-full rounded-full" aria-hidden="true" aria-busy="true"></span>
+		} else if userAvatarHasImage(p) {
+			<img
+				src={ userAvatarSrc(p) }
+				alt={ userAvatarAlt(p) }
+				class={ userAvatarImgClass(p) }
+				if attr := userAvatarLoadingAttr(p); attr != "" {
+					loading={ attr }
+				}
+				decoding="async"
+			/>
+		} else if p.IsAgent {
+			<span class={ userAvatarAgentClass(p) } aria-hidden="true">
+				<i data-lucide="bot" class={ userAvatarBotIconClass(p.Size) }></i>
+			</span>
+		} else {
+			<span class={ userAvatarFallbackClass(p) } aria-hidden="true">
+				<span class={ userAvatarLetterClass(p.Size, userAvatarTwoLetters(p.Name, p.Size)) }>{ userAvatarLetters(p.Name, p.Size) }</span>
+			</span>
+		}
+	</span>
+}

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -367,7 +367,7 @@
              aria-label="My Account"
              title="My Account">
             {{if .SessionUserID}}
-            <img src="/avatars/{{.SessionUserID}}" alt="" class="w-7 h-7 rounded-full object-cover" />
+            {{renderComponent "UserAvatar" (userAvatarProps .SessionUserID .SessionAvatarVersion .AdminUsername "lg")}}
             {{else}}
             <i data-lucide="user-circle" class="w-5 h-5" aria-hidden="true"></i>
             {{end}}


### PR DESCRIPTION
## Summary

- Builds `components.UserAvatar` — the shared identity badge now used by the sidebar profile, mobile navbar, activity timeline (rail tile + inline actor), feed, transaction owner badge, household member card, and design sandbox. `components.AvatarURL` / `AgentAvatarURL` / `AvatarURLWith` is the single source of truth for `/avatars/{id}` URL construction; the parallel `feedAvatarURL` / `avatarURLStr` / `feedAvatarID` / `feedFirstChar` helpers are deleted.
- Splits the global DiceBear style into per-actor styles. Users render with `avatar.dicebear_style_user` (default `shapes`); agents with `avatar.dicebear_style_agent` (default `bottts`) so agent activity reads as obviously non-human. `/avatars/{id}` now accepts `?type=user|agent` and `?size=N`; the legacy single-style key remains a back-compat alias. Settings → System renders two side-by-side picker cards.
- Seven sizes (xs/sm/md/lg/xl/2xl/3xl: 16→56px), two-letter initial fallback (xs/sm stay single-letter to fit), `Decorative` (`alt=""`), `Lazy` (`loading="lazy"` — wired into timeline + feed + tx owner badge), `Loading` (daisy skeleton circle). Pixel size threads through to `?size=` for proportional SVG payloads.

## Sandbox

`/design#user-avatar` showcases the full matrix — sizes, image / agent identicon / bot fallback / two-letter initials, Ring (timeline rail), Inline (in-text actor), the bb-tx-owner-badge bespoke geometry, the sidebar profile shape, the URL helper outputs, Loading / Lazy / Decorative flags, and the dual Alpine-bound preview seeds.

<img src="https://i.img402.dev/sf9ghv2och.jpg" width="800" alt="/design#user-avatar — full sandbox section">

## Settings → System

Two side-by-side picker cards. Each saves to its own `app_config` key (`avatar.dicebear_style_user` / `avatar.dicebear_style_agent`) and updates the in-process style without a restart.

<img src="https://i.img402.dev/di52e35ob1.jpg" width="800" alt="Settings → System — dual style picker">

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/templates/... ./internal/admin/...` green
- [x] Sidebar profile, mobile navbar, activity timeline (feed + tx detail), member cards, tx-list owner badges all still render
- [x] Settings → System: both pickers save independently, previews repaint on style change, legacy `avatar.dicebear_style` key falls through to user-style slot on first boot
- [x] Lazy loading verified: 100 `loading="lazy"` on /transactions; 3 on /feed
- [x] DiceBear pre-sizing verified: `?size=16` on XS avatars, `?size=24` on MD, etc.
- [x] Agent identicons (ID + IsAgent) route URL to `?type=agent`; bot tile still fires when no ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)
