### PR TITLE
feat(agents): consistent DiceBear avatars for agents, surfaced across the app

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -74,17 +75,42 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 		// URLs are built from it. When the row is an agent key,
 		// upgrade the actor type so the agent DiceBear style wins
 		// regardless of the URL's ?type= param.
+		//
+		// Every run mints a fresh per-run key (name "agent:<slug>:<runID>"),
+		// so seeding on the key UUID would give the same agent a different
+		// robot on every run. Instead we recover the agent's stable slug
+		// from the key name and seed on that — so an agent's activity rows
+		// share one avatar that matches its /agents/<slug> profile. Keys
+		// whose name isn't in that shape (HTTP MCP keys, the stdio
+		// singleton) fall back to the key UUID seed.
 		if key, kerr := a.Queries.GetApiKey(r.Context(), uid); kerr == nil {
+			seed := idStr
 			if key.ActorType == "agent" {
 				actor = avatar.ActorAgent
+				if slug, ok := agentSlugFromKeyName(key.Name); ok {
+					seed = slug
+				}
 			}
-			serveGeneratedAvatarForActor(w, r, idStr, actor, size)
+			serveGeneratedAvatarForActor(w, r, seed, actor, size)
 			return
 		}
 
 		// Unknown id — generate a stable pattern from the raw string.
 		serveGeneratedAvatarForActor(w, r, idStr, actor, size)
 	}
+}
+
+// agentSlugFromKeyName recovers an agent's slug from a minted run-key
+// name of the form "agent:<slug>:<runID>" (see
+// service.Orchestrator key minting). Returns ok=false for any other
+// shape — operator-created agent keys, HTTP MCP keys, the stdio
+// singleton — so the caller keeps seeding on the key UUID for those.
+func agentSlugFromKeyName(name string) (string, bool) {
+	parts := strings.Split(name, ":")
+	if len(parts) != 3 || parts[0] != "agent" || parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
 }
 
 // parseActorType reads the `?type=` query param and normalises it

