### PR TITLE
feat(onboarding): land users on /getting-started after setup, stop bouncing feed

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"breadbox/internal/app"
-	"breadbox/internal/appconfig"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
@@ -23,8 +22,10 @@ import (
 const feedWindowDays = 3
 
 // FeedHandler serves GET / — the activity-style household home page.
-// Until onboarding is dismissed, the root path redirects to /getting-started
-// (matching the old DashboardHandler behaviour).
+// The Getting Started guide stays linked from the sidebar (driven by
+// `onboarding_dismissed`) so first-run users can still reach it, but the
+// root path no longer bounces there. Post-setup landing happens once,
+// from the setup handler — see CreateAdminHandler in setup.go.
 //
 // The aggregation pipeline is:
 //
@@ -37,12 +38,6 @@ const feedWindowDays = 3
 func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-
-		// Redirect to getting-started page if onboarding is not dismissed.
-		if !appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false) {
-			http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
-			return
-		}
 
 		// Anchor every wall-clock decision (day buckets, "Today" hero
 		// counters, absolute-time tooltips) to the viewer's browser

--- a/internal/admin/setup.go
+++ b/internal/admin/setup.go
@@ -78,14 +78,23 @@ func CreateAdminHandler(a *app.App, sm *scs.SessionManager, _ *TemplateRenderer)
 		}
 
 		// Create household user + admin account in a single transaction.
-		if err := createLinkedAdmin(ctx, a, name, username, hashedPassword); err != nil {
+		account, err := createLinkedAdmin(ctx, a, name, username, hashedPassword)
+		if err != nil {
 			renderCreateAdmin(w, r, sm, name, username, "Failed to create admin account", nil)
 			return
 		}
 
-		// Set flash and redirect to login.
-		SetFlash(ctx, sm, "success", "Admin account created. Sign in to get started.")
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		// Auto-login the freshly created admin so we can land them
+		// directly on the Getting Started guide. Browsers still see the
+		// password field in the submitted form, so password-manager
+		// save prompts continue to work without a separate /login step.
+		if err := sm.RenewToken(ctx); err != nil {
+			a.Logger.Error("setup: renew session token", "error", err)
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+		SetLoginSessionKeys(ctx, sm, account, a.Queries)
+		http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
 	}
 }
 
@@ -116,11 +125,13 @@ func renderCreateAdmin(w http.ResponseWriter, r *http.Request, sm *scs.SessionMa
 	}
 }
 
-// createLinkedAdmin creates a household user and linked admin auth account in a single transaction.
-func createLinkedAdmin(ctx context.Context, a *app.App, name, username string, hashedPassword []byte) error {
+// createLinkedAdmin creates a household user and linked admin auth account in
+// a single transaction and returns the newly created auth account so the
+// caller can hydrate the session for auto-login.
+func createLinkedAdmin(ctx context.Context, a *app.App, name, username string, hashedPassword []byte) (db.AuthAccount, error) {
 	tx, err := a.DB.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return db.AuthAccount{}, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback(ctx)
 
@@ -131,20 +142,23 @@ func createLinkedAdmin(ctx context.Context, a *app.App, name, username string, h
 		Email: pgconv.Text(username),
 	})
 	if err != nil {
-		return fmt.Errorf("create user: %w", err)
+		return db.AuthAccount{}, fmt.Errorf("create user: %w", err)
 	}
 
-	_, err = qtx.CreateAuthAccount(ctx, db.CreateAuthAccountParams{
+	account, err := qtx.CreateAuthAccount(ctx, db.CreateAuthAccountParams{
 		UserID:         user.ID,
 		Username:       username,
 		HashedPassword: hashedPassword,
 		Role:           RoleAdmin,
 	})
 	if err != nil {
-		return fmt.Errorf("create auth account: %w", err)
+		return db.AuthAccount{}, fmt.Errorf("create auth account: %w", err)
 	}
 
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return db.AuthAccount{}, fmt.Errorf("commit: %w", err)
+	}
+	return account, nil
 }
 
 // programmaticSetupRequest is the JSON body for POST /admin/api/setup.
@@ -257,7 +271,7 @@ func ProgrammaticSetupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFu
 			return
 		}
 
-		if err := createLinkedAdmin(ctx, a, req.Name, req.Username, hashedPassword); err != nil {
+		if _, err := createLinkedAdmin(ctx, a, req.Name, req.Username, hashedPassword); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{
 				"error": "Failed to create admin account",
 			})


### PR DESCRIPTION
## Summary
- Setup auto-logs-in the new admin and redirects straight to `/getting-started`. Browsers still see the submitted password field, so password-manager save prompts continue to work without a separate `/login` step.
- `/` (Feed) no longer bounces to `/getting-started` while onboarding is undismissed — the feed always renders. The Getting Started entry in the sidebar stays visible (still driven by `onboarding_dismissed`) so users can return to the guide anytime until they explicitly hide it.

## Test plan
- [ ] Fresh install: complete setup → land on `/getting-started`, logged in.
- [ ] Visit `/` before dismissing onboarding → see the Feed (not redirected). Sidebar still shows "Getting Started".
- [ ] Dismiss onboarding → sidebar entry disappears; `/` still renders the Feed.
- [ ] Re-open via Settings → sidebar entry returns; `/` still renders the Feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)