### PR TITLE
docs(openapi): describe every tag and wire Mintlify rebuild trigger

### DIFF
--- a/.github/workflows/trigger-docs-rebuild.yml
+++ b/.github/workflows/trigger-docs-rebuild.yml
@@ -1,0 +1,31 @@
+name: Trigger docs rebuild
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "openapi.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: trigger-docs-rebuild
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Mintlify deployment
+        env:
+          MINTLIFY_API_KEY: ${{ secrets.MINTLIFY_API_KEY }}
+          MINTLIFY_PROJECT_ID: ${{ secrets.MINTLIFY_PROJECT_ID }}
+        run: |
+          if [ -z "$MINTLIFY_API_KEY" ] || [ -z "$MINTLIFY_PROJECT_ID" ]; then
+            echo "::error::MINTLIFY_API_KEY and MINTLIFY_PROJECT_ID secrets are required."
+            exit 1
+          fi
+          curl -fsSL -X POST "https://api.mintlify.com/v1/project/update/$MINTLIFY_PROJECT_ID" \
+            -H "Authorization: Bearer $MINTLIFY_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"trigger":"openapi-spec-changed"}'
+          echo "Mintlify rebuild queued."

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -65,20 +65,40 @@ tags:
     description: Liveness and readiness probes. No authentication.
   - name: Version
     description: Server version metadata.
+  - name: Auth
+    description: Device-code grant and the unauthenticated headless bootstrap probe.
   - name: Accounts
+    description: Household bank accounts synced from providers.
   - name: Transactions
+    description: Cursor-paginated transactions, counts, summaries, and merchant rollups.
   - name: Comments
+    description: Conversation comments attached to a transaction.
   - name: Annotations
+    description: Activity-timeline events for a transaction (category changes, comments, tags, system events).
   - name: Tags
+    description: Free-form labels applied to transactions.
   - name: Categories
+    description: Two-level category tree, import/export, and merges.
   - name: Connections
+    description: Bank-side links (Plaid items, Teller enrollments, CSV-import buckets) and the hosted-link page that mints them.
   - name: Sync
+    description: Manual sync triggers, sync history, and per-provider health.
   - name: Rules
+    description: Categorization rule engine with retroactive apply and preview.
   - name: Account Links
+    description: Dependent-to-primary reconciliation links and transaction match management.
   - name: Reports
+    description: Agent-submitted reports and the household read/unread state.
   - name: Users
+    description: Household members and the login accounts attached to them.
   - name: API Keys
+    description: Scoped credentials for REST and MCP clients.
   - name: Settings
+    description: Provider credentials and other app-config knobs.
+  - name: Agents
+    description: Scheduled Claude Agent SDK definitions, run history, transcripts, and prompt blocks.
+  - name: Webhooks
+    description: Stored webhook events and on-demand replay.
 
 paths:
   # -- Health & version (no auth) --


### PR DESCRIPTION
## Summary

- Adds descriptions to every tag in `openapi.yaml`, including the previously-missing `Auth`, `Agents`, and `Webhooks` tags that operations were already referencing. Mintlify uses these descriptions to label the auto-generated API Reference sidebar.
- Adds a tiny GitHub Actions workflow that fires the Mintlify deploy API whenever `openapi.yaml` changes on `main`, so the docs site at https://docs.breadbox.sh stays in sync without manual intervention.

Pairs with canalesb93/breadbox-docs PR that wires `docs.json` to consume this spec.

## Setup needed

The trigger workflow needs two repo secrets:
- `MINTLIFY_API_KEY` — from the Mintlify dashboard
- `MINTLIFY_PROJECT_ID` — the breadbox-docs project ID

Until those are populated the workflow logs an error and exits non-zero; nothing else breaks.

## Test plan

- [ ] CI passes (no Go changes — only YAML + the doc spec).
- [ ] After secrets are populated, push a no-op edit to `openapi.yaml` on `main` and confirm the workflow fires and the docs rebuild is queued in the Mintlify dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)