### PR TITLE
fix(ui): match comment-card tail to header bg in dark mode

### DIFF
--- a/input.css
+++ b/input.css
@@ -2885,7 +2885,8 @@
   .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
     background: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
   }
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after,
+  /* Composer card has no header — its tail points at the card body, so
+   * match the lifted card surface. */
   .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
     border-right-color: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
   }
@@ -2894,6 +2895,16 @@
    * it slightly so the header reads as a defined band rather than a hole. */
   .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
     background: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
+  }
+  /* Comment-card tail points at the header bar (top: 6px lands inside the
+   * 0.5rem padding + 1.55 line-height header), so match the header's
+   * lifted background — not the card body. In light mode both surfaces
+   * composite to nearly the same color so the body-matching value above
+   * looked right; in dark mode the header is visibly lighter than the
+   * card, and a body-coloured tail reads as a notch hanging below the
+   * header. */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
+    border-right-color: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
   }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #1531. The prominent comment card's left-pointing tail (`::after`) was filled with the lifted card-body color in both modes. Light mode worked because the header's `base-200 60%` over `base-100` composites to nearly the same color as the body fill, so the tail blended with the header it visually points at. In dark mode the header is overridden to a *lighter* mix than the card body (`base-100 86%/white 14%` vs `base-100 92%/white 8%`), so a body-coloured tail read as a dark notch hanging below the lighter header band.

The dark-mode override now splits the rule: the comment card's `::after` matches the header mix; the composer card's `::after` keeps matching the lifted body (composer has no header).

## Evidence — dark mode

<table>
  <tr><th>Before (tail = card body, mismatched)</th><th>After (tail = header bg, blends)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/gk781w2c7p.jpg" width="400" alt="dark mode before — tail darker than header"></td>
    <td><img src="https://i.img402.dev/qe0xmkibnm.jpg" width="400" alt="dark mode after — tail matches header"></td>
  </tr>
</table>

Real `/transactions/{id}` page in dark mode, with comment + composer rendered together (comment tail matches its lighter header; composer tail still matches its darker body):

<img src="https://i.img402.dev/7420ebeh8a.jpg" width="800" alt="transaction detail — dark mode after">

Light mode — no regression (tail still composites to the header's appearance):

<img src="https://i.img402.dev/saq4hv8tdu.jpg" width="800" alt="design sandbox — light mode after">

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `getComputedStyle` in dark mode: comment-card `::after` `border-right-color` now matches header `background-color` (`oklch(0.265)` vs the previous `0.213`)
- [x] Composer-card `::after` in dark mode still matches its body (`oklch(0.213)`) — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)