### PR TITLE
feat(ui): Nova-flavored daisyUI overlay — Inter Variable, inset-ring cards, unified join shadow

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -149,7 +149,10 @@ Don't pile new `!important` onto daisy classes.
 
 | Selector | Why |
 |---|---|
-| `.btn { transition: …; !important }` + `.btn:active { transform: scale(0.97) !important }` | Adds the press feedback daisy lacks; `!important` because daisy ships a same-specificity rule. |
+| `.btn { background-clip: padding-box; transition: …; !important }` + `.btn:active:not(:disabled):not([aria-haspopup]) { transform: translateY(1px) !important }` | Nova-flavored press feedback. `translateY` (not `scale`) so ring/border treatments stay crisp; `bg-clip-padding` so the ring doesn't bleed at press; `:not([aria-haspopup])` so dropdown triggers don't bob when opening a menu. `!important` because daisy ships same-specificity transitions. |
+| `.join:has(> .btn-{tone}, …) { box-shadow: ring + drop }` + items inside get `box-shadow: none !important` | Lifts daisy's per-button depth shadow onto the `.join` container so split-buttons render as one unit (no seam at the inner edges of join-items). Scoped via `:has()` to joins containing a solid-tone button — flat joins (pagination, ghost segmented) stay flat. |
+| `.modal-box { box-shadow: …; !important }` | Nova ring + soft drop replaces daisy's default shadow-2xl. `!important` because daisy's plugin layer emits a same-specificity rule that wins on source order otherwise. |
+| `.dropdown-content { box-shadow: ring + drop }` (NO `!important`) | Nova default elevation for floating menus. Deliberately no `!important` so per-caller `shadow-lg`/`shadow-xl` (the daisyui.md-mandated standard dropdown shape, settings_modal tab picker, etc.) still wins by specificity. |
 | `.modal-backdrop { transition: opacity 0.2s ease !important }` | Small backdrop polish. |
 | `[x-collapse] { transition: height …; !important }` | Alpine's `x-collapse` plugin sets inline styles; the rule overrides. |
 | `.drawer-side { z-index: 40 !important }` | Stacks above the sticky mobile navbar (z-30). |

--- a/input.css
+++ b/input.css
@@ -74,9 +74,11 @@
   --color-error: oklch(0.577 0.245 27.325);
   --color-error-content: oklch(0.985 0 0);
 
+  /* Radii tuned to shadcn Nova: rounded-xl (12px) on cards/modals,
+     rounded-lg (8px) on buttons/inputs, 4px on checkboxes. */
   --radius-selector: 0.25rem;
   --radius-field: 0.5rem;
-  --radius-box: 0.625rem;
+  --radius-box: 0.75rem;
 
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
@@ -123,7 +125,7 @@
 
   --radius-selector: 0.25rem;
   --radius-field: 0.5rem;
-  --radius-box: 0.625rem;
+  --radius-box: 0.75rem;
 
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
@@ -325,9 +327,22 @@
   .breadcrumbs { scrollbar-width: none; -ms-overflow-style: none; }
   .breadcrumbs::-webkit-scrollbar { display: none; }
 
-  /* ── Cards: shadcn-style — border, not shadow ── */
+  /* ── Cards: shadcn Nova-style — inset ring, transparent border ──
+     Nova uses `ring-1 ring-foreground/10` on cards instead of a 1px border,
+     so the surface reads flatter and the edge feels like a subtle inset
+     against the page rather than a stamped rectangle. We replicate it via
+     a 0/0/0/1 box-shadow tinted with the base-content foreground.
+
+     IMPORTANT: we keep a `border: 1px solid transparent` here so per-caller
+     `border-{tone}/{alpha}` modifiers (`.bb-danger-card` and the
+     warning/error-banner cards under /sync-logs, /users, /my-account,
+     /tags) still light up — Tailwind `border-{color}` utilities only
+     set `border-color` and rely on the base to provide width + style.
+     Removing the border entirely makes those destructive-action tints
+     silently invisible. */
   .bb-card {
-    @apply bg-base-100 rounded-xl border border-base-300;
+    @apply bg-base-100 rounded-xl border border-transparent;
+    box-shadow: 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.08);
     transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.2s ease;
   }
 
