### PR TITLE
feat: assign_series rule action — auto-apply a series like a category (PR3)

### DIFF
--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -158,6 +158,27 @@ Appends a comment authored by the rule. Accumulates — multiple rules can each 
 
 - Sync-only. Retroactive apply does **not** materialize `add_comment` actions (they're meant to narrate a specific sync event, not back-fill chatter).
 
+### `assign_series`
+
+```json
+{ "type": "assign_series", "merchant_key": "spotify", "create_if_missing": true }
+```
+
+Links the matching transaction to a recurring series (subscription). Provide **exactly one** of:
+
+- `series_short_id` — assign to an existing series by its short ID. Validated at rule-create time (must resolve).
+- `merchant_key` + `create_if_missing: true` — mint a household series keyed on `merchant_key` if one doesn't already exist at that signature, then assign.
+
+Behavior:
+
+- Materializes **inside the sync transaction** (resolve-or-mint → back-link → recompute rollups), so the link commits atomically with the rest of the sync.
+- **Link-and-rollup only** — it never overwrites a detector-snapped cadence or `detection_signals`, and it back-links NULL-fill only (never steals a charge already in another series).
+- Honors **sticky-reject**: minting at a `rejected` signature is a no-op (a rule can't resurrect a series the user dismissed).
+- Last-writer-wins across a pipeline: a higher-priority rule's `assign_series` overrides a lower one (a transaction joins at most one series).
+- **Sync-time only in v1.** Retroactive apply (`apply_rules`) does not yet materialize `assign_series` — existing transactions join when they next sync, or via the imperative `assign_series` MCP/REST tool.
+
+This is the declarative counterpart to the `assign_series` MCP tool: author the rule once and every future matching charge auto-joins the series with zero agent runs.
+
 ### Combining actions
 
 A rule can carry multiple actions of different types. Override (`category_override=true`) suppresses only the `set_category` part — `add_tag` and `add_comment` still fire.

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -186,6 +186,10 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 		}
 		agentOrch.FireSyncCompleteAgents(ctx)
 	}
+	// Materialize assign_series rule actions inside the sync transaction
+	// (resolve-or-mint + link). Function-pointer hook keeps the sync engine
+	// decoupled from the series service — same pattern as OnSyncComplete.
+	a.SyncEngine.AssignSeriesInTx = a.Service.AssignSeriesFromRuleTx
 	agentSched.Start(ctx)
 	a.AgentOrchestrator = agentOrch
 	a.AgentScheduler = agentSched

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -491,10 +491,11 @@ func toStringSlice(v interface{}) ([]string, bool) {
 // Unknown types are rejected by ValidateActions. Read-time tolerates unknown
 // types by skipping them with a logged warning (see sync/rule_resolver).
 var validActionTypes = map[string]bool{
-	"set_category": true,
-	"add_tag":      true,
-	"remove_tag":   true,
-	"add_comment":  true,
+	"set_category":  true,
+	"add_tag":       true,
+	"remove_tag":    true,
+	"add_comment":   true,
+	"assign_series": true,
 }
 
 // tagSlugPattern enforces the tag slug format: lowercase alphanumerics with
@@ -513,7 +514,7 @@ func (s *Service) ValidateActions(ctx context.Context, actions []RuleAction) err
 	seenCategory := false
 	for _, a := range actions {
 		if !validActionTypes[a.Type] {
-			return fmt.Errorf("%w: unknown action type %q (expected set_category|add_tag|remove_tag|add_comment)", ErrInvalidParameter, a.Type)
+			return fmt.Errorf("%w: unknown action type %q (expected set_category|add_tag|remove_tag|add_comment|assign_series)", ErrInvalidParameter, a.Type)
 		}
 		switch a.Type {
 		case "set_category":
@@ -537,6 +538,20 @@ func (s *Service) ValidateActions(ctx context.Context, actions []RuleAction) err
 		case "add_comment":
 			if a.Content == "" {
 				return fmt.Errorf("%w: add_comment action requires content", ErrInvalidParameter)
+			}
+		case "assign_series":
+			hasSeries := strings.TrimSpace(a.SeriesShortID) != ""
+			hasKey := strings.TrimSpace(a.MerchantKey) != ""
+			if hasSeries == hasKey {
+				return fmt.Errorf("%w: assign_series requires exactly one of series_short_id or merchant_key", ErrInvalidParameter)
+			}
+			if hasKey && !a.CreateIfMissing {
+				return fmt.Errorf("%w: assign_series with merchant_key requires create_if_missing=true", ErrInvalidParameter)
+			}
+			if hasSeries {
+				if _, err := s.resolveSeriesID(ctx, a.SeriesShortID); err != nil {
+					return fmt.Errorf("%w: assign_series series_short_id %q not found", ErrInvalidParameter, a.SeriesShortID)
+				}
 			}
 		}
 	}
@@ -1265,6 +1280,9 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 			tagRemoves = append(tagRemoves, a.TagSlug)
 		case "add_comment":
 			// sync-only; skip retroactively.
+		case "assign_series":
+			// Sync-time only in v1; retroactive apply of assign_series is a
+			// follow-up (it needs per-transaction resolve-or-mint + rollup).
 		}
 	}
 	hasWriteAction := categorySetCatID.Valid || len(tagAdds) > 0 || len(tagRemoves) > 0
