### PR TITLE
fix(openapi): merge duplicate /api/v1/agents/runs/{shortId} entries

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2496,9 +2496,6 @@ paths:
           content:
             application/json:
               schema: { type: object, additionalProperties: true }
-  /api/v1/agents/runs/{shortId}:
-    parameters:
-      - { name: shortId, in: path, required: true, schema: { type: string } }
     patch:
       tags: [Agents]
       summary: Set or clear the operator note on a run


### PR DESCRIPTION
## Summary

- `openapi.yaml` declared `/api/v1/agents/runs/{shortId}` twice — once with `GET` (run detail), once with `PATCH` (operator note) — which is invalid YAML (duplicate mapping key).
- Merged both operations under a single path entry. Operation IDs, parameters, request/response shapes are unchanged, so consumers see the same surface.
- Caught by Mintlify's OpenAPI ingestion in [breadbox-docs#53](https://github.com/canalesb93/breadbox-docs/pull/53), which deploys the auto-generated API Reference from this spec.

Without this fix, Mintlify cannot render the agent-run endpoints and the docs deployment fails strict validation with `duplicated mapping key (2499:3)`.

## Test plan

- [ ] CI green
- [ ] After merge, the `Trigger docs rebuild` workflow fires
- [ ] breadbox-docs#53 Mintlify deploy check turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)