### PR TITLE
feat(recurring): surface type in the UI — chip, filter, type-aware copy

### DIFF
--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -46,6 +46,7 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 		var currencyOrder []string
 		activeCount := 0
 		usersWithSeries := map[string]bool{}
+		typesPresent := map[string]bool{}
 
 		for _, s := range all {
 			// A rejected verdict ("Not a subscription") is a dismissal — it
@@ -58,6 +59,9 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 			row := subscriptionRow(s, catName, userName)
 			if row.UserID != "" {
 				usersWithSeries[row.UserID] = true
+			}
+			if row.Type != "" {
+				typesPresent[row.Type] = true
 			}
 			if s.Status == service.SeriesStatusCandidate {
 				candidates = append(candidates, row)
@@ -107,6 +111,7 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 			Candidates:     candidates,
 			Active:         active,
 			Users:          subscriptionUserFilters(ctx, a, usersWithSeries),
+			Types:          subscriptionTypeFilters(typesPresent),
 		}
 
 		data := map[string]any{
@@ -186,6 +191,8 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 		Source:          s.DetectionSource,
 		SourceLabel:     sourceLabel(s.DetectionSource),
 	}
+	row.Type = s.Type
+	row.TypeLabel = recurringTypeLabel(s.Type)
 	row.RenewalLabel, row.RenewalTone = subscriptionRenewal(s)
 	row.DaysUntilRenewal = s.DaysUntilRenewal
 	if s.LastAmount != nil {
@@ -200,8 +207,24 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 		row.UserID = *s.UserID
 		row.OwnerName = userName[*s.UserID]
 	}
-	row.Search = strings.ToLower(strings.Join([]string{s.Name, s.MerchantKey, row.CadenceLabel, row.CategoryName, row.OwnerName}, " "))
+	row.Search = strings.ToLower(strings.Join([]string{s.Name, s.MerchantKey, row.CadenceLabel, row.CategoryName, row.OwnerName, row.TypeLabel}, " "))
 	return row
+}
+
+// recurringTypeLabel renders the structured type for display.
+func recurringTypeLabel(t string) string {
+	switch t {
+	case service.SeriesTypeSubscription:
+		return "Subscription"
+	case service.SeriesTypeBill:
+		return "Bill"
+	case service.SeriesTypeLoan:
+		return "Loan"
+	case service.SeriesTypeOther:
+		return "Other"
+	default:
+		return "Subscription"
+	}
 }
 
 // subscriptionRenewal derives an attention chip (label + daisy tone) from a
@@ -227,7 +250,14 @@ func subscriptionRenewal(s service.SeriesResponse) (string, string) {
 	case service.SeriesHealthOverdue:
 		return fmt.Sprintf("%dd overdue", -days), "warning"
 	case service.SeriesHealthStale:
-		return "Likely cancelled", "error"
+		// Type-aware copy: a bill/loan that goes silent has "lapsed" (you may
+		// have missed a payment), whereas a subscription has likely been cancelled.
+		switch s.Type {
+		case service.SeriesTypeBill, service.SeriesTypeLoan:
+			return "Lapsed?", "error"
+		default:
+			return "Likely cancelled", "error"
+		}
 	default:
 		return "", ""
 	}