@@ -1418,6 +1436,11 @@ func actionAuditFields(a RuleAction) (string, string) {
 		return "tag", a.TagSlug
 	case "add_comment":
 		return "comment", a.Content
+	case "assign_series":
+		if a.SeriesShortID != "" {
+			return "series", a.SeriesShortID
+		}
+		return "series", a.MerchantKey
 	}
 	return "", ""
 }

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -178,6 +178,91 @@ func (s *Service) AssignSeries(ctx context.Context, in AssignSeriesInput, actor 
 	return resp, nil
 }
 
+// AssignSeriesFromRuleTx materializes an `assign_series` rule action INSIDE the
+// sync transaction (the engine calls this via the Engine.AssignSeriesInTx hook,
+// so the sync package never imports service). It resolves the target series by
+// short_id, or matches/mints one by merchant_key signature, then back-links the
+// single transaction (NULL-fill only) and recomputes rollups — all on the
+// provided tx so it commits atomically with the sync.
+//
+// It is deliberately link-and-rollup only: it never sharpens cadence/signals,
+// so it can't downgrade a detector's snapped values (PATCH A is moot here).
+// Sticky-reject is honored (a rejected signature is skipped). Failures to
+// resolve are returned as nil (the rule no-ops) rather than failing the sync.
+func (s *Service) AssignSeriesFromRuleTx(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, seriesShortID, merchantKey string, createIfMissing bool) error {
+	qtx := s.Queries.WithTx(tx)
+
+	var seriesID pgtype.UUID
+	switch {
+	case strings.TrimSpace(seriesShortID) != "":
+		id, err := qtx.GetRecurringSeriesUUIDByShortID(ctx, seriesShortID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil // rule references a missing series — no-op, don't break sync
+			}
+			return fmt.Errorf("resolve series %q: %w", seriesShortID, err)
+		}
+		seriesID = id
+	case createIfMissing && strings.TrimSpace(merchantKey) != "":
+		key := strings.TrimSpace(merchantKey)
+		existing, matchErr := qtx.MatchSeriesForUpdate(ctx, db.MatchSeriesForUpdateParams{
+			MerchantKey:     key,
+			IsoCurrencyCode: pgtype.Text{}, // rule mints a household-level series
+			UserID:          pgtype.UUID{},
+		})
+		switch {
+		case matchErr == nil:
+			if existing.Confidence == SeriesConfidenceRejected {
+				return nil // sticky reject — never re-mint at this signature
+			}
+			seriesID = existing.ID
+		case errors.Is(matchErr, pgx.ErrNoRows):
+			inserted, err := qtx.InsertRecurringSeries(ctx, db.InsertRecurringSeriesParams{
+				Name:            key,
+				MerchantKey:     key,
+				Cadence:         SeriesCadenceUnknown,
+				AmountTolerance: pgconv.NumericCents(100),
+				Status:          SeriesStatusCandidate,
+				DetectionSource: SeriesSourceRule,
+				Confidence:      SeriesConfidenceAuto,
+			})
+			if err != nil {
+				return fmt.Errorf("insert rule series: %w", err)
+			}
+			seriesID = inserted.ID
+		default:
+			return fmt.Errorf("match series: %w", matchErr)
+		}
+	default:
+		return nil // nothing actionable
+	}
+
+	if _, err := qtx.BackLinkSeriesMembers(ctx, db.BackLinkSeriesMembersParams{
+		SeriesID:       seriesID,
+		TransactionIds: []pgtype.UUID{txnID},
+	}); err != nil {
+		return fmt.Errorf("back-link series member: %w", err)
+	}
+
+	row, err := qtx.GetRecurringSeriesByID(ctx, seriesID)
+	if err != nil {
+		return fmt.Errorf("reload series: %w", err)
+	}
+	occCount, lastAmount, lastSeen, err := s.seriesRollup(ctx, qtx, seriesID)
+	if err != nil {
+		return err
+	}
+	upd := updateParamsFromRow(row)
+	upd.OccurrenceCount = occCount
+	upd.LastAmount = lastAmount
+	upd.LastSeenDate = lastSeen
+	upd.NextExpectedDate = nextExpectedDate(upd.Cadence, lastSeen)
+	if _, err := qtx.UpdateRecurringSeries(ctx, upd); err != nil {
+		return fmt.Errorf("update series rollup: %w", err)
+	}
+	return nil
+}
+
 // linkSeriesMembers back-links transactions to an existing series (NULL-fill
 // only) and recomputes its rollups, in one transaction. Used by the
 // existing-series branch of AssignSeries.

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -397,3 +397,123 @@ func TestAssignSeries_RequiresSeriesOrCreate(t *testing.T) {
 		t.Fatal("expected error when create_if_missing is false and no series_id, got nil")
 	}
 }