--- a/internal/admin/avatars_test.go
+++ b/internal/admin/avatars_test.go
@@ -1,0 +1,40 @@
+//go:build !headless && !lite
+
+package admin
+
+import "testing"
+
+// TestAgentSlugFromKeyName covers the parse that lets agent-authored
+// activity (whose actor_id is the per-run api_key UUID) resolve back to
+// the agent's stable slug, so every run of an agent shares one avatar
+// matching its /agents/<slug> profile. Only the minted run-key shape
+// "agent:<slug>:<runID>" should match; anything else falls back to
+// seeding on the key UUID.
+func TestAgentSlugFromKeyName(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantSlug string
+		wantOK   bool
+	}{
+		{"minted run key", "agent:daily-triage:r4nd0m42", "daily-triage", true},
+		{"single-char slug", "agent:x:abc123de", "x", true},
+		{"hyphenated slug", "agent:sync-improve:run1234", "sync-improve", true},
+		{"empty slug segment", "agent::run1234", "", false},
+		{"wrong prefix", "mcp:daily-triage:run1234", "", false},
+		{"too few segments", "agent:daily-triage", "", false},
+		{"too many segments", "agent:daily-triage:run:extra", "", false},
+		{"bare uuid (http mcp key)", "d290f1ee-6c54-4b01-90e6-d701748f0851", "", false},
+		{"empty string", "", "", false},
+		{"human key name", "My laptop key", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSlug, gotOK := agentSlugFromKeyName(tc.in)
+			if gotOK != tc.wantOK || gotSlug != tc.wantSlug {
+				t.Fatalf("agentSlugFromKeyName(%q) = (%q, %v), want (%q, %v)",
+					tc.in, gotSlug, gotOK, tc.wantSlug, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -80,6 +80,15 @@ templ AgentRunRow(p AgentRunRowProps) {
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 min-w-0">
 					if p.ShowAgent && p.AgentName != "" {
+						@UserAvatar(UserAvatarProps{
+							ID:         p.AgentSlug,
+							Name:       p.AgentName,
+							IsAgent:    true,
+							Size:       UserAvatarXS,
+							Decorative: true,
+							Lazy:       true,
+							Class:      "shrink-0",
+						})
 						<span class="font-medium text-sm text-base-content truncate">{ p.AgentName }</span>
 					}
 					@agentRunAccessoryIcons(p)

--- a/internal/templates/components/page_header.templ
+++ b/internal/templates/components/page_header.templ
@@ -7,6 +7,11 @@ package components
 //   - Subtitle: optional muted paragraph below the title (also used to
 //               carry small dynamic counts, e.g. "237 transactions").
 //   - Icon:     optional Lucide icon name; rendered inline-left of the title.
+//   - Leading:  optional templ.Component rendered left of the whole title
+//               block (avatar / identicon). Use for identity headers — e.g.
+//               an agent's DiceBear avatar on /agents/<slug>. Takes
+//               precedence over the inline Icon visually; pass one or the
+//               other, not both.
 //   - Action:   optional templ.Component for the page's PRIMARY action
 //               (typically a btn-primary). Right-aligned.
 //   - SecondaryAction: optional templ.Component for one secondary action
@@ -40,6 +45,10 @@ type PageHeaderProps struct {
 	Subtitle             string
 	Icon                 string // optional Lucide icon name
 	SubtitleHideOnMobile bool
+	// Leading is an optional visual rendered immediately left of the
+	// title block (e.g. an identity avatar). Nil keeps the classic
+	// title-only layout.
+	Leading templ.Component
 	// SecondaryAction is rendered before Action in the trailing slot.
 	// Convention: secondary-styled button (use PageHeaderSecondaryAction).
 	SecondaryAction templ.Component
@@ -51,23 +60,14 @@ type PageHeaderProps struct {
 
 templ PageHeader(p PageHeaderProps) {
 	<div class="bb-page-header">
-		<div class="min-w-0">
-			if p.Icon != "" {
-				<h1 class="bb-page-title flex items-center gap-2">
-					@LucideIcon(p.Icon, "w-6 h-6 text-primary shrink-0")
-					<span>{ p.Title }</span>
-				</h1>
-			} else {
-				<h1 class="bb-page-title">{ p.Title }</h1>
-			}
-			if p.Subtitle != "" {
-				if p.SubtitleHideOnMobile {
-					<p class="text-sm text-base-content/50 mt-1 hidden sm:block">{ p.Subtitle }</p>
-				} else {
-					<p class="text-sm text-base-content/50 mt-1">{ p.Subtitle }</p>
-				}
-			}
-		</div>
+		if p.Leading != nil {
+			<div class="flex items-center gap-3 min-w-0">
+				@p.Leading
+				@pageHeaderTitleBlock(p)
+			</div>
+		} else {
+			@pageHeaderTitleBlock(p)
+		}
 		if p.SecondaryAction != nil || p.Action != nil {
 			<div class="flex items-center gap-2 shrink-0">
 				if p.SecondaryAction != nil {
@@ -77,6 +77,29 @@ templ PageHeader(p PageHeaderProps) {
 					@p.Action
 				}
 			</div>
+		}
+	</div>
+}
+
+// pageHeaderTitleBlock is the title + subtitle column shared by the
+// leading-avatar and title-only layouts, so the two branches can't
+// drift apart.
+templ pageHeaderTitleBlock(p PageHeaderProps) {
+	<div class="min-w-0">
+		if p.Icon != "" {
+			<h1 class="bb-page-title flex items-center gap-2">
+				@LucideIcon(p.Icon, "w-6 h-6 text-primary shrink-0")
+				<span>{ p.Title }</span>
+			</h1>
+		} else {
+			<h1 class="bb-page-title">{ p.Title }</h1>
+		}
+		if p.Subtitle != "" {
+			if p.SubtitleHideOnMobile {
+				<p class="text-sm text-base-content/50 mt-1 hidden sm:block">{ p.Subtitle }</p>
+			} else {
+				<p class="text-sm text-base-content/50 mt-1">{ p.Subtitle }</p>
+			}
 		}
 	</div>
 }

--- a/internal/templates/components/pages/agent_detail.templ
+++ b/internal/templates/components/pages/agent_detail.templ
@@ -29,6 +29,7 @@ templ AgentDetail(p AgentDetailProps) {
 	@components.PageHeader(components.PageHeaderProps{
 		Title:    p.Name,
 		Subtitle: agentDetailSubtitle(p),
+		Leading:  agentDetailAvatar(p),
 		Action:   agentDetailHeaderActions(p),
 	})
 	if !p.Enabled {
@@ -37,6 +38,19 @@ templ AgentDetail(p AgentDetailProps) {
 	@agentDetailStats(p.Stats)
 	@agentDetailConfig(p)
 	@agentDetailRecentRuns(p)
+}
+
+// agentDetailAvatar is the identity avatar in the page header's leading
+// slot — the agent's DiceBear robot, seeded by its stable slug so it
+// matches the same agent everywhere it appears (list, run rows, feed).
+templ agentDetailAvatar(p AgentDetailProps) {
+	@components.UserAvatar(components.UserAvatarProps{
+		ID:      p.Slug,
+		Name:    p.Name,
+		IsAgent: true,
+		Size:    components.UserAvatarXL,
+		Class:   "shrink-0",
+	})
 }
 
 // agentDetailHeaderActions renders the primary "Run" + secondary

--- a/internal/templates/components/pages/agent_form.templ
+++ b/internal/templates/components/pages/agent_form.templ
@@ -54,9 +54,17 @@ templ AgentForm(p AgentFormProps) {
 			<!-- Identity: icon header + name + slug -->
 			<div class="p-5 sm:p-6">
 				<div class="bb-icon-header">
-					<div class="bb-icon-header__tile bb-icon-tile--primary">
-						@components.LucideIcon("bot", "w-5 h-5")
-					</div>
+					<span class="w-10 h-10 rounded-full overflow-hidden bg-base-200 shrink-0 inline-flex items-center justify-center" title="Avatar is generated from the slug">
+						<img
+							x-ref="agentAvatar"
+							src={ agentFormAvatarSrc(p.Form.Slug) }
+							alt="Agent avatar preview"
+							class="w-full h-full object-cover"
+							width="40"
+							height="40"
+							decoding="async"
+						/>
+					</span>
 					<div class="bb-icon-header__text">
 						<h2 class="text-sm font-semibold">
 							if p.Mode == "edit" {
@@ -91,6 +99,7 @@ templ AgentForm(p AgentFormProps) {
 							minlength="2"
 							maxlength="64"
 							required
+							@input="$refs.agentAvatar && ($refs.agentAvatar.src = agentAvatarPreviewSrc($event.target.value))"
 						/>
 						<p class="text-xs text-base-content/40 mt-1.5">Lowercase letters, digits, dashes. 2–64 chars. Used in URLs and the audit trail.</p>
 						@agentFormFieldError(p.FieldErr("slug"))

--- a/internal/templates/components/pages/agent_form_types.go
+++ b/internal/templates/components/pages/agent_form_types.go
@@ -2,6 +2,26 @@
 
 package pages
 
+import (
+	"strings"
+
+	"breadbox/internal/templates/components"
+)
+
+// agentFormAvatarSrc builds the initial src for the form's live avatar
+// preview tile. Edit mode seeds on the agent's slug so you see the same
+// robot that appears in the list / detail / run rows; new mode (empty
+// slug) uses a stable "new-agent" placeholder so the tile shows a robot
+// rather than a broken image before a slug is typed. The Alpine factory
+// (agentAvatarPreviewSrc) swaps this on every slug keystroke.
+func agentFormAvatarSrc(slug string) string {
+	seed := strings.TrimSpace(slug)
+	if seed == "" {
+		seed = "new-agent"
+	}
+	return components.AvatarURLWith(seed, "", "agent", 80)
+}
+
 // AgentFormProps is the view-model the AgentForm templ reads. Built in
 // admin/agent_form_page.go from the service.AgentDefinitionResponse (edit
 // mode) or empty defaults (new mode).

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -87,9 +87,14 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 			<a href={ templ.SafeURL(agentRunHeaderBackHref(p)) } class="btn btn-ghost btn-sm btn-square" title="Back to runs">
 				@components.LucideIcon("arrow-left", "w-4 h-4")
 			</a>
-			<div class="bb-run-header__icon">
-				@components.LucideIcon("bot", "w-4 h-4")
-			</div>
+			@components.UserAvatar(components.UserAvatarProps{
+				ID:         p.Run.AgentSlug,
+				Name:       p.Run.AgentName,
+				IsAgent:    true,
+				Size:       components.UserAvatarLg,
+				Decorative: true,
+				Class:      "shrink-0",
+			})
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 flex-wrap">
 					if p.Run.AgentName != "" {

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -157,23 +157,36 @@ templ agentsListRow(a AgentsListRowProps) {
 		data-agent-slug={ a.Slug }
 	>
 		<td class="align-middle">
-			<div class="flex items-center gap-2">
-				<a href={ templ.SafeURL(fmt.Sprintf("/agents/%s", a.Slug)) } class="font-medium text-sm hover:underline">
-					{ a.Name }
-				</a>
-				if a.TriggerOnSyncComplete {
-					<span class="badge badge-soft badge-info badge-xs gap-1" title="Fires after every successful sync">
-						@components.LucideIcon("refresh-cw", "w-2.5 h-2.5")
-						sync
-					</span>
-				}
-				if !a.Enabled {
-					<span class="badge badge-ghost badge-xs">Disabled</span>
-				}
+			<div class="flex items-center gap-2.5">
+				@components.UserAvatar(components.UserAvatarProps{
+					ID:         a.Slug,
+					Name:       a.Name,
+					IsAgent:    true,
+					Size:       components.UserAvatarMd,
+					Decorative: true,
+					Lazy:       true,
+					Class:      "shrink-0",
+				})
+				<div class="min-w-0">
+					<div class="flex items-center gap-2">
+						<a href={ templ.SafeURL(fmt.Sprintf("/agents/%s", a.Slug)) } class="font-medium text-sm hover:underline">
+							{ a.Name }
+						</a>
+						if a.TriggerOnSyncComplete {
+							<span class="badge badge-soft badge-info badge-xs gap-1" title="Fires after every successful sync">
+								@components.LucideIcon("refresh-cw", "w-2.5 h-2.5")
+								sync
+							</span>
+						}
+						if !a.Enabled {
+							<span class="badge badge-ghost badge-xs">Disabled</span>
+						}
+					</div>
+					if a.Description != "" {
+						<div class="text-xs text-base-content/50 mt-0.5 line-clamp-1 max-w-md">{ a.Description }</div>
+					}
+				</div>
 			</div>
-			if a.Description != "" {
-				<div class="text-xs text-base-content/50 mt-0.5 line-clamp-1 max-w-md">{ a.Description }</div>
-			}
 		</td>
 		<td class="align-middle text-xs">
 			if a.ScheduleCron != "" {

--- a/internal/templates/components/pages/agents_shell.templ
+++ b/internal/templates/components/pages/agents_shell.templ
@@ -129,9 +129,15 @@ templ agentRunModal(p agentRunModalProps) {
 				<div class="rounded-xl bg-base-100 border border-base-300 divide-y divide-base-200 max-h-72 overflow-y-auto">
 					<template x-for="opt in filtered" :key="opt.Slug">
 						<div class="flex items-center gap-3 px-3 py-2.5 hover:bg-base-200/50">
-							<div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-								@components.LucideIcon("bot", "w-4 h-4 text-primary")
-							</div>
+							<span class="w-8 h-8 rounded-full overflow-hidden bg-base-200 shrink-0 inline-flex items-center justify-center">
+								<img
+									:src="'/avatars/' + encodeURIComponent(opt.Slug) + '?type=agent&size=48'"
+									:alt="opt.Name + ' avatar'"
+									class="w-full h-full object-cover"
+									loading="lazy"
+									decoding="async"
+								/>
+							</span>
 							<div class="min-w-0 flex-1">
 								<div class="text-sm font-medium truncate" x-text="opt.Name"></div>
 								<div class="text-xs text-base-content/50 line-clamp-1" x-text="opt.Description" x-show="opt.Description"></div>

--- a/internal/templates/components/user_avatar.go
+++ b/internal/templates/components/user_avatar.go
@@ -230,12 +230,13 @@ func userAvatarPixelSize(s UserAvatarSize) int {
 }
 
 // userAvatarHasImage reports whether the component should render an
-// <img> path versus a fallback (letter or bot tile). When SrcOverride
-// is set we always render an image; otherwise only when ID is set.
+// <img> path versus a fallback (letter or bot tile). An image renders
+// whenever SrcOverride or ID is set — agents included: an agent WITH an
+// ID resolves to its own DiceBear identicon via ?type=agent
+// (userAvatarSrc routes the actor type), so distinct agents read as
+// distinct robots rather than the one generic bot tile. Only an agent
+// with NO ID falls through to the bot-tile branch in the templ.
 func userAvatarHasImage(p UserAvatarProps) bool {
-	if p.IsAgent {
-		return false
-	}
 	return p.SrcOverride != "" || p.ID != ""
 }
 

--- a/internal/templates/components/user_avatar.templ
+++ b/internal/templates/components/user_avatar.templ
@@ -8,11 +8,14 @@ package components
 //
 // Three render paths:
 //
-//   - <img> when ID (or SrcOverride) is set and the actor is a user.
-//     URL is built via AvatarURL(id, version); version is the
-//     session avatar_v cache-buster.
-//   - Bot tile when IsAgent is true — `bg-primary/10` ring with a
-//     lucide "bot" glyph sized to the variant.
+//   - <img> when ID (or SrcOverride) is set. For users the URL is built
+//     via AvatarURL(id, version); for agents (IsAgent) it routes through
+//     AgentAvatarURL → ?type=agent so the server picks the configured
+//     agent DiceBear style (default "bottts"). Seed an agent with its
+//     stable slug and each one renders as a distinct robot.
+//   - Bot tile when IsAgent is true but no ID/SrcOverride is set —
+//     `bg-primary/10` with a lucide "bot" glyph sized to the variant
+//     (the generic "some agent" fallback).
 //   - Letter fallback when neither ID nor IsAgent is set — first
 //     A–Z / 0–9 char of Name, or "?" if Name is empty too.
 //

--- a/static/js/admin/components/agent_form.js
+++ b/static/js/admin/components/agent_form.js
@@ -279,6 +279,18 @@ document.addEventListener('alpine:init', function () {
         if (window.bbWireSlugInput) window.bbWireSlugInput('agent-name', 'agent-slug');
       },
 
+      // ---- avatar preview ------------------------------------------------
+      //
+      // Mirrors the server-side agentFormAvatarSrc helper: the agent's
+      // DiceBear robot is seeded by its slug, so the preview tile updates
+      // live as the operator types (or as the slug auto-derives from the
+      // name — slug.js dispatches an `input` event we listen to). Empty
+      // slug falls back to the "new-agent" placeholder seed.
+      agentAvatarPreviewSrc: function (slug) {
+        var seed = (slug || '').trim() || 'new-agent';
+        return '/avatars/' + encodeURIComponent(seed) + '?type=agent&size=80';
+      },
+
       // ---- cron picker ---------------------------------------------------
       presets: PRESETS,
 


### PR DESCRIPTION
Gives every agent a distinct, consistent DiceBear avatar (keyed to its slug) and surfaces it across the whole app — list, detail, run rows, the run-an-agent picker, the create/edit form, and its authored activity — instead of the single generic "bot" tile every agent shared before.

## What changed

Agents now render a **distinct DiceBear robot** (the configured agent style, default `bottts`) seeded by their **stable slug**, so the same face follows an agent everywhere it appears.

<img src="https://i.img402.dev/k7smrjlfd9.jpg" width="850" alt="Agents list — a distinct robot per agent">

| Detail header | Run-an-agent picker |
|---|---|
| <img src="https://i.img402.dev/cn5mc8qn8k.jpg" width="420" alt="Agent detail header avatar"> | <img src="https://i.img402.dev/ug5y131cru.jpg" width="420" alt="Run-an-agent modal avatar"> |

The create/edit form shows a **live preview** that updates as the slug derives from the name — so you see the agent's face (the very same one it'll have in the list/feed) before you ever save it. The run-detail header gets it too.

| Form — live preview | Run detail header |
|---|---|
| <img src="https://i.img402.dev/8rlbed1ney.jpg" width="420" alt="Agent form live avatar preview"> | <img src="https://i.img402.dev/vsymrbejla.jpg" width="420" alt="Run detail header avatar"> |

Note the **same purple heart-eyes robot** for "Manual Review" across the list, detail header, run picker, and run detail — consistency is the point.

## How it works — two wires that were never connected

The avatar infrastructure already existed: a separate agent DiceBear style, `?type=agent` URL routing, the `AgentAvatarURL` helper, even a `/design` sandbox example *documenting* the dual-style behavior. But two things short-circuited it:

1. **`UserAvatar.userAvatarHasImage` forced every agent to the generic bot tile** — `IsAgent` returned `false` for the `<img>` path unconditionally, so the agent identicon never rendered. Now an agent **with an ID** renders its robot; only an agent with **no ID** falls back to the bot tile (the generic "some agent" case).

2. **Agent-authored activity seeded a different robot per run.** Each run mints an ephemeral `actor_type='agent'` api_key, and that per-run UUID is what's stored as `actor_id` on annotations — so the feed / timeline / transaction-owner avatars changed every run. `AvatarHandler` now recovers the agent's stable slug from the key name (`agent:<slug>:<runID>`) and seeds on **that**, so an agent's authored activity shares one avatar that matches its `/agents/<slug>` profile.

### Why slug is the avatar key

`slug` is on every agent view-model, it's the canonical identity (URLs, api-key names), and — critically — it's the *only* agent identity recoverable from authored activity **without a DB join**. So the profile avatar and the activity avatar agree by construction, with **zero schema change** (no migration, no `avatar_seed` column).

## Also

- New reusable `PageHeader.Leading` slot (a `templ.Component` rendered left of the title) for identity headers — used by the agent detail page; refactors the title block out so the two layouts can't drift.
- Status tiles on run rows stay status-colored (run outcome ≠ identity).

## Testing

- `go build ./...`, `go vet ./...` clean.
- New unit test `TestAgentSlugFromKeyName` covers the key-name parse (minted shape matches; UUIDs / HTTP-MCP keys / human key names fall back to seeding on the key UUID).
- `go test ./...` green (one unrelated timing-flake in `internal/agent` passes in isolation).
- Validated in a real browser against the dev DB with live DiceBear — screenshots above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
