### PR TITLE
feat(ui): three-state theme control (system/light/dark) as a reusable component

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -93,6 +93,9 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.UserAvatar(p), nil
 	},
+	"ThemeToggle": func(_ any) (templ.Component, error) {
+		return components.ThemeToggle(), nil
+	},
 	"SettingsModal": func(data any) (templ.Component, error) {
 		m, ok := data.(map[string]any)
 		if !ok {

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1328,6 +1328,25 @@ func kbdGlyphRefs() []kbdGlyphRef {
 
 // ─── Keyboard shortcut badges ──────────────────────────────────────────
 
+templ SectionThemeControls() {
+	<div class="flex flex-col gap-6">
+		@designExample("ThemeToggle (compact)", "Cycling icon button used in the sidebar + design navbar. One click steps system → light → dark → system; the glyph (monitor / sun / moon) reflects the current preference, so \"system\" stays distinguishable. Backed by $store.theme — try it and watch the navbar toggle above stay in sync.") {
+			<div class="flex items-center gap-3">
+				@components.ThemeToggle()
+				<span class="text-sm text-base-content/60" x-data x-text="$store.theme.title"></span>
+			</div>
+		}
+		@designExample("ThemeControl (segmented)", "Explicit System / Light / Dark control for Settings → General. A daisy join surfaces all three states at once and makes \"System\" reselectable — the way back to OS-following after a manual override. Binds to the same $store.theme as the icon toggle.") {
+			<div class="flex flex-col gap-3">
+				@components.ThemeControl()
+				<p class="text-xs text-base-content/45 leading-snug max-w-md">
+					Theme is a per-browser preference (localStorage <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">bb-theme</code>), never server-stored. "System" removes <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">data-theme</code> so daisyUI's prefers-color-scheme drives it.
+				</p>
+			</div>
+		}
+	</div>
+}
+
 templ SectionKbd() {
 	<div class="flex flex-col gap-6">
 		@designExample("Single key (Kbd)", "Use for one-key shortcuts. Hides on touch devices via $store.device.isTouch + sm: breakpoint.") {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -123,6 +123,13 @@ func DesignSections() []DesignSection {
 			Group:       "foundations",
 			Render:      func() templ.Component { return SectionKbd() },
 		},
+		{
+			Slug:        "theme-controls",
+			Title:       "Theme controls",
+			Description: "ThemeToggle (compact cycling icon button — system → light → dark) and ThemeControl (explicit System/Light/Dark segmented control). Both bind to the shared $store.theme; \"system\" follows the OS via prefers-color-scheme.",
+			Group:       "foundations",
+			Render:      func() templ.Component { return SectionThemeControls() },
+		},
 
 		// ── Layout ──────────────────────────────────────────────────
 		{

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -20,13 +20,39 @@ templ SettingsGeneral(p SettingsProps) {
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
 			Title:    "General",
-			Subtitle: "Schedule, log retention, and avatars",
+			Subtitle: "Appearance, schedule, log retention, and avatars",
 		})
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 			@settingsSyncSection(p)
+			@settingsAppearanceSection()
 			@settingsAvatarsSection(p)
 		</div>
 	</div>
+}
+
+// ---------------------------------------------------------------------
+// General — Appearance
+// ---------------------------------------------------------------------
+
+// settingsAppearanceSection holds the explicit theme control. It's the
+// settings-screen counterpart to the sidebar ThemeToggle — both bind to
+// the same client-side $store.theme, so changing one updates the other.
+// No form / CSRF: theme is a per-browser localStorage preference, never
+// server-stored (a member's dark-mode choice shouldn't follow them across
+// devices or leak to other household members).
+templ settingsAppearanceSection() {
+	@components.SettingsSection(components.SettingsSectionProps{
+		Icon:    "palette",
+		Title:   "Appearance",
+		Caption: "Saved in this browser only",
+	}) {
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Theme",
+			Caption: "System follows your OS light/dark setting",
+		}) {
+			@components.ThemeControl()
+		}
+	}
 }
 
 // SettingsSystem renders the System tab — encryption key status and

--- a/internal/templates/components/theme_toggle.templ
+++ b/internal/templates/components/theme_toggle.templ
@@ -1,0 +1,69 @@
+package components
+
+// Theme controls — two shapes over the same client-side `$store.theme`
+// (registered in base.html). Theme is a per-browser preference held in
+// localStorage (`bb-theme`), never server-stored: a household member's
+// dark-mode choice shouldn't leak across devices or to other users.
+//
+// The store has three states:
+//   - "system" — no data-theme; daisyUI's prefers-color-scheme drives it
+//   - "light"  — forces data-theme="light"
+//   - "dark"   — forces data-theme="dark"
+//
+// "system" is the default and the only way to follow the OS again after a
+// manual override, which the old two-state sun/moon swap could never do.
+
+// ThemeToggle is the compact icon button used in the sidebar and the
+// design-system navbar. One click cycles system → light → dark → system;
+// the glyph reflects the *preference* (monitor / sun / moon), not the
+// resolved theme, so "system" stays legible as its own state.
+//
+// All three glyphs render server-side and are gated by x-show once Alpine
+// hydrates. x-cloak hides them until then so a reload doesn't flash all
+// three; btn-square reserves the box so there's no layout shift.
+templ ThemeToggle() {
+	<button
+		type="button"
+		class="btn btn-sm btn-square btn-ghost text-base-content/60"
+		x-data
+		@click="$store.theme.cycle()"
+		:title="$store.theme.title"
+		:aria-label="$store.theme.title"
+	>
+		<span x-cloak x-show="$store.theme.preference === 'system'" class="contents">
+			@LucideIcon("monitor", "w-4 h-4")
+		</span>
+		<span x-cloak x-show="$store.theme.preference === 'light'" class="contents">
+			@LucideIcon("sun", "w-4 h-4")
+		</span>
+		<span x-cloak x-show="$store.theme.preference === 'dark'" class="contents">
+			@LucideIcon("moon", "w-4 h-4")
+		</span>
+	</button>
+}
+
+// ThemeControl is the explicit segmented control for the Settings →
+// General → Appearance section. A daisy `join` of three buttons makes all
+// states visible at once (unlike the cycling icon) and surfaces "System"
+// as a first-class, reselectable option. The active button binds to
+// `$store.theme.preference` so it stays in sync with the sidebar toggle.
+templ ThemeControl() {
+	<div class="join" x-data role="group" aria-label="Theme preference">
+		@themeControlButton("system", "monitor", "System")
+		@themeControlButton("light", "sun", "Light")
+		@themeControlButton("dark", "moon", "Dark")
+	</div>
+}
+
+templ themeControlButton(value, icon, label string) {
+	<button
+		type="button"
+		class="join-item btn btn-sm gap-1.5"
+		:class={ "$store.theme.preference === '" + value + "' ? 'btn-primary' : 'btn-ghost'" }
+		:aria-pressed={ "$store.theme.preference === '" + value + "'" }
+		@click={ "$store.theme.set('" + value + "')" }
+	>
+		@LucideIcon(icon, "w-4 h-4")
+		{ label }
+	</button>
+}

--- a/internal/templates/components/theme_toggle.templ
+++ b/internal/templates/components/theme_toggle.templ
@@ -55,11 +55,16 @@ templ ThemeControl() {
 	</div>
 }
 
+// Inactive segments are a plain (neutral) btn, not btn-ghost — ghost
+// renders borderless/transparent, so the unselected states vanish and the
+// control stops reading as a segmented group. Plain btn gives each segment
+// a defined surface + the join's hairline seams; the active one is
+// btn-primary. Matches the canonical join segmented control in /design.
 templ themeControlButton(value, icon, label string) {
 	<button
 		type="button"
 		class="join-item btn btn-sm gap-1.5"
-		:class={ "$store.theme.preference === '" + value + "' ? 'btn-primary' : 'btn-ghost'" }
+		:class={ "$store.theme.preference === '" + value + "' ? 'btn-primary' : ''" }
 		:aria-pressed={ "$store.theme.preference === '" + value + "'" }
 		@click={ "$store.theme.set('" + value + "')" }
 	>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -18,16 +18,22 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
   <script>
-    // Apply persisted theme override before paint so we don't flash the
-    // wrong theme on reload. Absent value falls through to daisyUI's
-    // prefers-color-scheme default ("light --default, dark --prefersdark"
-    // in input.css). Wrapped in try/catch because localStorage throws in
-    // private-mode Safari and the toggle should degrade gracefully.
+    // Apply the persisted theme preference before paint so we don't flash
+    // the wrong theme on reload. Three states (mirrors $store.theme below):
+    //   'light' / 'dark' — force data-theme to that override
+    //   'system' / absent / anything else — remove data-theme and let
+    //     daisyUI's prefers-color-scheme default drive it ("light --default,
+    //     dark --prefersdark" in input.css). Selecting "system" is the only
+    //     way back to OS-following after a manual override.
+    // Wrapped in try/catch because localStorage throws in private-mode
+    // Safari and the toggle should degrade gracefully.
     (function () {
       try {
         var t = localStorage.getItem('bb-theme');
         if (t === 'light' || t === 'dark') {
           document.documentElement.dataset.theme = t;
+        } else {
+          delete document.documentElement.dataset.theme;
         }
       } catch (_) { /* best-effort */ }
     })();
@@ -149,6 +155,66 @@
       Alpine.store('device', {
         isTouch: mqTouch.matches,
         isMobile: mqMobile.matches,
+      });
+    });
+  </script>
+
+  <script>
+    // Alpine store: $store.theme
+    //
+    // Single source of truth for the theme preference, shared by every
+    // ThemeToggle / ThemeControl instance (sidebar, design navbar,
+    // Settings → General). Three states:
+    //   'system' — no data-theme; daisyUI's prefers-color-scheme drives it
+    //   'light'  — forces data-theme="light"
+    //   'dark'   — forces data-theme="dark"
+    //
+    // Persisted to localStorage('bb-theme'); the pre-paint <head> script
+    // reapplies it on the next load so reloads never flash the other theme.
+    // Theme is intentionally per-browser, not server-stored — a member's
+    // dark-mode choice shouldn't follow them across devices or leak to
+    // other household members. `systemDark` is tracked reactively so the
+    // toggle glyph updates live when the OS flips while in 'system'.
+    document.addEventListener('alpine:init', function() {
+      var KEY = 'bb-theme';
+      var mq = window.matchMedia('(prefers-color-scheme: dark)');
+      function read() {
+        try {
+          var v = localStorage.getItem(KEY);
+          if (v === 'light' || v === 'dark' || v === 'system') return v;
+        } catch (_) { /* private-mode Safari */ }
+        return 'system';
+      }
+      function apply(pref) {
+        var root = document.documentElement;
+        if (pref === 'light' || pref === 'dark') root.dataset.theme = pref;
+        else delete root.dataset.theme;
+      }
+      Alpine.store('theme', {
+        preference: read(),
+        systemDark: mq.matches,
+        get resolved() {
+          return this.preference === 'system'
+            ? (this.systemDark ? 'dark' : 'light')
+            : this.preference;
+        },
+        get title() {
+          return 'Theme: ' + this.preference + ' (click to change)';
+        },
+        set: function(pref) {
+          if (pref !== 'light' && pref !== 'dark' && pref !== 'system') return;
+          this.preference = pref;
+          try { localStorage.setItem(KEY, pref); } catch (_) {}
+          apply(pref);
+        },
+        cycle: function() {
+          var next = { system: 'light', light: 'dark', dark: 'system' };
+          this.set(next[this.preference] || 'system');
+        },
+        init: function() {
+          var self = this;
+          mq.addEventListener('change', function(e) { self.systemDark = e.matches; });
+        },
       });
     });
   </script>
@@ -300,9 +366,9 @@
          the native daisy `navbar` component. Sticky so it stays in view
          while the gallery scrolls; the design gallery's anchor links
          and sticky outline both offset for this bar's height.
-         The theme toggle is short-lived: it writes data-theme to <html>
-         per click but never persists. Page reload drops the attribute
-         and the sandbox returns to system theme via prefers-color-scheme. -->
+         The theme toggle is the shared ThemeToggle component, backed by
+         $store.theme — selecting light/dark/system persists to
+         localStorage just like the sidebar toggle. -->
     <div class="navbar bg-base-100 border-b border-base-300 sticky top-0 z-30 px-4 sm:px-6">
       <div class="navbar-start">
         <a
@@ -314,21 +380,7 @@
         </a>
       </div>
       <div class="navbar-end gap-1">
-        <label
-          class="swap swap-rotate btn btn-ghost btn-sm btn-square text-base-content/60"
-          title="Toggle theme (resets on reload)"
-        >
-          <input
-            type="checkbox"
-            class="sr-only"
-            x-data="{ dark: matchMedia('(prefers-color-scheme: dark)').matches }"
-            x-model="dark"
-            @change="document.documentElement.dataset.theme = dark ? 'dark' : 'light'"
-            aria-label="Toggle theme"
-          />
-          {{ lucide "sun" "swap-off w-4 h-4" }}
-          {{ lucide "moon" "swap-on w-4 h-4" }}
-        </label>
+        {{renderComponent "ThemeToggle" nil}}
         <a href="/" class="btn btn-ghost btn-sm gap-1.5 text-base-content/60">
           {{ lucide "arrow-left" "w-3.5 h-3.5" }}
           Back to app
@@ -418,31 +470,11 @@
             Breadbox
           </a>
           <div class="flex items-center gap-1 shrink-0">
-            <!-- Theme toggle (sun/moon). Persists override to
-                 localStorage; the inline <head> script reapplies on
-                 next load so reloads don't flash the other theme. -->
-            <label
-              class="swap swap-rotate btn btn-sm btn-square btn-ghost text-base-content/60"
-              title="Toggle theme"
-              x-data="{
-                dark: (document.documentElement.dataset.theme
-                  ? document.documentElement.dataset.theme === 'dark'
-                  : matchMedia('(prefers-color-scheme: dark)').matches),
-              }"
-              @change="
-                document.documentElement.dataset.theme = dark ? 'dark' : 'light';
-                try { localStorage.setItem('bb-theme', dark ? 'dark' : 'light'); } catch (_) {}
-              "
-            >
-              <input
-                type="checkbox"
-                class="sr-only"
-                x-model="dark"
-                aria-label="Toggle theme"
-              />
-              {{ lucide "sun" "swap-off w-4 h-4" }}
-              {{ lucide "moon" "swap-on w-4 h-4" }}
-            </label>
+            <!-- Theme toggle — shared ThemeToggle component. Cycles
+                 system → light → dark via $store.theme, persisting the
+                 choice to localStorage; the inline <head> script reapplies
+                 it on next load so reloads don't flash the other theme. -->
+            {{renderComponent "ThemeToggle" nil}}
             <!-- Close button — only visible on mobile/tablet (< lg) -->
             <label for="bb-drawer"
                    class="btn btn-sm btn-square btn-ghost lg:hidden"


### PR DESCRIPTION
## What

Reworks the theme toggle into a **three-state control** (System / Light / Dark) and extracts it into **reusable templ components** adopted everywhere theme switching happens.

### The problem
The old sidebar toggle was a two-state sun/moon swap. The moment you clicked it, `data-theme` was pinned to `light` or `dark` **forever** — there was no way to go back to following your OS. Two divergent inline copies (sidebar + design navbar) also duplicated the logic.

### The fix
- **`$store.theme`** (in `base.html`) — one source of truth. Three states persisted to `localStorage('bb-theme')`. **"System" removes `data-theme`** so daisyUI's `prefers-color-scheme` drives it again — the way back to OS-following after a manual override. Tracks `systemDark` reactively, so the glyph updates live when the OS flips while on System.
- **Pre-paint `<head>` script** now removes `data-theme` for system/absent, so reloads never flash the wrong theme in any of the three states.
- **`components.ThemeToggle`** — compact cycling icon button (monitor → sun → moon), adopted in the **sidebar** and the **design-system navbar** via the `renderComponent` bridge, replacing the two inline copies.
- **`components.ThemeControl`** — explicit System/Light/Dark segmented control (daisy `join`), added to **Settings → General → Appearance**. Unselected segments are a defined neutral `btn` (not ghost), matching the canonical segmented control in `/design`.
- Both shapes bind to the same store — change one, the others update live.
- Added a **Theme controls** section to the `/design` sandbox.

Theme stays **per-browser** (localStorage), never server-stored — a household member's dark-mode choice shouldn't follow them across devices or leak to other members. The Appearance caption says as much ("Saved in this browser only").

## Validation

Verified in a real browser (Chrome DevTools MCP): all three states cycle correctly, "system" removes `data-theme`, localStorage persists, the pre-paint script reapplies on reload with no flash, and the two toggle shapes stay in sync via the shared store. Confirmed via `getComputedStyle` that inactive segments have a real surface + border in both themes (not transparent).

### Settings → General → Appearance (new section)

<table>
  <tr><th>Light</th><th>Dark</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/5tg3nb5a0m.jpg" width="400" alt="appearance — light"></td>
    <td><img src="https://i.img402.dev/g5ojtqp8bv.jpg" width="400" alt="appearance — dark"></td>
  </tr>
</table>

### `/design` sandbox — both components

<table>
  <tr><th>Light</th><th>Dark</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ch694hpsg6.jpg" width="400" alt="theme controls — light"></td>
    <td><img src="https://i.img402.dev/r9qnwj0hmk.jpg" width="400" alt="theme controls — dark"></td>
  </tr>
</table>

> Note: the `/design` sandbox shots predate the ghost→neutral segment tweak; the Settings shots above are current.

## Notes
- Generated `*_templ.go` files are gitignored (CI regenerates), so only the `.templ` sources appear in the diff.
- No DB / migration / API changes — purely client-side theme state + UI components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
