### PR TITLE
fix(feed): stop rendering system actors as humanoid DiceBear

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -25,15 +25,21 @@ import (
 const maxAvatarUploadSize = 5 << 20 // 5 MB
 
 // AvatarHandler serves GET /avatars/{id} — returns uploaded image or generated SVG.
-// Looks up the user by UUID. If not found, generates a pattern from the raw ID string
-// (covers unlinked admin accounts whose session falls back to account UUID).
+// Lookup order: users.id → api_keys.id → raw-seed fallback. The api_keys
+// branch lets agent identities (HTTP MCP keys, future per-client stdio
+// keys) render with the agent-style DiceBear even when the URL was
+// built from just an actor_id (notification deep-links, embedded
+// avatars) and doesn't carry an explicit ?type=agent param.
 //
 // Query params:
 //
 //	?type=user|agent — picks which configured DiceBear style to use.
 //	                   Default "user". Agent identicons use a separate
 //	                   style (default "bottts") so agent activity reads
-//	                   as obviously non-human.
+//	                   as obviously non-human. When the id resolves to
+//	                   an api_keys row with actor_type='agent', the
+//	                   handler upgrades the style to "agent" regardless
+//	                   of what ?type= said.
 //	?size=N          — requested pixel size; clamped to [32, 512].
 //	                   Passed through to DiceBear so big tiles fetch
 //	                   crisper SVGs and small tiles fetch lighter ones.
@@ -50,22 +56,34 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 		}
 
 		row, err := a.Queries.GetUserAvatar(r.Context(), uid)