+
+// netflixSeriesRow finds a candidate/active series by merchant_key in the list.
+func findSeriesByKey(t *testing.T, svc *service.Service, key string) *service.SeriesResponse {
+	t.Helper()
+	all, err := svc.ListSeries(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("list series: %v", err)
+	}
+	for i := range all {
+		if all[i].MerchantKey == key {
+			return &all[i]
+		}
+	}
+	return nil
+}
+
+func TestAssignSeriesFromRuleTx_MintAndLink(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM", "Netflix", 1599, "2026-05-15")
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := svc.AssignSeriesFromRuleTx(ctx, tx, txn.ID, "", "netflix", true); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("AssignSeriesFromRuleTx mint: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	row := findSeriesByKey(t, svc, "netflix")
+	if row == nil {
+		t.Fatal("rule did not mint a netflix series")
+	}
+	if row.DetectionSource != service.SeriesSourceRule {
+		t.Errorf("detection_source = %q, want rule", row.DetectionSource)
+	}
+	if row.OccurrenceCount != 1 {
+		t.Errorf("occurrence_count = %d, want 1", row.OccurrenceCount)
+	}
+	if n := countLinkedMembers(t, pool, row.ID); n != 1 {
+		t.Errorf("linked members = %d, want 1", n)
+	}
+}
+
+func TestAssignSeriesFromRuleTx_ExistingByShortID(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID, members := seedRecurring(t, queries, "SPOTIFY", []string{"2026-02-15", "2026-03-15", "2026-04-15"})
+	created, err := svc.UpsertSeriesCandidate(ctx, spotifyUpsert(members), service.SystemActor())
+	if err != nil {
+		t.Fatalf("seed series: %v", err)
+	}
+	extra := testutil.MustCreateTransaction(t, queries, acctID, "SPOTIFY_X", "SPOTIFY", 999, "2026-05-15")
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := svc.AssignSeriesFromRuleTx(ctx, tx, extra.ID, created.ShortID, "", false); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("AssignSeriesFromRuleTx by short_id: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	refreshed, _ := svc.GetSeries(ctx, created.ShortID)
+	if refreshed.OccurrenceCount != 4 {
+		t.Errorf("occurrence_count = %d, want 4", refreshed.OccurrenceCount)
+	}
+	if n := countLinkedMembers(t, pool, created.ID); n != 4 {
+		t.Errorf("linked members = %d, want 4", n)
+	}
+}
+
+func TestAssignSeriesFromRuleTx_StickyRejectSkips(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID, members := seedRecurring(t, queries, "SPOTIFY", []string{"2026-02-15", "2026-03-15", "2026-04-15"})
+	// Create at the SAME signature the rule mints under (NULL currency + user)
+	// so the rule's match finds the rejected row and skips.
+	householdUpsert := service.SeriesUpsert{
+		Name:         "Spotify",
+		MerchantKey:  "spotify",
+		Cadence:      service.SeriesCadenceMonthly,
+		Source:       service.SeriesSourceDeterministic,
+		MemberTxnIDs: members,
+	}
+	created, _ := svc.UpsertSeriesCandidate(ctx, householdUpsert, service.SystemActor())
+	if _, err := svc.ReviewSeries(ctx, created.ShortID, service.VerdictReject, service.Actor{Type: "user", Name: "Tester"}); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	extra := testutil.MustCreateTransaction(t, queries, acctID, "SPOTIFY_X", "SPOTIFY", 999, "2026-05-15")
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Rule tries to mint at the rejected signature — must be a no-op.
+	if err := svc.AssignSeriesFromRuleTx(ctx, tx, extra.ID, "", "spotify", true); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("AssignSeriesFromRuleTx sticky: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// No new series, and the rejected one was not touched (still 3 members).
+	if total, _ := queries.CountRecurringSeries(ctx); total != 1 {
+		t.Errorf("series count = %d, want 1 (sticky reject must not mint)", total)
+	}
+	if n := countLinkedMembers(t, pool, created.ID); n != 3 {
+		t.Errorf("rejected series members = %d, want 3 (extra txn must not link)", n)
+	}
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -441,6 +441,11 @@ type RuleAction struct {
 	CategorySlug string `json:"category_slug,omitempty"`
 	TagSlug      string `json:"tag_slug,omitempty"`
 	Content      string `json:"content,omitempty"`
+	// assign_series fields: assign matching transactions to an existing series
+	// (SeriesShortID) or mint one keyed on MerchantKey (CreateIfMissing).
+	SeriesShortID   string `json:"series_short_id,omitempty"`
+	MerchantKey     string `json:"merchant_key,omitempty"`
+	CreateIfMissing bool   `json:"create_if_missing,omitempty"`
 }
 
 // ActivityEntry represents a single event in a transaction's activity timeline.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -67,6 +67,13 @@ type Engine struct {
 	// so the hook can correlate; runs in the same goroutine as Sync so the
 	// hook should hand off async if it might block.
 	OnSyncComplete func(ctx context.Context, connectionID pgtype.UUID)
+
+	// AssignSeriesInTx materializes an `assign_series` rule action INSIDE the
+	// sync transaction — resolving/minting a recurring series and back-linking
+	// the transaction. Wired by the app layer in serve.go (function pointer, no
+	// import cycle — the same pattern as OnSyncComplete). Nil-safe: when unset
+	// (series subsystem not wired) the action is a no-op.
+	AssignSeriesInTx func(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, seriesShortID, merchantKey string, createIfMissing bool) error
 }
 
 // NewEngine creates a new sync engine.
@@ -788,6 +795,16 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 		src := sourceByKey["comment|"+content]
 		if err := e.applyCommentFromRule(ctx, tx, dbTxn.ID, content, src.ruleID, src.ruleShortID, src.ruleName); err != nil {
 			return result.Sources, err
+		}
+	}
+
+	// assign_series: link the transaction to a recurring series within the sync
+	// tx (resolve-or-mint + rollup), via the app-wired hook so the sync package
+	// stays decoupled from the series service. No-op when the hook is unset.
+	if result.SeriesAssign != nil && e.AssignSeriesInTx != nil {
+		if err := e.AssignSeriesInTx(ctx, tx, dbTxn.ID,
+			result.SeriesAssign.SeriesShortID, result.SeriesAssign.MerchantKey, result.SeriesAssign.CreateIfMissing); err != nil {
+			return result.Sources, fmt.Errorf("apply assign_series: %w", err)
 		}
 	}
 

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -91,6 +91,10 @@ type RuleActions struct {
 	// Comments is the accumulated list of comment content strings from
 	// add_comment actions.
 	Comments []string
+	// SeriesAssign, when non-nil, links the transaction to a recurring series.
+	// Last-writer-wins: the highest-priority matching rule owns the assignment
+	// (a transaction belongs to at most one series).
+	SeriesAssign *SeriesAssignIntent
 	// Sources records per-action provenance for the audit trail. For
 	// set_category, only the winning (last) rule's source is retained.
 	// For tag actions, only net-surviving adds/removes have sources.
@@ -101,10 +105,23 @@ type RuleActions struct {
 // Kept local so the sync package doesn't import service (preserves the
 // one-way service → sync dependency direction).
 type typedAction struct {
-	Type         string
-	CategorySlug string
-	TagSlug      string
-	Content      string
+	Type            string
+	CategorySlug    string
+	TagSlug         string
+	Content         string
+	SeriesShortID   string
+	MerchantKey     string
+	CreateIfMissing bool
+}
+
+// SeriesAssignIntent is the resolved assign_series action: link the
+// transaction to an existing series (SeriesShortID) or mint one keyed on
+// MerchantKey (CreateIfMissing). A transaction joins at most one series, so
+// this is last-writer-wins across matching rules.
+type SeriesAssignIntent struct {
+	SeriesShortID   string
+	MerchantKey     string
+	CreateIfMissing bool
 }
 
 // RuleResolver loads transaction rules and evaluates them during sync.
@@ -296,6 +313,11 @@ func parseTypedActions(raw []byte, ruleID pgtype.UUID, logger *slog.Logger) []ty
 		case "add_comment":
 			content, _ := m["content"].(string)
 			out = append(out, typedAction{Type: t, Content: content})
+		case "assign_series":
+			seriesShortID, _ := m["series_short_id"].(string)
+			merchantKey, _ := m["merchant_key"].(string)
+			createIfMissing, _ := m["create_if_missing"].(bool)
+			out = append(out, typedAction{Type: t, SeriesShortID: seriesShortID, MerchantKey: merchantKey, CreateIfMissing: createIfMissing})
 		default:
 			logger.Warn("skipping unknown rule action type",
 				"rule_id", pgconv.FormatUUID(ruleID), "type", t)
@@ -529,6 +551,26 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 					ActionField: "comment",
 					ActionValue: a.Content,
 				})
+			case "assign_series":
+				if a.SeriesShortID == "" && a.MerchantKey == "" {
+					continue
+				}
+				// Last-writer-wins: a transaction joins at most one series, so a
+				// later-stage rule overrides an earlier assignment and supersedes
+				// its audit source.
+				result.SeriesAssign = &SeriesAssignIntent{
+					SeriesShortID:   a.SeriesShortID,
+					MerchantKey:     a.MerchantKey,
+					CreateIfMissing: a.CreateIfMissing,
+				}
+				result.Sources = dropSeriesSource(result.Sources)
+				result.Sources = append(result.Sources, RuleActionSource{
+					RuleID:      rule.id,
+					RuleShortID: rule.shortID,
+					RuleName:    rule.name,
+					ActionField: "series",
+					ActionValue: seriesActionValue(a),
+				})
 			}
 		}
 	}
