### PR TITLE
feat(brand): swap breadbox icon for the egg-fried mark everywhere

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -305,6 +305,10 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			// remaining html/template pages don't fall back to the
 			// JS-driven `<i data-lucide>` placeholder.
 			components.LucideFuncMap(),
+			// `brand` renders a vendored brand SVG (breadbox mark,
+			// partner logos) inline — mirrors the @BrandIcon templ
+			// component for html/template pages.
+			components.BrandFuncMap(),
 		),
 	}
 	if err := tr.parseTemplates(); err != nil {

--- a/internal/templates/components/brand.go
+++ b/internal/templates/components/brand.go
@@ -5,6 +5,7 @@ package components
 import (
 	"embed"
 	"fmt"
+	"html/template"
 	"strings"
 )
 
@@ -49,4 +50,20 @@ func renderBrandIcon(slug, class string) string {
 		merged += " " + class
 	}
 	return strings.Replace(raw, "<svg ", fmt.Sprintf(`<svg class=%q `, merged), 1)
+}
+
+// BrandFuncMap returns the html/template func registration that mirrors
+// the @BrandIcon templ component for legacy html/template pages.
+//
+// Usage:
+//
+//	{{ brand "breadbox" "w-5 h-5" }}
+//
+// Pass "" for class when no extra classes are needed.
+func BrandFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"brand": func(slug, class string) template.HTML {
+			return template.HTML(renderBrandIcon(slug, class))
+		},
+	}
 }

--- a/internal/templates/components/brand/breadbox.svg
+++ b/internal/templates/components/brand/breadbox.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" stroke="#1a1a1a" stroke-linecap="round" stroke-linejoin="round" fill="#fff" paint-order="stroke">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" stroke="#1a1a1a" stroke-linecap="round" stroke-linejoin="round" fill="#fff" paint-order="stroke">
+  <title>Breadbox</title>
   <path stroke-width="2" d="M10.7424 2.0715c5 0 4.2576 2.3568 6.2576 5.7011C18.7122 10.6357 21.9304 10 21.9304 14c0 4.5-3.6771 3.5-5.6096 5-1.9749 1.5329-2.4655 3-5.9655 3-1.5796 0-1.9231-2.532-2.9407-3.5987C4.9943 15.8639 3.7945 17.6707 2.7515 16 1.1084 13.3681 2.9368 9.4932 4.4319 6.7224c1.8089-3.3526 4.0918-4.6509 6.3105-4.6509z"/>
   <circle fill="#ffc300" paint-order="fill" cx="11.5" cy="12" r="3.5"/>
 </svg>

--- a/internal/templates/components/layout/wizard.templ
+++ b/internal/templates/components/layout/wizard.templ
@@ -42,9 +42,7 @@ templ Wizard(p WizardProps) {
 			<div class="bb-wizard-container">
 				<!-- Brand mark -->
 				<div class="bb-wizard-brand">
-					<div class="bb-wizard-brand-icon">
-						@components.LucideIcon("package", "w-6 h-6")
-					</div>
+					@components.BrandIcon("breadbox", "w-10 h-10")
 				</div>
 				<!-- Card -->
 				<div class="bb-wizard-card">

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -371,7 +371,7 @@
           </label>
         </div>
         <div class="flex-1 min-w-0 flex items-center gap-2">
-          {{ lucide "package" "w-4 h-4 shrink-0 opacity-70" }}
+          {{ brand "breadbox" "w-4 h-4 shrink-0 opacity-70" }}
           <a href="/" class="text-sm font-semibold truncate">Breadbox</a>
         </div>
         <div class="flex-none flex items-center gap-1">
@@ -414,7 +414,7 @@
         <!-- Brand + theme toggle + close button row -->
         <div class="flex items-center justify-between mb-5">
           <a href="/" class="bb-sidebar-brand !mb-0 !px-0 !py-0">
-            {{ lucide "package" "w-5 h-5" }}
+            {{ brand "breadbox" "w-5 h-5" }}
             Breadbox
           </a>
           <div class="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## Summary

- Replaces the lucide `package` placeholder used across the admin chrome (mobile topbar, sidebar brand, wizard layout) and the `static/favicon.svg` with a dedicated breadbox mark — fried egg on a craggy white.
- The favicon is also what the MCP server hands out as its connector icon (`internal/mcp/server.go::loadBreadboxIcon`), so MCP picker UIs (Claude.ai connectors, Inspector) pick it up automatically.
- Mark is vendored at `internal/templates/components/brand/breadbox.svg` and rendered via the existing `@BrandIcon` templ component. Adds a `brand` html/template func (paired with `lucide`) so `base.html` can render it inline too.
- Wizard layout drops the `bg-primary` 40×40 tile around the mark since the mark now carries its own colors.

## Screenshots

<table>
  <tr><th>Login (wizard)</th><th>Dashboard — desktop</th><th>Dashboard — mobile</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/q7odzr952f.jpg" width="320" alt="login — egg-fried brand mark above card"></td>
    <td><img src="https://i.img402.dev/kh02230y0s.jpg" width="320" alt="dashboard desktop — sidebar brand"></td>
    <td><img src="https://i.img402.dev/unft5fht53.jpg" width="200" alt="dashboard mobile — topbar brand"></td>
  </tr>
</table>

## Test plan

- [x] `go build ./...`, `templ generate`, `make css` clean
- [x] Login page renders the new mark at `w-10 h-10`
- [x] Dashboard sidebar renders the new mark at `w-5 h-5`
- [x] Mobile topbar renders the new mark at `w-4 h-4 opacity-70`
- [x] No stale `lucide-package` refs left in rendered HTML
- [x] Tab favicon updates