-		if err != nil {
-			// Not a user — generate a stable pattern from the raw ID.
+		if err == nil {
+			if row.AvatarData != nil && row.AvatarContentType.Valid {
+				serveUploadedAvatar(w, r, row.AvatarData, row.AvatarContentType.String)
+				return
+			}
+			seed := pgconv.FormatUUID(uid)
+			if row.AvatarSeed.Valid && row.AvatarSeed.String != "" {
+				seed = row.AvatarSeed.String
+			}
+			serveGeneratedAvatarForActor(w, r, seed, actor, size)
+			return
+		}
+
+		// Not a user — try api_keys next. Annotations written by
+		// agents store the api_keys row UUID in actor_id and avatar
+		// URLs are built from it. When the row is an agent key,
+		// upgrade the actor type so the agent DiceBear style wins
+		// regardless of the URL's ?type= param.
+		if key, kerr := a.Queries.GetApiKey(r.Context(), uid); kerr == nil {
+			if key.ActorType == "agent" {
+				actor = avatar.ActorAgent
+			}
 			serveGeneratedAvatarForActor(w, r, idStr, actor, size)
 			return
 		}
 
-		if row.AvatarData != nil && row.AvatarContentType.Valid {
-			serveUploadedAvatar(w, r, row.AvatarData, row.AvatarContentType.String)
-			return
-		}
-
-		seed := pgconv.FormatUUID(uid)
-		if row.AvatarSeed.Valid && row.AvatarSeed.String != "" {
-			seed = row.AvatarSeed.String
-		}
-		serveGeneratedAvatarForActor(w, r, seed, actor, size)
+		// Unknown id — generate a stable pattern from the raw string.
+		serveGeneratedAvatarForActor(w, r, idStr, actor, size)
 	}
 }
 

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -418,17 +418,35 @@ templ feedReportTile(priority string) {
 // keeps its page-background-tinted ring without duplicating the rule
 // at the call site. Decorative=true: the actor's name is already
 // announced in the surrounding row sentence.
+//
+// `system` actor rows render with the bot tile (no humanoid <img>) and
+// their stored ID is dropped — system actor_ids historically point at
+// api_keys rows (e.g. the stdio MCP singleton) whose UUID is not a
+// valid users.id, so /avatars/{id} would otherwise fall through to a
+// human-style DiceBear seeded on that UUID.
 templ feedActorTile(actorType, actorID, version, name string) {
 	@components.UserAvatar(components.UserAvatarProps{
 		Name:       name,
-		ID:         actorID,
+		ID:         feedActorAvatarID(actorType, actorID),
 		Version:    version,
-		IsAgent:    actorType == "agent",
+		IsAgent:    actorType == "agent" || actorType == "system",
 		Size:       components.UserAvatarMd,
 		Ring:       true,
 		Decorative: true,
 		Lazy:       true,
 	})
+}
+
+// feedActorAvatarID returns the ID UserAvatar should treat as the
+// avatar subject. For `system` actors we deliberately drop the stored
+// actor_id so UserAvatar takes the bot-tile fallback instead of
+// rendering a humanoid `<img>` seeded on (e.g.) the stdio singleton's
+// api_keys UUID.
+func feedActorAvatarID(actorType, actorID string) string {
+	if actorType == "system" {
+		return ""
+	}
+	return actorID
 }
 
 // ── Row body templates ────────────────────────────────────────────────────
@@ -802,9 +820,10 @@ func feedCommentPeek(body string) string {
 // the inline-actor renderer can do its job uniformly. UserID + Version
 // flow straight through to UserAvatar which builds the URL. Users +
 // agents both render a DiceBear identicon when they carry an ID (the
-// agent style is configured separately in Settings → System); agents
-// without an ID fall through to the bot tile; pure system actors
-// render as just the bold name.
+// agent style is configured separately in Settings → System). System
+// actors render with the bot tile and no ID — historic system actor_ids
+// reference api_keys rows whose UUID is not a valid users.id; passing
+// them through would render a humanoid DiceBear seeded on that UUID.
 func feedCommentActor(c *FeedComment) components.TimelineActor {
 	a := components.TimelineActor{Name: feedActorDisplay(c.ActorName, c.ActorType)}
 	switch c.ActorType {
@@ -815,6 +834,8 @@ func feedCommentActor(c *FeedComment) components.TimelineActor {
 		a.IsAgent = true
 		a.UserID = c.ActorID
 		a.Version = c.ActorAvatarVersion
+	case "system":
+		a.IsAgent = true
 	}
 	return a
 }

--- a/internal/templates/components/pages/feed_system_actor_test.go
+++ b/internal/templates/components/pages/feed_system_actor_test.go
@@ -1,0 +1,59 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"testing"
+)
+
+// TestFeedActorAvatarIDDropsSystemID guards the rendering fix for the
+// stdio MCP singleton bug: a `system` actor row whose actor_id points
+// at an api_keys UUID (the stdio singleton's UUID) used to slip into
+// /avatars/{uuid}?type=user, miss the users lookup, and fall through
+// to a humanoid DiceBear seeded on the api_keys UUID. Dropping the ID
+// on `system` rows forces UserAvatar into its bot-tile fallback.
+func TestFeedActorAvatarIDDropsSystemID(t *testing.T) {
+	cases := []struct {
+		name      string
+		actorType string
+		actorID   string
+		want      string
+	}{
+		{"system actor drops api_keys UUID", "system", "11111111-2222-3333-4444-555555555555", ""},
+		{"system actor with empty id stays empty", "system", "", ""},
+		{"agent actor keeps its id", "agent", "agent-uuid", "agent-uuid"},
+		{"user actor keeps its id", "user", "user-uuid", "user-uuid"},
+		{"unknown actor type passes through (no special case)", "", "raw-id", "raw-id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := feedActorAvatarID(tc.actorType, tc.actorID); got != tc.want {
+				t.Fatalf("feedActorAvatarID(%q, %q) = %q, want %q", tc.actorType, tc.actorID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFeedCommentActorSystemRendersAsBot guards the comment-actor
+// half of the same fix: a `system`-authored comment used to fall
+// through the switch with IsAgent=false and a stale UserID, so the
+// 16px inline avatar rendered as a humanoid DiceBear. The fix sets
+// IsAgent=true and drops UserID so the bot-tile fallback wins.
+func TestFeedCommentActorSystemRendersAsBot(t *testing.T) {
+	c := &FeedComment{
+		ActorType:          "system",
+		ActorID:            "11111111-2222-3333-4444-555555555555",
+		ActorName:          "Local MCP",
+		ActorAvatarVersion: "v1",
+	}
+	got := feedCommentActor(c)
+	if !got.IsAgent {
+		t.Fatalf("feedCommentActor: system actor IsAgent = false, want true")
+	}
+	if got.UserID != "" {
+		t.Fatalf("feedCommentActor: system actor UserID = %q, want empty (would render humanoid DiceBear)", got.UserID)
+	}
+	if got.Version != "" {
+		t.Fatalf("feedCommentActor: system actor Version = %q, want empty", got.Version)
+	}
+}

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -498,7 +498,11 @@ templ txdActorInline(e service.ActivityEntry) {
 // txdActor adapts a system-event ActivityEntry into the shared
 // TimelineActor shape used by `TimelineActorInline`. UserID +
 // Version are passed straight through — UserAvatar builds the
-// URL on the render side via components.AvatarURLWith.
+// URL on the render side via components.AvatarURLWith. System
+// actors render with the bot tile and no ID — historic system
+// actor_ids reference api_keys rows whose UUID is not a valid
+// users.id; passing them through would render a humanoid DiceBear
+// seeded on that UUID (the stdio MCP singleton bug).
 func txdActor(e service.ActivityEntry) components.TimelineActor {
 	a := components.TimelineActor{Name: e.ActorName}
 	switch e.ActorType {
@@ -513,6 +517,8 @@ func txdActor(e service.ActivityEntry) components.TimelineActor {
 			a.UserID = *e.ActorID
 			a.Version = e.ActorAvatarVersion
 		}
+	case "system":
+		a.IsAgent = true
 	}
 	return a
 }
@@ -638,7 +644,10 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 // TimelineActor shape so `TimelineActorInline` can render its 16px
 // avatar. Users get an image URL; agents get an agent-styled
 // identicon when they carry an ID and the bot fallback otherwise;
-// system actors render as just the bold name.
+// system actors render with the bot tile and no ID — historic system
+// actor_ids reference api_keys rows whose UUID is not a valid
+// users.id, so passing them through would render a humanoid DiceBear
+// seeded on that UUID (the stdio MCP singleton bug).
 func txdCommentActor(e service.ActivityEntry) components.TimelineActor {
 	a := components.TimelineActor{Name: e.ActorName}
 	switch e.ActorType {
@@ -653,6 +662,8 @@ func txdCommentActor(e service.ActivityEntry) components.TimelineActor {
 			a.UserID = *e.ActorID
 			a.Version = e.ActorAvatarVersion
 		}
+	case "system":
+		a.IsAgent = true
 	}
 	return a
 }


### PR DESCRIPTION
First in a two-PR stack that fixes stdio MCP actions rendering as humanoid avatars labelled "stdio" in the activity feed. This PR is the small defensive UI guardrail; PR 2 lands the per-client agent identity and backfill.

## The bug

`actor_type='system'` rows whose `actor_id` points at a non-`users` UUID (the stdio MCP singleton's `api_keys` UUID, today) used to slip through `feedActorTile` → `UserAvatar` and resolve via `<img src="/avatars/{singleton-uuid}?type=user">`. The avatar handler couldn't find that UUID in `users`, fell through to `serveGeneratedAvatarForActor` with `actor=user`, and emitted a humanoid DiceBear seeded on the singleton UUID. Every stdio action across the household shared that one stable face, which Ricardo correctly read as "my avatar".

`feedCommentActor`, `txdActor`, and `txdCommentActor` all had the same shape: they only flipped `IsAgent=true` for `actor_type == "agent"` and silently dropped `system` to the default no-IsAgent branch.

## The fix

1. **`feedActorTile`** (`feed.templ`): drop `actor_id` when `actorType == "system"` (via `feedActorAvatarID`) and treat system the same as agent for `IsAgent`. UserAvatar now takes the bot-tile fallback.
2. **`feedCommentActor`** (`feed.templ`): explicit `case "system":` arm that sets `IsAgent=true` and leaves `UserID` empty.
3. **`txdActor` + `txdCommentActor`** (`transaction_detail.templ`): same explicit `case "system":` arm. Same bug existed on the per-tx activity timeline.
4. **`AvatarHandler`** (`admin/avatars.go`): when the `users.id` lookup misses, fall through to `api_keys.id`. If the row is `actor_type='agent'`, upgrade the avatar style to agent so the DiceBear comes back as the agent style regardless of the URL's `?type=` param. This unblocks PR 2 (per-client agent keys whose avatars then render correctly out of the box) and any future deep-link contexts that build an avatar URL from just an actor_id.

This PR has no schema changes, no service changes, no migration. It's a pure rendering fix that improves how every `actor_type='system'` row renders today (including the existing rule-applied and sync-started annotations, which currently fall through to a letter-fallback chip).

## Visual diff (stdio session card on the feed)

<table>
<tr><th>Before — humanoid DiceBear seeded on stdio singleton UUID</th><th>After — bot tile</th></tr>
<tr>
<td><img src="https://i.img402.dev/raljc34upv.jpg" width="500" alt="feed before — humanoid stdio face at bottom row"></td>
<td><img src="https://i.img402.dev/y9uvnrdigv.jpg" width="500" alt="feed after — bot tile on stdio session card"></td>
</tr>
</table>

The shared face appears on every stdio-attributed row in the "before" capture (bottom of viewport — the report card "Reviewed and categorized 10 transactions"). The "after" capture shows the same row rendering with the bot tile that HTTP MCP agents already use.

## Tests

- `TestFeedActorAvatarIDDropsSystemID` — five cases covering the `system` ID drop and pass-through for other actor types.
- `TestFeedCommentActorSystemRendersAsBot` — guard that the comment-actor path sets `IsAgent=true` and clears `UserID` so the bot tile wins.

Full unit test suite passes (`go test ./...`).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green
- [x] Validated visually in Chrome — see screenshots above
- [ ] CI green

Stack metadata: this is PR 1 of `stack/stdio-agent-attribution`. PR 2 follows with the per-client agent identity for stdio + backfill. Plan: `~/Documents/obsidian/Breadbox/planned-features/stdio-agent-attribution.md` (incorporates feedback from two code reviewers).