@@ -545,6 +587,32 @@ func dropCategorySource(src []RuleActionSource) []RuleActionSource {
 	kept := src[:0]
 	for _, s := range src {
 		if s.ActionField == "category" {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept
+}
+
+// seriesActionValue is the audit value for an assign_series action: the
+// series short_id when assigning to an existing series, else the merchant_key
+// the series is minted under.
+func seriesActionValue(a typedAction) string {
+	if a.SeriesShortID != "" {
+		return a.SeriesShortID
+	}
+	return a.MerchantKey
+}
+
+// dropSeriesSource removes any prior series source so the final source slice
+// records only the winning (last) rule's provenance for the assignment.
+func dropSeriesSource(src []RuleActionSource) []RuleActionSource {
+	if len(src) == 0 {
+		return src
+	}
+	kept := src[:0]
+	for _, s := range src {
+		if s.ActionField == "series" {
 			continue
 		}
 		kept = append(kept, s)


### PR DESCRIPTION
A transaction rule can now **auto-apply a recurring series**, the same way it auto-applies a category — resolving the maintainer's framing ("why not auto-apply a series like a category?"). Assignment is per-row and fits a rule; the detector still owns the aggregate *discovery*.

## What's included
- **Action shape**: `{type: assign_series, series_short_id}` **XOR** `{merchant_key, create_if_missing: true}`.
- **Sync-time materialization** inside the sync transaction via a function-pointer hook (`Engine.AssignSeriesInTx`, wired in `serve.go`) — keeps the sync engine decoupled from the series service, same pattern as `OnSyncComplete`. Service-side `AssignSeriesFromRuleTx` does resolve-or-mint → back-link → rollup on the sync tx.
- **Safe by construction**: link-and-rollup only (never overwrites a detector-snapped cadence/signals — PATCH A is moot here), NULL-fill back-link (never steals a charge already in another series), honors **sticky-reject** (no re-mint at a rejected signature), last-writer-wins across the pipeline.
- **Validation** (`service/rules.go`): XOR + `create_if_missing` requirement + the `series_short_id` must resolve; audit field; retroactive apply skips it.
- **Tests**: mint+link, assign-by-short_id, sticky-reject no-op. **Docs**: `rule-dsl.md`.

## Deferred (tracked as follow-up tasks)
`series`/`in_series` conditions · retroactive `assign_series` · `series_assigned` annotation kind · `near_miss` feed · `review_series` re-key/split.

## Verification
All three build tags + `go vet` + sync & service integration suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
