### PR TITLE
feat(workflows): code-defined preset registry + EnableWorkflowFromPreset

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -288,6 +288,8 @@ Agent definitions are scheduled Claude Agent SDK runs that call breadbox MCP to 
 | GET | `/agents/{slug}/runs` | R | Offset-paginated run history; `?limit=50&offset=0` (max 200); filters: `status`, `trigger`, `hit_cap` (`max_turns`/`max_budget`/`any`), `start`, `end` |
 | GET | `/agents/runs` | R | Cross-agent run history with `agent_slug`+`agent_name` per row; same filters as `/agents/{slug}/runs` plus optional `agent=<slug>` to narrow to one definition |
 | GET | `/agents/prompt-blocks` | R | Parsed view of the embedded `prompts/agents/*.md` library — id, title, description, group (`strategy`/`depth`/`integration`/`knowledge`), and full markdown content |
+| GET | `/workflow-presets` | R | List the code-defined Workflow preset gallery, annotated with enabled-state |
+| POST | `/workflow-presets/{slug}/enable` | W | Instantiate a workflow from a preset (409 if already enabled) |
 | GET | `/agents/runs/recent-errors` | R | Errored runs across all agents in the last `hours` (default 24, max 168); `?limit=5` (max 50); joined with `agent_slug`+`agent_name` for deep-link |
 | GET | `/agents/runs/{shortId}` | R | One run detail (by short_id or UUID) |
 | PATCH | `/agents/runs/{shortId}` | W | Set/clear the operator note on a run. Body `{ "note": "..." }`; empty string clears. Capped at 2000 chars |

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -127,6 +127,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/agents/runs/{shortId}/transcript", GetAgentRunTranscriptHandler(svc, a))
 		r.Get("/agents/{slug}", GetAgentDefinitionHandler(svc))
 		r.Get("/agents/{slug}/runs", ListAgentRunsHandler(svc))
+		r.Get("/workflow-presets", ListWorkflowPresetsHandler(svc))
 		r.Get("/providers", ListProvidersHandler(a))
 		r.Get("/providers/{name}", GetProviderHandler(a))
 		r.Get("/headless/bootstrap", HeadlessBootstrapHandler(svc, a, version))
@@ -203,6 +204,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Put("/settings/providers/teller", UpdateTellerConfigHandler(a))
 			// Agents — write endpoints (full_access scope).
 			r.Post("/agents", CreateAgentDefinitionHandler(svc))
+			r.Post("/workflow-presets/{slug}/enable", EnableWorkflowPresetHandler(svc))
 			r.Put("/agents/settings", UpdateAgentSettingsHandler(svc, a))
 			r.Patch("/agents/{slug}", UpdateAgentDefinitionHandler(svc))
 			r.Delete("/agents/{slug}", DeleteAgentDefinitionHandler(svc))

--- a/internal/api/workflow_presets.go
+++ b/internal/api/workflow_presets.go
@@ -1,0 +1,49 @@
+//go:build !lite
+
+package api
+
+import (
+	"net/http"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Workflow presets are the code-defined gallery templates. Listing is a read;
+// enabling instantiates a workflow (agent_definition) and needs write scope.
+
+// ListWorkflowPresetsHandler — GET /workflow-presets
+func ListWorkflowPresetsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out, err := svc.ListWorkflowPresets(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list workflow presets")
+			return
+		}
+		writeData(w, out)
+	}
+}
+
+// EnableWorkflowPresetHandler — POST /workflow-presets/{slug}/enable
+// Optional body: {"enabled": true} to start the workflow immediately
+// (default false — instantiated but paused for review).
+func EnableWorkflowPresetHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		var input struct {
+			Enabled bool `json:"enabled"`
+		}
+		if err := decodeJSONOptional(r, &input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+		wf, err := svc.EnableWorkflowFromPreset(r.Context(), slug, service.EnableWorkflowFromPresetParams{Enabled: input.Enabled})
+		if err != nil {
+			writeServiceError(w, err, "Workflow preset not found", "Failed to enable workflow preset")
+			return
+		}
+		writeJSON(w, http.StatusCreated, wf)
+	}
+}

