### PR TITLE
fix(ui): kbd visibility on .btn-soft / .btn-secondary / .btn-ghost

### DIFF
--- a/input.css
+++ b/input.css
@@ -2390,20 +2390,23 @@
     color: oklch(from var(--color-base-content) l c h / 0.7);
   }
 
-  /* When a kbd lives inside a daisy tooltip OR a solid-tone .btn, the
-     surrounding surface and the muted base-200/foreground/0.7 combo
-     wash out (the surface is already dark/colored and the muted ground
-     fights the surrounding text). Use a translucent tint of the current
-     foreground so the kbd pill reads as a subtle inset of whatever
-     parent text colour it sits in. `currentColor` adapts automatically
-     across solid-tone buttons, tooltips, and either theme. */
+  /* When a kbd lives inside ANY .btn or daisy tooltip, the default
+     base-200 ground can collide with the surface. `.btn-soft` (and
+     daisy 5's per-tone soft variants) sit in the base-200 luminance
+     range — a base-200 kbd on a base-200-tinted button is invisible.
+     ghost/outline buttons sit on the page base-100 with a base-200
+     kbd that reads as a faint smudge. Solid-tone surfaces clash too.
+
+     Replace the default ground with `color-mix(currentColor 22%)`
+     so the kbd always tints toward whatever foreground colour
+     surrounds it. `currentColor` adapts across every button variant
+     (primary / secondary / accent / neutral / ghost / outline / soft /
+     link / tone-specific) + tooltips + both themes from a single rule,
+     with no per-theme or per-variant override. */
+  .btn .bb-kbd,
   .tooltip .bb-kbd,
-  [role="tooltip"] .bb-kbd,
-  .btn-primary .bb-kbd,
-  .btn-secondary .bb-kbd,
-  .btn-accent .bb-kbd,
-  .btn-neutral .bb-kbd {
-    background: color-mix(in oklab, currentColor 18%, transparent);
+  [role="tooltip"] .bb-kbd {
+    background: color-mix(in oklab, currentColor 22%, transparent);
     color: inherit;
   }
 
@@ -2426,23 +2429,18 @@
     border-left: 1px solid oklch(from var(--color-base-content) l c h / 0.10);
   }
 
-  /* Same currentColor-tint treatment as .bb-kbd above. */
+  /* Same currentColor-tint treatment as .bb-kbd above — widened to any
+     .btn so .btn-soft / ghost / outline get the inversion too. */
+  .btn .bb-kbd-combo,
   .tooltip .bb-kbd-combo,
