### PR TITLE
chore(ui): drop unused Chart.js script tag

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -457,7 +457,7 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 
 // RenderWithTempl hosts a templ-rendered page body inside the existing
 // html/template base layout (nav, drawer, cmd-K palette, progress bar,
-// CSRF shim, Alpine/chart.js scripts). The component is rendered to a
+// CSRF shim, Alpine scripts). The component is rendered to a
 // buffer and passed to the layout via the TemplContent slot added in
 // layout/base.html. Pages migrated to templ call this instead of
 // Render — no base.html rewrite needed. See issue #462.

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -79,7 +79,6 @@
        and runs createIcons() before DOMContentLoaded. Eliminates the CDN-dependent FOUC where
        <i data-lucide> placeholders rendered empty until the CDN round-trip completed. -->
   <script defer src="/static/js/vendor/lucide.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
   {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}">{{end}}
   <script>
     // Auto-inject CSRF token into all same-origin fetch requests.


### PR DESCRIPTION
## Summary
- `internal/templates/layout/base.html` was loading `chart.js@4.5.1` synchronously in `<head>` (~280 KB, render-blocking) on every admin page.
- A codebase sweep finds zero `new Chart(...)`, `<canvas>`, `Chart.` calls, or any other references — it's dead weight.
- Removed the script tag + the comment that mentions `chart.js`.

## Why
First step in fixing the lucide icon flash on page reloads. Cuts ~280 KB of synchronous head JS that was contributing to time-to-interactive on cold loads.

## Test plan
- [x] `make generate` + `go build ./...` + `go vet ./...` clean.
- [x] `grep -rE '\bnew Chart\b|\bChart\.|<canvas' static internal` returns zero matches.
- [x] Search for any string mention of `chart.js` / `chartjs` outside generated assets — only the now-fixed code comment in `templates.go` came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)