### PR TITLE
fix(openapi): quote flow-mapping description containing a comma

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -358,7 +358,7 @@ paths:
         - $ref: "#/components/parameters/Fields"
         - { name: account_id, in: query, schema: { type: string }, description: Filter by account UUID or short_id (repeatable). }
         - { name: connection_id, in: query, schema: { type: string }, description: Filter by connection. }
-        - { name: user_id, in: query, schema: { type: string }, description: Filter by attributed user (uses `COALESCE(attributed_user_id, connection.user_id)`). }
+        - { name: user_id, in: query, schema: { type: string }, description: "Filter by attributed user (uses `COALESCE(attributed_user_id, connection.user_id)`)." }
         - { name: category_id, in: query, schema: { type: string }, description: Filter by category. }
         - { name: tag, in: query, schema: { type: string }, description: Filter by tag slug. }
         - { name: search, in: query, schema: { type: string }, description: Substring/word/fuzzy search on name + merchant_name. Comma-separated values are OR'd. }


### PR DESCRIPTION
## Summary

The `user_id` query parameter on `GET /api/v1/transactions` used YAML flow-mapping syntax (`- { name: ..., description: ... }`) with an unquoted description that contained a literal comma inside a backtick-quoted SQL fragment:

```yaml
- { name: user_id, in: query, schema: { type: string }, description: Filter by attributed user (uses `COALESCE(attributed_user_id, connection.user_id)`). }
```

In flow context the comma terminates the `description` value and opens a new flow-mapping entry — silently. `yaml.v3` and `yq` both parse this without error (it's technically valid YAML), so [breadbox#1582](https://github.com/canalesb93/breadbox/pull/1582) won't catch it either. The bug only surfaces against a strict OpenAPI validator (Mintlify's, or `redocly lint`):

```
Failed to validate OpenAPI schema:
  /api/v1/transactions/get/parameters/5:
  Property connection.user_id)`). is not expected to be here
```

Wrap the description in double quotes so the comma stays inside the scalar. Wire surface unchanged.

This is the **third** OpenAPI bug Mintlify caught for us today (#1579, #1580, this) — see #1582 for a follow-up that will eventually need to grow into a full OpenAPI 3.1 schema validator to catch this third class of issue too.

## Test plan

- [ ] CI green
- [ ] After merge, `Trigger docs rebuild` workflow fires
- [ ] docs.breadbox.sh deployment turns green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)