### PR TITLE
feat: series tags → linked transactions inherit them

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -87,6 +87,8 @@ Unauthenticated device-code dance the CLI uses to mint API keys on a remote host
 | GET | `/series/{id}` | R | Single series (accepts UUID or short_id) |
 | POST | `/series` | W | Create a missed series (`merchant_key`+`create_if_missing`) or assign by `series_id`; links `transaction_ids` (≤50), optional `confirm` |
 | POST | `/series/{id}/transactions` | W | Link transactions (≤50, NULL-fill only) to a series; optional `confirm` |
+| POST | `/series/{id}/tags` | W | Attach a tag to a series; linked transactions inherit it |
+| DELETE | `/series/{id}/tags/{slug}` | W | Detach a tag; strips series-inherited copies from members (keeps user-added) |
 | PATCH | `/series/{id}` | W | Apply a verdict: `confirm`/`reject`/`pause`/`cancel` (user confirmation outranks agent) |
 
 ## Rules

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -256,6 +256,14 @@ Apply a verdict: `confirm` (it is a subscription → `active`), `reject` (NOT a 
 
 Create a recurring series detection missed, or link transactions to an existing one — the agent's path to fix gaps. Provide `series_id` to assign to an existing series, **or** `merchant_key` + `create_if_missing:true` to mint one (funnels through the same dedup + sticky-reject arbitration as the detector, so re-creating a user-rejected series at the same signature is a no-op). Pass `transaction_ids` (≤50) to back-link members (NULL-fill only — never steals a charge already in another series). `confirm:true` flips it straight to `active`; omit to leave a reviewable `candidate`. Use after `list_series(status=candidate)` shows nothing for a subscription the user says exists.
 
+### add_series_tag (Write)
+
+Attach an existing tag to a recurring series. The tag is materialized onto every linked transaction (they inherit it) and applied to future members as they join — so tagging the Netflix series tags all its charges. The tag must already exist (create it with `create_tag` first). Returns the updated series (including its `tags`).
+
+### remove_series_tag (Write)
+
+Detach a tag from a recurring series and strip the series-inherited copies from its linked transactions. Provenance-scoped: a tag a user added directly to a transaction survives.
+
 ---
 
 ## Transaction Rules Tools

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -181,6 +181,7 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 	if s.CategoryID != nil {
 		row.CategoryName = catName[*s.CategoryID]
 	}
+	row.Tags = s.Tags
 	if s.UserID != nil {
 		row.UserID = *s.UserID
 		row.OwnerName = userName[*s.UserID]

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -189,6 +189,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Patch("/tags/{slug}", UpdateTagHandler(svc))
 			r.Post("/series", AssignSeriesHandler(svc))
 			r.Post("/series/{id}/transactions", LinkSeriesTransactionsHandler(svc))
+			r.Post("/series/{id}/tags", AddSeriesTagHandler(svc))
+			r.Delete("/series/{id}/tags/{slug}", RemoveSeriesTagHandler(svc))
 			r.Patch("/series/{id}", ReviewSeriesHandler(svc))
 			r.Delete("/tags/{slug}", DeleteTagHandler(svc))
 			r.Put("/settings/providers/plaid", UpdatePlaidConfigHandler(a))

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -121,6 +121,57 @@ func LinkSeriesTransactionsHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// addSeriesTagRequest is the body for POST /api/v1/series/{id}/tags.
+type addSeriesTagRequest struct {
+	TagSlug string `json:"tag_slug"`
+}
+
+// AddSeriesTagHandler attaches a tag to a series; the tag is materialized onto
+// the series' linked transactions. POST /api/v1/series/{id}/tags (write).
+func AddSeriesTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var body addSeriesTagRequest
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+		if strings.TrimSpace(body.TagSlug) == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "tag_slug is required")
+			return
+		}
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.AddSeriesTag(r.Context(), id, body.TagSlug, actor); err != nil {
+			writeServiceError(w, err, "Series or tag not found", "Failed to add series tag")
+			return
+		}
+		s, err := svc.GetSeries(r.Context(), id)
+		if err != nil {
+			writeServiceError(w, err, "Series not found", "Failed to load series")
+			return
+		}
+		writeData(w, s)
+	}
+}
+
+// RemoveSeriesTagHandler detaches a tag from a series and strips the
+// series-inherited copies from its members. DELETE /api/v1/series/{id}/tags/{slug} (write).
+func RemoveSeriesTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		slug := chi.URLParam(r, "slug")
+		if err := svc.RemoveSeriesTag(r.Context(), id, slug); err != nil {
+			writeServiceError(w, err, "Series or tag not found", "Failed to remove series tag")
+			return
+		}
+		s, err := svc.GetSeries(r.Context(), id)
+		if err != nil {
+			writeServiceError(w, err, "Series not found", "Failed to load series")
+			return
+		}
+		writeData(w, s)
+	}
+}
+
 // reviewSeriesRequest is the body for PATCH /api/v1/series/{id}.
 type reviewSeriesRequest struct {
 	Verdict string `json:"verdict"` // confirm | reject | pause | cancel

--- a/internal/db/migrations/20260530190011_series_tags.sql
+++ b/internal/db/migrations/20260530190011_series_tags.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+-- series_tags: tags attached to a recurring series. A series' tags are
+-- materialized onto its linked transactions (transaction_tags) with provenance
+-- added_by_type='system' + added_by_id=<series short_id>, so they show up
+-- everywhere transaction tags do, and removal can strip exactly the
+-- series-inherited rows without touching user-added tags.
+-- Additive-only: one new table. Safe on the shared dev DB.
+CREATE TABLE series_tags (
+    series_id  UUID        NOT NULL REFERENCES recurring_series(id) ON DELETE CASCADE,
+    tag_id     UUID        NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (series_id, tag_id)
+);
+
+CREATE INDEX series_tags_tag_id_idx ON series_tags (tag_id);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS series_tags;

--- a/internal/db/queries/series_tags.sql
+++ b/internal/db/queries/series_tags.sql
@@ -1,0 +1,46 @@
+-- name: AddSeriesTag :execrows
+INSERT INTO series_tags (series_id, tag_id)
+VALUES ($1, $2)
+ON CONFLICT (series_id, tag_id) DO NOTHING;
+
+-- name: RemoveSeriesTag :execrows
+DELETE FROM series_tags WHERE series_id = $1 AND tag_id = $2;
+
+-- name: ListSeriesTagSlugs :many
+SELECT t.slug
+FROM tags t
+JOIN series_tags st ON st.tag_id = t.id
+WHERE st.series_id = $1
+ORDER BY t.slug;
+
+-- name: ListSeriesTagIDs :many
+SELECT tag_id FROM series_tags WHERE series_id = $1;
+
+-- ApplySeriesTagsToTransactions materializes ALL of a series' tags onto the
+-- given transactions (the just-linked members). Provenance marks them as
+-- series-inherited so RemoveSeriesTagFromMembers can strip exactly these.
+-- name: ApplySeriesTagsToTransactions :exec
+INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_id, added_by_name)
+SELECT u.txn_id, st.tag_id, 'system', s.short_id, s.name
+FROM series_tags st
+JOIN recurring_series s ON s.id = st.series_id
+CROSS JOIN unnest($2::uuid[]) AS u(txn_id)
+WHERE st.series_id = $1
+ON CONFLICT (transaction_id, tag_id) DO NOTHING;
+
+-- ApplySeriesTagToAllMembers materializes ONE tag onto every current member of
+-- a series (used when a tag is newly added to the series — backfill).
+-- name: ApplySeriesTagToAllMembers :exec
+INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_id, added_by_name)
+SELECT t.id, $2, 'system', s.short_id, s.name
+FROM transactions t
+JOIN recurring_series s ON s.id = $1
+WHERE t.series_id = $1 AND t.deleted_at IS NULL
+ON CONFLICT (transaction_id, tag_id) DO NOTHING;
+
+-- RemoveSeriesTagFromMembers strips a series-inherited tag from all members.
+-- Scoped by provenance (added_by_type='system' + added_by_id=series short_id)
+-- so a tag the user added manually to a member survives.
+-- name: RemoveSeriesTagFromMembers :exec
+DELETE FROM transaction_tags
+WHERE tag_id = $1 AND added_by_type = 'system' AND added_by_id = $2;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -386,6 +386,14 @@ func (s *MCPServer) buildToolRegistry() {
 			Name: "assign_series", Title: "Assign / Create Subscription", Classification: ToolWrite,
 			Description: "Create a recurring series detection missed, or link transactions to an existing one — the agent's path to fix gaps. Provide series_id to assign to an existing series, OR merchant_key + create_if_missing:true to mint one (funnels through the same dedup + sticky-reject arbitration as the detector, so re-creating a user-rejected series at the same signature is a no-op). Pass transaction_ids (≤50) to back-link members (NULL-fill only — never steals a charge already in another series). confirm:true flips it straight to active; omit to leave a reviewable candidate. Use after list_series(status=candidate) shows nothing for a subscription the user says exists.",
 		}, s.handleAssignSeries, s),
