### PR TITLE
feat(series): recurring-series sprint — conditions, renewal-health, explain feed, rekey/split, UI chip

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -88,6 +88,8 @@ Unauthenticated device-code dance the CLI uses to mint API keys on a remote host
 | GET | `/series/{id}` | R | Single series (accepts UUID or short_id) |
 | POST | `/series` | W | Create a missed series (`merchant_key`+`create_if_missing`) or assign by `series_id`; links `transaction_ids` (≤50), optional `confirm` |
 | POST | `/series/{id}/transactions` | W | Link transactions (≤50, NULL-fill only) to a series; optional `confirm` |
+| POST | `/series/{id}/rekey` | W | Correct a series' `merchant_key` (+ repoint members); errors on collision / sticky-reject |
+| POST | `/series/{id}/split` | W | Move `transaction_ids` (≤50, current members) into a new series under `new_merchant_key` |
 | POST | `/series/{id}/tags` | W | Attach a tag to a series; linked transactions inherit it |
 | DELETE | `/series/{id}/tags/{slug}` | W | Detach a tag; strips series-inherited copies from members (keeps user-added) |
 | PATCH | `/series/{id}` | W | Apply a verdict: `confirm`/`reject`/`pause`/`cancel` (user confirmation outranks agent) |

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -84,6 +84,7 @@ Unauthenticated device-code dance the CLI uses to mint API keys on a remote host
 | Method | Path | Scope | Description |
 |--------|------|-------|-------------|
 | GET | `/series` | R | List recurring series; optional `?status=active\|candidate\|paused\|cancelled` |
+| GET | `/series/explain` | R | Near-miss feed: recurring-looking merchants not yet a series + the detector's verdict (why) |
 | GET | `/series/{id}` | R | Single series (accepts UUID or short_id) |
 | POST | `/series` | W | Create a missed series (`merchant_key`+`create_if_missing`) or assign by `series_id`; links `transaction_ids` (≤50), optional `confirm` |
 | POST | `/series/{id}/transactions` | W | Link transactions (≤50, NULL-fill only) to a series; optional `confirm` |

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -260,6 +260,14 @@ Apply a verdict: `confirm` (it is a subscription → `active`), `reject` (NOT a 
 
 Create a recurring series detection missed, or link transactions to an existing one — the agent's path to fix gaps. Provide `series_id` to assign to an existing series, **or** `merchant_key` + `create_if_missing:true` to mint one (funnels through the same dedup + sticky-reject arbitration as the detector, so re-creating a user-rejected series at the same signature is a no-op). Pass `transaction_ids` (≤50) to back-link members (NULL-fill only — never steals a charge already in another series). `confirm:true` flips it straight to `active`; omit to leave a reviewable `candidate`. Use after `list_series(status=candidate)` shows nothing for a subscription the user says exists.
 
+### rekey_series (Write)
+
+Correct a series' `merchant_key` when detection grouped it under a wrong or fallback key (e.g. `payment` → `spotify`). Repoints the series and its linked transactions to `new_merchant_key`. Refuses to silently merge: errors if a live series already exists at the new key, or that key is sticky-rejected. Corrects *historical* grouping — incoming charges still key off the provider name at sync time (a merchant-key alias table is future work).
+
+### split_series (Write)
+
+Break an over-grouped series in two: move `transaction_ids` (≤50, each a current member of the source series) into a brand-new series under `new_merchant_key`. The fix for the detector sweeping a stray charge into a real subscription (e.g. a $4.99 add-on bundled with a $139/yr renewal). The new series inherits the source's currency / user / category; rollups recompute on both sides. Errors if `new_merchant_key` equals the source key, already has a series, or any listed transaction isn't a current member. Returns the new series.
+
 ### add_series_tag (Write)
 
 Attach an existing tag to a recurring series. The tag is materialized onto every linked transaction (they inherit it) and applied to future members as they join — so tagging the Netflix series tags all its charges. The tag must already exist (create it with `create_tag` first). Returns the updated series (including its `tags`).

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -242,7 +242,7 @@ Admin-only tag CRUD. Agents typically don't need these — `add_transaction_tag`
 
 ### list_series (Read)
 
-List detected recurring series. Optional `status` filter (`active` | `candidate` | `paused` | `cancelled`). Each row carries `cadence`, `expected_amount` + `iso_currency_code` (never sum across currencies), `next_expected_date`, `occurrence_count`, `confidence` (`auto` | `confirmed` | `rejected`), and `detection_signals` — the raw evidence the detector used. Read `status=candidate` to find series awaiting a verdict.
+List detected recurring series. Optional `status` filter (`active` | `candidate` | `paused` | `cancelled`). Each row carries `cadence`, `expected_amount` + `iso_currency_code` (never sum across currencies), `next_expected_date`, `occurrence_count`, `confidence` (`auto` | `confirmed` | `rejected`), and `detection_signals` — the raw evidence the detector used. Active series also carry a derived `renewal_health` (`active` | `due_soon` | `overdue` | `stale` | `unknown`) and signed `days_until_renewal` (negative = overdue) so you can answer "what renews soon" and "what looks cancelled" without re-deriving cadence math — `stale` means a full cadence cycle elapsed past the expected charge. Read `status=candidate` to find series awaiting a verdict.
 
 ### get_series (Read)
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -248,6 +248,10 @@ List detected recurring series. Optional `status` filter (`active` | `candidate`
 
 Get one series by short ID or UUID, including its full `detection_signals` (`occurrence_count`, `interval_cv`, `cadence_snap_error`, `amount_branch`, `merchant_key_is_fallback`). Inspect before reviewing a candidate.
 
+### explain_series_candidates (Read)
+
+Answer "why isn't *merchant* a subscription?". Returns `near_misses` — every recurring-looking merchant group that is **not** already a series, each annotated with the detector's verdict: `qualifies:true` (passes every gate but isn't tracked yet — confirm it with `assign_series`) or a specific `reason` it fell short (`too_few_occurrences`, `irregular_cadence`, `interval_too_variable`, `amount_unstable`, `same_day_duplicates`). Each row carries a human `explanation` plus the raw numbers (`occurrence_count`, `nearest_cadence`, `median_gap_days`, `interval_cv`, `amount_min`/`amount_max`, `first_seen`/`last_seen`). Read-only analysis over the trailing detection window — the precision-first detector deliberately stays quiet on these, so this surfaces what it skipped (ordered most-charges-first, capped at 50).
+
 ### review_series (Write)
 
 Apply a verdict: `confirm` (it is a subscription → `active`), `reject` (NOT a subscription → sticky at that amount band, never re-proposed), `pause`, or `cancel`. A user's prior confirmation outranks a later agent write. This is how an agent adjudicates candidates from `list_series(status=candidate)`.

--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -175,7 +175,7 @@ Behavior:
 - **Link-and-rollup only** — it never overwrites a detector-snapped cadence or `detection_signals`, and it back-links NULL-fill only (never steals a charge already in another series).
 - Honors **sticky-reject**: minting at a `rejected` signature is a no-op (a rule can't resurrect a series the user dismissed).
 - Last-writer-wins across a pipeline: a higher-priority rule's `assign_series` overrides a lower one (a transaction joins at most one series).
-- **Sync-time only in v1.** Retroactive apply (`apply_rules`) does not yet materialize `assign_series` — existing transactions join when they next sync, or via the imperative `assign_series` MCP/REST tool.
+- **Retroactive apply** is supported via single-rule apply (`POST /rules/{id}/apply` / `apply_rules` with a `rule_id`): every matching existing transaction is linked using the same resolve-or-mint materialization as the sync path. (The bulk *apply-all* path does not yet materialize `assign_series` — apply the rule individually.)
 
 This is the declarative counterpart to the `assign_series` MCP tool: author the rule once and every future matching charge auto-joins the series with zero agent runs.
 

--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -71,8 +71,12 @@ Combinators nest. Max depth: **10**. Empty / zero-value condition (`{}`) means *
 | `user_id`           | string  | Family member UUID                                              |
 | `user_name`         | string  | Family member display name                                      |
 | `tags`              | tags    | List of current transaction tag slugs (special, see below)      |
+| `series`            | string  | `short_id` of the recurring series the transaction belongs to (empty when unassigned) |
+| `in_series`         | bool    | Whether the transaction is linked to any recurring series       |
 
 > **Raw vs assigned category.** `provider_category_primary` / `provider_category_detailed` are the provider's classification — they don't change when Breadbox, a rule, or the user reassigns. Use `category` when you want to react to the *current* category, including mid-pass rule updates (see "Rule chaining" below).
+
+> **Series membership timing.** `series` / `in_series` reflect a transaction's *current* `series_id`. A brand-new transaction has no series until the post-sync detector links it, so these fields are `""` / `false` on the create pass — they're most useful for re-synced/changed rows and for **retroactive apply** over historical data (e.g. tag everything already in a series, or exclude series members from a catch-all rule). They are the read-half companion to the `assign_series` action (the write-half). A rule **matches** on series membership but cannot **discover** a series — detection is an aggregate decision the detector owns; see `docs/data-model.md` and the recurring-series design notes.
 
 ### Operators per field type
 

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -174,6 +174,7 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 		Source:          s.DetectionSource,
 		SourceLabel:     sourceLabel(s.DetectionSource),
 	}
+	row.RenewalLabel, row.RenewalTone = subscriptionRenewal(s)
 	if s.LastAmount != nil {
 		row.HasAmount = true
 		row.Amount = math.Abs(*s.LastAmount)
@@ -188,6 +189,35 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 	}
 	row.Search = strings.ToLower(strings.Join([]string{s.Name, s.MerchantKey, row.CadenceLabel, row.CategoryName, row.OwnerName}, " "))
 	return row
+}
+
+// subscriptionRenewal derives an attention chip (label + daisy tone) from a
+// series' renewal health (shipped on SeriesResponse). Returns empty for
+// comfortably-renewing / no-projection series — only due_soon / overdue /
+// stale earn a chip, so the ledger highlights what needs a look. Health is
+// only populated for active series, so candidates/paused/cancelled get nothing.
+func subscriptionRenewal(s service.SeriesResponse) (string, string) {
+	days := 0
+	if s.DaysUntilRenewal != nil {
+		days = *s.DaysUntilRenewal
+	}
+	switch s.RenewalHealth {
+	case service.SeriesHealthDueSoon:
+		switch {
+		case days <= 0:
+			return "Due today", "info"
+		case days == 1:
+			return "Due tomorrow", "info"
+		default:
+			return fmt.Sprintf("Renews in %dd", days), "info"
+		}
+	case service.SeriesHealthOverdue:
+		return fmt.Sprintf("%dd overdue", -days), "warning"
+	case service.SeriesHealthStale:
+		return "Likely cancelled", "error"
+	default:
+		return "", ""
+	}
 }
 
 // subscriptionSignalsShape is the subset of detection_signals (§6.6) the UI

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -79,6 +79,18 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 			}
 		}
 