@@ -337,7 +352,29 @@
 
   .bb-card--interactive:hover {
     @apply bg-base-200/50;
-    border-color: var(--color-base-300);
+    box-shadow: 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.12);
+  }
+
+  /* Dark mode: boost the ring opacity so the card edge stays legible
+     against the near-black base. base-content is near-white in dark,
+     so a 0.08 alpha (light-mode value) washes out — 0.14 restores
+     parity with the light-mode visual weight. Two selectors because
+     the theme can be set manually via `<html data-theme="dark">` OR
+     auto-resolved via `prefers-color-scheme` when no data-theme is
+     present (see the toggle-restore script in base.html). */
+  [data-theme="dark"] .bb-card {
+    box-shadow: 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.14);
+  }
+  [data-theme="dark"] .bb-card--interactive:hover {
+    box-shadow: 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.20);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) .bb-card {
+      box-shadow: 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.14);
+    }
+    :root:not([data-theme]) .bb-card--interactive:hover {
+      box-shadow: 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.20);
+    }
   }
 
   /* ── Form card primitives ── */
@@ -1004,15 +1041,74 @@
     @apply text-sm text-base-content/50 max-w-sm mb-6 leading-relaxed;
   }
 
-  /* ── Button polish ── */
+  /* ── Button polish (Nova-flavored) ──
+     Nova ships a 1px-translate press feedback (`active:translate-y-px`) +
+     `bg-clip-padding` so any ring/border treatment stays crisp on press.
+     We override daisy's same-specificity rule with `!important`. */
   .btn {
+    background-clip: padding-box;
     transition: background-color 0.15s ease, color 0.15s ease,
                 border-color 0.15s ease, transform 0.1s ease,
                 box-shadow 0.15s ease, opacity 0.15s ease !important;
   }
 
-  .btn:active:not(:disabled) {
-    transform: scale(0.97) !important;
+  .btn:active:not(:disabled):not([aria-haspopup]) {
+    transform: translateY(1px) !important;
+  }
+
+  /* ── Join: unified depth on the bar, not on each segment ──
+     Daisy ships a per-button depth shadow + inset top-highlight (driven
+     by --depth in the light theme). In a `.join` split-button, that
+     highlight rims the inner edge of every .join-item, leaving a
+     visible vertical seam where two solid buttons meet — the eye
+     reads the bar as two stacked rectangles instead of one unit.
+     The drop shadow has the same problem: it ends abruptly at each
+     button's footprint.
+
+     Fix: lift the depth onto the .join container, suppress per-item
+     depth shadow on solid-tone buttons inside. Scoped via :has() to
+     joins that actually contain a solid-tone (.btn-primary etc.)
+     button so ghost-only joins (pagination, segmented filters) stay
+     flat. */
+  .join:has(> .btn-primary, > .btn-secondary, > .btn-accent,
+            > .btn-neutral, > .btn-info, > .btn-success,
+            > .btn-warning, > .btn-error,
+            > .dropdown > .btn-primary, > .dropdown > .btn-secondary,
+            > .dropdown > .btn-accent, > .dropdown > .btn-neutral,
+            > .dropdown > .btn-info, > .dropdown > .btn-success,
+            > .dropdown > .btn-warning, > .dropdown > .btn-error,
+            > .dropdown > [role="button"].btn-primary,
+            > .dropdown > [role="button"].btn-secondary,
+            > .dropdown > [role="button"].btn-accent,
+            > .dropdown > [role="button"].btn-neutral,
+            > .dropdown > [role="button"].btn-info,
+            > .dropdown > [role="button"].btn-success,
+            > .dropdown > [role="button"].btn-warning,
+            > .dropdown > [role="button"].btn-error) {
+    border-radius: var(--radius-field);
+    box-shadow:
+      oklch(from var(--color-base-content) l c h / 0.06) 0 0.5px 0 0.5px inset,
+      oklch(0 0 0 / 0.10) 0 3px 2px -2px,
+      oklch(0 0 0 / 0.10) 0 4px 3px -2px;
+  }
+
+  .join:has(> .btn-primary, > .btn-secondary, > .btn-accent,
+            > .btn-neutral, > .btn-info, > .btn-success,
+            > .btn-warning, > .btn-error,
+            > .dropdown > .btn-primary, > .dropdown > .btn-secondary,
+            > .dropdown > .btn-accent, > .dropdown > .btn-neutral,
+            > .dropdown > .btn-info, > .dropdown > .btn-success,
+            > .dropdown > .btn-warning, > .dropdown > .btn-error,
+            > .dropdown > [role="button"].btn-primary,
+            > .dropdown > [role="button"].btn-secondary,
+            > .dropdown > [role="button"].btn-accent,
+            > .dropdown > [role="button"].btn-neutral,
+            > .dropdown > [role="button"].btn-info,
+            > .dropdown > [role="button"].btn-success,
+            > .dropdown > [role="button"].btn-warning,
+            > .dropdown > [role="button"].btn-error)
+          :is(.btn, [role="button"]).join-item {
+    box-shadow: none !important;
   }
 
   /* Button radius convention — see unlayered .btn-sm / .btn-xs override
@@ -1332,6 +1428,26 @@
    * ──────────────────────────────────────────────────────────── */
   .modal-box {
     overscroll-behavior: contain;
+    /* Nova-style inset ring on modals — replaces the hard daisy shadow-2xl
+       with a foreground-tinted ring + soft drop. `!important` because
+       daisyUI's plugin layer emits a same-specificity `.modal-box`
+       box-shadow that wins on source order otherwise. */
+    box-shadow:
+      0 0 0 1px oklch(from var(--color-base-content) l c h / 0.10),
+      0 10px 30px -10px oklch(0 0 0 / 0.18) !important;
+  }
+
+  /* Floating menus / dropdown content — same inset-ring treatment so
+     overflow popups read consistently with cards and modals. No
+     !important here: callers that opt into a heavier elevation via
+     Tailwind `shadow-lg`/`shadow-xl` (the daisyui.md-mandated standard
+     dropdown shape, plus settings_modal's tab picker) must keep their
+     stronger shadow. Specificity carries this for callers that don't
+     opt in. */
+  .dropdown-content {
+    box-shadow:
+      0 0 0 1px oklch(from var(--color-base-content) l c h / 0.08),
+      0 6px 20px -6px oklch(0 0 0 / 0.12);
   }
 
   /* ── Suppress WebKit's native search-clear (×) on overlay pickers ──

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -53,10 +53,25 @@
       } catch (_) { /* best-effort */ }
     })();
   </script>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', system-ui, -apple-system, sans-serif; }</style>
