### PR TITLE
feat(mcp): per-client agent identity for stdio MCP

### DIFF
--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -51,13 +51,21 @@ func AddMCPCmd(root *cobra.Command) {
 	root.AddCommand(legacy)
 }
 
-// runMCPStdio launches the stdio MCP server. The body is the same as
-// cmd/breadbox/main.go::runMCPStdio with one change: instead of fabricating
-// an in-memory `agent` context, it ensures a singleton system-actor row
-// exists in api_keys and attaches that to the context. The new check
-// constraint on api_keys.actor_type rejects a synthetic id of "stdio"
-// because no row matches it; the singleton key gives every stdio audit
-// row a real `system` actor to point at.
+// runMCPStdio launches the stdio MCP server. Process-start attaches
+// the "Local MCP" fallback agent identity to the root ctx so any code
+// path that runs before the MCP `initialize` handshake completes (or
+// comes from a client that omits clientInfo entirely) has a valid
+// actor. The dispatcher (`MCPServer.makeToolDefLogged`) upgrades the
+// ctx to a per-client agent identity on each tool call once clientInfo
+// is available, so tool-call-level attribution stays sharp without
+// touching this bootstrap.
+//
+// The fallback row is the relabelled stdio singleton (see migration
+// 20260526092106_api_keys_client_fingerprint.sql) — same UUID, same
+// key_prefix as the pre-PR singleton, now with actor_type='agent',
+// actor_name='Local MCP', and client_fingerprint='unknown@@stdio'.
+// Pre-PR annotations that reference that UUID re-render correctly
+// through the agent branch without any data backfill.
 func runMCPStdio(parent context.Context, version string) error {
 	cfg, err := config.Load()
 	if err != nil {
@@ -75,15 +83,14 @@ func runMCPStdio(parent context.Context, version string) error {
 	}
 	defer a.DB.Close()
 
-	// Ensure a system-actor API key row exists so ContextWithAPIKey can
-	// point at a real `actor_type='system'` record. The plaintext is never
-	// exposed externally — this row is purely a DB-side anchor for the
-	// audit trail.
-	systemKey, err := ensureStdioSystemKey(ctx, a.Queries)
+	// Attach the Local MCP fallback identity. The dispatcher swaps in
+	// per-client keys once clientInfo arrives; this is just the safe
+	// floor for anything that runs before then.
+	fallbackKey, err := ensureLocalMCPFallbackKey(ctx, a.Queries)
 	if err != nil {
-		return fmt.Errorf("ensure stdio system key: %w", err)
+		return fmt.Errorf("ensure local mcp fallback key: %w", err)
 	}
-	ctx = service.ContextWithAPIKey(ctx, systemKey)
+	ctx = service.ContextWithAPIKey(ctx, fallbackKey)
 
 	mcpServer := breadboxmcp.NewMCPServer(a.Service, version)
 
@@ -114,16 +121,24 @@ func runMCPStdio(parent context.Context, version string) error {
 	return server.Run(ctx, &mcpsdk.StdioTransport{})
 }
 
-// stdioSystemKeyPrefix is the unique prefix of the singleton stdio key
-// row. It's looked up by prefix on each startup; missing rows are
-// inserted with actor_type='system', actor_name='stdio'.
+// stdioSystemKeyPrefix is the prefix of the legacy stdio singleton row,
+// kept as a stable lookup handle. The migration relabels its actor
+// fields in place; new installs (no migration history to relabel)
+// create the row fresh below in the agent-typed shape.
 const stdioSystemKeyPrefix = "bb_stdio_singleton"
 
-// ensureStdioSystemKey looks up (or creates) the stdio singleton api_keys
-// row that ContextWithAPIKey attaches to all stdio MCP calls. The
-// returned db.ApiKey lets the actor be attributed as system/stdio in the
-// audit log.
-func ensureStdioSystemKey(ctx context.Context, q *db.Queries) (*db.ApiKey, error) {
+// ensureLocalMCPFallbackKey returns the "Local MCP" fallback agent
+// identity row that gets attached to the root ctx at process start.
+// Used by anything that runs before the MCP `initialize` handshake
+// completes — the dispatcher upgrades to a per-client agent identity
+// per tool call once clientInfo is available.
+//
+// On an existing install the migration has already relabelled the
+// stdio singleton to actor_type='agent' / actor_name='Local MCP' /
+// client_fingerprint='unknown@@stdio'; this helper just looks it up.
+// On a fresh install with no prior stdio history the row doesn't
+// exist yet, so we create it in the agent-typed shape directly.
+func ensureLocalMCPFallbackKey(ctx context.Context, q *db.Queries) (*db.ApiKey, error) {
 	key, err := q.GetApiKeyByPrefix(ctx, stdioSystemKeyPrefix)
 	if err == nil {
 		return &key, nil
@@ -131,17 +146,12 @@ func ensureStdioSystemKey(ctx context.Context, q *db.Queries) (*db.ApiKey, error
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return nil, err
 	}
-	// The hash is a fixed sentinel — the row is never used as a valid
-	// credential at the HTTP layer (no client can present a "key" whose
-	// SHA-256 equals this literal string). Its only job is to be a
-	// stable api_keys row for ContextWithAPIKey to attach to.
-	row, err := q.CreateApiKey(ctx, db.CreateApiKeyParams{
-		Name:      "MCP Stdio",
-		KeyHash:   "stdio-singleton-not-a-real-credential",
-		KeyPrefix: stdioSystemKeyPrefix,
-		Scope:     "full_access",
-		ActorType: "system",
-		ActorName: pgText("stdio"),
+	row, err := q.CreateMCPClientApiKey(ctx, db.CreateMCPClientApiKeyParams{
+		Name:              "mcp-client:" + service.MCPClientFallbackFingerprint,
+		KeyHash:           "mcp-client-not-a-real-credential:" + service.MCPClientFallbackFingerprint,
+		KeyPrefix:         stdioSystemKeyPrefix,
+		ActorName:         pgText(service.MCPClientFallbackActorName),
+		ClientFingerprint: pgText(service.MCPClientFallbackFingerprint),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/db/migrations/20260526092106_api_keys_client_fingerprint.sql
+++ b/internal/db/migrations/20260526092106_api_keys_client_fingerprint.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+-- Adds a client fingerprint column to api_keys so the MCP server can
+-- auto-create stable per-client agent identities (one row per distinct
+-- MCP client name+host+transport) from the clientInfo block sent on
+-- the `initialize` handshake.
+--
+-- HTTP MCP api_keys (user-created credentials) leave this NULL — the
+-- partial unique index doesn't include them. Auto-managed MCP-client
+-- rows set it to `lower(coalesce(title, name)) + "@" + lower(host) + "@" + transport`
+-- (host falls back to "" when no websiteURL is present). The index
+-- guarantees we never create two rows for the same fingerprint, even
+-- under a concurrent first-call race.
+--
+-- The fallback "Local MCP" row (relabelled from the old stdio
+-- singleton) carries `unknown@@stdio` so the same EnsureMCPClientAgentKey
+-- lookup-then-insert path returns it for `initialize` requests that
+-- omit clientInfo entirely.
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS client_fingerprint TEXT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_client_fingerprint_idx
+    ON api_keys (client_fingerprint)
+    WHERE client_fingerprint IS NOT NULL;
+
+-- Relabel the existing stdio singleton in-place. It was created with
+-- actor_type='system' and actor_name='stdio'; with the per-client
+-- lookup landing it becomes the no-clientInfo fallback identity, so
+-- it's now an agent named "Local MCP" with the reserved fingerprint
+-- `unknown@@stdio`. Old annotations.actor_id rows pointing at this
+-- UUID render correctly without any data backfill — they re-resolve
+-- through the same row, which is now an agent.
+UPDATE api_keys
+SET    actor_type = 'agent',
+       actor_name = 'Local MCP',
+       client_fingerprint = 'unknown@@stdio',
+       name = 'mcp-client:unknown@@stdio'
+WHERE  key_prefix = 'bb_stdio_singleton'
+  AND  actor_type = 'system';
+
+-- +goose Down
+-- Roll back the relabel first so we don't leave an orphan
+-- client_fingerprint when the column is dropped.
+UPDATE api_keys
+SET    actor_type = 'system',
+       actor_name = 'stdio',
+       client_fingerprint = NULL,
+       name = 'MCP Stdio'
+WHERE  key_prefix = 'bb_stdio_singleton'
+  AND  client_fingerprint = 'unknown@@stdio';
+
+DROP INDEX IF EXISTS api_keys_client_fingerprint_idx;
+
+ALTER TABLE api_keys
+    DROP COLUMN IF EXISTS client_fingerprint;

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -10,7 +10,27 @@ SELECT * FROM api_keys WHERE key_hash = $1;
 SELECT * FROM api_keys WHERE key_prefix = $1 LIMIT 1;
 
 -- name: ListApiKeys :many
-SELECT * FROM api_keys ORDER BY created_at DESC;
+-- Filters out auto-managed MCP-client identities (client_fingerprint
+-- IS NOT NULL). Those rows exist to anchor agent attribution + the
+-- per-client avatar to a stable api_keys.id; they're not user-revocable
+-- credentials and showing them in /settings/api-keys would confuse
+-- users who don't recognise the "mcp-client:claude-desktop@@stdio"
+-- prefix or have no way to act on the row.
+SELECT * FROM api_keys WHERE client_fingerprint IS NULL ORDER BY created_at DESC;
+
+-- name: GetApiKeyByClientFingerprint :one
+-- Drives EnsureMCPClientAgentKey's lookup half. Returns the per-client
+-- agent identity row, or pgx.ErrNoRows for the insert path.
+SELECT * FROM api_keys WHERE client_fingerprint = $1 LIMIT 1;
+
+-- name: CreateMCPClientApiKey :one
+-- Auto-creates the per-client agent identity row on first contact
+-- from a new MCP client. key_hash is a per-fingerprint sentinel that
+-- never matches a presented SHA-256, so the row is identity-only —
+-- it can never authenticate a real request.
+INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type, actor_name, client_fingerprint)
+VALUES ($1, $2, $3, 'full_access', 'agent', $4, $5)
+RETURNING *;
 
 -- name: RevokeApiKey :exec
 UPDATE api_keys SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -194,6 +194,49 @@ func (s *MCPServer) resolveTransportID(req *mcpsdk.CallToolRequest) string {
 	return s.stdioFallbackTransportID
 }
 
+// rebindActorFromClientInfo upgrades the ctx's actor identity to the
+// per-client agent key resolved from the MCP `initialize` handshake's
+// clientInfo block. Returns the original ctx unchanged when there's
+// no session, no initialize-params, or the service helper fails — the
+// pre-PR behaviour (Local MCP fallback singleton attached at process
+// start, or the HTTP request's own API key) is preserved.
+//
+// MUST be called BEFORE ensureAuditSession in the dispatcher.
+// ensureAuditSession reads ActorFromContext(ctx) to stamp the
+// mcp_sessions row's api_key_id + api_key_name on first call, and
+// those columns never re-stamp. Rebinding after the session row is
+// created would permanently record the wrong key for every session.
+func (s *MCPServer) rebindActorFromClientInfo(ctx context.Context, req *mcpsdk.CallToolRequest, transportID string) context.Context {
+	if req == nil || req.Session == nil {
+		return ctx
+	}
+	ip := req.Session.InitializeParams()
+	if ip == nil || ip.ClientInfo == nil {
+		return ctx
+	}
+	transport := "stdio"
+	if id := req.Session.ID(); id != "" && id != transportID {
+		// HTTP sessions advertise their MCP-Session-Id; stdio falls
+		// back to the per-process transport id we stamped ourselves.
+		transport = "http"
+	}
+	clientInfo := service.MCPClientInfo{
+		Name:       ip.ClientInfo.Name,
+		Version:    ip.ClientInfo.Version,
+		Title:      ip.ClientInfo.Title,
+		WebsiteURL: ip.ClientInfo.WebsiteURL,
+	}
+	key, err := s.svc.EnsureMCPClientAgentKey(ctx, clientInfo, transport)
+	if err != nil || key == nil {
+		// Service-layer fallback already returned the Local MCP
+		// singleton when possible; outright failure means the
+		// migration hasn't applied. Keep the existing ctx so the
+		// caller's pre-PR behaviour stays intact.
+		return ctx
+	}
+	return service.ContextWithAPIKey(ctx, key)
+}
+
 // ensureAuditSession resolves (lazy-creating on first call) the
 // mcp_sessions row bound to a transport id and returns its UUID as a
 // string for LogToolCall. Captures clientInfo from the initialize
@@ -448,6 +491,18 @@ func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcps
 				// audit trail captures clientInfo without requiring
 				// agents to explicitly call create_session.
 				transportID := s.resolveTransportID(req)
+
+				// Upgrade the actor from whatever auth/middleware put
+				// on the ctx (typically the stdio "Local MCP" singleton
+				// or an HTTP API key) to the per-client agent identity
+				// keyed off clientInfo + transport. MUST happen before
+				// ensureAuditSession runs — that helper reads
+				// ActorFromContext(ctx) to stamp mcp_sessions.api_key_id
+				// and mcp_sessions.api_key_name on first call, and those
+				// columns are write-once. Doing this swap after would
+				// permanently record the wrong key for every session.
+				ctx = s.rebindActorFromClientInfo(ctx, req, transportID)
+
 				auditSessionID := s.ensureAuditSession(ctx, req, transportID)
 
 				// Optional per-call reason via _meta.reason — replaces the

--- a/internal/service/mcp_client_keys.go
+++ b/internal/service/mcp_client_keys.go
@@ -1,0 +1,171 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// MCPClientFallbackFingerprint is the reserved fingerprint for the
+// single "Local MCP" identity used when an MCP session doesn't send a
+// clientInfo block on initialize. The relabelled stdio singleton row
+// carries this value (see migration
+// 20260526092106_api_keys_client_fingerprint.sql).
+const MCPClientFallbackFingerprint = "unknown@@stdio"
+
+// MCPClientFallbackActorName is the actor_name used both by the
+// fallback singleton and by per-client rows whose clientInfo carried
+// no usable label. Mirrored in the migration's UPDATE.
+const MCPClientFallbackActorName = "Local MCP"
+
+// MCPClientFingerprint normalises a clientInfo + transport pair into
+// the stable identity key that EnsureMCPClientAgentKey uses to look
+// up (or create) the per-client api_keys row. The format is
+// `lower(label) + "@" + lower(host) + "@" + transport`:
+//
+//   - label = Title || Name (whichever is non-empty); collapsed
+//     whitespace + lowercased so case/whitespace variants don't
+//     fragment the identity
+//   - host = lowercased host portion of WebsiteURL (falls back to ""
+//     when the URL is empty or unparseable). Including host
+//     disambiguates two unrelated clients that share a name (e.g.
+//     "claude" — see reviewer concern in the planning doc).
+//   - transport = "stdio" | "http"
+//
+// Returns MCPClientFallbackFingerprint when there is no usable label
+// at all; the caller's EnsureMCPClientAgentKey will then return the
+// pre-relabelled singleton fallback row.
+func MCPClientFingerprint(client MCPClientInfo, transport string) string {
+	label := strings.TrimSpace(client.Title)
+	if label == "" {
+		label = strings.TrimSpace(client.Name)
+	}
+	if label == "" {
+		return MCPClientFallbackFingerprint
+	}
+	label = collapseWhitespace(strings.ToLower(label))
+	host := ""
+	if client.WebsiteURL != "" {
+		if u, err := url.Parse(client.WebsiteURL); err == nil {
+			host = strings.ToLower(u.Hostname())
+		}
+	}
+	return fmt.Sprintf("%s@%s@%s", label, host, transport)
+}
+
+// collapseWhitespace folds any run of whitespace down to a single
+// underscore so "Claude Desktop" and "claude  desktop" fingerprint
+// identically. Underscore (not space) so the fingerprint itself never
+// contains a space — it lands in api_keys.name + key_prefix where
+// surrounding tooling treats whitespace as a delimiter.
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			if !prevSpace && b.Len() > 0 {
+				b.WriteRune('_')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	out := b.String()
+	return strings.TrimRight(out, "_")
+}
+
+// EnsureMCPClientAgentKey returns the per-client agent identity row
+// for a given (clientInfo, transport) pair. Idempotent: the first
+// call creates the row, every later call returns it. On concurrent
+// first-call from the same client, both goroutines see the partial
+// unique index conflict and the loser re-reads the winner's row.
+//
+// On total failure (DB down, unexpected error), the caller gets the
+// fallback "Local MCP" singleton so the request still has a valid
+// actor — same shape as the existing pre-PR behaviour, just no
+// humanoid avatar. The error is returned for logging; the dispatcher
+// chooses to swallow it.
+func (s *Service) EnsureMCPClientAgentKey(ctx context.Context, client MCPClientInfo, transport string) (*db.ApiKey, error) {
+	fingerprint := MCPClientFingerprint(client, transport)
+
+	if row, err := s.Queries.GetApiKeyByClientFingerprint(ctx, pgconv.TextIfNotEmpty(fingerprint)); err == nil {
+		_ = s.Queries.UpdateApiKeyLastUsed(ctx, row.ID)
+		return &row, nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return s.fallbackMCPClientKey(ctx, fingerprint, err)
+	}
+
+	actorName := strings.TrimSpace(client.Title)
+	if actorName == "" {
+		actorName = strings.TrimSpace(client.Name)
+	}
+	if actorName == "" {
+		actorName = MCPClientFallbackActorName
+	}
+
+	row, err := s.Queries.CreateMCPClientApiKey(ctx, db.CreateMCPClientApiKeyParams{
+		Name:              "mcp-client:" + fingerprint,
+		KeyHash:           "mcp-client-not-a-real-credential:" + fingerprint,
+		KeyPrefix:         "bb_mcp_" + first8(sha256Hex(fingerprint)),
+		ActorName:         pgconv.TextIfNotEmpty(actorName),
+		ClientFingerprint: pgconv.TextIfNotEmpty(fingerprint),
+	})
+	if err == nil {
+		return &row, nil
+	}
+
+	// Insert race: a concurrent first-call already created the row.
+	// The partial unique index kicked the loser out; re-read the
+	// winner's row.
+	if row2, lookupErr := s.Queries.GetApiKeyByClientFingerprint(ctx, pgconv.TextIfNotEmpty(fingerprint)); lookupErr == nil {
+		_ = s.Queries.UpdateApiKeyLastUsed(ctx, row2.ID)
+		return &row2, nil
+	}
+	return s.fallbackMCPClientKey(ctx, fingerprint, err)
+}
+
+// fallbackMCPClientKey returns the relabelled stdio singleton (the
+// reserved fingerprint = MCPClientFallbackFingerprint) when an
+// otherwise-clean lookup/insert path errors out. The intent is to
+// hand the dispatcher *some* valid actor instead of falling back to
+// SystemActor — which would render even more confusingly than the
+// pre-fix singleton path.
+func (s *Service) fallbackMCPClientKey(ctx context.Context, attemptedFingerprint string, cause error) (*db.ApiKey, error) {
+	slog.Warn("EnsureMCPClientAgentKey: falling back to Local MCP singleton",
+		"fingerprint", attemptedFingerprint, "error", cause)
+	row, err := s.Queries.GetApiKeyByClientFingerprint(ctx, pgconv.TextIfNotEmpty(MCPClientFallbackFingerprint))
+	if err != nil {
+		// The migration that relabels the singleton hasn't applied
+		// yet (e.g. mid-deploy on a fresh install with no stdio
+		// history). Surface the original error so the caller can
+		// fall back to its pre-PR behaviour.
+		return nil, fmt.Errorf("ensure mcp client agent key: %w", cause)
+	}
+	return &row, nil
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func first8(s string) string {
+	if len(s) <= 8 {
+		return s
+	}
+	return s[:8]
+}

--- a/internal/service/mcp_client_keys_integration_test.go
+++ b/internal/service/mcp_client_keys_integration_test.go
@@ -1,0 +1,134 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+)
+
+// TestEnsureMCPClientAgentKey_LookupOrCreate verifies the happy path
+// — first call inserts the per-client row with actor_type='agent'
+// and the expected fingerprint shape, repeat calls return the same
+// id, and the row is filtered out of ListAPIKeys.
+func TestEnsureMCPClientAgentKey_LookupOrCreate(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	client := service.MCPClientInfo{
+		Name:       "claude",
+		Title:      "Claude Desktop",
+		Version:    "1.4.0",
+		WebsiteURL: "https://claude.ai",
+	}
+
+	first, err := svc.EnsureMCPClientAgentKey(ctx, client, "stdio")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if first == nil {
+		t.Fatal("first call returned nil row")
+	}
+	if first.ActorType != "agent" {
+		t.Fatalf("ActorType = %q, want agent", first.ActorType)
+	}
+	if !first.ActorName.Valid || first.ActorName.String != "Claude Desktop" {
+		t.Fatalf("ActorName = %+v, want Claude Desktop", first.ActorName)
+	}
+	wantFP := "claude_desktop@claude.ai@stdio"
+	if !first.ClientFingerprint.Valid || first.ClientFingerprint.String != wantFP {
+		t.Fatalf("ClientFingerprint = %+v, want %q", first.ClientFingerprint, wantFP)
+	}
+
+	second, err := svc.EnsureMCPClientAgentKey(ctx, client, "stdio")
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	firstID := pgconv.FormatUUID(first.ID)
+	secondID := pgconv.FormatUUID(second.ID)
+	if secondID != firstID {
+		t.Fatalf("second call returned a different row: first=%s second=%s", firstID, secondID)
+	}
+
+	// /settings/api-keys must not list this auto-managed row.
+	listed, err := svc.ListAPIKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	for _, k := range listed {
+		if k.ID == firstID {
+			t.Fatalf("auto-managed key leaked into ListAPIKeys: %+v", k)
+		}
+	}
+}
+
+// TestEnsureMCPClientAgentKey_ConcurrentInsertRace fires two
+// EnsureMCPClientAgentKey calls in parallel for the same fingerprint.
+// The partial unique index on api_keys.client_fingerprint guarantees
+// at most one row; the losing goroutine must re-read the winner's row
+// and both callers must end up with the same id.
+func TestEnsureMCPClientAgentKey_ConcurrentInsertRace(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	client := service.MCPClientInfo{
+		Name:  "race-tester",
+		Title: "Race Tester",
+	}
+
+	var wg sync.WaitGroup
+	var keyA, keyB string
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		k, err := svc.EnsureMCPClientAgentKey(ctx, client, "stdio")
+		if err == nil && k != nil {
+			keyA = pgconv.FormatUUID(k.ID)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		k, err := svc.EnsureMCPClientAgentKey(ctx, client, "stdio")
+		if err == nil && k != nil {
+			keyB = pgconv.FormatUUID(k.ID)
+		}
+	}()
+	wg.Wait()
+
+	if keyA == "" || keyB == "" {
+		t.Fatalf("both concurrent calls expected to succeed: a=%q b=%q", keyA, keyB)
+	}
+	if keyA != keyB {
+		t.Fatalf("concurrent calls returned different rows: a=%q b=%q (partial unique index should have collapsed them)", keyA, keyB)
+	}
+}
+
+// TestEnsureMCPClientAgentKey_FallbackToLocalMCP covers the path
+// where clientInfo carries no usable label at all — the helper
+// resolves to the relabelled "Local MCP" fallback singleton instead
+// of inserting yet another row.
+func TestEnsureMCPClientAgentKey_FallbackToLocalMCP(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	row, err := svc.EnsureMCPClientAgentKey(ctx, service.MCPClientInfo{}, "stdio")
+	if err != nil {
+		t.Fatalf("EnsureMCPClientAgentKey on empty clientInfo: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected fallback row, got nil")
+	}
+	if !row.ClientFingerprint.Valid || row.ClientFingerprint.String != service.MCPClientFallbackFingerprint {
+		t.Fatalf("ClientFingerprint = %+v, want %q", row.ClientFingerprint, service.MCPClientFallbackFingerprint)
+	}
+	if !row.ActorName.Valid || row.ActorName.String != service.MCPClientFallbackActorName {
+		t.Fatalf("ActorName = %+v, want %q", row.ActorName, service.MCPClientFallbackActorName)
+	}
+	if row.ActorType != "agent" {
+		t.Fatalf("ActorType = %q, want agent (the migration must have relabelled the singleton)", row.ActorType)
+	}
+}

--- a/internal/service/mcp_client_keys_test.go
+++ b/internal/service/mcp_client_keys_test.go
@@ -1,0 +1,78 @@
+//go:build !lite
+
+package service
+
+import "testing"
+
+func TestMCPClientFingerprint(t *testing.T) {
+	cases := []struct {
+		name      string
+		client    MCPClientInfo
+		transport string
+		want      string
+	}{
+		{
+			name:      "title wins over name",
+			client:    MCPClientInfo{Name: "claude", Title: "Claude Desktop", WebsiteURL: "https://claude.ai"},
+			transport: "stdio",
+			want:      "claude_desktop@claude.ai@stdio",
+		},
+		{
+			name:      "name fallback when no title",
+			client:    MCPClientInfo{Name: "cursor", WebsiteURL: "https://cursor.sh"},
+			transport: "stdio",
+			want:      "cursor@cursor.sh@stdio",
+		},
+		{
+			name:      "no website is empty host",
+			client:    MCPClientInfo{Name: "myscript"},
+			transport: "stdio",
+			want:      "myscript@@stdio",
+		},
+		{
+			name:      "uppercase + whitespace normalisation",
+			client:    MCPClientInfo{Title: "  Claude  Desktop  ", WebsiteURL: "HTTPS://CLAUDE.AI/x"},
+			transport: "http",
+			want:      "claude_desktop@claude.ai@http",
+		},
+		{
+			name:      "completely empty falls back to reserved singleton",
+			client:    MCPClientInfo{},
+			transport: "stdio",
+			want:      MCPClientFallbackFingerprint,
+		},
+		{
+			name:      "title-only with no website",
+			client:    MCPClientInfo{Title: "VS Code"},
+			transport: "stdio",
+			want:      "vs_code@@stdio",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MCPClientFingerprint(tc.client, tc.transport)
+			if got != tc.want {
+				t.Fatalf("MCPClientFingerprint = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCollapseWhitespaceTrim covers the trailing-underscore strip that
+// keeps fingerprints with trailing whitespace from collecting an
+// orphan `_` separator.
+func TestCollapseWhitespaceTrim(t *testing.T) {
+	cases := map[string]string{
+		"foo bar":      "foo_bar",
+		"  foo  bar  ": "foo_bar",
+		"foo":          "foo",
+		"  foo":        "foo",
+		"foo  ":        "foo",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := collapseWhitespace(in); got != want {
+			t.Errorf("collapseWhitespace(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Second in the `stack/stdio-agent-attribution` stack (atop #1560). Replaces the shared stdio singleton "system actor" identity with per-client agent identities derived from the MCP `initialize` handshake's `clientInfo`, with a "Local MCP" fallback when no clientInfo is sent.

Plan: `~/Documents/obsidian/Breadbox/planned-features/stdio-agent-attribution.md` (revision 2, addresses two reviewers).

## Why

Today every stdio MCP tool call attaches the same `bb_stdio_singleton` `api_keys` row to the request ctx, with `actor_type='system'` and `actor_name='stdio'`. Annotations get attributed to that singleton; the feed and per-tx timeline render every stdio action with the same humanoid DiceBear (the bug PR 1 fixed at the render layer) and the same "stdio" label.

`mcp_sessions` already captures `clientInfo.{Name,Title,Version,WebsiteURL}` on the `initialize` handshake — we just never propagated it to actor identity.

## How

1. **`api_keys.client_fingerprint`** (`20260526092106_api_keys_client_fingerprint.sql`). Nullable `TEXT` + a partial unique index on `(client_fingerprint) WHERE client_fingerprint IS NOT NULL`. User-created HTTP MCP keys stay NULL and are unaffected. Same migration also relabels the existing singleton row in place: `actor_type` → `agent`, `actor_name` → `Local MCP`, `client_fingerprint` → `unknown@@stdio`. Historic annotations whose `actor_id` references the singleton UUID re-render correctly through the agent branch — no annotations backfill needed.

2. **`MCPClientFingerprint(clientInfo, transport)`** (`internal/service/mcp_client_keys.go`). Normalised to `lower(label) + "@" + lower(websiteURL_host) + "@" + transport`, where `label = Title || Name`. Whitespace collapsed to `_`. Empty clientInfo collapses to the reserved `unknown@@stdio` fingerprint so the helper returns the relabelled singleton. Including the WebsiteURL host disambiguates two unrelated clients that share a name (a reviewer concern; the obvious case is two tools both calling themselves "claude").

3. **`Service.EnsureMCPClientAgentKey(ctx, clientInfo, transport)`**. Lookup → insert → re-lookup-on-conflict, mirroring the `EnsureMCPSessionForTransport` race pattern. Updates `last_used_at` on hits so a future "agents" admin view can show last-seen. On total failure (DB down, migration unapplied), returns the relabelled singleton as a last-resort fallback so callers always get *some* valid actor.

4. **MCP dispatcher rebind** (`internal/mcp/server.go::rebindActorFromClientInfo`). Called from `makeToolDefLogged` immediately AFTER resolving transport id and **BEFORE** `ensureAuditSession`. Read the comment in the dispatcher — this ordering is load-bearing because `ensureAuditSession` reads `ActorFromContext(ctx)` to stamp `mcp_sessions.api_key_id` and `api_key_name` once per session, and those columns never re-stamp. Reviewer #1 flagged the desync risk; the ordering invariant is the fix.

5. **Stdio bootstrap relabel** (`internal/cli/mcp.go`). `ensureStdioSystemKey` → `ensureLocalMCPFallbackKey`. Process-start attaches the Local MCP fallback identity to the root ctx so anything that runs before `initialize` (and any client that omits clientInfo entirely) has a valid actor.

6. **`ListApiKeys` filter** (`internal/db/queries/api_keys.sql`). `WHERE client_fingerprint IS NULL`. Auto-managed MCP-client rows don't pollute `/settings/api-keys` — they're not user-revocable credentials. Reviewer #2 flagged this.

7. **`mcp-client:<fingerprint>` name prefix** (NOT `agent:mcp:<fingerprint>`). Reviewer #1 caught that `AgentRunShortIDFromContext` (`internal/service/actor.go:85`) silently misparses any `agent:foo:bar` name, returning the last `:`-segment as a "run short id". The `mcp-client:` prefix fails the parser's initial `agent:` prefix check and returns `""` cleanly. No parser change.

## What's deliberately out of scope

- **Historic `mcp_sessions.api_key_name` / `agent_sessions.actor_name` backfill.** Existing rows still display "stdio" because their snapshot was taken before this PR. The avatar tile renders correctly today (PR 1's fix is render-time and resolves via `actor_type`), so the only residual cosmetic gap is the frozen label on pre-existing sessions. New sessions land with the right name.
- **`mcp_tool_calls` actor backfill.** Low-visibility (admin sessions log only); rewrite cost not justified.
- **Custom agent avatars.** Phase 4 in the plan, deferred. The data model is ready (`api_keys.id` is now the stable per-agent identity; the avatar handler in PR 1 already falls through to `api_keys.id` on a `users.id` miss). Adding `avatar_data BYTEA` + an upload UI is a follow-up.

## Visual diff

The bot tile from PR 1 carries over (the avatar fix is render-time). New stdio sessions with `clientInfo` will start rendering with their client name (e.g. "Claude Desktop") + bot tile; sessions with no clientInfo render as "Local MCP" + bot tile.

<img src="https://i.img402.dev/vtqgqwl5sf.jpg" width="800" alt="feed after PR 2 — bot tile + Local MCP / per-client labels for new sessions; historic snapshots keep their stdio label">

## Tests

Unit (no DB):
- `TestMCPClientFingerprint` — title-wins-over-name, name-fallback, no-website host, uppercase + whitespace normalisation, completely-empty-falls-back-to-reserved, title-only no-website.
- `TestCollapseWhitespaceTrim` — trailing underscore strip + idempotent on already-clean input.

Integration (DB-backed):
- `TestEnsureMCPClientAgentKey_LookupOrCreate` — first call inserts, repeat returns same id, row is filtered out of `ListAPIKeys`.
- `TestEnsureMCPClientAgentKey_ConcurrentInsertRace` — two goroutines racing on the same fingerprint both return the same id; partial unique index collapses the race.
- `TestEnsureMCPClientAgentKey_FallbackToLocalMCP` — empty `clientInfo` resolves to the relabelled singleton; asserts the migration ran (the row exists with `actor_type='agent'` + `actor_name='Local MCP'`).

All passing locally (`go test ./...` + `go test -tags integration -p 1 ./internal/service/...`).

## Test plan

- [x] Unit + integration suite green
- [x] Migration applies cleanly to a fresh `breadbox_test` DB
- [x] Migration applies cleanly to the existing dev `breadbox` DB (singleton relabel verified — see screenshot above)
- [x] Bot tile renders on existing stdio rows (PR 1's render fix carries over)
- [ ] CI green
- [ ] PR 1 lands first, then this PR

Stack: PR 1 of 2 is #1560 (UI guardrails). This PR is PR 2.
