### PR TITLE
feat(install): foolproofing — port prompt, pre-flight checks, secret-redacted log dumps

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,3 +1,3 @@
 {$DOMAIN} {
-    reverse_proxy breadbox:8080
+    reverse_proxy breadbox:{$SERVER_PORT:8080}
 }

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -5,7 +5,10 @@ services:
     env_file: .env
     command: ["sh", "-c", "/app/breadbox migrate && /app/breadbox serve"]
     ports:
-      - "8080:8080"
+      # Both sides of the mapping come from .env's SERVER_PORT so the host
+      # publishes the same port the binary listens on. The :-8080 default
+      # keeps existing installs working when SERVER_PORT is unset.
+      - "${SERVER_PORT:-8080}:${SERVER_PORT:-8080}"
     depends_on:
       db:
         condition: service_healthy
@@ -28,7 +31,7 @@ services:
       # empty until a backup runs.
       - breadbox_backups:/var/lib/breadbox/backups
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health/ready"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:${SERVER_PORT:-8080}/health/ready"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -549,7 +549,19 @@ printf "\n"
 if [ -f "${INSTALL_DIR}/.env" ]; then
     warn "Existing .env found at ${INSTALL_DIR}/.env"
     info "To avoid overwriting your configuration, the existing .env will be preserved."
-    info "To start fresh, run: $0 --uninstall"
+    info "To start fresh, run: curl -fsSL https://breadbox.sh/install.sh | bash -s -- --uninstall"
+    # --domain / --port can't take effect when reusing an existing .env —
+    # the env-generation block is skipped. Warn loudly so the user doesn't
+    # think their flag worked, then point at the in-place edit.
+    if [ -n "$DOMAIN_ARG" ] || [ -n "$PORT_ARG" ]; then
+        printf "\n"
+        warn "Note: --domain / --port have no effect when reusing an existing .env."
+        warn "To change settings on this install:"
+        warn "  1. Edit ${INSTALL_DIR}/.env (DOMAIN= and/or SERVER_PORT=)"
+        warn "  2. cd ${INSTALL_DIR} && docker compose -f docker-compose.prod.yml up -d"
+        warn "Or uninstall first to start fresh:"
+        warn "  curl -fsSL https://breadbox.sh/install.sh | bash -s -- --uninstall"
+    fi
     printf "\n"
     ENV_EXISTS=1
 else
@@ -758,6 +770,38 @@ if [ "$NO_START" = "1" ]; then
     exit 0
 fi
 
+# --- Pre-flight port check ---
+#
+# Catch "port already in use" up-front instead of letting the user wait 60s
+# for the health probe to time out. Uses `ss` (universally available on
+# systemd hosts via iproute2) — falls back to lsof if ss is missing.
+# Compose's port-mapping clash error is also clear, but we want to refuse
+# *before* generating volumes / pulling images / starting containers.
+check_port_in_use() {
+    port="$1"
+    if command -v ss >/dev/null 2>&1; then
+        ss -ltn "sport = :${port}" 2>/dev/null | tail -n +2 | grep -q .
+    elif command -v lsof >/dev/null 2>&1; then
+        lsof -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+    else
+        # No tool available — skip the check. Compose will surface the
+        # error if there's a real conflict.
+        return 1
+    fi
+}
+
+if check_port_in_use "$PORT_VALUE"; then
+    error "Port ${PORT_VALUE} is already in use on this host."
+    error "Pick a different port with: --port=N (or stop the conflicting service first)."
+    error "Check what's listening:"
+    if command -v ss >/dev/null 2>&1; then
+        error "  ss -ltnp 'sport = :${PORT_VALUE}'"
+    else
+        error "  lsof -iTCP:${PORT_VALUE} -sTCP:LISTEN"
+    fi
+    exit 1
+fi
+
 # --- Start services ---
 
 info "Starting Breadbox..."
@@ -766,8 +810,12 @@ info "Starting Breadbox..."
 # shellcheck disable=SC2086
 if ! docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" up -d; then
     error "docker compose up failed. Last 20 lines of compose logs:"
+    # Redact DSN-style credentials before dumping to the terminal — see the
+    # health-failure block below for the same precaution.
     # shellcheck disable=SC2086
-    docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" logs --tail 20 || true
+    docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" logs --tail 20 2>&1 \
+        | sed -E 's#(://[^:@/]+:)[^@]+@#\1REDACTED@#g' \
+        || true
     exit 1
 fi
 
@@ -826,7 +874,7 @@ if [ "$healthy" -eq 1 ]; then
         info "View logs:     cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs -f"
         info "Update:        cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} pull && docker compose -f ${COMPOSE_FILE} up -d"
     fi
-    info "Uninstall:     ${0} --uninstall"
+    info "Uninstall:     curl -fsSL https://breadbox.sh/install.sh | bash -s -- --uninstall"
     printf "\n"
     if [ -z "$DOMAIN_VALUE" ]; then
         printf "${DIM}To enable HTTPS later, edit .env to set DOMAIN=, then:${NC}\n"
