### PR TITLE
feat(transactions): flag for attention — flagged_at + flag/unflag + Flagged filter

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -56,6 +56,8 @@ Unauthenticated device-code dance the CLI uses to mint API keys on a remote host
 | DELETE | `/transactions/{id}/metadata/{key}` | W | Remove one metadata key |
 | PUT | `/transactions/{id}/metadata` | W | Replace the entire metadata object |
 | DELETE | `/transactions/{id}/metadata` | W | Clear metadata to `{}` |
+| POST | `/transactions/{id}/flag` | W | Flag for attention (optional `reason` → comment) |
+| DELETE | `/transactions/{id}/flag` | W | Clear the flag |
 | POST | `/transactions/{transaction_id}/comments` | W | Add a comment |
 | PUT | `/transactions/{transaction_id}/comments/{id}` | W | Edit a comment |
 | DELETE | `/transactions/{transaction_id}/comments/{id}` | W | Delete a comment |

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -118,6 +118,10 @@ func parseAdminTxFilters(r *http.Request) service.AdminTransactionListParams {
 		b := v == "true"
 		params.Pending = &b
 	}
+	if v := q.Get("flagged"); v != "" {
+		b := v == "true"
+		params.Flagged = &b
+	}
 	if v := q.Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
 		params.SearchMode = &v
 	}
@@ -328,6 +332,7 @@ func renderTransactions(w http.ResponseWriter, r *http.Request, tr *TemplateRend
 		FilterMinAmount:   q.Get("min_amount"),
 		FilterMaxAmount:   q.Get("max_amount"),
 		FilterPending:     q.Get("pending"),
+		FilterFlagged:     q.Get("flagged"),
 		FilterSearch:      q.Get("search"),
 		FilterSearchMode:  q.Get("search_mode"),
 		FilterSearchField: q.Get("search_field"),
@@ -1435,7 +1440,7 @@ func TimelineRowsHandler(a *app.App, sm *scs.SessionManager, svc *service.Servic
 var txFilterParams = []string{
 	"start_date", "end_date", "account_id", "user_id",
 	"connection_id", "category", "min_amount", "max_amount",
-	"pending", "search", "search_mode", "search_field", "sort",
+	"pending", "flagged", "search", "search_mode", "search_field", "sort",
 	"tags", "any_tag",
 }
 

--- a/internal/admin/transactions_filter_chips.go
+++ b/internal/admin/transactions_filter_chips.go
@@ -85,6 +85,9 @@ func buildTransactionFilterChips(
 	} else if props.FilterPending == "false" {
 		add("Pending: No", "pending")
 	}
+	if props.FilterFlagged == "true" {
+		add("Flagged", "flagged")
+	}
 
 	// Tag chips drop a single slug out of the CSV rather than clearing the
 	// whole list. "tags" and "any_tag" are exclusive in the UI but handled

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -4,6 +4,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	mw "breadbox/internal/middleware"
@@ -30,6 +32,16 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 		return false
 	}
 	return true
+}
+
+// decodeJSONOptional decodes the JSON body into v when one is present. An empty
+// body is treated as success (v keeps its zero values); a malformed non-empty
+// body returns an error. Use for endpoints whose request body is optional.
+func decodeJSONOptional(r *http.Request, v any) error {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
 }
 
 // writeServiceError maps a service-layer sentinel error to the canonical

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -189,6 +189,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Delete("/transactions/{id}/metadata/{key}", RemoveTransactionMetadataKeyHandler(svc))
 			r.Put("/transactions/{id}/metadata", ReplaceTransactionMetadataHandler(svc))
 			r.Delete("/transactions/{id}/metadata", ClearTransactionMetadataHandler(svc))
+			r.Post("/transactions/{id}/flag", FlagTransactionHandler(svc))
+			r.Delete("/transactions/{id}/flag", UnflagTransactionHandler(svc))
 			r.Post("/tags", CreateTagHandler(svc))
 			r.Patch("/tags/{slug}", UpdateTagHandler(svc))
 			r.Post("/series", AssignSeriesHandler(svc))