@@ -547,6 +577,28 @@ func subscriptionUserFilters(ctx context.Context, a *app.App, owners map[string]
 		out = append(out, pages.SubscriptionUserFilter{ID: id, Name: u.Name, First: first})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// subscriptionTypeFilters builds the "filter by type" options from the types
+// actually present, in a stable order. Returns nil for a single type (no filter
+// worth showing).
+func subscriptionTypeFilters(present map[string]bool) []pages.SubscriptionTypeFilter {
+	if len(present) < 2 {
+		return nil
+	}
+	order := []struct{ value, label string }{
+		{service.SeriesTypeSubscription, "Subscriptions"},
+		{service.SeriesTypeBill, "Bills"},
+		{service.SeriesTypeLoan, "Loans"},
+		{service.SeriesTypeOther, "Other"},
+	}
+	var out []pages.SubscriptionTypeFilter
+	for _, o := range order {
+		if present[o.value] {
+			out = append(out, pages.SubscriptionTypeFilter{Value: o.value, Label: o.label})
+		}
+	}
 	return out
 }
 

--- a/internal/admin/subscriptions_renewal_test.go
+++ b/internal/admin/subscriptions_renewal_test.go
@@ -18,27 +18,46 @@ func TestSubscriptionRenewal(t *testing.T) {
 		name      string
 		health    string
 		days      *int
+		typ       string
 		wantLabel string
 		wantTone  string
 	}{
-		{"active stays quiet", service.SeriesHealthActive, days(30), "", ""},
-		{"unknown stays quiet", service.SeriesHealthUnknown, nil, "", ""},
-		{"empty (non-active) stays quiet", "", nil, "", ""},
-		{"due in 3 days", service.SeriesHealthDueSoon, days(3), "Renews in 3d", "info"},
-		{"due tomorrow", service.SeriesHealthDueSoon, days(1), "Due tomorrow", "info"},
-		{"due today", service.SeriesHealthDueSoon, days(0), "Due today", "info"},
-		{"overdue 5 days", service.SeriesHealthOverdue, days(-5), "5d overdue", "warning"},
-		{"stale → likely cancelled", service.SeriesHealthStale, days(-60), "Likely cancelled", "error"},
+		{"active stays quiet", service.SeriesHealthActive, days(30), service.SeriesTypeSubscription, "", ""},
+		{"unknown stays quiet", service.SeriesHealthUnknown, nil, service.SeriesTypeSubscription, "", ""},
+		{"empty (non-active) stays quiet", "", nil, "", "", ""},
+		{"due in 3 days", service.SeriesHealthDueSoon, days(3), service.SeriesTypeSubscription, "Renews in 3d", "info"},
+		{"due tomorrow", service.SeriesHealthDueSoon, days(1), service.SeriesTypeSubscription, "Due tomorrow", "info"},
+		{"due today", service.SeriesHealthDueSoon, days(0), service.SeriesTypeSubscription, "Due today", "info"},
+		{"overdue 5 days", service.SeriesHealthOverdue, days(-5), service.SeriesTypeSubscription, "5d overdue", "warning"},
+		{"stale subscription → likely cancelled", service.SeriesHealthStale, days(-60), service.SeriesTypeSubscription, "Likely cancelled", "error"},
+		{"stale loan → lapsed", service.SeriesHealthStale, days(-60), service.SeriesTypeLoan, "Lapsed?", "error"},
+		{"stale bill → lapsed", service.SeriesHealthStale, days(-45), service.SeriesTypeBill, "Lapsed?", "error"},
+		{"stale other → likely cancelled", service.SeriesHealthStale, days(-90), service.SeriesTypeOther, "Likely cancelled", "error"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := service.SeriesResponse{RenewalHealth: tc.health, DaysUntilRenewal: tc.days}
+			s := service.SeriesResponse{RenewalHealth: tc.health, DaysUntilRenewal: tc.days, Type: tc.typ}
 			label, tone := subscriptionRenewal(s)
 			if label != tc.wantLabel || tone != tc.wantTone {
-				t.Errorf("subscriptionRenewal(%q, %v) = (%q, %q), want (%q, %q)",
-					tc.health, tc.days, label, tone, tc.wantLabel, tc.wantTone)
+				t.Errorf("subscriptionRenewal(health=%q, type=%q) = (%q, %q), want (%q, %q)",
+					tc.health, tc.typ, label, tone, tc.wantLabel, tc.wantTone)
 			}
 		})
+	}
+}
+
+func TestRecurringTypeLabel(t *testing.T) {
+	cases := map[string]string{
+		service.SeriesTypeSubscription: "Subscription",
+		service.SeriesTypeBill:         "Bill",
+		service.SeriesTypeLoan:         "Loan",
+		service.SeriesTypeOther:        "Other",
+		"":                             "Subscription", // safe default
+	}
+	for in, want := range cases {
+		if got := recurringTypeLabel(in); got != want {
+			t.Errorf("recurringTypeLabel(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -26,6 +26,7 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 		<!-- Status + verdict toolbar -->
 		<div class="flex items-center flex-wrap gap-2 mb-6">
 			<span class={ "badge badge-soft badge-sm", "badge-" + p.Series.StatusTone }>{ p.Series.StatusLabel }</span>
+			<span class="badge badge-ghost badge-sm">{ p.Series.TypeLabel }</span>
 			if p.Series.Status == "candidate" {
 				<span class={ "badge badge-soft badge-sm", "badge-" + p.Series.BandTone }>{ p.Series.ConfidenceBand } confidence</span>
 			}
@@ -49,6 +50,9 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 			Icon:  "repeat",
 			Title: "Details",
 		}) {
+			@components.SettingsRow(components.SettingsRowProps{Label: "Type", Caption: "Subscription, bill, loan, or other"}) {
+				<span class="badge badge-soft badge-neutral badge-sm">{ p.Series.TypeLabel }</span>
+			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Cadence"}) {
 				<span class="text-sm">{ p.Series.CadenceLabel }</span>
 			}

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -42,6 +42,21 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 				}
 			</div>
 		}
+		if len(p.Types) > 1 {
+			<!-- Filter by type (subscription / bill / loan / other) -->
+			<div class="flex items-center gap-2 mb-6 overflow-x-auto">
+				<div class="join">
+					<button
+						@click="filterType = 'all'"
+						:class="filterType === 'all' ? 'btn-active' : ''"
+						class="join-item btn btn-xs"
+					>All</button>
+					for _, t := range p.Types {
+						@subscriptionsTypeFilterBtn(t)
+					}
+				</div>
+			</div>
+		}
 		<!-- Stat tiles: Active · Monthly-equivalent (per currency) · Candidates -->
 		<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterUser === 'all'">
 			<div class="grid grid-cols-3 divide-x divide-base-300">
@@ -130,14 +145,23 @@ templ subscriptionsUserFilterBtn(u SubscriptionUserFilter) {
 	</button>
 }
 
+templ subscriptionsTypeFilterBtn(t SubscriptionTypeFilter) {
+	<button
+		@click={ fmt.Sprintf("filterType = %q", t.Value) }
+		:class={ fmt.Sprintf("filterType === %q ? 'btn-active' : ''", t.Value) }
+		class="join-item btn btn-xs"
+	>{ t.Label }</button>
+}
+
 // subscriptionCandidateCard is one auto-detected series awaiting a verdict.
 templ subscriptionCandidateCard(s SubscriptionRow) {
 	<div
 		x-data="{ why: false }"
 		data-series-card
 		data-filter-user={ s.UserID }
+		data-type={ s.Type }
 		data-search={ s.Search }
-		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser)"
+		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && (filterType === 'all' || filterType === $el.dataset.type)"
 		x-cloak
 		class="bb-card p-4"
 	>
@@ -145,6 +169,7 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 			<div class="min-w-0 flex-1">
 				<div class="flex items-center gap-2 flex-wrap">
 					<span class="text-sm font-semibold text-base-content truncate">{ s.Name }</span>
+					<span class="badge badge-ghost badge-xs">{ s.TypeLabel }</span>
 					<span class={ "badge badge-soft badge-sm", "badge-" + s.BandTone }>{ s.ConfidenceBand } confidence</span>
 				</div>
 				<div class="text-xs text-base-content/50 mt-1">{ s.SignalSummary }</div>
@@ -218,8 +243,9 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 	<tr
 		data-series-card
 		data-filter-user={ s.UserID }
+		data-type={ s.Type }
 		data-search={ s.Search }
-		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && matches($el)"
+		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && (filterType === 'all' || filterType === $el.dataset.type) && matches($el)"
 		x-cloak
 		class="hover:bg-base-200/30 transition-colors"
 	>
@@ -229,7 +255,10 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 					@components.LucideIcon("repeat", "w-4 h-4 text-base-content opacity-40")
 				</div>
 				<div class="min-w-0">
-					<div class="text-sm font-medium truncate text-base-content">{ s.Name }</div>
+					<div class="flex items-center gap-2 min-w-0">
+						<span class="text-sm font-medium truncate text-base-content">{ s.Name }</span>
+						<span class="badge badge-ghost badge-xs shrink-0">{ s.TypeLabel }</span>
+					</div>
 					if s.CategoryName != "" {
 						<div class="text-xs text-base-content/40 truncate">{ s.CategoryName }</div>
 					}

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -16,6 +16,9 @@ type SubscriptionsListProps struct {
 
 	// Household-member filter strip. Only rendered when len > 1.
 	Users []SubscriptionUserFilter
+	// Type filter strip (subscription/bill/loan/other present in the data).
+	// Only rendered when len > 1 — no point offering a filter for one type.
+	Types []SubscriptionTypeFilter
 
 	// status == 'candidate' — get the Confirm / Not-a-subscription actions.
 	Candidates []SubscriptionRow
@@ -36,6 +39,12 @@ type SubscriptionUserFilter struct {
 	First string // first letter for the avatar circle
 }
 
+// SubscriptionTypeFilter — one option in the "filter by type" segmented control.
+type SubscriptionTypeFilter struct {
+	Value string // subscription | bill | loan | other — matches row data-type
+	Label string // "Subscriptions" | "Bills" | "Loans" | "Other"
+}
+
 // SubscriptionRow is one series card. Fields are pre-formatted in the handler.
 type SubscriptionRow struct {
 	ShortID     string // short_id — drives detail link + verdict PATCH
@@ -48,6 +57,9 @@ type SubscriptionRow struct {
 	Status      string // active | paused | cancelled | candidate
 	StatusLabel string
 	StatusTone  string // success | warning | neutral | info
+
+	Type      string // subscription | bill | loan | other (raw, drives the filter)
+	TypeLabel string // "Subscription" | "Bill" | "Loan" | "Other"
 
 	// Renewal-health attention chip (active series only). Empty when the
 	// subscription renews comfortably or has no projection — only the states a

--- a/static/js/admin/components/subscriptions.js
+++ b/static/js/admin/components/subscriptions.js
@@ -27,6 +27,7 @@
     Alpine.data('subscriptionsList', function () {
       return {
         filterUser: 'all',
+        filterType: 'all',
         filter: '',
 
         init: function () {


### PR DESCRIPTION
Surfaces the structured `type` on the **/recurring** page — the experience half of the type work.

- **Type chip** on every ledger row + candidate card + the detail header/config grid (`Subscription` / `Bill` / `Loan` / `Other`).
- **Type filter** — a daisy `join` segmented control (All / Subscriptions / Bills / Loans / Other), shown only when >1 type is present; filters both the review queue and the tracked ledger.
- **Type-aware renewal copy** — a stale bill/loan reads **"Lapsed?"** rather than "Likely cancelled" (which only makes sense for a subscription).

### Validation
build+vet default/headless/lite; unit (`recurringTypeLabel` + type-aware `subscriptionRenewal`); browser-validated against `breadbox_test` (seeded varied-type series) — chips render per type, the filter shows and narrows to a single type, urgency sort + renewal chip intact. (Validated on the test DB because the shared local dev DB can't take the type migration without breaking other worktree servers; the deployed instance gets the migration on merge.)

<img src="https://i.img402.dev/320464ivc6.jpg" width="800" alt="/recurring with type chips + filter">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