+  <link rel="preconnect" href="https://rsms.me/" crossorigin>
+  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+  <style>
+    /* Inter Variable + OpenType features mirroring shadcn's Nova polish.
+       - cv11: more humanist single-storey g (matches Nova preview text)
+       - ss01: stylistic alternates (the 'a' shape that gives Inter its "tightened" look)
+       - cv02: rounded l
+       Tabular nums everywhere — numbers in tables and tx lists stop jittering. */
+    :root { font-family: 'Inter var', 'Inter', system-ui, -apple-system, sans-serif; }
+    @supports (font-variation-settings: normal) {
+      :root { font-family: 'Inter var', 'Inter', system-ui, -apple-system, sans-serif; }
+    }
+    body {
+      font-family: 'Inter var', 'Inter', system-ui, -apple-system, sans-serif;
+      font-feature-settings: 'cv11', 'ss01', 'cv02';
+      font-synthesis-weight: none;
+      text-rendering: optimizeLegibility;
+    }
+  </style>
   <!--
     Speculation Rules — Chromium-only predictive prefetch of sidebar nav.
     Chrome 122+ fetches matching links when it predicts the user is about


### PR DESCRIPTION
## Summary

Faithful port of shadcn/ui's **Nova** component style onto our daisyUI 5 + Tailwind v4 admin UI. Nova doesn't change colours (our palette is already the shadcn New York neutral) — it changes _component shape_. This PR captures the highest-impact visual moves with the smallest possible footprint: three files, +147/-13 lines.

### What changed

| Layer | Change |
|---|---|
| **Font** | Inter Variable from `rsms.me` + OpenType `cv11`/`ss01`/`cv02` features. Replaces static Inter from Google Fonts. |
| **Tokens** | `--radius-box` 0.625rem → 0.75rem so cards/modals/alerts land at Nova's `rounded-xl`. Buttons/inputs stay at `rounded-lg`. |
| **`.bb-card`** | Border → foreground-tinted **inset ring** (`box-shadow: 0 0 0 1px oklch(from base-content l c h / α)`). Keeps a transparent border so per-caller `border-{tone}/{alpha}` modifiers still light up. Dark-mode ring boosted to α=0.14 for legibility. |
| **`.btn`** | `bg-clip-padding` + `active:translateY(1px)` instead of `scale(0.97)`. `:not([aria-haspopup])` so dropdown triggers don't bob. |
| **`.join`** | Daisy's per-button depth was creating a visible seam in split-buttons. Lifted shadow onto the `.join` container via `:has(.btn-{tone})`, suppressed per-item. Flat joins (pagination, ghost segmented) untouched. |
| **`.modal-box`** | Foreground ring + soft drop. `!important` because daisy's plugin layer wins source-order otherwise. |
| **`.dropdown-content`** | Matching ring + drop. **No `!important`** — per-caller `shadow-lg`/`shadow-xl` (daisyui.md standard, settings modal) still wins. |
| **Docs** | `.claude/rules/daisyui.md` "Spec'd overrides" table updated. Old `scale(0.97)` line was stale. |

