### PR TITLE
feat(ui): cmdk trigger design example + kbd polish pass (sidebar, modal, chord)

### DIFF
--- a/input.css
+++ b/input.css
@@ -1420,6 +1420,55 @@
    * ──────────────────────────────────────────────────────────── */
   .modal-box {
     overscroll-behavior: contain;
+    /* Nova-style inset ring on modals — replaces the hard daisy shadow-2xl
+       with a foreground-tinted ring + soft drop. `!important` because
+       daisyUI's plugin layer emits a same-specificity `.modal-box`
+       box-shadow that wins on source order otherwise. NOTE: re-added in
+       this PR after #1548 inadvertently dropped it during rebase. */
+    box-shadow:
+      0 0 0 1px oklch(from var(--color-base-content) l c h / 0.10),
+      0 10px 30px -10px oklch(0 0 0 / 0.18) !important;
+  }
+
+  /* Dark-mode modal lift. daisy 5's `.modal-box` defaults to bg-base-100,
+     but in the dark theme base-100 IS the page background (oklch 0.145),
+     so the modal recesses instead of lifting and the black drop shadow
+     is invisible against the dark backdrop. shadcn solves this with a
+     separate `--popover` token one luminance step lighter than
+     `--background`; daisy 5 doesn't expose that distinction, so we lift
+     the modal surface to base-200 in dark only (light-mode keeps the
+     stock bg-base-100 / white). Also bump the ring + drop opacities so
+     the edge stays legible against the near-black page. Same dual-
+     selector pattern as the .bb-card dark boost above (manual data-theme
+     + auto via prefers-color-scheme when none is set). */
+  [data-theme="dark"] .modal-box {
+    /* `!important` on background-color too — daisy's plugin layer emits
+       `.modal-box { background: var(--color-base-100) }` at the same
+       specificity, which wins source-order. */
+    background-color: var(--color-base-200) !important;
+    box-shadow:
+      0 0 0 1px oklch(from var(--color-base-content) l c h / 0.14),
+      0 20px 40px -12px oklch(0 0 0 / 0.50) !important;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) .modal-box {
+      background-color: var(--color-base-200) !important;
+      box-shadow:
+        0 0 0 1px oklch(from var(--color-base-content) l c h / 0.14),
+        0 20px 40px -12px oklch(0 0 0 / 0.50) !important;
+    }
+  }
+
+  /* Floating menus / dropdown content — same inset-ring treatment so
+     overflow popups read consistently with cards and modals. No
+     !important here: callers that opt into a heavier elevation via
+     Tailwind `shadow-lg`/`shadow-xl` (the daisyui.md-mandated standard
+     dropdown shape, settings_modal tab picker) still win by specificity.
+     Re-added in this PR after #1548 inadvertently dropped it. */
+  .dropdown-content {
+    box-shadow:
+      0 0 0 1px oklch(from var(--color-base-content) l c h / 0.08),
+      0 6px 20px -6px oklch(0 0 0 / 0.12);
   }
 
   /* ── Suppress WebKit's native search-clear (×) on overlay pickers ──
@@ -1692,11 +1741,11 @@
   .bb-sidebar-search-hint {
     @apply ml-auto flex items-center gap-0.5 text-[0.6rem] text-base-content/25;
   }
-
-  .bb-sidebar-search-hint kbd {
-    @apply inline-flex items-center justify-center min-w-[1.1rem] h-4 px-0.5
-           text-[0.55rem] font-medium bg-base-200 border border-base-300 rounded;
-  }
+  /* The legacy `.bb-sidebar-search-hint kbd` rule was removed — the hint
+     now renders via the shared `KbdCombo` templ component, which emits
+     `<span class="bb-kbd-combo">` (not `<kbd>`). The kbd inversion happens
+     via the `.bb-sidebar-search .bb-kbd / .bb-kbd-combo` rules near the
+     shortcut-badges block above. */
 
   /* ── Sidebar user profile ── */
   .bb-sidebar-profile {
@@ -1949,10 +1998,6 @@
 
   .bb-shortcuts-keys {
     @apply flex items-center gap-1.5;
-  }
-
-  .bb-shortcuts-then {
-    @apply text-[0.6rem] text-base-content/25;
   }
 
   .bb-shortcuts-footer {
@@ -2391,23 +2436,37 @@
   }
 
   /* When a kbd lives inside ANY .btn or daisy tooltip, the default
-     base-200 ground can collide with the surface. `.btn-soft` (and
-     daisy 5's per-tone soft variants) sit in the base-200 luminance
-     range — a base-200 kbd on a base-200-tinted button is invisible.
-     ghost/outline buttons sit on the page base-100 with a base-200
-     kbd that reads as a faint smudge. Solid-tone surfaces clash too.
+     base-200 ground can collide with the surface. `.btn-soft` sits in
+     the base-200 luminance range — a base-200 kbd on a base-200-tinted
+     button is invisible. ghost/outline buttons sit on the page base-100
+     with a base-200 kbd that reads as a faint smudge. Solid-tone
+     surfaces clash too.
 
      Replace the default ground with `color-mix(currentColor 22%)`
      so the kbd always tints toward whatever foreground colour
-     surrounds it. `currentColor` adapts across every button variant
-     (primary / secondary / accent / neutral / ghost / outline / soft /
-     link / tone-specific) + tooltips + both themes from a single rule,
-     with no per-theme or per-variant override. */
+     surrounds it. `currentColor` adapts across every button variant +
+     tooltips + both themes from a single rule. */
   .btn .bb-kbd,
   .tooltip .bb-kbd,
   [role="tooltip"] .bb-kbd {
     background: color-mix(in oklab, currentColor 22%, transparent);
     color: inherit;
+  }
+
+  /* Sidebar command-palette trigger gets a special-case rule because the
+     parent `.bb-sidebar-search` deliberately sets a translucent text
+     colour (`text-base-content/35`) for the muted "Search..." label.
+     Using `currentColor` would inherit that translucency and produce a
+     ~5% alpha kbd ground (invisible). Use the opaque `--color-base-content`
+     directly so the kbd glyph stays at full saturation and the pill ring
+     gets a 14% tint against the bg-base-200/50 trigger surface. */
+  .bb-sidebar-search .bb-kbd,
+  .bb-sidebar-search .bb-kbd-combo {
+    background: color-mix(in oklab, var(--color-base-content) 14%, transparent);
+    color: var(--color-base-content);
+  }
+  .bb-sidebar-search .bb-kbd-combo .bb-kbd-combo__key + .bb-kbd-combo__key {
+    border-left-color: color-mix(in oklab, var(--color-base-content) 22%, transparent);
   }
 
   /* Blended modifier pill: ⌘│K rendered as one tight badge with a hairline
@@ -2429,8 +2488,10 @@
     border-left: 1px solid oklch(from var(--color-base-content) l c h / 0.10);
   }
 
-  /* Same currentColor-tint treatment as .bb-kbd above — widened to any
-     .btn so .btn-soft / ghost / outline get the inversion too. */
+  /* Same currentColor-tint treatment as .bb-kbd above for .bb-kbd-combo
+     — widened to any .btn / tooltip so soft / ghost / outline surfaces
+     all read as a tinted inset of the surrounding fg. Sidebar-search is
+     handled by the separate rule above (opaque base-content variant). */
   .btn .bb-kbd-combo,
   .tooltip .bb-kbd-combo,
   [role="tooltip"] .bb-kbd-combo {

--- a/internal/templates/components/kbd.templ
+++ b/internal/templates/components/kbd.templ
@@ -17,10 +17,12 @@ templ Kbd(key string) {
 	<kbd class="bb-kbd hidden sm:inline-flex" x-show="!$store.device.isTouch">{ kbdGlyph(key) }</kbd>
 }
 
-// KbdChord renders a sequence of keys separated by a faint "then" label,
-// using the canonical `.bb-kbd` + `.bb-shortcuts-then` styling. The whole
-// chord hides on touch via the same guards as `Kbd`. Calling with 0 or 1
-// keys degrades gracefully.
+// KbdChord renders a sequence of keys as adjacent .bb-kbd pills with a
+// small gap (e.g. `[G][D]` for the vim-style `g d` chord). Distinct from
+// `KbdCombo` (one fused pill `⌘│K`) by the gap between standalone keys —
+// adjacency reads as "press in sequence" without a verbose "then" label.
+// The whole chord hides on touch via the same guards as `Kbd`. Calling
+// with 0 or 1 keys degrades gracefully.
 templ KbdChord(keys ...string) {
 	if len(keys) > 0 {
 		// Order matters: `hidden` must come AFTER the layout class, and the
@@ -30,10 +32,7 @@ templ KbdChord(keys ...string) {
 		// `sm:inline-flex` handles the desktop layout; nothing competes with
 		// `hidden` at the base breakpoint.
 		<span class="hidden sm:inline-flex items-center gap-1" x-show="!$store.device.isTouch">
-			for i, k := range keys {
-				if i > 0 {
-					<span class="bb-shortcuts-then">then</span>
-				}
+			for _, k := range keys {
 				<kbd class="bb-kbd">{ kbdGlyph(k) }</kbd>
 			}
 		</span>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1382,9 +1382,16 @@ templ SectionKbd() {
 				</div>
 			</div>
 		}
-		@designExample("Command palette trigger (sidebar)", "Live shape: this is the `.bb-sidebar-search` div that lives at the top of the desktop sidebar — clicking it dispatches `open-cmdk`. Pattern is search-icon + label + trailing KbdCombo hint. The kbd uses the same currentColor-tint surface override as buttons, so it stays legible against the muted base-200/50 trigger surface in both themes.") {
-			<div class="max-w-xs">
-				<div class="bb-sidebar-search" role="button" tabindex="0">
+		@designExample("Command palette trigger (sidebar)", "Live shape: this is the `.bb-sidebar-search` div from the top of the desktop sidebar. Clicking it (or pressing Enter when focused) dispatches `open-cmdk` and actually opens the palette — wired up here so the demo behaves like the live trigger. The kbd uses an opaque `var(--color-base-content)` tint (not currentColor) so it stays legible against the muted bg-base-200/50 surface — currentColor would have inherited the parent's text-base-content/35 translucency and rendered ~5%-alpha.") {
+			<div class="max-w-[13rem]">
+				<div
+					class="bb-sidebar-search"
+					x-data
+					@click="$dispatch('open-cmdk')"
+					@keydown.enter="$dispatch('open-cmdk')"
+					role="button"
+					tabindex="0"
+				>
 					@components.LucideIcon("search", "")
 					<span>Search...</span>
 					<span class="bb-sidebar-search-hint">

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1366,7 +1366,7 @@ templ SectionKbd() {
 				</div>
 			</div>
 		}
-		@designExample("Chord (KbdChord)", "Sequential keys separated by a faint \"then\" label — for vim-style g-prefixed navigation.") {
+		@designExample("Chord (KbdChord)", "Sequential keys rendered as adjacent pills (e.g. [G][D]) — the small gap reads as \"press in sequence\". Distinct from KbdCombo, which fuses keys into one pill for held-simultaneously modifier combos.") {
 			<div class="flex flex-col gap-3 text-sm max-w-sm">
 				<div class="flex items-center justify-between gap-3 py-1">
 					<span class="text-base-content/70">Go to dashboard</span>
@@ -1379,6 +1379,17 @@ templ SectionKbd() {
 				<div class="flex items-center justify-between gap-3 py-1">
 					<span class="text-base-content/70">Go to rules</span>
 					@components.KbdChord("g", "r")
+				</div>
+			</div>
+		}
+		@designExample("Command palette trigger (sidebar)", "Live shape: this is the `.bb-sidebar-search` div that lives at the top of the desktop sidebar — clicking it dispatches `open-cmdk`. Pattern is search-icon + label + trailing KbdCombo hint. The kbd uses the same currentColor-tint surface override as buttons, so it stays legible against the muted base-200/50 trigger surface in both themes.") {
+			<div class="max-w-xs">
+				<div class="bb-sidebar-search" role="button" tabindex="0">
+					@components.LucideIcon("search", "")
+					<span>Search...</span>
+					<span class="bb-sidebar-search-hint">
+						@components.KbdCombo("cmd", "k")
+					</span>
 				</div>
 			</div>
 		}

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -936,13 +936,12 @@
                          item declares a shortcutId that matches a registered
                          spec. Hidden on touch ($store.device.isTouch) so
                          phones/tablets don't display a key hint that can
-                         never fire. Chord tokens carry a `then` flag so the
-                         separator interleaves correctly ('g' then 'd'). -->
+                         never fire. Chord tokens render as adjacent pills
+                         ('g' 'd') with a small gap — no inline "then" label. -->
                     <template x-if="shortcutTokensFor(item).length > 0">
                       <div class="bb-cmdk-item-shortcut" x-show="!$store.device.isTouch">
                         <template x-for="(tok, ti) in shortcutTokensFor(item)" :key="ti">
                           <span>
-                            <span x-show="tok.then" class="bb-shortcuts-then">then</span>
                             <!-- Blended combo pill: renders ⌘│K as one tight
                                  badge so modifier combos don't read as two
                                  disconnected keycaps (see .bb-kbd-combo). -->
@@ -2064,14 +2063,12 @@
       // blended pill (.bb-kbd-combo) instead of adjacent standalone kbds.
       function toTokens(keys) {
         if (!keys) return [];
-        // Chord: sequential keys joined by "then".
+        // Chord: sequential keys rendered as adjacent pills (gap-1 by CSS).
+        // No separator — the gap reads as "press in sequence".
         if (keys.chord && Array.isArray(keys.chord)) {
-          var out = [];
-          keys.chord.forEach(function(k, i) {
-            if (i > 0) out.push({ then: true });
-            out.push({ label: esc(bbKbdGlyph(k)) });
+          return keys.chord.map(function(k) {
+            return { label: esc(bbKbdGlyph(k)) };
           });
-          return out;
         }
         // Array form — treat as simultaneous chord rendered as a single
         // blended pill so the keys read as a unit rather than two
@@ -2097,7 +2094,6 @@
       function renderTokens(tokens) {
         if (!tokens || !tokens.length) return '';
         return tokens.map(function(t) {
-          if (t.then) return '<span class="bb-shortcuts-then">then</span>';
           if (t.combo) {
             return '<span class="bb-kbd-combo">' +
               t.combo.map(function(k) {


### PR DESCRIPTION
## Summary

Bundles four small Nova-polish moves spotted while reviewing the previous kbd PRs.

| # | Change | Why |
|---|---|---|
| 1 | Add `.bb-sidebar-search` to `/design` | The Cmd+K trigger that lives at the top of the desktop sidebar wasn't represented in the gallery. Now reviewers can spot-check the same shape that ships. |
| 2 | Fix invisible kbd inside `.bb-sidebar-search` | The trigger uses `bg-base-200/50` + a translucent fg (`text-base-content/35`). The default `.bb-kbd` ground blended in. `currentColor` would have inherited the parent's translucency (~5%-alpha kbd). New rule uses opaque `var(--color-base-content)` for both bg-tint and glyph (14% / opaque). |
| 3 | Drop `[G] then [D]` → `[G][D]` for KbdChord | The user requested the tighter format. Gap between adjacent pills already reads as "press in sequence" and distinguishes from fused combos (`⌘│K`). Removes the inline "then" span emits in `KbdChord`, the help-modal renderer, and the `bbKbdGlyph` JS tokenizer/renderer. Drops dead `.bb-shortcuts-then` + `.bb-sidebar-search-hint kbd` CSS rules. |
| 4 | Restore + extend modal/dropdown shadows | PR #1548 inadvertently dropped my `.modal-box` and `.dropdown-content` `box-shadow` rules during rebase. Re-add. Also adds a **dark-mode lift** for `.modal-box`: daisy's default `bg-base-100` IS the dark page bg (oklch 0.145), so modals recess. Override to `base-200` under both `[data-theme="dark"]` and `@media (prefers-color-scheme: dark) :root:not([data-theme])`, with boosted ring + drop. |

## Evidence

### Sidebar search trigger — kbd visibility

| Before (kbd blends into trigger) | After (opaque base-content tint) |
|---|---|
| <img src="https://i.img402.dev/xqc9f87y0h.jpg" width="380" alt="sidebar search before"> | <img src="https://i.img402.dev/ylsc4kioy3.jpg" width="380" alt="sidebar search after"> |

### `/design/c/kbd` — new "Command palette trigger" example + chord without "then"

<img src="https://i.img402.dev/gz3g5owuxy.jpg" width="900" alt="cmdk trigger design example">

### Settings modal in dark mode (restored shadow + lifted bg)

<img src="https://i.img402.dev/8qje3xcu3y.jpg" width="900" alt="settings modal with dark-mode lift">

## Computed-style verification (dark theme)

```
.bb-sidebar-search .bb-kbd-combo:
  bg  = oklab(0.985 0 0 / 0.14)          ← visible white tint
  fg  = oklch(0.985 0 0)                 ← opaque white glyph

.modal-box (dark):
  bg     = oklch(0.205 0 0)              ← base-200 lift (was 0.145 / page bg)
  shadow = 0 0 0 1px white@14%,           ← ring
           0 20px 40px -12px black@50%    ← drop
```

## Test plan

- [x] `templ generate`, `make css`, `go build`, `go vet` all clean
- [x] `/design/c/kbd?embed=1` renders all 8 examples including the new "Command palette trigger" (live sidebar shape)
- [x] Settings modal opened via `open-settings` event computes `background: oklch(0.205 0 0)` in dark mode (lifted)
- [x] No `.bb-shortcuts-then` nodes in the DOM after navigating across pages with shortcut hints
- [x] Per-caller `shadow-xl` on `.dropdown-content` (settings modal tab picker) survives — `dropdown-content` `box-shadow` rule has no `!important`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
