### PR TITLE
feat(recurring): rename Subscriptions → Recurring (umbrella; subscription becomes a type)

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -141,11 +141,20 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Get("/tags", TagsPageHandler(svc, sm, tr))
 
-		// Subscriptions — recurring-series list + detail. Editor scope: the
+		// Recurring — recurring-series list + detail. Editor scope: the
 		// candidate-confirmation surface is the single human-adjudication point
-		// for detected series.
-		r.Get("/subscriptions", SubscriptionsListPageHandler(a, svc, sm, tr))
-		r.Get("/subscriptions/{id}", SubscriptionDetailHandler(a, sm, tr, svc))
+		// for detected series. Captures all recurring charges (subscriptions,
+		// bills, loans) — "subscription" is one type, not the umbrella.
+		r.Get("/recurring", SubscriptionsListPageHandler(a, svc, sm, tr))
+		r.Get("/recurring/{id}", SubscriptionDetailHandler(a, sm, tr, svc))
+		// Back-compat redirects from the former "Subscriptions" route (302 so a
+		// later change isn't browser-cached).
+		r.Get("/subscriptions", func(w http.ResponseWriter, req *http.Request) {
+			http.Redirect(w, req, "/recurring", http.StatusFound)
+		})
+		r.Get("/subscriptions/{id}", func(w http.ResponseWriter, req *http.Request) {
+			http.Redirect(w, req, "/recurring/"+chi.URLParam(req, "id"), http.StatusFound)
+		})
 
 		// Design-system sandbox. /design is the full gallery; /design/c/{slug}
 		// renders a single component family in isolation for focused screenshots.

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -110,8 +110,8 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 		}
 
 		data := map[string]any{
-			"PageTitle":   "Subscriptions",
-			"CurrentPage": "subscriptions",
+			"PageTitle":   "Recurring",
+			"CurrentPage": "recurring",
 			"CSRFToken":   GetCSRFToken(r),
 			"Flash":       GetFlash(ctx, sm),
 		}
