### PR TITLE
fix(apikeys): default actor_type to user, not agent

### DIFF
--- a/internal/api/api_keys.go
+++ b/internal/api/api_keys.go
@@ -58,7 +58,7 @@ func CreateAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 		if req.ActorType == "" {
-			req.ActorType = "agent"
+			req.ActorType = "user"
 		}
 		if req.ActorType != "user" && req.ActorType != "agent" && req.ActorType != "system" {
 			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "actor_type must be user, agent, or system")

--- a/internal/api/keys_me_integration_test.go
+++ b/internal/api/keys_me_integration_test.go
@@ -50,11 +50,12 @@ func TestWhoami_ReturnsCallerIdentity(t *testing.T) {
 	if got.Scope != "full_access" {
 		t.Errorf("Scope = %q want full_access", got.Scope)
 	}
-	// The legacy CreateAPIKeyLegacy call used by setupTestEnv defaults
-	// actor_type to "agent" (per the new schema default), so this row
-	// should report the default.
-	if got.ActorType != "agent" {
-		t.Errorf("ActorType = %q want agent (default)", got.ActorType)
+	// CreateAPIKeyLegacy (used by setupTestEnv) defaults actor_type to
+	// "user" — the safe default for human-driven entry points. Agent
+	// runtime keys opt in explicitly so the startup
+	// CleanupOrphanedAgentApiKeys sweep doesn't reap dashboard keys.
+	if got.ActorType != "user" {
+		t.Errorf("ActorType = %q want user (default)", got.ActorType)
 	}
 	if got.ID == "" {
 		t.Error("ID is empty")

--- a/internal/api/transactions_lifecycle_integration_test.go
+++ b/internal/api/transactions_lifecycle_integration_test.go
@@ -51,8 +51,8 @@ func TestDeleteTransaction_SoftDeletes(t *testing.T) {
 	if len(annots) != 1 {
 		t.Fatalf("want 1 transaction_deleted annotation, got %d", len(annots))
 	}
-	if annots[0].ActorType != "agent" {
-		t.Fatalf("want actor_type=agent, got %q", annots[0].ActorType)
+	if annots[0].ActorType != "user" {
+		t.Fatalf("want actor_type=user, got %q", annots[0].ActorType)
 	}
 }
 

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -20,13 +20,17 @@ import (
 const base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 // CreateAPIKeyParams collects the inputs for minting a new API key. Actor
-// fields default to `agent` when omitted so existing callers keep their
-// behavior. CLI's `auth bootstrap` passes `user`, the stdio bootstrap passes
-// `system` (see ensureStdioSystemKey).
+// fields default to `user` when omitted — the safe default for any
+// human-driven entry point (admin dashboard form, REST `POST
+// /api/v1/api-keys`, OAuth client mint). Agent runtime keys are short-lived
+// and must opt in explicitly with `ActorType: "agent"` (see
+// `MintRunAPIKey`); otherwise the startup
+// `CleanupOrphanedAgentApiKeys` sweep silently revokes them after 1 hour.
+// The stdio bootstrap passes `system` (see ensureStdioSystemKey).
 type CreateAPIKeyParams struct {
 	Name      string
 	Scope     string
-	ActorType string // "user" | "agent" | "system"; defaults to "agent"
+	ActorType string // "user" | "agent" | "system"; defaults to "user"
 	ActorName string // optional display name, falls back to Name
 }
 
@@ -44,7 +48,7 @@ func (s *Service) CreateAPIKey(ctx context.Context, p CreateAPIKeyParams) (*Crea
 	}
 	actorType := p.ActorType
 	if actorType == "" {
-		actorType = "agent"
+		actorType = "user"
 	}
 	if actorType != "user" && actorType != "agent" && actorType != "system" {
 		return nil, fmt.Errorf("invalid actor_type: %s", actorType)

--- a/internal/service/apikeys_actor_integration_test.go
+++ b/internal/service/apikeys_actor_integration_test.go
@@ -25,7 +25,11 @@ func TestCreateAPIKey_StoresActorColumns(t *testing.T) {
 		actorType string
 		actorName string
 	}{
-		{"agent default", "", ""},
+		// Empty ActorType defaults to "user" — the safe default for
+		// human-facing entry points (dashboard, REST). Agent runtime keys
+		// must opt in explicitly so the startup CleanupOrphanedAgentApiKeys
+		// sweep doesn't reap user keys after the 1-hour grace.
+		{"user default", "", ""},
 		{"explicit agent", "agent", "bot-alpha"},
 		{"user actor", "user", "ricardo"},
 		{"system actor", "system", "stdio"},
@@ -43,7 +47,7 @@ func TestCreateAPIKey_StoresActorColumns(t *testing.T) {
 			}
 			wantType := tc.actorType
 			if wantType == "" {
-				wantType = "agent"
+				wantType = "user"
 			}
 			if got.ActorType != wantType {
 				t.Errorf("ActorType = %q want %q", got.ActorType, wantType)

--- a/internal/service/comments_apikeys_integration_test.go
+++ b/internal/service/comments_apikeys_integration_test.go
@@ -412,6 +412,97 @@ func TestCreateAPIKey_DefaultScope(t *testing.T) {
 	}
 }
 
+// TestCreateAPIKey_DefaultActorTypeIsUser locks in the post-fix default:
+// callers that don't set ActorType (admin dashboard form, OAuth client mint,
+// REST POST /api/v1/api-keys without an explicit body field) get
+// actor_type='user', not 'agent'. Regression for the bug where the silent
+// 'agent' default caused dashboard-created keys to be reaped by the startup
+// CleanupOrphanedAgentApiKeys sweep on every server restart.
+func TestCreateAPIKey_DefaultActorTypeIsUser(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// CreateAPIKeyLegacy — the entry point the admin dashboard uses.
+	legacy, err := svc.CreateAPIKeyLegacy(ctx, "dashboard-key", "full_access")
+	if err != nil {
+		t.Fatalf("CreateAPIKeyLegacy failed: %v", err)
+	}
+	if legacy.ActorType != "user" {
+		t.Errorf("CreateAPIKeyLegacy actor_type = %q, want %q", legacy.ActorType, "user")
+	}
+
+	// CreateAPIKey with an empty ActorType — the REST handler's path when the
+	// request body omits actor_type.
+	implicit, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+		Name:  "rest-key",
+		Scope: "full_access",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey failed: %v", err)
+	}
+	if implicit.ActorType != "user" {
+		t.Errorf("CreateAPIKey (empty ActorType) actor_type = %q, want %q", implicit.ActorType, "user")
+	}
+
+	// Explicit ActorType="agent" still works — orchestrator must keep minting
+	// short-lived agent keys.
+	explicit, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+		Name:      "agent-key",
+		Scope:     "full_access",
+		ActorType: "agent",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey(agent) failed: %v", err)
+	}
+	if explicit.ActorType != "agent" {
+		t.Errorf("CreateAPIKey(ActorType=agent) actor_type = %q, want %q", explicit.ActorType, "agent")
+	}
+}
+
+// TestCreateAPIKey_LegacyKeyNotReapedByOrphanCleanup is the end-to-end
+// regression for the dev-VM symptom: a key minted via the dashboard path,
+// aged past the 1-hour grace window, must survive a startup
+// CleanupOrphanedAgentApiKeys sweep.
+func TestCreateAPIKey_LegacyKeyNotReapedByOrphanCleanup(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	result, err := svc.CreateAPIKeyLegacy(ctx, "long-lived-dashboard-key", "full_access")
+	if err != nil {
+		t.Fatalf("CreateAPIKeyLegacy: %v", err)
+	}
+
+	// Age the key past the cleanup's 1-hour grace.
+	if _, err := pool.Exec(ctx,
+		"UPDATE api_keys SET created_at = NOW() - INTERVAL '2 hours' WHERE id = $1::uuid",
+		result.ID,
+	); err != nil {
+		t.Fatalf("age key: %v", err)
+	}
+
+	if _, err := queries.CleanupOrphanedAgentApiKeys(ctx); err != nil {
+		t.Fatalf("CleanupOrphanedAgentApiKeys: %v", err)
+	}
+
+	keys, err := svc.ListAPIKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	var found *service.APIKeyResponse
+	for i := range keys {
+		if keys[i].ID == result.ID {
+			found = &keys[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("dashboard key %q missing from ListAPIKeys", result.ID)
+	}
+	if found.RevokedAt != nil {
+		t.Fatalf("dashboard key was revoked by orphan cleanup; revoked_at = %q", *found.RevokedAt)
+	}
+}
+
 func TestCreateAPIKey_ReadOnlyScope(t *testing.T) {
 	svc, _, _ := newService(t)
 	ctx := context.Background()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2295,6 +2295,17 @@ paths:
               properties:
                 name: { type: string }
                 scope: { type: string, enum: [full_access, read_only] }
+                actor_type:
+                  type: string
+                  enum: [user, agent, system]
+                  default: user
+                  description: |
+                    Attribution category. Defaults to `user` for human-driven
+                    integrations. `agent` keys are short-lived runtime
+                    credentials minted by the agent orchestrator and are
+                    auto-revoked after 1 hour by the startup cleanup sweep —
+                    do not request `agent` for long-lived integrations.
+                actor_name: { type: string, nullable: true }
       responses:
         "201":
           description: Created key (plaintext returned once).


### PR DESCRIPTION
## Summary

- The admin dashboard "Create API key" form (via `CreateAPIKeyLegacy`) and `POST /api/v1/api-keys` without an explicit `actor_type` body field both fell through to a silent `actor_type='agent'` default in `service.CreateAPIKey`.
- The startup `CleanupOrphanedAgentApiKeys` sweep (`internal/cli/serve.go:150`) then revoked any `actor_type='agent'` key older than 1 hour — wiping every dashboard-created key on each server restart.
- On `breadbox.exe.xyz`, where `main` auto-deploys on push, this surfaced as "all my API keys are getting auto-revoked."

## The fix

Flip the silent default to `"user"` in:

- `internal/service/apikeys.go` — the service-layer default (and `CreateAPIKeyLegacy`, which inherits it).
- `internal/api/api_keys.go` — `POST /api/v1/api-keys` when the body omits `actor_type`.

Agent runtime keys are still minted via `service.MintRunAPIKey` (`internal/service/agents.go:1077`), which passes `ActorType: "agent"` explicitly — those keep the short-lived semantics the orphan sweep was designed for. Every other legitimate caller (`cli/init.go`, `cli/auth_bootstrap_full.go`, `service/device_codes.go`) already passes `"user"` explicitly, so no caller actually relied on the silent agent default.

Also documents `actor_type` (with the new `user` default and a note about agent reaping) on the OpenAPI request schema — previously the body schema didn't mention the field at all.

## Regression coverage

- New `TestCreateAPIKey_DefaultActorTypeIsUser` (`internal/service/comments_apikeys_integration_test.go`) — asserts both `CreateAPIKeyLegacy` and `CreateAPIKey{}` produce `actor_type='user'`, and that an explicit `ActorType: "agent"` still works.
- New `TestCreateAPIKey_LegacyKeyNotReapedByOrphanCleanup` — end-to-end: mint via `CreateAPIKeyLegacy`, age past the 1-hour grace, run `CleanupOrphanedAgentApiKeys`, assert the key is still alive.
- Updated `TestCreateAPIKey_StoresActorColumns` and `TestWhoami_ReturnsCallerIdentity` — both documented the buggy default as the expected behavior.
- Updated `TestDeleteTransaction_SoftDeletes` — the annotation row now correctly attributes the deletion to `actor_type='user'` (the test env's API key).

## Operational note

Existing dashboard keys on `breadbox.exe.xyz` are already revoked and cannot be un-revoked by this fix — you'll need to mint new ones after deploy. They'll stick this time.

## Test plan

- [x] `make sqlc && templ generate`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `DATABASE_URL=… go test -tags integration -count=1 -p 1 ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)