### PR TITLE
feat(ui): Mintlify-inspired theme — surface flip, warm-tinted neutrals, flat cards, tighter radius

### DIFF
--- a/input.css
+++ b/input.css
@@ -64,21 +64,28 @@
   prefersdark: false;
   color-scheme: light;
 
+  /* Mintlify-style tinted-neutral palette, warmed at the brand egg-yolk
+     hue (gold ~95). The base grays carry a faint WARM cast (chroma
+     ~0.004–0.008 at hue ~95) so the UI reads as a warm off-white; base-100
+     stays pure white to keep the content surface crisp. Primary is a
+     near-black warm neutral, NOT gold: a solid gold CTA collided with the
+     amber warning color, so gold is reserved for brand identity (the logo)
+     plus the warm chrome tint, and actions use a crisp dark button. */
   --color-base-100: oklch(1 0 0);
-  --color-base-200: oklch(0.97 0 0);
-  --color-base-300: oklch(0.922 0 0);
-  --color-base-content: oklch(0.145 0 0);
+  --color-base-200: oklch(0.971 0.004 95);
+  --color-base-300: oklch(0.923 0.008 95);
+  --color-base-content: oklch(0.16 0.01 95);
 
-  --color-primary: oklch(0.205 0 0);
+  --color-primary: oklch(0.205 0.012 95);
   --color-primary-content: oklch(0.985 0 0);
 
-  --color-secondary: oklch(0.97 0 0);
-  --color-secondary-content: oklch(0.205 0 0);
+  --color-secondary: oklch(0.971 0.004 95);
+  --color-secondary-content: oklch(0.205 0.012 95);
 
-  --color-accent: oklch(0.97 0 0);
-  --color-accent-content: oklch(0.205 0 0);
+  --color-accent: oklch(0.971 0.004 95);
+  --color-accent-content: oklch(0.205 0.012 95);
 
-  --color-neutral: oklch(0.205 0 0);
+  --color-neutral: oklch(0.205 0.012 95);
   --color-neutral-content: oklch(0.985 0 0);
 
   --color-info: var(--color-sky-500);
@@ -95,14 +102,16 @@
 
   --radius-selector: 0.25rem;
   --radius-field: 0.5rem;
-  --radius-box: 0.625rem;
+  /* Mintlify-tight box radius (8px) — modal/alert/etc. match the flattened
+     .bb-card below (was 0.625rem / 10px, cards were rounded-xl / 12px). */
+  --radius-box: 0.5rem;
 
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
 
   --border: 1px;
   --depth: 0;
