### PR TITLE
fix(openapi): quote descriptions containing colon-space pairs

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3134,7 +3134,7 @@ components:
         action: { type: string, enum: [link, relink] }
         connection_id:
           type: string
-          description: Present only for `action: "relink"` — the connection being re-authenticated.
+          description: 'Present only for `action: "relink"` — the connection being re-authenticated.'
         single_use: { type: boolean }
         redirect_url:
           type: string
@@ -3147,10 +3147,10 @@ components:
           enum: [pending, active, completed, failed, expired, consumed]
         error_code:
           type: string
-          description: Present only on `status: "failed"`.
+          description: 'Present only on `status: "failed"`.'
         error_message:
           type: string
-          description: Present only on `status: "failed"`.
+          description: 'Present only on `status: "failed"`.'
         result_connection_ids:
           type: array
           items: { type: string }


### PR DESCRIPTION
## Summary

- Three property descriptions in `openapi.yaml` contained the YAML mapping-value delimiter `: ` inside unquoted scalars (e.g. `description: Present only on \`status: "failed"\`.`). YAML parsers treat the embedded `: ` as the start of a nested mapping, which makes the spec invalid.
- Wrapped each affected description in single quotes. No semantic change — same text reaches consumers.
- Caught after [breadbox#1579](https://github.com/canalesb93/breadbox/pull/1579) (the duplicate-path fix) unblocked the parser past line 2499, exposing this second parse error at line 3137.
- Final blocker for [breadbox-docs#53](https://github.com/canalesb93/breadbox-docs/pull/53)'s Mintlify deploy. Verified locally with \`yq '.paths | keys | length'\` → returns 112 cleanly.

## Test plan

- [ ] CI green
- [ ] After merge, the `Trigger docs rebuild` workflow fires
- [ ] breadbox-docs#53 Mintlify deploy check turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)