+		makeToolDefLogged(ToolSpec{
+			Name: "add_series_tag", Title: "Tag a Subscription", Classification: ToolWrite,
+			Description: "Attach an existing tag to a recurring series. The tag is materialized onto every linked transaction (they inherit it) and applied to future members as they join — so tagging the Netflix series tags all its charges. The tag must already exist (create it first with create_tag).",
+		}, s.handleAddSeriesTag, s),
+		makeToolDefLogged(ToolSpec{
+			Name: "remove_series_tag", Title: "Untag a Subscription", Classification: ToolWrite,
+			Description: "Detach a tag from a recurring series and strip the series-inherited copies from its linked transactions. Provenance-scoped: a tag a user added directly to a transaction survives.",
+		}, s.handleRemoveSeriesTag, s),
 
 		// --- Query + aggregate ---
 		makeToolDefLogged(ToolSpec{

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -90,6 +90,52 @@ func (s *MCPServer) handleReviewSeries(ctx context.Context, _ *mcpsdk.CallToolRe
 	return jsonResult(series)
 }
 
+type seriesTagInput struct {
+	ID      string `json:"id" jsonschema:"required,Series short ID or UUID."`
+	TagSlug string `json:"tag_slug" jsonschema:"required,Tag slug (must already exist)."`
+}
+
+func (s *MCPServer) handleAddSeriesTag(ctx context.Context, _ *mcpsdk.CallToolRequest, input seriesTagInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.ID == "" || input.TagSlug == "" {
+		return errorResult(fmt.Errorf("id and tag_slug are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	if err := s.svc.AddSeriesTag(context.Background(), input.ID, input.TagSlug, actor); err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return errorResult(fmt.Errorf("series not found")), nil, nil
+		}
+		return errorResult(err), nil, nil
+	}
+	series, err := s.svc.GetSeries(context.Background(), input.ID)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(series)
+}
+
+func (s *MCPServer) handleRemoveSeriesTag(ctx context.Context, _ *mcpsdk.CallToolRequest, input seriesTagInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.ID == "" || input.TagSlug == "" {
+		return errorResult(fmt.Errorf("id and tag_slug are required")), nil, nil
+	}
+	if err := s.svc.RemoveSeriesTag(context.Background(), input.ID, input.TagSlug); err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return errorResult(fmt.Errorf("series not found")), nil, nil
+		}
+		return errorResult(err), nil, nil
+	}
+	series, err := s.svc.GetSeries(context.Background(), input.ID)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(series)
+}
+
 func (s *MCPServer) handleAssignSeries(ctx context.Context, _ *mcpsdk.CallToolRequest, input assignSeriesInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -107,6 +107,7 @@ type SeriesResponse struct {
 	NextExpectedDate *string         `json:"next_expected_date,omitempty"`
 	OccurrenceCount  int             `json:"occurrence_count"`
 	DetectionSignals json.RawMessage `json:"detection_signals,omitempty"`
+	Tags             []string        `json:"tags,omitempty"`
 	CreatedAt        string          `json:"created_at"`
 	UpdatedAt        string          `json:"updated_at"`
 }
@@ -243,6 +244,12 @@ func (s *Service) AssignSeriesFromRuleTx(ctx context.Context, tx pgx.Tx, txnID p
 	}); err != nil {
 		return fmt.Errorf("back-link series member: %w", err)
 	}
+	if err := qtx.ApplySeriesTagsToTransactions(ctx, db.ApplySeriesTagsToTransactionsParams{
+		SeriesID: seriesID,
+		Column2:  []pgtype.UUID{txnID},
+	}); err != nil {
+		return fmt.Errorf("apply series tags to member: %w", err)
+	}
 
 	row, err := qtx.GetRecurringSeriesByID(ctx, seriesID)
 	if err != nil {
@@ -296,6 +303,12 @@ func (s *Service) linkSeriesMembers(ctx context.Context, idOrShort string, membe
 			TransactionIds: memberIDs,
 		}); err != nil {
 			return nil, fmt.Errorf("back-link members: %w", err)
+		}
+		if err := qtx.ApplySeriesTagsToTransactions(ctx, db.ApplySeriesTagsToTransactionsParams{
+			SeriesID: row.ID,
+			Column2:  memberIDs,
+		}); err != nil {
+			return nil, fmt.Errorf("apply series tags to members: %w", err)
 		}
 	}
 	occCount, lastAmount, lastSeen, err := s.seriesRollup(ctx, qtx, row.ID)
