### PR TITLE
fix(onboarding): redirect post-setup to /setup/save-key

### DIFF
--- a/internal/admin/setup.go
+++ b/internal/admin/setup.go
@@ -84,17 +84,20 @@ func CreateAdminHandler(a *app.App, sm *scs.SessionManager, _ *TemplateRenderer)
 			return
 		}
 
-		// Auto-login the freshly created admin so we can land them
-		// directly on the Getting Started guide. Browsers still see the
-		// password field in the submitted form, so password-manager
-		// save prompts continue to work without a separate /login step.
+		// Auto-login the freshly created admin and land them on the
+		// one-time encryption-key reveal. SaveKeyHandler falls through
+		// to /getting-started when the key isn't in env or has already
+		// been acknowledged, so this is safe in all configurations.
+		// Browsers still see the password field in the submitted form,
+		// so password-manager save prompts continue to work without a
+		// separate /login step.
 		if err := sm.RenewToken(ctx); err != nil {
 			a.Logger.Error("setup: renew session token", "error", err)
 			http.Redirect(w, r, "/login", http.StatusSeeOther)
 			return
 		}
 		SetLoginSessionKeys(ctx, sm, account, a.Queries)
-		http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
+		http.Redirect(w, r, "/setup/save-key", http.StatusSeeOther)
 	}
 }
 


### PR DESCRIPTION
## Summary

The one-time encryption-key reveal at `/setup/save-key` was an orphaned route — nothing in the post-install flow linked or redirected to it, so a fresh `install.sh` deploy generated `ENCRYPTION_KEY` silently into `.env` and the admin never saw it on screen.

## How it got orphaned

- **#1506** added the reveal page **and** a soft hint banner on `/getting-started`. The final polish commit in that same PR dropped the banner (rationale: "they've either already saved the key or can find their way back via the documentation" — which left the route discoverable from nowhere).
- **#1559** then flipped post-`/setup` from `/login` → auto-login + redirect to `/getting-started`, blowing past the place the banner used to live.

Result: `/setup/save-key` renders fine if you type the URL, but the install flow never sends anyone there.

## Fix

Redirect post-setup directly to `/setup/save-key` instead of `/getting-started` (`internal/admin/setup.go`). `SaveKeyHandler` already redirects to `/getting-started` when:

- `ENCRYPTION_KEY` isn't in env (nothing to reveal), or
- `encryption_key_acknowledged_at` is already stamped (one-time gate).

So this is safe in all configurations — install.sh deploys see the reveal page, `breadbox doctor` re-runs and existing setups fall straight through to the guide. After the admin clicks "I've saved it — continue" the existing handler still lands them on `/getting-started`, so #1559's UX goal is preserved.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./internal/admin/...` clean
- [ ] Fresh `install.sh` → `/setup` → submit admin form lands on `/setup/save-key` with the env key revealed
- [ ] Clicking "Continue" on `/setup/save-key` stamps acknowledgment and redirects to `/getting-started`
- [ ] Second visit to `/setup` (admin already exists) still redirects to `/` (unchanged)
- [ ] Existing installs where the key is already acknowledged: any flow that touches `/setup/save-key` falls through to `/getting-started`

🤖 Generated with [Claude Code](https://claude.com/claude-code)