### PR TITLE
feat(config): consolidate persistent data under BB_DATA_DIR (/var/lib/breadbox in Docker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **MCP tool `list_annotations`** now wraps its response in a `{ "annotations": [...] }` envelope. The previous bare-array shape failed client-side schema validation on clients that strictly enforce the MCP spec — `structuredContent` is required to be a JSON record, not an array. The new envelope matches every other list tool (`list_accounts`, `list_categories`, `list_tags`, …) and the REST `/transactions/{id}/annotations` endpoint.
 
+### Changed
+
+- **Persistent runtime data now lives under a single root.** Agent NDJSON transcripts and scheduled pg_dump backups both default to subdirectories of `BB_DATA_DIR` (resolves to `/var/lib/breadbox` when `ENVIRONMENT=docker`, empty for local dev so cwd-relative defaults still apply). One Docker / Fly / Railway volume mount at `/var/lib/breadbox` covers both; the per-subsystem env vars (`BACKUP_DIR`, `BREADBOX_AGENT_TRANSCRIPT_DIR`) still override.
+
+  This is a soft-breaking change for self-hosters running this repo's `docker-compose.prod.yml`. Old layout: two named volumes `breadbox_transcripts:/app/transcripts` + `breadbox_backups:/var/lib/breadbox/backups`. New layout: one volume `breadbox_data:/var/lib/breadbox`. Compose, `fly.toml`, and `deploy/install.sh` are all updated. **To migrate existing data on Docker installs** (steps run from the install dir):
+
+  ```bash
+  # 1. Stop the stack so files quiesce.
+  docker compose down
+
+  # 2. Copy transcripts from the old volume to the new layout. The
+  #    helper container has both volumes mounted side by side.
+  docker run --rm \
+    -v ${PWD##*/}_breadbox_transcripts:/old \
+    -v ${PWD##*/}_breadbox_data:/new \
+    alpine sh -c 'mkdir -p /new/transcripts && cp -a /old/. /new/transcripts/'
+
+  # 3. Copy backups likewise.
+  docker run --rm \
+    -v ${PWD##*/}_breadbox_backups:/old \
+    -v ${PWD##*/}_breadbox_data:/new \
+    alpine sh -c 'mkdir -p /new/backups && cp -a /old/. /new/backups/'
+
+  # 4. Bring the stack back up against the new compose.
+  docker compose up -d
+
+  # 5. After verifying Settings → Agents shows old transcripts and
+  #    Settings → Backups shows old backup files, drop the orphan volumes.
+  docker volume rm ${PWD##*/}_breadbox_transcripts ${PWD##*/}_breadbox_backups
+  ```
+
+  Skipping the migration leaves prior transcripts and backups stranded on the old volumes — Breadbox still works, but old data is invisible until copied over. Fresh installs are unaffected.
+
 ### Added
 
 - **`breadbox agent test` CLI** for diagnosing the agent subsystem end-to-end: verifies auth is configured, sidecar binary is discoverable, and a tiny "say OK" prompt round-trips through the SDK. Exit code 3 = no auth, 5 = no binary.

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -13,23 +13,17 @@ services:
       db:
         condition: service_healthy
     volumes:
-      # Agent NDJSON transcripts are written to /app/transcripts inside
-      # the container (see app_config key agent.transcript_dir, default
-      # "transcripts/agents"). Without this named volume, every
-      # `docker compose up -d` recreates the container and silently
-      # wipes the transcript history — the admin "open transcript" link
-      # then 404s for every prior run. Keep this mount even if you
-      # don't use the agents feature; the directory is empty until an
-      # agent runs.
-      - breadbox_transcripts:/app/transcripts
-      # Scheduled pg_dump backups are written to /var/lib/breadbox/backups
-      # when ENVIRONMENT=docker (see internal/cli/serve.go). Without this
-      # named volume, files live in the container's writable layer and
-      # every `docker compose up -d` wipes them — Settings → Backups
-      # then shows an empty list after every redeploy. Keep this mount
-      # even if you haven't enabled a schedule yet; the directory is
-      # empty until a backup runs.
-      - breadbox_backups:/var/lib/breadbox/backups
+      # Persistent runtime data root. In ENVIRONMENT=docker the binary
+      # defaults BB_DATA_DIR to /var/lib/breadbox; agent NDJSON
+      # transcripts land at /var/lib/breadbox/transcripts/agents and
+      # scheduled pg_dump backups at /var/lib/breadbox/backups. One
+      # named volume covers both. Without it, every `docker compose
+      # up -d` recreates the container and silently wipes transcript
+      # history (admin "open transcript" → 404 for prior runs) and
+      # the backups list (Settings → Backups → empty after redeploy).
+      # Keep this mount even if you use neither feature — the
+      # directories are created on demand.
+      - breadbox_data:/var/lib/breadbox
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:${SERVER_PORT:-8080}/health/ready"]
       interval: 30s
@@ -85,7 +79,6 @@ services:
 
 volumes:
   postgres_data:
-  breadbox_transcripts:
-  breadbox_backups:
+  breadbox_data:
   caddy_data:
   caddy_config:

--- a/deploy/fly-deploy.md
+++ b/deploy/fly-deploy.md
@@ -33,11 +33,14 @@ Edit:
 flyctl launch --no-deploy --copy-config
 
 # Persistent storage for agent transcripts and pg_dump backups.
-flyctl volumes create breadbox_transcripts --size 1
-flyctl volumes create breadbox_backups     --size 5
+# Both live under /var/lib/breadbox (set automatically when
+# ENVIRONMENT=docker), so one volume covers both.
+flyctl volumes create breadbox_data --size 6
 ```
 
-(Sizes are starting points; extend later with `flyctl volumes extend`.)
+(Size is a starting point — ~5 GB of backups + ~1 GB of transcripts
+covers a typical household install. Extend later with
+`flyctl volumes extend`.)
 
 ## 3. Set up Postgres
 
@@ -138,8 +141,8 @@ flyctl certs create breadbox.yourdomain.com
   min_machines_running = 0
   ```
   Machines cold-start on the next HTTP request (~1–2 seconds).
-- Storage: transcripts + backups grow with usage. Defaults (1 GB + 5 GB)
-  cover modest household use; extend later if needed.
+- Storage: transcripts + backups share one 6 GB volume by default;
+  extend later with `flyctl volumes extend` if needed.
 
 ## Troubleshooting
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -146,7 +146,7 @@ do_uninstall() {
     printf "  ${INSTALL_DIR}/.env\n"
     printf "  ${INSTALL_DIR}/.breadbox-version\n"
     printf "\n"
-    printf "${YELLOW}Docker volumes (postgres, transcripts, backups, and caddy if used) are NOT removed.${NC}\n"
+    printf "${YELLOW}Docker volumes (postgres, breadbox data, and caddy if used) are NOT removed.${NC}\n"
     printf "To remove all breadbox volumes (DESTROYS data):\n"
     printf "  docker volume rm \$(docker volume ls -q | grep breadbox)\n"
     printf "\n"
@@ -485,7 +485,7 @@ for arg in "$@"; do
             printf "  --port=N               HTTP port to listen on (default: 8080)\n"
             printf "  --version=vX.Y.Z       Pin to a specific release tag (default: latest GitHub release)\n"
             printf "  --no-start             Write the install but don't 'docker compose up' it\n"
-            printf "  --purge-volumes        Drop existing postgres/transcripts/backups volumes before install\n"
+            printf "  --purge-volumes        Drop existing postgres/breadbox-data volumes before install\n"
             printf "                         (DESTRUCTIVE — wipes prior data; use when re-installing fresh)\n"
             printf "  --register-daemon      Register launchd (macOS) or systemd (Linux) unit\n"
             printf "  --no-register-daemon   Skip daemon registration (no boot-time autostart)\n"
@@ -792,7 +792,11 @@ if [ "$ENV_EXISTS" = "0" ] && [ -n "$EXISTING_PG_VOLUME" ]; then
     printf "\n"
     if [ "$PURGE_VOLUMES" = "1" ] || prompt_yn "Drop existing volumes and start fresh? (DESTROYS all prior data)" "n"; then
         info "Removing existing volumes..."
-        for vol in "${PROJECT_NAME}_postgres_data" "${PROJECT_NAME}_breadbox_transcripts" "${PROJECT_NAME}_breadbox_backups"; do
+        # breadbox_transcripts / breadbox_backups are the pre-BB_DATA_DIR
+        # volume names — list them too so --purge-volumes wipes old installs
+        # cleanly. Fresh installs only have breadbox_data; the docker
+        # volume rm calls for the legacy names will no-op via 2>/dev/null.
+        for vol in "${PROJECT_NAME}_postgres_data" "${PROJECT_NAME}_breadbox_data" "${PROJECT_NAME}_breadbox_transcripts" "${PROJECT_NAME}_breadbox_backups"; do
             docker volume rm "$vol" 2>/dev/null && success "Removed $vol" || true
         done
         printf "\n"

--- a/deploy/railway-deploy.md
+++ b/deploy/railway-deploy.md
@@ -91,16 +91,18 @@ available" badge in the sidebar when a newer GitHub release exists.
 Railway's default container filesystem is **ephemeral** — every deploy
 resets it. Breadbox writes two things to disk that you'll want to keep:
 
-- Agent NDJSON transcripts → `/app/transcripts`
+- Agent NDJSON transcripts → `/var/lib/breadbox/transcripts/agents`
 - Scheduled pg_dump backups → `/var/lib/breadbox/backups`
 
-Add a Railway Volume (dashboard: **Settings** → **Volumes** → **+ New
-Volume**) mounted at each path. Two volumes, ~1 GB and ~5 GB respectively
-are reasonable starting sizes for a household install.
+Both live under `/var/lib/breadbox`, so a **single** Railway Volume
+mounted at that path covers both. In the dashboard: **Settings** →
+**Volumes** → **+ New Volume**, mount path `/var/lib/breadbox`,
+~6 GB is a reasonable starting size for a household install (5 GB of
+backups + 1 GB of transcripts).
 
-If you don't add volumes, the transcripts page in `/agents` will reset
-on every deploy and Settings → Backups will appear empty. Functionality
-is otherwise intact.
+If you don't add the volume, the transcripts page in `/agents` will
+reset on every deploy and Settings → Backups will appear empty.
+Functionality is otherwise intact.
 
 ## Cost notes
 
@@ -141,6 +143,6 @@ image — no extra Railway config needed. If agents fail, check
 - **Single replica.** `numReplicas: 1` in `railway.json` — Breadbox's
   scheduler isn't designed for multi-instance coordination. Don't
   scale horizontally.
-- **Ephemeral filesystem by default.** Mount volumes (see above) for
-  transcripts and backups.
+- **Ephemeral filesystem by default.** Mount the `/var/lib/breadbox`
+  volume (see "Persistent storage" above) for transcripts and backups.
 - **No multi-region.** Same reason as the replica limit.

--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,7 @@
 #   2. `primary_region` — your nearest Fly region (iad, sjc, lhr, syd…)
 #
 # Everything else is set up for a single-machine Breadbox install with
-# persistent volumes for transcripts + backups and HTTP health checks.
+# one persistent volume for transcripts + backups and HTTP health checks.
 
 app = "breadbox"
 primary_region = "iad"
@@ -48,23 +48,17 @@ primary_region = "iad"
   method = "GET"
   path = "/health/ready"
 
-# Persistent storage. The breadbox container writes:
-#   - NDJSON agent-run transcripts to /app/transcripts
-#   - Scheduled pg_dump backups to /var/lib/breadbox/backups
-# Both should survive deploys. Create the volumes once before the first
-# deploy:
-#   flyctl volumes create breadbox_transcripts --region <primary_region> --size 1
-#   flyctl volumes create breadbox_backups     --region <primary_region> --size 5
+# Persistent storage. The breadbox container writes everything under
+# /var/lib/breadbox (set automatically when ENVIRONMENT=docker):
+#   - /var/lib/breadbox/transcripts/agents — NDJSON agent-run transcripts
+#   - /var/lib/breadbox/backups            — scheduled pg_dump backups
+# One volume covers both. Create it once before the first deploy:
+#   flyctl volumes create breadbox_data --region <primary_region> --size 6
 
 [[mounts]]
-  source = "breadbox_transcripts"
-  destination = "/app/transcripts"
-  initial_size = "1gb"
-
-[[mounts]]
-  source = "breadbox_backups"
-  destination = "/var/lib/breadbox/backups"
-  initial_size = "5gb"
+  source = "breadbox_data"
+  destination = "/var/lib/breadbox"
+  initial_size = "6gb"
 
 [[vm]]
   size = "shared-cpu-1x"

--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -276,7 +276,7 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 			params.GlobalMaxBudgetUSD = &zero
 		}
 
-		if _, err := svc.UpdateAgentSettings(r.Context(), params, a.Config.EncryptionKey); err != nil {
+		if _, err := svc.UpdateAgentSettings(r.Context(), params, a.Config.EncryptionKey, a.Config.DataDir); err != nil {
 			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/agents")
 			return
 		}

--- a/internal/admin/agent_run_live.go
+++ b/internal/admin/agent_run_live.go
@@ -44,7 +44,7 @@ type AgentRunLivePayload struct {
 // group); same transcript parsing as the full page handler so the
 // in-place patch matches what the initial server-side render would
 // have produced.
-func AgentRunLiveHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+func AgentRunLiveHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer, dataDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		shortID := chi.URLParam(r, "shortId")
@@ -90,7 +90,7 @@ func AgentRunLiveHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 			path = *run.TranscriptPath
 		}
 		if path == "" && run.ID != "" {
-			dir := appconfig.String(ctx, svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
+			dir := appconfig.String(ctx, svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(dataDir))
 			if dir != "" {
 				path = filepath.Join(dir, run.ID+".ndjson")
 			}

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -41,7 +41,7 @@ const agentRunTranscriptMaxEvents = 500
 // the filter dropdown + the "Run an agent" modal picker), and the
 // 30-day stats rollup. Definitions + runs are fetched in parallel
 // since they're independent reads.
-func AgentRunsListPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+func AgentRunsListPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer, dataDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -169,7 +169,7 @@ func computeAgentRunsStats(ctx context.Context, svc *service.Service, defs []ser
 // AgentRunDetailPageHandler serves GET /agents/runs/{shortId}. Resolves the
 // run, parses the NDJSON transcript file (best-effort; missing file just
 // surfaces an Error message), and renders the detail templ.
-func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer, dataDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		shortID := chi.URLParam(r, "shortId")
@@ -250,7 +250,7 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 			path = *run.TranscriptPath
 		}
 		if path == "" && run.ID != "" {
-			dir := appconfig.String(ctx, svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
+			dir := appconfig.String(ctx, svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(dataDir))
 			if dir != "" {
 				path = filepath.Join(dir, run.ID+".ndjson")
 			}

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -32,7 +32,7 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		settings, err := svc.GetAgentSettings(ctx, a.Config.EncryptionKey)
+		settings, err := svc.GetAgentSettings(ctx, a.Config.EncryptionKey, a.Config.DataDir)
 		if err != nil {
 			http.Error(w, "Failed to load agent settings: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -183,7 +183,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// PageHeader. /agents?agent=<slug> filters the runs feed to one
 		// agent, which subsumes the old /agents/{slug}/runs route.
 		// Legacy /agents/runs and /agents/{slug}/runs 301-redirect.
-		r.Get("/agents", AgentRunsListPageHandler(svc, sm, tr))
+		r.Get("/agents", AgentRunsListPageHandler(svc, sm, tr, a.Config.DataDir))
 		r.Get("/agents/definitions", AgentsListPageHandler(svc, sm, tr))
 		r.Get("/agents/new", AgentFormPageHandler(svc, sm, tr))
 		// /agents/{slug} is the per-agent landing page (lifetime stats +
@@ -191,7 +191,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// from the detail page's Edit button.
 		r.Get("/agents/{slug}", AgentDetailPageHandler(svc, sm, tr))
 		r.Get("/agents/{slug}/edit", AgentFormPageHandler(svc, sm, tr))
-		r.Get("/agents/runs/{shortId}", AgentRunDetailPageHandler(svc, sm, tr))
+		r.Get("/agents/runs/{shortId}", AgentRunDetailPageHandler(svc, sm, tr, a.Config.DataDir))
 		r.Get("/agents/runs", func(w http.ResponseWriter, r *http.Request) {
 			// Preserve query params so bookmarked filter URLs still work.
 			target := "/agents"
@@ -401,7 +401,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// polls every 3 s while a run is in_progress. Read-only, all
 		// roles (an editor restriction would block dashboards that
 		// want to keep an eye on someone else's runs).
-		r.Get("/agents/runs/{shortId}/live", AgentRunLiveHandler(svc, sm, tr))
+		r.Get("/agents/runs/{shortId}/live", AgentRunLiveHandler(svc, sm, tr, a.Config.DataDir))
 
 		// Editor+ API routes (categorization, tagging, access management).
 		r.Group(func(r chi.Router) {

--- a/internal/agent/transcript_dir.go
+++ b/internal/agent/transcript_dir.go
@@ -2,7 +2,10 @@
 
 package agent
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // TranscriptDirEnvVar is the env-var name that supplies the fallback
 // transcript_dir when app_config has no explicit value.
@@ -14,18 +17,24 @@ const TranscriptDirEnvVar = "BREADBOX_AGENT_TRANSCRIPT_DIR"
 // Precedence (highest first):
 //
 //  1. operator config in app_config — handled by the caller via
-//     appconfig.String(..., KeyAgentTranscriptDir, DefaultTranscriptDir())
+//     appconfig.String(..., KeyAgentTranscriptDir, DefaultTranscriptDir(dataDir))
 //  2. BREADBOX_AGENT_TRANSCRIPT_DIR env var — local-dev hook for sharing
 //     one transcript dir across multiple worktree servers
-//  3. "transcripts/agents" — cwd-relative, matches the Docker image's
-//     /app/transcripts/agents working directory
+//  3. <dataDir>/transcripts/agents when dataDir is non-empty — derived
+//     from BB_DATA_DIR (defaults to /var/lib/breadbox in ENVIRONMENT=docker)
+//  4. "transcripts/agents" — cwd-relative, used when no data root is
+//     configured (local dev outside Docker)
 //
-// The Docker image still resolves to /app/transcripts/agents because the
-// env var is unset and the working directory is /app. Local worktree
-// sessions get a stable home-shared dir via the session-start hook.
-func DefaultTranscriptDir() string {
+// In Docker images dataDir resolves to /var/lib/breadbox, so transcripts
+// land at /var/lib/breadbox/transcripts/agents alongside the backups
+// dir — one volume covers both. Local worktree sessions get a stable
+// home-shared dir via the session-start hook (env var path 2).
+func DefaultTranscriptDir(dataDir string) string {
 	if v := os.Getenv(TranscriptDirEnvVar); v != "" {
 		return v
+	}
+	if dataDir != "" {
+		return filepath.Join(dataDir, "transcripts", "agents")
 	}
 	return "transcripts/agents"
 }

--- a/internal/agent/transcript_dir_test.go
+++ b/internal/agent/transcript_dir_test.go
@@ -10,18 +10,37 @@ import (
 
 func TestDefaultTranscriptDir(t *testing.T) {
 	cases := []struct {
-		name string
-		env  string
-		want string
+		name    string
+		env     string
+		dataDir string
+		want    string
 	}{
-		{name: "unset → cwd-relative default", env: "", want: "transcripts/agents"},
-		{name: "set → honored", env: "/var/lib/breadbox/transcripts/agents", want: "/var/lib/breadbox/transcripts/agents"},
+		{
+			name: "no env, no dataDir → cwd-relative default",
+			want: "transcripts/agents",
+		},
+		{
+			name:    "no env, dataDir set → joined under dataDir",
+			dataDir: "/var/lib/breadbox",
+			want:    "/var/lib/breadbox/transcripts/agents",
+		},
+		{
+			name:    "env set wins over dataDir",
+			env:     "/tmp/shared-transcripts",
+			dataDir: "/var/lib/breadbox",
+			want:    "/tmp/shared-transcripts",
+		},
+		{
+			name: "env set, no dataDir → env honored",
+			env:  "/tmp/shared-transcripts",
+			want: "/tmp/shared-transcripts",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(agent.TranscriptDirEnvVar, tc.env)
-			if got := agent.DefaultTranscriptDir(); got != tc.want {
-				t.Fatalf("DefaultTranscriptDir() = %q, want %q", got, tc.want)
+			if got := agent.DefaultTranscriptDir(tc.dataDir); got != tc.want {
+				t.Fatalf("DefaultTranscriptDir(%q) = %q, want %q", tc.dataDir, got, tc.want)
 			}
 		})
 	}

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -412,7 +412,7 @@ func GetAgentRunHandler(svc *service.Service) http.HandlerFunc {
 // 404s the whole way to completion. The SPA then sits on "Run starting…"
 // until the run finishes and shows the whole thing at once instead of
 // streaming. The fallback gives the polling loop something to read live.
-func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
+func GetAgentRunTranscriptHandler(svc *service.Service, a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "shortId")
 		run, err := svc.GetAgentRun(r.Context(), id)
@@ -425,7 +425,7 @@ func GetAgentRunTranscriptHandler(svc *service.Service) http.HandlerFunc {
 			path = *run.TranscriptPath
 		}
 		if path == "" && run.ID != "" {
-			dir := appconfig.String(r.Context(), svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
+			dir := appconfig.String(r.Context(), svc.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(a.Config.DataDir))
 			if dir != "" {
 				path = filepath.Join(dir, run.ID+".ndjson")
 			}
@@ -474,7 +474,7 @@ func AgentSubsystemStatusHandler(svc *service.Service) http.HandlerFunc {
 // GetAgentSettingsHandler returns the agent.* config with masked tokens.
 func GetAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		out, err := svc.GetAgentSettings(r.Context(), a.Config.EncryptionKey)
+		out, err := svc.GetAgentSettings(r.Context(), a.Config.EncryptionKey, a.Config.DataDir)
 		if err != nil {
 			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to read agent settings")
 			return
@@ -498,7 +498,7 @@ func UpdateAgentSettingsHandler(svc *service.Service, a *app.App) http.HandlerFu
 			GlobalMaxBudgetUSD: req.GlobalMaxBudgetUSD,
 			RuntimePath:        req.RuntimePath,
 			TranscriptDir:      req.TranscriptDir,
-		}, a.Config.EncryptionKey)
+		}, a.Config.EncryptionKey, a.Config.DataDir)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
 				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -122,7 +122,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/agents/runs", ListAllAgentRunsHandler(svc))
 		r.Get("/agents/runs/recent-errors", ListRecentErroredAgentRunsHandler(svc))
 		r.Get("/agents/runs/{shortId}", GetAgentRunHandler(svc))
-		r.Get("/agents/runs/{shortId}/transcript", GetAgentRunTranscriptHandler(svc))
+		r.Get("/agents/runs/{shortId}/transcript", GetAgentRunTranscriptHandler(svc, a))
 		r.Get("/agents/{slug}", GetAgentDefinitionHandler(svc))
 		r.Get("/agents/{slug}/runs", ListAgentRunsHandler(svc))
 		r.Get("/providers", ListProvidersHandler(a))

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -150,7 +150,7 @@ func runAgentRun(parent context.Context, slug string, jsonOut bool, promptPrefix
 	// process; the in-memory semaphore is just belt-and-suspenders).
 	sidecar := &agent.Sidecar{
 		BinaryPath:    appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, ""),
-		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir()),
+		TranscriptDir: appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(a.Config.DataDir)),
 	}
 	orch := service.NewOrchestrator(a.Service, sidecar, 1, cfg.EncryptionKey, logger)
 
@@ -232,7 +232,7 @@ func runAgentTest(parent context.Context) error {
 	defer a.DB.Close()
 
 	binaryPath := appconfig.String(ctx, a.Queries, appconfig.KeyAgentRuntimePath, "")
-	transcriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
+	transcriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(a.Config.DataDir))
 	sidecar := &agent.Sidecar{
 		BinaryPath:    binaryPath,
 		TranscriptDir: transcriptDir,

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -165,7 +165,7 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	// via Settings → Agents → "breadbox-agent transcripts dir" if they
 	// want them elsewhere. Daily cleanup (iter-25) still prunes whatever
 	// path is in effect.
-	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
+	agentTranscriptDir := appconfig.String(ctx, a.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(cfg.DataDir))
 	agentSidecar := &agent.Sidecar{
 		BinaryPath:    agentRuntimePath,
 		TranscriptDir: agentTranscriptDir,
@@ -187,8 +187,8 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	if _, err := exec.LookPath("pg_dump"); err == nil {
 		backupDir := os.Getenv("BACKUP_DIR")
 		if backupDir == "" {
-			if cfg.Environment == "docker" {
-				backupDir = "/var/lib/breadbox/backups"
+			if cfg.DataDir != "" {
+				backupDir = filepath.Join(cfg.DataDir, "backups")
 			} else {
 				backupDir = filepath.Join(".", "backups")
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,14 @@ type Config struct {
 	Environment   string
 	LogLevel      string // LOG_LEVEL: debug, info, warn, error
 
+	// DataDir is the root directory for persistent runtime data (agent
+	// transcripts, scheduled pg_dump backups, future cached blobs).
+	// Sourced from BB_DATA_DIR; defaults to "/var/lib/breadbox" when
+	// ENVIRONMENT=docker, empty otherwise. When empty, per-subsystem
+	// defaults fall back to cwd-relative paths. Per-subsystem env vars
+	// (BREADBOX_AGENT_TRANSCRIPT_DIR, BACKUP_DIR) still override.
+	DataDir string
+
 	// May come from env (overrides app_config) or app_config table
 	PlaidClientID string
 	PlaidSecret   string

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -36,6 +36,7 @@ func Load() (*Config, error) {
 		Environment:   env,
 		ServerPort:    resolveServerPort(),
 		LogLevel:      os.Getenv("LOG_LEVEL"),
+		DataDir:       resolveDataDir(env),
 		ConfigSources: make(map[string]string),
 	}
 
@@ -247,6 +248,22 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// resolveDataDir returns the persistent-data root used by transcripts,
+// backups, and any other runtime-writable state. BB_DATA_DIR wins when
+// set. Otherwise we default to /var/lib/breadbox in Docker (matches the
+// FHS convention and what docker-compose.prod.yml + fly.toml mount as a
+// volume) and leave empty in local / CLI contexts so cwd-relative
+// fallbacks apply.
+func resolveDataDir(env string) string {
+	if v := os.Getenv("BB_DATA_DIR"); v != "" {
+		return v
+	}
+	if env == "docker" {
+		return "/var/lib/breadbox"
+	}
+	return ""
 }
 
 // resolveServerPort returns the HTTP listen port. Tries SERVER_PORT first

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -24,7 +24,7 @@ func seedSubscriptionAuth(t *testing.T, svc *service.Service) []byte {
 	tok := "sk-ant-oat01-FAKE-TEST-TOKEN-FOR-INTEGRATION"
 	if _, err := svc.UpdateAgentSettings(context.Background(), service.UpdateAgentSettingsParams{
 		SubscriptionToken: &tok,
-	}, devEncKey); err != nil {
+	}, devEncKey, ""); err != nil {
 		t.Fatalf("seed subscription auth: %v", err)
 	}
 	return devEncKey

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -49,7 +49,7 @@ type UpdateAgentSettingsParams struct {
 
 // GetAgentSettings reads agent.* keys from app_config, decrypts tokens,
 // returns masked values.
-func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSettingsResponse, error) {
+func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte, dataDir string) (*AgentSettingsResponse, error) {
 	authMode := appconfig.String(ctx, s.Queries, appconfig.KeyAgentAuthMode, appconfig.AuthModeSubscription)
 
 	subToken, _, err := appconfig.ReadEncrypted(ctx, s.Queries, appconfig.KeyAgentSubscriptionToken, encKey)
@@ -66,7 +66,7 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSe
 	runtimePath := appconfig.String(ctx, s.Queries, appconfig.KeyAgentRuntimePath, "")
 	// Default matches serve.go fallback — keeps the Settings → Agents
 	// form showing the active path on a fresh install rather than blank.
-	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir())
+	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(dataDir))
 	globalBudget := readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)
 
 	return &AgentSettingsResponse{
@@ -81,7 +81,7 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte) (*AgentSe
 }
 
 // UpdateAgentSettings writes the non-nil fields and returns the new masked state.
-func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettingsParams, encKey []byte) (*AgentSettingsResponse, error) {
+func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettingsParams, encKey []byte, dataDir string) (*AgentSettingsResponse, error) {
 	if p.AuthMode != nil {
 		if *p.AuthMode != appconfig.AuthModeSubscription && *p.AuthMode != appconfig.AuthModeAPIKey {
 			return nil, fmt.Errorf("%w: auth_mode must be subscription or api_key", ErrInvalidParameter)
@@ -127,7 +127,7 @@ func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettings
 			return nil, fmt.Errorf("set transcript_dir: %w", err)
 		}
 	}
-	return s.GetAgentSettings(ctx, encKey)
+	return s.GetAgentSettings(ctx, encKey, dataDir)
 }
 
 // AgentSubsystemStatus is a cheap, side-effect-free readiness report for

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -222,7 +222,7 @@ func TestMintRunAPIKey_ScopeFromToolScope(t *testing.T) {
 
 func TestGetAgentSettings_DefaultsWhenUnset(t *testing.T) {
 	svc, _, _ := newService(t)
-	s, err := svc.GetAgentSettings(context.Background(), devEncKey)
+	s, err := svc.GetAgentSettings(context.Background(), devEncKey, "")
 	if err != nil {
 		t.Fatalf("get settings: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestUpdateAgentSettings_TokenMaskedNeverReturnedPlaintext(t *testing.T) {
 	token := plain
 	s, err := svc.UpdateAgentSettings(context.Background(), service.UpdateAgentSettingsParams{
 		SubscriptionToken: &token,
-	}, devEncKey)
+	}, devEncKey, "")
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestUpdateAgentSettings_TokenMaskedNeverReturnedPlaintext(t *testing.T) {
 	}
 
 	// Confirm GET returns the same masked form (and not plaintext).
-	got, err := svc.GetAgentSettings(context.Background(), devEncKey)
+	got, err := svc.GetAgentSettings(context.Background(), devEncKey, "")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -273,13 +273,13 @@ func TestUpdateAgentSettings_ClearTokenWithEmptyString(t *testing.T) {
 	set := "sk-ant-oat01-some-value-12345"
 	if _, err := svc.UpdateAgentSettings(context.Background(), service.UpdateAgentSettingsParams{
 		SubscriptionToken: &set,
-	}, devEncKey); err != nil {
+	}, devEncKey, ""); err != nil {
 		t.Fatalf("set: %v", err)
 	}
 	empty := ""
 	cleared, err := svc.UpdateAgentSettings(context.Background(), service.UpdateAgentSettingsParams{
 		SubscriptionToken: &empty,
-	}, devEncKey)
+	}, devEncKey, "")
 	if err != nil {
 		t.Fatalf("clear: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestUpdateAgentSettings_RejectsInvalidAuthMode(t *testing.T) {
 	bad := "banana"
 	_, err := svc.UpdateAgentSettings(context.Background(), service.UpdateAgentSettingsParams{
 		AuthMode: &bad,
-	}, devEncKey)
+	}, devEncKey, "")
 	if !errors.Is(err, service.ErrInvalidParameter) {
 		t.Errorf("err = %v, want ErrInvalidParameter", err)
 	}


### PR DESCRIPTION
## Summary

- Introduces `BB_DATA_DIR` (defaults to `/var/lib/breadbox` when `ENVIRONMENT=docker`, empty otherwise) as the single persistent-data root for agent transcripts + scheduled pg_dump backups.
- Transcripts move from `/app/transcripts/agents` → `/var/lib/breadbox/transcripts/agents`. Backups stay at `/var/lib/breadbox/backups`. One volume mount now covers both.
- Updates `docker-compose.prod.yml`, `fly.toml`, `deploy/install.sh`, and the Railway/Fly deploy docs to one volume.
- Local dev unchanged — without `ENVIRONMENT=docker`, defaults stay cwd-relative.
- Existing per-subsystem env vars (`BACKUP_DIR`, `BREADBOX_AGENT_TRANSCRIPT_DIR`) still override and take precedence.

## Why

`/app/*` is the app's code directory in the Docker image — putting writable runtime state under it mixes immutable build artifacts with mutable user data and is non-canonical. FHS says variable state belongs under `/var/lib/<app>/`. Concretely, this caused a problem when building a real Railway template: Railway only allows **one Volume per service**, so a template with two unrelated mount paths couldn't be assembled cleanly. Same friction applies to any PaaS or compose-managed install — the two paths forced two volumes for no good reason.

This change makes the data layout match how Postgres ships (`/var/lib/postgresql/data`) and how the wider Unix world expects persistent state. One volume per service is the canonical shape across Fly, Railway, k8s PVCs, etc.

## Breaking change (soft) for Docker self-hosters

Anyone running this repo's `docker-compose.prod.yml` had:

- `breadbox_transcripts:/app/transcripts`
- `breadbox_backups:/var/lib/breadbox/backups`

After this lands, the same compose file uses one volume:

- `breadbox_data:/var/lib/breadbox`

Existing data on the old volumes isn't lost — it's just no longer visible to Breadbox. CHANGELOG.md under \`Unreleased → Changed\` has a copy-paste migration that bind-mounts both old and new volumes into an Alpine helper container, copies the data over, and then drops the orphans. Skipping the migration is fine if you don't care about old transcripts/backups; fresh installs are unaffected.

Fly users following \`deploy/fly-deploy.md\` get a similar story: one \`breadbox_data\` volume instead of two. The doc is updated.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` (unit) green — including the updated \`transcript_dir_test.go\` table tests covering: no env + no dataDir → cwd default; dataDir set → joined; env wins over dataDir.
- [ ] DB-backed integration suite in CI — touches \`service.GetAgentSettings\` / \`UpdateAgentSettings\` signatures (now accept \`dataDir\`), so settings-related integration tests will exercise the change.
- [ ] Manual sanity check on a Docker install after merge to confirm the migration steps in CHANGELOG produce the right end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)