### PR TITLE
feat(recurring): structured type field (subscription|bill|loan|other), inferred + overridable

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -90,6 +90,7 @@ Unauthenticated device-code dance the CLI uses to mint API keys on a remote host
 | POST | `/series/{id}/transactions` | W | Link transactions (≤50, NULL-fill only) to a series; optional `confirm` |
 | POST | `/series/{id}/rekey` | W | Correct a series' `merchant_key` (+ repoint members); errors on collision / sticky-reject |
 | POST | `/series/{id}/split` | W | Move `transaction_ids` (≤50, current members) into a new series under `new_merchant_key` |
+| POST | `/series/{id}/type` | W | Set the series type (`subscription`/`bill`/`loan`/`other`); sticky override of the inferred type |
 | POST | `/series/{id}/tags` | W | Attach a tag to a series; linked transactions inherit it |
 | DELETE | `/series/{id}/tags/{slug}` | W | Detach a tag; strips series-inherited copies from members (keeps user-added) |
 | PATCH | `/series/{id}` | W | Apply a verdict: `confirm`/`reject`/`pause`/`cancel` (user confirmation outranks agent) |

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -242,7 +242,7 @@ Admin-only tag CRUD. Agents typically don't need these — `add_transaction_tag`
 
 ### list_series (Read)
 
-List detected recurring series. Optional `status` filter (`active` | `candidate` | `paused` | `cancelled`). Each row carries `cadence`, `expected_amount` + `iso_currency_code` (never sum across currencies), `next_expected_date`, `occurrence_count`, `confidence` (`auto` | `confirmed` | `rejected`), and `detection_signals` — the raw evidence the detector used. Active series also carry a derived `renewal_health` (`active` | `due_soon` | `overdue` | `stale` | `unknown`) and signed `days_until_renewal` (negative = overdue) so you can answer "what renews soon" and "what looks cancelled" without re-deriving cadence math — `stale` means a full cadence cycle elapsed past the expected charge. Read `status=candidate` to find series awaiting a verdict.
+List detected recurring series. Optional `status` filter (`active` | `candidate` | `paused` | `cancelled`). Each row carries `type` (`subscription` | `bill` | `loan` | `other` — inferred from category, set via `set_series_type`), `cadence`, `expected_amount` + `iso_currency_code` (never sum across currencies), `next_expected_date`, `occurrence_count`, `confidence` (`auto` | `confirmed` | `rejected`), and `detection_signals` — the raw evidence the detector used. Active series also carry a derived `renewal_health` (`active` | `due_soon` | `overdue` | `stale` | `unknown`) and signed `days_until_renewal` (negative = overdue) so you can answer "what renews soon" and "what looks cancelled" without re-deriving cadence math — `stale` means a full cadence cycle elapsed past the expected charge. Read `status=candidate` to find series awaiting a verdict.
 
 ### get_series (Read)
 
