### PR TITLE
fix(ui): right-align external-link icons in avatar menu, add separator

### DIFF
--- a/internal/templates/components/sidebar_user_menu.templ
+++ b/internal/templates/components/sidebar_user_menu.templ
@@ -78,6 +78,7 @@ templ SidebarUserMenu(p SidebarUserMenuProps) {
 				<span class="flex-1">Settings</span>
 			</button>
 		</li>
+		<hr class="border-base-300 my-1 mx-2"/>
 		<li>
 			<a
 				href="https://docs.breadbox.sh"
@@ -87,7 +88,7 @@ templ SidebarUserMenu(p SidebarUserMenuProps) {
 			>
 				@LucideIcon("book-open", "w-3.5 h-3.5")
 				<span class="flex-1">Documentation</span>
-				@LucideIcon("square-arrow-out-up-right", "w-3 h-3 opacity-50")
+				@LucideIcon("square-arrow-out-up-right", "w-3 h-3 opacity-50 ml-auto")
 			</a>
 		</li>
 		<li>
@@ -99,7 +100,7 @@ templ SidebarUserMenu(p SidebarUserMenuProps) {
 			>
 				@LucideIcon("github", "w-3.5 h-3.5")
 				<span class="flex-1">GitHub</span>
-				@LucideIcon("square-arrow-out-up-right", "w-3 h-3 opacity-50")
+				@LucideIcon("square-arrow-out-up-right", "w-3 h-3 opacity-50 ml-auto")
 			</a>
 		</li>
 		if p.IsEditor {


### PR DESCRIPTION
## Summary
- Right-align the trailing `square-arrow-out-up-right` icon on Documentation and GitHub rows in the sidebar avatar menu (added `ml-auto`).
- Insert an `<hr>` divider between Settings and the resource links so the two groups read as distinct.

## Screenshot

<img src="https://i.img402.dev/ewp4r5jbhc.jpg" width="360" alt="avatar menu — after">

## Test plan
- [x] `templ generate` + `go vet ./internal/templates/components/...`
- [x] Validated in a headless Chrome against the local dev server — separator visible after Settings, external-link icons flush right on Documentation / GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
