### PR TITLE
fix(install): make systemd-unit warning teach the correct sudo pattern

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -340,7 +340,10 @@ register_daemon_systemd() {
     unit_dest="/etc/systemd/system/breadbox.service"
 
     if [ "$(id -u)" != "0" ]; then
-        warn "Registering a systemd unit requires root. Re-run with sudo to enable this feature."
+        warn "Registering a systemd unit requires root. To enable it, re-run as:"
+        warn "  curl -fsSL https://breadbox.sh/install.sh | sudo bash -s -- --register-daemon"
+        warn "(Note: 'sudo curl … | bash' applies sudo to curl only, not bash —"
+        warn "the script then runs as your user. Put sudo in front of bash.)"
         return 1
     fi
 


### PR DESCRIPTION
## Summary

When `install.sh` can't register a systemd unit because the script isn't running as root, the warning said only:

> warning: Registering a systemd unit requires root. Re-run with sudo to enable this feature.

That left users to guess how. The natural guess — `sudo curl -fsSL https://breadbox.sh/install.sh | bash` — applies sudo to **curl**, not **bash**. The script then runs as the regular user and the registration silently bails again. Reported by user testing on `bb-test-2.exe.xyz` after running exactly that incantation.

## Fix

Expand the warning to spell out the working invocation and call out the gotcha:

```
warning: Registering a systemd unit requires root. To enable it, re-run as:
warning:   curl -fsSL https://breadbox.sh/install.sh | sudo bash -s -- --register-daemon
warning: (Note: 'sudo curl … | bash' applies sudo to curl only, not bash —
warning: the script then runs as your user. Put sudo in front of bash.)
```

Single-call-site fix — same warning fires from the interactive prompt path and the `--register-daemon` flag path. No other behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)