@@ -875,15 +923,22 @@ else
     error "Common causes:"
     error "  1. Port ${PORT} is already used by another process on this host."
     error "     Re-run with --port=N to pick a different one, or stop the"
-    error "     conflicting service. Check with: lsof -iTCP:${PORT} -sTCP:LISTEN"
+    error "     conflicting service. Check with:"
+    error "       ss -ltnp 'sport = :${PORT}'    (or: lsof -iTCP:${PORT} -sTCP:LISTEN)"
     error "  2. Postgres is still initializing (rare on first install — wait"
     error "     a few seconds and retry from the install dir, or check the"
     error "     db logs: docker compose -f ${COMPOSE_FILE} logs db)"
     error "  3. The breadbox container hit a startup error (most likely the"
     error "     migration failed). See the last 30 lines:"
     error ""
+    # Redact credentials embedded in DSN-style URLs before dumping logs to
+    # the user's terminal. goose/pgx errors sometimes include the DSN, and
+    # POSTGRES_PASSWORD was generated for this install just a moment ago —
+    # we don't want it landing in scrollback / CI captures / shell history.
     # shellcheck disable=SC2086
-    docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" logs --tail 30 breadbox || true
+    docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" logs --tail 30 breadbox 2>&1 \
+        | sed -E 's#(://[^:@/]+:)[^@]+@#\1REDACTED@#g' \
+        || true
     error ""
     error "Full logs: cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs"
     exit 1

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -418,6 +418,7 @@ NO_REGISTER_DAEMON=0
 NO_START=0
 PURGE_VOLUMES=0
 DOMAIN_ARG=""
+PORT_ARG=""
 VERSION_ARG=""
 
 for arg in "$@"; do
@@ -430,6 +431,7 @@ for arg in "$@"; do
         --no-start) NO_START=1 ;;
         --purge-volumes) PURGE_VOLUMES=1 ;;
         --domain=*) DOMAIN_ARG="${arg#--domain=}" ;;
+        --port=*) PORT_ARG="${arg#--port=}" ;;
         --version=*) VERSION_ARG="${arg#--version=}" ;;
         --help|-h)
             printf "Usage: install.sh [OPTIONS]\n\n"
@@ -438,6 +440,7 @@ for arg in "$@"; do
             printf "  --yes, -y              Skip interactive prompts; accept defaults\n"
             printf "  --install-docker       Install Docker automatically (Linux only)\n"
             printf "  --domain=HOST          Configure the install for HTTPS at HOST (enables Caddy)\n"
+            printf "  --port=N               HTTP port to listen on (default: 8080)\n"
             printf "  --version=vX.Y.Z       Pin to a specific release tag (default: latest GitHub release)\n"
             printf "  --no-start             Write the install but don't 'docker compose up' it\n"
             printf "  --purge-volumes        Drop existing postgres/transcripts/backups volumes before install\n"
@@ -574,6 +577,32 @@ else
     CADDY_PROFILE=""
 fi
 
+# --- Port prompt ---
+#
+# Most users want 8080 — but some platforms (exe.dev, some cloud PaaS,
+# certain reverse proxies) route to a specific port number that isn't
+# 8080. Prompting up-front catches those cases before the install
+# completes and the user discovers "service unavailable" later.
+PORT_VALUE="$PORT_ARG"
+if [ -z "$PORT_VALUE" ] && [ "$ENV_EXISTS" = "0" ]; then
+    printf "\n"
+    info "Optional: HTTP port for Breadbox to listen on (default 8080)."
+    info "Change this only if 8080 is already taken on this host, OR if"
+    info "your reverse proxy / hosting platform expects a specific port."
+    PORT_VALUE=$(prompt_value "Port" "8080")
+fi
+PORT_VALUE="${PORT_VALUE:-8080}"
+# Sanity-check: digits-only, 1-65535.
+case "$PORT_VALUE" in
+    ''|*[!0-9]*) die "--port must be a number, got: ${PORT_VALUE}" ;;
+esac
+if [ "$PORT_VALUE" -lt 1 ] || [ "$PORT_VALUE" -gt 65535 ]; then
+    die "--port must be 1-65535, got: ${PORT_VALUE}"
+fi
+if [ "$PORT_VALUE" != "8080" ]; then
+    info "Listening on port: ${PORT_VALUE}"
+fi
+
 printf "\n"
 
 # --- Create install directory ---
@@ -647,7 +676,7 @@ POSTGRES_DB=breadbox
 ENCRYPTION_KEY=${ENCRYPTION_KEY}
 
 # --- Server ---
-SERVER_PORT=8080
+SERVER_PORT=${PORT_VALUE}
 ENVIRONMENT=docker
 
 # --- Domain (for Caddy HTTPS) ---
@@ -785,6 +814,8 @@ if [ "$healthy" -eq 1 ]; then
         info "Setup wizard:  ${BOLD}https://${DOMAIN_VALUE}/setup${NC}"
     else
         info "Setup wizard:  ${BOLD}http://localhost:${PORT}/setup${NC}"
