### PR TITLE
ci(openapi): add YAML-validity test alongside drift test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/crypto v0.47.0
 	golang.org/x/image v0.24.0
 	golang.org/x/time v0.15.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/internal/api/openapi_yaml_test.go
+++ b/internal/api/openapi_yaml_test.go
@@ -1,0 +1,70 @@
+//go:build !lite
+
+// Spec sanity check: parse openapi.yaml as YAML and fail loudly on syntax
+// errors or duplicate keys. Catches bugs that the regex-based drift test
+// in openapi_drift_test.go cannot see — duplicate `paths` entries, malformed
+// scalars, embedded `: ` in unquoted descriptions, indentation breaks.
+//
+// Untagged with `integration` so it runs in the default `go test ./...`
+// pass and not just the integration matrix.
+package api
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAPIYAMLValid(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	specPath := filepath.Join(filepath.Dir(file), "..", "..", "openapi.yaml")
+	body, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+
+	// Parse as a Node tree so we can walk the AST and detect duplicate
+	// mapping keys — yaml.v3's Unmarshal into map[string]any silently
+	// overwrites duplicates, which is exactly the failure mode Mintlify's
+	// strict parser rejected. Node-mode preserves both entries.
+	var root yaml.Node
+	if err := yaml.Unmarshal(body, &root); err != nil {
+		t.Fatalf("openapi.yaml failed to parse as YAML: %v", err)
+	}
+
+	if dup := findDuplicateKey(&root); dup != "" {
+		t.Fatalf("openapi.yaml has duplicate mapping key: %s", dup)
+	}
+}
+
+// findDuplicateKey walks the YAML node tree and returns a "key (line:col)"
+// description of the first duplicate mapping key it finds, or empty string
+// if none.
+func findDuplicateKey(n *yaml.Node) string {
+	if n == nil {
+		return ""
+	}
+	if n.Kind == yaml.MappingNode {
+		seen := make(map[string]int, len(n.Content)/2)
+		for i := 0; i < len(n.Content)-1; i += 2 {
+			key := n.Content[i]
+			if prev, dup := seen[key.Value]; dup {
+				return fmt.Sprintf("%q first at line %d, again at line %d", key.Value, prev, key.Line)
+			}
+			seen[key.Value] = key.Line
+		}
+	}
+	for _, child := range n.Content {
+		if dup := findDuplicateKey(child); dup != "" {
+			return dup
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

`TestOpenAPIDrift` only checks that the set of `{METHOD, /path}` pairs in `openapi.yaml` matches `router.go`. It uses regex to keep the dep footprint at zero, which is fine for what it tests — but it cannot see the two failure modes that broke Mintlify's spec ingestion this morning:

1. **Duplicate top-level path keys** ([#1579](https://github.com/canalesb93/breadbox/pull/1579)) — the regex collapses dupes into a single set entry, so the drift test reads `/api/v1/agents/runs/{shortId}` declared twice as one path.
2. **Unquoted scalars containing `: `** ([#1580](https://github.com/canalesb93/breadbox/pull/1580)) — sits far from any path/method line, invisible to the regex.

This PR adds a sibling test that parses `openapi.yaml` as a `yaml.Node` tree and walks it looking for duplicate mapping keys. Pure parse-time check, no DB. Untagged with `integration`, so it runs in the default `go test ./...` pass — fails fast in CI before the integration matrix.

`gopkg.in/yaml.v3` was already in `go.sum` as a transitive dep; promoted it to a direct require.

## Verification

Manually injected both failure modes and observed clear failures:

- Duplicate `/health` key:
  ```
  openapi.yaml has duplicate mapping key: "/health" first at line 105, again at line 111
  ```
- Unquoted `description: ...key: "value"...`:
  ```
  openapi.yaml failed to parse as YAML: yaml: line 3391: mapping values are not allowed in this context
  ```

## Test plan

- [ ] CI green on this branch
- [ ] Confirm the test runs as part of the default `go test ./...` pass (not gated behind `-tags=integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)