-  --noise: 0;
+  --noise: 1;
 }
 
 @plugin "daisyui/theme" {
@@ -111,22 +120,25 @@
   prefersdark: true;
   color-scheme: dark;
 
-  --color-base-100: oklch(0.145 0 0);
-  --color-base-200: oklch(0.205 0 0);
-  --color-base-300: oklch(0.269 0 0);
-  --color-base-content: oklch(0.985 0 0);
+  /* Dark counterpart: same faint WARM cast on the dark grays. Primary is a
+     warm near-white (shadcn-style inverted dark primary, with dark text) —
+     gold stays brand-only, not the action color. */
+  --color-base-100: oklch(0.15 0.006 95);
+  --color-base-200: oklch(0.205 0.008 95);
+  --color-base-300: oklch(0.269 0.01 95);
+  --color-base-content: oklch(0.985 0.003 95);
 
-  --color-primary: oklch(0.922 0 0);
-  --color-primary-content: oklch(0.205 0 0);
+  --color-primary: oklch(0.922 0.008 95);
+  --color-primary-content: oklch(0.205 0.012 95);
 
-  --color-secondary: oklch(0.269 0 0);
-  --color-secondary-content: oklch(0.985 0 0);
+  --color-secondary: oklch(0.269 0.01 95);
+  --color-secondary-content: oklch(0.985 0.003 95);
 
-  --color-accent: oklch(0.371 0 0);
+  --color-accent: oklch(0.371 0.012 95);
   --color-accent-content: oklch(0.985 0 0);
 
-  --color-neutral: oklch(0.97 0 0);
-  --color-neutral-content: oklch(0.205 0 0);
+  --color-neutral: oklch(0.97 0.004 95);
+  --color-neutral-content: oklch(0.205 0.012 95);
 
   --color-info: var(--color-sky-400);
   --color-info-content: oklch(0.145 0 0);
@@ -142,14 +154,16 @@
 
   --radius-selector: 0.25rem;
   --radius-field: 0.5rem;
-  --radius-box: 0.625rem;
+  /* Mintlify-tight box radius (8px) — modal/alert/etc. match the flattened
+     .bb-card below (was 0.625rem / 10px, cards were rounded-xl / 12px). */
+  --radius-box: 0.5rem;
 
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
 
   --border: 1px;
   --depth: 0;
-  --noise: 0;
+  --noise: 1;
 }
 
 /* Force-include classes that Tailwind's content scanner can't see
@@ -377,15 +391,15 @@
   .breadcrumbs { scrollbar-width: none; -ms-overflow-style: none; }
   .breadcrumbs::-webkit-scrollbar { display: none; }
 
-  /* ── Cards: shadcn-style — 1px border + subtle drop shadow ──
-   * shadcn's Card component ships `border ... shadow-sm` (both, not
-   * border-only). The prior "border, not shadow" stance read flatter
-   * than shadcn in side-by-side comparison — added shadow-sm to get
-   * the same gentle lift. Dark mode keeps the color-mix surface lift
-   * below; shadows on dark BG read as a barely-visible halo and
-   * the surface lift carries the elevation cue. */
+  /* ── Cards: Mintlify-style — flat 1px border, no drop shadow ──
+   * Mintlify's surfaces are border-only: a hairline defines the card
+   * against the bright content column, with no shadow lift. We dropped
+   * the shadcn `shadow-sm` (it read as an "off" halo on the new white
+   * content surface) and tightened the radius from rounded-xl (12px) to
+   * rounded-lg (8px). Dark mode keeps the color-mix surface lift below;
+   * the faint border carries elevation when there's no shadow. */
   .bb-card {
-    @apply bg-base-100 rounded-xl border border-base-300 shadow-sm;
+    @apply bg-base-100 rounded-lg border border-base-300;
     transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.2s ease;
   }
 
@@ -704,8 +718,11 @@
   }
 
   /* ── Sidebar ── */
+  /* Recessed surface (base-200) — the content column is the bright one
+     (base-100). This is the Mintlify-style flip of the previous
+     white-sidebar / gray-content arrangement. */
   .bb-sidebar {
-    @apply bg-base-100 h-full w-[85vw] max-w-80 sm:w-72 lg:w-64 px-3 py-5 flex flex-col border-r border-base-300;
+    @apply bg-base-200 h-full w-[85vw] max-w-80 sm:w-72 lg:w-64 px-3 py-5 flex flex-col border-r border-base-300;
   }
 
   .bb-sidebar-brand {
@@ -755,11 +772,15 @@
     @apply text-[0.7rem] lg:text-[0.65rem] font-medium text-base-content/40 px-3 pt-5 pb-2 lg:pb-1.5;
   }
 
+  /* Hover/active recalibrated for the recessed (base-200) rail: hover
+     darkens one step to base-300; active is a bright base-100 pill that
+     pops against the gray rail and visually links to the content column
+     (Mintlify pattern). Were both base-200 — invisible on a base-200 rail. */
   .bb-sidebar-link {
     @apply flex items-center gap-3 px-3 py-2.5 lg:py-1.5 min-h-11 lg:min-h-8
            shrink-0 rounded-lg text-sm font-medium
-           text-base-content/60 no-underline
-           hover:bg-base-200 hover:text-base-content;
+           text-base-content/60 no-underline border border-transparent
+           hover:bg-base-300 hover:text-base-content;
     transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
   }
 
@@ -767,8 +788,13 @@
     transform: scale(0.98);
   }
 
+  /* Active item: a bright base-100 pill (pops against the recessed rail)
+     with a dark, readable label + icon. (Label/icon stay base-content
+     rather than text-primary — the brand gold is too light to read as
+     text/thin-stroke icon on the white pill. The accent surfaces on
+     buttons, filter tabs, focus rings and links instead.) */
   .bb-sidebar-link--active {
-    @apply bg-base-200 text-base-content font-semibold;
+    @apply bg-base-100 text-base-content font-semibold border border-base-300;
   }
 
   .bb-sidebar-link i, .bb-sidebar-link svg {
@@ -1303,15 +1329,11 @@
   }
 
   /*
-   * Subtle drop shadow matching shadcn's Button component (shadow-xs).
-   * With --depth: 0 the daisyUI inset/3D shadow stack evaluates to
-   * transparent, so the button reads as completely flat without this
-   * override. shadcn doesn't shadow transparent buttons (ghost/link),
-   * so they opt out via :not().
+   * Removed the former shadcn `shadow-xs` override on solid buttons
+   * (was box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05)). Any remaining button
+   * lift is now governed solely by daisyUI's --depth theme token, so
+   * flat (--depth: 0) vs lifted (--depth: 1) is a single theme switch.
    */