+		// Order the ledger by renewal urgency: overdue → due-soon → upcoming
+		// (ascending days), then series with no projection, then likely-cancelled
+		// (stale) last. Surfaces "what's renewing soon" at the top, leveraging the
+		// renewal chip, without a separate section.
+		sort.SliceStable(active, func(i, j int) bool {
+			gi, gj := renewalSortGroup(active[i]), renewalSortGroup(active[j])
+			if gi != gj {
+				return gi < gj
+			}
+			return renewalSortDays(active[i]) < renewalSortDays(active[j])
+		})
+
 		var monthlyTotals []pages.SubscriptionMonthlyTotal
 		for _, cur := range currencyOrder {
 			monthlyTotals = append(monthlyTotals, pages.SubscriptionMonthlyTotal{
@@ -175,6 +187,7 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 		SourceLabel:     sourceLabel(s.DetectionSource),
 	}
 	row.RenewalLabel, row.RenewalTone = subscriptionRenewal(s)
+	row.DaysUntilRenewal = s.DaysUntilRenewal
 	if s.LastAmount != nil {
 		row.HasAmount = true
 		row.Amount = math.Abs(*s.LastAmount)
@@ -218,6 +231,30 @@ func subscriptionRenewal(s service.SeriesResponse) (string, string) {
 	default:
 		return "", ""
 	}
+}
+
+// renewalSortGroup buckets an active-ledger row for the renewal-urgency sort:
+// 0 = has a projection and isn't stale (overdue/due-soon/upcoming), 1 = no
+// projection (paused/cancelled/unknown cadence), 2 = stale ("likely
+// cancelled") — pushed to the bottom since it isn't really "upcoming".
+func renewalSortGroup(r pages.SubscriptionRow) int {
+	switch {
+	case r.RenewalTone == "error": // stale / likely cancelled
+		return 2
+	case r.DaysUntilRenewal == nil:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// renewalSortDays is the secondary key (ascending) within a group — most
+// overdue first, then soonest upcoming. Missing projection sorts as 0.
+func renewalSortDays(r pages.SubscriptionRow) int {
+	if r.DaysUntilRenewal == nil {
+		return 0
+	}
+	return *r.DaysUntilRenewal
 }
 
 // subscriptionSignalsShape is the subset of detection_signals (§6.6) the UI

--- a/internal/admin/subscriptions_renewal_test.go
+++ b/internal/admin/subscriptions_renewal_test.go
@@ -1,0 +1,44 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestSubscriptionRenewal covers the renewal-health → attention-chip mapping
+// that drives the /subscriptions ledger chip. Only due_soon / overdue / stale
+// earn a chip; comfortably-renewing and no-projection series stay quiet.
+func TestSubscriptionRenewal(t *testing.T) {
+	days := func(n int) *int { return &n }
+
+	cases := []struct {
+		name      string
+		health    string
+		days      *int
+		wantLabel string
+		wantTone  string
+	}{
+		{"active stays quiet", service.SeriesHealthActive, days(30), "", ""},
+		{"unknown stays quiet", service.SeriesHealthUnknown, nil, "", ""},
+		{"empty (non-active) stays quiet", "", nil, "", ""},
+		{"due in 3 days", service.SeriesHealthDueSoon, days(3), "Renews in 3d", "info"},
+		{"due tomorrow", service.SeriesHealthDueSoon, days(1), "Due tomorrow", "info"},
+		{"due today", service.SeriesHealthDueSoon, days(0), "Due today", "info"},
+		{"overdue 5 days", service.SeriesHealthOverdue, days(-5), "5d overdue", "warning"},
+		{"stale → likely cancelled", service.SeriesHealthStale, days(-60), "Likely cancelled", "error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := service.SeriesResponse{RenewalHealth: tc.health, DaysUntilRenewal: tc.days}
+			label, tone := subscriptionRenewal(s)
+			if label != tc.wantLabel || tone != tc.wantTone {
+				t.Errorf("subscriptionRenewal(%q, %v) = (%q, %q), want (%q, %q)",
+					tc.health, tc.days, label, tone, tc.wantLabel, tc.wantTone)
+			}
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -114,6 +114,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/tags", ListTagsHandler(svc))
 		r.Get("/tags/{slug}", GetTagHandler(svc))
 		r.Get("/series", ListSeriesHandler(svc))
+		r.Get("/series/explain", ExplainSeriesCandidatesHandler(svc)) // static before /series/{id}
 		r.Get("/series/{id}", GetSeriesHandler(svc))
 		r.Get("/settings/providers", GetProviderConfigHandler(a))
 		// Agents — read endpoints. Specific paths before /agents/{slug} param.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -190,6 +190,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Patch("/tags/{slug}", UpdateTagHandler(svc))
 			r.Post("/series", AssignSeriesHandler(svc))
 			r.Post("/series/{id}/transactions", LinkSeriesTransactionsHandler(svc))
+			r.Post("/series/{id}/rekey", RekeySeriesHandler(svc))
+			r.Post("/series/{id}/split", SplitSeriesHandler(svc))
 			r.Post("/series/{id}/tags", AddSeriesTagHandler(svc))
 			r.Delete("/series/{id}/tags/{slug}", RemoveSeriesTagHandler(svc))
 			r.Patch("/series/{id}", ReviewSeriesHandler(svc))

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -30,6 +30,21 @@ func ListSeriesHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// ExplainSeriesCandidatesHandler returns the near-miss / explain feed: every
+// recurring-looking merchant group that is NOT already a series, with the
+// detector's verdict on why it did or didn't qualify.
+// GET /api/v1/series/explain — mirrors the explain_series_candidates MCP tool.
+func ExplainSeriesCandidatesHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		nearMisses, err := svc.ExplainSeriesCandidates(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to explain series candidates")
+			return
+		}
+		writeData(w, map[string]any{"near_misses": nearMisses})
+	}
+}
+
 // GetSeriesHandler returns a single series by short_id or uuid.
 // GET /api/v1/series/{id} — mirrors the get_series MCP tool.
 func GetSeriesHandler(svc *service.Service) http.HandlerFunc {

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -187,6 +187,64 @@ func RemoveSeriesTagHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// rekeySeriesRequest is the body for POST /api/v1/series/{id}/rekey.
+type rekeySeriesRequest struct {
+	NewMerchantKey string `json:"new_merchant_key"`
+}
+
+// RekeySeriesHandler corrects a series' merchant_key (and repoints its members).
+// POST /api/v1/series/{id}/rekey — mirrors the rekey_series MCP tool (write).
+func RekeySeriesHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var body rekeySeriesRequest
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+		if strings.TrimSpace(body.NewMerchantKey) == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "new_merchant_key is required")
+			return
+		}
+		actor := service.ActorFromContext(r.Context())
+		s, err := svc.RekeySeries(r.Context(), id, body.NewMerchantKey, actor)
+		if err != nil {
+			writeServiceError(w, err, "Series not found", "Failed to re-key series")
+			return
+		}
+		writeData(w, s)
+	}
+}
+
+// splitSeriesRequest is the body for POST /api/v1/series/{id}/split.
+type splitSeriesRequest struct {
+	NewMerchantKey string   `json:"new_merchant_key"`
+	Name           string   `json:"name,omitempty"`
+	TransactionIDs []string `json:"transaction_ids"`
+}
+
+// SplitSeriesHandler moves a subset of a series' members into a new series.
+// POST /api/v1/series/{id}/split — mirrors the split_series MCP tool (write).
+func SplitSeriesHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var body splitSeriesRequest
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+		if strings.TrimSpace(body.NewMerchantKey) == "" || len(body.TransactionIDs) == 0 {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "new_merchant_key and transaction_ids are required")
+			return
+		}
+		actor := service.ActorFromContext(r.Context())
+		s, err := svc.SplitSeries(r.Context(), id, body.TransactionIDs, body.NewMerchantKey, body.Name, actor)
+		if err != nil {
+			writeServiceError(w, err, "Series not found", "Failed to split series")
+			return
+		}
+		writeData(w, s)
+	}
+}
+
 // reviewSeriesRequest is the body for PATCH /api/v1/series/{id}.
 type reviewSeriesRequest struct {
 	Verdict string `json:"verdict"` // confirm | reject | pause | cancel

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -391,6 +391,14 @@ func (s *MCPServer) buildToolRegistry() {
 			Description: "Create a recurring series detection missed, or link transactions to an existing one — the agent's path to fix gaps. Provide series_id to assign to an existing series, OR merchant_key + create_if_missing:true to mint one (funnels through the same dedup + sticky-reject arbitration as the detector, so re-creating a user-rejected series at the same signature is a no-op). Pass transaction_ids (≤50) to back-link members (NULL-fill only — never steals a charge already in another series). confirm:true flips it straight to active; omit to leave a reviewable candidate. Use after list_series(status=candidate) shows nothing for a subscription the user says exists.",
 		}, s.handleAssignSeries, s),
 		makeToolDefLogged(ToolSpec{
+			Name: "rekey_series", Title: "Re-key a Subscription", Classification: ToolWrite,
+			Description: "Correct a series' merchant_key when detection grouped it under a wrong or fallback key (e.g. 'payment' → 'spotify'). Repoints the series and its linked transactions to the new key. Refuses to silently merge: errors if a live series already exists at the new key, or that key is sticky-rejected. Corrects historical grouping — future charges still key off the provider name.",
+		}, s.handleRekeySeries, s),
+		makeToolDefLogged(ToolSpec{
+			Name: "split_series", Title: "Split a Subscription", Classification: ToolWrite,
+			Description: "Break an over-grouped series into two: move the given transaction_ids (≤50, each a current member of the source series) into a brand-new series under new_merchant_key. The fix for the detector sweeping a stray charge into a real subscription (e.g. a $4.99 add-on bundled with a $139/yr renewal). The new series inherits the source's currency/user/category; rollups recompute on both. Errors if new_merchant_key equals the source key or already has a series.",
+		}, s.handleSplitSeries, s),
+		makeToolDefLogged(ToolSpec{
 			Name: "add_series_tag", Title: "Tag a Subscription", Classification: ToolWrite,
 			Description: "Attach an existing tag to a recurring series. The tag is materialized onto every linked transaction (they inherit it) and applied to future members as they join — so tagging the Netflix series tags all its charges. The tag must already exist (create it first with create_tag).",
 		}, s.handleAddSeriesTag, s),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -379,6 +379,10 @@ func (s *MCPServer) buildToolRegistry() {
 			Description: "Get one recurring series by short ID or UUID, including its full detection_signals. Use before reviewing a candidate to inspect the evidence (occurrence_count, interval_cv, cadence_snap_error, amount_branch, monotonic drift).",
 		}, s.handleGetSeries, s),
 		makeToolDefLogged(ToolSpec{
+			Name: "explain_series_candidates", Title: "Explain Near-Miss Subscriptions", Classification: ToolRead,
+			Description: "Answer \"why isn't <merchant> a subscription?\". Reports every recurring-looking merchant group that is NOT already a series, with the detector's verdict: qualifies=true (eligible but not tracked yet — confirm it with assign_series) or a specific reason it fell short (too_few_occurrences, irregular_cadence, interval_too_variable, amount_unstable, same_day_duplicates). Each row carries a human explanation plus the numbers (occurrence_count, nearest_cadence, median_gap_days, interval_cv, amount min/max). Read-only analysis over the trailing detection window — the precision-first detector deliberately stays quiet on these, so this is how you surface what it skipped.",
+		}, s.handleExplainSeriesCandidates, s),
+		makeToolDefLogged(ToolSpec{
 			Name: "review_series", Title: "Review Subscription", Classification: ToolWrite,
 			Description: "Apply a verdict to a recurring series: confirm (it is a subscription → active), reject (NOT a subscription → sticky, never re-proposed at that amount band), pause, or cancel. A user's prior confirmation outranks a later agent write. This is how an agent adjudicates the candidates surfaced by list_series(status=candidate).",
 		}, s.handleReviewSeries, s),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -143,6 +143,7 @@ func TestToolRegistryScopeContract(t *testing.T) {
 		"list_transaction_rules",
 		"list_series",
 		"get_series",
+		"explain_series_candidates",
 	}
 	if len(readNames) != len(wantReads) {
 		t.Errorf("read tool count = %d, want %d (got %v)", len(readNames), len(wantReads), readNames)

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -52,6 +52,16 @@ func (s *MCPServer) handleListSeries(_ context.Context, _ *mcpsdk.CallToolReques
 	return jsonResult(map[string]any{"series": series})
 }
 
+type explainSeriesInput struct{}
+
+func (s *MCPServer) handleExplainSeriesCandidates(_ context.Context, _ *mcpsdk.CallToolRequest, _ explainSeriesInput) (*mcpsdk.CallToolResult, any, error) {
+	nearMisses, err := s.svc.ExplainSeriesCandidates(context.Background())
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]any{"near_misses": nearMisses})
+}
+
 func (s *MCPServer) handleGetSeries(_ context.Context, _ *mcpsdk.CallToolRequest, input getSeriesInput) (*mcpsdk.CallToolResult, any, error) {
 	if input.ID == "" {
 		return errorResult(fmt.Errorf("id is required")), nil, nil

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -146,6 +146,54 @@ func (s *MCPServer) handleRemoveSeriesTag(ctx context.Context, _ *mcpsdk.CallToo
 	return jsonResult(series)
 }
 
+type rekeySeriesInput struct {
+	ID     string `json:"id" jsonschema:"required,Series short ID or UUID to re-key."`
+	NewKey string `json:"new_merchant_key" jsonschema:"required,The corrected normalized merchant key (e.g. 'spotify' rather than a fallback like 'payment'). Members' merchant_key is repointed to match."`
+}
+
+func (s *MCPServer) handleRekeySeries(ctx context.Context, _ *mcpsdk.CallToolRequest, input rekeySeriesInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.ID == "" || input.NewKey == "" {
+		return errorResult(fmt.Errorf("id and new_merchant_key are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	series, err := s.svc.RekeySeries(context.Background(), input.ID, input.NewKey, actor)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return errorResult(fmt.Errorf("series not found")), nil, nil
+		}
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(series)
+}
+
+type splitSeriesInput struct {
+	ID             string   `json:"id" jsonschema:"required,Source series short ID or UUID to split."`
+	NewKey         string   `json:"new_merchant_key" jsonschema:"required,Merchant key for the new series the split-out charges move into. Must not already have a series and must differ from the source key."`
+	Name           string   `json:"name,omitempty" jsonschema:"Optional display name for the new series; defaults to a title-cased new_merchant_key."`
+	TransactionIDs []string `json:"transaction_ids" jsonschema:"required,Transactions (short ID or UUID) to move out of the source series into the new one. Each must currently belong to the source series. Max 50."`
+}
+
+func (s *MCPServer) handleSplitSeries(ctx context.Context, _ *mcpsdk.CallToolRequest, input splitSeriesInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.ID == "" || input.NewKey == "" || len(input.TransactionIDs) == 0 {
+		return errorResult(fmt.Errorf("id, new_merchant_key, and transaction_ids are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	series, err := s.svc.SplitSeries(context.Background(), input.ID, input.TransactionIDs, input.NewKey, input.Name, actor)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return errorResult(fmt.Errorf("series not found")), nil, nil
+		}
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(series)
+}
+
 func (s *MCPServer) handleAssignSeries(ctx context.Context, _ *mcpsdk.CallToolRequest, input assignSeriesInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -1264,6 +1264,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 	var categorySetSlug string
 	var tagAdds []string
 	var tagRemoves []string
+	var seriesAssign *RuleAction
 	for _, a := range rule.Actions {
 		switch a.Type {
 		case "set_category":
@@ -1281,11 +1282,11 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		case "add_comment":
 			// sync-only; skip retroactively.
 		case "assign_series":
-			// Sync-time only in v1; retroactive apply of assign_series is a
-			// follow-up (it needs per-transaction resolve-or-mint + rollup).
+			aCopy := a
+			seriesAssign = &aCopy
 		}
 	}
-	hasWriteAction := categorySetCatID.Valid || len(tagAdds) > 0 || len(tagRemoves) > 0
+	hasWriteAction := categorySetCatID.Valid || len(tagAdds) > 0 || len(tagRemoves) > 0 || seriesAssign != nil
 	if !hasWriteAction {
 		return 0, fmt.Errorf("%w: rule has no applicable actions", ErrInvalidParameter)
 	}
@@ -1381,6 +1382,18 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 				if _, err := s.materializeRuleTagRemove(ctx, tx, txnID, slug, ruleUUID, ruleShortID, ruleName); err != nil {
 					tx.Rollback(ctx)
 					return totalMatched, err
+				}
+			}
+		}
+
+		// assign_series: resolve-or-mint the series and link each matched txn
+		// (NULL-fill) within the batch tx — same materialization the sync path
+		// uses, so retroactive and sync-time behave identically.
+		if seriesAssign != nil {
+			for _, txnID := range matchIDs {
+				if err := s.AssignSeriesFromRuleTx(ctx, tx, txnID, seriesAssign.SeriesShortID, seriesAssign.MerchantKey, seriesAssign.CreateIfMissing); err != nil {
+					tx.Rollback(ctx)
+					return totalMatched, fmt.Errorf("apply assign_series retroactively: %w", err)
 				}
 			}
 		}

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -41,6 +41,8 @@ var validConditionFields = map[string]string{
 	"user_id":                    "string",
 	"user_name":                  "string",
 	"tags":                       "tags",
+	"series":                     "string", // recurring-series short_id the txn belongs to
+	"in_series":                  "bool",   // whether the txn belongs to any recurring series
 }
 
 // stringOps are operators valid for string fields.
@@ -347,6 +349,10 @@ func evaluateLeaf(c *CompiledCondition, tctx TransactionContext) bool {
 		return evalString(c, tctx.UserName)
 	case "tags":
 		return evalTags(c, tctx.Tags)
+	case "series":
+		return evalString(c, tctx.SeriesShortID)
+	case "in_series":
+		return evalBool(c, tctx.InSeries)
 	}
 	return false
 }
@@ -1190,18 +1196,20 @@ func (s *Service) ListActiveRulesForSync(ctx context.Context) ([]TransactionRule
 const transactionContextQuery = `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
 	COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 	t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
-	COALESCE(array_agg(DISTINCT tag.slug) FILTER (WHERE tag.slug IS NOT NULL), ARRAY[]::text[])
+	COALESCE(array_agg(DISTINCT tag.slug) FILTER (WHERE tag.slug IS NOT NULL), ARRAY[]::text[]),
+	COALESCE(rs.short_id, ''), (t.series_id IS NOT NULL)
 	FROM transactions t
 	JOIN accounts a ON t.account_id = a.id
 	JOIN bank_connections bc ON a.connection_id = bc.id
 	LEFT JOIN users u ON bc.user_id = u.id
 	LEFT JOIN transaction_tags tt ON tt.transaction_id = t.id
 	LEFT JOIN tags tag ON tag.id = tt.tag_id
+	LEFT JOIN recurring_series rs ON rs.id = t.series_id
 	WHERE t.deleted_at IS NULL
 	AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
 
 // transactionContextGroupBy is the GROUP BY clause matching transactionContextQuery.
-const transactionContextGroupBy = ` GROUP BY t.id, t.provider_name, t.provider_merchant_name, t.amount, t.provider_category_primary, t.provider_category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name`
+const transactionContextGroupBy = ` GROUP BY t.id, t.provider_name, t.provider_merchant_name, t.amount, t.provider_category_primary, t.provider_category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name, rs.short_id, t.series_id`
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
@@ -1223,6 +1231,8 @@ func scanTransactionContextRow(dest []any) *transactionContextRow {
 	dest[9] = &r.tctx.UserID
 	dest[10] = &r.tctx.UserName
 	dest[11] = &r.tctx.Tags
+	dest[12] = &r.tctx.SeriesShortID
+	dest[13] = &r.tctx.InSeries
 	return r
 }
 
@@ -1319,7 +1329,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		rowCount := 0
 		for rows.Next() {
 			rowCount++
-			dest := make([]any, 12)
+			dest := make([]any, 14)
 			r := scanTransactionContextRow(dest)
 			if err := rows.Scan(dest...); err != nil {
 				rows.Close()
@@ -1542,7 +1552,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		rowCount := 0
 		for rows.Next() {
 			rowCount++
-			dest := make([]any, 12)
+			dest := make([]any, 14)
 			r := scanTransactionContextRow(dest)
 			if err := rows.Scan(dest...); err != nil {
 				rows.Close()
@@ -1778,12 +1788,13 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 	baseQuery := `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
 		COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 		t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
-		t.date, COALESCE(c.slug, '')
+		t.date, COALESCE(c.slug, ''), COALESCE(rs.short_id, ''), (t.series_id IS NOT NULL)
 		FROM transactions t
 		JOIN accounts a ON t.account_id = a.id
 		JOIN bank_connections bc ON a.connection_id = bc.id
 		LEFT JOIN users u ON bc.user_id = u.id
 		LEFT JOIN categories c ON t.category_id = c.id
+		LEFT JOIN recurring_series rs ON rs.id = t.series_id
 		WHERE t.deleted_at IS NULL AND t.category_override = FALSE
 		AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
 
@@ -1830,7 +1841,7 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 			if err := rows.Scan(&id, &tctx.Name, &tctx.MerchantName, &tctx.Amount,
 				&tctx.CategoryPrimary, &tctx.CategoryDetailed,
 				&tctx.Pending, &tctx.Provider, &tctx.AccountID, &tctx.UserID, &tctx.UserName,
-				&date, &catSlug); err != nil {
+				&date, &catSlug, &tctx.SeriesShortID, &tctx.InSeries); err != nil {
 				rows.Close()
 				return nil, fmt.Errorf("scan transaction: %w", err)
 			}

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -43,7 +43,21 @@ const (
 	SeriesConfidenceAuto      = "auto"
 	SeriesConfidenceConfirmed = "confirmed"
 	SeriesConfidenceRejected  = "rejected"
+
+	// Renewal-health buckets — a derived (not stored) read-side signal computed
+	// from an active series' projected next_expected_date relative to today.
+	// Surfaced on SeriesResponse so agents and the UI can answer "what renews
+	// soon" and "what looks cancelled" without re-deriving the cadence math.
+	SeriesHealthActive  = "active"   // next charge comfortably in the future
+	SeriesHealthDueSoon = "due_soon" // renews within the next week
+	SeriesHealthOverdue = "overdue"  // past due but within one cadence cycle (likely just lag)
+	SeriesHealthStale   = "stale"    // missed a full cadence cycle — likely cancelled
+	SeriesHealthUnknown = "unknown"  // no prediction (irregular/unknown cadence or no charges yet)
 )
+
+// renewalDueSoonWindowDays is how far ahead a projected charge still counts as
+// "due soon" rather than merely "active".
+const renewalDueSoonWindowDays = 7
 
 var validSeriesCadence = map[string]bool{
 	SeriesCadenceWeekly: true, SeriesCadenceBiweekly: true, SeriesCadenceMonthly: true,
@@ -105,7 +119,13 @@ type SeriesResponse struct {
 	LastAmount       *float64        `json:"last_amount,omitempty"`
 	LastSeenDate     *string         `json:"last_seen_date,omitempty"`
 	NextExpectedDate *string         `json:"next_expected_date,omitempty"`
-	OccurrenceCount  int             `json:"occurrence_count"`
+	// RenewalHealth is a derived bucket (active|due_soon|overdue|stale|unknown)
+	// computed from NextExpectedDate vs today; only populated for active series.
+	RenewalHealth string `json:"renewal_health,omitempty"`
+	// DaysUntilRenewal is the signed day count to NextExpectedDate (negative =
+	// overdue). Nil when there's no prediction. Populated for active series.
+	DaysUntilRenewal *int `json:"days_until_renewal,omitempty"`
+	OccurrenceCount  int  `json:"occurrence_count"`
 	DetectionSignals json.RawMessage `json:"detection_signals,omitempty"`
 	Tags             []string        `json:"tags,omitempty"`
 	CreatedAt        string          `json:"created_at"`
@@ -819,6 +839,7 @@ func seriesFromRow(r db.RecurringSeries) SeriesResponse {
 	if len(r.DetectionSignals) > 0 {
 		resp.DetectionSignals = json.RawMessage(r.DetectionSignals)
 	}
+	resp.RenewalHealth, resp.DaysUntilRenewal = seriesRenewalHealth(r.Status, r.Cadence, r.NextExpectedDate, time.Now())
 	return resp
 }
 
@@ -875,6 +896,39 @@ func nextExpectedDate(cadence string, lastSeen pgtype.Date) pgtype.Date {
 		return pgtype.Date{}
 	}
 	return pgconv.Date(next)
+}
+
+// seriesRenewalHealth derives the renewal-health bucket and signed days-until
+// for an active series, from its projected next_expected_date relative to now.
+//
+// Buckets: due_soon (0..window ahead), active (further ahead), overdue (past
+// due but within one cadence cycle — likely processing lag), stale (missed a
+// full cycle — likely cancelled). Returns ("", nil) for non-active series and
+// ("unknown", nil) when no projection exists (irregular cadence / no charges).
+func seriesRenewalHealth(status, cadence string, nextExpected pgtype.Date, now time.Time) (string, *int) {
+	if status != SeriesStatusActive {
+		return "", nil
+	}
+	interval := cadenceIntervalDays(cadence)
+	if !nextExpected.Valid || interval == 0 {
+		return SeriesHealthUnknown, nil
+	}
+	// Day-granular difference; truncate both ends to midnight UTC so partial
+	// days don't flip the sign.
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	exp := time.Date(nextExpected.Time.Year(), nextExpected.Time.Month(), nextExpected.Time.Day(), 0, 0, 0, 0, time.UTC)
+	days := int(exp.Sub(today).Hours() / 24)
+	d := days
+	switch {
+	case days < -interval:
+		return SeriesHealthStale, &d
+	case days < 0:
+		return SeriesHealthOverdue, &d
+	case days <= renewalDueSoonWindowDays:
+		return SeriesHealthDueSoon, &d
+	default:
+		return SeriesHealthActive, &d
+	}
 }
 
 func numericDollars(f float64) pgtype.Numeric {

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -772,6 +772,18 @@ func (s *Service) SplitSeries(ctx context.Context, idOrShort string, memberIDsOr
 			ErrInvalidParameter, len(memberIDs)-int(moved), len(memberIDs))
 	}
 
+	// Strip the SOURCE series' inherited tags from the moved members — they no
+	// longer belong to it, so its system-provenance tags are stale. Scoped by
+	// provenance (added_by_type='system' + added_by_id=source short_id) so a tag
+	// the user added directly to the transaction survives. The new series has no
+	// tags yet; a later add_series_tag will re-materialize via ApplySeriesTagToAllMembers.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM transaction_tags
+		 WHERE transaction_id = ANY($1::uuid[]) AND added_by_type = 'system' AND added_by_id = $2`,
+		memberIDs, src.ShortID); err != nil {
+		return nil, fmt.Errorf("strip source-inherited tags from moved members: %w", err)
+	}
+
 	newRow, err := s.applyRollup(ctx, qtx, nw.ID)
 	if err != nil {
 		return nil, err

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -13,6 +13,7 @@ import (
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -596,6 +597,195 @@ func (s *Service) ReviewSeries(ctx context.Context, idOrShort string, verdict Se
 	return &resp, nil
 }
 
+// RekeySeries changes a series' merchant_key (correcting a wrong or over-merged
+// detection key) and repoints its members' transactions.merchant_key to match,
+// so the series and its history stay consistent under the new key. It refuses
+// to silently merge: if a live series already exists at the new signature
+// (merchant_key + currency + user), or that signature is sticky-rejected, it
+// errors and tells the caller to move members instead.
+//
+// Scope note: incoming charges still derive their key from the provider name at
+// sync time, so a future charge of this merchant lands under the
+// provider-derived key, not the re-keyed one — re-key corrects the *historical*
+// grouping, not the normalizer. A merchant-key alias table is future work.
+func (s *Service) RekeySeries(ctx context.Context, idOrShort, newKey string, actor Actor) (*SeriesResponse, error) {
+	newKey = strings.TrimSpace(newKey)
+	if newKey == "" {
+		return nil, fmt.Errorf("%w: new merchant_key is required", ErrInvalidParameter)
+	}
+	id, err := s.resolveSeriesID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin rekey: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	row, err := qtx.GetRecurringSeriesByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get series: %w", err)
+	}
+	if strings.TrimSpace(row.MerchantKey) == newKey {
+		resp := seriesFromRow(row)
+		return &resp, nil // no-op: already at this key
+	}
+
+	// Collision / sticky-reject guard on the target signature.
+	match, mErr := qtx.MatchSeriesForUpdate(ctx, db.MatchSeriesForUpdateParams{
+		MerchantKey:     newKey,
+		IsoCurrencyCode: row.IsoCurrencyCode,
+		UserID:          row.UserID,
+	})
+	if mErr != nil && !errors.Is(mErr, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("match target key: %w", mErr)
+	}
+	if mErr == nil && match.ID != row.ID {
+		if match.Confidence == SeriesConfidenceRejected {
+			return nil, fmt.Errorf("%w: %q is a sticky-rejected signature; re-key would resurrect it", ErrInvalidParameter, newKey)
+		}
+		return nil, fmt.Errorf("%w: a series already exists at %q — re-key won't merge; move members there instead", ErrInvalidParameter, newKey)
+	}
+
+	// Repoint members' merchant_key so detection stays consistent, then the series'.
+	if _, err := tx.Exec(ctx,
+		`UPDATE transactions SET merchant_key = $2, updated_at = NOW() WHERE series_id = $1 AND deleted_at IS NULL`,
+		row.ID, newKey); err != nil {
+		return nil, fmt.Errorf("repoint member keys: %w", err)
+	}
+	upd := updateParamsFromRow(row)
+	upd.MerchantKey = newKey
+	updated, err := qtx.UpdateRecurringSeries(ctx, upd)
+	if err != nil {
+		return nil, fmt.Errorf("update series key: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit rekey: %w", err)
+	}
+	resp := seriesFromRow(updated)
+	return &resp, nil
+}
+
+// SplitSeries moves a subset of a series' members into a brand-new series under
+// newKey — the fix for an over-grouped series (e.g. a variable $4.99 charge
+// swept in with a $139/yr renewal). The new series inherits the source's
+// currency / user / category / cadence as a starting point; rollups recompute
+// on both sides. It errors if newKey equals the source key, if a live series
+// already exists at newKey, or if any listed transaction isn't a current member
+// of the source — so a split never steals from a third series or no-ops silently.
+func (s *Service) SplitSeries(ctx context.Context, idOrShort string, memberIDsOrShorts []string, newKey, newName string, actor Actor) (*SeriesResponse, error) {
+	newKey = strings.TrimSpace(newKey)
+	if newKey == "" {
+		return nil, fmt.Errorf("%w: new merchant_key is required", ErrInvalidParameter)
+	}
+	if len(memberIDsOrShorts) == 0 {
+		return nil, fmt.Errorf("%w: at least one transaction to split out is required", ErrInvalidParameter)
+	}
+	if len(memberIDsOrShorts) > seriesAssignMaxMembers {
+		return nil, fmt.Errorf("%w: at most %d transactions per split", ErrInvalidParameter, seriesAssignMaxMembers)
+	}
+	id, err := s.resolveSeriesID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	memberIDs, err := s.resolveTransactionIDs(ctx, memberIDsOrShorts)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin split: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	src, err := qtx.GetRecurringSeriesByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get series: %w", err)
+	}
+	if strings.TrimSpace(src.MerchantKey) == newKey {
+		return nil, fmt.Errorf("%w: split key must differ from the source key %q", ErrInvalidParameter, newKey)
+	}
+
+	// The target signature must be free — split creates a fresh series.
+	_, mErr := qtx.MatchSeriesForUpdate(ctx, db.MatchSeriesForUpdateParams{
+		MerchantKey:     newKey,
+		IsoCurrencyCode: src.IsoCurrencyCode,
+		UserID:          src.UserID,
+	})
+	if mErr != nil && !errors.Is(mErr, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("match target key: %w", mErr)
+	}
+	if mErr == nil {
+		return nil, fmt.Errorf("%w: a series already exists at %q — assign the members to it instead of splitting", ErrInvalidParameter, newKey)
+	}
+
+	name := strings.TrimSpace(newName)
+	if name == "" {
+		name = slugs.TitleCase(newKey)
+	}
+	nw, err := qtx.InsertRecurringSeries(ctx, db.InsertRecurringSeriesParams{
+		UserID:           src.UserID,
+		Name:             name,
+		MerchantKey:      newKey,
+		Cadence:          src.Cadence,
+		ExpectedDay:      src.ExpectedDay,
+		ExpectedAmount:   pgtype.Numeric{}, // recomputed from the split-out members
+		AmountTolerance:  src.AmountTolerance,
+		IsoCurrencyCode:  src.IsoCurrencyCode,
+		CategoryID:       src.CategoryID,
+		Status:           SeriesStatusCandidate,
+		DetectionSource:  seriesSourceForActor(actor),
+		Confidence:       SeriesConfidenceAuto,
+		ConfirmedByType:  pgtype.Text{},
+		LastAmount:       pgtype.Numeric{},
+		LastSeenDate:     pgtype.Date{},
+		NextExpectedDate: pgtype.Date{},
+		OccurrenceCount:  0,
+		DetectionSignals: nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("insert split series: %w", err)
+	}
+
+	// Move the listed members from source → new (and repoint their merchant_key).
+	// Guarded on series_id = source so it never steals a charge from a third series.
+	ct, err := tx.Exec(ctx,
+		`UPDATE transactions SET series_id = $2, merchant_key = $3, updated_at = NOW()
+		 WHERE id = ANY($4::uuid[]) AND series_id = $1 AND deleted_at IS NULL`,
+		src.ID, nw.ID, newKey, memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("move members: %w", err)
+	}
+	if moved := ct.RowsAffected(); int(moved) != len(memberIDs) {
+		return nil, fmt.Errorf("%w: %d of %d transactions are not current members of the source series",
+			ErrInvalidParameter, len(memberIDs)-int(moved), len(memberIDs))
+	}
+
+	newRow, err := s.applyRollup(ctx, qtx, nw.ID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.applyRollup(ctx, qtx, src.ID); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit split: %w", err)
+	}
+	resp := seriesFromRow(newRow)
+	return &resp, nil
+}
+
 // GetSeries returns a single series by short_id or uuid.
 func (s *Service) GetSeries(ctx context.Context, idOrShort string) (*SeriesResponse, error) {
 	id, err := s.resolveSeriesID(ctx, idOrShort)
@@ -754,6 +944,27 @@ func (s *Service) seriesRollup(ctx context.Context, q *db.Queries, seriesID pgty
 		return 0, pgtype.Numeric{}, pgtype.Date{}, fmt.Errorf("series rollup: %w", err)
 	}
 	return int32(roll.OccurrenceCount), roll.LastAmount, roll.LastSeenDate, nil
+}
+
+// applyRollup recomputes a series' occurrence/last-amount/last-seen from its
+// live members and persists them (plus the projected next_expected_date),
+// returning the refreshed row. Used after membership changes (re-key keeps
+// membership but is harmless; split changes it on both sides).
+func (s *Service) applyRollup(ctx context.Context, qtx *db.Queries, id pgtype.UUID) (db.RecurringSeries, error) {
+	row, err := qtx.GetRecurringSeriesByID(ctx, id)
+	if err != nil {
+		return db.RecurringSeries{}, fmt.Errorf("get series for rollup: %w", err)
+	}
+	occ, lastAmt, lastSeen, err := s.seriesRollup(ctx, qtx, id)
+	if err != nil {
+		return db.RecurringSeries{}, err
+	}
+	upd := updateParamsFromRow(row)
+	upd.OccurrenceCount = occ
+	upd.LastAmount = lastAmt
+	upd.LastSeenDate = lastSeen
+	upd.NextExpectedDate = nextExpectedDate(upd.Cadence, lastSeen)
+	return qtx.UpdateRecurringSeries(ctx, upd)
 }
 
 func (s *Service) resolveOptionalUserID(ctx context.Context, idOrShort *string) (pgtype.UUID, error) {

--- a/internal/service/series_detect.go
+++ b/internal/service/series_detect.go
@@ -70,6 +70,18 @@ type detectionSignals struct {
 	DetectorVersion   int     `json:"detector_version"`
 }
 
+// Rejection reasons surfaced by evaluateGroup (and the explain feed). The empty
+// string means the group qualifies. These are stable identifiers — agents and
+// the UI map them to human copy ("why isn't this a subscription?").
+const (
+	seriesRejectTooFewCharges     = "too_few_charges"       // fewer than 2 charges — nothing to compare
+	seriesRejectSameDayDuplicates = "same_day_duplicates"   // all charges land on one day, no cadence
+	seriesRejectIrregularCadence  = "irregular_cadence"     // gap doesn't snap to any known cadence
+	seriesRejectTooFewOccurrences = "too_few_occurrences"   // below the precision-first occurrence floor
+	seriesRejectIntervalVariable  = "interval_too_variable" // day-gaps too irregular (interval_cv over gate)
+	seriesRejectAmountUnstable    = "amount_unstable"       // amounts neither tight-band nor clean drift
+)
+
 // groupAnalysis is the verdict for one candidate group.
 type groupAnalysis struct {
 	cadence             string
@@ -78,16 +90,55 @@ type groupAnalysis struct {
 	signals             detectionSignals
 }
 
+// groupDiagnostics carries the best-effort numbers computed about a group
+// regardless of whether it qualified — so a rejected near-miss can still
+// explain itself (how many charges, nearest cadence, interval variance, amount
+// spread). Reason is "" when the group qualified.
+type groupDiagnostics struct {
+	Reason            string
+	OccurrenceCount   int
+	NearestCadence    string  // closest cadence center even if it didn't snap
+	MedianGapDays     float64
+	IntervalCV        float64
+	AmountMinCents    int64
+	AmountMaxCents    int64
+	AmountSpreadRatio float64
+}
+
 // analyzeGroup applies the precision-first gates to one merchant+currency group
 // of charges and decides whether it is a recurring series. Pure arithmetic, no
-// I/O — the unit-tested core of the detector.
+// I/O — the unit-tested core of the detector. Thin wrapper over evaluateGroup
+// preserving the historical (analysis, ok) shape for the detection path.
 func analyzeGroup(charges []chargePoint, merchantKey, currency string) (groupAnalysis, bool) {
+	a, diag := evaluateGroup(charges, merchantKey, currency)
+	return a, diag.Reason == ""
+}
+
+// evaluateGroup is the gate core. It returns the accepted analysis (when
+// diag.Reason == "") plus diagnostics that are populated as far as the gates
+// got — so the explain feed can report *why* a near-miss fell short using the
+// same arithmetic the detector used. The accepted path is byte-identical to the
+// pre-refactor analyzeGroup.
+func evaluateGroup(charges []chargePoint, merchantKey, currency string) (groupAnalysis, groupDiagnostics) {
+	diag := groupDiagnostics{OccurrenceCount: len(charges)}
 	if len(charges) < 2 {
-		return groupAnalysis{}, false
+		diag.Reason = seriesRejectTooFewCharges
+		return groupAnalysis{}, diag
 	}
 	sorted := make([]chargePoint, len(charges))
 	copy(sorted, charges)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].date.Before(sorted[j].date) })
+
+	// Amount spread is meaningful for diagnostics regardless of the gate outcome.
+	amounts := make([]int64, len(sorted))
+	for i, c := range sorted {
+		amounts[i] = c.amountCents
+	}
+	minAmt, maxAmt := minMaxInt(amounts)
+	diag.AmountMinCents, diag.AmountMaxCents = minAmt, maxAmt
+	if minAmt > 0 {
+		diag.AmountSpreadRatio = round3(float64(maxAmt) / float64(minAmt))
+	}
 
 	// Day gaps between consecutive charges.
 	gaps := make([]float64, 0, len(sorted)-1)
@@ -95,13 +146,17 @@ func analyzeGroup(charges []chargePoint, merchantKey, currency string) (groupAna
 		gaps = append(gaps, sorted[i].date.Sub(sorted[i-1].date).Hours()/24)
 	}
 	medGap := median(gaps)
+	diag.MedianGapDays = round3(medGap)
 	if medGap <= 0 {
-		return groupAnalysis{}, false // same-day duplicates, not a cadence
+		diag.Reason = seriesRejectSameDayDuplicates
+		return groupAnalysis{}, diag
 	}
 
 	cadence, snapErr := snapCadence(medGap)
+	diag.NearestCadence = nearestCadenceName(medGap)
 	if cadence == SeriesCadenceIrregular {
-		return groupAnalysis{}, false // precision-first: detector never emits irregular
+		diag.Reason = seriesRejectIrregularCadence // precision-first: detector never emits irregular
+		return groupAnalysis{}, diag
 	}
 
 	// Occurrence floor depends on cadence: annual/semiannual qualify at 2.
@@ -110,28 +165,29 @@ func analyzeGroup(charges []chargePoint, merchantKey, currency string) (groupAna
 		floor = seriesMinOccurrencesAnnual
 	}
 	if len(sorted) < floor {
-		return groupAnalysis{}, false
+		diag.NearestCadence = cadence
+		diag.Reason = seriesRejectTooFewOccurrences
+		return groupAnalysis{}, diag
 	}
 
 	// Interval regularity — only meaningful with ≥2 gaps. The 2-charge annual
 	// case relies on the cadence-snap gate instead.
 	cv := coeffVar(gaps)
+	diag.IntervalCV = round3(cv)
+	diag.NearestCadence = cadence
 	if len(gaps) >= 2 && cv > seriesMaxIntervalCV {
-		return groupAnalysis{}, false
+		diag.Reason = seriesRejectIntervalVariable
+		return groupAnalysis{}, diag
 	}
 
 	// Amount stability: tight band OR monotonic-drift (gated on clean cadence).
-	amounts := make([]int64, len(sorted))
-	for i, c := range sorted {
-		amounts[i] = c.amountCents
-	}
 	branch, ok := amountStability(amounts, snapErr)
 	if !ok {
-		return groupAnalysis{}, false
+		diag.Reason = seriesRejectAmountUnstable
+		return groupAnalysis{}, diag
 	}
 
 	medAmt := medianInt(amounts)
-	minAmt, maxAmt := minMaxInt(amounts)
 	expected := medAmt
 	if branch == "monotonic_drift" {
 		expected = amounts[len(amounts)-1] // current price renews
@@ -164,7 +220,21 @@ func analyzeGroup(charges []chargePoint, merchantKey, currency string) (groupAna
 		expectedAmountCents: expected,
 		expectedDay:         modalDayOfMonth(sorted, cadence),
 		signals:             sig,
-	}, true
+	}, diag
+}
+
+// nearestCadenceName returns the closest cadence center to a median gap,
+// ignoring the snap tolerance — used for diagnostics so an irregular near-miss
+// can still say "looks roughly monthly".
+func nearestCadenceName(medGap float64) string {
+	best := SeriesCadenceIrregular
+	bestErr := math.MaxFloat64
+	for _, c := range cadenceCenters {
+		if e := math.Abs(medGap-c.center) / c.center; e < bestErr {
+			bestErr, best = e, c.name
+		}
+	}
+	return best
 }
 
 // snapCadence maps a median day-gap to a canonical cadence if it lands within

--- a/internal/service/series_detect_test.go
+++ b/internal/service/series_detect_test.go
@@ -5,6 +5,8 @@ package service
 import (
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func cp(date string, cents int64) chargePoint {
@@ -104,3 +106,56 @@ func TestSnapCadence(t *testing.T) {
 		}
 	}
 }
+
+// --- renewal-health derivation (seriesRenewalHealth) ---
+
+func mkDate(s string) pgtype.Date {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return pgtype.Date{Time: t, Valid: true}
+}
+
+func TestSeriesRenewalHealth(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name         string
+		status       string
+		cadence      string
+		nextExpected pgtype.Date
+		wantHealth   string
+		wantDays     *int // nil means "expect nil pointer"
+	}{
+		{"non-active is empty", SeriesStatusCandidate, SeriesCadenceMonthly, mkDate("2026-06-15"), "", nil},
+		{"paused is empty", SeriesStatusPaused, SeriesCadenceMonthly, mkDate("2026-06-15"), "", nil},
+		{"no projection → unknown", SeriesStatusActive, SeriesCadenceIrregular, pgtype.Date{}, SeriesHealthUnknown, nil},
+		{"future beyond window → active", SeriesStatusActive, SeriesCadenceMonthly, mkDate("2026-06-29"), SeriesHealthActive, intp(30)},
+		{"within a week → due_soon", SeriesStatusActive, SeriesCadenceMonthly, mkDate("2026-06-05"), SeriesHealthDueSoon, intp(6)},
+		{"today → due_soon", SeriesStatusActive, SeriesCadenceMonthly, mkDate("2026-05-30"), SeriesHealthDueSoon, intp(0)},
+		{"a few days late, within cycle → overdue", SeriesStatusActive, SeriesCadenceMonthly, mkDate("2026-05-20"), SeriesHealthOverdue, intp(-10)},
+		{"missed a full monthly cycle → stale", SeriesStatusActive, SeriesCadenceMonthly, mkDate("2026-04-01"), SeriesHealthStale, intp(-59)},
+		{"weekly 10 days late → stale", SeriesStatusActive, SeriesCadenceWeekly, mkDate("2026-05-20"), SeriesHealthStale, intp(-10)},
+		{"weekly 5 days late → overdue", SeriesStatusActive, SeriesCadenceWeekly, mkDate("2026-05-25"), SeriesHealthOverdue, intp(-5)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHealth, gotDays := seriesRenewalHealth(tc.status, tc.cadence, tc.nextExpected, now)
+			if gotHealth != tc.wantHealth {
+				t.Errorf("health = %q, want %q", gotHealth, tc.wantHealth)
+			}
+			switch {
+			case tc.wantDays == nil && gotDays != nil:
+				t.Errorf("days = %d, want nil", *gotDays)
+			case tc.wantDays != nil && gotDays == nil:
+				t.Errorf("days = nil, want %d", *tc.wantDays)
+			case tc.wantDays != nil && gotDays != nil && *gotDays != *tc.wantDays:
+				t.Errorf("days = %d, want %d", *gotDays, *tc.wantDays)
+			}
+		})
+	}
+}
+
+func intp(i int) *int { return &i }

--- a/internal/service/series_detect_test.go
+++ b/internal/service/series_detect_test.go
@@ -159,3 +159,69 @@ func TestSeriesRenewalHealth(t *testing.T) {
 }
 
 func intp(i int) *int { return &i }
+
+// --- evaluateGroup rejection reasons (the explain-feed verdicts) ---
+
+func TestEvaluateGroup_Reasons(t *testing.T) {
+	cases := []struct {
+		name       string
+		charges    []chargePoint
+		wantReason string
+	}{
+		{
+			name:       "single charge",
+			charges:    []chargePoint{cp("2026-01-15", 999)},
+			wantReason: seriesRejectTooFewCharges,
+		},
+		{
+			name:       "all same day",
+			charges:    []chargePoint{cp("2026-01-15", 999), cp("2026-01-15", 999), cp("2026-01-15", 999)},
+			wantReason: seriesRejectSameDayDuplicates,
+		},
+		{
+			name:       "irregular gaps dont snap",
+			charges:    []chargePoint{cp("2026-01-01", 999), cp("2026-02-15", 999), cp("2026-04-01", 999)},
+			wantReason: seriesRejectIrregularCadence,
+		},
+		{
+			name:       "only two monthly charges",
+			charges:    []chargePoint{cp("2026-01-15", 999), cp("2026-02-15", 999)},
+			wantReason: seriesRejectTooFewOccurrences,
+		},
+		{
+			name:       "monthly-ish but intervals too variable",
+			charges:    []chargePoint{cp("2026-01-01", 999), cp("2026-01-26", 999), cp("2026-02-25", 999), cp("2026-04-05", 999)},
+			wantReason: seriesRejectIntervalVariable,
+		},
+		{
+			name:       "clean monthly cadence but scattered amounts",
+			charges:    []chargePoint{cp("2026-01-15", 999), cp("2026-02-15", 2999), cp("2026-03-15", 500), cp("2026-04-15", 1500)},
+			wantReason: seriesRejectAmountUnstable,
+		},
+		{
+			name:       "clean monthly subscription qualifies",
+			charges:    []chargePoint{cp("2026-01-15", 999), cp("2026-02-15", 999), cp("2026-03-15", 999)},
+			wantReason: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, diag := evaluateGroup(tc.charges, "merchant", "USD")
+			if diag.Reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q (occ=%d, medGap=%.1f, cv=%.3f, nearest=%s)",
+					diag.Reason, tc.wantReason, diag.OccurrenceCount, diag.MedianGapDays, diag.IntervalCV, diag.NearestCadence)
+			}
+		})
+	}
+}
+
+func TestEvaluateGroup_AnalyzeGroupAgreesWithReason(t *testing.T) {
+	// analyzeGroup's ok must equal "reason is empty" for the same input.
+	charges := []chargePoint{cp("2026-01-15", 999), cp("2026-02-15", 999), cp("2026-03-15", 999)}
+	_, ok := analyzeGroup(charges, "m", "USD")
+	_, diag := evaluateGroup(charges, "m", "USD")
+	if ok != (diag.Reason == "") {
+		t.Errorf("analyzeGroup ok=%v but evaluateGroup reason=%q — wrappers disagree", ok, diag.Reason)
+	}
+}

--- a/internal/service/series_detector.go
+++ b/internal/service/series_detector.go
@@ -173,6 +173,160 @@ func (s *Service) detectForUser(ctx context.Context, effUser pgtype.UUID, opts d
 	return emitted, nil
 }
 
+// seriesExplainMaxRows caps the explain feed so a noisy account doesn't return
+// hundreds of one-off merchants.
+const seriesExplainMaxRows = 50
+
+// SeriesNearMiss is one merchant group that is NOT currently a recurring series,
+// annotated with the detector's verdict: either it qualifies (eligible but not
+// yet tracked) or it fell short of a specific precision-first gate. This is the
+// read-side "why isn't this a subscription?" feed — pure analysis over existing
+// transactions, no writes.
+type SeriesNearMiss struct {
+	MerchantKey       string   `json:"merchant_key"`
+	Name              string   `json:"name"`
+	Currency          *string  `json:"iso_currency_code,omitempty"`
+	OccurrenceCount   int      `json:"occurrence_count"`
+	Qualifies         bool     `json:"qualifies"`        // true = passes every gate but isn't tracked yet
+	Reason            string   `json:"reason,omitempty"` // gate it failed (empty when Qualifies)
+	Explanation       string   `json:"explanation"`      // human one-liner
+	NearestCadence    string   `json:"nearest_cadence,omitempty"`
+	MedianGapDays     float64  `json:"median_gap_days,omitempty"`
+	IntervalCV        float64  `json:"interval_cv,omitempty"`
+	AmountMin         *float64 `json:"amount_min,omitempty"`
+	AmountMax         *float64 `json:"amount_max,omitempty"`
+	AmountSpreadRatio float64  `json:"amount_spread_ratio,omitempty"`
+	FirstSeen         *string  `json:"first_seen,omitempty"`
+	LastSeen          *string  `json:"last_seen,omitempty"`
+}
+
+// ExplainSeriesCandidates reports, per merchant group that is not already a
+// recurring series, the detector's verdict over the trailing detection window —
+// the same gates the live detector runs, but surfacing the *reason* a group did
+// (or didn't) qualify. Read-only: no merchant_key backfill, no upserts.
+//
+// Groups already represented by a recurring_series row (any status) are
+// excluded — they're hits, not near-misses. Single-charge groups are dropped as
+// noise. Results are ordered most-charges-first (closest to qualifying) and
+// capped at seriesExplainMaxRows.
+func (s *Service) ExplainSeriesCandidates(ctx context.Context) ([]SeriesNearMiss, error) {
+	users, err := s.distinctEffectiveUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := s.existingSeriesMerchantKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	since := time.Now().AddDate(0, 0, -seriesDetectWindowDays)
+
+	var out []SeriesNearMiss
+	for _, u := range users {
+		rows, err := s.loadCandidateCharges(ctx, u, &since)
+		if err != nil {
+			return nil, err
+		}
+		i := 0
+		for i < len(rows) {
+			j := i
+			for j < len(rows) && rows[j].merchantKey == rows[i].merchantKey && rows[j].currency == rows[i].currency {
+				j++
+			}
+			group := rows[i:j]
+			i = j
+
+			key := group[0].merchantKey
+			if existing[key] {
+				continue // already a series — not a near-miss
+			}
+			if len(group) < 2 {
+				continue // single charge: nothing to explain
+			}
+
+			charges := make([]chargePoint, len(group))
+			for k, r := range group {
+				charges[k] = chargePoint{date: r.date, amountCents: r.amountCents}
+			}
+			_, diag := evaluateGroup(charges, key, group[0].currency)
+
+			nm := SeriesNearMiss{
+				MerchantKey:       key,
+				Name:              slugs.TitleCase(key),
+				OccurrenceCount:   diag.OccurrenceCount,
+				Qualifies:         diag.Reason == "",
+				Reason:            diag.Reason,
+				Explanation:       nearMissExplanation(diag),
+				NearestCadence:    diag.NearestCadence,
+				MedianGapDays:     diag.MedianGapDays,
+				IntervalCV:        diag.IntervalCV,
+				AmountSpreadRatio: diag.AmountSpreadRatio,
+			}
+			if group[0].currency != "" {
+				c := group[0].currency
+				nm.Currency = &c
+			}
+			if diag.AmountMaxCents > 0 {
+				mn := float64(diag.AmountMinCents) / 100
+				mx := float64(diag.AmountMaxCents) / 100
+				nm.AmountMin, nm.AmountMax = &mn, &mx
+			}
+			// Rows are ordered by date asc within a group.
+			fs := group[0].date.Format("2006-01-02")
+			ls := group[len(group)-1].date.Format("2006-01-02")
+			nm.FirstSeen, nm.LastSeen = &fs, &ls
+			out = append(out, nm)
+		}
+	}
+
+	sort.SliceStable(out, func(a, b int) bool { return out[a].OccurrenceCount > out[b].OccurrenceCount })
+	if len(out) > seriesExplainMaxRows {
+		out = out[:seriesExplainMaxRows]
+	}
+	return out, nil
+}
+
+// existingSeriesMerchantKeys returns the set of merchant_keys that already have
+// a recurring_series row (any status), so the explain feed can skip them.
+func (s *Service) existingSeriesMerchantKeys(ctx context.Context) (map[string]bool, error) {
+	rows, err := s.Pool.Query(ctx, `SELECT DISTINCT merchant_key FROM recurring_series`)
+	if err != nil {
+		return nil, fmt.Errorf("load existing series keys: %w", err)
+	}
+	defer rows.Close()
+	set := map[string]bool{}
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			return nil, fmt.Errorf("scan series key: %w", err)
+		}
+		set[k] = true
+	}
+	return set, rows.Err()
+}
+
+// nearMissExplanation renders a one-line human explanation for a group's verdict,
+// folding in the actual numbers so the message is concrete.
+func nearMissExplanation(diag groupDiagnostics) string {
+	switch diag.Reason {
+	case "":
+		return fmt.Sprintf("Looks like a %s subscription (%d charges) — eligible but not tracked yet.", diag.NearestCadence, diag.OccurrenceCount)
+	case seriesRejectTooFewOccurrences:
+		return fmt.Sprintf("Only %d charges seen; a %s series needs more before it's trustworthy.", diag.OccurrenceCount, diag.NearestCadence)
+	case seriesRejectIrregularCadence:
+		return fmt.Sprintf("Charge timing is irregular (~%.0f-day gaps); doesn't match a known cadence.", diag.MedianGapDays)
+	case seriesRejectIntervalVariable:
+		return fmt.Sprintf("Charge intervals vary too much (interval_cv %.2f) for a reliable %s cadence.", diag.IntervalCV, diag.NearestCadence)
+	case seriesRejectAmountUnstable:
+		return fmt.Sprintf("Amounts swing too much ($%.2f–$%.2f) to be a steady subscription.", float64(diag.AmountMinCents)/100, float64(diag.AmountMaxCents)/100)
+	case seriesRejectSameDayDuplicates:
+		return "All charges fall on one day — looks like duplicates, not a recurring cycle."
+	case seriesRejectTooFewCharges:
+		return "Only one charge so far — nothing to compare yet."
+	default:
+		return "Did not qualify as a recurring series."
+	}
+}
+
 // populateMerchantKeys derives transactions.merchant_key for the user's rows
 // that don't have one yet, using the same Go normalizer the sync path uses. The
 // backfill's "UPDATE merchant_key first" step; a no-op once rows are populated.

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -725,6 +725,56 @@ func TestSplitSeries(t *testing.T) {
 	}
 }
 
+func TestSplitSeries_StripsSourceInheritedTags(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	testutil.MustCreateTag(t, queries, "on-prime", "On Prime")
+	testutil.MustCreateTag(t, queries, "user-pin", "User Pin")
+	acctID := seedTxnFixture(t, queries)
+	a := testutil.MustCreateTransaction(t, queries, acctID, "AP_1", "Amazon Prime", 13900, "2025-05-01")
+	keep := testutil.MustCreateTransaction(t, queries, acctID, "AP_2", "Amazon Prime", 13900, "2026-05-01")
+	stray := testutil.MustCreateTransaction(t, queries, acctID, "AP_VID", "Amazon Prime Video", 499, "2026-04-10")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	series, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		Name: "Amazon Prime", MerchantKey: "amazonprime", Cadence: service.SeriesCadenceAnnual,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: []string{a.ShortID, keep.ShortID, stray.ShortID},
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	// Inherit the series tag onto all members (provenance system + series short_id).
+	if err := svc.AddSeriesTag(ctx, series.ShortID, "on-prime", actor); err != nil {
+		t.Fatalf("add series tag: %v", err)
+	}
+	// A tag the user added directly to the stray charge (non-system provenance).
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_name)
+		 SELECT $1, id, 'user', 'Tester' FROM tags WHERE slug = 'user-pin'`, stray.ID); err != nil {
+		t.Fatalf("insert user tag: %v", err)
+	}
+	if !txnHasTag(t, pool, stray.ID, "on-prime") || !txnHasTag(t, pool, stray.ID, "user-pin") {
+		t.Fatal("precondition: stray should carry both tags before the split")
+	}
+
+	if _, err := svc.SplitSeries(ctx, series.ShortID, []string{stray.ShortID}, "primevideo", "Prime Video", actor); err != nil {
+		t.Fatalf("SplitSeries: %v", err)
+	}
+
+	// The moved member loses the SOURCE series' inherited tag but keeps the user tag.
+	if txnHasTag(t, pool, stray.ID, "on-prime") {
+		t.Error("moved member should no longer carry the source series' inherited tag")
+	}
+	if !txnHasTag(t, pool, stray.ID, "user-pin") {
+		t.Error("a user-added tag must survive the split (provenance-scoped strip)")
+	}
+	// A member that stayed keeps the source tag.
+	if !txnHasTag(t, pool, keep.ID, "on-prime") {
+		t.Error("a member that stayed should keep the source series' inherited tag")
+	}
+}
+
 func keysOf(m map[string]service.SeriesNearMiss) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -538,6 +538,90 @@ func TestRuleConditions_InSeriesAndSeries(t *testing.T) {
 	}
 }
 
+// TestExplainSeriesCandidates verifies the near-miss / explain feed: a 2-charge
+// group is reported as too_few_occurrences, a clean 3-charge group qualifies but
+// is untracked, and a merchant already represented by a series is excluded.
+func TestExplainSeriesCandidates(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Near-miss: only 2 monthly charges → too_few_occurrences.
+	testutil.MustCreateTransaction(t, queries, acctID, "HULU_1", "Hulu", 1799, "2026-03-10")
+	testutil.MustCreateTransaction(t, queries, acctID, "HULU_2", "Hulu", 1799, "2026-04-10")
+	// Qualifying but untracked: 3 clean monthly charges, steady amount.
+	testutil.MustCreateTransaction(t, queries, acctID, "DISNEY_1", "Disney Plus", 1399, "2026-02-12")
+	testutil.MustCreateTransaction(t, queries, acctID, "DISNEY_2", "Disney Plus", 1399, "2026-03-12")
+	testutil.MustCreateTransaction(t, queries, acctID, "DISNEY_3", "Disney Plus", 1399, "2026-04-12")
+	// Already a series: linked netflix charges must be excluded from the feed.
+	n1 := testutil.MustCreateTransaction(t, queries, acctID, "NFLX_1", "Netflix", 1599, "2026-02-15")
+	n2 := testutil.MustCreateTransaction(t, queries, acctID, "NFLX_2", "Netflix", 1599, "2026-03-15")
+	n3 := testutil.MustCreateTransaction(t, queries, acctID, "NFLX_3", "Netflix", 1599, "2026-04-15")
+
+	// Populate merchant_key the way sync would — explain is read-only and assumes
+	// the key is already set (the engine sets it at upsert; backfill fills history).
+	for key, name := range map[string]string{"hulu": "Hulu", "disneyplus": "Disney Plus", "netflix": "Netflix"} {
+		if _, err := pool.Exec(ctx, `UPDATE transactions SET merchant_key=$1 WHERE provider_name=$2`, key, name); err != nil {
+			t.Fatalf("set merchant_key: %v", err)
+		}
+	}
+
+	if _, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		Name: "Netflix", MerchantKey: "netflix", Cadence: service.SeriesCadenceMonthly,
+		ExpectedAmount: seriesF64Ptr(15.99), Currency: seriesStrPtr("USD"),
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: []string{n1.ShortID, n2.ShortID, n3.ShortID},
+	}, service.SystemActor()); err != nil {
+		t.Fatalf("seed netflix series: %v", err)
+	}
+
+	nm, err := svc.ExplainSeriesCandidates(ctx)
+	if err != nil {
+		t.Fatalf("ExplainSeriesCandidates: %v", err)
+	}
+
+	byKey := map[string]service.SeriesNearMiss{}
+	for _, m := range nm {
+		byKey[m.MerchantKey] = m
+	}
+
+	if _, ok := byKey["netflix"]; ok {
+		t.Error("netflix is already a series; it must not appear in the near-miss feed")
+	}
+
+	hulu, ok := byKey["hulu"]
+	if !ok {
+		t.Fatalf("hulu near-miss missing from feed (got keys %v)", keysOf(byKey))
+	}
+	if hulu.Reason != "too_few_occurrences" {
+		t.Errorf("hulu reason = %q, want too_few_occurrences", hulu.Reason)
+	}
+	if hulu.Qualifies {
+		t.Error("hulu should not qualify with only 2 charges")
+	}
+	if hulu.OccurrenceCount != 2 {
+		t.Errorf("hulu occurrence_count = %d, want 2", hulu.OccurrenceCount)
+	}
+	if hulu.Explanation == "" {
+		t.Error("hulu near-miss should carry a human explanation")
+	}
+
+	disney, ok := byKey["disneyplus"]
+	if !ok {
+		t.Fatalf("disneyplus near-miss missing from feed (got keys %v)", keysOf(byKey))
+	}
+	if !disney.Qualifies {
+		t.Errorf("disneyplus should qualify (3 clean monthly charges); reason=%q", disney.Reason)
+	}
+}
+
+func keysOf(m map[string]service.SeriesNearMiss) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func txnHasTag(t *testing.T, pool *pgxpool.Pool, txnID pgtype.UUID, slug string) bool {
 	t.Helper()
 	var n int

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -463,6 +463,81 @@ func TestApplyRuleRetroactively_AssignSeries(t *testing.T) {
 	}
 }
 
+// TestRuleConditions_InSeriesAndSeries exercises the read-half of the
+// rules-engine composition: a rule conditioned on series membership
+// (in_series) or a specific series (series eq short_id) matches only the
+// linked transactions when applied retroactively. This validates the
+// recurring_series JOIN + scan added to the retroactive context query.
+func TestRuleConditions_InSeriesAndSeries(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	testutil.MustCreateTag(t, queries, "subscription-charge", "Subscription charge")
+	testutil.MustCreateTag(t, queries, "is-netflix", "Is Netflix")
+	acctID := seedTxnFixture(t, queries)
+	n1 := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_1", "Netflix", 1599, "2026-03-15")
+	n2 := testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_2", "Netflix", 1599, "2026-04-15")
+	loose := testutil.MustCreateTransaction(t, queries, acctID, "STARBUCKS", "Starbucks", 599, "2026-04-16")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	// Link the two Netflix charges to a series; Starbucks stays unlinked.
+	series, err := svc.AssignSeries(ctx, service.AssignSeriesInput{
+		MerchantKey: "netflix", CreateIfMissing: true, TransactionIDs: []string{n1.ShortID, n2.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("assign series: %v", err)
+	}
+
+	// Rule 1: in_series eq true → add_tag subscription-charge. Should hit the
+	// two members, skip Starbucks.
+	inSeriesRule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Members get a tag",
+		Conditions: service.Condition{Field: "in_series", Op: "eq", Value: true},
+		Actions:    []service.RuleAction{{Type: "add_tag", TagSlug: "subscription-charge"}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create in_series rule: %v", err)
+	}
+	matched, err := svc.ApplyRuleRetroactively(ctx, inSeriesRule.ID)
+	if err != nil {
+		t.Fatalf("apply in_series rule: %v", err)
+	}
+	if matched != 2 {
+		t.Errorf("in_series matched = %d, want 2 (the two linked charges)", matched)
+	}
+	if !txnHasTag(t, pool, n1.ID, "subscription-charge") || !txnHasTag(t, pool, n2.ID, "subscription-charge") {
+		t.Error("expected both series members to receive the subscription-charge tag")
+	}
+	if txnHasTag(t, pool, loose.ID, "subscription-charge") {
+		t.Error("unlinked transaction was wrongly tagged by an in_series rule")
+	}
+
+	// Rule 2: series eq <short_id> → add_tag is-netflix. Targets the specific
+	// series by its short_id, exercising the recurring_series JOIN.
+	seriesRule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Netflix series tag",
+		Conditions: service.Condition{Field: "series", Op: "eq", Value: series.ShortID},
+		Actions:    []service.RuleAction{{Type: "add_tag", TagSlug: "is-netflix"}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create series rule: %v", err)
+	}
+	matched, err = svc.ApplyRuleRetroactively(ctx, seriesRule.ID)
+	if err != nil {
+		t.Fatalf("apply series rule: %v", err)
+	}
+	if matched != 2 {
+		t.Errorf("series eq matched = %d, want 2", matched)
+	}
+	if !txnHasTag(t, pool, n1.ID, "is-netflix") {
+		t.Error("expected the matched series member to receive the is-netflix tag")
+	}
+	if txnHasTag(t, pool, loose.ID, "is-netflix") {
+		t.Error("unlinked transaction was wrongly tagged by a series eq rule")
+	}
+}
+
 func txnHasTag(t *testing.T, pool *pgxpool.Pool, txnID pgtype.UUID, slug string) bool {
 	t.Helper()
 	var n int

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -413,6 +413,55 @@ func findSeriesByKey(t *testing.T, svc *service.Service, key string) *service.Se
 	return nil
 }
 
+func TestApplyRuleRetroactively_AssignSeries(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM 1", "Netflix", 1599, "2026-03-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM 2", "Netflix", 1599, "2026-04-15")
+	other := testutil.MustCreateTransaction(t, queries, acctID, "STARBUCKS", "Starbucks", 599, "2026-04-16")
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Netflix → series",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "Netflix"},
+		Actions:    []service.RuleAction{{Type: "assign_series", MerchantKey: "netflix", CreateIfMissing: true}},
+		Actor:      service.Actor{Type: "user", ID: "u1", Name: "Tester"},
+	})
+	if err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	n, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("matched = %d, want 2 (only the two Netflix charges)", n)
+	}
+
+	row := findSeriesByKey(t, svc, "netflix")
+	if row == nil {
+		t.Fatal("retroactive assign_series did not mint a netflix series")
+	}
+	if row.DetectionSource != service.SeriesSourceRule {
+		t.Errorf("detection_source = %q, want rule", row.DetectionSource)
+	}
+	if row.OccurrenceCount != 2 {
+		t.Errorf("occurrence_count = %d, want 2", row.OccurrenceCount)
+	}
+	if n := countLinkedMembers(t, pool, row.ID); n != 2 {
+		t.Errorf("linked members = %d, want 2", n)
+	}
+	// The non-matching charge stays unlinked.
+	var seriesID pgtype.UUID
+	if err := pool.QueryRow(ctx, `SELECT series_id FROM transactions WHERE id=$1`, other.ID).Scan(&seriesID); err != nil {
+		t.Fatalf("query other txn: %v", err)
+	}
+	if seriesID.Valid {
+		t.Error("non-matching transaction was wrongly linked to a series")
+	}
+}
+
 func TestAssignSeriesFromRuleTx_MintAndLink(t *testing.T) {
 	svc, queries, pool := newService(t)
 	ctx := context.Background()

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -614,6 +614,117 @@ func TestExplainSeriesCandidates(t *testing.T) {
 	}
 }
 
