### PR TITLE
fix(install): banner color escape parsing + uninstall volume list

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -75,13 +75,19 @@ fi
 # Color helpers (disabled when not a terminal or NO_COLOR is set)
 # ---------------------------------------------------------------------------
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[1;33m'
-    BLUE='\033[0;34m'
-    BOLD='\033[1m'
-    DIM='\033[2m'
-    NC='\033[0m'
+    # Pre-interpret the escapes via $(printf ...) so each variable holds
+    # an actual ESC byte rather than the literal text "\033". Avoids a
+    # subtle bug where `printf "...\\_\\${NC}\n"` would consume the
+    # trailing `\\` as a backslash literal and leak `\033[0m` as visible
+    # text — exactly what happened on the bottom-right of the ASCII
+    # banner.
+    RED=$(printf '\033[0;31m')
+    GREEN=$(printf '\033[0;32m')
+    YELLOW=$(printf '\033[1;33m')
+    BLUE=$(printf '\033[0;34m')
+    BOLD=$(printf '\033[1m')
+    DIM=$(printf '\033[2m')
+    NC=$(printf '\033[0m')
 else
     RED='' GREEN='' YELLOW='' BLUE='' BOLD='' DIM='' NC=''
 fi
@@ -140,8 +146,9 @@ do_uninstall() {
     printf "  ${INSTALL_DIR}/.env\n"
     printf "  ${INSTALL_DIR}/.breadbox-version\n"
     printf "\n"
-    printf "${YELLOW}Docker volumes (postgres_data, caddy_data, caddy_config) are NOT removed.${NC}\n"
-    printf "To remove volumes: docker volume rm breadbox_postgres_data breadbox_caddy_data breadbox_caddy_config\n"
+    printf "${YELLOW}Docker volumes (postgres, transcripts, backups, and caddy if used) are NOT removed.${NC}\n"
+    printf "To remove all breadbox volumes (DESTROYS data):\n"
+    printf "  docker volume rm \$(docker volume ls -q | grep breadbox)\n"
     printf "\n"
 
     # When invoked via `curl | bash -s -- --uninstall`, stdin is the pipe.


### PR DESCRIPTION
## Summary

Two small follow-ups from the post-merge install testing on `bb-test.exe.xyz`.

### 1. Banner showed `\033[0m` as visible text

The color vars were defined as literal strings (`NC='\033[0m'`), then substituted into a printf format string. Most banner lines were fine, but the bottom ascii-art line ends `\\_\\${NC}\n` — after shell parse it becomes `\_\\033[0m\n`. printf consumed the `\\` as one backslash literal, leaving `033[0m` as plain text. Every install printed `\033[0m` at the end of the banner.

**Fix:** define the colors via `$(printf '\033[1m')` so the variables hold actual ESC bytes instead of literal `"\033"` text. After shell parse the format becomes `\_\<ESC>[0m\n`; printf emits `\` + ESC + `[0m`, the terminal correctly reads it as the `\` from the ascii art plus an ANSI reset.

Verified with `cat -v` on a PTY-allocated ssh session:
```
^[[1m |____/|_|  \___|\__,_|\__,_|_.__/ \___/_/\_\^[[0m
```

### 2. `--uninstall`'s volume-removal hint was wrong

It printed:
```
docker volume rm breadbox_postgres_data breadbox_caddy_data breadbox_caddy_config
```

Two problems:
- For localhost-only installs (no Caddy), `caddy_data` / `caddy_config` don't exist — running the message verbatim errors with `no such volume` (reported by user)
- It missed `breadbox_transcripts` and `breadbox_backups`, which always exist regardless of profile

**Fix:** print the robust `docker volume rm $(docker volume ls -q | grep breadbox)` form. Removes whatever exists; same shape as the README example.

## Test plan

- [x] Banner renders clean on the VM (ESC bytes interpreted as ANSI, no leaking `\033[0m` text)
- [x] `od -c` confirms BOLD/NC vars hold actual ESC bytes
- [ ] Re-run install on bb-test-2 to confirm visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)