### PR TITLE
fix(ui): render absolute timestamps in the viewer's timezone, not the server's

### DIFF
--- a/cmd/breadbox/main_full.go
+++ b/cmd/breadbox/main_full.go
@@ -18,6 +18,15 @@ import (
 	// pgx stdlib driver registration is needed for goose's database/sql
 	// migrations regardless of which subcommand runs.
 	_ "github.com/jackc/pgx/v5/stdlib"
+
+	// Embed the IANA tzdata into the binary so time.LoadLocation always
+	// resolves named zones (e.g. "America/Los_Angeles") regardless of
+	// whether the host ships /usr/share/zoneinfo. Without this, a deploy on
+	// a minimal image (scratch/distroless, or a bare static binary) silently
+	// falls back to time.Local for the viewer's bb_tz cookie zone, rendering
+	// every absolute timestamp in the server's timezone. Cron schedule
+	// timezones depend on the same lookup. ~450KB; correctness over size.
+	_ "time/tzdata"
 )
 
 // version is set at build time via -ldflags "-X main.version=...".

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -83,10 +84,13 @@ func AccessPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templat
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
+		// Render absolute creation dates in the viewer's timezone (bb_tz
+		// cookie) rather than the server's — see UserLocation.
+		loc := UserLocation(r)
 		// Split keys into active and revoked for cleaner display.
 		var activeKeys, revokedKeys []pages.AccessKeyRow
 		for _, k := range keys {
-			row := buildAccessKeyRow(k)
+			row := buildAccessKeyRow(k, loc)
 			if k.RevokedAt != nil {
 				revokedKeys = append(revokedKeys, row)
 			} else {
@@ -95,14 +99,14 @@ func AccessPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templat
 		}
 		var activeClients, revokedClients []pages.AccessClientRow
 		for _, c := range clients {
-			row := buildAccessClientRow(c)
+			row := buildAccessClientRow(c, loc)
 			if c.RevokedAt != nil {
 				revokedClients = append(revokedClients, row)
 			} else {
 				activeClients = append(activeClients, row)
 			}
 		}
-		data := BaseTemplateData(r, sm, "api-keys","Access")
+		data := BaseTemplateData(r, sm, "api-keys", "Access")
 		props := pages.AccessProps{
 			IsAdmin:        IsAdmin(sm, r),
 			CSRFToken:      GetCSRFToken(r),
@@ -124,34 +128,37 @@ func renderAccess(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager
 
 // buildAccessKeyRow flattens a service.APIKeyResponse into the templ-side
 // view-model, pre-rendering the date helpers (`formatDateShort`,
-// `relativeTime`) the old html/template called via funcMap.
-func buildAccessKeyRow(k service.APIKeyResponse) pages.AccessKeyRow {
+// `relativeTime`) the old html/template called via funcMap. loc is the
+// viewer's timezone (admin.UserLocation) so the absolute creation date
+// renders in their wall clock, not the server's.
+func buildAccessKeyRow(k service.APIKeyResponse, loc *time.Location) pages.AccessKeyRow {
 	return pages.AccessKeyRow{
 		ID:               k.ID,
 		Name:             k.Name,
 		KeyPrefix:        k.KeyPrefix,
 		Scope:            k.Scope,
-		CreatedAtShort:   timefmt.FormatRFC3339(k.CreatedAt, timefmt.LayoutDateShort),
+		CreatedAtShort:   timefmt.FormatRFC3339In(k.CreatedAt, loc, timefmt.LayoutDateShort),
 		LastUsedRelative: timefmt.RelativeRFC3339Ptr(k.LastUsedAt),
 	}
 }
 
 // buildAccessClientRow flattens a service.OAuthClientResponse into the
-// templ-side view-model, pre-rendering the creation date.
-func buildAccessClientRow(c service.OAuthClientResponse) pages.AccessClientRow {
+// templ-side view-model, pre-rendering the creation date. loc is the viewer's
+// timezone (admin.UserLocation).
+func buildAccessClientRow(c service.OAuthClientResponse, loc *time.Location) pages.AccessClientRow {
 	return pages.AccessClientRow{
 		ID:             c.ID,
 		Name:           c.Name,
 		ClientIDPrefix: c.ClientIDPrefix,
 		Scope:          c.Scope,
-		CreatedAtShort: timefmt.FormatRFC3339(c.CreatedAt, timefmt.LayoutDateShort),
+		CreatedAtShort: timefmt.FormatRFC3339In(c.CreatedAt, loc, timefmt.LayoutDateShort),
 	}
 }
 
 // APIKeyNewPageHandler serves GET /admin/api-keys/new.
 func APIKeyNewPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		data := BaseTemplateData(r, sm, "api-keys","Create API Key")
+		data := BaseTemplateData(r, sm, "api-keys", "Create API Key")
 		renderAPIKeyNew(w, r, tr, data, pages.APIKeyNewProps{
 			CSRFToken: GetCSRFToken(r),
 			Breadcrumbs: []components.Breadcrumb{
@@ -204,7 +211,7 @@ func APIKeyCreatedPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http
 			http.Redirect(w, r, "/settings/api-keys", http.StatusSeeOther)
 			return
 		}
-		data := BaseTemplateData(r, sm, "api-keys","API Key Created")
+		data := BaseTemplateData(r, sm, "api-keys", "API Key Created")
 		renderAPIKeyCreated(w, r, tr, data, pages.APIKeyCreatedProps{
 			KeyName:      name,
 			PlaintextKey: key,

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -213,6 +213,9 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 
 			// Project webhook events into the templ view-model with
 			// pre-rendered relative + full timestamps.
+			// Full timestamps render in the viewer's timezone (bb_tz cookie,
+			// see UserLocation) so a UTC server doesn't show UTC clocks.
+			loc := UserLocation(r)
 			whRows := make([]pages.LogsWebhookRow, 0, len(result.Events))
 			for _, e := range result.Events {
 				whRows = append(whRows, pages.LogsWebhookRow{
@@ -225,7 +228,7 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 					PayloadHash:       e.PayloadHash,
 					ErrorMessage:      e.ErrorMessage,
 					CreatedAtRelative: timefmt.RelativeRFC3339Ptr(e.CreatedAt),
-					CreatedAtFull:     timefmt.FormatRFC3339Ptr(e.CreatedAt, timefmt.LayoutDateTime),
+					CreatedAtFull:     timefmt.FormatRFC3339PtrIn(e.CreatedAt, loc, timefmt.LayoutDateTime),
 				})
 			}
 
@@ -309,4 +312,3 @@ func encodeSyncStatusQuery(status, connID, trigger, dateFrom, dateTo string) str
 	}
 	return v.Encode()
 }
-

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -99,6 +99,9 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 		}
 
 		t, _ := time.Parse(time.RFC3339, report.CreatedAt)
+		// Render the absolute created-at clock in the viewer's timezone
+		// (bb_tz cookie) rather than the server's — see UserLocation.
+		loc := UserLocation(r)
 
 		detail := pages.ReportDetailReport{
 			ID:            report.ID,
@@ -107,7 +110,7 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 			Priority:      report.Priority,
 			Tags:          report.Tags,
 			DisplayAuthor: reportDisplayAuthor(report.CreatedByName, report.Author),
-			CreatedAt:     t.Format("Jan 2, 2006 at 3:04 PM"),
+			CreatedAt:     t.In(loc).Format("Jan 2, 2006 at 3:04 PM"),
 			CreatedAtRel:  relativeTime(t),
 			IsRead:        report.ReadAt != nil,
 		}

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
@@ -26,7 +27,7 @@ func SessionDetailHandler(svc *service.Service, sm *scs.SessionManager, tr *Temp
 		}
 
 		data := BaseTemplateData(r, sm, "logs", "Session Detail")
-		props := buildSessionDetailProps(detail)
+		props := buildSessionDetailProps(detail, UserLocation(r))
 		renderSessionDetail(w, r, tr, data, props)
 	}
 }
@@ -41,8 +42,10 @@ func renderSessionDetail(w http.ResponseWriter, r *http.Request, tr *TemplateRen
 // buildSessionDetailProps projects service.MCPSessionDetailResponse
 // into the flat view-model the templ renders. Pre-renders relative
 // time and pretty-prints request/response JSON so the templ stays
-// free of admin funcMap helpers.
-func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.SessionDetailProps {
+// free of admin funcMap helpers. loc is the viewer's timezone
+// (admin.UserLocation) so per-tool-call absolute timestamps render in
+// their wall clock, not the server's.
+func buildSessionDetailProps(detail service.MCPSessionDetailResponse, loc *time.Location) pages.SessionDetailProps {
 	out := pages.SessionDetailProps{
 		Session: pages.SessionDetailHeader{
 			Purpose:       detail.Purpose,
@@ -66,7 +69,7 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 				Sequence:       c.Sequence,
 				OffsetLabel:    c.OffsetLabel,
 				CreatedAt:      c.CreatedAt,
-				CreatedAtAbs:   timefmt.FormatRFC3339(c.CreatedAt, timefmt.LayoutDateTime),
+				CreatedAtAbs:   timefmt.FormatRFC3339In(c.CreatedAt, loc, timefmt.LayoutDateTime),
 				CreatedAtRel:   timefmt.RelativeRFC3339(c.CreatedAt),
 			}
 			if c.DurationMs != nil {

--- a/internal/admin/timezone.go
+++ b/internal/admin/timezone.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -20,6 +21,16 @@ const userTZCookie = "bb_tz"
 // cookie is missing, blank, or names a zone the runtime can't resolve —
 // matches pre-cookie behaviour, so the very first request from a brand-new
 // session still renders something sensible before the cookie round-trips.
+//
+// The JS shim writes the value through encodeURIComponent, so a slash-bearing
+// IANA name like "America/Los_Angeles" arrives percent-encoded as
+// "America%2FLos_Angeles". Go's net/http never percent-decodes cookie values,
+// so we PathUnescape here before LoadLocation — otherwise every multi-segment
+// zone (i.e. nearly all of them) fails to resolve and silently falls back to
+// the server's timezone, which is exactly the bug this guards against.
+// PathUnescape (not QueryUnescape) is used so a literal '+' in zones like
+// "Etc/GMT+5" survives; values without a '%' pass through unchanged, so an
+// already-decoded cookie still works.
 func UserLocation(r *http.Request) *time.Location {
 	if r == nil {
 		return time.Local
@@ -28,7 +39,11 @@ func UserLocation(r *http.Request) *time.Location {
 	if err != nil || c.Value == "" {
 		return time.Local
 	}
-	loc, err := time.LoadLocation(c.Value)
+	name := c.Value
+	if decoded, derr := url.PathUnescape(name); derr == nil {
+		name = decoded
+	}
+	loc, err := time.LoadLocation(name)
 	if err != nil {
 		return time.Local
 	}

--- a/internal/admin/timezone_test.go
+++ b/internal/admin/timezone_test.go
@@ -21,6 +21,14 @@ func TestUserLocation(t *testing.T) {
 		{name: "valid IANA name resolves", setCookie: true, cookieVal: "America/Los_Angeles", want: "America/Los_Angeles"},
 		{name: "valid UTC resolves", setCookie: true, cookieVal: "UTC", want: "UTC"},
 		{name: "garbage zone falls back to local", setCookie: true, cookieVal: "Not/A/Real/Zone", want: time.Local.String()},
+		// The JS shim writes encodeURIComponent(tz), so a slash-bearing zone
+		// arrives percent-encoded. Without server-side PathUnescape this fails
+		// LoadLocation and silently falls back to the server TZ — the bug.
+		{name: "percent-encoded slash zone resolves", setCookie: true, cookieVal: "America%2FLos_Angeles", want: "America/Los_Angeles"},
+		{name: "percent-encoded Europe zone resolves", setCookie: true, cookieVal: "Europe%2FLondon", want: "Europe/London"},
+		// PathUnescape (not QueryUnescape) so a '+' in the decoded zone name
+		// survives rather than being turned into a space.
+		{name: "percent-encoded plus zone resolves", setCookie: true, cookieVal: "Etc%2FGMT%2B5", want: "Etc/GMT+5"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -398,7 +398,7 @@ templ feedRow(it FeedItem, now time.Time) {
 // feedSyncTile is the icon tile for a sync row. Tinted by status.
 templ feedSyncTile(status string) {
 	<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-200", feedSyncTileBg(status) } aria-hidden="true">
-		@components.LucideIcon(feedSyncIcon(status), "w-3 h-3 " + feedSyncTileText(status))
+		@components.LucideIcon(feedSyncIcon(status), "w-3 h-3 "+feedSyncTileText(status))
 	</span>
 }
 
@@ -406,7 +406,7 @@ templ feedSyncTile(status string) {
 // priority (critical/warning/info → error/warning/primary palette).
 templ feedReportTile(priority string) {
 	<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-200", feedReportTileBg(priority) } aria-hidden="true">
-		@components.LucideIcon(feedReportIcon(priority), "w-3 h-3 " + feedReportTileText(priority))
+		@components.LucideIcon(feedReportIcon(priority), "w-3 h-3 "+feedReportTileText(priority))
 	</span>
 }
 
@@ -898,7 +898,6 @@ templ feedTxRefList(samples []FeedTransactionRef, additional int) {
 
 // ── String helpers ────────────────────────────────────────────────────────
 
-
 func feedActorDisplay(name, actorType string) string {
 	if name != "" {
 		return name
@@ -1317,15 +1316,5 @@ func feedRelativeTimestamp(s string, now time.Time) string {
 }
 
 func feedFormatTimestamp(s string, now time.Time) string {
-	if s == "" {
-		return ""
-	}
-	loc := time.Local
-	if !now.IsZero() {
-		loc = now.Location()
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.In(loc).Format("Jan 2, 2006 3:04 PM")
-	}
-	return s
+	return timefmt.FormatRFC3339At(s, now, timefmt.LayoutDateTime)
 }

--- a/internal/templates/components/timeline_helpers.go
+++ b/internal/templates/components/timeline_helpers.go
@@ -82,22 +82,11 @@ func timelineIconColor(tone string) string {
 // the supplied now (typically derived from the viewer's browser TZ via
 // `admin.UserLocation`). Falls back to time.Local when now is the zero
 // value so callers without an anchor still get a sensible render.
-// Unparseable input is returned unchanged.
+// Unparseable input is returned unchanged. Thin wrapper over the canonical
+// timefmt.FormatRFC3339At so this and the home feed's tooltip render
+// identically.
 func formatTimelineTimestamp(s string, now time.Time) string {
-	if s == "" {
-		return ""
-	}
-	loc := time.Local
-	if !now.IsZero() {
-		loc = now.Location()
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.In(loc).Format("Jan 2, 2006 3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.In(loc).Format("Jan 2, 2006 3:04 PM")
-	}
-	return s
+	return timefmt.FormatRFC3339At(s, now, timefmt.LayoutDateTime)
 }
 
 // relativeTimelineTimestamp renders an RFC3339 timestamp as a short relative

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -25,30 +25,84 @@ const (
 	LayoutDateShort = "Jan 2, 3:04 PM"
 )
 
-// FormatRFC3339 parses an RFC3339 (or RFC3339Nano) timestamp string and
-// renders it via layout in the local timezone. Empty input yields ""; an
-// unparseable string is returned unchanged so callers don't display
-// "0001-01-01..." on bad data.
-func FormatRFC3339(s, layout string) string {
+// FormatRFC3339In parses an RFC3339 (or RFC3339Nano) timestamp string and
+// renders it via layout anchored to loc. This is the canonical
+// timezone-aware absolute-time formatter — pair it with admin.UserLocation(r)
+// so a UTC-running server renders the viewer's wall clock, not its own. A nil
+// loc falls back to time.Local. Empty input yields ""; an unparseable string
+// is returned unchanged so callers don't display "0001-01-01..." on bad data.
+func FormatRFC3339In(s string, loc *time.Location, layout string) string {
 	if s == "" {
 		return ""
 	}
+	if loc == nil {
+		loc = time.Local
+	}
 	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format(layout)
+		return t.In(loc).Format(layout)
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format(layout)
+		return t.In(loc).Format(layout)
 	}
 	return s
 }
 
+// FormatRFC3339At is FormatRFC3339In with the location taken from a `now`
+// anchor (now.Location()). It's the shape used by page assemblers that already
+// thread a single `now` built from admin.UserLocation(r) — the home feed and
+// the per-tx activity timeline both render their absolute-time tooltips
+// through this so the two surfaces can never disagree. A zero now falls back
+// to time.Local.
+func FormatRFC3339At(s string, now time.Time, layout string) string {
+	loc := time.Local
+	if !now.IsZero() {
+		loc = now.Location()
+	}
+	return FormatRFC3339In(s, loc, layout)
+}
+
+// FormatTimeIn renders an already-parsed time.Time via layout anchored to
+// loc — the time.Time twin of FormatRFC3339In for callers that hold a
+// timestamptz value rather than an RFC3339 string. A zero t yields ""; a nil
+// loc falls back to time.Local.
+func FormatTimeIn(t time.Time, loc *time.Location, layout string) string {
+	if t.IsZero() {
+		return ""
+	}
+	if loc == nil {
+		loc = time.Local
+	}
+	return t.In(loc).Format(layout)
+}
+
+// FormatRFC3339 parses an RFC3339 (or RFC3339Nano) timestamp string and
+// renders it via layout in the SERVER's timezone. Deprecated for anything
+// shown to a viewer: a UTC-running server renders every absolute time in UTC.
+// Prefer FormatRFC3339In with a viewer location from admin.UserLocation(r).
+// This server-local form remains only for contexts with no request/viewer
+// (CLI output, server logs). Empty input yields ""; an unparseable string is
+// returned unchanged.
+func FormatRFC3339(s, layout string) string {
+	return FormatRFC3339In(s, time.Local, layout)
+}
+
 // FormatRFC3339Ptr is FormatRFC3339 for nullable *string inputs. nil and
-// empty both render as "".
+// empty both render as "". Server-local — see FormatRFC3339's caveat and
+// prefer FormatRFC3339In for viewer-facing output.
 func FormatRFC3339Ptr(s *string, layout string) string {
 	if s == nil {
 		return ""
 	}
 	return FormatRFC3339(*s, layout)
+}
+
+// FormatRFC3339PtrIn is FormatRFC3339In for nullable *string inputs — the
+// viewer-timezone twin of FormatRFC3339Ptr. nil and empty both render as "".
+func FormatRFC3339PtrIn(s *string, loc *time.Location, layout string) string {
+	if s == nil {
+		return ""
+	}
+	return FormatRFC3339In(*s, loc, layout)
 }
 
 // RelativeRFC3339 parses an RFC3339 (or RFC3339Nano) timestamp string and


### PR DESCRIPTION
## The bug

Absolute timestamps in the **feed** (and the per-tx activity timeline, connections, etc.) rendered in the **server's** timezone instead of the viewer's. The relative string ("2 hours ago") was correct — which is the tell, because relative time is duration math and timezone-agnostic.

## Root cause

`base.html` stashes the browser's IANA zone in a `bb_tz` cookie via `encodeURIComponent(tz)`, so a slash-bearing name arrives **percent-encoded**: `America/Los_Angeles` → `America%2FLos_Angeles`. Go's `net/http` never percent-decodes cookie values, so `UserLocation` called `time.LoadLocation("America%2FLos_Angeles")`, which **errors**, and silently fell back to `time.Local`. Every multi-segment zone (i.e. essentially all of them) hit this, so absolute times rendered as server-local — UTC on the deploy.

## Fix

1. **`UserLocation`** `url.PathUnescape`'s the cookie before `LoadLocation`. `PathUnescape` (not `QueryUnescape`) so a literal `+` in zones like `Etc/GMT+5` survives; plain values pass through unchanged → backward compatible. This one change repairs the feed, the activity timeline, connections, and transactions — every surface that already threads `UserLocation(r)`.
2. **Embed `time/tzdata`** in the server binary so `LoadLocation` resolves named zones on any host (bare static binary / minimal image), independent of system tzdata. Cron schedule TZs use the same lookup.
3. **Consolidate the formatter** so this can't drift again: `timefmt.FormatRFC3339In` / `FormatRFC3339At` / `FormatTimeIn` / `FormatRFC3339PtrIn` are the canonical timezone-aware renderers. The two duplicate templ helpers (`formatTimelineTimestamp`, `feedFormatTimestamp`) now delegate to them; `FormatRFC3339` is kept but documented server-local-only.
4. **Swept the server-TZ stragglers** with a visible clock + request access — API keys, MCP sessions, webhook logs, agent reports — to thread `UserLocation(r)`.

## Evidence (end-to-end, against a running build)

Same feed event = one UTC instant (`5:39 AM May 30 UTC`), fetched with the **percent-encoded** cookie the JS actually writes. Server TZ is **PDT**, so the non-Pacific rows prove the encoded cookie is decoded and applied:

| `bb_tz` cookie (as the JS writes it) | Rendered absolute tooltip | Zone |
|---|---|---|
| `America%2FLos_Angeles` | May 29, 2026 **10:39 PM** | PDT (UTC−7) ✓ |
| `America%2FNew_York` | May 30, 2026 **1:39 AM** | EDT (UTC−4) ✓ |
| `Asia%2FTokyo` | May 30, 2026 **2:39 PM** | JST (UTC+9) ✓ |
| `Asia/Tokyo` (raw, control) | May 30, 2026 **2:39 PM** | decode is a safe no-op ✓ |

Before the fix, **all four** rows showed PDT (`10:39 PM`). No screenshot: the markup is unchanged (only the computed string differs) and the local Chrome was held by a parallel session — the rendered tooltip values above are the proof.

## Tests

- `internal/admin/timezone_test.go`: added percent-encoded cases (`America%2FLos_Angeles`, `Europe%2FLondon`, `Etc%2FGMT%2B5`).
- `go build/vet/test` green on **default**, **`-tags=headless`**, and **`-tags=lite`**; integration suite green for `admin`, `service`, `timefmt`.

## Out of scope (follow-up)

- Agent-run observability pages format event instants directly with no `loc` threading (5 templ files + props refactor + transcript-zone verification) — deliberately left for a focused PR.
- Date-only labels (connection/user created-at) have no clock to shift, so no visible TZ impact.
