### PR TITLE
fix(deploy): split Railway migrate into preDeployCommand

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,8 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "/app/breadbox migrate && /app/breadbox serve",
+    "preDeployCommand": ["/app/breadbox migrate"],
+    "startCommand": "/app/breadbox serve",
     "healthcheckPath": "/health/ready",
     "healthcheckTimeout": 60,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary

Railway interpreted \`/app/breadbox migrate && /app/breadbox serve\` as one shell-wrapped process. Migration succeeded, but after \`migrate\` exited 0 the shell tried to exec \`serve\` and the parent process reported only ~0.58 MB resident — the wrapper stayed alive but the Go binary never bound a port. Healthchecks returned \"service unavailable\" until Railway gave up.

This PR splits the migrate step into Railway's \`preDeployCommand\`:

\`\`\`diff
   "deploy": {
-    "startCommand": "/app/breadbox migrate && /app/breadbox serve",
+    "preDeployCommand": ["/app/breadbox migrate"],
+    "startCommand": "/app/breadbox serve",
\`\`\`

Per [Railway's pre-deploy docs](https://docs.railway.com/guides/pre-deploy-command), pre-deploy:
- Runs in a **separate container** before the main start step (filesystem changes aren't persisted; volumes aren't mounted — fine, migrations only need \`DATABASE_URL\`).
- **Blocks the deploy** if it fails (no main container ever starts).
- Doesn't pollute the main container with a shell wrapper, so \`serve\` runs as PID 1 and Railway's process tracker sees the actual Go binary.

Same split was applied to the published Railway template (\`railway.com/deploy/fXUDm0\`) via the dashboard.

## Why not just shell-fix the chain

\`sh -c \"... && ...\"\` works in compose because compose's own process-tracking and healthchecks tolerate the wrapper. Railway's healthcheck + memory-usage instrumentation reads the wrapper as the app, which led to the silent failure here. Pre-deploy is the canonical Railway shape and gives much better failure surfacing — if migrations fail, you see it in a dedicated pre-deploy log instead of a cryptic \"never bound to a port\" healthcheck error.

## What stays the same

- \`docker-compose.prod.yml\` keeps the chained command (it's correct in compose-land).
- \`render.yaml\` keeps \`dockerCommand: sh -c \"... && ...\"\` because \`preDeployCommand\` isn't supported under \`runtime: image\` on Render — Render's process model doesn't have the same issue.
- \`fly.toml\` doesn't use either; Fly uses the image's default \`CMD\` directly. (Possible follow-up to verify Fly behavior — file an issue if it crops up.)

## Test plan

- [ ] Click \`railway.com/deploy/fXUDm0\` in incognito → confirm pre-deploy step shows \"migrate\" log, main container shows \"serve\" log, healthcheck flips green, \`/setup\` renders.
- [ ] For repo-direct deploys (\`railway up\` from a checkout), confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)