+        info "${DIM}  …or visit your public URL if this host is behind a reverse proxy${NC}"
+        info "${DIM}  pointing at port ${PORT}.${NC}"
     fi
     info "Config file:   ${INSTALL_DIR}/.env"
     info "Version pin:   ${INSTALL_DIR}/.breadbox-version (${IMAGE_TAG})"
@@ -840,6 +871,20 @@ else:
     fi
 else
     error "Breadbox did not become healthy within 60 seconds."
-    error "Check logs: cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs"
+    error ""
+    error "Common causes:"
+    error "  1. Port ${PORT} is already used by another process on this host."
+    error "     Re-run with --port=N to pick a different one, or stop the"
+    error "     conflicting service. Check with: lsof -iTCP:${PORT} -sTCP:LISTEN"
+    error "  2. Postgres is still initializing (rare on first install — wait"
+    error "     a few seconds and retry from the install dir, or check the"
+    error "     db logs: docker compose -f ${COMPOSE_FILE} logs db)"
+    error "  3. The breadbox container hit a startup error (most likely the"
+    error "     migration failed). See the last 30 lines:"
+    error ""
+    # shellcheck disable=SC2086
+    docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" logs --tail 30 breadbox || true
+    error ""
+    error "Full logs: cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs"
     exit 1
 fi


### PR DESCRIPTION
## Summary

User-driven foolproofing pass after `bb-test-2.exe.xyz` install testing surfaced multiple footguns. The headline ask was "prompt for a port"; the scope grew to cover the related rough edges.

## Changes

### Port handling end-to-end
- `--port=N` flag + interactive prompt (defaults to 8080, with copy explaining when to change it). Validated as digits-only in 1–65535.
- `docker-compose.prod.yml` env-interpolates the port mapping AND the container healthcheck URL: `${SERVER_PORT:-8080}:${SERVER_PORT:-8080}` + `http://localhost:${SERVER_PORT:-8080}/health/ready`.
- `Caddyfile` reverse-proxies to `breadbox:{$SERVER_PORT:8080}` (Caddy's env-with-default syntax). Caddy gets the env from `env_file: .env` on the service.

### Pre-flight port-conflict check
`ss -ltn "sport = :${PORT_VALUE}"` (falls back to lsof) BEFORE `docker compose up`. Refuses immediately with a clear remediation instead of waiting 60s for the health probe to time out.

### Secret-redacted log dumps
Both the compose-start-failure block and the new health-failure block pipe `docker compose logs --tail N` through `sed -E 's#(://[^:@/]+:)[^@]+@#\1REDACTED@#g'` before printing to the terminal. goose/pgx migrate errors can include the full DSN, which embeds the freshly-generated POSTGRES_PASSWORD — without redaction it lands in scrollback / CI captures.

### Actionable health-failure guidance
Three numbered causes (port conflict / postgres init / migration error) with concrete commands, plus the last 30 lines of breadbox container logs inline (now redacted, per above).

### Reinstall-warning when --port / --domain are silently dropped
Passing `--port=9000` on a host with an existing `.env` previously did nothing (the .env regen block is gated on `ENV_EXISTS=0`) but the install still reported success. Now warns explicitly with two remediation paths (edit .env in place + restart, OR `--uninstall` first).

### Uninstall hint fix
`$0` in the success message expands to `/tmp/breadbox-install.NNNN.sh` under `curl | bash`, but the bootstrap deletes that temp file on exit. Two hints (success message + "existing .env" warning) replaced with the canonical:
```
curl -fsSL https://breadbox.sh/install.sh | bash -s -- --uninstall
```

### External-URL hint on success
When DOMAIN is unset, the success message used to say only "Setup wizard: http://localhost:8080/setup" — wrong for users behind a reverse proxy. Now adds a dim follow-up reminding them to visit their public URL if the host is fronted.

## Test plan

- [x] Default port flow: fresh install on bb-test-2.exe.xyz, doctor renders, no regressions
- [x] `--port=9000` end-to-end: container binds 9000, health probe hits 9000, port mapping is 9000:9000 (verified by manually substituting compose file — script's own download from main can't be tested until merged)
- [x] Pre-flight port check fires when 8080 is occupied: error before docker compose up
- [x] Redaction regex tested on representative DSN string
- [x] Uninstall hint reflects the curl one-liner
- [x] All build-tag configs (default/headless/lite) untouched; no Go changes

## Open follow-ups (deliberately scoped out)

- **README/docs reference :8080 literally** in many places (`deploy/README.md` lines 7, 53, 160, 173, 277, 307). Worth a small docs-only PR.
- **Caddy/breadbox partial-restart drift** — if a user edits SERVER_PORT in .env and only `docker compose up -d breadbox` (not caddy), Caddy keeps proxying to the old port. Edge case; document later.
- **PaaS auto-detection** — Heroku/Fly/Railway export `PORT`; could default `--port` to that. Bigger surface, future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)