### PR TITLE
fix(agents): converge agent identity to one definition name + avatar

### DIFF
--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -69,6 +69,17 @@ Don't blur these. Cron callers must use `RunOrSkip`; HTTP callers must use `RunN
 
 CRUD mutations on agent_definitions call `svc.OnDefinitionChanged()` which the orchestrator wires to `AgentScheduler.Reload(ctx)`. The full sequence: service method updates DB → notifies hook → scheduler removes all per-agent entries → re-registers from DB. Don't add new mutation paths without calling the hook.
 
+### Run-key attribution — the run key IS the actor
+
+Every write a run makes must be attributed to its minted run key (`agent:<slug>:<runID>`, `actor_type='agent'`, `actor_name=def.Name`, `agent_definition_id=def.ID`), NOT to the MCP `clientInfo`. The Claude Agent SDK presents a generic shared `clientInfo` ("claude-code") on every connection; if attribution falls back to it, every agent collapses onto one identity and the feed shows one session under several names + avatars.
+
+Two load-bearing pieces enforce this:
+
+1. `AssembleJobSpec` passes the run key in `BREADBOX_API_KEY`; `runMCPStdio` (`internal/cli/mcp.go`) binds it as the actor floor via `ValidateAPIKey`. If you change how the sidecar reaches MCP, keep the run key as the bound actor.
+2. `MCPServer.rebindActorFromClientInfo` (`internal/mcp/server.go`) is gated on `service.AgentRunShortIDFromContext(ctx) == ""` — it upgrades anonymous stdio / external clients to a per-`clientInfo` key but **never** clobbers a real run key. Don't remove that guard.
+
+`api_keys.agent_definition_id` (set at mint) is the durable link; `Service.ResolveAgentSlugForActor` / `GetAgentIdentityByApiKeyID` resolve any agent actor → its definition (name + slug avatar). Render an agent's identity through these, not through the raw stamped `actor_name`.
+
 ## Tests + CI
 
 - Service-layer integration tests: `internal/service/agents_test.go`, `agent_orchestrator_test.go` (one TestMain shared with the rest of `service_test`).

--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -10,13 +10,13 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/avatar"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -106,11 +106,7 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 // shape — operator-created agent keys, HTTP MCP keys, the stdio
 // singleton — so the caller keeps seeding on the key UUID for those.
 func agentSlugFromKeyName(name string) (string, bool) {
-	parts := strings.Split(name, ":")
-	if len(parts) != 3 || parts[0] != "agent" || parts[1] == "" {
-		return "", false
-	}
-	return parts[1], true
+	return service.ParseAgentKeySlug(name)
 }
 
 // parseActorType reads the `?type=` query param and normalises it

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -223,6 +223,11 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		// Reports that the service folded into a bulk_action / agent_session
 		// card are NOT in `leftoverReports` — they render as part of that
 		// card's headline.
