### PR TITLE
feat: retroactive apply for assign_series rule action

### DIFF
--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -175,7 +175,7 @@ Behavior:
 - **Link-and-rollup only** — it never overwrites a detector-snapped cadence or `detection_signals`, and it back-links NULL-fill only (never steals a charge already in another series).
 - Honors **sticky-reject**: minting at a `rejected` signature is a no-op (a rule can't resurrect a series the user dismissed).
 - Last-writer-wins across a pipeline: a higher-priority rule's `assign_series` overrides a lower one (a transaction joins at most one series).
-- **Sync-time only in v1.** Retroactive apply (`apply_rules`) does not yet materialize `assign_series` — existing transactions join when they next sync, or via the imperative `assign_series` MCP/REST tool.
+- **Retroactive apply** is supported via single-rule apply (`POST /rules/{id}/apply` / `apply_rules` with a `rule_id`): every matching existing transaction is linked using the same resolve-or-mint materialization as the sync path. (The bulk *apply-all* path does not yet materialize `assign_series` — apply the rule individually.)
 
 This is the declarative counterpart to the `assign_series` MCP tool: author the rule once and every future matching charge auto-joins the series with zero agent runs.
 

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -1264,6 +1264,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 	var categorySetSlug string
 	var tagAdds []string
 	var tagRemoves []string
+	var seriesAssign *RuleAction
 	for _, a := range rule.Actions {
 		switch a.Type {
 		case "set_category":
@@ -1281,11 +1282,11 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		case "add_comment":
 			// sync-only; skip retroactively.
 		case "assign_series":
-			// Sync-time only in v1; retroactive apply of assign_series is a
-			// follow-up (it needs per-transaction resolve-or-mint + rollup).
+			aCopy := a
+			seriesAssign = &aCopy
 		}
 	}
-	hasWriteAction := categorySetCatID.Valid || len(tagAdds) > 0 || len(tagRemoves) > 0
+	hasWriteAction := categorySetCatID.Valid || len(tagAdds) > 0 || len(tagRemoves) > 0 || seriesAssign != nil
 	if !hasWriteAction {
 		return 0, fmt.Errorf("%w: rule has no applicable actions", ErrInvalidParameter)
 	}
@@ -1381,6 +1382,18 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 				if _, err := s.materializeRuleTagRemove(ctx, tx, txnID, slug, ruleUUID, ruleShortID, ruleName); err != nil {
 					tx.Rollback(ctx)
 					return totalMatched, err
+				}
+			}
+		}
+
+		// assign_series: resolve-or-mint the series and link each matched txn
+		// (NULL-fill) within the batch tx — same materialization the sync path
+		// uses, so retroactive and sync-time behave identically.
+		if seriesAssign != nil {
+			for _, txnID := range matchIDs {
+				if err := s.AssignSeriesFromRuleTx(ctx, tx, txnID, seriesAssign.SeriesShortID, seriesAssign.MerchantKey, seriesAssign.CreateIfMissing); err != nil {
+					tx.Rollback(ctx)
+					return totalMatched, fmt.Errorf("apply assign_series retroactively: %w", err)
 				}
 			}
 		}

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -413,6 +413,55 @@ func findSeriesByKey(t *testing.T, svc *service.Service, key string) *service.Se
 	return nil
 }
 
+func TestApplyRuleRetroactively_AssignSeries(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM 1", "Netflix", 1599, "2026-03-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM 2", "Netflix", 1599, "2026-04-15")
+	other := testutil.MustCreateTransaction(t, queries, acctID, "STARBUCKS", "Starbucks", 599, "2026-04-16")
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Netflix → series",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "Netflix"},
+		Actions:    []service.RuleAction{{Type: "assign_series", MerchantKey: "netflix", CreateIfMissing: true}},
+		Actor:      service.Actor{Type: "user", ID: "u1", Name: "Tester"},
+	})
+	if err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	n, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("matched = %d, want 2 (only the two Netflix charges)", n)
+	}
+
+	row := findSeriesByKey(t, svc, "netflix")
+	if row == nil {
+		t.Fatal("retroactive assign_series did not mint a netflix series")
+	}
+	if row.DetectionSource != service.SeriesSourceRule {
+		t.Errorf("detection_source = %q, want rule", row.DetectionSource)
+	}
+	if row.OccurrenceCount != 2 {
+		t.Errorf("occurrence_count = %d, want 2", row.OccurrenceCount)
+	}
+	if n := countLinkedMembers(t, pool, row.ID); n != 2 {
+		t.Errorf("linked members = %d, want 2", n)
+	}
+	// The non-matching charge stays unlinked.
+	var seriesID pgtype.UUID
+	if err := pool.QueryRow(ctx, `SELECT series_id FROM transactions WHERE id=$1`, other.ID).Scan(&seriesID); err != nil {
+		t.Fatalf("query other txn: %v", err)
+	}
+	if seriesID.Valid {
+		t.Error("non-matching transaction was wrongly linked to a series")
+	}
+}
+
 func TestAssignSeriesFromRuleTx_MintAndLink(t *testing.T) {
 	svc, queries, pool := newService(t)
 	ctx := context.Background()


### PR DESCRIPTION
Completes the now-merged `assign_series` rule action: a rule authored today should also link **existing** transactions, not only future syncs.

## What changed
- `ApplyRuleRetroactively` (`POST /rules/{id}/apply` / `apply_rules` with a `rule_id`) now materializes `assign_series`: for each matching transaction it calls the tx-aware `AssignSeriesFromRuleTx` inside the existing per-batch transaction — the **same** resolve-or-mint → NULL-fill link → rollup the sync path uses (sticky-reject honored, never steals a charge already in another series).
- `assign_series` now counts as a write action, so an `assign_series`-only rule no longer errors `no applicable actions`.
- It picks up a `rule_applied` annotation through the existing audit loop.

## Scope
Single-rule apply only. Bulk **apply-all** does not yet materialize `assign_series` (apply the rule individually) — documented in `rule-dsl.md`, tracked for follow-up.

## Verification
All three build tags + `go vet` + the full service integration suite green. New test: retroactive mint + link of the matching charges, non-matching charge stays unlinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
