### PR TITLE
feat(ui): auto-derive slug from display name in tag + agent forms

### DIFF
--- a/internal/templates/components/pages/agent_form.templ
+++ b/internal/templates/components/pages/agent_form.templ
@@ -29,6 +29,7 @@ templ AgentForm(p AgentFormProps) {
 	<!-- Alpine factory + initial-state JSON. Loaded synchronously (no
 	     defer) so Alpine.data('agentForm', …) registers before Alpine —
 	     itself <script defer> from <head> — fires alpine:init. -->
+	<script src="/static/js/admin/slug.js"></script>
 	<script src="/static/js/admin/components/agent_form.js"></script>
 	@templ.JSONScript("agent-form-data", agentFormInitialJSON(p.Form))
 	@components.BreadcrumbNav(agentFormBreadcrumbs(p))

--- a/internal/templates/components/pages/category_form.templ
+++ b/internal/templates/components/pages/category_form.templ
@@ -19,6 +19,7 @@ import (
 templ CategoryForm(p CategoryFormProps) {
 	if !p.IsEdit {
 		@templ.JSONScript("category-form-picker-data", p.Categories)
+		<script src="/static/js/admin/slug.js"></script>
 	}
 	@components.CategoryPickerScript()
 	@components.BreadcrumbNav(p.Breadcrumbs)
@@ -89,6 +90,23 @@ templ CategoryForm(p CategoryFormProps) {
 						/>
 					</div>
 					if !p.IsEdit {
+						<!-- Slug preview (read-only, server-derived from display name) -->
+						<div>
+							<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="slug_preview">
+								Slug <span class="text-base-content/30">(auto-generated)</span>
+							</label>
+							<input
+								type="text"
+								id="slug_preview"
+								:value="window.bbSlugifyCategory ? window.bbSlugifyCategory(displayName) : ''"
+								class="bb-form-input font-mono text-sm bg-base-200/40 text-base-content/60"
+								readonly
+								disabled
+								tabindex="-1"
+								placeholder="generated from display name"
+							/>
+							<p class="text-xs text-base-content/40 mt-1.5">Generated automatically. A numeric suffix (<code>_2</code>, <code>_3</code>, &hellip;) is appended if this slug already exists.</p>
+						</div>
 						<!-- Parent picker (create mode only) -->
 						<div>
 							<label class="block text-xs font-medium text-base-content/50 mb-1.5">Parent Category</label>

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -7,6 +7,7 @@ import "breadbox/internal/templates/components"
 // html/template version byte-for-byte so behavior (live chip preview,
 // Alpine submit flow) is preserved.
 templ TagForm(p TagFormProps) {
+	<script src="/static/js/admin/slug.js"></script>
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -66,6 +66,21 @@ templ TagForm(p TagFormProps) {
 					</span>
 				</div>
 				<div class="space-y-4">
+					<!-- Display name -->
+					<div>
+						<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="display_name">
+							Display Name <span class="text-error">*</span>
+						</label>
+						<input
+							type="text"
+							id="display_name"
+							x-model="displayName"
+							class="bb-form-input"
+							required
+							maxlength="128"
+							placeholder="Needs Review"
+						/>
+					</div>
 					<!-- Slug -->
 					<div>
 						<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="slug">
@@ -90,21 +105,6 @@ templ TagForm(p TagFormProps) {
 							/>
 							<p class="text-xs text-base-content/40 mt-1.5">Lowercase, hyphens or colons. Immutable after creation.</p>
 						}
-					</div>
-					<!-- Display name -->
-					<div>
-						<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="display_name">
-							Display Name <span class="text-error">*</span>
-						</label>
-						<input
-							type="text"
-							id="display_name"
-							x-model="displayName"
-							class="bb-form-input"
-							required
-							maxlength="128"
-							placeholder="Needs Review"
-						/>
 					</div>
 					<!-- Description -->
 					<div>

--- a/internal/templates/components/pages/tag_form_types.go
+++ b/internal/templates/components/pages/tag_form_types.go
@@ -104,6 +104,14 @@ function tagForm() {
     error: '',
     presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c'],
 
+    init: function() {
+      // Auto-derive slug from the display name while the slug field is
+      // still empty / untouched. Edit mode renders a read-only <code>
+      // for the slug (no input element) so wireSlugInput is a no-op.
+      // See static/js/admin/slug.js.
+      if (window.bbWireSlugInput) window.bbWireSlugInput('display_name', 'slug');
+    },
+
     restorePageState: function() {
       if (window.bbProgress) window.bbProgress.finish();
       var main = document.querySelector('main');

--- a/static/js/admin/components/agent_form.js
+++ b/static/js/admin/components/agent_form.js
@@ -271,6 +271,12 @@ document.addEventListener('alpine:init', function () {
           var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
           this.tzLabel = tz || '';
         } catch (e) { this.tzLabel = ''; }
+
+        // Auto-derive slug from the name field while the slug is still
+        // empty / untouched. Edit mode loads with a non-empty slug, so
+        // the wiring treats it as already-touched and stays out of the
+        // way. See static/js/admin/slug.js.
+        if (window.bbWireSlugInput) window.bbWireSlugInput('agent-name', 'agent-slug');
       },
 
       // ---- cron picker ---------------------------------------------------

--- a/static/js/admin/slug.js
+++ b/static/js/admin/slug.js
@@ -1,0 +1,58 @@
+// Shared "auto-derive slug from display name" helper for admin forms that
+// have both a Name/Display Name field and a Slug field side-by-side
+// (agent form, tag create form).
+//
+// Exposes two globals:
+//   - window.bbSlugify(text)
+//     Returns a URL-safe slug (lowercase [a-z0-9-], max 64 chars, no
+//     leading/trailing dash). Suitable for both the agent slug pattern
+//     and the tag slug pattern (the tag pattern also allows colons, but
+//     those aren't reachable from a typed name).
+//
+//   - window.bbWireSlugInput(nameId, slugId)
+//     Wires a name input to populate a slug input as the user types — but
+//     only while the user hasn't touched the slug field themselves. Edit
+//     forms whose slug starts pre-populated are treated as "already
+//     touched" so the user-chosen slug is never overwritten.
+//
+// We detect "user typed in the slug" via Event.isTrusted, which is true
+// for real keystrokes and false for our own dispatchEvent calls. That
+// lets us synthesise an `input` event after writing the new slug — so
+// any Alpine `x-model` binding picks up the new value — without flipping
+// the "touched" flag ourselves.
+//
+// Accented characters survive the NFKD pass as their base letter plus a
+// combining mark; the [^a-z0-9]+ collapse drops the mark together with
+// any spaces, so "Café Bar" -> "cafe-bar" without an explicit diacritic
+// strip step.
+
+(function () {
+  function slugify(name) {
+    return String(name == null ? '' : name)
+      .normalize('NFKD')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 64);
+  }
+
+  function wire(nameId, slugId) {
+    var nameEl = document.getElementById(nameId);
+    var slugEl = document.getElementById(slugId);
+    if (!nameEl || !slugEl) return;
+    var touched = !!slugEl.value;
+    slugEl.addEventListener('input', function (e) {
+      if (e.isTrusted) touched = true;
+    });
+    nameEl.addEventListener('input', function () {
+      if (touched) return;
+      var next = slugify(nameEl.value);
+      if (next === slugEl.value) return;
+      slugEl.value = next;
+      slugEl.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  window.bbSlugify = slugify;
+  window.bbWireSlugInput = wire;
+})();

--- a/static/js/admin/slug.js
+++ b/static/js/admin/slug.js
@@ -25,6 +25,11 @@
 // combining mark; the [^a-z0-9]+ collapse drops the mark together with
 // any spaces, so "Café Bar" -> "cafe-bar" without an explicit diacritic
 // strip step.
+//
+// Categories use a slightly different rule (underscores, not hyphens, and
+// "&" is folded to a separator) — bbSlugifyCategory mirrors the server-side
+// service.GenerateSlug in internal/service/categories.go exactly so the
+// preview shown to users matches what the server actually writes.
 
 (function () {
   function slugify(name) {
@@ -34,6 +39,15 @@
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '')
       .slice(0, 64);
+  }
+
+  function slugifyCategory(name) {
+    return String(name == null ? '' : name)
+      .toLowerCase()
+      .replace(/[ \-&]/g, '_')
+      .replace(/[^a-z0-9_]/g, '')
+      .replace(/_+/g, '_')
+      .replace(/^_+|_+$/g, '');
   }
 
   function wire(nameId, slugId) {
@@ -54,5 +68,6 @@
   }
 
   window.bbSlugify = slugify;
+  window.bbSlugifyCategory = slugifyCategory;
   window.bbWireSlugInput = wire;
 })();


### PR DESCRIPTION
## Summary

Two related polish items in admin forms:

1. **Auto-derive slug** on the agent (`/agents/new`, `/agents/{slug}/edit`) and tag create (`/tags/new`) forms. Typing in the Name / Display Name field populates the Slug field — `"Manual Review"` → `"manual-review"` — only while the user hasn't touched the slug themselves. Edit screens that load with a pre-populated slug are treated as already-touched and never overwritten.
2. **Consistent field order + category slug preview**. Tag form now shows Display Name above Slug (was inverted) to match the agent form. Category create form now surfaces the server-derived slug as a disabled preview input below Display Name so users can see what slug will be created before submitting. Edit mode unchanged.

Shared helper at `static/js/admin/slug.js`:
- `window.bbSlugify(text)` — agent + tag rule (NFKD, lowercase, `[^a-z0-9]+` → `-`, max 64 chars).
- `window.bbSlugifyCategory(text)` — category rule, mirrors `service.GenerateSlug` exactly (`[ \-&]` → `_`, strip non-`[a-z0-9_]`, collapse `_+`, trim). Verified against the existing `TestGenerateSlug_Variants` cases.
- `window.bbWireSlugInput(nameId, slugId)` — listens for `input` on the name field, fills the slug field while untouched, and uses `Event.isTrusted` to distinguish real keystrokes from the synthetic `input` we dispatch to keep Alpine `x-model` in sync.

Categories use a different mechanism since the server is the source of truth for the slug: the preview field binds `:value="bbSlugifyCategory(displayName)"` on a `disabled` input — Alpine re-evaluates whenever `displayName` changes. The help text under the preview notes that the server appends `_2`, `_3`, etc. if the slug already exists, so the value the user sees may end up with a numeric suffix.

## Evidence

<table>
  <tr><th>Agent form (/agents/new)</th><th>Tag form (/tags/new)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/fqdcksh3d9.jpg" width="420" alt="agent form auto-fill"></td>
    <td><img src="https://i.img402.dev/m8g70umtl4.jpg" width="420" alt="tag form: Display Name above Slug"></td>
  </tr>
  <tr><th colspan="2">Category form (/categories/new) — disabled live preview</th></tr>
  <tr>
    <td colspan="2"><img src="https://i.img402.dev/iqpnpj273x.jpg" width="800" alt="category form slug preview"></td>
  </tr>
</table>

Validated end-to-end against real Chromium via Playwright. Assertions covered:
- Create flow: typing `Daily Triage` derives `daily-triage` in agent slug; typing `Needs Review` derives `needs-review` in tag slug.
- Touched: after a user types in the slug, subsequent name typing leaves the slug alone.
- Edit mode: appending text to an existing agent's name does NOT mutate the pre-populated slug.
- Tag field order: `display_name` precedes `slug` in DOM order.
- Category preview matches all five `TestGenerateSlug_Variants` cases (`Food & Drink → food_drink`, `General Merchandise → general_merchandise`, `  Travel   → travel`, `123 Numbers → 123_numbers`, `Already_valid → already_valid`).
- Category preview input is `disabled` + `readonly` so it can't be edited.

## Test plan

- [ ] `/agents/new`: type a Name, watch Slug fill in real time, then edit Slug — further typing in Name leaves the Slug alone.
- [ ] `/agents/{slug}/edit`: edit the Name — Slug stays put.
- [ ] `/tags/new`: type Display Name, watch Slug fill (preview chip also updates). Display Name now appears above Slug.
- [ ] `/tags/{slug}/edit`: Slug stays read-only `<code>`; no autofill side-effect.
- [ ] `/categories/new`: type Display Name with spaces, `&`, etc.; watch the disabled Slug preview update.
- [ ] `/categories/{slug}/edit`: form is unchanged (no preview field added in edit mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)