## Before / After

### Feed

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/eq3ussxubw.jpg" width="400" alt="feed before"></td>
    <td><img src="https://i.img402.dev/r5ago6io2v.jpg" width="400" alt="feed after"></td>
  </tr>
</table>

### Transactions list

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/fqf6b95trq.jpg" width="400" alt="tx before"></td>
    <td><img src="https://i.img402.dev/8r8xiamt5j.jpg" width="400" alt="tx after"></td>
  </tr>
</table>

### Transaction detail (cards-heavy)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/67nxvs9v4s.jpg" width="400" alt="tx detail before"></td>
    <td><img src="https://i.img402.dev/v3dgy9o0ou.jpg" width="400" alt="tx detail after"></td>
  </tr>
</table>

### `.join` split-button seam fix

<table>
  <tr><th>Before (visible inner seam)</th><th>After (unified bar)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ylodgz9ffi.jpg" width="400" alt="split button before"></td>
    <td><img src="https://i.img402.dev/1qw9q1rvno.jpg" width="400" alt="split button after"></td>
  </tr>
</table>

### Destructive-card visibility (post-review fix)

<img src="https://i.img402.dev/vev1mfrdtz.jpg" width="600" alt="/my-account danger card with restored border">

## Pre-merge code review (`/code-review medium`)

Six findings, all addressed in the same branch before merge:

1. **`.bb-card` lost its `border` shorthand** — callers using `border-{color}/{opacity}` (no width modifier) rendered with `border-width: 0`, silently dropping destructive-action visual signals on `/my-account`, `/sync-logs`, `/users`, `/tags`, `.bb-danger-card`. **Fix:** added `border 1px solid transparent` on the base — modifiers now light up the tint while the default look is unchanged.
2. **`.modal-box` shadow rule was dead code** — daisy's plugin-layer same-specificity rule beat us on source order. Verified via `getComputedStyle`. **Fix:** added `!important` (added to the spec doc).
3. **`.dropdown-content` `!important` clobbered per-caller `shadow-*` utilities** — including the daisyui.md-mandated `shadow-lg` standard and `settings_modal.templ:110`'s `shadow-xl`. **Fix:** dropped `!important` (specificity-only).
4. **`.btn:active` change contradicted `.claude/rules/daisyui.md` "Spec'd overrides"** — table still said `scale(0.97)`. **Fix:** updated the table to reflect translate-y + `:not([aria-haspopup])` + `bg-clip-padding`, plus added new entries for `.join`/`.modal-box`/`.dropdown-content`.
5. **`.join:has()` selector missed `.dropdown > .btn-info/.btn-success/.btn-warning/.btn-error`** — inconsistent coverage. **Fix:** added the missing four variants for both `.btn-*` and `[role="button"].btn-*` branches.
6. **`.bb-card` ring at 8% opacity may be too subtle in dark mode** — base-content is near-white, washes out against base-200. **Fix:** added `[data-theme="dark"]` + `@media (prefers-color-scheme: dark)` overrides bumping the alpha to 0.14 (hover 0.20).

All six verified live via Chrome DevTools `getComputedStyle` after the rebuild.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make css` rebuilds without errors
- [x] Visual: `/feed`, `/transactions`, `/transactions/{id}`, `/my-account`, `/settings`, `/design` all render correctly at 1280×800 in dark mode (current OS preference) — captured above
- [x] Per-caller `border-{tone}/{alpha}` on `.bb-card` renders the colored border (verified `borderColor: oklab(red / 0.2)` + `borderWidth: 1px solid`)
- [x] Per-caller `shadow-xl` on `.dropdown-content` survives (Tailwind utility wins, not Nova default)
- [x] `.modal-box` shadow is the Nova ring + soft drop (daisy default beaten by `!important`)
- [x] `.join` split-button seam eliminated
- [ ] _Out of scope:_ deeper dark-mode visual audit across every page (boosted to 14%, but only `/my-account` + `/settings` were spot-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