--- a/internal/db/migrations/20260531081609_agent_definitions_source_template.sql
+++ b/internal/db/migrations/20260531081609_agent_definitions_source_template.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- source_template records which code-defined Workflow preset a definition was
+-- instantiated from (NULL = hand-authored). The preset gallery uses it to show
+-- "enabled vs available" and to prevent enabling the same preset twice. Presets
+-- are NOT seeded rows — a row only exists once the household enables one.
+ALTER TABLE agent_definitions ADD COLUMN source_template TEXT NULL;
+
+-- +goose Down
+ALTER TABLE agent_definitions DROP COLUMN IF EXISTS source_template;

--- a/internal/db/queries/agent_definitions.sql
+++ b/internal/db/queries/agent_definitions.sql
@@ -2,9 +2,9 @@
 INSERT INTO agent_definitions (
     name, slug, prompt, system_prompt, schedule_cron,
     tool_scope, allowed_tools, model, max_turns, max_budget_usd, enabled,
-    quiet_hours_start, quiet_hours_end, trigger_on_sync_complete
+    quiet_hours_start, quiet_hours_end, trigger_on_sync_complete, source_template
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 RETURNING *;
 
 -- name: GetAgentDefinition :one

--- a/internal/middleware/service_errors.go
+++ b/internal/middleware/service_errors.go
@@ -39,6 +39,8 @@ func MapServiceError(err error) (ServiceErrorResponse, bool) {
 		return ServiceErrorResponse{Status: http.StatusBadRequest, Code: "INVALID_CURSOR", Message: err.Error()}, true
 	case errors.Is(err, service.ErrForbidden):
 		return ServiceErrorResponse{Status: http.StatusForbidden, Code: "FORBIDDEN", Message: err.Error()}, true
+	case errors.Is(err, service.ErrConflict):
+		return ServiceErrorResponse{Status: http.StatusConflict, Code: "CONFLICT", Message: err.Error()}, true
 	case errors.Is(err, service.ErrSyncInProgress):
 		return ServiceErrorResponse{Status: http.StatusConflict, Code: "SYNC_IN_PROGRESS", Message: err.Error()}, true
 	case errors.Is(err, service.ErrUserHasDependents):

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -77,6 +77,9 @@ type AgentDefinitionResponse struct {
 	// TriggerOnSyncComplete fires this agent after every successful sync
 	// (in addition to any cron schedule). Disabled by default.
 	TriggerOnSyncComplete bool             `json:"trigger_on_sync_complete"`
+	// SourceTemplate is the workflow-preset slug this definition was
+	// instantiated from, or nil if it was hand-authored.
+	SourceTemplate        *string          `json:"source_template,omitempty"`
 	LastRun               *AgentRunSummary `json:"last_run,omitempty"`
 	// CostStats30d is populated only by ListAgentDefinitions (the surface
 	// where users want to compare spend at a glance). Single-row
@@ -213,7 +216,8 @@ type CreateAgentDefinitionParams struct {
 	Enabled               bool
 	QuietHoursStart       *string // "HH:MM" 24-hour; nil disables window
 	QuietHoursEnd         *string
-	TriggerOnSyncComplete bool // fire after each successful sync completes
+	TriggerOnSyncComplete bool    // fire after each successful sync completes
+	SourceTemplate        *string // preset slug this was instantiated from; nil = hand-authored
 }
 
 // UpdateAgentDefinitionParams uses pointer fields for PATCH semantics:
@@ -460,6 +464,7 @@ func (s *Service) CreateAgentDefinition(ctx context.Context, p CreateAgentDefini
 		QuietHoursStart:       pgconv.TextPtrIfNotEmpty(p.QuietHoursStart),
 		QuietHoursEnd:         pgconv.TextPtrIfNotEmpty(p.QuietHoursEnd),
 		TriggerOnSyncComplete: p.TriggerOnSyncComplete,
+		SourceTemplate:        pgconv.TextPtrIfNotEmpty(p.SourceTemplate),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create agent definition: %w", err)
@@ -1373,6 +1378,7 @@ func agentDefinitionFromRow(row db.AgentDefinition, lastRun *AgentRunSummary) Ag
 		QuietHoursStart:       pgconv.TextPtr(row.QuietHoursStart),
 		QuietHoursEnd:         pgconv.TextPtr(row.QuietHoursEnd),
 		TriggerOnSyncComplete: row.TriggerOnSyncComplete,
+		SourceTemplate:        pgconv.TextPtr(row.SourceTemplate),
 		LastRun:               lastRun,
 		CreatedAt:       pgconv.TimestampStr(row.CreatedAt),
 		UpdatedAt:       pgconv.TimestampStr(row.UpdatedAt),

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -12,6 +12,9 @@ var (
 	ErrInvalidParameter = errors.New("invalid parameter")
 	ErrSyncInProgress   = errors.New("sync already in progress")
 	ErrForbidden        = errors.New("forbidden")
+	// ErrConflict signals that a request conflicts with current state (e.g.
+	// enabling a workflow preset that is already enabled). Maps to 409.
+	ErrConflict = errors.New("conflict")
 	// ErrInvalidState signals that an entity is in a state that disallows the
 	// requested transition (e.g. completing an already-expired hosted-link
 	// session). Distinct from ErrInvalidParameter (bad input) and ErrNotFound

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -1,0 +1,205 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// WorkflowPreset is a code-defined, ready-to-enable Workflow template. Presets
+// are NOT seeded database rows — the gallery renders them from this registry,
+// and enabling one INSTANTIATES an agent_definition (tagged with source_template
+// = the preset Slug). Each preset's base prompt is composed from the reusable
+// blocks under prompts/agents/ so prompt content lives in one place.
+type WorkflowPreset struct {
+	Slug        string // stable identifier; also the slug of the instantiated workflow
+	Name        string // user-facing title
+	Category    string // gallery grouping
+	Icon        string // lucide icon name
+	Description string // one-line gallery card copy
+
+	// PromptBlocks are prompt-block IDs (filenames under prompts/agents/ sans
+	// .md) composed in order into the workflow's base prompt.
+	PromptBlocks []string
+
+	// Default run configuration applied when the preset is enabled.
+	ToolScope             string // "read_only" | "read_write"
+	Model                 string // empty = DefaultAgentModel
+	MaxTurns              int    // 0 = DefaultAgentMaxTurns
+	ScheduleCron          string // empty = no cron
+	TriggerOnSyncComplete bool   // fire after each successful sync
+}
+
+// workflowPresets is the starter catalog. Order is the gallery display order.
+// Grouped by Category. More presets land in later iterations (the 13-preset
+// backlog); these three span the read↔write trust spectrum and all three
+// trigger models (post-sync, cron-weekly, cron-monthly).
+var workflowPresets = []WorkflowPreset{
+	{
+		Slug:        "routine-reviewer",
+		Name:        "Routine Reviewer",
+		Category:    "Categorization & Review",
+		Icon:        "sparkles",
+		Description: "Auto-categorizes newly-synced transactions and flags anything it's unsure about.",
+		PromptBlocks: []string{
+			"strategy-routine-review",
+			"review-depth-efficient",
+			"category-system",
+		},
+		ToolScope:             "read_write",
+		TriggerOnSyncComplete: true,
+	},
+	{
+		Slug:        "weekly-money-digest",
+		Name:        "Weekly Money Digest",
+		Category:    "Insights & Reports",
+		Icon:        "bar-chart-3",
+		Description: "A Monday-morning summary of last week's spending by category and top merchants.",
+		PromptBlocks: []string{
+			"strategy-spending-report",
+		},
+		ToolScope:    "read_only",
+		ScheduleCron: "0 7 * * 1", // Mondays at 7:00
+	},
+	{
+		Slug:        "subscription-auditor",
+		Name:        "Subscription Auditor",
+		Category:    "Insights & Reports",
+		Icon:        "repeat",
+		Description: "Finds recurring charges and subscriptions, flagging price hikes and likely-forgotten ones.",
+		PromptBlocks: []string{
+			"strategy-anomaly-detection",
+			"merchant-analysis",
+		},
+		ToolScope:    "read_write",
+		ScheduleCron: "0 8 1 * *", // 1st of the month at 08:00
+	},
+}
+
+// WorkflowPresetView is a preset plus its enablement state, for the gallery.
+type WorkflowPresetView struct {
+	WorkflowPreset
+	// Enabled is true when this preset has been instantiated as a workflow.
+	Enabled bool `json:"enabled"`
+	// WorkflowSlug is the slug of the instantiated workflow (when Enabled).
+	WorkflowSlug *string `json:"workflow_slug,omitempty"`
+	// WorkflowEnabled is the instantiated workflow's own enabled toggle
+	// (a workflow can be instantiated but paused). Nil when not instantiated.
+	WorkflowEnabled *bool `json:"workflow_enabled,omitempty"`
+}
+
+// presetBySlug returns the preset with the given slug.
+func presetBySlug(slug string) (WorkflowPreset, bool) {
+	for _, p := range workflowPresets {
+		if p.Slug == slug {
+			return p, true
+		}
+	}
+	return WorkflowPreset{}, false
+}
+
+// composePresetPrompt concatenates the named prompt blocks into a single base
+// prompt. Returns an error if any block ID is unknown — this is the eager
+// validation that surfaces a typo at test time, not at a user's run.
+func composePresetPrompt(blockIDs []string) (string, error) {
+	blocks, err := loadPromptBlocks()
+	if err != nil {
+		return "", fmt.Errorf("load prompt blocks: %w", err)
+	}
+	byID := make(map[string]string, len(blocks))
+	for _, b := range blocks {
+		byID[b.ID] = b.Content
+	}
+	parts := make([]string, 0, len(blockIDs))
+	for _, id := range blockIDs {
+		content, ok := byID[id]
+		if !ok {
+			return "", fmt.Errorf("workflow preset references unknown prompt block %q", id)
+		}
+		parts = append(parts, strings.TrimSpace(content))
+	}
+	return strings.Join(parts, "\n\n"), nil
+}
+
+// ListWorkflowPresets returns the catalog annotated with enablement state by
+// matching each preset against existing agent_definitions via source_template.
+func (s *Service) ListWorkflowPresets(ctx context.Context) ([]WorkflowPresetView, error) {
+	defs, err := s.ListAgentDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bySource := make(map[string]AgentDefinitionResponse, len(defs))
+	for _, d := range defs {
+		if d.SourceTemplate != nil {
+			bySource[*d.SourceTemplate] = d
+		}
+	}
+	out := make([]WorkflowPresetView, 0, len(workflowPresets))
+	for _, p := range workflowPresets {
+		view := WorkflowPresetView{WorkflowPreset: p}
+		if d, ok := bySource[p.Slug]; ok {
+			view.Enabled = true
+			slug := d.Slug
+			en := d.Enabled
+			view.WorkflowSlug = &slug
+			view.WorkflowEnabled = &en
+		}
+		out = append(out, view)
+	}
+	return out, nil
+}
+
+// EnableWorkflowFromPresetParams carries optional overrides applied when a
+// preset is instantiated. Empty fields fall back to the preset's defaults.
+type EnableWorkflowFromPresetParams struct {
+	// Enabled controls whether the instantiated workflow runs immediately.
+	// Defaults to false (instantiated but paused) so a household can review it.
+	Enabled bool
+}
+
+// EnableWorkflowFromPreset instantiates a workflow from a preset: it composes
+// the base prompt, applies the preset defaults, stamps source_template, and
+// creates the agent_definition. Returns ErrConflict if the preset is already
+// enabled (one instance per preset).
+func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, params EnableWorkflowFromPresetParams) (*AgentDefinitionResponse, error) {
+	preset, ok := presetBySlug(slug)
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown workflow preset %q", ErrNotFound, slug)
+	}
+
+	// One instance per preset. Reject a second enable so the gallery toggles an
+	// existing workflow rather than duplicating it.
+	views, err := s.ListWorkflowPresets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range views {
+		if v.Slug == slug && v.Enabled {
+			return nil, fmt.Errorf("%w: workflow preset %q is already enabled", ErrConflict, slug)
+		}
+	}
+
+	prompt, err := composePresetPrompt(preset.PromptBlocks)
+	if err != nil {
+		return nil, err
+	}
+
+	create := CreateAgentDefinitionParams{
+		Name:                  preset.Name,
+		Slug:                  preset.Slug,
+		Prompt:                prompt,
+		ToolScope:             preset.ToolScope,
+		Model:                 preset.Model,
+		MaxTurns:              preset.MaxTurns,
+		Enabled:               params.Enabled,
+		TriggerOnSyncComplete: preset.TriggerOnSyncComplete,
+		SourceTemplate:        &preset.Slug,
+	}
+	if preset.ScheduleCron != "" {
+		cron := preset.ScheduleCron
+		create.ScheduleCron = &cron
+	}
+	return s.CreateAgentDefinition(ctx, create)
+}

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+func TestEnableWorkflowFromPreset(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// All presets start "available" (not enabled).
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+	if len(views) < 3 {
+		t.Fatalf("expected >=3 presets, got %d", len(views))
+	}
+	for _, v := range views {
+		if v.Enabled {
+			t.Fatalf("preset %q unexpectedly enabled on a fresh DB", v.Slug)
+		}
+	}
+
+	// Enable the flagship — it instantiates a workflow stamped with source_template.
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	if wf.SourceTemplate == nil || *wf.SourceTemplate != "routine-reviewer" {
+		t.Fatalf("source_template = %v, want routine-reviewer", wf.SourceTemplate)
+	}
+	if wf.Slug != "routine-reviewer" {
+		t.Fatalf("slug = %q, want routine-reviewer", wf.Slug)
+	}
+	if wf.ToolScope != "read_write" {
+		t.Fatalf("tool_scope = %q, want read_write", wf.ToolScope)
+	}
+	if !wf.TriggerOnSyncComplete {
+		t.Fatalf("routine-reviewer should trigger on sync complete")
+	}
+	if wf.Enabled {
+		t.Fatalf("workflow should be instantiated paused (Enabled=false)")
+	}
+	if len(wf.Prompt) == 0 {
+		t.Fatalf("composed prompt is empty")
+	}
+
+	// The gallery now reflects it as enabled.
+	views, err = svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+	var found bool
+	for _, v := range views {
+		if v.Slug == "routine-reviewer" {
+			found = true
+			if !v.Enabled || v.WorkflowSlug == nil || *v.WorkflowSlug != "routine-reviewer" {
+				t.Fatalf("routine-reviewer view not marked enabled: %+v", v)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("routine-reviewer not in preset views")
+	}
+
+	// One instance per preset — a second enable conflicts.
+	if _, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{}); !errors.Is(err, service.ErrConflict) {
+		t.Fatalf("double-enable err = %v, want ErrConflict", err)
+	}
+
+	// Unknown preset -> not found.
+	if _, err := svc.EnableWorkflowFromPreset(ctx, "no-such-preset", service.EnableWorkflowFromPresetParams{}); !errors.Is(err, service.ErrNotFound) {
+		t.Fatalf("unknown preset err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/service/workflow_presets_test.go
+++ b/internal/service/workflow_presets_test.go
@@ -1,0 +1,45 @@
+//go:build !lite
+
+package service
+
+import "testing"
+
+// TestWorkflowPresetsCompose is the eager-validation guard: every registered
+// preset must reference real prompt blocks and produce a non-empty base prompt.
+// A typo in a preset's PromptBlocks fails here (in the unit shard), not at a
+// household's run.
+func TestWorkflowPresetsCompose(t *testing.T) {
+	if len(workflowPresets) == 0 {
+		t.Fatal("workflowPresets registry is empty")
+	}
+	seen := map[string]bool{}
+	for _, p := range workflowPresets {
+		if p.Slug == "" || p.Name == "" || p.Category == "" {
+			t.Errorf("preset %+v missing slug/name/category", p)
+		}
+		if seen[p.Slug] {
+			t.Errorf("duplicate preset slug %q", p.Slug)
+		}
+		seen[p.Slug] = true
+		if p.ToolScope != "read_only" && p.ToolScope != "read_write" {
+			t.Errorf("preset %q has invalid tool_scope %q", p.Slug, p.ToolScope)
+		}
+		if len(p.PromptBlocks) == 0 {
+			t.Errorf("preset %q has no prompt blocks", p.Slug)
+		}
+		prompt, err := composePresetPrompt(p.PromptBlocks)
+		if err != nil {
+			t.Errorf("preset %q failed to compose prompt: %v", p.Slug, err)
+			continue
+		}
+		if len(prompt) == 0 {
+			t.Errorf("preset %q composed an empty prompt", p.Slug)
+		}
+	}
+}
+
+func TestComposePresetPrompt_UnknownBlock(t *testing.T) {
+	if _, err := composePresetPrompt([]string{"definitely-not-a-real-block"}); err == nil {
+		t.Fatal("composePresetPrompt with an unknown block returned nil error")
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2900,6 +2900,51 @@ paths:
               schema:
                 type: array
                 items: { type: object, additionalProperties: true }
+  /api/v1/workflow-presets:
+    get:
+      tags: [Agents]
+      summary: List the Workflow preset gallery
+      description: |
+        Returns the code-defined Workflow presets, each annotated with whether
+        it has been enabled (instantiated as a workflow). Presets are templates,
+        not stored rows — a row exists only once the preset is enabled.
+      responses:
+        "200":
+          description: Bare JSON array of preset views (`{slug, name, category, icon, description, enabled, ...}`).
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: object, additionalProperties: true }
+  /api/v1/workflow-presets/{slug}/enable:
+    parameters:
+      - { name: slug, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [Agents]
+      summary: Enable a Workflow preset
+      description: |
+        Instantiate a workflow from the preset (composes its base prompt, applies
+        the preset defaults, stamps `source_template`). Optional body
+        `{"enabled": true}` starts it immediately (default: paused for review).
+        Returns the created workflow. **Requires `full_access` scope.** 409 if the
+        preset is already enabled.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled: { type: boolean, description: Start the workflow immediately (default false). }
+      responses:
+        "201":
+          description: The instantiated workflow.
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { description: The preset is already enabled. }
   /api/v1/agents/runs/recent-errors:
     parameters:
       - { name: hours, in: query, schema: { type: integer, default: 24, minimum: 1, maximum: 168 } }


### PR DESCRIPTION
## Workflows sprint — PR 4a: code-defined preset registry

The heart of the Workflows feature — a gallery of **codified, ready-to-enable presets** — built **additively** on the existing agent runtime. (The DB-table rename `agent_definitions → workflows` is a *breaking* migration on the shared dev DB, so it's a separate, coordinated slice; this PR touches no existing behavior.)

### What ships
- **Migration** — additive `agent_definitions.source_template TEXT NULL` (preset provenance; `NULL` = hand-authored). **Presets are not seeded rows** — a row exists only once a household enables one (avoids the "wall of starter agents you can't run" trap the team already reverted).
- **Registry** (`internal/service/workflow_presets.go`, `//go:build !lite`) — the **3 starter presets**, each composing its base prompt from the existing `prompts/agents/` blocks:
  | Preset | Trigger | Scope | Blocks |
  |---|---|---|---|
  | ⭐ Routine Reviewer | post-sync | read_write | strategy-routine-review + review-depth-efficient + category-system |
  | Weekly Money Digest | cron Mon 07:00 | read_only | strategy-spending-report |
  | Subscription Auditor | cron 1st 08:00 | read_write | strategy-anomaly-detection + merchant-analysis |
- **`EnableWorkflowFromPreset`** — instantiates a workflow (composes the prompt, applies preset defaults, stamps `source_template`); **one instance per preset** (`409` on re-enable). **`ListWorkflowPresets`** annotates each preset with enabled-state.
- `source_template` threaded through `CreateAgentDefinitionParams` + `AgentDefinitionResponse` + the row mapper + the sqlc INSERT/RETURNING. New **`ErrConflict` → 409** sentinel (reusable).
- **REST** — `GET /api/v1/workflow-presets`, `POST /api/v1/workflow-presets/{slug}/enable` (+ openapi + api-endpoints).

### Validation
```
go build ./... / go vet ./... / go build -tags=lite ./...   PASS
integration: service / api / mcp                            ok
unit: TestWorkflowPresetsCompose                            ok   (eager block-ID validation in the unit shard)
integration: TestEnableWorkflowFromPreset                  ok   (instantiate → source_template → enabled-state → 409 → 404)
```
`TestWorkflowPresetsCompose` runs in the **unit shard** — a typo in any preset's prompt-block list fails CI immediately, never a user's run.

**Next:** the gallery UI (PR 5) renders this registry; the `agents → workflows` API/UI/MCP rename (4b) and the breaking DB-table rename (4c) are subsequent slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
