### PR TITLE
docs(deploy): wire Railway deploy button to real one-click template

### DIFF
--- a/deploy/railway-deploy.md
+++ b/deploy/railway-deploy.md
@@ -22,9 +22,10 @@ Pick one entrypoint:
   railway init        # picks a name + creates the project
   railway link        # link this dir to that project
   ```
-- **Deploy button** (skips the GitHub-pick step; you still need to add
-  Postgres in step 2):
-  [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https%3A%2F%2Fgithub.com%2Fcanalesb93%2Fbreadbox)
+- **Deploy button** (one-click — provisions Breadbox + Postgres + a
+  `/var/lib/breadbox` volume, sets `DATABASE_URL` from Postgres,
+  auto-generates `ENCRYPTION_KEY`. Skip to step 5 after it finishes):
+  [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/fXUDm0)
 
 ### 2. Add Postgres to the project — **before** the first deploy
 


### PR DESCRIPTION
## Summary

- Replaces the bare \`railway.com/new/template?template=<github-url>\` shortcut (which is just \"deploy from repo\" — no DB, no env vars, no volume) with the actual multi-service template URL: \`railway.com/deploy/fXUDm0\`.
- The new template (created in the Railway dashboard) provisions both the Breadbox service and a Postgres service, wires \`DATABASE_URL\` via reference variable, auto-generates a 64-char hex \`ENCRYPTION_KEY\` at deploy time, and mounts one \`/var/lib/breadbox\` volume.
- Stacks on #1581 (BB_DATA_DIR refactor) — the single-volume layout is what makes the one-click flow viable on Railway, which limits services to one Volume each.

## What the user does now

1. Click the button.
2. Railway provisions both services + DB credentials + encryption key + volume automatically.
3. Open Settings → Networking → Generate Domain (still manual — not part of the template).
4. Hit \`/setup\` to create the admin.

No more \"crashes on startup because DATABASE_URL is unset\" footgun.

## Test plan

- [ ] Open the new URL in an incognito window signed in to a fresh Railway workspace, verify both services provision, \`DATABASE_URL\` and \`ENCRYPTION_KEY\` appear under Breadbox variables (encryption key as a 64-char hex value), and the volume mounts at \`/var/lib/breadbox\`.
- [ ] Health check passes (\`/health/ready\`).
- [ ] \`/setup\` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)