### PR TITLE
feat(ui): settings polish — sign out row, inline empty, soft banner, 2-col

### DIFF
--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -36,16 +36,7 @@ templ accessOAuthClientsSection(p AccessProps) {
 			Right:   accessCreateClientButton(),
 		}) {
 			if len(p.ActiveClients) == 0 && len(p.RevokedClients) == 0 {
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-					@components.EmptyState(components.EmptyStateProps{
-						Icon:     "fingerprint",
-						Title:    "No OAuth clients yet",
-						Body:     "Create an OAuth client to connect external AI services to your Breadbox MCP server.",
-						CTAHref:  templ.SafeURL("/settings/oauth-clients/new"),
-						CTAIcon:  "plus",
-						CTALabel: "Create your first client",
-					})
-				}
+				@accessEmptyRow("Create one to connect external AI services to your MCP server.")
 			} else {
 				for _, c := range p.ActiveClients {
 					@accessActiveClientRow(c, p.IsAdmin, p.CSRFToken)
@@ -69,6 +60,19 @@ templ accessOAuthClientsSection(p AccessProps) {
 				</div>
 			</div>
 		}
+	</div>
+}
+
+// accessEmptyRow renders a quiet caption inside a section body when
+// no rows exist yet. The header already carries the section name, an
+// icon, and the Create button — repeating any of that as a separate
+// "empty state card" inside would just stack a card on a card. So
+// we keep it to one short hint line.
+templ accessEmptyRow(hint string) {
+	<div class="bb-settings-row">
+		<div class="bb-settings-row__main">
+			<p class="text-sm text-base-content/50">{ hint }</p>
+		</div>
 	</div>
 }
 
@@ -168,16 +172,7 @@ templ accessAPIKeysSection(p AccessProps) {
 			Right:   accessCreateKeyButton(),
 		}) {
 			if len(p.ActiveKeys) == 0 && len(p.RevokedKeys) == 0 {
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-					@components.EmptyState(components.EmptyStateProps{
-						Icon:     "key",
-						Title:    "No API keys yet",
-						Body:     "Create an API key to connect MCP agents or integrate with external tools.",
-						CTAHref:  templ.SafeURL("/settings/api-keys/new"),
-						CTAIcon:  "plus",
-						CTALabel: "Create your first key",
-					})
-				}
+				@accessEmptyRow("Create one to connect MCP agents or integrate with external tools.")
 			} else {
 				for _, k := range p.ActiveKeys {
 					@accessActiveKeyRow(k, p.IsAdmin, p.CSRFToken)

--- a/internal/templates/components/pages/backups.templ
+++ b/internal/templates/components/pages/backups.templ
@@ -41,33 +41,31 @@ templ Backups(p BackupsProps) {
 					</div>
 				}
 				@backupsStats(p)
-				@backupsScheduleSection(p)
+				<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+					@backupsScheduleSection(p)
+					@backupsRestoreSection(p)
+				</div>
 				@backupsFilesSection(p)
-				@backupsRestoreSection(p)
 			}
 		</div>
 	</div>
 }
 