@@ -429,13 +442,20 @@ func (s *Service) UpsertSeriesCandidate(ctx context.Context, in SeriesUpsert, ac
 		}
 	}
 
-	// 4. Back-link member transactions (NULL-fill only).
+	// 4. Back-link member transactions (NULL-fill only) and materialize the
+	// series' tags onto the freshly-linked members (NULL-fill via ON CONFLICT).
 	if len(memberIDs) > 0 {
 		if _, err := qtx.BackLinkSeriesMembers(ctx, db.BackLinkSeriesMembersParams{
 			SeriesID:       base.ID,
 			TransactionIds: memberIDs,
 		}); err != nil {
 			return nil, fmt.Errorf("back-link members: %w", err)
+		}
+		if err := qtx.ApplySeriesTagsToTransactions(ctx, db.ApplySeriesTagsToTransactionsParams{
+			SeriesID: base.ID,
+			Column2:  memberIDs,
+		}); err != nil {
+			return nil, fmt.Errorf("apply series tags to members: %w", err)
 		}
 	}
 
@@ -570,7 +590,73 @@ func (s *Service) GetSeries(ctx context.Context, idOrShort string) (*SeriesRespo
 		return nil, fmt.Errorf("get series: %w", err)
 	}
 	resp := seriesFromRow(row)
