### PR TITLE
fix(install): dash compatibility + /dev/tty prompts + uninstall docs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -216,6 +216,32 @@ Simple cron-driven equivalent:
 0 3 * * * cd /opt/breadbox && docker compose pull && docker compose up -d >> /var/log/breadbox-update.log 2>&1
 ```
 
+## Uninstalling
+
+Same one-liner pattern, with `--uninstall`:
+
+```bash
+curl -fsSL https://breadbox.sh/install.sh | bash -s -- --uninstall
+```
+
+This stops + removes the containers and deletes the install directory's
+`docker-compose.prod.yml`, `Caddyfile`, `.env`, and `.breadbox-version`.
+
+**The postgres volume is preserved by default** so your transactions and
+connection data survive accidental uninstalls. To wipe it too:
+
+```bash
+docker volume rm $(docker volume ls -q | grep breadbox)
+```
+
+If you'd rather work from the install directory directly:
+
+```bash
+cd ~/.breadbox      # or /opt/breadbox for root installs
+docker compose -f docker-compose.prod.yml down -v   # -v drops volumes
+rm -rf ~/.breadbox
+```
+
 ## Environment Variables Reference
 
 | Variable | Required | Default | Description |

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -29,12 +29,32 @@ if command -v curl >/dev/null 2>&1; then
     tmpfile="${TMPDIR:-/tmp}/breadbox-install.$$.sh"
     trap 'rm -f "$tmpfile"' EXIT INT TERM
     curl -fsSL "$URL" -o "$tmpfile"
-    sh "$tmpfile" "$@"
+    # install.sh uses bash features (BASH_SOURCE, [[, here-strings).
+    # Use `bash` explicitly so the shebang's semantics apply even on
+    # systems where /bin/sh is dash. Fall back to `sh` only if bash is
+    # truly missing — but that's a configuration the installer wouldn't
+    # survive anyway.
+    if command -v bash >/dev/null 2>&1; then
+        bash "$tmpfile" "$@"
+    else
+        echo "error: bash not found. Breadbox's installer requires bash. Install it via your package manager (e.g. 'apt install bash') and retry." >&2
+        exit 1
+    fi
 elif command -v wget >/dev/null 2>&1; then
     tmpfile="${TMPDIR:-/tmp}/breadbox-install.$$.sh"
     trap 'rm -f "$tmpfile"' EXIT INT TERM
     wget -qO "$tmpfile" "$URL"
-    sh "$tmpfile" "$@"
+    # install.sh uses bash features (BASH_SOURCE, [[, here-strings).
+    # Use `bash` explicitly so the shebang's semantics apply even on
+    # systems where /bin/sh is dash. Fall back to `sh` only if bash is
+    # truly missing — but that's a configuration the installer wouldn't
+    # survive anyway.
+    if command -v bash >/dev/null 2>&1; then
+        bash "$tmpfile" "$@"
+    else
+        echo "error: bash not found. Breadbox's installer requires bash. Install it via your package manager (e.g. 'apt install bash') and retry." >&2
+        exit 1
+    fi
 else
     echo "error: neither curl nor wget found. Install one of them and retry." >&2
     exit 1

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -144,12 +144,21 @@ do_uninstall() {
     printf "To remove volumes: docker volume rm breadbox_postgres_data breadbox_caddy_data breadbox_caddy_config\n"
     printf "\n"
 
-    printf "Continue? [y/N] "
-    read -r confirm
-    case "$confirm" in
-        [yY]|[yY][eE][sS]) ;;
-        *) info "Uninstall cancelled."; exit 0 ;;
-    esac
+    # When invoked via `curl | bash -s -- --uninstall`, stdin is the pipe.
+    # _bb_read_line falls back to /dev/tty so the prompt actually works.
+    # If neither is available (cron, etc.), require --yes to avoid silently
+    # destroying state.
+    if [ "${AUTO_YES:-0}" != "1" ]; then
+        printf "Continue? [y/N] "
+        if ! _bb_read_line; then
+            error "No terminal available for confirmation. Re-run with --yes to skip the prompt."
+            exit 1
+        fi
+        case "$ans" in
+            [yY]|[yY][eE][sS]) ;;
+            *) info "Uninstall cancelled."; exit 0 ;;
+        esac
+    fi
 
     rm -f "$INSTALL_DIR/$COMPOSE_FILE"
     rm -f "$INSTALL_DIR/Caddyfile"
@@ -172,8 +181,31 @@ check_command() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Helper: read one line into $ans. Tries the right source for each
+# invocation pattern; returns 1 only when nothing produces a line.
+#
+# Preference order:
+#   1. Stdin when it's a TTY — interactive `bash install.sh`
+#   2. /dev/tty — `curl | bash` case (stdin is the drained install pipe,
+#      but the controlling terminal is still available)
+#   3. Stdin as a last resort — heredoc / here-string testing patterns
+#      and headless ssh with piped input
+#
+# Per-read redirection avoids dash's quirk where `exec 3</dev/tty` exits
+# the shell on open failure even inside a conditional.
+_bb_read_line() {
+    if [ -t 0 ]; then
+        read -r ans
+        return $?
+    fi
+    if read -r ans </dev/tty 2>/dev/null; then
+        return 0
+    fi
+    read -r ans 2>/dev/null || return 1
+}
+
 # Prompt for a yes/no answer. Returns 0 for yes, 1 for no.
-# Respects AUTO_YES (treats "yes" as the default when non-interactive).
+# Respects AUTO_YES (treats default as the answer when --yes is set).
 prompt_yn() {
     question="$1"
     default="${2:-n}"
@@ -183,18 +215,15 @@ prompt_yn() {
         return 1
     fi
 
-    if [ ! -t 0 ]; then
-        # Non-interactive (piped). Use default.
-        [ "$default" = "y" ] && return 0
-        return 1
-    fi
-
     if [ "$default" = "y" ]; then
         printf "%s [Y/n] " "$question"
     else
         printf "%s [y/N] " "$question"
     fi
-    read -r ans
+    if ! _bb_read_line; then
+        # No readable source (headless cron / -T ssh). Fall back to default.
+        ans="$default"
+    fi
     ans=${ans:-$default}
     case "$ans" in
         [yY]|[yY][eE][sS]) return 0 ;;
@@ -207,7 +236,7 @@ prompt_value() {
     question="$1"
     default="${2:-}"
 
-    if [ "${AUTO_YES:-0}" = "1" ] || [ ! -t 0 ]; then
+    if [ "${AUTO_YES:-0}" = "1" ]; then
         printf "%s" "$default"
         return
     fi
@@ -217,7 +246,9 @@ prompt_value() {
     else
         printf "%s: " "$question" >&2
     fi
-    read -r ans
+    if ! _bb_read_line; then
+        ans="$default"
+    fi
     printf "%s" "${ans:-$default}"
 }
 
@@ -769,8 +800,11 @@ if [ "$healthy" -eq 1 ]; then
     if [ -n "$doctor_out" ]; then
         # Use python (preinstalled on macOS + most Linux distros) to filter
         # the JSON. Fall back to printing the raw output if python is absent.
+        # POSIX-portable: pipe data to python via stdin; -c passes the script
+        # so stdin stays available for the data. The earlier `<<<` here-string
+        # was a bashism that crashed under dash.
         if check_command python3; then
-            python3 -c '
+            printf "%s" "$doctor_out" | python3 -c '
 import json, sys
 try:
     d = json.loads(sys.stdin.read())
@@ -785,7 +819,7 @@ if fails:
     print("  full report: docker compose exec breadbox /app/breadbox doctor")
 else:
     print("doctor: ok (%d checks passed)" % len(checks))
-' <<< "$doctor_out" || printf "%s\n" "$doctor_out"
+' || printf "%s\n" "$doctor_out"
         else
             printf "%s\n" "$doctor_out"
         fi


### PR DESCRIPTION
## Summary

Follow-up to #1563. The fresh installer crashed under \`curl | bash\` on a fresh Ubuntu VM because two new bashisms hit dash:

1. **\`<<<\` here-string** for the doctor JSON filter (line 788 in #1563)
2. **\`exec 3</dev/tty\`** in the new prompt-FD detection — dash treats exec redirection failures as terminal even inside an \`elif\` conditional, so any environment without \`/dev/tty\` (cron, \`ssh -T\`) killed the script.

The bootstrap (\`deploy/bootstrap.sh\`) invokes the installer with \`sh\`, which is dash on Ubuntu — so the installer's \`#!/usr/bin/env bash\` shebang was being ignored. Reported by my own testing on \`bb-test.exe.xyz\` (thanks to Ricardo for re-running the install one-liner immediately after the merge — caught it within minutes).

Also: prompts were silently being skipped during \`curl | bash\` runs because stdin was the drained install pipe. Now they fall through to \`/dev/tty\` so the domain prompt actually fires in the canonical install flow.

## Changes

### \`deploy/install.sh\`
- Replace \`<<<\` here-string with \`printf | python3 -c\` (stdin pipe to \`-c\` script — works in dash, bash, zsh)
- Drop the \`exec 3</dev/tty 2>/dev/null\` FD-init trick. Read from /dev/tty per-prompt inline; fall back to stdin EOF-safe
- \`_bb_read_line\` preference order: stdin-when-TTY → /dev/tty → stdin-as-last-resort. Returns 1 only when truly headless
- \`do_uninstall\` now honors \`AUTO_YES\` (was missing — \`--yes --uninstall\` would sit waiting for a "y" it couldn't get)

### \`deploy/bootstrap.sh\`
- \`sh "\$tmpfile" "\$@"\` → \`bash "\$tmpfile" "\$@"\`. install.sh's shebang says bash; the bootstrap was overriding it. Defensive — install.sh is dash-portable now, but a future bashism shouldn't be able to re-break the live install path
- ⚠️ The live \`breadbox.sh\` bootstrap is mirrored into \`breadbox-site\`; that copy also needs this edit before users see the bash fix

### \`deploy/README.md\`
- New "Uninstalling" section. The README mentioned \`--uninstall\` as a flag but never gave users the one-liner. Surfaces the volume-preservation behavior + the full-wipe command

## Test plan

- [x] \`curl | bash\` works on fresh Ubuntu (dash as /bin/sh)
- [x] \`bash install.sh\` interactive — prompts read from stdin
- [x] \`bash install.sh --yes --no-register-daemon\` — non-interactive, defaults
- [x] \`bash install.sh --yes --uninstall\` — proceeds without sitting on a phantom y/N prompt
- [x] \`dash install.sh\` — fresh install + doctor summary + uninstall all clean

Verified end-to-end on \`bb-test.exe.xyz\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)