+// backupsEncryptionAlert is intentionally subtle when things are fine
+// (info-tone reminder that the key matters) and escalates only when
+// the key is actually missing.
 templ backupsEncryptionAlert(p BackupsProps) {
-	<div class="alert alert-warning rounded-xl">
-		@components.LucideIcon("shield-alert", "w-5 h-5 flex-shrink-0")
-		<div>
-			<h3 class="font-semibold text-sm">Back up your ENCRYPTION_KEY separately</h3>
-			<p class="text-xs mt-1 leading-relaxed">
-				Database backups contain encrypted bank credentials that are useless without the matching
-				<code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">ENCRYPTION_KEY</code>.
-				If you lose the key, all bank connections must be re-linked from scratch. Store it in a
-				password manager or secure vault — never commit it to version control.
-			</p>
-			if !p.HasEncryptionKey {
-				<p class="text-xs mt-2 text-error font-semibold">
-					@components.LucideIcon("alert-triangle", "w-3.5 h-3.5 inline mr-0.5")
-					No encryption key is currently set. Bank credentials cannot be stored or restored.
-				</p>
-			}
+	if !p.HasEncryptionKey {
+		<div role="alert" class="alert alert-error alert-soft rounded-xl text-sm">
+			@components.LucideIcon("alert-triangle", "w-4 h-4 shrink-0")
+			<span>No <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">ENCRYPTION_KEY</code> set. Bank credentials can't be stored or restored.</span>
 		</div>
-	</div>
+	} else {
+		<div role="status" class="alert alert-info alert-soft rounded-xl text-sm">
+			@components.LucideIcon("info", "w-4 h-4 shrink-0")
+			<span>Store <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">ENCRYPTION_KEY</code> separately — without it, backups can't be restored.</span>
+		</div>
+	}
 }
 
 templ backupsStats(p BackupsProps) {

--- a/internal/templates/components/pages/my_account.templ
+++ b/internal/templates/components/pages/my_account.templ
@@ -17,7 +17,6 @@ templ MyAccount(p MyAccountProps) {
 		@settingsTabHeader(settingsTabHeaderProps{
 			Title:    "Account",
 			Subtitle: myAccountSubtitle(p),
-			Right:    myAccountSignOutForm(p.CSRFToken),
 		})
 		if p.IsUnlinked {
 			<div role="alert" class="alert alert-warning mb-6 rounded-xl">
@@ -34,32 +33,51 @@ templ MyAccount(p MyAccountProps) {
 				@myAccountProfileSection(p)
 			}
 			@myAccountPasswordSection(p.CSRFToken)
+			@myAccountSessionSection(p)
 			@myAccountDangerSection(p.CSRFToken)
 		</div>
 	</div>
 }
 
 func myAccountSubtitle(p MyAccountProps) string {
-	if p.AdminUsername != "" {
-		base := "Signed in as " + p.AdminUsername
-		if p.RoleDisplay != "" {
-			base += " · " + p.RoleDisplay
-		}
-		return base
-	}
-	return "Profile, password, and account data"
+	return "Profile, password, and session"
 }
 
-templ myAccountSignOutForm(csrfToken string) {
-	<form method="POST" action="/logout" class="shrink-0">
-		if csrfToken != "" {
-			<input type="hidden" name="_csrf" value={ csrfToken }/>
+// myAccountSessionSection renders a header-less section holding the
+// single Sign out row. The row's own label + caption carry enough
+// context; a Section header would just stack two titles for one
+// action. Sits above the Danger zone — not destructive, so it
+// doesn't belong inside that group.
+templ myAccountSessionSection(p MyAccountProps) {
+	@components.SettingsSection(components.SettingsSectionProps{}) {
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Sign out",
+			Caption: myAccountSignOutCaption(p),
+		}) {
+			<form method="POST" action="/logout">
+				if p.CSRFToken != "" {
+					<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+				}
+				<button type="submit" class="btn btn-ghost btn-sm gap-1.5">
+					@components.LucideIcon("log-out", "w-4 h-4")
+					Sign out
+				</button>
+			</form>
 		}
-		<button type="submit" class="btn btn-ghost btn-sm gap-2 text-base-content/60 hover:text-base-content">
-			@components.LucideIcon("log-out", "w-4 h-4")
-			Sign out
-		</button>
-	</form>
+	}
+}
+
+// myAccountSignOutCaption surfaces who you're signed in as (and the
+// role) on the same row as the sign-out action — the info that used
+// to live in the tab header subtitle.
+func myAccountSignOutCaption(p MyAccountProps) string {
+	if p.AdminUsername == "" {
+		return "End this browser session"
+	}
+	if p.RoleDisplay == "" {
+		return "Signed in as " + p.AdminUsername
+	}
+	return "Signed in as " + p.AdminUsername + " · " + p.RoleDisplay
 }
 
 // myAccountProfileSection renders the linked household member's profile

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -22,7 +22,7 @@ templ SettingsGeneral(p SettingsProps) {
 			Title:    "General",
 			Subtitle: "Schedule, log retention, and avatars",
 		})
-		<div class="space-y-6">
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 			@settingsSyncSection(p)
 			@settingsAvatarsSection(p)
 		</div>
@@ -38,7 +38,7 @@ templ SettingsSystem(p SettingsProps) {
 			Title:    "System",
 			Subtitle: "Security and runtime information",
 		})
-		<div class="space-y-6">
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 			@settingsSecuritySection(p)
 			@settingsRuntimeSection(p)
 		</div>
@@ -54,7 +54,7 @@ templ SettingsHelp(p SettingsProps) {
 			Title:    "Help",
 			Subtitle: "Setup guide and resources",
 		})
-		<div class="space-y-6">
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 			@settingsResourcesSection(p)
 			@settingsDeveloperSection()
 		</div>


### PR DESCRIPTION
## Summary

Four follow-up polish items bundled together:

1. **Sign out** — moved out of the tab header into its own header-less section above Danger zone. The row's caption surfaces who you're signed in as (and the role), so the header doesn't need to repeat it.
2. **API Keys empty state** — dropped the embedded EmptyState card inside each section (was stacking a card on a card). Now a single quiet hint line.
3. **Backups encryption banner** — was a heavy four-line alert-warning. Now a one-line alert-info reminder that escalates to alert-error only when the key is actually missing.
4. **2-column layout on wide viewports** for the tabs whose sections are short enough to read side-by-side: General (Sync + Avatars), System (Security + Runtime), Help (Resources + Developer), Backups (Schedule + Restore, with Files table spanning full width below). Single-col below `lg`. Tabs whose sections are wide by nature (Account, Providers, MCP, Agents) stay single-column.

## Screenshots

General — Sync left, Avatars right:

<img src="https://i.img402.dev/vepk9ca8n1.jpg" width="900" alt="General — 2 columns">

API Keys — quiet inline empty hint, no card-in-card:

<img src="https://i.img402.dev/ghy4fnyw1x.jpg" width="900" alt="API Keys — flat empty state">

Backups — soft info banner, Schedule + Restore side-by-side, Files full-width:

<img src="https://i.img402.dev/vjgsrimxol.jpg" width="900" alt="Backups — soft banner + 2-col schedule/restore">

Account — sign out off the header (now in its own row further down):

<img src="https://i.img402.dev/2308qn7efb.jpg" width="900" alt="Account — clean header">

## Test plan

- [x] `go build ./... && go vet ./... && go test ./internal/templates/... ./internal/admin/...`
- [ ] Reviewer: General/System/Help/Backups at ≥1024px width — two columns; resize to mobile — single column
- [ ] Reviewer: API Keys with zero keys — clean hint, no card-in-card
- [ ] Reviewer: Backups banner reads quietly; remove `ENCRYPTION_KEY` env var → escalates to red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