--- a/internal/api/transaction_flag.go
+++ b/internal/api/transaction_flag.go
@@ -1,0 +1,49 @@
+//go:build !lite
+
+package api
+
+import (
+	"net/http"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Flag a transaction for human attention. The reason (optional) is stored as a
+// comment annotation, not a column. Reads expose flagged_at on the transaction;
+// filter the list with ?flagged=true. Both require full_access scope.
+
+// FlagTransactionHandler — POST /transactions/{id}/flag  body: {"reason": "..."} (optional)
+func FlagTransactionHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var input struct {
+			Reason string `json:"reason"`
+		}
+		// Body is optional; tolerate an empty/absent body but reject malformed JSON.
+		if err := decodeJSONOptional(r, &input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.FlagTransaction(r.Context(), id, input.Reason, actor); err != nil {
+			writeServiceError(w, err, "Transaction not found", "Failed to flag transaction")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// UnflagTransactionHandler — DELETE /transactions/{id}/flag
+func UnflagTransactionHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.UnflagTransaction(r.Context(), id); err != nil {
+			writeServiceError(w, err, "Transaction not found", "Failed to unflag transaction")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -28,6 +28,7 @@ type transactionFilters struct {
 	MinAmount     *float64
 	MaxAmount     *float64
 	Pending       *bool
+	Flagged       *bool
 	Search        *string
 	SearchMode    *string
 	ExcludeSearch *string
@@ -89,6 +90,12 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (f transact
 	}
 
 	f.Pending, err = parseBoolParam(q, "pending")
+	if err != nil {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		return
+	}
+
+	f.Flagged, err = parseBoolParam(q, "flagged")
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
@@ -174,6 +181,7 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			MinAmount:     f.MinAmount,
 			MaxAmount:     f.MaxAmount,
 			Pending:       f.Pending,
+			Flagged:       f.Flagged,
 			Search:        f.Search,
 			SearchMode:    f.SearchMode,
 			ExcludeSearch: f.ExcludeSearch,
@@ -237,6 +245,7 @@ func CountTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			MinAmount:     f.MinAmount,
 			MaxAmount:     f.MaxAmount,
 			Pending:       f.Pending,
+			Flagged:       f.Flagged,
 			Search:        f.Search,
 			SearchMode:    f.SearchMode,
 			ExcludeSearch: f.ExcludeSearch,

--- a/internal/db/migrations/20260531074239_transaction_flagged_at.sql
+++ b/internal/db/migrations/20260531074239_transaction_flagged_at.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- transactions.flagged_at: a lightweight "look at this" marker. Set by an agent
+-- (or a user) to surface a transaction for human attention. The REASON for a
+-- flag is recorded as a comment annotation, not a column — annotations are the
+-- canonical historical-context log. NULL = not flagged.
+ALTER TABLE transactions ADD COLUMN flagged_at TIMESTAMPTZ NULL;
+
+-- Partial index so the "Flagged" filter (flagged_at IS NOT NULL) stays cheap as
+-- the ledger grows — only flagged rows are indexed.
+CREATE INDEX transactions_flagged_at_idx ON transactions (flagged_at) WHERE flagged_at IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS transactions_flagged_at_idx;
+ALTER TABLE transactions DROP COLUMN IF EXISTS flagged_at;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -447,6 +447,18 @@ func (s *MCPServer) buildToolRegistry() {
 			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
 		}, s.handleClearTransactionMetadata, s),
 
+		// --- Flag (surface a transaction for human attention) ---
+		makeToolDefLogged(ToolSpec{
+			Name: "flag_transaction", Title: "Flag Transaction", Classification: ToolWrite,
+			Description: "Flag a transaction for human attention (sets flagged_at) without changing its category. Pass an optional `reason` — it's recorded as a comment annotation on the timeline. This is the 'look at this' escape hatch: when you auto-categorize but are unsure, or spot something worth a human glance, flag it instead of guessing. Retrieve flagged transactions with query_transactions(flagged=true). Idempotent: re-flagging refreshes the timestamp.",
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
+		}, s.handleFlagTransaction, s),
+		makeToolDefLogged(ToolSpec{
+			Name: "unflag_transaction", Title: "Unflag Transaction", Classification: ToolWrite,
+			Description: "Clear the flag on a transaction (sets flagged_at = NULL). No-op if it isn't flagged.",
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
+		}, s.handleUnflagTransaction, s),
+
 		// --- Activity timeline ---
 		makeToolDefLogged(ToolSpec{
 			Name: "list_annotations", Title: "List Activity Timeline", Classification: ToolRead,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -25,6 +25,7 @@ type queryTransactionsInput struct {
 	MinAmount     *float64 `json:"min_amount,omitempty" jsonschema:"Minimum amount (positive=debit, negative=credit)"`
 	MaxAmount     *float64 `json:"max_amount,omitempty" jsonschema:"Maximum amount (positive=debit, negative=credit)"`
 	Pending       *bool    `json:"pending,omitempty" jsonschema:"Filter by pending status"`
+	Flagged       *bool    `json:"flagged,omitempty" jsonschema:"Filter to flagged transactions (true) or unflagged (false). Omit to return both. Use flagged=true to retrieve transactions an agent or you have flagged for attention."`
 	Search        string   `json:"search,omitempty" jsonschema:"Search transaction name or merchant. Comma-separated values are ORed (e.g. starbucks,amazon matches either)."`
 	SearchMode    string   `json:"search_mode,omitempty" jsonschema:"How to match the search term: contains (default, substring match), words (all words must match, good for multi-word queries), fuzzy (typo-tolerant via trigram similarity)"`
 	ExcludeSearch string   `json:"exclude_search,omitempty" jsonschema:"Exclude transactions whose name or merchant matches this text. Comma-separated values are ORed. Use to filter out known merchants."`
@@ -46,6 +47,7 @@ type countTransactionsInput struct {
 	MinAmount     *float64 `json:"min_amount,omitempty" jsonschema:"Minimum amount"`
 	MaxAmount     *float64 `json:"max_amount,omitempty" jsonschema:"Maximum amount"`
 	Pending       *bool    `json:"pending,omitempty" jsonschema:"Filter by pending status"`
+	Flagged       *bool    `json:"flagged,omitempty" jsonschema:"Filter to flagged transactions (true) or unflagged (false). Omit to return both. Use flagged=true to retrieve transactions an agent or you have flagged for attention."`
 	Search        string   `json:"search,omitempty" jsonschema:"Search name or merchant. Comma-separated values are ORed."`
 	SearchMode    string   `json:"search_mode,omitempty" jsonschema:"Search mode: contains (default), words, fuzzy"`
 	ExcludeSearch string   `json:"exclude_search,omitempty" jsonschema:"Exclude transactions matching this text"`
@@ -101,6 +103,7 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 		MinAmount:     input.MinAmount,
 		MaxAmount:     input.MaxAmount,
 		Pending:       input.Pending,
+		Flagged:       input.Flagged,
 		Search:        optStr(input.Search),
 		ExcludeSearch: optStr(input.ExcludeSearch),
 		Tags:          input.Tags,
@@ -159,6 +162,7 @@ func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToo
 		MinAmount:     input.MinAmount,
 		MaxAmount:     input.MaxAmount,
 		Pending:       input.Pending,
+		Flagged:       input.Flagged,
 		Search:        optStr(input.Search),
 		ExcludeSearch: optStr(input.ExcludeSearch),
 		Tags:          input.Tags,

--- a/internal/mcp/tools_flag.go
+++ b/internal/mcp/tools_flag.go
@@ -1,0 +1,54 @@
+//go:build !lite
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/service"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The flag tools let an agent surface a transaction for human attention without
+// changing its category. flag_transaction sets flagged_at; the reason is
+// recorded as a comment annotation. Retrieve flagged rows with
+// query_transactions(flagged=true). This is the "look at this" escape hatch the
+// auto-apply workflow uses when it is unsure about a transaction.
+
+type flagTransactionInput struct {
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction to flag."`
+	Reason        string `json:"reason,omitempty" jsonschema:"Optional reason for the flag, recorded as a comment annotation on the transaction's timeline. Keep it short and specific (e.g. 'amount looks high for this merchant')."`
+}
+
+type unflagTransactionInput struct {
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction to unflag."`
+}
+
+func (s *MCPServer) handleFlagTransaction(ctx context.Context, _ *mcpsdk.CallToolRequest, input flagTransactionInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.TransactionID == "" {
+		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	if err := s.svc.FlagTransaction(context.Background(), input.TransactionID, input.Reason, actor); err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]any{"transaction_id": input.TransactionID, "flagged": true})
+}
+
+func (s *MCPServer) handleUnflagTransaction(ctx context.Context, _ *mcpsdk.CallToolRequest, input unflagTransactionInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.TransactionID == "" {
+		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
+	}
+	if err := s.svc.UnflagTransaction(context.Background(), input.TransactionID); err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]any{"transaction_id": input.TransactionID, "flagged": false})
+}

--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -33,6 +33,7 @@ var validFields = map[string]bool{
 	"created_at":                   true,
 	"updated_at":                   true,
 	"metadata":                     true,
+	"flagged_at":                   true,
 }
 
 // fieldAliases expand shorthand names to groups of fields.
@@ -163,6 +164,8 @@ func FilterTransactionFields(t TransactionResponse, fields map[string]bool) map[
 			m["updated_at"] = t.UpdatedAt
 		case "metadata":
 			m["metadata"] = t.Metadata
+		case "flagged_at":
+			m["flagged_at"] = t.FlaggedAt
 		}
 		// Keys outside the switch are silently ignored. ParseFields already
 		// rejects unknown names; review delegation strips "transaction." before

--- a/internal/service/fields_test.go
+++ b/internal/service/fields_test.go
@@ -193,7 +193,7 @@ func strPtr(s string) *string { return &s }
 
 func TestFilterTransactionFields_AllFields(t *testing.T) {
 	// Build a fieldSet with all valid fields
-	fields, err := ParseFields("id,account_id,account_name,user_name,amount,iso_currency_code,date,authorized_date,datetime,authorized_datetime,provider_name,provider_merchant_name,category,category_override,provider_category_primary,provider_category_detailed,provider_category_confidence,provider_payment_channel,pending,created_at,updated_at,metadata")
+	fields, err := ParseFields("id,account_id,account_name,user_name,amount,iso_currency_code,date,authorized_date,datetime,authorized_datetime,provider_name,provider_merchant_name,category,category_override,provider_category_primary,provider_category_detailed,provider_category_confidence,provider_payment_channel,pending,created_at,updated_at,metadata,flagged_at")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/service/transaction_flag.go
+++ b/internal/service/transaction_flag.go
@@ -1,0 +1,77 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// FlagTransaction marks a transaction for human attention by setting flagged_at
+// = NOW(). An optional reason is recorded as a comment annotation — annotations
+// are the canonical historical-context log, so there is deliberately no
+// flag_reason column. The flag + comment are written atomically. Re-flagging an
+// already-flagged row refreshes the timestamp (last-write-wins).
+func (s *Service) FlagTransaction(ctx context.Context, txnID, reason string, actor Actor) error {
+	uid, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return ErrNotFound
+	}
+	reason = strings.TrimSpace(reason)
+	if len(reason) > MaxCommentLength {
+		return fmt.Errorf("%w: reason must be at most %d characters", ErrInvalidParameter, MaxCommentLength)
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin flag transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	tag, err := tx.Exec(ctx,
+		`UPDATE transactions SET flagged_at = NOW() WHERE id = $1 AND deleted_at IS NULL`, uid)
+	if err != nil {
+		return fmt.Errorf("flag transaction: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+
+	if reason != "" {
+		if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
+			TransactionID: uid,
+			Kind:          "comment",
+			ActorType:     normalizeAnnotationActorType(actor.Type),
+			ActorID:       actor.ID,
+			ActorName:     actor.Name,
+			Payload:       map[string]interface{}{"content": reason},
+		}); err != nil {
+			return fmt.Errorf("write flag reason comment: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit flag transaction: %w", err)
+	}
+	return nil
+}
+
+// UnflagTransaction clears the flag (flagged_at = NULL). No-op-safe: succeeds as
+// long as the transaction exists.
+func (s *Service) UnflagTransaction(ctx context.Context, txnID string) error {
+	uid, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return ErrNotFound
+	}
+	tag, err := s.Pool.Exec(ctx,
+		`UPDATE transactions SET flagged_at = NULL WHERE id = $1 AND deleted_at IS NULL`, uid)
+	if err != nil {
+		return fmt.Errorf("unflag transaction: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/service/transaction_flag_integration_test.go
+++ b/internal/service/transaction_flag_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+func TestFlagTransaction(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn_flag", "Suspicious Co", 99900, "2026-04-01")
+	other := testutil.MustCreateTransaction(t, queries, acctID, "txn_plain", "Normal Co", 1200, "2026-04-02")
+	id := txn.ShortID
+	agent := service.Actor{Type: "agent", ID: "agent-1", Name: "Routine Reviewer"}
+
+	// Fresh transaction is not flagged.
+	if got, _ := svc.GetTransaction(ctx, id); got.FlaggedAt != nil {
+		t.Fatalf("fresh transaction FlaggedAt = %v, want nil", *got.FlaggedAt)
+	}
+
+	// Flag with a reason -> flagged_at set + the reason recorded as a comment.
+	if err := svc.FlagTransaction(ctx, id, "amount looks high for this merchant", agent); err != nil {
+		t.Fatalf("FlagTransaction: %v", err)
+	}
+	got, err := svc.GetTransaction(ctx, id)
+	if err != nil {
+		t.Fatalf("GetTransaction: %v", err)
+	}
+	if got.FlaggedAt == nil {
+		t.Fatalf("FlaggedAt is nil after flagging")
+	}
+	comments, err := svc.ListComments(ctx, id)
+	if err != nil {
+		t.Fatalf("ListComments: %v", err)
+	}
+	var foundReason bool
+	for _, c := range comments {
+		if c.Content == "amount looks high for this merchant" {
+			foundReason = true
+		}
+	}
+	if !foundReason {
+		t.Fatalf("flag reason was not recorded as a comment; comments=%+v", comments)
+	}
+
+	// query_transactions(flagged=true) returns the flagged row, not the other.
+	tru, fls := true, false
+	flagged, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &tru, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=true): %v", err)
+	}
+	if !containsTxn(flagged.Transactions, id) || containsTxn(flagged.Transactions, other.ShortID) {
+		t.Fatalf("flagged=true returned wrong set: %v", txnIDs(flagged.Transactions))
+	}
+	unflaggedList, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &fls, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=false): %v", err)
+	}
+	if containsTxn(unflaggedList.Transactions, id) || !containsTxn(unflaggedList.Transactions, other.ShortID) {
+		t.Fatalf("flagged=false returned wrong set: %v", txnIDs(unflaggedList.Transactions))
+	}
+
+	// Unflag clears it.
+	if err := svc.UnflagTransaction(ctx, id); err != nil {
+		t.Fatalf("UnflagTransaction: %v", err)
+	}
+	if got, _ := svc.GetTransaction(ctx, id); got.FlaggedAt != nil {
+		t.Fatalf("FlaggedAt = %v after unflag, want nil", *got.FlaggedAt)
+	}
+
+	// Flagging a missing transaction is ErrNotFound.
+	if err := svc.FlagTransaction(ctx, "nonexistent", "", agent); err == nil {
+		t.Fatalf("FlagTransaction(missing) = nil, want error")
+	}
+}
+
+func containsTxn(rows []service.TransactionResponse, shortID string) bool {
+	for _, r := range rows {
+		if r.ShortID == shortID || r.ID == shortID {
+			return true
+		}
+	}
+	return false
+}
+
+func txnIDs(rows []service.TransactionResponse) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.ShortID)
+	}
+	return out
+}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -223,7 +223,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name, " +
 		"au.short_id AS attributed_user_short_id, au.name AS attributed_user_name, " +
 		"COALESCE(au.short_id, u.short_id) AS effective_user_short_id, " +
-		"t.metadata " +
+		"t.metadata, t.flagged_at " +
 		"FROM transactions t " +
 		"JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -315,6 +315,13 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		buf.WriteString(strconv.Itoa(argN))
 		args = append(args, *params.Pending)
 		argN++
+	}
+	if params.Flagged != nil {
+		if *params.Flagged {
+			buf.WriteString(" AND t.flagged_at IS NOT NULL")
+		} else {
+			buf.WriteString(" AND t.flagged_at IS NULL")
+		}
 	}
 
 	if params.Search != nil {
@@ -459,6 +466,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			attributedUserName     pgtype.Text
 			effectiveUserShortID   pgtype.Text
 			metadata               []byte
+			flaggedAt              pgtype.Timestamptz
 		)
 
 		if err := rows.Scan(
@@ -473,7 +481,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			&catSlug, &catDisplayName, &catIcon, &catColor,
 			&catPrimarySlug, &catPrimaryDisplayName,
 			&attributedUserShortID, &attributedUserName,
-			&effectiveUserShortID, &metadata,
+			&effectiveUserShortID, &metadata, &flaggedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan transaction: %w", err)
 		}
@@ -532,6 +540,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			CreatedAt:           pgconv.TimestampStr(createdAt),
 			UpdatedAt:           pgconv.TimestampStr(updatedAt),
 			Metadata:            metadataToRaw(metadata),
+			FlaggedAt:           timestampStr(flaggedAt),
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -707,6 +716,13 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 		args = append(args, *params.Pending)
 		argN++
 	}