+	if slugs, err := s.Queries.ListSeriesTagSlugs(ctx, id); err == nil {
+		resp.Tags = slugs
+	}
 	return &resp, nil
+}
+
+// AddSeriesTag attaches an existing tag (by slug) to a series and materializes
+// it onto the series' current members (NULL-fill, provenance=system+series).
+func (s *Service) AddSeriesTag(ctx context.Context, idOrShort, tagSlug string, actor Actor) error {
+	id, err := s.resolveSeriesID(ctx, idOrShort)
+	if err != nil {
+		return err
+	}
+	tag, err := s.Queries.GetTagBySlug(ctx, tagSlug)
+	if err != nil {
+		return fmt.Errorf("%w: tag %q not found", ErrInvalidParameter, tagSlug)
+	}
+	if _, err := s.Queries.AddSeriesTag(ctx, db.AddSeriesTagParams{SeriesID: id, TagID: tag.ID}); err != nil {
+		return fmt.Errorf("add series tag: %w", err)
+	}
+	if err := s.Queries.ApplySeriesTagToAllMembers(ctx, db.ApplySeriesTagToAllMembersParams{ID: id, TagID: tag.ID}); err != nil {
+		return fmt.Errorf("apply series tag to members: %w", err)
+	}
+	return nil
+}
+
+// RemoveSeriesTag detaches a tag from a series and strips the series-inherited
+// copies from its members (provenance-scoped, so user-added tags survive).
+func (s *Service) RemoveSeriesTag(ctx context.Context, idOrShort, tagSlug string) error {
+	id, err := s.resolveSeriesID(ctx, idOrShort)
+	if err != nil {
+		return err
+	}
+	row, err := s.Queries.GetRecurringSeriesByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("get series: %w", err)
+	}
+	tag, err := s.Queries.GetTagBySlug(ctx, tagSlug)
+	if err != nil {
+		return fmt.Errorf("%w: tag %q not found", ErrInvalidParameter, tagSlug)
+	}
+	if _, err := s.Queries.RemoveSeriesTag(ctx, db.RemoveSeriesTagParams{SeriesID: id, TagID: tag.ID}); err != nil {
+		return fmt.Errorf("remove series tag: %w", err)
+	}
+	if err := s.Queries.RemoveSeriesTagFromMembers(ctx, db.RemoveSeriesTagFromMembersParams{
+		TagID:     tag.ID,
+		AddedByID: pgconv.Text(row.ShortID),
+	}); err != nil {
+		return fmt.Errorf("remove series tag from members: %w", err)
+	}
+	return nil
+}
+
+// ListSeriesTags returns the tag slugs attached to a series.
+func (s *Service) ListSeriesTags(ctx context.Context, idOrShort string) ([]string, error) {
+	id, err := s.resolveSeriesID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	slugs, err := s.Queries.ListSeriesTagSlugs(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list series tags: %w", err)
+	}
+	return slugs, nil
 }
 
 // ListSeries returns series, optionally filtered by status. With no status it

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -411,6 +412,96 @@ func findSeriesByKey(t *testing.T, svc *service.Service, key string) *service.Se
 		}
 	}
 	return nil
