### PR TITLE
feat(deploy): Fly.io + Railway one-click support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ account.
 Full install docs — binary download, Go source, manual Docker, daemon
 registration: **[docs.breadbox.sh/install](https://docs.breadbox.sh/install)**.
 
+### Or deploy to a managed platform
+
+- **[Fly.io](deploy/fly-deploy.md)** — `flyctl deploy` against the
+  [`fly.toml`](fly.toml) at the repo root. Managed Postgres + persistent
+  volumes. ~5 minutes.
+- **[Railway](deploy/railway-deploy.md)** — one-click "Deploy on
+  Railway" button; auto-attached Postgres add-on. ~3 minutes.
+
+Both work without extra config thanks to Breadbox's 12-factor `$PORT`
+handling — the platform-injected port flows through to the binary.
+
 ## CLI
 
 The same `breadbox` binary doubles as a `gh`-style CLI for driving any

--- a/deploy/fly-deploy.md
+++ b/deploy/fly-deploy.md
@@ -1,0 +1,177 @@
+# Deploy Breadbox to Fly.io
+
+This guide walks through deploying Breadbox to [Fly.io](https://fly.io)
+using the [`fly.toml`](../fly.toml) at the repo root. About 5 minutes
+assuming you already have a Fly account.
+
+**Prereqs**
+- `flyctl` installed → [install docs](https://fly.io/docs/flyctl/install/)
+- `flyctl auth login`
+
+## 1. Get fly.toml
+
+In an empty directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/canalesb93/breadbox/main/fly.toml \
+    -o fly.toml
+```
+
+(Or clone the whole repo if you'd rather work from a checkout —
+`fly.toml` is at the root so `flyctl` finds it automatically.)
+
+Edit:
+- `app = "breadbox"` — pick a globally-unique name (Fly will reject
+  duplicates)
+- `primary_region = "iad"` — pick the [Fly region](https://fly.io/docs/reference/regions/)
+  nearest you (`sjc`, `lhr`, `syd`, `gru`, etc.)
+
+## 2. Create the app + persistent volumes
+
+```bash
+# Creates the app from fly.toml without deploying yet.
+flyctl launch --no-deploy --copy-config
+
+# Persistent storage for agent transcripts and pg_dump backups.
+flyctl volumes create breadbox_transcripts --size 1
+flyctl volumes create breadbox_backups     --size 5
+```
+
+(Sizes are starting points; extend later with `flyctl volumes extend`.)
+
+## 3. Set up Postgres
+
+Pick one of these — Fly's managed offering is simplest, but any
+Postgres 16+ instance works.
+
+### Option A: Fly Managed Postgres (recommended)
+
+```bash
+flyctl mpg create --name breadbox-db
+flyctl mpg attach breadbox-db --app <your-breadbox-app>
+```
+
+`flyctl mpg attach` sets `DATABASE_URL` as a Fly secret automatically.
+
+### Option B: External (Neon, Supabase, RDS, …)
+
+Get your connection string from your provider, then:
+
+```bash
+flyctl secrets set DATABASE_URL='postgres://user:pass@host:5432/breadbox?sslmode=require'
+```
+
+Most managed Postgres providers require `sslmode=require` — include it.
+
+## 4. Set the encryption key
+
+```bash
+flyctl secrets set ENCRYPTION_KEY=$(openssl rand -hex 32)
+```
+
+> **Save this key.** It encrypts your bank-provider credentials at rest.
+> Losing it locks you out of stored Plaid / Teller tokens and you'd have
+> to re-link each connection.
+
+## 5. Deploy
+
+```bash
+flyctl deploy
+```
+
+Fly pulls `ghcr.io/canalesb93/breadbox:latest`, creates the machine,
+runs migrations on first boot, and starts Breadbox. Tail logs in another
+terminal:
+
+```bash
+flyctl logs
+```
+
+You should see lines like:
+```
+breadbox starting version=... addr=:PORT environment=docker
+```
+
+## 6. Create your admin account
+
+```bash
+open https://<your-app>.fly.dev/setup
+```
+
+Fill out the form, sign in, you're set. Visit `/connections` to link your
+first bank.
+
+## Updating
+
+```bash
+flyctl deploy
+```
+
+By default this re-pulls `ghcr.io/canalesb93/breadbox:latest`. To pin a
+specific release, edit `fly.toml`:
+
+```toml
+[build]
+  image = "ghcr.io/canalesb93/breadbox:v0.1.0"
+```
+
+Then `flyctl deploy` again. The admin dashboard shows an "update
+available" indicator in the sidebar when a newer GitHub release exists.
+
+## Custom domain
+
+```bash
+flyctl certs create breadbox.yourdomain.com
+# follow the CNAME / A record instructions Fly prints
+```
+
+## Cost notes
+
+- The default config (`auto_stop_machines = "off"`, `min_machines_running = 1`)
+  keeps one `shared-cpu-1x` / 512 MB machine running 24/7 so scheduled
+  syncs and the agent runtime can fire. Roughly **$2/month** at Fly's
+  shared-CPU pricing.
+- If you only use Breadbox interactively (MCP queries, no scheduled
+  syncs/agents), flip those in `fly.toml`:
+  ```toml
+  auto_stop_machines = "stop"
+  min_machines_running = 0
+  ```
+  Machines cold-start on the next HTTP request (~1–2 seconds).
+- Storage: transcripts + backups grow with usage. Defaults (1 GB + 5 GB)
+  cover modest household use; extend later if needed.
+
+## Troubleshooting
+
+**502 / "instance refused connection"**
+Usually a port mismatch. Breadbox listens on Fly's injected `$PORT`
+automatically; check that you didn't set `SERVER_PORT` as a secret
+(`flyctl secrets list`). If it's there, unset it:
+```bash
+flyctl secrets unset SERVER_PORT
+```
+
+**Health check failing**
+```bash
+flyctl logs --app <your-app>
+```
+The most common errors are an invalid `DATABASE_URL` or an
+`ENCRYPTION_KEY` that isn't 64 hex chars. Both are set as secrets, so
+`flyctl secrets list` shows what's there (values are hidden — verify by
+re-setting if unsure).
+
+**Migration error on first deploy**
+Fly's MPG sometimes takes a minute to be reachable after `mpg attach`.
+Re-run `flyctl deploy` after a minute, or check `flyctl logs db` if
+using an external Postgres.
+
+## Limitations
+
+- **Single instance only.** Breadbox's scheduler and agent runtime
+  aren't designed for multi-machine coordination. Keep `min_machines_running = 1`
+  unless you're certain.
+- **No multi-region.** Same reason — the scheduler would fire from each
+  region.
+- **Volume regions.** Fly volumes are region-pinned. If you change
+  `primary_region` later, you'll need to migrate the volumes
+  (`flyctl volumes fork` or recreate + restore).

--- a/deploy/railway-deploy.md
+++ b/deploy/railway-deploy.md
@@ -1,0 +1,136 @@
+# Deploy Breadbox to Railway
+
+[Railway](https://railway.com) builds Breadbox directly from this repo's
+Dockerfile, attaches a managed Postgres add-on, and gives you a public
+HTTPS URL. About 3 minutes end-to-end.
+
+## One-click deploy
+
+Click the button — Railway forks the repo, builds, and prompts you for
+the required secrets (`ENCRYPTION_KEY`). Postgres attaches automatically
+and exposes `DATABASE_URL` to the service.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https%3A%2F%2Fgithub.com%2Fcanalesb93%2Fbreadbox)
+
+After deploy:
+1. Open the service URL Railway prints (`*.up.railway.app`)
+2. Visit `/setup` to create your admin account
+3. Visit `/connections` to link your first bank
+
+## Manual deploy (full control)
+
+If you'd rather configure things yourself, or you want to use an
+existing project:
+
+### 1. Create a project from the repo
+
+```bash
+railway login
+railway init                # picks a name + creates the project
+railway link                # link this dir to that project
+```
+
+Or skip the CLI and click "New Project" → "Deploy from GitHub repo" in
+the Railway dashboard, then point it at `canalesb93/breadbox`.
+
+### 2. Add Postgres
+
+In the dashboard: **+ New** → **Database** → **Add PostgreSQL**.
+Railway sets `DATABASE_URL` automatically on the service.
+
+### 3. Set the encryption key
+
+```bash
+railway variables set ENCRYPTION_KEY=$(openssl rand -hex 32)
+```
+
+> **Save this key.** It encrypts your bank-provider credentials at rest.
+> Losing it locks you out of stored Plaid / Teller tokens.
+
+### 4. Deploy
+
+```bash
+railway up
+```
+
+Railway reads `deploy/railway.json` to find the Dockerfile + start
+command, builds the image, and exposes a public URL.
+
+### 5. Generate a public domain (one click)
+
+In the dashboard: **Settings** → **Networking** → **Generate Domain**.
+You get `*.up.railway.app`. Custom domains supported under the same
+panel.
+
+## Updating
+
+Railway auto-deploys on every push to the configured branch (default
+`main`). To pull a new upstream release:
+
+```bash
+git fetch upstream
+git merge upstream/main
+git push
+```
+
+Railway picks it up and redeploys. The admin dashboard shows an "update
+available" badge in the sidebar when a newer GitHub release exists.
+
+## Persistent storage
+
+Railway's default container filesystem is **ephemeral** — every deploy
+resets it. Breadbox writes two things to disk that you'll want to keep:
+
+- Agent NDJSON transcripts → `/app/transcripts`
+- Scheduled pg_dump backups → `/var/lib/breadbox/backups`
+
+Add a Railway Volume (dashboard: **Settings** → **Volumes** → **+ New
+Volume**) mounted at each path. Two volumes, ~1 GB and ~5 GB respectively
+are reasonable starting sizes for a household install.
+
+If you don't add volumes, the transcripts page in `/agents` will reset
+on every deploy and Settings → Backups will appear empty. Functionality
+is otherwise intact.
+
+## Cost notes
+
+- Railway's starter plan includes $5/month of usage. A small Breadbox
+  install (1 vCPU, 512 MB, plus Postgres at 1 GB storage) typically
+  fits inside that.
+- Scheduled syncs and the agent runtime require the service to stay
+  running. Railway doesn't auto-sleep by default, so cron / agent
+  schedules fire reliably.
+
+## Troubleshooting
+
+**Build fails with `sqlc: command not found`**
+The Dockerfile downloads sqlc inside the builder stage. If Railway's
+build cache is corrupted, click "Redeploy" with cache cleared.
+
+**Service crashes on startup with `failed to connect to db`**
+Make sure the Postgres add-on is **attached** to the service — in the
+dashboard, the service should list `DATABASE_URL` under Variables and
+the Postgres plugin should show the service as a connected client.
+
+**Health check fails**
+```bash
+railway logs
+```
+The most common cause is an invalid `ENCRYPTION_KEY` (must be 64 hex
+chars) or the Postgres add-on still spinning up. Re-deploy after a
+minute.
+
+**MCP / agent runtime not working**
+The bundled `breadbox-agent` sidecar is included in the multi-arch
+image — no extra Railway config needed. If agents fail, check
+`flyctl logs` style: it's almost always a missing Anthropic credential
+(set via the admin UI at `/agents`).
+
+## Limitations
+
+- **Single replica.** `numReplicas: 1` in `railway.json` — Breadbox's
+  scheduler isn't designed for multi-instance coordination. Don't
+  scale horizontally.
+- **Ephemeral filesystem by default.** Mount volumes (see above) for
+  transcripts and backups.
+- **No multi-region.** Same reason as the replica limit.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,71 @@
+# Breadbox on Fly.io
+#
+# Template fly.toml. Copy to your project root, edit the placeholders
+# below, then follow deploy/fly-deploy.md for the full walkthrough.
+#
+# Required edits:
+#   1. `app`            — pick a globally-unique name
+#   2. `primary_region` — your nearest Fly region (iad, sjc, lhr, syd…)
+#
+# Everything else is set up for a single-machine Breadbox install with
+# persistent volumes for transcripts + backups and HTTP health checks.
+
+app = "breadbox"
+primary_region = "iad"
+
+[build]
+  # Public multi-arch image from this repo's release workflow.
+  # To pin a release: change `:latest` to e.g. `:v0.1.0`.
+  image = "ghcr.io/canalesb93/breadbox:latest"
+
+[env]
+  ENVIRONMENT = "docker"
+  # SERVER_PORT is intentionally unset — Fly injects $PORT into the
+  # container, and Breadbox's 12-factor fallback (internal/config/load.go)
+  # picks it up automatically.
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+
+  # Breadbox runs scheduled syncs and the agent runtime, so the machine
+  # must stay running. If you only use Breadbox interactively (MCP queries,
+  # no scheduled syncs and no scheduled agents), you can flip these to
+  # save cost — auto_stop_machines = "stop", min_machines_running = 0.
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 200
+    soft_limit = 150
+
+[[http_service.checks]]
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "30s"
+  method = "GET"
+  path = "/health/ready"
+
+# Persistent storage. The breadbox container writes:
+#   - NDJSON agent-run transcripts to /app/transcripts
+#   - Scheduled pg_dump backups to /var/lib/breadbox/backups
+# Both should survive deploys. Create the volumes once before the first
+# deploy:
+#   flyctl volumes create breadbox_transcripts --region <primary_region> --size 1
+#   flyctl volumes create breadbox_backups     --region <primary_region> --size 5
+
+[[mounts]]
+  source = "breadbox_transcripts"
+  destination = "/app/transcripts"
+  initial_size = "1gb"
+
+[[mounts]]
+  source = "breadbox_backups"
+  destination = "/var/lib/breadbox/backups"
+  initial_size = "5gb"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "/app/breadbox migrate && /app/breadbox serve",
+    "healthcheckPath": "/health/ready",
+    "healthcheckTimeout": 60,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5,
+    "numReplicas": 1
+  }
+}


### PR DESCRIPTION
## Summary

Stack on the foundation laid in #1570 (12-factor `\$PORT` fallback) with two concrete deploy paths. Both work because the binary now picks up the platform-injected port automatically — zero per-platform code in the binary.

## Fly.io

- **`fly.toml`** at repo root — single-machine Breadbox running the public GHCR image, force_https, 30s `/health/ready` check, two persistent volumes (transcripts + backups). `auto_stop_machines = "off"` by default so scheduled syncs + agent runtime continue firing (~$2/mo on `shared-cpu-1x`); one-line cost-opt note for users who only use Breadbox interactively.
- **[`deploy/fly-deploy.md`](deploy/fly-deploy.md)** — ~5-minute walkthrough: copy fly.toml, create app + volumes, attach Postgres (Fly MPG or external), set `ENCRYPTION_KEY`, deploy, `/setup`. Also covers updates, custom domains, cost notes, and the common troubleshooting cases.

## Railway

- **`railway.json`** at repo root — Dockerfile builder + `startCommand` that includes the migrate step (the bare Dockerfile CMD is just `serve`, so migrate has to come from this config or the first deploy breaks). Healthcheck on `/health/ready`, restart-on-failure with 5 retries, single replica.
- **[`deploy/railway-deploy.md`](deploy/railway-deploy.md)** — walkthrough with the one-click "Deploy on Railway" button as the primary path, manual deploy as fallback. Calls out Railway's ephemeral filesystem and recommends Railway Volumes for `/app/transcripts` + `/var/lib/breadbox/backups`.

## Why root-level config files

Both `flyctl` and Railway's auto-detect look at the **repo root**:
- `flyctl launch --from <repo>` clones into pwd and reads `fly.toml` there
- Railway's one-click template clones the repo and looks for `railway.json` at the root

Placing these in `deploy/` would silently fall through to auto-detect mode — which skips the migrate-then-serve startCommand override (Dockerfile's `CMD` is `breadbox serve` only) and breaks first deploys. Root-level placement is the standard convention for deploy-friendly projects (Plausible, Umami, Mealie all do this).

## README

Adds a "Or deploy to a managed platform" subsection under Quick start pointing at both walkthroughs. One sentence per platform.

## Test plan

- [x] `python3 -c "import json; json.loads(open('railway.json').read())"` — JSON valid
- [x] `fly.toml` reviewed against Fly's [reference docs](https://fly.io/docs/reference/configuration/) — syntax + keys check out
- [x] README links resolve
- [ ] **End-to-end test deferred** — requires actual Fly.io / Railway accounts to validate the walkthrough; primary risk is the Fly MPG attach flow (their CLI changed names in 2026)

## Follow-up candidates (not in this PR)

- Render (`render.yaml` blueprint) — same shape, third 12-factor PaaS
- Coolify (1-paragraph doc) — homelab favorite, our compose works as-is
- Unraid Community Apps (XML template) — homelab marketplace, larger surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)