@@ -259,6 +259,10 @@ Apply a verdict: `confirm` (it is a subscription → `active`), `reject` (NOT a 
 ### assign_series (Write)
 
 Create a recurring series detection missed, or link transactions to an existing one — the agent's path to fix gaps. Provide `series_id` to assign to an existing series, **or** `merchant_key` + `create_if_missing:true` to mint one (funnels through the same dedup + sticky-reject arbitration as the detector, so re-creating a user-rejected series at the same signature is a no-op). Pass `transaction_ids` (≤50) to back-link members (NULL-fill only — never steals a charge already in another series). `confirm:true` flips it straight to `active`; omit to leave a reviewable `candidate`. Use after `list_series(status=candidate)` shows nothing for a subscription the user says exists.
+
+### set_series_type (Write)
+
+Set a recurring series' `type`: `subscription` (streaming/SaaS/memberships), `bill` (rent/utilities/insurance/telecom), `loan` (mortgage/auto/student/personal), or `other`. The detector infers the type from the linked charges' dominant category at first detection; this is the correction handle. The override is **sticky** — re-detection won't revert it. (`assign_series` also accepts an optional `type` when minting.)
 
 ### rekey_series (Write)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -192,6 +192,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/series/{id}/transactions", LinkSeriesTransactionsHandler(svc))
 			r.Post("/series/{id}/rekey", RekeySeriesHandler(svc))
 			r.Post("/series/{id}/split", SplitSeriesHandler(svc))
+			r.Post("/series/{id}/type", SetSeriesTypeHandler(svc))
 			r.Post("/series/{id}/tags", AddSeriesTagHandler(svc))
 			r.Delete("/series/{id}/tags/{slug}", RemoveSeriesTagHandler(svc))
 			r.Patch("/series/{id}", ReviewSeriesHandler(svc))

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -68,6 +68,7 @@ type assignSeriesRequest struct {
 	CreateIfMissing bool     `json:"create_if_missing,omitempty"`
 	Name            string   `json:"name,omitempty"`
 	Cadence         string   `json:"cadence,omitempty"`
+	Type            string   `json:"type,omitempty"`
 	ExpectedAmount  *float64 `json:"expected_amount,omitempty"`
 	Currency        *string  `json:"currency,omitempty"`
 	CategoryID      *string  `json:"category_id,omitempty"`
@@ -98,6 +99,7 @@ func AssignSeriesHandler(svc *service.Service) http.HandlerFunc {
 			CreateIfMissing: body.CreateIfMissing,
 			Name:            body.Name,
 			Cadence:         body.Cadence,
+			Type:            body.Type,
 			ExpectedAmount:  body.ExpectedAmount,
 			Currency:        body.Currency,
 			CategoryID:      body.CategoryID,
@@ -239,6 +241,30 @@ func SplitSeriesHandler(svc *service.Service) http.HandlerFunc {
 		s, err := svc.SplitSeries(r.Context(), id, body.TransactionIDs, body.NewMerchantKey, body.Name, actor)
 		if err != nil {
 			writeServiceError(w, err, "Series not found", "Failed to split series")
+			return
+		}
+		writeData(w, s)
+	}
+}
+
+// setSeriesTypeRequest is the body for POST /api/v1/series/{id}/type.
+type setSeriesTypeRequest struct {
+	Type string `json:"type"` // subscription | bill | loan | other
+}
+
+// SetSeriesTypeHandler overrides a series' type (sticky correction).
+// POST /api/v1/series/{id}/type — mirrors the set_series_type MCP tool (write).
+func SetSeriesTypeHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var body setSeriesTypeRequest
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+		actor := service.ActorFromContext(r.Context())
+		s, err := svc.SetSeriesType(r.Context(), id, body.Type, actor)
+		if err != nil {
+			writeServiceError(w, err, "Series not found", "Failed to set series type")
 			return
 		}
 		writeData(w, s)

--- a/internal/db/migrations/20260531074852_recurring_series_type.sql
+++ b/internal/db/migrations/20260531074852_recurring_series_type.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+
+-- recurring_series.type: the structured classification axis for a recurring
+-- charge. The detector captures ALL recurring charges (subscriptions, bills,
+-- loans), so "subscription" is one type, not the umbrella. Inferred from the
+-- members' dominant category at first detection and user/agent-overridable;
+-- default 'subscription' (the most common) for existing rows + when no category
+-- signal exists. Additive (ADD COLUMN with default) — safe on the shared dev DB.
+ALTER TABLE recurring_series
+    ADD COLUMN type TEXT NOT NULL DEFAULT 'subscription'
+        CHECK (type IN ('subscription', 'bill', 'loan', 'other'));
+
+CREATE INDEX recurring_series_type_idx
+    ON recurring_series (type)
+    WHERE deleted_at IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS recurring_series_type_idx;
+ALTER TABLE recurring_series DROP COLUMN IF EXISTS type;

--- a/internal/db/queries/recurring_series.sql
+++ b/internal/db/queries/recurring_series.sql
@@ -49,9 +49,22 @@ SET user_id = $2,
     next_expected_date = $17,
     occurrence_count = $18,
     detection_signals = $19,
+    type = $20,
     updated_at = NOW()
 WHERE id = $1
 RETURNING *;
+
+-- SeriesDominantMemberCategory returns the most common category slug among a
+-- series' live members — used to infer the series type at first detection.
+-- Returns no rows when every member is uncategorized.
+-- name: SeriesDominantMemberCategory :one
+SELECT c.slug
+FROM transactions t
+JOIN categories c ON t.category_id = c.id
+WHERE t.series_id = $1 AND t.deleted_at IS NULL
+GROUP BY c.slug
+ORDER BY COUNT(*) DESC, c.slug ASC
+LIMIT 1;
 
 -- BackLinkSeriesMembers attaches the given transactions to a series, NULL-fill
 -- only — it never clobbers a manual/rule assignment. Returns rows affected.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -391,6 +391,10 @@ func (s *MCPServer) buildToolRegistry() {
 			Description: "Create a recurring series detection missed, or link transactions to an existing one — the agent's path to fix gaps. Provide series_id to assign to an existing series, OR merchant_key + create_if_missing:true to mint one (funnels through the same dedup + sticky-reject arbitration as the detector, so re-creating a user-rejected series at the same signature is a no-op). Pass transaction_ids (≤50) to back-link members (NULL-fill only — never steals a charge already in another series). confirm:true flips it straight to active; omit to leave a reviewable candidate. Use after list_series(status=candidate) shows nothing for a subscription the user says exists.",
 		}, s.handleAssignSeries, s),
 		makeToolDefLogged(ToolSpec{
+			Name: "set_series_type", Title: "Set Recurring Type", Classification: ToolWrite,
+			Description: "Set a recurring series' type: subscription (streaming/SaaS/memberships), bill (rent/utilities/insurance/telecom), loan (mortgage/auto/student/personal), or other. Detection infers the type from the charges' category on first detection; use this to correct it. The override is sticky — re-detection won't change it back.",
+		}, s.handleSetSeriesType, s),
+		makeToolDefLogged(ToolSpec{
 			Name: "rekey_series", Title: "Re-key a Subscription", Classification: ToolWrite,
 			Description: "Correct a series' merchant_key when detection grouped it under a wrong or fallback key (e.g. 'payment' → 'spotify'). Repoints the series and its linked transactions to the new key. Refuses to silently merge: errors if a live series already exists at the new key, or that key is sticky-rejected. Corrects historical grouping — future charges still key off the provider name.",
 		}, s.handleRekeySeries, s),

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -31,6 +31,7 @@ type assignSeriesInput struct {
 	CreateIfMissing bool     `json:"create_if_missing,omitempty" jsonschema:"Mint a new series keyed on merchant_key when no series_id is given."`
 	Name            string   `json:"name,omitempty" jsonschema:"Optional display name for a minted series."`
 	Cadence         string   `json:"cadence,omitempty" jsonschema:"Optional cadence for a minted series: weekly, biweekly, monthly, quarterly, semiannual, annual."`
+	Type            string   `json:"type,omitempty" jsonschema:"Optional recurring-charge type for a minted series: subscription, bill, loan, or other. Omit to infer from the linked charges' category."`
 	ExpectedAmount  *float64 `json:"expected_amount,omitempty" jsonschema:"Optional expected charge amount in dollars, paired with currency."`
 	Currency        string   `json:"currency,omitempty" jsonschema:"ISO currency code for expected_amount (e.g. USD)."`
 	CategoryID      string   `json:"category_id,omitempty" jsonschema:"Optional suggested category short ID or UUID."`
@@ -91,6 +92,29 @@ func (s *MCPServer) handleReviewSeries(ctx context.Context, _ *mcpsdk.CallToolRe
 	}
 	actor := service.ActorFromContext(ctx)
 	series, err := s.svc.ReviewSeries(context.Background(), input.ID, verdict, actor)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return errorResult(fmt.Errorf("series not found")), nil, nil
+		}
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(series)
+}
+
+type setSeriesTypeInput struct {
+	ID   string `json:"id" jsonschema:"required,Series short ID or UUID."`
+	Type string `json:"type" jsonschema:"required,One of: subscription, bill, loan, other."`
+}
+
+func (s *MCPServer) handleSetSeriesType(ctx context.Context, _ *mcpsdk.CallToolRequest, input setSeriesTypeInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.ID == "" || input.Type == "" {
+		return errorResult(fmt.Errorf("id and type are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	series, err := s.svc.SetSeriesType(context.Background(), input.ID, input.Type, actor)
 	if err != nil {
 		if errors.Is(err, service.ErrNotFound) {
 			return errorResult(fmt.Errorf("series not found")), nil, nil
@@ -211,6 +235,7 @@ func (s *MCPServer) handleAssignSeries(ctx context.Context, _ *mcpsdk.CallToolRe
 		CreateIfMissing: input.CreateIfMissing,
 		Name:            input.Name,
 		Cadence:         input.Cadence,
+		Type:            input.Type,
 		ExpectedAmount:  input.ExpectedAmount,
 		Currency:        opt(input.Currency),
 		CategoryID:      opt(input.CategoryID),

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -45,6 +45,13 @@ const (
 	SeriesConfidenceConfirmed = "confirmed"
 	SeriesConfidenceRejected  = "rejected"
 
+	// Recurring-charge type — the structured classification axis (mirrors the
+	// CHECK in the type migration). "subscription" is one type, not the umbrella.
+	SeriesTypeSubscription = "subscription" // streaming, SaaS, memberships
+	SeriesTypeBill         = "bill"         // rent, utilities, insurance, telecom
+	SeriesTypeLoan         = "loan"         // mortgage, auto/student/personal loans
+	SeriesTypeOther        = "other"        // recurring but uncategorized
+
 	// Renewal-health buckets — a derived (not stored) read-side signal computed
 	// from an active series' projected next_expected_date relative to today.
 	// Surfaced on SeriesResponse so agents and the UI can answer "what renews
@@ -69,6 +76,35 @@ var validSeriesCadence = map[string]bool{
 var validSeriesSource = map[string]bool{
 	SeriesSourceDeterministic: true, SeriesSourceAgent: true,
 	SeriesSourceUser: true, SeriesSourceRule: true,
+}
+
+var validSeriesType = map[string]bool{
+	SeriesTypeSubscription: true, SeriesTypeBill: true,
+	SeriesTypeLoan: true, SeriesTypeOther: true,
+}
+
+// inferSeriesType maps a (Plaid PFC) category slug to a recurring-charge type.
+// Prefix-based so it's robust to the full taxonomy; unknown/empty → subscription
+// (the most common recurring charge that isn't a bill or loan).
+func inferSeriesType(categorySlug string) string {
+	switch {
+	case categorySlug == "":
+		return SeriesTypeSubscription
+	case categorySlug == "loan_payments_insurance_payment":
+		return SeriesTypeBill // insurance is a bill, not a loan
+	case categorySlug == "loan_payments_credit_card_payment":
+		return SeriesTypeOther // a card payment is a transfer, not a tracked sub/bill/loan
+	case strings.HasPrefix(categorySlug, "loan_payments"):
+		return SeriesTypeLoan // mortgage, auto, student, personal
+	case strings.HasPrefix(categorySlug, "rent_and_utilities"):
+		return SeriesTypeBill // rent, gas/electric, internet/cable, phone, water
+	case categorySlug == "general_services_insurance":
+		return SeriesTypeBill
+	case strings.HasPrefix(categorySlug, "entertainment"):
+		return SeriesTypeSubscription // streaming, music, games
+	default:
+		return SeriesTypeSubscription
+	}
 }
 
 // SeriesVerdict is a human/agent adjudication applied via ReviewSeries.
@@ -96,6 +132,7 @@ type SeriesUpsert struct {
 	Currency         *string
 	CategoryID       *string  // short_id or uuid; advisory
 	Source           string   // deterministic|agent|user|rule (defaults deterministic)
+	Type             string   // subscription|bill|loan|other — explicit assertion (caller); when empty, inferred at first detection from the members' dominant category, then sticky
 	MemberTxnIDs     []string // transactions to back-link (short_id or uuid)
 	DetectionSignals []byte   // raw JSON signals (§6.6)
 }
@@ -114,6 +151,7 @@ type SeriesResponse struct {
 	IsoCurrencyCode  *string         `json:"iso_currency_code,omitempty"`
 	CategoryID       *string         `json:"category_id,omitempty"`
 	Status           string          `json:"status"`
+	Type             string          `json:"type"`
 	DetectionSource  string          `json:"detection_source"`
 	Confidence       string          `json:"confidence"`
 	ConfirmedByType  *string         `json:"confirmed_by_type,omitempty"`
@@ -144,6 +182,7 @@ type AssignSeriesInput struct {
 	CreateIfMissing bool     // mint a series if no SeriesID
 	Name            string   // optional display label for a minted series
 	Cadence         string   // optional proposed cadence for a minted series
+	Type            string   // optional subscription|bill|loan|other for a minted series
 	ExpectedAmount  *float64 // optional, paired with Currency
 	Currency        *string
 	CategoryID      *string  // short_id or uuid, advisory
@@ -180,6 +219,7 @@ func (s *Service) AssignSeries(ctx context.Context, in AssignSeriesInput, actor 
 			Name:           in.Name,
 			MerchantKey:    in.MerchantKey,
 			Cadence:        in.Cadence,
+			Type:           in.Type,
 			ExpectedAmount: in.ExpectedAmount,
 			Currency:       in.Currency,
 			CategoryID:     in.CategoryID,
@@ -492,6 +532,23 @@ func (s *Service) UpsertSeriesCandidate(ctx context.Context, in SeriesUpsert, ac
 	upd.LastAmount = lastAmount
 	upd.LastSeenDate = lastSeen
 
+	// Type: sticky once set. updateParamsFromRow already preserved base.Type. On
+	// the FIRST detection of a series (fresh insert) infer it from the members'
+	// dominant category; on later writes leave it alone so a re-detect can't
+	// override a refined value. An explicit caller assertion (in.Type) always
+	// wins — that's how an agent/rule sets the type directly.
+	if !haveExisting {
+		if t := s.inferTypeFromMembers(ctx, qtx, base.ID); t != "" {
+			upd.Type = t
+		}
+	}
+	if in.Type != "" {
+		if !validSeriesType[in.Type] {
+			return nil, fmt.Errorf("%w: invalid type %q", ErrInvalidParameter, in.Type)
+		}
+		upd.Type = in.Type
+	}
+
 	// An unadjudicated (auto) candidate may have its proposed fields sharpened
 	// by a fresh write; a confirmed series gets rollups only (its adjudicated
 	// fields are sacred). Confidence/status are never downgraded by the proposal
@@ -798,6 +855,45 @@ func (s *Service) SplitSeries(ctx context.Context, idOrShort string, memberIDsOr
 	return &resp, nil
 }
 
+// inferTypeFromMembers derives a recurring-charge type from the dominant
+// category of a series' linked members. Returns "" when every member is
+// uncategorized (caller keeps the existing/default type).
+func (s *Service) inferTypeFromMembers(ctx context.Context, qtx *db.Queries, seriesID pgtype.UUID) string {
+	slug, err := qtx.SeriesDominantMemberCategory(ctx, seriesID)
+	if err != nil || slug == "" {
+		return ""
+	}
+	return inferSeriesType(slug)
+}
+
+// SetSeriesType is the explicit type override (user/agent correction). Unlike
+// detection's first-time inference, this always wins and is sticky thereafter.
+func (s *Service) SetSeriesType(ctx context.Context, idOrShort, seriesType string, actor Actor) (*SeriesResponse, error) {
+	seriesType = strings.TrimSpace(seriesType)
+	if !validSeriesType[seriesType] {
+		return nil, fmt.Errorf("%w: type must be one of subscription, bill, loan, other", ErrInvalidParameter)
+	}
+	id, err := s.resolveSeriesID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.Queries.GetRecurringSeriesByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get series: %w", err)
+	}
+	upd := updateParamsFromRow(row)
+	upd.Type = seriesType
+	updated, err := s.Queries.UpdateRecurringSeries(ctx, upd)
+	if err != nil {
+		return nil, fmt.Errorf("set series type: %w", err)
+	}
+	resp := seriesFromRow(updated)
+	return &resp, nil
+}
+
 // GetSeries returns a single series by short_id or uuid.
 func (s *Service) GetSeries(ctx context.Context, idOrShort string) (*SeriesResponse, error) {
 	id, err := s.resolveSeriesID(ctx, idOrShort)
@@ -1031,6 +1127,7 @@ func updateParamsFromRow(r db.RecurringSeries) db.UpdateRecurringSeriesParams {
 		NextExpectedDate: r.NextExpectedDate,
 		OccurrenceCount:  r.OccurrenceCount,
 		DetectionSignals: r.DetectionSignals,
+		Type:             r.Type, // preserve type on every update unless a caller overrides it
 	}
 }
 
@@ -1049,6 +1146,7 @@ func seriesFromRow(r db.RecurringSeries) SeriesResponse {
 		IsoCurrencyCode:  textPtr(r.IsoCurrencyCode),
 		CategoryID:       uuidPtr(r.CategoryID),
 		Status:           r.Status,
+		Type:             r.Type,
 		DetectionSource:  r.DetectionSource,
 		Confidence:       r.Confidence,
 		ConfirmedByType:  textPtr(r.ConfirmedByType),

--- a/internal/service/series_detect_test.go
+++ b/internal/service/series_detect_test.go
@@ -225,3 +225,31 @@ func TestEvaluateGroup_AnalyzeGroupAgreesWithReason(t *testing.T) {
 		t.Errorf("analyzeGroup ok=%v but evaluateGroup reason=%q — wrappers disagree", ok, diag.Reason)
 	}
 }
+
+// --- recurring type inference (inferSeriesType) ---
+
+func TestInferSeriesType(t *testing.T) {
+	cases := map[string]string{
+		"":                                  SeriesTypeSubscription,
+		"loan_payments":                     SeriesTypeLoan,
+		"loan_payments_mortgage_payment":    SeriesTypeLoan,
+		"loan_payments_car_payment":         SeriesTypeLoan,
+		"loan_payments_student_loan_payment": SeriesTypeLoan,
+		"loan_payments_personal_loan_payment": SeriesTypeLoan,
+		"loan_payments_insurance_payment":   SeriesTypeBill, // insurance is a bill, not a loan
+		"loan_payments_credit_card_payment": SeriesTypeOther,
+		"rent_and_utilities_rent":           SeriesTypeBill,
+		"rent_and_utilities_internet_and_cable": SeriesTypeBill,
+		"rent_and_utilities_gas_and_electricity": SeriesTypeBill,
+		"general_services_insurance":        SeriesTypeBill,
+		"entertainment_tv_and_movies":       SeriesTypeSubscription,
+		"entertainment_music_and_audio":     SeriesTypeSubscription,
+		"food_and_drink_coffee":             SeriesTypeSubscription, // default
+		"general_merchandise_electronics":   SeriesTypeSubscription, // default
+	}
+	for slug, want := range cases {
+		if got := inferSeriesType(slug); got != want {
+			t.Errorf("inferSeriesType(%q) = %q, want %q", slug, got, want)
+		}
+	}
+}

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -775,6 +775,98 @@ func TestSplitSeries_StripsSourceInheritedTags(t *testing.T) {
 	}
 }
 
+func TestSeriesType_InferenceStickyAndOverride(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries) // one account for all merchant groups
+
+	seedMerchant := func(name string, dates ...string) []string {
+		ids := make([]string, 0, len(dates))
+		for _, d := range dates {
+			txn := testutil.MustCreateTransaction(t, queries, acctID, name+"_"+d, name, 999, d)
+			ids = append(ids, txn.ShortID)
+		}
+		return ids
+	}
+	mustCategory := func(slug, name string) {
+		if _, err := pool.Exec(ctx, `INSERT INTO categories (slug, display_name) VALUES ($1,$2) ON CONFLICT (slug) DO NOTHING`, slug, name); err != nil {
+			t.Fatalf("ensure category %s: %v", slug, err)
+		}
+	}
+	categorize := func(providerName, slug string) {
+		if _, err := pool.Exec(ctx, `UPDATE transactions SET category_id=(SELECT id FROM categories WHERE slug=$1) WHERE provider_name=$2`, slug, providerName); err != nil {
+			t.Fatalf("categorize %s: %v", providerName, err)
+		}
+	}
+
+	// Mortgage charges categorized as loan_payments_mortgage_payment → infer loan.
+	members := seedMerchant("WELLS FARGO MTG", "2026-02-01", "2026-03-01", "2026-04-01")
+	mustCategory("loan_payments_mortgage_payment", "Mortgage")
+	categorize("WELLS FARGO MTG", "loan_payments_mortgage_payment")
+
+	series, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		Name: "Wells Fargo Mortgage", MerchantKey: "wellsfargomtg", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: members,
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if series.Type != service.SeriesTypeLoan {
+		t.Errorf("inferred type = %q, want loan", series.Type)
+	}
+
+	// Sticky: recategorize members + re-detect → type must NOT change.
+	mustCategory("entertainment_tv_and_movies", "TV & Movies")
+	categorize("WELLS FARGO MTG", "entertainment_tv_and_movies")
+	re, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		MerchantKey: "wellsfargomtg", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: members,
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("re-detect: %v", err)
+	}
+	if re.Type != service.SeriesTypeLoan {
+		t.Errorf("type after re-detect = %q, want loan (sticky once inferred)", re.Type)
+	}
+
+	// Explicit override wins and is validated.
+	over, err := svc.SetSeriesType(ctx, series.ShortID, service.SeriesTypeBill, service.Actor{Type: "user", Name: "Tester"})
+	if err != nil {
+		t.Fatalf("set type: %v", err)
+	}
+	if over.Type != service.SeriesTypeBill {
+		t.Errorf("type after override = %q, want bill", over.Type)
+	}
+	if _, err := svc.SetSeriesType(ctx, series.ShortID, "nonsense", service.Actor{Type: "user"}); err == nil {
+		t.Error("expected invalid type to be rejected")
+	}
+
+	// Uncategorized members default to subscription.
+	plain := seedMerchant("ACME SAAS", "2026-02-09", "2026-03-09", "2026-04-09")
+	sub, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		MerchantKey: "acmesaas", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: plain,
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint plain: %v", err)
+	}
+	if sub.Type != service.SeriesTypeSubscription {
+		t.Errorf("uncategorized type = %q, want subscription (default)", sub.Type)
+	}
+
+	// AssignSeries with an explicit type on a fresh mint.
+	ins := seedMerchant("GEICO", "2026-02-05", "2026-03-05", "2026-04-05")
+	a, err := svc.AssignSeries(ctx, service.AssignSeriesInput{
+		MerchantKey: "geico", CreateIfMissing: true, Type: service.SeriesTypeBill, TransactionIDs: ins,
+	}, service.Actor{Type: "user", Name: "Tester"})
+	if err != nil {
+		t.Fatalf("assign with type: %v", err)
+	}
+	if a.Type != service.SeriesTypeBill {
+		t.Errorf("assigned type = %q, want bill", a.Type)
+	}
+}
+
 func keysOf(m map[string]service.SeriesNearMiss) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1876,6 +1876,7 @@ paths:
                 create_if_missing: { type: boolean }
                 name: { type: string }
                 cadence: { type: string, enum: [weekly, biweekly, monthly, quarterly, semiannual, annual] }
+                type: { type: string, enum: [subscription, bill, loan, other], description: "Optional type for a minted series; inferred from category when omitted." }
                 expected_amount: { type: number }
                 currency: { type: string }
                 category_id: { type: string }
@@ -1981,6 +1982,29 @@ paths:
       responses:
         "200":
           description: Re-keyed series.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RecurringSeries" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/series/{id}/type:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Series]
+      summary: Set a recurring series' type
+      description: "**Requires `full_access` scope.** Overrides the series type (`subscription`|`bill`|`loan`|`other`). Sticky correction — re-detection won't change it back."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [type]
+              properties:
+                type: { type: string, enum: [subscription, bill, loan, other] }
+      responses:
+        "200":
+          description: Updated series.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/RecurringSeries" }
@@ -3276,6 +3300,7 @@ components:
         expected_amount: { type: number, nullable: true }
         iso_currency_code: { type: string, nullable: true }
         status: { type: string, description: "`active`|`paused`|`cancelled`|`candidate`." }
+        type: { type: string, description: "Recurring-charge type: `subscription`|`bill`|`loan`|`other`. Inferred from the members' dominant category at first detection; user/agent-overridable + sticky." }
         confidence: { type: string, description: "`auto`|`confirmed`|`rejected` — the verdict axis." }
         detection_source: { type: string, description: "`deterministic`|`agent`|`user`|`rule`." }
         last_amount: { type: number, nullable: true }


### PR DESCRIPTION
Adds a structured **`type`** to recurring charges (`subscription` | `bill` | `loan` | `other`) so the feature differentiates a mortgage from Netflix — the read-half of the "Recurring is the umbrella, subscription is one type" direction. Tags stay freeform; `type` carries the taxonomy.

### How it works
- **Migration** (additive, timestamped after main's latest): `recurring_series.type NOT NULL DEFAULT 'subscription'` + CHECK + partial index.
- **Inference** — `inferSeriesType` maps Plaid PFC category slugs: `loan_payments_*` → loan (insurance → bill, credit-card → other), `rent_and_utilities_*` + `general_services_insurance` → bill, `entertainment_*` → subscription, else subscription. `inferTypeFromMembers` reads the members' dominant category and runs **only on first detection** — sticky thereafter, so a re-detect never reverts a refined type. An explicit caller type (`assign_series`) always wins.
- **Override** — `SetSeriesType` (sticky, validated).
- **Surfaces** — MCP `set_series_type` (write) + `type` on `assign_series`; REST `POST /series/{id}/type` + `type` on the assign body; `type` on `get`/`list_series`.

### Validation
build+vet default/headless/lite; unit (`inferSeriesType` table); service+api+mcp integration incl. OpenAPI drift — inference (loan from mortgage category), stickiness (re-detect after recategorize keeps the type), explicit override + validation, uncategorized→subscription default, and `assign_series` with explicit type. Docs updated (openapi, api-endpoints, mcp-tools-reference).

Note: existing rows default to `subscription` until re-detected or set; a re-infer backfill can follow if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