+}
+
+func txnHasTag(t *testing.T, pool *pgxpool.Pool, txnID pgtype.UUID, slug string) bool {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM transaction_tags tt JOIN tags t ON t.id = tt.tag_id WHERE tt.transaction_id = $1 AND t.slug = $2`,
+		txnID, slug).Scan(&n); err != nil {
+		t.Fatalf("txnHasTag: %v", err)
+	}
+	return n > 0
+}
+
+func TestSeriesTags_MembersInherit(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	testutil.MustCreateTag(t, queries, "subscriptions", "Subscriptions")
+	acctID := seedTxnFixture(t, queries)
+	t1 := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_1", "Netflix", 1599, "2026-03-15")
+	t2 := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_2", "Netflix", 1599, "2026-04-15")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	series, err := svc.AssignSeries(ctx, service.AssignSeriesInput{
+		MerchantKey: "netflix", CreateIfMissing: true, TransactionIDs: []string{t1.ShortID, t2.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("create series: %v", err)
+	}
+
+	// Attach a tag to the series → existing members are backfilled.
+	if err := svc.AddSeriesTag(ctx, series.ShortID, "subscriptions", actor); err != nil {
+		t.Fatalf("AddSeriesTag: %v", err)
+	}
+	if !txnHasTag(t, pool, t1.ID, "subscriptions") || !txnHasTag(t, pool, t2.ID, "subscriptions") {
+		t.Error("existing members did not inherit the series tag on add (backfill)")
+	}
+
+	// A member linked AFTER the tag exists inherits it at link time.
+	t3 := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_3", "Netflix", 1599, "2026-05-15")
+	if _, err := svc.AssignSeries(ctx, service.AssignSeriesInput{
+		SeriesID: &series.ShortID, TransactionIDs: []string{t3.ShortID},
+	}, actor); err != nil {
+		t.Fatalf("link new member: %v", err)
+	}
+	if !txnHasTag(t, pool, t3.ID, "subscriptions") {
+		t.Error("newly-linked member did not inherit the series tag")
+	}
+
+	// GetSeries reflects the series' tags.
+	got, _ := svc.GetSeries(ctx, series.ShortID)
+	if len(got.Tags) != 1 || got.Tags[0] != "subscriptions" {
+		t.Errorf("GetSeries.Tags = %v, want [subscriptions]", got.Tags)
+	}
+}
+
+func TestSeriesTags_RemoveStripsInheritedKeepsUserTags(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	testutil.MustCreateTag(t, queries, "subscriptions", "Subscriptions")
+	userTag := testutil.MustCreateTag(t, queries, "important", "Important")
+	acctID := seedTxnFixture(t, queries)
+	tx1 := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_1", "Netflix", 1599, "2026-04-15")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	series, err := svc.AssignSeries(ctx, service.AssignSeriesInput{
+		MerchantKey: "netflix", CreateIfMissing: true, TransactionIDs: []string{tx1.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("create series: %v", err)
+	}
+	if err := svc.AddSeriesTag(ctx, series.ShortID, "subscriptions", actor); err != nil {
+		t.Fatalf("AddSeriesTag: %v", err)
+	}
+	// User manually adds a different tag to the member.
+	if _, err := queries.AddTransactionTag(ctx, db.AddTransactionTagParams{
+		TransactionID: tx1.ID, TagID: userTag.ID,
+		AddedByType: "user", AddedByID: pgconv.Text("u1"), AddedByName: "Tester",
+	}); err != nil {
+		t.Fatalf("user add tag: %v", err)
+	}
+
+	if err := svc.RemoveSeriesTag(ctx, series.ShortID, "subscriptions"); err != nil {
+		t.Fatalf("RemoveSeriesTag: %v", err)
+	}
+	if txnHasTag(t, pool, tx1.ID, "subscriptions") {
+		t.Error("series-inherited tag was not stripped from member on remove")
+	}
+	if !txnHasTag(t, pool, tx1.ID, "important") {
+		t.Error("user-added tag was wrongly stripped by RemoveSeriesTag")
+	}
 }
 
 func TestAssignSeriesFromRuleTx_MintAndLink(t *testing.T) {

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -65,6 +65,17 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 			@components.SettingsRow(components.SettingsRowProps{Label: "Suggested category"}) {
 				<span class="text-sm">{ subscriptionDetailField(p.Series.CategoryName) }</span>
 			}
+			@components.SettingsRow(components.SettingsRowProps{Label: "Tags", Caption: "Linked charges inherit these"}) {
+				if len(p.Series.Tags) > 0 {
+					<span class="inline-flex flex-wrap gap-1.5">
+						for _, tag := range p.Series.Tags {
+							<span class="badge badge-soft badge-neutral badge-sm">{ tag }</span>
+						}
+					</span>
+				} else {
+					<span class="text-base-content/40 text-sm">—</span>
+				}
+			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Expected day"}) {
 				<span class="text-sm">{ subscriptionDetailField(p.ExpectedDay) }</span>
 			}

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -67,6 +67,7 @@ type SubscriptionRow struct {
 	Source       string // deterministic | agent | user | rule
 	SourceLabel  string
 	CategoryName string
+	Tags         []string // tag slugs attached to the series (inherited by members)
 
 	// Monthly-equivalent contribution (active rows) — used nowhere in the row
 	// itself but kept for parity / future per-row display.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1946,6 +1946,44 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/RecurringSeries" }
         "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/series/{id}/tags:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Series]
+      summary: Attach a tag to a recurring series
+      description: "**Requires `full_access` scope.** Attaches an existing tag to the series and materializes it onto the series' linked transactions (they inherit the tag). Returns the updated series."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tag_slug]
+              properties:
+                tag_slug: { type: string }
+      responses:
+        "200":
+          description: Updated series (includes its tags).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RecurringSeries" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/series/{id}/tags/{slug}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+      - { name: slug, in: path, required: true, schema: { type: string } }
+    delete:
+      tags: [Series]
+      summary: Detach a tag from a recurring series
+      description: "**Requires `full_access` scope.** Detaches the tag and strips the series-inherited copies from its members (provenance-scoped, so user-added tags survive)."
+      responses:
+        "200":
+          description: Updated series.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RecurringSeries" }
+        "404": { $ref: "#/components/responses/NotFound" }
 
   # -- Users --
   /api/v1/users:
@@ -3181,6 +3219,7 @@ components:
         next_expected_date: { type: string, format: date, nullable: true }
         occurrence_count: { type: integer }
         detection_signals: { type: object, nullable: true, additionalProperties: true }
+        tags: { type: array, items: { type: string } }
         created_at: { type: string, format: date-time }
       additionalProperties: true
     Category:


### PR DESCRIPTION
Implements the maintainer's top backlog idea: **attach tags to a recurring series, and every linked transaction inherits them.**

## How it works
Series tags are **materialized** into `transaction_tags` with provenance (`added_by_type='system'`, `added_by_id=<series short_id>`):
- **On add** → backfilled onto all current members.
- **On link** → applied to members as they join (detector, `assign_series` rule action, manual/agent `assign_series`).
- **On remove** → only the series-inherited copies are stripped (provenance-scoped), so a tag a user added *directly* to a charge survives.

Because they're real `transaction_tags` rows, inherited tags show up everywhere transaction tags already do (lists, filters, rules) — no query changes.

## Surface
- **Migration**: `series_tags` join table (additive).
- **Service**: `AddSeriesTag` / `RemoveSeriesTag` / `ListSeriesTags`; `SeriesResponse.tags`; materialization wired into every link point.
- **REST**: `POST /series/{id}/tags`, `DELETE /series/{id}/tags/{slug}` (full_access).
- **MCP**: `add_series_tag` / `remove_series_tag` (agent parity).
- **UI**: Tags row on the subscription detail page (chips).
- openapi + api-endpoints + mcp-tools-reference; 2 integration tests (inherit on add/link; remove strips inherited, keeps user-added).

## Follow-up (tracked)
Interactive tag-editing UI on the detail page (add/remove from the browser) — task #2.

## Verification
All three build tags + `go vet` + OpenAPI drift + MCP contract + service/api/mcp/sync integration green. Detail-page Tags row browser-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