+		//
+		// agentSeedCache memoizes the report-author → avatar-seed resolution
+		// across the loop so repeat agents don't re-query; "" is cached too
+		// (a miss is a decision, not a retry).
+		agentSeedCache := map[string]string{}
 		for _, rep := range leftoverReports {
 			if rep.CreatedAt == "" {
 				continue
@@ -236,14 +241,20 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 			// Seed the report's avatar from the agent it ran under so the
 			// row shows the same robot as the agent's other activity,
-			// instead of the generic bot tile. Resolves only for run keys
-			// linked to a definition (new reports); operator/historical
-			// reports leave it empty and keep the bot fallback.
+			// instead of the generic bot tile. Only agent-authored reports
+			// can resolve — the actor_type guard skips a DB query for
+			// operator/system reports, and the cache dedups repeat agents.
 			reportAvatarSeed := ""
-			if rep.CreatedByID != nil {
-				if slug, ok := svc.ResolveAgentSlugForActor(ctx, *rep.CreatedByID); ok {
-					reportAvatarSeed = slug
+			if rep.CreatedByType == "agent" && rep.CreatedByID != nil {
+				id := *rep.CreatedByID
+				seed, cached := agentSeedCache[id]
+				if !cached {
+					if slug, ok := svc.ResolveAgentSlugForActor(ctx, id); ok {
+						seed = slug
+					}
+					agentSeedCache[id] = seed
 				}
+				reportAvatarSeed = seed
 			}
 			items = append(items, pages.FeedItem{
 				Type:         "report",

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -234,6 +234,17 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			if ts.Before(windowStart) || ts.After(windowEnd) {
 				continue
 			}
+			// Seed the report's avatar from the agent it ran under so the
+			// row shows the same robot as the agent's other activity,
+			// instead of the generic bot tile. Resolves only for run keys
+			// linked to a definition (new reports); operator/historical
+			// reports leave it empty and keep the bot fallback.
+			reportAvatarSeed := ""
+			if rep.CreatedByID != nil {
+				if slug, ok := svc.ResolveAgentSlugForActor(ctx, *rep.CreatedByID); ok {
+					reportAvatarSeed = slug
+				}
+			}
 			items = append(items, pages.FeedItem{
 				Type:         "report",
 				Timestamp:    ts,
@@ -247,6 +258,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 					Tags:          rep.Tags,
 					DisplayAuthor: reportDisplayAuthor(rep.CreatedByName, rep.Author),
 					IsUnread:      rep.ReadAt == nil,
+					AvatarSeed:    reportAvatarSeed,
 				},
 			})
 		}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"breadbox/internal/app"
@@ -83,14 +84,36 @@ func runMCPStdio(parent context.Context, version string) error {
 	}
 	defer a.DB.Close()
 
-	// Attach the Local MCP fallback identity. The dispatcher swaps in
-	// per-client keys once clientInfo arrives; this is just the safe
-	// floor for anything that runs before then.
-	fallbackKey, err := ensureLocalMCPFallbackKey(ctx, a.Queries)
-	if err != nil {
-		return fmt.Errorf("ensure local mcp fallback key: %w", err)
+	// Bind the actor floor for this stdio session.
+	//
+	// A scheduled agent run spawns this process with its minted per-run
+	// key in BREADBOX_API_KEY (see service.AssembleJobSpec). Binding that
+	// key makes every write the agent performs attributable to the agent
+	// itself — agent:<slug>:<runID>, which carries the agent_definition
+	// link — instead of the SDK's generic "claude-code" clientInfo. The
+	// dispatcher's clientInfo rebind is gated to never overwrite a real
+	// run key (see MCPServer.rebindActorFromClientInfo).
+	//
+	// Interactive stdio (Claude Desktop, etc.) and any run without a
+	// valid key fall back to the relabelled "Local MCP" singleton — the
+	// same safe floor as before; the dispatcher then swaps in a
+	// per-client identity once clientInfo arrives.
+	var floorKey *db.ApiKey
+	if rawKey := strings.TrimSpace(os.Getenv("BREADBOX_API_KEY")); rawKey != "" {
+		if runKey, kerr := a.Service.ValidateAPIKey(ctx, rawKey); kerr == nil {
+			floorKey = runKey
+		} else {
+			logger.Warn("BREADBOX_API_KEY set but not a valid key; using Local MCP identity", "error", kerr)
+		}
 	}
-	ctx = service.ContextWithAPIKey(ctx, fallbackKey)
+	if floorKey == nil {
+		fallbackKey, err := ensureLocalMCPFallbackKey(ctx, a.Queries)
+		if err != nil {
+			return fmt.Errorf("ensure local mcp fallback key: %w", err)
+		}
+		floorKey = fallbackKey
+	}
+	ctx = service.ContextWithAPIKey(ctx, floorKey)
 
 	mcpServer := breadboxmcp.NewMCPServer(a.Service, version)
 

--- a/internal/db/migrations/20260530120000_api_keys_agent_definition_id.sql
+++ b/internal/db/migrations/20260530120000_api_keys_agent_definition_id.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- Link a minted per-run agent API key to the agent_definition it runs
+-- for, so every piece of an agent's activity can resolve to ONE
+-- canonical identity (the definition's name + a slug-seeded avatar)
+-- instead of the generic MCP clientInfo ("claude-code") the Claude
+-- Agent SDK presents on every connection.
+--
+-- Nullable + ON DELETE SET NULL: human/system keys and the auto-managed
+-- mcp-client identities carry no definition; deleting a definition
+-- preserves its historical run keys (they fall back to slug-from-name
+-- resolution at render time).
+ALTER TABLE api_keys
+    ADD COLUMN agent_definition_id UUID NULL REFERENCES agent_definitions(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_api_keys_agent_definition_id
+    ON api_keys (agent_definition_id)
+    WHERE agent_definition_id IS NOT NULL;
+
+-- Backfill existing per-run keys (name format `agent:<slug>:<runShortID>`)
+-- by matching the embedded slug to agent_definitions.slug. Best-effort;
+-- keys whose slug no longer maps to a live definition stay NULL.
+UPDATE api_keys ak
+SET agent_definition_id = ad.id
+FROM agent_definitions ad
+WHERE ak.actor_type = 'agent'
+  AND ak.name LIKE 'agent:%:%'
+  AND ad.slug = SPLIT_PART(ak.name, ':', 2)
+  AND ak.agent_definition_id IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_api_keys_agent_definition_id;
+ALTER TABLE api_keys DROP COLUMN IF EXISTS agent_definition_id;

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -1,10 +1,22 @@
 -- name: CreateApiKey :one
-INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type, actor_name)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type, actor_name, agent_definition_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING *;
 
 -- name: GetApiKeyByHash :one
 SELECT * FROM api_keys WHERE key_hash = $1;
+
+-- name: GetAgentIdentityByApiKeyID :one
+-- Canonical agent identity for an actor: the agent_definition linked to
+-- the api_keys row at mint (per-run keys). Lets every surface render an
+-- agent's activity under one name + slug-seeded avatar instead of the
+-- MCP clientInfo the SDK presents. Returns no rows for non-agent keys
+-- or run keys minted before agent_definition_id existed (callers fall
+-- back to parsing the slug from the key name).
+SELECT ad.id, ad.short_id, ad.name, ad.slug
+FROM api_keys ak
+JOIN agent_definitions ad ON ad.id = ak.agent_definition_id
+WHERE ak.id = $1;
 
 -- name: GetApiKeyByPrefix :one
 SELECT * FROM api_keys WHERE key_prefix = $1 LIMIT 1;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -218,7 +218,11 @@ func (s *MCPServer) rebindActorFromClientInfo(ctx context.Context, req *mcpsdk.C
 	// rebinding to it collapses every agent onto one client key and
 	// erases per-agent attribution (the bug that made one session show
 	// three different actor names + avatars). Leave the run key in place.
-	if service.AgentRunShortIDFromContext(ctx) != "" {
+	//
+	// IsAgentRunContext also checks actor_type='agent', so a non-agent key
+	// merely *named* "agent:..." can't suppress the rebind and spoof an
+	// agent identity.
+	if service.IsAgentRunContext(ctx) {
 		return ctx
 	}
 	ip := req.Session.InitializeParams()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -210,6 +210,17 @@ func (s *MCPServer) rebindActorFromClientInfo(ctx context.Context, req *mcpsdk.C
 	if req == nil || req.Session == nil {
 		return ctx
 	}
+	// Never clobber a scheduled agent's run key. A run is already
+	// authenticated as its per-run key (agent:<slug>:<runID>, bound from
+	// BREADBOX_API_KEY in runMCPStdio), which carries the agent's real
+	// identity + agent_definition link. The clientInfo the Claude Agent
+	// SDK sends is the generic shared "claude-code" host identity —
+	// rebinding to it collapses every agent onto one client key and
+	// erases per-agent attribution (the bug that made one session show
+	// three different actor names + avatars). Leave the run key in place.
+	if service.AgentRunShortIDFromContext(ctx) != "" {
+		return ctx
+	}
 	ip := req.Session.InitializeParams()
 	if ip == nil || ip.ClientInfo == nil {
 		return ctx

--- a/internal/service/actor.go
+++ b/internal/service/actor.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
@@ -103,6 +104,36 @@ func AgentRunShortIDFromContext(ctx context.Context) string {
 		return ""
 	}
 	return rest[lastColon+1:]
+}
+
+// ParseAgentKeySlug extracts the agent slug from a per-run key name of
+// the form "agent:<slug>:<runID>" (minted by Orchestrator.MintRunAPIKey).
+// Returns ok=false for any other shape. This is the single canonical Go
+// parser for that contract — the avatar handler and the actor resolver
+// both call it so the format lives in one place. Keep it in lock-step
+// with the key name built in MintRunAPIKey and the SPLIT_PART backfill.
+func ParseAgentKeySlug(name string) (string, bool) {
+	parts := strings.Split(name, ":")
+	if len(parts) != 3 || parts[0] != "agent" || parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
+}
+
+// IsAgentRunContext reports whether ctx is authenticated as a scheduled
+// agent's per-run key: actor_type='agent' AND a parseable
+// "agent:<slug>:<runID>" name. It gates behavior that must apply ONLY to
+// real agent runs — notably never letting the MCP clientInfo rebind
+// clobber the run key. The actor_type check is load-bearing: a non-agent
+// key that merely happens to be named "agent:..." must NOT be treated as
+// a run (otherwise an operator could spoof an agent identity).
+func IsAgentRunContext(ctx context.Context) bool {
+	v, ok := ctx.Value(ctxKeyAPIKey).(apiKeyCtxValue)
+	if !ok || v.actorType != "agent" {
+		return false
+	}
+	_, parsed := ParseAgentKeySlug(v.name)
+	return parsed
 }
 
 // ActorFromContext builds an Actor from the request context.

--- a/internal/service/agent_identity_test.go
+++ b/internal/service/agent_identity_test.go
@@ -71,3 +71,27 @@ func TestResolveAgentSlugForActor_NonAgentKey(t *testing.T) {
 		t.Errorf("expected ok=false for an empty actor id")
 	}
 }
+
+// TestResolveAgentSlugForActor_FallbackFromKeyName covers the
+// slug-from-name fallback: an agent key with NO agent_definition_id link
+// (definition deleted via ON DELETE SET NULL, or a run key minted before
+// the FK existed) still resolves to its slug from the immutable key name,
+// so the agent's avatar keeps rendering instead of falling to the bot tile.
+func TestResolveAgentSlugForActor_FallbackFromKeyName(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	res, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+		Name:      "agent:orphan-slug:Run99",
+		Scope:     "full_access",
+		ActorType: "agent",
+		// deliberately no AgentDefinitionID — simulates a deleted/pre-FK link
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	slug, ok := svc.ResolveAgentSlugForActor(ctx, res.ID)
+	if !ok || slug != "orphan-slug" {
+		t.Fatalf("fallback resolve = (%q,%v), want (orphan-slug,true)", slug, ok)
+	}
+}

--- a/internal/service/agent_identity_test.go
+++ b/internal/service/agent_identity_test.go
@@ -1,0 +1,73 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestMintRunAPIKey_CarriesDefinitionIdentity is the core of the
+// identity-convergence fix: a minted per-run key must carry the agent's
+// DISPLAY name (def.Name) as actor_name and a durable agent_definition_id
+// link, so every write the run makes resolves to one canonical identity
+// (definition name + slug-seeded avatar) instead of the SDK's clientInfo.
+func TestMintRunAPIKey_CarriesDefinitionIdentity(t *testing.T) {
+	svc, _, _ := newService(t)
+	def := mustCreateAgentDefinition(t, svc, "ident-mint", true)
+	ctx := context.Background()
+
+	res, err := svc.MintRunAPIKey(ctx, def, "Run12345")
+	if err != nil {
+		t.Fatalf("MintRunAPIKey: %v", err)
+	}
+
+	// actor_name is the display name, not the slug — the feed reads
+	// "Test ident-mint", never "ident-mint" or "claude-code".
+	key, err := svc.ValidateAPIKey(ctx, res.PlaintextKey)
+	if err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	if !key.ActorName.Valid || key.ActorName.String != def.Name {
+		t.Errorf("actor_name = %q, want def.Name %q", key.ActorName.String, def.Name)
+	}
+	if !key.AgentDefinitionID.Valid {
+		t.Fatalf("agent_definition_id not set on minted run key")
+	}
+
+	// The key resolves to the definition's slug — the avatar seed shared
+	// across every surface the agent's activity appears on.
+	slug, ok := svc.ResolveAgentSlugForActor(ctx, res.ID)
+	if !ok {
+		t.Fatalf("ResolveAgentSlugForActor: expected ok for a run key")
+	}
+	if slug != def.Slug {
+		t.Errorf("resolved slug = %q, want def.Slug %q", slug, def.Slug)
+	}
+}
+
+// TestResolveAgentSlugForActor_NonAgentKey confirms the resolver returns
+// ok=false for keys with no definition link (human keys, external
+// mcp-client identities) so render code falls back cleanly rather than
+// inventing an agent identity.
+func TestResolveAgentSlugForActor_NonAgentKey(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	res, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+		Name:      "human-key-ident",
+		Scope:     "full_access",
+		ActorType: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if slug, ok := svc.ResolveAgentSlugForActor(ctx, res.ID); ok {
+		t.Errorf("expected ok=false for a non-agent key, got slug=%q", slug)
+	}
+	if _, ok := svc.ResolveAgentSlugForActor(ctx, ""); ok {
+		t.Errorf("expected ok=false for an empty actor id")
+	}
+}

--- a/internal/service/agent_run_context_test.go
+++ b/internal/service/agent_run_context_test.go
@@ -1,0 +1,65 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+)
+
+func TestParseAgentKeySlug(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"run key", "agent:review-agent:Run12345", "review-agent", true},
+		{"hyphenated slug", "agent:sync-improve:abc", "sync-improve", true},
+		{"empty slug", "agent::Run1", "", false},
+		{"mcp-client key", "mcp-client:claude_code@@stdio", "", false},
+		{"too few parts", "agent:review-agent", "", false},
+		{"too many parts", "agent:review:agent:run", "", false},
+		{"human key name", "My laptop key", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseAgentKeySlug(tc.in)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("ParseAgentKeySlug(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestIsAgentRunContext covers the rebind gate. The actor_type='agent'
+// check is load-bearing: a non-agent key merely NAMED like a run key
+// must NOT be treated as a run (otherwise an operator could create a
+// full_access user key named "agent:..." and suppress the clientInfo
+// rebind to spoof an agent identity).
+func TestIsAgentRunContext(t *testing.T) {
+	mk := func(actorType, name string) context.Context {
+		return ContextWithAPIKey(context.Background(), &db.ApiKey{
+			ID: mustUUID(0x11), Name: name, ActorType: actorType,
+		})
+	}
+	cases := []struct {
+		name string
+		ctx  context.Context
+		want bool
+	}{
+		{"real run key", mk("agent", "agent:review-agent:Run1"), true},
+		{"spoofed user key named agent:*", mk("user", "agent:review-agent:Run1"), false},
+		{"local mcp fallback (agent type, mcp-client name)", mk("agent", "mcp-client:claude_code@@stdio"), false},
+		{"agent key, non-run name", mk("agent", "some-other-agent-key"), false},
+		{"no key in ctx", context.Background(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAgentRunContext(tc.ctx); got != tc.want {
+				t.Fatalf("IsAgentRunContext = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -1079,11 +1079,18 @@ func (s *Service) MintRunAPIKey(ctx context.Context, def *AgentDefinitionRespons
 	if def.ToolScope == "read_only" {
 		scope = "read_only"
 	}
+	// ActorName is the agent's DISPLAY name (def.Name) — every write the
+	// run makes stamps this, so the feed reads "Routine Review" rather
+	// than the slug or the SDK's generic "claude-code" clientInfo.
+	// AgentDefinitionID is the durable link that lets any of the run's
+	// activity resolve back to this one definition (name + slug avatar).
+	// The slug still lives in the key Name for the avatar seed.
 	return s.CreateAPIKey(ctx, CreateAPIKeyParams{
-		Name:      fmt.Sprintf("agent:%s:%s", def.Slug, runShortID),
-		Scope:     scope,
-		ActorType: "agent",
-		ActorName: def.Slug,
+		Name:              fmt.Sprintf("agent:%s:%s", def.Slug, runShortID),
+		Scope:             scope,
+		ActorType:         "agent",
+		ActorName:         def.Name,
+		AgentDefinitionID: def.ID,
 	})
 }
 

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -32,6 +32,11 @@ type CreateAPIKeyParams struct {
 	Scope     string
 	ActorType string // "user" | "agent" | "system"; defaults to "user"
 	ActorName string // optional display name, falls back to Name
+	// AgentDefinitionID links a per-run agent key back to the
+	// agent_definition it runs for (UUID string; empty for non-agent
+	// keys). Set by MintRunAPIKey so all of an agent's activity resolves
+	// to one canonical identity. See GetAgentIdentityByApiKeyID.
+	AgentDefinitionID string
 }
 
 // CreateAPIKey mints a new API key and returns the full record plus the
@@ -84,13 +89,20 @@ func (s *Service) CreateAPIKey(ctx context.Context, p CreateAPIKeyParams) (*Crea
 	if p.ActorName != "" {
 		actorName = pgtype.Text{String: p.ActorName, Valid: true}
 	}
+	var agentDefID pgtype.UUID
+	if p.AgentDefinitionID != "" {
+		if err := agentDefID.Scan(p.AgentDefinitionID); err != nil {
+			return nil, fmt.Errorf("invalid agent_definition_id: %w", err)
+		}
+	}
 	apiKey, err := s.Queries.CreateApiKey(ctx, db.CreateApiKeyParams{
-		Name:      p.Name,
-		KeyHash:   keyHash,
-		KeyPrefix: keyPrefix,
-		Scope:     scope,
-		ActorType: actorType,
-		ActorName: actorName,
+		Name:              p.Name,
+		KeyHash:           keyHash,
+		KeyPrefix:         keyPrefix,
+		Scope:             scope,
+		ActorType:         actorType,
+		ActorName:         actorName,
+		AgentDefinitionID: agentDefID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create api key: %w", err)
@@ -163,6 +175,27 @@ func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*db.ApiKey, e
 	}()
 
 	return &apiKey, nil
+}
+
+// ResolveAgentSlugForActor returns the agent_definition slug an actor
+// (an api_keys UUID) runs for, when that key is a per-run agent key
+// linked to a definition (set at mint via agent_definition_id). The slug
+// is the avatar seed, so an agent's robot is identical everywhere its
+// activity surfaces. ok=false for non-agent actors, external mcp-client
+// identities, and keys with no definition link.
+func (s *Service) ResolveAgentSlugForActor(ctx context.Context, actorID string) (string, bool) {
+	if actorID == "" {
+		return "", false
+	}
+	var uid pgtype.UUID
+	if err := uid.Scan(actorID); err != nil {
+		return "", false
+	}
+	row, err := s.Queries.GetAgentIdentityByApiKeyID(ctx, uid)
+	if err != nil {
+		return "", false
+	}
+	return row.Slug, true
 }
 
 func apiKeyFromRow(r db.ApiKey) APIKeyResponse {

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -91,7 +91,8 @@ func (s *Service) CreateAPIKey(ctx context.Context, p CreateAPIKeyParams) (*Crea
 	}
 	var agentDefID pgtype.UUID
 	if p.AgentDefinitionID != "" {
-		if err := agentDefID.Scan(p.AgentDefinitionID); err != nil {
+		var err error
+		if agentDefID, err = pgconv.ParseUUID(p.AgentDefinitionID); err != nil {
 			return nil, fmt.Errorf("invalid agent_definition_id: %w", err)
 		}
 	}
@@ -187,15 +188,23 @@ func (s *Service) ResolveAgentSlugForActor(ctx context.Context, actorID string) 
 	if actorID == "" {
 		return "", false
 	}
-	var uid pgtype.UUID
-	if err := uid.Scan(actorID); err != nil {
-		return "", false
-	}
-	row, err := s.Queries.GetAgentIdentityByApiKeyID(ctx, uid)
+	uid, err := pgconv.ParseUUID(actorID)
 	if err != nil {
 		return "", false
 	}
-	return row.Slug, true
+	if row, rerr := s.Queries.GetAgentIdentityByApiKeyID(ctx, uid); rerr == nil {
+		return row.Slug, true
+	}
+	// No live definition link — the key's agent_definition_id is NULL
+	// because the definition was deleted (ON DELETE SET NULL) or the run
+	// key predates the column. Recover the slug from the immutable key
+	// name ("agent:<slug>:<runID>") so the agent's avatar still renders.
+	if key, kerr := s.Queries.GetApiKey(ctx, uid); kerr == nil && key.ActorType == "agent" {
+		if slug, ok := ParseAgentKeySlug(key.Name); ok {
+			return slug, true
+		}
+	}
+	return "", false
 }
 
 func apiKeyFromRow(r db.ApiKey) APIKeyResponse {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -550,7 +550,13 @@ templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
 // author this stays correct as long as DisplayAuthor is set.
 func feedReportActor(r *FeedReport) components.TimelineActor {
 	return components.TimelineActor{
-		Name:    r.DisplayAuthor,
+		Name: r.DisplayAuthor,
+		// UserID seeds the avatar: when the report resolves to its
+		// agent_definition, this is the slug, so the row renders the
+		// agent's robot via /avatars/<slug>?type=agent (UserAvatar routes
+		// IsAgent through ?type=agent). Empty seed falls back to the
+		// bot tile — same as before for operator/historical reports.
+		UserID:  r.AvatarSeed,
 		IsAgent: true,
 	}
 }

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -211,6 +211,13 @@ type FeedReport struct {
 	Tags          []string
 	DisplayAuthor string
 	IsUnread      bool
+	// AvatarSeed is the agent_definition slug the report's author runs
+	// for, resolved from the minted run key. When set, the report row
+	// renders the agent's DiceBear robot (the same one on the agent's
+	// list/detail pages) instead of the generic bot tile. Empty for
+	// operator-authored reports and historical reports whose run key no
+	// longer links to a definition.
+	AvatarSeed string
 }
 
 // FeedComment carries one standalone comment row.


### PR DESCRIPTION
Converges agent identity so a single agent run no longer shows up in the feed under several names + inconsistent avatars. All agent activity now resolves to one `agent_definition` — its name + a slug-seeded robot — everywhere it appears.

## The bug

One scheduled run, three identities:

| Feed row | Name shown | Source | Avatar |
|---|---|---|---|
| "updated 3 transactions" | **Claude Code** | MCP `clientInfo.Title` | robot A (per-client key UUID) |
| "filed a report" | **Review Agent** | the agent's free-text `author` arg | generic bot tile (no resolvable id) |
| "commented on Amazon" | **claude-code** | MCP `clientInfo.Name` | robot B (different seed) |

## Root cause

Every run mints an `agent:<slug>:<runID>` key — the only token carrying the agent's slug → `agent_definition`. The orchestrator passes it to the sidecar's stdio MCP as `BREADBOX_API_KEY`… **but nothing read it.** `breadbox mcp` bound a generic "Local MCP" floor, then `rebindActorFromClientInfo` swapped in a key minted **per MCP `clientInfo`**. Since every agent connects with the Claude Agent SDK's identical `clientInfo` ("claude-code"), they all collapsed onto one shared identity — and each feed surface read a different denormalized field, producing the 3-name / 2-avatar / 1-missing mess.

## The fix — anchor attribution on `agent_definition`

- **`api_keys.agent_definition_id`** — new FK (additive migration; backfilled from existing run-key names) is the durable, rename-safe link.
- **`MintRunAPIKey`** sets `actor_name = def.Name` (the display name, was the slug) and stamps the FK.
- **`breadbox mcp`** (stdio) now binds `BREADBOX_API_KEY` as the actor floor via `ValidateAPIKey` — the run is authenticated as its own key.
- **`rebindActorFromClientInfo`** is gated on `AgentRunShortIDFromContext` — it still upgrades anonymous stdio / external MCP clients to a per-`clientInfo` identity, but **never clobbers a real run key**.
- **`ResolveAgentSlugForActor` / `GetAgentIdentityByApiKeyID`** resolve any agent actor → its definition (name + slug avatar). The report feed row seeds its avatar from that, replacing the bot tile.

Result: every **new** agent run renders **one name (`def.Name`) + one slug-seeded robot** across the feed, timeline, transaction owner badges, and reports.

## Honest limitation (re: "converge old + new")

The migration backfill links every existing **run key** to its definition, so any activity attributed to a run key converges retroactively. But the activity in the screenshot was attributed to the **shared `mcp-client` clientInfo key** (the bug), which has no recorded link to a specific agent — that data was never captured, so those exact pre-fix rows can't be re-attributed to "Routine Review". Verified on the dev DB: existing reports point to non-run-key actors (`resolves=f`). **New runs are fully correct**; this is a forward fix with best-effort historical backfill.

## Validation

- New integration tests (`agent_identity_test.go`): `MintRunAPIKey` stamps the FK + `def.Name`; `ResolveAgentSlugForActor` resolves a run key to its slug and returns `ok=false` for non-agent keys.
- Migration applied to the dev DB — backfill linked all **54** existing `agent:test-manual-review:*` keys → "Manual Review" + seed `test-manual-review`.
- `go build`/`vet`/`test` green across the **default / headless / lite** matrix; feed page renders without regression.
- Full live feed-convergence needs a real agent run (the sidecar can't run in this sandbox), but the data + resolution path are validated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
