### PR TITLE
fix(ui): restore comment-card header inner-curve radius (regressed by #1548)

### DIFF
--- a/input.css
+++ b/input.css
@@ -2865,14 +2865,22 @@
   border-radius: 0.5rem;
   overflow: visible;
 }
-/* Header bar (was the "Name commented X ago" meta line) */
+/* Header bar (was the "Name commented X ago" meta line).
+ * The card carries a 1px border + 0.5rem outer radius, so the header
+ * sits one pixel inside the curve. Match the inner curve exactly
+ * (outer radius minus border width) — using the same 0.5rem here
+ * leaves the gray fill curving inside the border arc, exposing a
+ * thin wedge of the card background at the top corners (only visible
+ * in dark mode, where the card body and the header are different
+ * shades). Originally fixed in #1531; restored here after #1548's
+ * conflict resolution silently dropped the calc(). */
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
   background: color-mix(in srgb, var(--color-base-200) 60%, transparent);
   border-bottom: 1px solid var(--color-base-300);
   padding: 0.5rem 0.875rem;
   margin: 0;
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
+  border-top-left-radius: calc(0.5rem - 1px);
+  border-top-right-radius: calc(0.5rem - 1px);
 }
 /* Body (was the chat-bubble) */
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) .bb-comment-bubble {


### PR DESCRIPTION
## Summary
#1531 set the prominent comment card's header top corners to `calc(0.5rem - 1px)` so the gray fill follows the card's *inner* border curve. #1548's conflict resolution silently reverted both top-corner declarations back to `0.5rem`, reopening the original bug: a 1px wedge of the card body shows between the gray header fill and the rounded top border.

The wedge was invisible in light mode because the card body and header composite to nearly the same color, but in dark mode the card body is darker than the lifted header — so the gap reads as a thin dark strip at the very top of the card. Reported by the user immediately after #1556 merged.

Restoring the `calc()` and adding a sticky comment naming the prior reverts so a future conflict resolver doesn't drop it a third time.

## Evidence — dark mode (3× zoom)

<table>
  <tr><th>Before — 1px wedge of card body at top corners</th><th>After — gray meets the inner curve cleanly</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/njqmz6kgac.jpg" width="400" alt="dark mode before — gap at top"></td>
    <td><img src="https://i.img402.dev/j24c47f487.jpg" width="400" alt="dark mode after — no gap"></td>
  </tr>
</table>

## Test plan
- [x] `getComputedStyle` on header: `border-top-left-radius` resolves to `7px` (was `8px`)
- [x] `go build ./...` + `go vet ./...` clean
- [x] Verified visually in dark mode on `/design` → Activity timeline → prominent variant
- [x] Light mode unaffected (was already invisible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)