+	if params.Flagged != nil {
+		if *params.Flagged {
+			buf.WriteString(" AND t.flagged_at IS NOT NULL")
+		} else {
+			buf.WriteString(" AND t.flagged_at IS NULL")
+		}
+	}
 
 	if params.Search != nil {
 		mode := ""
@@ -771,7 +787,8 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"(SELECT COUNT(*) FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'comment' AND ann.deleted_at IS NULL) AS comment_count, " +
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
-		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id " +
+		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id, " +
+		"t.flagged_at " +
 		"FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -885,6 +902,13 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		buf.WriteString(strconv.Itoa(argN))
 		args = append(args, *params.Pending)
 		argN++
+	}
+	if params.Flagged != nil {
+		if *params.Flagged {
+			buf.WriteString(" AND t.flagged_at IS NOT NULL")
+		} else {
+			buf.WriteString(" AND t.flagged_at IS NULL")
+		}
 	}
 
 	if params.Search != nil {
@@ -1012,6 +1036,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			createdAt        pgtype.Timestamptz
 			updatedAt        pgtype.Timestamptz
 			effectiveUserID  pgtype.UUID
+			flaggedAt        pgtype.Timestamptz
 		)
 
 		if err := rows.Scan(
@@ -1020,7 +1045,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
 			&categoryOverride, &pending, &commentCount, &hasPendingReview, &createdAt, &updatedAt,
-			&effectiveUserID,
+			&effectiveUserID, &flaggedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
 		}
