### PR TITLE
feat(ui): shadcn-style kbd — font-sans text pills, surface-aware inversion, design-sandbox demos

### DIFF
--- a/input.css
+++ b/input.css
@@ -2394,36 +2394,83 @@
     transition: opacity 0.2s ease;
   }
 
-  /* ── Keyboard shortcut badges ── */
+  /* ── Keyboard shortcut badges (shadcn Nova .cn-kbd port) ──
+     Nova reads kbd hints as small *text* pills, not code-style keycaps:
+     `font-sans` (not mono), `text-xs` (12px), `bg-muted` ground, no
+     border, no faux-3D shadow. Reads more like a UI affordance and
+     less like an inline `<code>`.
+
+     Two contexts where we restyle:
+     • Inside a daisy `.tooltip` — the tooltip surface is dark
+       (base-content), so the muted bg/fg gets near-invisible. Invert
+       to `--color-base-100` at 20% on the dark tip, with the tip's
+       own foreground color. Matches Nova's `in-data-[slot=tooltip-content]`
+       override.
+     • Inside a solid-tone `.btn` (primary/secondary/accent/neutral) —
+       the button bg is dark, the surrounding text is white. Same
+       inversion trick. */
   .bb-kbd {
-    @apply inline-flex items-center justify-center min-w-[1.25rem] h-[1.25rem]
-           text-[0.6rem] font-mono font-medium leading-none
-           rounded px-1;
+    @apply inline-flex items-center justify-center gap-1
+           min-w-5 h-5 px-1
+           text-xs font-sans font-medium leading-none
+           rounded-sm;
     background: var(--color-base-200);
     color: oklch(from var(--color-base-content) l c h / 0.7);
-    border: 1px solid var(--color-base-300);
-    box-shadow: 0 1px 0 oklch(from var(--color-base-content) l c h / 0.08);
+  }
+
+  /* When a kbd lives inside a daisy tooltip OR a solid-tone .btn, the
+     surrounding surface and the muted base-200/foreground/0.7 combo
+     wash out (the surface is already dark/colored and the muted ground
+     fights the surrounding text). Use a translucent tint of the current
+     foreground so the kbd pill reads as a subtle inset of whatever
+     parent text colour it sits in. `currentColor` adapts automatically
+     across solid-tone buttons, tooltips, and either theme. */
+  .tooltip .bb-kbd,
+  [role="tooltip"] .bb-kbd,
+  .btn-primary .bb-kbd,
+  .btn-secondary .bb-kbd,
+  .btn-accent .bb-kbd,
+  .btn-neutral .bb-kbd {
+    background: color-mix(in oklab, currentColor 18%, transparent);
+    color: inherit;
   }
 
   /* Blended modifier pill: ⌘│K rendered as one tight badge with a hairline
      divider between cells and only the outer corners rounded. Inherits the
-     background / border palette from .bb-kbd so light/dark mode stays in
-     sync — only the shape is different (no per-cell rounding). */
+     background / fg palette from .bb-kbd so light/dark mode stays in sync —
+     only the shape is different (no per-cell rounding). */
   .bb-kbd-combo {
-    @apply inline-flex items-center h-[1.25rem] rounded overflow-hidden
-           font-mono font-medium text-[0.6rem] leading-none;
+    @apply inline-flex items-center h-5 rounded-sm overflow-hidden
+           font-sans font-medium text-xs leading-none;
     background: var(--color-base-200);
     color: oklch(from var(--color-base-content) l c h / 0.7);
-    border: 1px solid var(--color-base-300);
-    box-shadow: 0 1px 0 oklch(from var(--color-base-content) l c h / 0.08);
   }
 
   .bb-kbd-combo__key {
-    @apply inline-flex items-center justify-center min-w-[1.25rem] px-1 h-full;
+    @apply inline-flex items-center justify-center min-w-5 px-1 h-full;
   }
 
   .bb-kbd-combo__key + .bb-kbd-combo__key {
-    border-left: 1px solid var(--color-base-300);
+    border-left: 1px solid oklch(from var(--color-base-content) l c h / 0.10);
+  }
+
+  /* Same currentColor-tint treatment as .bb-kbd above. */
+  .tooltip .bb-kbd-combo,
+  [role="tooltip"] .bb-kbd-combo,
+  .btn-primary .bb-kbd-combo,
+  .btn-secondary .bb-kbd-combo,
+  .btn-accent .bb-kbd-combo,
+  .btn-neutral .bb-kbd-combo {
+    background: color-mix(in oklab, currentColor 18%, transparent);
+    color: inherit;
+  }
+  .tooltip .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
+  [role="tooltip"] .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
+  .btn-primary .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
+  .btn-secondary .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
+  .btn-accent .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
+  .btn-neutral .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key {
+    border-left-color: color-mix(in oklab, currentColor 30%, transparent);
   }
 
   /* ── Triage mode: compact review rows ── */

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1382,6 +1382,96 @@ templ SectionKbd() {
 				</div>
 			</div>
 		}
