### PR TITLE
feat(config): fall back to $PORT for 12-factor PaaS compatibility

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -596,6 +596,15 @@ fi
 # 8080. Prompting up-front catches those cases before the install
 # completes and the user discovers "service unavailable" later.
 PORT_VALUE="$PORT_ARG"
+# 12-factor / PaaS convention: Heroku, Fly.io, Railway, Render, Cloud Run
+# all inject PORT into the runtime environment. When the user runs the
+# installer on a host where PORT is already exported, default to it
+# instead of forcing them to discover and translate it. --port=N still
+# wins; this only kicks in when --port wasn't given.
+if [ -z "$PORT_VALUE" ] && [ -n "${PORT:-}" ]; then
+    PORT_VALUE="$PORT"
+    info "Detected PORT=${PORT} in the environment (12-factor convention) — using as default."
+fi
 if [ -z "$PORT_VALUE" ] && [ "$ENV_EXISTS" = "0" ]; then
     printf "\n"
     info "Optional: HTTP port for Breadbox to listen on (default 8080)."

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -143,6 +143,97 @@ func TestLoad_ServerPort_FromEnv(t *testing.T) {
 	}
 }
 
+// TestLoad_ServerPort_FallsBackToPortEnv exercises the PaaS port-injection
+// convention. Heroku, Fly.io, Railway, Render, Cloud Run, etc. inject
+// PORT (not SERVER_PORT). When SERVER_PORT is unset but PORT is set,
+// Breadbox must bind to PORT.
+func TestLoad_ServerPort_FallsBackToPortEnv(t *testing.T) {
+	savedServer := os.Getenv("SERVER_PORT")
+	savedPort := os.Getenv("PORT")
+	t.Cleanup(func() {
+		if savedServer != "" {
+			os.Setenv("SERVER_PORT", savedServer)
+		} else {
+			os.Unsetenv("SERVER_PORT")
+		}
+		if savedPort != "" {
+			os.Setenv("PORT", savedPort)
+		} else {
+			os.Unsetenv("PORT")
+		}
+	})
+
+	os.Unsetenv("SERVER_PORT")
+	os.Setenv("PORT", "3000")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ServerPort != "3000" {
+		t.Errorf("expected PORT fallback to give '3000', got %q", cfg.ServerPort)
+	}
+}
+
+// TestLoad_ServerPort_PrefersServerPortOverPort verifies that when both
+// SERVER_PORT and PORT are set, SERVER_PORT wins. That way a user who
+// has set both (e.g. PORT leaked from another tool's env) gets the
+// value they explicitly chose for Breadbox.
+func TestLoad_ServerPort_PrefersServerPortOverPort(t *testing.T) {
+	savedServer := os.Getenv("SERVER_PORT")
+	savedPort := os.Getenv("PORT")
+	t.Cleanup(func() {
+		if savedServer != "" {
+			os.Setenv("SERVER_PORT", savedServer)
+		} else {
+			os.Unsetenv("SERVER_PORT")
+		}
+		if savedPort != "" {
+			os.Setenv("PORT", savedPort)
+		} else {
+			os.Unsetenv("PORT")
+		}
+	})
+
+	os.Setenv("SERVER_PORT", "7777")
+	os.Setenv("PORT", "3000")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ServerPort != "7777" {
+		t.Errorf("expected SERVER_PORT to win over PORT, got %q", cfg.ServerPort)
+	}
+}
+
+// TestLoad_ServerPort_DefaultsTo8080 verifies the final fallback when
+// neither SERVER_PORT nor PORT is set.
+func TestLoad_ServerPort_DefaultsTo8080(t *testing.T) {
+	savedServer := os.Getenv("SERVER_PORT")
+	savedPort := os.Getenv("PORT")
+	t.Cleanup(func() {
+		if savedServer != "" {
+			os.Setenv("SERVER_PORT", savedServer)
+		} else {
+			os.Unsetenv("SERVER_PORT")
+		}
+		if savedPort != "" {
+			os.Setenv("PORT", savedPort)
+		} else {
+			os.Unsetenv("PORT")
+		}
+	})
+
+	os.Unsetenv("SERVER_PORT")
+	os.Unsetenv("PORT")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.ServerPort != "8080" {
+		t.Errorf("expected default '8080', got %q", cfg.ServerPort)
+	}
+}
+
 func TestLoad_PlaidEnvVars(t *testing.T) {
 	vars := map[string]string{
 		"PLAID_CLIENT_ID": "test-client",

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -34,7 +34,7 @@ func Load() (*Config, error) {
 
 	cfg := &Config{
 		Environment:   env,
-		ServerPort:    getEnv("SERVER_PORT", "8080"),
+		ServerPort:    resolveServerPort(),
 		LogLevel:      os.Getenv("LOG_LEVEL"),
 		ConfigSources: make(map[string]string),
 	}
@@ -247,6 +247,22 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// resolveServerPort returns the HTTP listen port. Tries SERVER_PORT first
+// (the Breadbox-specific name), then PORT (the 12-factor convention used
+// by Heroku, Fly.io, Railway, Render, Cloud Run, and most PaaS hosts),
+// then defaults to 8080. The PORT fallback makes Breadbox deployable on
+// any PaaS that injects a runtime port without the user having to
+// translate it to SERVER_PORT.
+func resolveServerPort() string {
+	if v := os.Getenv("SERVER_PORT"); v != "" {
+		return v
+	}
+	if v := os.Getenv("PORT"); v != "" {
+		return v
+	}
+	return "8080"
 }
 
 func getEnvInt(key string, fallback int) int {


### PR DESCRIPTION
## Summary

Heroku, Fly.io, Railway, Render, Cloud Run, and most modern PaaS hosts inject `$PORT` (not `$SERVER_PORT`) into the container and expect the app to bind to it. Before this PR, Breadbox ignored `PORT` and stayed on its default 8080 — every PaaS deploy was broken until the user noticed and manually translated `PORT` into a `SERVER_PORT` override.

This is the foundation for Fly.io / Railway / Render deploy support (next PR). With this in, those platforms become a config-file-plus-button exercise, no per-platform code in the binary.

## Changes

### `internal/config/load.go`
Factor port resolution into `resolveServerPort()` that tries `SERVER_PORT` → `PORT` → `"8080"`. `SERVER_PORT` wins when both are set, so a user who explicitly chose a port doesn't get overridden by an environmentally-leaked `PORT`.

### `internal/config/config_test.go`
Four unit tests covering the matrix:
- `SERVER_PORT` only → wins (existing test)
- `PORT` only → wins (new)
- Both set → `SERVER_PORT` wins (new)
- Neither set → default `8080` (new)

### `deploy/install.sh`
When `--port=` wasn't passed and the shell has `PORT` exported, default `PORT_VALUE` to it with an info message:
```
:: Detected PORT=3000 in the environment (12-factor convention) — using as default.
```
Symmetric with the binary's behavior — lets users on PORT-exporting hosts run the installer without translating.

## Test plan

- [x] `go test ./internal/config/` — all 4 port tests pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `bash -n deploy/install.sh` clean

## Follow-up

A separate PR will add Fly.io-specific deploy assets (`fly.toml` template + walkthrough doc). Other platforms (Railway, Render, Coolify) are equally cheap to add now that the binary handles `PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)