@@ -1062,6 +1087,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			Pending:             pending,
 			CommentCount:        int(commentCount),
 			HasPendingReview:    hasPendingReview,
+			FlaggedAt:           timestampStr(flaggedAt),
 			CreatedAt:           pgconv.TimestampStr(createdAt),
 			UpdatedAt:           pgconv.TimestampStr(updatedAt),
 		})
@@ -1160,7 +1186,8 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 		"(SELECT COUNT(*) FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'comment' AND ann.deleted_at IS NULL) AS comment_count, " +
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
-		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id " +
+		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id, " +
+		"t.flagged_at " +
 		"FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -1201,6 +1228,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			createdAt        pgtype.Timestamptz
 			updatedAt        pgtype.Timestamptz
 			effectiveUserID  pgtype.UUID
+			flaggedAt        pgtype.Timestamptz
 		)
 		if err := rows.Scan(
 			&id, &accountID, &accountName,
@@ -1208,7 +1236,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
 			&categoryOverride, &pending, &commentCount, &hasPendingReview, &createdAt, &updatedAt,
-			&effectiveUserID,
+			&effectiveUserID, &flaggedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
 		}
@@ -1247,6 +1275,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			Pending:             pending,
 			CommentCount:        int(commentCount),
 			HasPendingReview:    hasPendingReview,
