### PR TITLE
fix(ui): brand marks match Lucide icon weight (alpha-strip currentColor)

### DIFF
--- a/input.css
+++ b/input.css
@@ -273,6 +273,15 @@
    * header) and shouldn't intercept clicks. */
   svg.brand, svg.brand * { pointer-events: none; }
 
+  /* Brand marks that fill with currentColor (Plaid, MCP) must mirror the
+   * svg.lucide alpha-strip above. Without it, a muted container color —
+   * text-base-content/45 (settings section headers) or /65 (settings-rail
+   * tabs) — bleeds its alpha into the fill, so the mark renders a softer
+   * gray than the Lucide icons sitting right next to it. The baked-fill
+   * marks (GitHub, Anthropic, Claude, Teller) use explicit fills and
+   * ignore `color`, so this is a no-op for them. */
+  svg.brand { color: rgb(from currentColor r g b / 1); }
+
   /* Two kinds of brand mark live here:
    *
    *   1. Monochrome marks meant to read as UI icons (Plaid, MCP). Their


### PR DESCRIPTION
Follow-up to #1595: makes the Plaid and MCP brand marks render at the **same visual weight** as the Lucide icons beside them.

## Problem

#1595 switched Plaid + MCP to `fill="currentColor"` so they follow the theme color (no longer always white). They do follow the theme now — but they came out a **softer gray** than the Lucide icons sitting next to them in the settings rail and section headers.

## Cause

`input.css` force-strips the alpha on Lucide icons:

```css
svg.lucide { color: rgb(from currentColor r g b / 1); }
```

so a Lucide icon inside a muted container (`text-base-content/45` in section headers, `/65` in the settings-rail tabs) still paints at **full** opacity. There was **no equivalent rule for `svg.brand`**, so the brand `fill="currentColor"` paths inherited the container's *reduced* alpha — 45% / 65% — and read lighter than every Lucide icon around them.

## Fix

Mirror the alpha-strip for brand marks:

```css
svg.brand { color: rgb(from currentColor r g b / 1); }
```

The baked-fill marks (GitHub, Anthropic, Claude, Teller) use explicit hex fills and ignore `color`, so this is a no-op for them — only the two `currentColor` marks (Plaid, MCP) are affected.

## Validation

Faithful headless render against the **real compiled `styles.css`**, reproducing the settings rail (MCP next to Lucide tabs) and section headers (Plaid next to a Lucide section icon), in light + dark, before vs after. In **BEFORE** the MCP/Plaid marks are dimmer than their Lucide siblings; in **AFTER** they match.

<img src="https://i.img402.dev/se8fkxx1qe.png" width="900" alt="Brand icon weight — before vs after, light and dark">

`styles.css` is a build artifact and isn't committed; the diff is the single `input.css` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
