### PR TITLE
fix(ui): render GitHub brand icon in the avatar menu

### DIFF
--- a/internal/templates/components/user_menu.templ
+++ b/internal/templates/components/user_menu.templ
@@ -42,7 +42,7 @@ templ userMenuItems(p SidebarUserMenuProps, logoutFormID string) {
 			rel="noopener noreferrer"
 			@click="$el.closest('[popover]')?.hidePopover()"
 		>
-			@LucideIcon("github", "w-3.5 h-3.5")
+			@BrandIcon("github", "w-3.5 h-3.5")
 			<span class="flex-1">GitHub</span>
 			@LucideIcon("square-arrow-out-up-right", "w-3 h-3 opacity-50 ml-auto")
 		</a>


### PR DESCRIPTION
Render the GitHub brand mark in the avatar (top-right) menu — the row showed no icon before.

## Problem

The avatar menu's **GitHub** row called `@LucideIcon("github", …)`, but `lucide-go` (v0.16.0) dropped brand icons. `Icon()` returns an empty string for unknown names, so the row rendered with **no icon** at all — just the "GitHub" label and the external-link glyph.

## Fix

Swap to `@BrandIcon("github", "w-3.5 h-3.5")` — the vendored brand-SVG component already used by the settings page. The shipped `brand/github.svg` is byte-identical to thesvg's `github` default mark (same path, `viewBox="0 0 1024 1024"`, `scale(64)`), and `input.css` already handles the dark-mode flip (`svg.brand-github path { fill: #fff }`).

The change is in the shared `userMenuItems`, so it fixes **both** the live topbar menu and the `/design` sidebar demo, which render the same body.

One line changed in `internal/templates/components/user_menu.templ`.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./internal/templates/...` all pass.
- Logged into a local server and confirmed the rendered HTML now emits `<svg class="brand brand-github …">` (zero `lucide-github` left).
- Real-browser screenshot of the open menu:

<img src="https://i.img402.dev/nd2p2eoz23.jpg" width="360" alt="Avatar menu — GitHub row now shows the Octocat mark">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