+		@designExample("Inside a button (trailing hint)", "kbd inline at the trailing edge of a button. Surface-aware: on a solid-tone button (primary/secondary/accent/neutral) the kbd inverts to a translucent base-100 tint with white-ish glyph; on ghost / soft / outline it keeps the muted base-200 ground.") {
+			<div class="flex flex-wrap items-center gap-3">
+				<button type="button" class="btn btn-primary btn-sm gap-2">
+					Submit
+					@components.KbdCombo("cmd", "enter")
+				</button>
+				<button type="button" class="btn btn-neutral btn-sm gap-2">
+					Save draft
+					@components.Kbd("s")
+				</button>
+				<button type="button" class="btn btn-ghost btn-sm gap-2">
+					Cancel
+					@components.Kbd("esc")
+				</button>
+				<button type="button" class="btn btn-outline btn-sm gap-2">
+					Open
+					@components.KbdCombo("cmd", "o")
+				</button>
+				<button type="button" class="btn btn-soft btn-sm gap-2">
+					Delete
+					@components.KbdCombo("cmd", "shift", "delete")
+				</button>
+			</div>
+		}
+		@designExample("Inside a tooltip (hover hint)", "daisy `tooltip` renders text via ::before from data-tip — for a true kbd-in-tooltip surface, hand-roll a hoverable wrapper with an absolute popover. The kbd auto-inverts against the dark tooltip ground via .tooltip / [role=\"tooltip\"] descendant rules.") {
+			<div class="flex flex-wrap items-center gap-4">
+				<div class="relative inline-block group" role="tooltip-host">
+					<button type="button" class="btn btn-ghost btn-sm gap-2" aria-describedby="kbd-tt-1">
+						@components.LucideIcon("search", "w-3.5 h-3.5")
+						Search
+					</button>
+					<div
+						id="kbd-tt-1"
+						role="tooltip"
+						class="absolute -top-2 left-1/2 -translate-x-1/2 -translate-y-full
+						       hidden group-hover:flex group-focus-within:flex
+						       items-center gap-2
+						       bg-neutral text-neutral-content
+						       rounded-md px-2 py-1.5 text-xs whitespace-nowrap
+						       shadow-lg z-10
+						       after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2
+						       after:border-4 after:border-transparent after:border-t-neutral"
+					>
+						<span>Open search</span>
+						@components.KbdCombo("cmd", "k")
+					</div>
+				</div>
+				<div class="relative inline-block group" role="tooltip-host">
+					<button type="button" class="btn btn-primary btn-sm gap-2" aria-describedby="kbd-tt-2">
+						@components.LucideIcon("send-horizontal", "w-3.5 h-3.5")
+						Submit comment
+					</button>
+					<div
+						id="kbd-tt-2"
+						role="tooltip"
+						class="absolute -top-2 left-1/2 -translate-x-1/2 -translate-y-full
+						       hidden group-hover:flex group-focus-within:flex
+						       items-center gap-2
+						       bg-neutral text-neutral-content
+						       rounded-md px-2 py-1.5 text-xs whitespace-nowrap
+						       shadow-lg z-10
+						       after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2
+						       after:border-4 after:border-transparent after:border-t-neutral"
+					>
+						<span>Submit and post</span>
+						@components.KbdCombo("cmd", "enter")
+					</div>
+				</div>
+				<div class="relative inline-block group" role="tooltip-host">
+					<button type="button" class="btn btn-ghost btn-sm btn-square" aria-label="Close" aria-describedby="kbd-tt-3">
+						@components.LucideIcon("x", "w-4 h-4")
+					</button>
+					<div
+						id="kbd-tt-3"
+						role="tooltip"
+						class="absolute -top-2 left-1/2 -translate-x-1/2 -translate-y-full
+						       hidden group-hover:flex group-focus-within:flex
+						       items-center gap-2
+						       bg-neutral text-neutral-content
+						       rounded-md px-2 py-1.5 text-xs whitespace-nowrap
+						       shadow-lg z-10
+						       after:content-[''] after:absolute after:top-full after:left-1/2 after:-translate-x-1/2
+						       after:border-4 after:border-transparent after:border-t-neutral"
+					>
+						<span>Dismiss</span>
+						@components.Kbd("esc")
+					</div>
+				</div>
+			</div>
+		}
 		@designExample("Glyph mapping reference", "Tokens auto-translate to symbols via kbdGlyph (Go) / bbKbdGlyph (JS). Keep the two in sync when adding new glyphs.") {
 			<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 text-sm">
 				for _, g := range kbdGlyphRefs() {


### PR DESCRIPTION
## Summary

Follow-up to #1549: port the breadbox kbd to **shadcn/ui Nova's `.cn-kbd`** style and add two new design-system examples covering kbd-in-button and kbd-in-tooltip surfaces.

Nova reads keyboard hints as **small text pills**, not keycap-shaped code chips: `font-sans` (not mono), `text-xs`, muted ground, no border, no faux-3D shadow. The breadbox `.bb-kbd` was the older keycap shape (mono, 9.6px, 1px border, 1px bottom shadow). This commit replaces the body while preserving the existing `h-5 / min-w-5` sizing so every existing call site stays pixel-pinned in the layout.

The interesting bit is **surface-aware inversion**: a kbd inside a solid-tone button (or inside a tooltip) gets a `color-mix(in oklab, currentColor 18%, transparent)` background and `color: inherit`, so the pill reads as a subtle inset of whatever foreground colour surrounds it — works across both themes from one rule, no per-theme override.

## Before / After

| Before (mono keycaps, bordered) | After (Nova text pills) |
|---|---|
| <img src="https://i.img402.dev/e0p6ee8dhe.jpg" width="400" alt="kbd before"> | <img src="https://i.img402.dev/xnz1if30pu.jpg" width="400" alt="kbd after"> |

### New design-sandbox examples

The second screenshot is the new "Inside a button" + "Inside a tooltip" examples on `/design/c/kbd?embed=1`. Tooltips force-shown for the capture (`group-hover:flex` is the runtime behaviour; tested live).

<img src="https://i.img402.dev/b3ezt5t5f8.jpg" width="900" alt="kbd inside button + inside tooltip examples">

## Changes

| File | Change |
|---|---|
| `input.css` ~2398 | `.bb-kbd` + `.bb-kbd-combo` ported to Nova: `font-sans`, `text-xs`, `rounded-sm`, `bg-base-200`, no border, no shadow. Same `h-5 / min-w-5` sizing — no layout shift at existing call sites. |
| `input.css` (new) | Surface-aware inversion: when a kbd lives inside `.tooltip` / `[role="tooltip"]` / `.btn-primary` / `.btn-secondary` / `.btn-accent` / `.btn-neutral`, the ground becomes `color-mix(in oklab, currentColor 18%, transparent)` and the glyph uses `color: inherit`. Combo dividers tint at 30%. |
| `internal/templates/components/pages/design_sections.templ` (new) | **"Inside a button (trailing hint)"** — primary/neutral/ghost/outline/soft buttons each with a trailing Kbd or KbdCombo. Demonstrates surface-aware inversion on solid tones vs muted ground on flat. |
| `internal/templates/components/pages/design_sections.templ` (new) | **"Inside a tooltip (hover hint)"** — three buttons with hand-rolled `[role="tooltip"]` popovers above. daisy's `tooltip`/`data-tip` is text-only via `::before`; for a real DOM kbd-in-tooltip we hover-show an absolute div using Tailwind `group-hover:flex group-focus-within:flex`. CSS-only, no Alpine. |

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make css` rebuilds without errors
- [x] `/design/c/kbd` renders all 7 sections including the two new examples (Single key, Modifier combo, Chord, Inside a button, Inside a tooltip, Glyph mapping, Inline in a toolbar)
- [x] Verified live via Chrome DevTools `getComputedStyle`: kbd inside `.btn-primary` shows `font-family: ui-sans-serif...`, `height: 20px`, `background: oklab(... / 0.18)` (currentColor mix). Three `[role="tooltip"]` siblings render, hover-show works.
- [x] New tooltip-popover icons use the post-#1546 `@components.LucideIcon` server-render path (per `.claude/rules/ui.md` icon convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
