### PR TITLE
fix(ui): render en-dash entity in tx paginator label

### DIFF
--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -91,7 +91,7 @@ templ TxResults(p TxResultsProps) {
 		<div class="bb-paginator" id="bb-tx-paginator">
 			<div class="bb-paginator__info">
 				<span class="text-xs text-base-content/50 tabular-nums hidden sm:inline">
-					Showing { fmt.Sprintf("%d&ndash;%d", p.ShowingStart, p.ShowingEnd) } of { strconv.Itoa(p.Total) }
+					@templ.Raw(fmt.Sprintf("Showing %d&ndash;%d of %d", p.ShowingStart, p.ShowingEnd, p.Total))
 				</span>
 				<div class="bb-paginator__per-page">
 					<label class="text-xs text-base-content/40 whitespace-nowrap">Per page</label>


### PR DESCRIPTION
## Summary

- Tx list paginator was showing `Showing 101&ndash;150 of 947` literally — the `&ndash;` HTML entity rendered as text instead of an en-dash.
- Templ auto-escapes expression interpolations (`{ fmt.Sprintf(...) }`), so `&` became `&amp;`. Wrap the label in `@templ.Raw(...)` so the entity reaches the browser intact — matches the existing pattern in `rules.templ` and `logs.templ`.

## Test plan

- [x] `templ generate` + `go build ./...` + `go vet ./...` clean.
- [x] `go test ./internal/templates/...` passes.
- [x] Manual: `curl /transactions?per_page=50&page=3` now returns `Showing 101&ndash;150 of 947` (HTML entity), which browsers render as the en-dash.