### PR TITLE
fix(ui): brand marks follow resolved theme, not raw OS preference

### DIFF
--- a/input.css
+++ b/input.css
@@ -311,13 +311,25 @@
    *
    *   2. Marks that keep their official baked-in fill because the fill IS
    *      the brand. The black-on-light ones (GitHub, Anthropic) need a
-   *      flip in dark mode so they don't disappear on a base-100 surface.
-   *      Claude orange already contrasts in both modes; Teller is
-   *      multi-color and stays. */
+   *      flip to white in dark mode so they don't disappear on a base-100
+   *      surface. Claude orange already contrasts in both modes; Teller is
+   *      multi-color and stays.
+   *
+   * The flip must follow the *resolved* daisy theme, not the raw OS
+   * preference — the theme toggle ($store.theme) can force
+   * data-theme="light"/"dark" independent of prefers-color-scheme. Keying
+   * only off @media (prefers-color-scheme: dark) makes the mark turn white
+   * on a forced-light page when the OS is dark (white-on-white, invisible),
+   * and stay black on a forced-dark page when the OS is light. So pair the
+   * media query (guarded against a forced-light override) with an explicit
+   * [data-theme="dark"] rule — the same shape the .select / .bb-tx-row /
+   * .bb-tx-avatar dark overrides use below. */
   @media (prefers-color-scheme: dark) {
-    svg.brand-github path,
-    svg.brand-anthropic path { fill: #fff; }
+    :root:not([data-theme="light"]) svg.brand-github path,
+    :root:not([data-theme="light"]) svg.brand-anthropic path { fill: #fff; }
   }
+  [data-theme="dark"] svg.brand-github path,
+  [data-theme="dark"] svg.brand-anthropic path { fill: #fff; }
 
   /*
    * Pre-hydration size for Lucide placeholders.

--- a/internal/templates/components/brand.templ
+++ b/internal/templates/components/brand.templ
@@ -7,7 +7,9 @@ package components
 // All marks ship with their official brand fills baked into the
 // <path> — the marks ARE the brand, so they don't inherit container
 // color. The dark-mode invert for black-on-light marks lives in
-// input.css under `@media (prefers-color-scheme: dark)`.
+// input.css, keyed off the resolved daisy theme (both
+// prefers-color-scheme and the [data-theme] override the theme toggle
+// sets) so the mark never flips white on a forced-light page.
 //
 // Pass "" for class when no extra classes are needed.
 templ BrandIcon(slug, class string) {


### PR DESCRIPTION
## Problem

The GitHub brand icon in the avatar menu (and the Anthropic mark) renders **white and invisible in light mode**.

## Root cause

GitHub/Anthropic are "baked-fill" brand marks — their `<path>` ships `fill="#181717"` (the fill *is* the brand), so unlike the `currentColor` marks (Plaid, MCP) they don't track text color. To keep them visible on dark surfaces, `input.css` flipped them to white in dark mode — but it keyed **only** off `@media (prefers-color-scheme: dark)`, i.e. the **OS** setting.

Breadbox's theme toggle (`$store.theme`) has three states and can force `data-theme="light"`/`"dark"` independent of the OS. So the OS media query and the *resolved* page theme can diverge:

- **OS dark + app forced light** → page is light, but the media query still fires → icon flips white → **white-on-white, invisible** ← the reported bug
- **OS light + app forced dark** → page is dark, but the media query doesn't fire → icon stays `#181717` → black-on-dark (the inverse bug)

## Fix

Adopt the dual-selector pattern the codebase already uses for theme-aware overrides (`.select` picker, `.bb-tx-row`, `.bb-tx-avatar` — `input.css:1394+`):

```css
@media (prefers-color-scheme: dark) {
  :root:not([data-theme="light"]) svg.brand-github path,
  :root:not([data-theme="light"]) svg.brand-anthropic path { fill: #fff; }
}
[data-theme="dark"] svg.brand-github path,
[data-theme="dark"] svg.brand-anthropic path { fill: #fff; }
```

The flip now follows the resolved daisy theme, not the raw OS preference.

## Validation

Measured `getComputedStyle(path).fill` against the icon vs. page background across all six theme×OS combinations (isolated render of the exact `BrandIcon("github")` markup with freshly-built CSS):

| OS \ app theme | light | dark | system |
|---|---|---|---|
| **OS dark**  | dark icon / light bg ✓ | white / dark ✓ | white / dark ✓ |
| **OS light** | dark / light ✓ | white / dark ✓ | dark / light ✓ |

Every combination now contrasts. Below is the previously-broken case (app theme **light**, OS **dark**) — the mark is now visibly dark on the light surface:

<img src="https://i.img402.dev/z75rv2ud45.png" width="800" alt="GitHub mark visible on light surface with app=light / OS=dark">

`styles.css` is a gitignored build artifact (Docker rebuilds it via `make css`); the committed change is `input.css` + the `brand.templ` doc comment. `go build ./...`, `go vet ./...`, and `go test ./internal/templates/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