+func TestRekeySeries(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	_, members := seedRecurring(t, queries, "SQ *PAYMENT", []string{"2026-02-15", "2026-03-15", "2026-04-15"})
+
+	// Mint under a fallback/over-merged key.
+	series, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		Name: "Payment", MerchantKey: "payment", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: members,
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	rekeyed, err := svc.RekeySeries(ctx, series.ShortID, "spotify", service.Actor{Type: "user", Name: "Tester"})
+	if err != nil {
+		t.Fatalf("RekeySeries: %v", err)
+	}
+	if rekeyed.MerchantKey != "spotify" {
+		t.Errorf("series merchant_key = %q, want spotify", rekeyed.MerchantKey)
+	}
+
+	// All members' merchant_key repointed to the new key.
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM transactions WHERE series_id = $1 AND merchant_key = $2`,
+		series.ID, "spotify").Scan(&n); err != nil {
+		t.Fatalf("count repointed members: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("repointed members = %d, want 3", n)
+	}
+
+	// Collision: re-keying into a key that already has a series is refused.
+	if _, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		Name: "Netflix", MerchantKey: "netflix", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic,
+	}, service.SystemActor()); err != nil {
+		t.Fatalf("mint netflix: %v", err)
+	}
+	if _, err := svc.RekeySeries(ctx, series.ShortID, "netflix", service.Actor{Type: "user"}); err == nil {
+		t.Error("expected re-key into an existing key to error (no silent merge)")
+	}
+}
+
+func TestSplitSeries(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	a := testutil.MustCreateTransaction(t, queries, acctID, "PRIME_1", "Amazon Prime", 13900, "2024-05-01")
+	b := testutil.MustCreateTransaction(t, queries, acctID, "PRIME_2", "Amazon Prime", 13900, "2025-05-01")
+	c := testutil.MustCreateTransaction(t, queries, acctID, "PRIME_3", "Amazon Prime", 13900, "2026-05-01")
+	stray := testutil.MustCreateTransaction(t, queries, acctID, "PRIME_VID", "Amazon Prime Video", 499, "2026-04-10")
+
+	series, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		Name: "Amazon Prime", MerchantKey: "amazonprime", Cadence: service.SeriesCadenceAnnual,
+		Source:       service.SeriesSourceDeterministic,
+		MemberTxnIDs: []string{a.ShortID, b.ShortID, c.ShortID, stray.ShortID},
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if series.OccurrenceCount != 4 {
+		t.Fatalf("source occurrence_count = %d, want 4", series.OccurrenceCount)
+	}
+
+	newS, err := svc.SplitSeries(ctx, series.ShortID, []string{stray.ShortID}, "primevideo", "Prime Video",
+		service.Actor{Type: "user", Name: "Tester"})
+	if err != nil {
+		t.Fatalf("SplitSeries: %v", err)
+	}
+	if newS.MerchantKey != "primevideo" {
+		t.Errorf("new series merchant_key = %q, want primevideo", newS.MerchantKey)
+	}
+	if newS.OccurrenceCount != 1 {
+		t.Errorf("new series occurrence_count = %d, want 1", newS.OccurrenceCount)
+	}
+
+	// The stray charge moved into the new series and was repointed.
+	var sid pgtype.UUID
+	var mkey string
+	if err := pool.QueryRow(ctx, `SELECT series_id, merchant_key FROM transactions WHERE id = $1`, stray.ID).Scan(&sid, &mkey); err != nil {
+		t.Fatalf("query stray: %v", err)
+	}
+	if pgconv.FormatUUID(sid) != newS.ID {
+		t.Errorf("stray series_id = %q, want %q", pgconv.FormatUUID(sid), newS.ID)
+	}
+	if mkey != "primevideo" {
+		t.Errorf("stray merchant_key = %q, want primevideo", mkey)
+	}
+
+	// Source series dropped to 3 members.
+	src, err := svc.GetSeries(ctx, series.ShortID)
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	if src.OccurrenceCount != 3 {
+		t.Errorf("source occurrence_count after split = %d, want 3", src.OccurrenceCount)
+	}
+
+	// Splitting out a transaction that isn't a member of the source errors.
+	other := testutil.MustCreateTransaction(t, queries, acctID, "OTHER", "Other Co", 100, "2026-01-01")
+	if _, err := svc.SplitSeries(ctx, series.ShortID, []string{other.ShortID}, "otherkey", "", service.Actor{Type: "user"}); err == nil {
+		t.Error("expected splitting a non-member to error")
+	}
+	// Splitting into a key that already has a series errors.
+	if _, err := svc.SplitSeries(ctx, series.ShortID, []string{a.ShortID}, "primevideo", "", service.Actor{Type: "user"}); err == nil {
+		t.Error("expected splitting into an existing key to error")
+	}
+}
+
 func keysOf(m map[string]service.SeriesNearMiss) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -547,6 +547,13 @@ type TransactionContext struct {
 	// Tags is populated from transaction_tags so tag-based conditions
 	// (field: "tags") can match against the transaction's current tags.
 	Tags []string
+	// SeriesShortID is the short_id of the recurring series this transaction
+	// belongs to (field: "series"), empty when unassigned. Populated from the
+	// recurring_series JOIN in the retroactive / preview context query.
+	SeriesShortID string
+	// InSeries reports whether the transaction is linked to any recurring
+	// series (field: "in_series").
+	InSeries bool
 }
 
 type TransactionRuleResponse struct {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -694,6 +694,14 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 			tctx.Category = slug
 		}
 	}
+	// Seed recurring-series membership so rules can condition on it via
+	// field="series" / field="in_series". series_id is NULL on freshly-synced
+	// rows (the detector links them post-sync), so this is populated mainly on
+	// changed / re-synced rows that already belong to a series.
+	if dbTxn.SeriesID.Valid {
+		tctx.InSeries = true
+		tctx.SeriesShortID = resolver.SeriesShortID(dbTxn.SeriesID)
+	}
 
 	// For changed transactions, load the current tag slugs so tag-based
 	// conditions can match. New transactions start with empty tags (any tags

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -49,6 +49,15 @@ type TransactionContext struct {
 	// (field: "tags") can match against the transaction's current tags.
 	// Updated mid-resolver as earlier-stage add_tag actions apply.
 	Tags []string
+	// SeriesShortID is the short_id of the recurring series this transaction
+	// belongs to (field: "series"), empty when unassigned. Resolved from the
+	// resolver's series cache at sync time. For newly-synced rows it is empty
+	// until the post-sync detector links them — series conditions therefore
+	// matter mostly for changed / re-synced rows and retroactive apply.
+	SeriesShortID string
+	// InSeries reports whether the transaction is linked to any recurring
+	// series (field: "in_series"). Same timing caveat as SeriesShortID.
+	InSeries bool
 }
 
 // RuleActionSource tracks which rule contributed which action for audit.
@@ -130,6 +139,7 @@ type RuleResolver struct {
 	rules           []compiledRule
 	slugCache       map[[16]byte]string      // category UUID bytes -> slug
 	slugToID        map[string]pgtype.UUID   // category slug -> UUID (reverse cache)
+	seriesShortID   map[[16]byte]string      // recurring_series UUID bytes -> short_id
 	uncategorizedID pgtype.UUID
 	hitCounts       map[[16]byte]int // rule UUID bytes -> hit count accumulator
 }
@@ -167,9 +177,10 @@ type ruleRow struct {
 // If the transaction_rules table does not exist, it logs a warning and proceeds with no rules.
 func NewRuleResolver(ctx context.Context, pool *pgxpool.Pool, provider string, logger *slog.Logger) (*RuleResolver, error) {
 	r := &RuleResolver{
-		slugCache: make(map[[16]byte]string),
-		slugToID:  make(map[string]pgtype.UUID),
-		hitCounts: make(map[[16]byte]int),
+		slugCache:     make(map[[16]byte]string),
+		slugToID:      make(map[string]pgtype.UUID),
+		seriesShortID: make(map[[16]byte]string),
+		hitCounts:     make(map[[16]byte]int),
 	}
 
 	// Load transaction rules. Gracefully handle missing table.
@@ -201,6 +212,25 @@ func NewRuleResolver(ctx context.Context, pool *pgxpool.Pool, provider string, l
 		}
 		r.slugCache[id.Bytes] = slug
 		r.slugToID[slug] = id
+	}
+
+	// Load the recurring-series id→short_id cache so the `series` condition
+	// field can resolve a transaction's series_id to its short_id without a
+	// per-row query. Tolerate a missing table (older deployments / lite) the
+	// same way loadRules does — series conditions simply won't match.
+	seriesRows, err := pool.Query(ctx, "SELECT id, short_id FROM recurring_series")
+	if err != nil {
+		logger.Warn("failed to load recurring series cache; series conditions will not match", "error", err)
+	} else {
+		defer seriesRows.Close()
+		for seriesRows.Next() {
+			var id pgtype.UUID
+			var shortID string
+			if err := seriesRows.Scan(&id, &shortID); err != nil {
+				return nil, fmt.Errorf("scan recurring series short_id: %w", err)
+			}
+			r.seriesShortID[id.Bytes] = shortID
+		}
 	}
 
 	return r, nil
@@ -415,6 +445,16 @@ func (r *RuleResolver) CategoryIDForSlug(slug string) pgtype.UUID {
 		return pgtype.UUID{}
 	}
 	return r.slugToID[slug]
+}
+
+// SeriesShortID returns the short_id for a recurring-series UUID, or empty
+// string if the series is unknown to the resolver's cache (e.g. minted after
+// resolver construction, or the table was unavailable at load time).
+func (r *RuleResolver) SeriesShortID(id pgtype.UUID) string {
+	if !id.Valid {
+		return ""
+	}
+	return r.seriesShortID[id.Bytes]
 }
 
 // ResolveWithContext evaluates all transaction rules in pipeline-stage order
@@ -759,6 +799,10 @@ func evaluateLeaf(c *compiledCondition, tctx TransactionContext) bool {
 		return evaluateString(c, tctx.UserName)
 	case "tags":
 		return evaluateTags(c, tctx.Tags)
+	case "series":
+		return evaluateString(c, tctx.SeriesShortID)
+	case "in_series":
+		return evaluateBool(c, tctx.InSeries)
 	default:
 		return false // unknown field
 	}

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -340,6 +340,75 @@ func TestEvaluateCondition_BoolNeq(t *testing.T) {
 	}
 }
 
+func TestEvaluateCondition_InSeries(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "in_series", Op: "eq", Value: true})
+
+	tctx := TransactionContext{InSeries: true}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected in_series eq true to match a series member")
+	}
+
+	tctx.InSeries = false
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected in_series eq true to fail for a non-member")
+	}
+}
+
+func TestEvaluateCondition_InSeriesNeq(t *testing.T) {
+	// in_series neq true == "not in any series".
+	cc := mustCompile(t, &Condition{Field: "in_series", Op: "neq", Value: true})
+
+	tctx := TransactionContext{InSeries: false}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected in_series neq true to match a non-member")
+	}
+
+	tctx.InSeries = true
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected in_series neq true to fail for a member")
+	}
+}
+
+func TestEvaluateCondition_SeriesEq(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "series", Op: "eq", Value: "AbC12xYz"})
+
+	tctx := TransactionContext{SeriesShortID: "AbC12xYz"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected series eq to match the assigned series short_id")
+	}
+
+	// Case-insensitive, like every other string field.
+	tctx.SeriesShortID = "abc12xyz"
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected series eq to match case-insensitively")
+	}
+
+	tctx.SeriesShortID = "OtherKey"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected series eq to fail for a different series")
+	}
+
+	// Unassigned transaction: SeriesShortID empty → no match.
+	tctx.SeriesShortID = ""
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected series eq to fail for an unassigned transaction")
+	}
+}
+
+func TestEvaluateCondition_SeriesIn(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "series", Op: "in", Value: []interface{}{"netflix01", "spotify02"}})
+
+	tctx := TransactionContext{SeriesShortID: "spotify02"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected series in to match a listed series")
+	}
+
+	tctx.SeriesShortID = "hulu0003"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected series in to fail for an unlisted series")
+	}
+}
+
 func TestEvaluateCondition_MerchantName(t *testing.T) {
 	cc := mustCompile(t, &Condition{Field: "provider_merchant_name", Op: "contains", Value: "amazon"})
 

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -80,7 +80,12 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 				<span class="text-sm">{ subscriptionDetailField(p.ExpectedDay) }</span>
 			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Next renewal"}) {
-				<span class="text-sm">{ subscriptionDetailField(p.NextExpected) }</span>
+				<span class="text-sm inline-flex items-center gap-2">
+					{ subscriptionDetailField(p.NextExpected) }
+					if p.Series.RenewalLabel != "" {
+						<span class={ "badge badge-soft badge-xs", "badge-" + p.Series.RenewalTone }>{ p.Series.RenewalLabel }</span>
+					}
+				</span>
 			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Last seen"}) {
 				<span class="text-sm">{ subscriptionDetailField(p.LastSeen) }</span>

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -245,7 +245,12 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 			}
 		</td>
 		<td>
-			<span class={ "badge badge-soft badge-sm", "badge-" + s.StatusTone }>{ s.StatusLabel }</span>
+			<span class="inline-flex items-center gap-1.5 flex-wrap">
+				<span class={ "badge badge-soft badge-sm", "badge-" + s.StatusTone }>{ s.StatusLabel }</span>
+				if s.RenewalLabel != "" {
+					<span class={ "badge badge-soft badge-xs", "badge-" + s.RenewalTone }>{ s.RenewalLabel }</span>
+				}
+			</span>
 		</td>
 		<td class="text-right">
 			if s.HasAmount {

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -54,6 +54,10 @@ type SubscriptionRow struct {
 	// user should act on (due soon / overdue / likely cancelled) get a chip.
 	RenewalLabel string // "Renews in 3d" | "5d overdue" | "Likely cancelled"
 	RenewalTone  string // info | warning | error
+	// DaysUntilRenewal is the signed day count to the next charge (negative =
+	// overdue), nil when there's no projection. Drives the ledger's
+	// renewal-urgency sort. Active series only.
+	DaysUntilRenewal *int
 
 	HasAmount bool
 	Amount    float64 // last_amount in dollars

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -49,6 +49,12 @@ type SubscriptionRow struct {
 	StatusLabel string
 	StatusTone  string // success | warning | neutral | info
 
+	// Renewal-health attention chip (active series only). Empty when the
+	// subscription renews comfortably or has no projection — only the states a
+	// user should act on (due soon / overdue / likely cancelled) get a chip.
+	RenewalLabel string // "Renews in 3d" | "5d overdue" | "Likely cancelled"
+	RenewalTone  string // info | warning | error
+
 	HasAmount bool
 	Amount    float64 // last_amount in dollars
 	Currency  string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1962,6 +1962,54 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/RecurringSeries" }
         "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/series/{id}/rekey:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Series]
+      summary: Re-key a recurring series
+      description: "**Requires `full_access` scope.** Corrects a series' `merchant_key` and repoints its members' `merchant_key` to match. Errors (400) if a live series already exists at the new key or it is sticky-rejected — re-key never silently merges. Corrects historical grouping; future charges still key off the provider name."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [new_merchant_key]
+              properties:
+                new_merchant_key: { type: string }
+      responses:
+        "200":
+          description: Re-keyed series.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RecurringSeries" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/series/{id}/split:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Series]
+      summary: Split a recurring series
+      description: "**Requires `full_access` scope.** Moves the given `transaction_ids` (max 50, each a current member of the source series) into a brand-new series under `new_merchant_key`. The fix for an over-grouped series. Errors (400) if `new_merchant_key` equals the source key, already has a series, or any listed transaction isn't a current member. Returns the new series."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [new_merchant_key, transaction_ids]
+              properties:
+                new_merchant_key: { type: string }
+                name: { type: string }
+                transaction_ids: { type: array, items: { type: string }, maxItems: 50 }
+      responses:
+        "200":
+          description: The new series the members were split into.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RecurringSeries" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /api/v1/series/{id}/tags:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string } }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3217,6 +3217,8 @@ components:
         last_amount: { type: number, nullable: true }
         last_seen_date: { type: string, format: date, nullable: true }
         next_expected_date: { type: string, format: date, nullable: true }
+        renewal_health: { type: string, description: "Derived (active series only): `active`|`due_soon`|`overdue`|`stale`|`unknown`, from next_expected_date vs today." }
+        days_until_renewal: { type: integer, nullable: true, description: "Signed days to next_expected_date (negative = overdue). Omitted when no projection." }
         occurrence_count: { type: integer }
         detection_signals: { type: object, nullable: true, additionalProperties: true }
         tags: { type: array, items: { type: string } }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1889,6 +1889,22 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/RecurringSeries" }
         "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/series/explain:
+    get:
+      tags: [Series]
+      summary: Explain near-miss subscriptions
+      description: "Answer \"why isn't <merchant> a subscription?\". Reports every recurring-looking merchant group that is not already a series, with the detector's verdict — `qualifies:true` (eligible but untracked) or a specific gate it failed (`too_few_occurrences`, `irregular_cadence`, `interval_too_variable`, `amount_unstable`, `same_day_duplicates`). Read-only analysis over the trailing detection window."
+      responses:
+        "200":
+          description: Near-miss merchant groups with detector verdicts.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  near_misses:
+                    type: array
+                    items: { $ref: "#/components/schemas/SeriesNearMiss" }
   /api/v1/series/{id}:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string } }
@@ -3223,6 +3239,26 @@ components:
         detection_signals: { type: object, nullable: true, additionalProperties: true }
         tags: { type: array, items: { type: string } }
         created_at: { type: string, format: date-time }
+      additionalProperties: true
+    SeriesNearMiss:
+      type: object
+      description: A recurring-looking merchant group that is not (yet) a series, with the detector's verdict.
+      properties:
+        merchant_key: { type: string }
+        name: { type: string }
+        iso_currency_code: { type: string, nullable: true }
+        occurrence_count: { type: integer }
+        qualifies: { type: boolean, description: "True when the group passes every gate but isn't tracked yet." }
+        reason: { type: string, description: "Gate it failed; empty when qualifies. `too_few_occurrences`|`irregular_cadence`|`interval_too_variable`|`amount_unstable`|`same_day_duplicates`|`too_few_charges`." }
+        explanation: { type: string, description: "Human one-line explanation with the numbers folded in." }
+        nearest_cadence: { type: string }
+        median_gap_days: { type: number }
+        interval_cv: { type: number }
+        amount_min: { type: number, nullable: true }
+        amount_max: { type: number, nullable: true }
+        amount_spread_ratio: { type: number }
+        first_seen: { type: string, format: date, nullable: true }
+        last_seen: { type: string, format: date, nullable: true }
       additionalProperties: true
     Category:
       type: object


### PR DESCRIPTION
Recurring-series / Subscriptions sprint — the agent/API surface plus the first experience polish. Each piece is green across default/headless/lite + service/api/mcp integration; OpenAPI drift green.

### What's in here
- **Rule conditions `series` / `in_series`** — the read-half of the rules-engine composition (the write-half `assign_series` action shipped earlier). Rules match on series membership at sync, retroactive apply, and preview.
- **Derived renewal-health signal** — every active series exposes `renewal_health` (active/due_soon/overdue/stale/unknown) + signed `days_until_renewal`, computed at response time (no migration). Covers stale/cancellation detection + the "upcoming renewals" data layer.
- **Near-miss / explain feed** — `ExplainSeriesCandidates` + `explain_series_candidates` MCP tool + `GET /series/explain`: "why isn't this a subscription?" with the detector's per-merchant verdict (extracted `evaluateGroup` from `analyzeGroup`, same gates, now surfacing a reason).
- **Re-key + split correction verbs** — `RekeySeries` / `SplitSeries` (service + `rekey_series`/`split_series` MCP + `POST /series/{id}/rekey` + `/split`) to fix detector grouping mistakes; split strips stale source-inherited tags from moved members.
- **Renewal-health chip + ledger sort** — the `/subscriptions` ledger shows an attention chip (Renews in Nd / Nd overdue / Likely cancelled) and orders by renewal urgency.

### Validation
build+vet on default/headless/lite; unit suite; service+api+mcp integration on breadbox_test; OpenAPI drift; live browser no-regression on /subscriptions. Docs updated each commit (rule-dsl, openapi, api-endpoints, mcp-tools-reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