-  [role="tooltip"] .bb-kbd-combo,
-  .btn-primary .bb-kbd-combo,
-  .btn-secondary .bb-kbd-combo,
-  .btn-accent .bb-kbd-combo,
-  .btn-neutral .bb-kbd-combo {
-    background: color-mix(in oklab, currentColor 18%, transparent);
+  [role="tooltip"] .bb-kbd-combo {
+    background: color-mix(in oklab, currentColor 22%, transparent);
     color: inherit;
   }
+  .btn .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
   .tooltip .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
-  [role="tooltip"] .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
-  .btn-primary .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
-  .btn-secondary .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
-  .btn-accent .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key,
-  .btn-neutral .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key {
-    border-left-color: color-mix(in oklab, currentColor 30%, transparent);
+  [role="tooltip"] .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key {
+    border-left-color: color-mix(in oklab, currentColor 35%, transparent);
   }
 
   /* ── Triage mode: compact review rows ── */

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1382,11 +1382,15 @@ templ SectionKbd() {
 				</div>
 			</div>
 		}
-		@designExample("Inside a button (trailing hint)", "kbd inline at the trailing edge of a button. Surface-aware: on a solid-tone button (primary/secondary/accent/neutral) the kbd inverts to a translucent base-100 tint with white-ish glyph; on ghost / soft / outline it keeps the muted base-200 ground.") {
+		@designExample("Inside a button (trailing hint)", "kbd inline at the trailing edge of a button. Surface-aware: every .btn variant (primary / secondary / accent / neutral / ghost / outline / soft / soft-tone) gets a `currentColor 22%`-tinted pill that always reads as an inset of whatever foreground colour surrounds it. One rule, both themes.") {
 			<div class="flex flex-wrap items-center gap-3">
 				<button type="button" class="btn btn-primary btn-sm gap-2">
 					Submit
 					@components.KbdCombo("cmd", "enter")
+				</button>
+				<button type="button" class="btn btn-secondary btn-sm gap-2">
+					Approve
+					@components.KbdCombo("cmd", "a")
 				</button>
 				<button type="button" class="btn btn-neutral btn-sm gap-2">
 					Save draft
@@ -1403,6 +1407,10 @@ templ SectionKbd() {
 				<button type="button" class="btn btn-soft btn-sm gap-2">
 					Delete
 					@components.KbdCombo("cmd", "shift", "delete")
+				</button>
+				<button type="button" class="btn btn-soft btn-error btn-sm gap-2">
+					Discard
+					@components.Kbd("d")
 				</button>
 			</div>
 		}


### PR DESCRIPTION
## Summary

Quick visibility fix on the kbd surface-aware rules shipped in #1550. The user spotted that the kbd inside `.btn-soft` (and the previously-missing `.btn-secondary`) was invisible in dark mode — the soft surface sits in the base-200 luminance range, and the original override only matched the four solid-tone variants (primary / secondary / accent / neutral), so soft / ghost / outline fell back to the default `bg-base-200` ground, which matches the soft button's own surface luminance and reads as a faint smudge or vanishes entirely.

### Computed-style proof (dark mode)

| Button | Before this PR | After this PR |
|---|---|---|
| `.btn-soft` | `kbdBg: base-200 (0.205)` on `btnBg: ~0.21` → blends | `kbdBg: light @ 22%` → visible light pill on mid-tone |
| `.btn-soft.btn-error` | `kbdBg: base-200` on red-tinted bg → muddy | `kbdBg: red @ 22%` → red glyph + red pill cohesive |
| `.btn-ghost` | `kbdBg: base-200` on transparent → faint smudge against page base-100 | `kbdBg: light @ 22%` → defined pill against page bg |
| `.btn-secondary` | (wasn't in the example) | `kbdBg: light @ 22%` on dark `.btn-secondary` bg → visible |

## Fix

Widen the surface-aware override to match **any `.btn`** rather than enumerating variants, and bump the mix alpha from 18% → 22% so mid-tone surfaces get enough contrast.

```diff
-  .tooltip .bb-kbd,
-  [role="tooltip"] .bb-kbd,
-  .btn-primary .bb-kbd,
-  .btn-secondary .bb-kbd,
-  .btn-accent .bb-kbd,
-  .btn-neutral .bb-kbd {
-    background: color-mix(in oklab, currentColor 18%, transparent);
+  .btn .bb-kbd,
+  .tooltip .bb-kbd,
+  [role="tooltip"] .bb-kbd {
+    background: color-mix(in oklab, currentColor 22%, transparent);
     color: inherit;
   }
```

Same change for `.bb-kbd-combo` and the per-cell divider. One rule, every button variant, both themes.

Also adds `.btn-secondary` and `.btn-soft.btn-error` to the design-sandbox "Inside a button" example so the variant matrix is honest about what's covered.

## Evidence

All seven button variants with their kbd hints, captured live at `/design/c/kbd?embed=1` after the fix:

<img src="https://i.img402.dev/sizkl0keby.jpg" width="900" alt="kbd visible across all button variants">

## Test plan

- [x] `templ generate`, `make css`, `go build`, `go vet` all clean
- [x] Verified computed style on each variant via Chrome DevTools — kbd `background` is `oklab(currentColor / 0.22)` in every case
- [x] No regression on the default `.bb-kbd` (outside any .btn/tooltip) — it still uses the `bg-base-200` + `base-content/0.7` text-pill default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