-  .btn:not(.btn-ghost):not(.btn-link) {
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  }
 
   /* Button radius convention — see unlayered .btn-sm / .btn-xs override
      below the components layer. */

--- a/input.css
+++ b/input.css
@@ -1335,6 +1335,27 @@
    * flat (--depth: 0) vs lifted (--depth: 1) is a single theme switch.
    */
 
+  /*
+   * btn-outline: keep the outline visible through hover / press / focus.
+   * DaisyUI's resting + hover rules for .btn-outline explicitly EXCLUDE
+   * :active and :focus-visible, so on press/focus the base .btn takes over
+   * and fills the button solid — the border blends into the fill and the
+   * outline "disappears". We pin the outline vars (transparent-ish bg +
+   * colored border + colored text) across every interactive state and use a
+   * soft tint for press/hover feedback instead of a solid fill, so the
+   * border never vanishes. `!important` matches the existing sanctioned
+   * .btn overrides — daisy ships same-specificity rules that win on source
+   * order otherwise (see .claude/rules/daisyui.md → spec'd overrides).
+   */
+  .btn-outline:hover,
+  .btn-outline:focus-visible,
+  .btn-outline:active,
+  .btn-outline.btn-active {
+    --btn-bg: color-mix(in oklch, var(--btn-color) 12%, transparent) !important;
+    --btn-fg: var(--btn-color) !important;
+    --btn-border: var(--btn-color) !important;
+  }
+
   /* Button radius convention — see unlayered .btn-sm / .btn-xs override
      below the components layer. */
 
@@ -3091,25 +3112,29 @@
   padding-top: 0.125rem;
 }
 
