### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -206,7 +206,7 @@ func (s *MCPServer) resolveTransportID(req *mcpsdk.CallToolRequest) string {
 // mcp_sessions row's api_key_id + api_key_name on first call, and
 // those columns never re-stamp. Rebinding after the session row is
 // created would permanently record the wrong key for every session.
-func (s *MCPServer) rebindActorFromClientInfo(ctx context.Context, req *mcpsdk.CallToolRequest, transportID string) context.Context {
+func (s *MCPServer) rebindActorFromClientInfo(ctx context.Context, req *mcpsdk.CallToolRequest) context.Context {
 	if req == nil || req.Session == nil {
 		return ctx
 	}
@@ -215,9 +215,10 @@ func (s *MCPServer) rebindActorFromClientInfo(ctx context.Context, req *mcpsdk.C
 		return ctx
 	}
 	transport := "stdio"
-	if id := req.Session.ID(); id != "" && id != transportID {
-		// HTTP sessions advertise their MCP-Session-Id; stdio falls
-		// back to the per-process transport id we stamped ourselves.
+	if req.Session.ID() != "" {
+		// HTTP sessions advertise their MCP-Session-Id; stdio has
+		// none and falls back to the per-process transport id we
+		// stamped ourselves.
 		transport = "http"
 	}
 	clientInfo := service.MCPClientInfo{
@@ -501,7 +502,7 @@ func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcps
 				// and mcp_sessions.api_key_name on first call, and those
 				// columns are write-once. Doing this swap after would
 				// permanently record the wrong key for every session.
-				ctx = s.rebindActorFromClientInfo(ctx, req, transportID)
+				ctx = s.rebindActorFromClientInfo(ctx, req)
 
 				auditSessionID := s.ensureAuditSession(ctx, req, transportID)
 


### PR DESCRIPTION
## Summary

Daily simplify-drift review of PRs merged in the last 24 hours. One real bug surfaced in the MCP per-client identity work shipped in #1561.

## PRs reviewed

- #1560 — fix(feed): stop rendering system actors as humanoid DiceBear
- #1561 — feat(mcp): per-client agent identity for stdio MCP
- #1562 — Add CSS for agent run detail page (prose, JSON viewer, chat thread)
- #1563 — chore(release): prep for v0.1.0
- #1564 — fix(install): dash compatibility + /dev/tty prompts + uninstall docs
- #1565 — fix(install): banner color escape parsing + uninstall volume list
- #1566 — docs(readme): full-res screenshots + CLI section + concise "What it is"
- #1567 — feat(cli): ship breadbox-cli lite binaries + install path for remote use
- #1568 — fix(install): make systemd-unit warning teach the correct sudo pattern
- #1569 — feat(install): foolproofing — port prompt, pre-flight checks, secret-redacted log dumps
- #1570 — feat(config): fall back to $PORT for 12-factor PaaS compatibility
- #1571 — feat(deploy): Fly.io + Railway one-click support
- #1572 — feat(install): friendlier fresh-install UX — drop scary doctor handoff, platform-aware URL
- #1573 — fix(onboarding): redirect post-setup to /setup/save-key
- #1574 — feat(install): detect Fly/Railway/Render/Codespaces, smarter prompts, platform-reachability check
- #1575 — fix(install): code-review feedback — trim verbosity, drop dead-code, fix reachability, doc Railway Postgres-first

## Changes

- `internal/mcp/server.go:218` — fix HTTP-vs-stdio transport detection in `rebindActorFromClientInfo`. `resolveTransportID` returns `req.Session.ID()` for HTTP, so the guard `id != "" && id != transportID` short-circuited false on every HTTP call — `transport` stayed `"stdio"` and HTTP clients fingerprinted alongside stdio ones, defeating the per-`(label, host, transport)` partitioning documented in `MCPClientFingerprint`. Detect HTTP by `req.Session.ID() != ""` directly (empty on stdio, non-empty on Streamable HTTP) and drop the now-unused `transportID` parameter from the function signature + its single caller in `makeToolDefLogged`.

The rest of the diff in the reviewed PRs was either justified (legacy `bb_stdio_singleton` prefix kept in `ensureLocalMCPFallbackKey` for migration back-compat; system-actor templ duplication across `feedActorTile`/`feedCommentActor`/`txdActor`/`txdCommentActor` with different input types) or cosmetic noise too small to be worth touching (`pgconv.TextIfNotEmpty` on values that are guaranteed non-empty after their preceding fallback). The bulk of the 24h merges was install-script polish — out of scope for go-tooling review.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — packages touched by the recent PRs (`mcp`, `service`, `admin`, `cli`, `config`) all pass. One unrelated pre-existing failure in `internal/agent/sidecar_processgroup_test.go::TestSidecarRun_ProcessGroupReapsGrandchild` reproduces on stock main in this container (process-group reaping doesn't work fully under the cloud sandbox).

https://claude.ai/code/session_01Dwt6hFLbwGUmWw4Bjt1BMr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dwt6hFLbwGUmWw4Bjt1BMr)_