+			FlaggedAt:           timestampStr(flaggedAt),
 			CreatedAt:           pgconv.TimestampStr(createdAt),
 			UpdatedAt:           pgconv.TimestampStr(updatedAt),
 		}
@@ -1319,7 +1348,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 			t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name,
 			t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence,
 			t.provider_payment_channel, t.pending, t.created_at, t.updated_at,
-			t.category_id, t.category_override, t.metadata
+			t.category_id, t.category_override, t.metadata, t.flagged_at
 		FROM transactions t
 		LEFT JOIN accounts a ON a.id = t.account_id
 		LEFT JOIN bank_connections bc ON bc.id = a.connection_id
@@ -1355,6 +1384,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		categoryID            pgtype.UUID
 		categoryOverride      string
 		metadata              []byte
+		flaggedAt             pgtype.Timestamptz
 	)
 
 	if err := s.Pool.QueryRow(ctx, q, uid).Scan(
@@ -1365,7 +1395,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		&datetime, &authorizedDatetime, &providerName, &providerMerchant,
 		&providerCatPrimary, &providerCatDetailed, &providerCatConf,
 		&providerChannel, &pending, &createdAt, &updatedAt,
-		&categoryID, &categoryOverride, &metadata,
+		&categoryID, &categoryOverride, &metadata, &flaggedAt,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -1409,6 +1439,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		CreatedAt:                  pgconv.TimestampStr(createdAt),
 		UpdatedAt:                  pgconv.TimestampStr(updatedAt),
 		Metadata:                   metadataToRaw(metadata),
+		FlaggedAt:                  timestampStr(flaggedAt),
 	}
 
 	if categoryID.Valid {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -74,6 +74,10 @@ type TransactionResponse struct {
 	// present as a JSON object (the empty object {} when nothing has been written).
 	// Written via the scoped metadata ops; never holds first-class fields.
 	Metadata json.RawMessage `json:"metadata"`
+
+	// FlaggedAt is set when the transaction is flagged for human attention
+	// (null when not flagged). The reason lives in a comment annotation.
+	FlaggedAt *string `json:"flagged_at,omitempty"`
 }
 
 type TransactionListResult struct {
@@ -104,6 +108,7 @@ type TransactionListParams struct {
 	MinAmount        *float64
 	MaxAmount        *float64
 	Pending          *bool
+	Flagged          *bool
 	Search           *string
 	SearchMode       *string // contains (default), words, fuzzy
 	ExcludeSearch    *string
@@ -128,6 +133,7 @@ type TransactionCountParams struct {
 	MinAmount        *float64
 	MaxAmount        *float64
 	Pending          *bool
+	Flagged          *bool
 	Search           *string
 	SearchMode       *string
 	ExcludeSearch    *string
@@ -316,6 +322,7 @@ type AdminTransactionListParams struct {
 	MinAmount     *float64
 	MaxAmount     *float64
 	Pending       *bool
+	Flagged       *bool
 	Search        *string
 	SearchMode    *string
 	SearchField   *string // "all" (default), "name", "merchant"
@@ -348,6 +355,7 @@ type AdminTransactionRow struct {
 	Pending             bool
 	CommentCount        int
 	HasPendingReview    bool
+	FlaggedAt           *string
 	CreatedAt           string
 	UpdatedAt           string
 	// Tags attached to this transaction. Populated as a separate batched

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -297,6 +297,14 @@ templ txFilters(p TransactionsProps) {
 						@txSelectOption("false", "No", p.FilterPending)
 					</select>
 				</label>
+				<label class="bb-filter-label">
+					Flagged
+					<select name="flagged" class="select select-sm w-full">
+						<option value="">All</option>
+						@txSelectOption("true", "Flagged only", p.FilterFlagged)
+						@txSelectOption("false", "Not flagged", p.FilterFlagged)
+					</select>
+				</label>
 			</div>
 			<!-- Search within filters -->
 			<div class="border-t border-base-200 pt-4 mb-4" x-data={ txSearchModeInit(p.FilterSearchMode) }>

--- a/internal/templates/components/pages/transactions_types.go
+++ b/internal/templates/components/pages/transactions_types.go
@@ -64,6 +64,7 @@ type TransactionsProps struct {
 	FilterMinAmount   string
 	FilterMaxAmount   string
 	FilterPending     string
+	FilterFlagged     string
 	FilterSearch      string
 	FilterSearchMode  string
 	FilterSearchField string
@@ -97,6 +98,7 @@ func (p TransactionsProps) HasActiveFilters() bool {
 		p.FilterMinAmount != "" ||
 		p.FilterMaxAmount != "" ||
 		p.FilterPending != "" ||
+		p.FilterFlagged != "" ||
 		len(p.FilterTags) > 0 ||
 		len(p.FilterAnyTag) > 0
 }

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -123,6 +123,13 @@ templ TxRow(tx service.AdminTransactionRow) {
 							<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(tx.CommentCount) }</span>
 						</span>
 					}
+					<!-- Slot 5 — Flag. -->
+					if tx.FlaggedAt != nil {
+						<span class="text-base-content/20">&middot;</span>
+						<span class="inline-flex items-center text-warning/70" title="Flagged for review">
+							@LucideIcon("flag", "w-3 h-3")
+						</span>
+					}
 				</div>
 				<!-- Mobile-only sub-line (<sm): date + category dot.
 				     Keeps the row informative on iPhone without crowding the name.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -369,6 +369,7 @@ paths:
         - { name: amount_min, in: query, schema: { type: number } }
         - { name: amount_max, in: query, schema: { type: number } }
         - { name: pending, in: query, schema: { type: boolean } }
+        - { name: flagged, in: query, schema: { type: boolean }, description: Filter to flagged (true) or unflagged (false) transactions. }
         - { name: deleted, in: query, schema: { type: string, enum: [include, only] }, description: Whether to include or restrict to soft-deleted transactions. }
         - { name: category_override, in: query, schema: { type: string, enum: [none, agent, user] }, description: Filter by category-override source (none/agent/user). }
       responses:
@@ -681,6 +682,37 @@ paths:
       description: "Delete one key from the `metadata` object. No-op if absent. **Requires `full_access` scope.**"
       responses:
         "204": { description: Removed. }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/v1/transactions/{id}/flag:
+    parameters: [{ $ref: "#/components/parameters/IDPath" }]
+    post:
+      tags: [Transactions]
+      summary: Flag a transaction
+      description: |
+        Mark a transaction for human attention (sets `flagged_at`). Optional body
+        `{"reason": "..."}` is recorded as a comment annotation. Retrieve flagged
+        rows with `?flagged=true`. **Requires `full_access` scope.**
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: { type: string, description: Optional reason, stored as a comment annotation. }
+      responses:
+        "204": { description: Flagged. }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    delete:
+      tags: [Transactions]
+      summary: Unflag a transaction
+      description: "Clears `flagged_at`. **Requires `full_access` scope.**"
+      responses:
+        "204": { description: Unflagged. }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
@@ -3222,6 +3254,11 @@ components:
           type: object
           additionalProperties: true
           description: Free-form JSONB enrichment store. Always an object (empty `{}` when unset).
+        flagged_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the transaction was flagged for human attention; null when not flagged. The reason lives in a comment annotation.
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
       additionalProperties: true


### PR DESCRIPTION
## Workflows sprint — PR 3: flag a transaction for attention

Adds **`transactions.flagged_at`** — a lightweight "look at this" marker an agent (or a user) sets to surface a transaction for human attention **without changing its category**. This is the auto-apply safety **escape hatch**: when Routine Reviewer is unsure, it *flags* instead of guessing. The **reason is a comment annotation** (annotations are the canonical context log — deliberately no `flag_reason` column, per the design decision).

### What ships
- **Migration** — additive `flagged_at TIMESTAMPTZ NULL` + a partial index `WHERE flagged_at IS NOT NULL` (keeps the Flagged filter cheap).
- **Service** — `FlagTransaction` (sets `flagged_at = NOW()` + records an optional reason as a comment, atomically) / `UnflagTransaction`; a `Flagged *bool` filter on `ListTransactions` / count / admin list; `FlaggedAt` surfaced on `TransactionResponse` + `AdminTransactionRow` + `fields.go`.
- **MCP** — `flag_transaction` / `unflag_transaction` write tools; a `flagged` filter on `query_transactions` + `count_transactions` so agents retrieve flagged rows with `query_transactions(flagged=true)`.
- **REST** — `POST`/`DELETE` `/transactions/{id}/flag`; `?flagged=true` on the list; `openapi.yaml` + `docs/api-endpoints.md`; a new `decodeJSONOptional` helper for the optional reason body.
- **Admin UI** — a **"Flagged" filter** select + removable chip on the transactions list, and a **flag indicator** (lucide `flag`, `text-warning`) on flagged rows.

### Validation
```
go build ./... / go vet ./... / go build -tags=lite ./...    PASS
integration: service / api / mcp / sync                       ok
new: TestFlagTransaction                                      ok
```
`TestFlagTransaction` proves: flag with a reason → `flagged_at` set + the reason appears as a comment; `flagged=true` includes only the flagged row and `flagged=false` excludes it; unflag clears it; flagging a missing transaction → not-found.

> **Screenshot deferred this iteration.** The shared dev `breadbox` DB has cross-worktree out-of-order migration conflicts right now, and applying this sprint's breaking `category_override` migration to it would risk other worktrees' running servers (CLAUDE.md caution). The admin filter + row indicator are templ-build-verified and the filter is integration-tested; I'll capture live UI screenshots on the gallery/drawer PR (the UI-heavy one). The **mobile** row indicator + the **detail-page** flag indicator are a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