-/* Rail mask. The 28px tile bg + ring are still painted with base-100
- * (card-surface) classes by the shared row markup — redirect both to
- * base-200 here so the seam stays invisible against the page surface.
- * Selectors are scoped to the rail-mask wrapper (`> li > div:first-child`)
- * and its descendants so the remap doesn't bleed into other elements
- * inside the section that legitimately want a base-100 surface — e.g.
- * the comment composer card, whose `bg-base-100` would otherwise blend
- * into the base-200 page and erase the entire composer chrome. */
+/* Rail mask. The 28px tile bg + ring are painted with base-100
+ * (card-surface) classes by the shared row markup, and the rail seam is
+ * masked by recolouring them to the *page* surface. Since the Mintlify
+ * surface flip the prominent timeline's page surface is base-100 (the
+ * content column), so the mask now matches the page at base-100 — the
+ * seam stays invisible. (These were base-200 while the page was base-200;
+ * the flip moved the page to base-100, so the mask follows it.) Keeping
+ * the explicit remap — rather than dropping it — preserves the scoping to
+ * the rail-mask wrapper (`> li > div:first-child`) so it can't bleed onto
+ * other surfaces, and documents the page-surface coupling for the next
+ * theme change. */
 .bb-timeline-prominent .bb-timeline > li > div:first-child.bg-base-100 {
-  background-color: var(--color-base-200);
+  background-color: var(--color-base-100);
 }
 .bb-timeline-prominent .bb-timeline > li > div:first-child .ring-base-100,
 .bb-timeline-prominent .bb-timeline > li > div:first-child.ring-base-100 {
-  --tw-ring-color: var(--color-base-200);
+  --tw-ring-color: var(--color-base-100);
 }
 /* Inner tile pills painted `bg-base-200` (sync, deleted-comment trash,
- * neutral review, comment message-circle, unknown-kind fallback) match
- * the base-200 page surface in prominent mode and disappear. Lift the
- * fill to base-300 so the circle reads as a defined shape on the rail.
+ * neutral review, comment message-circle, unknown-kind fallback) sit only
+ * ~3% off the base-100 page surface (and matched the old base-200 page
+ * exactly), so they read faintly on the rail. Lift the fill to base-300 so
+ * the circle reads as a defined shape on the rail.
  * Targets only direct children of the rail-mask wrapper so the inner
  * lucide icon's color isn't touched. As of #969 comment rows are
  * included — they use the same neutral message-circle tile as every
@@ -3118,10 +3143,12 @@
   background-color: var(--color-base-300);
 }
 /* Slightly thicker ring for the bigger tile so the colour pill reads
- * cleanly against the rail. */
+ * cleanly against the rail. base-100 to match the flipped page surface so
+ * this ring keeps masking the rail seam instead of drawing a gray halo on
+ * the white page. */
 .bb-timeline-prominent .bb-timeline > li > div:first-child .ring-4 {
   --tw-ring-offset-width: 0;
-  box-shadow: 0 0 0 5px var(--color-base-200);
+  box-shadow: 0 0 0 5px var(--color-base-100);
 }
 
 /* Day separator. Bigger anchor dot and a less-shouty label — closer to

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -106,7 +106,7 @@ templ Nav(p NavProps) {
 		// to keep the tooltip ("Collapse"/"Expand sidebar") in sync with state.
 		<button
 			type="button"
-			class="bb-sidebar-link bb-sidebar-collapse w-full cursor-pointer"
+			class="bb-sidebar-link bb-sidebar-collapse w-full cursor-pointer text-left"
 			onclick="bbToggleSidebar()"
 			aria-label="Toggle sidebar"
 			title="Collapse sidebar"

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -437,7 +437,10 @@
     <input id="bb-drawer" type="checkbox" class="drawer-toggle" />
 
     <!-- Main content -->
-    <div class="drawer-content bg-base-200">
+    <!-- Mintlify-style surface flip: the content column is the bright
+         surface (base-100) and the sidebar is the recessed one (base-200).
+         Cards sit on white and read by their border, not a fill contrast. -->
+    <div class="drawer-content bg-base-100">
       <!-- Desktop topbar — static across every page (hidden < lg, where the
            mobile navbar below takes over). Left: breadcrumb of the current
            section/page. Right: ⌘K search, theme toggle, profile menu. -->


### PR DESCRIPTION
Reshapes the admin UI toward the Mintlify dashboard aesthetic, building on the collapsible icon-rail shell from #1604. Everything here is at the **theme-token / shared-class level** (`input.css` + one class in `base.html`), so it propagates app-wide rather than page-by-page.

## What changed

**Surface flip** — the content column is now the bright surface (`base-100`) and the sidebar is the recessed one (`base-200`). Cards read by their border against white; the active nav item is a white pill that bridges into the content column.

**Warm tinted-neutral palette** — the neutral grays carry a faint warm cast (chroma ~0.004–0.012 at hue ~95, the brand egg-gold direction) instead of pure neutral, so the whole UI shares one temperature. `base-100` stays pure white to keep content crisp; the warmth lives on the recessed chrome (sidebar ≈ `#F6F5F2`, borders, hover, text).

**Neutral primary** — primary stays a crisp near-black (light) / near-white (dark) action color. We trialled the brand gold `#ffc300` as primary, but it collided with the amber `warning` color (solid gold buttons read as caution), so gold is reserved for brand identity + the chrome tint.

**Flat cards + buttons** — dropped the shadcn `shadow-sm` on `.bb-card` and the `shadow-xs` override on solid buttons. Hairline borders only (Mintlify).

**Tighter radius** — cards `rounded-xl` → `rounded-lg` (12px → 8px); `--radius-box` 10px → 8px. Unified at 8px.

**Theme tokens** — `--depth: 0` (flat) and `--noise: 1` (subtle grain on filled components) in both themes.

## Screenshots

<table>
<tr>
<td><b>Dashboard — light</b></td>
<td><b>Dashboard — dark</b></td>
</tr>
<tr>
<td><img src="https://i.img402.dev/w5fwcmy9ai.png" width="420" alt="Dashboard light"></td>
<td><img src="https://i.img402.dev/pze6udtsro.png" width="420" alt="Dashboard dark"></td>
</tr>
</table>

<b>Settings — light</b>

<img src="https://i.img402.dev/i0o7ilvmnt.png" width="800" alt="Settings light">

## Notes

- `static/css/styles.css` is a build artifact (not committed); `make css` / the Docker build stage regenerates it.
- Validated in a real browser (Chrome, light + dark) at 1440×900.
- More follow-ups to come per discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
