### PR TITLE
feat(agents): default agent avatars to bottts-neutral

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -36,7 +36,7 @@ const maxAvatarUploadSize = 5 << 20 // 5 MB
 //
 //	?type=user|agent — picks which configured DiceBear style to use.
 //	                   Default "user". Agent identicons use a separate
-//	                   style (default "bottts") so agent activity reads
+//	                   style (default "bottts-neutral") so agent activity reads
 //	                   as obviously non-human. When the id resolves to
 //	                   an api_keys row with actor_type='agent', the
 //	                   handler upgrades the style to "agent" regardless

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -63,7 +63,8 @@ const (
 	// KeyAvatarAgentStyle is the DiceBear style slug used for agent
 	// identicons. Agents render distinct avatars from users so an
 	// AI-authored activity row reads unambiguously against a human
-	// one. Default: "bottts" (robot-style identicons).
+	// one. Default: "bottts-neutral" (robot identicons on a flat
+	// transparent background).
 	KeyAvatarAgentStyle = "avatar.dicebear_style_agent"
 )
 

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -3,7 +3,7 @@
 //
 // The package tracks two DiceBear styles — one for human users
 // (avatar.dicebear_style_user, default "shapes") and one for AI
-// agents (avatar.dicebear_style_agent, default "bottts") — so a
+// agents (avatar.dicebear_style_agent, default "bottts-neutral") — so a
 // human-authored activity row reads unambiguously against an
 // agent-authored one. Both values live in app_config and are pushed
 // into the package via SetUserStyle / SetAgentStyle at server
@@ -41,10 +41,12 @@ const (
 	// symmetrical with DefaultAgentStyle.
 	DefaultUserStyle = "shapes"
 
-	// DefaultAgentStyle is the fallback for agent identicons. "bottts"
-	// is DiceBear's canonical robot style — agents read as obviously
-	// non-human against the user fallback aesthetic.
-	DefaultAgentStyle = "bottts"
+	// DefaultAgentStyle is the fallback for agent identicons.
+	// "bottts-neutral" is DiceBear's robot style on a flat, transparent
+	// background (no per-avatar colored tile) — agents read as obviously
+	// non-human while sitting cleanly on our own surfaces/rings instead
+	// of carrying their own background swatch.
+	DefaultAgentStyle = "bottts-neutral"
 
 	// DefaultAPIBaseURL is the DiceBear v9 HTTP API root. Tests
 	// override this via SetAPIBaseURL.

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -2668,7 +2668,7 @@ templ SectionUserAvatar() {
 				@components.UserAvatar(components.UserAvatarProps{ID: "drew-uuid", Name: "Drew Dawson", Size: components.UserAvatarLg, Version: "1735776000"})
 			</div>
 		}
-		@designExample("Agents — dual style + bot fallback", "IsAgent has two render paths. With an ID set, the URL routes through ?type=agent and the server picks the configured agent DiceBear style (default \"bottts\") — distinct from the user style so agent activity reads as obviously non-human. With no ID, the bot-tile fallback fires.") {
+		@designExample("Agents — dual style + bot fallback", "IsAgent has two render paths. With an ID set, the URL routes through ?type=agent and the server picks the configured agent DiceBear style (default \"bottts-neutral\") — distinct from the user style so agent activity reads as obviously non-human. With no ID, the bot-tile fallback fires.") {
 			<div class="flex flex-col gap-4">
 				<div class="flex flex-wrap items-center gap-4">
 					<span class="text-xs text-base-content/40 w-32">Agent identicon (ID + IsAgent)</span>
@@ -2858,7 +2858,7 @@ templ SectionUserAvatar() {
 				<div class="flex items-center gap-2">
 					<span class="text-xs text-base-content/40 w-24">Agent seeds</span>
 					for _, seed := range []string{"categorizer", "auditor", "reviewer", "scout"} {
-						<img class="w-10 h-10 rounded-full bg-base-200" alt={ "Preview " + seed } src={ "/avatars/preview/" + seed + "?style=bottts" }/>
+						<img class="w-10 h-10 rounded-full bg-base-200" alt={ "Preview " + seed } src={ "/avatars/preview/" + seed + "?style=bottts-neutral" }/>
 					}
 				</div>
 			</div>

--- a/internal/templates/components/user_avatar.templ
+++ b/internal/templates/components/user_avatar.templ
@@ -11,7 +11,7 @@ package components
 //   - <img> when ID (or SrcOverride) is set. For users the URL is built
 //     via AvatarURL(id, version); for agents (IsAgent) it routes through
 //     AgentAvatarURL → ?type=agent so the server picks the configured
-//     agent DiceBear style (default "bottts"). Seed an agent with its
+//     agent DiceBear style (default "bottts-neutral"). Seed an agent with its
 //     stable slug and each one renders as a distinct robot.
 //   - Bot tile when IsAgent is true but no ID/SrcOverride is set —
 //     `bg-primary/10` with a lucide "bot" glyph sized to the variant


### PR DESCRIPTION
Follow-up to #1596: makes **`bottts-neutral`** the default DiceBear style for agent avatars.

Same robot characters as `bottts`, but on a flat/transparent background instead of a per-avatar colored tile — so each agent's robot sits cleanly on our own surfaces and rings (sidebar, list rows, timeline rail, run picker) without carrying its own background swatch.

<img src="https://i.img402.dev/od65owegm6.jpg" width="850" alt="Agents list — bottts-neutral robots (flat background, still distinct per agent)">

Each agent is still distinct and slug-consistent — only the presentation changes (no colored badge behind the robot).

## Scope

One constant: `avatar.DefaultAgentStyle` (`"bottts"` → `"bottts-neutral"`). It's the **unset fallback** — drives the Settings → System agent-style picker default, the startup push, and the `AgentStyle()` fallback. Operators who have explicitly chosen an agent style are **unaffected**. Doc comments and the `/design` agent-preview seed updated to match. `bottts-neutral` was already in `AvailableStyles`, so no new option to register.

## Testing

`go build`/`go vet`/`go test ./internal/avatar/...` clean. Verified the live endpoint switched: agent avatar `viewBox` goes `180×180` (bottts) → `120×120` (bottts-neutral); screenshot above is the running app with the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