@@ -153,8 +153,8 @@ func SubscriptionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 		}
 
 		data := map[string]any{
-			"PageTitle":   s.Name + " — Subscription",
-			"CurrentPage": "subscriptions",
+			"PageTitle":   s.Name + " — Recurring",
+			"CurrentPage": "recurring",
 			"CSRFToken":   GetCSRFToken(r),
 			"Flash":       GetFlash(ctx, sm),
 		}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -133,7 +133,7 @@ func pageSectionLabel(currentPage string) string {
 	switch currentPage {
 	case "getting-started":
 		return "Setup"
-	case "feed", "transactions", "accounts", "subscriptions", "reports":
+	case "feed", "transactions", "accounts", "recurring", "reports":
 		return "Overview"
 	case "agents", "rules", "categories", "tags":
 		return "Manage"

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -56,7 +56,7 @@ templ Nav(p NavProps) {
 		@navLink("/transactions", "receipt", "Transactions", navActive(p.CurrentPage, "transactions"))
 		@navLink("/accounts", "wallet", "Accounts", navActive(p.CurrentPage, "accounts"))
 		if p.IsEditor {
-			@navLinkBadge("/subscriptions", "repeat", "Subscriptions", navActive(p.CurrentPage, "subscriptions"), p.SeriesCandidates, "", fmt.Sprintf("%d subscription candidates need review", p.SeriesCandidates))
+			@navLinkBadge("/recurring", "repeat", "Recurring", navActive(p.CurrentPage, "recurring"), p.SeriesCandidates, "", fmt.Sprintf("%d recurring charges need review", p.SeriesCandidates))
 		}
 		if p.IsAdmin {
 			@navLinkBadge("/reports", "file-text", "Reports", navActive(p.CurrentPage, "reports"), p.UnreadReports, "", fmt.Sprintf("%d unread reports", p.UnreadReports))

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -14,7 +14,7 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 	<script src="/static/js/admin/components/subscriptions.js"></script>
 	<div x-data="subscriptionsList">
 		@components.BreadcrumbNav([]components.Breadcrumb{
-			{Label: "Subscriptions", Href: "/subscriptions"},
+			{Label: "Recurring", Href: "/recurring"},
 			{Label: p.Series.Name},
 		})
 		@components.PageHeader(components.PageHeaderProps{
@@ -32,7 +32,7 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 			<div class="flex-1"></div>
 			switch p.Series.Status {
 				case "candidate":
-					@subscriptionVerdictBtn(p.Series, "reject", "Not a subscription", "x", "btn-ghost")
+					@subscriptionVerdictBtn(p.Series, "reject", "Not recurring", "x", "btn-ghost")
 					@subscriptionVerdictBtn(p.Series, "confirm", "Confirm", "check", "btn-primary")
 				case "active":
 					@subscriptionVerdictBtn(p.Series, "pause", "Pause", "pause", "btn-ghost")

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -20,8 +20,8 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 	<div x-data x-init="$store.shortcuts.setScope('subscriptions')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div x-data="subscriptionsList">
 		@components.PageHeader(components.PageHeaderProps{
-			Title:                "Subscriptions",
-			Subtitle:             "Recurring charges Breadbox has detected, and the candidates waiting on your call.",
+			Title:                "Recurring",
+			Subtitle:             "Recurring charges Breadbox has detected — subscriptions, bills, and more — plus the candidates waiting on your call.",
 			SubtitleHideOnMobile: true,
 			Action:               subscriptionsBetaBadge(),
 		})
@@ -79,7 +79,7 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 		if len(p.Candidates) == 0 && len(p.Active) == 0 {
 			@components.EmptyState(components.EmptyStateProps{
 				Icon:  "repeat",
-				Title: "No subscriptions detected yet",
+				Title: "No recurring charges detected yet",
 				Body:  "As your transactions sync, Breadbox spots recurring charges — same merchant, regular interval, steady amount — and surfaces them here for you to confirm.",
 			})
 		} else {
@@ -101,11 +101,11 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 			<!-- Confirmed / live ledger -->
 			if len(p.Active) > 0 {
 				<div class="flex items-center gap-2 mb-3">
-					<h2 class="text-sm font-semibold text-base-content">Subscriptions</h2>
+					<h2 class="text-sm font-semibold text-base-content">Tracked</h2>
 					<span class="badge badge-ghost badge-sm">{ fmt.Sprintf("%d", len(p.Active)) }</span>
 				</div>
 				@components.FilterSearchInput(components.FilterSearchInputProps{
-					Placeholder: "Filter subscriptions...",
+					Placeholder: "Filter recurring charges...",
 					XModel:      "filter",
 				})
 				<div class="mt-4">
@@ -176,7 +176,7 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 				class="btn btn-ghost btn-sm gap-1.5"
 			>
 				@components.LucideIcon("x", "w-4 h-4")
-				Not a subscription
+				Not recurring
 			</button>
 			<button
 				type="button"
@@ -197,7 +197,7 @@ templ subscriptionsActiveTable(p SubscriptionsListProps) {
 			<table class="table table-sm">
 				<thead class="text-xs text-base-content/60">
 					<tr>
-						<th class="min-w-[12rem]">Subscription</th>
+						<th class="min-w-[12rem]">Recurring charge</th>
 						<th class="hidden md:table-cell">Cadence</th>
 						<th class="hidden lg:table-cell">Next renewal</th>
 						<th>Status</th>
@@ -224,7 +224,7 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 		class="hover:bg-base-200/30 transition-colors"
 	>
 		<td>
-			<a href={ templ.SafeURL("/subscriptions/" + s.ShortID) } class="flex items-center gap-3 no-underline">
+			<a href={ templ.SafeURL("/recurring/" + s.ShortID) } class="flex items-center gap-3 no-underline">
 				<div class="w-8 h-8 rounded-md bg-base-200/60 flex items-center justify-center shrink-0">
 					@components.LucideIcon("repeat", "w-4 h-4 text-base-content opacity-40")
 				</div>

--- a/static/js/admin/components/subscriptions.js
+++ b/static/js/admin/components/subscriptions.js
@@ -45,7 +45,7 @@
         submitVerdict: function (seriesId, seriesName, verdict) {
           var label = {
             confirm: 'Confirmed',
-            reject: 'Marked not a subscription',
+            reject: 'Marked not recurring',
             pause: 'Paused',
             cancel: 'Cancelled',
           }[verdict] || 'Updated';
@@ -63,9 +63,9 @@
               }
               restorePageState();
               return res.json().then(function (data) {
-                toast((data.error && data.error.message) || 'Failed to update subscription.');
+                toast((data.error && data.error.message) || 'Failed to update recurring charge.');
               }).catch(function () {
-                toast('Failed to update subscription.');
+                toast('Failed to update recurring charge.');
               });
             })
             .catch(function () {


### PR DESCRIPTION
Renames the feature from **Subscriptions → Recurring**. The detector captures *all* recurring charges (mortgage, rent, insurance, utilities, loans), so "Subscriptions" mislabels most of them. "Recurring" is the honest umbrella; **subscription becomes one type** (a structured `type` field lands in the next PR). User-facing only — the `recurring_series` entity name is unchanged.

### Changes
- **Route**: canonical `/recurring` + `/recurring/{id}`; `/subscriptions` + `/subscriptions/{id}` **302-redirect** (muscle memory / old links).
- **Nav**: label "Recurring" (repeat icon kept) + needs-review badge tooltip; `pageSectionLabel` + `navActive` keyed on `recurring`.
- **Copy**: page title/subtitle (broadened to "subscriptions, bills, and more"), empty state, ledger section header ("Tracked"), filter placeholder, table header ("Recurring charge"), detail breadcrumb, verdict button "Not a subscription" → "Not recurring" (list + detail + JS toast).

### Validation
build+vet default/headless/lite; unit suite incl. admin route-drift + page-section-coverage + scripts-lint; browser-checked that `/recurring` renders and `/subscriptions` redirects to it.

<img src="https://i.img402.dev/lm7ro0fqfh.jpg" width="800" alt="Recurring page after rename">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
