### PR TITLE
fix(openapi): resolve two broken $refs (Error → ErrorEnvelope, add BadGateway)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -869,7 +869,7 @@ paths:
           description: Provider exchange failed.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Error" }
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
   /api/v1/connections/{id}:
     parameters: [{ $ref: "#/components/parameters/IDPath" }]
     get:
@@ -2823,6 +2823,11 @@ components:
           schema: { $ref: "#/components/schemas/ErrorEnvelope" }
     InternalError:
       description: Unexpected server error.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+    BadGateway:
+      description: Upstream provider failed.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/ErrorEnvelope" }


### PR DESCRIPTION
## Summary

Swagger validation surfaced two pre-existing **Error**-severity issues that have been in `openapi.yaml` since it was hand-authored:

| Severity | Line | Code | Message |
| --- | --- | --- | --- |
| Error | 872 | 32523-28 | `Reference Error - Invalid object key "Error" at position 2 in "/components/schemas/Error": key not found in object` |
| Error | 1405 | 52189-35 | `Reference Error - Invalid object key "BadGateway" at position 2 in "/components/responses/BadGateway": key not found in object` |

- **Line 872** referenced `#/components/schemas/Error`, but the canonical envelope schema is `ErrorEnvelope` (defined at line 2831). Repointed the ref. Every other 4xx/5xx response in the spec already uses `ErrorEnvelope`, so wire shape is unchanged.
- **Line 1405** referenced `#/components/responses/BadGateway`, which was never defined. Added a `BadGateway` response component alongside the existing `BadRequest`, `NotFound`, etc., reusing `ErrorEnvelope` for the body.

Mintlify's prod ingestion tolerates broken refs silently, but strict OpenAPI validators reject them. Folding them in here so future spec-quality reports stop being noisy.

## Out of scope

The Swagger dump also flagged ~58 **Hint**-severity rows of the form `nullable has no special meaning, if not set on purpose use type="null" instead` — that's OpenAPI 3.0 → 3.1 syntax drift. Real to-do, but mechanical and large enough to deserve its own PR. Filed mentally as a follow-up.

## Test plan

- [ ] CI green
- [ ] After merge, `Trigger docs rebuild` workflow fires
- [ ] Swagger spec-quality report drops back to zero Errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)