### PR TITLE
feat(recurring): interactive series-tag editing on the detail page

### DIFF
--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -144,6 +144,25 @@ func SubscriptionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 			a.Logger.Error("series members", "error", err)
 		}
 
+		// Add-tag options = the vocabulary minus tags already on the series.
+		onSeries := map[string]bool{}
+		for _, tg := range row.Tags {
+			onSeries[tg] = true
+		}
+		var tagOptions []pages.SubscriptionTagOption
+		if tags, terr := svc.ListTags(ctx); terr == nil {
+			for _, t := range tags {
+				if onSeries[t.Slug] {
+					continue
+				}
+				name := t.DisplayName
+				if name == "" {
+					name = t.Slug
+				}
+				tagOptions = append(tagOptions, pages.SubscriptionTagOption{Slug: t.Slug, Name: name})
+			}
+		}
+
 		props := pages.SubscriptionDetailProps{
 			CSRFToken:       GetCSRFToken(r),
 			Series:          row,
@@ -155,6 +174,7 @@ func SubscriptionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 			Confidence:      s.Confidence,
 			Members:         subscriptionMembers(members),
 			PriceChanges:    subscriptionPriceChanges(members),
+			AvailableTags:   tagOptions,
 		}
 
 		data := map[string]any{

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -70,15 +70,36 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 				<span class="text-sm">{ subscriptionDetailField(p.Series.CategoryName) }</span>
 			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Tags", Caption: "Linked charges inherit these"}) {
-				if len(p.Series.Tags) > 0 {
-					<span class="inline-flex flex-wrap gap-1.5">
-						for _, tag := range p.Series.Tags {
-							<span class="badge badge-soft badge-neutral badge-sm">{ tag }</span>
-						}
-					</span>
-				} else {
-					<span class="text-base-content/40 text-sm">—</span>
-				}
+				<div class="flex flex-wrap items-center gap-1.5">
+					for _, tag := range p.Series.Tags {
+						<span class="badge badge-soft badge-neutral badge-sm gap-1">
+							{ tag }
+							<button
+								type="button"
+								@click={ fmt.Sprintf("removeSeriesTag(%q, %q)", p.Series.ShortID, tag) }
+								class="cursor-pointer opacity-60 hover:opacity-100 bg-transparent inline-flex"
+								aria-label="Remove tag"
+							>
+								@components.LucideIcon("x", "w-3 h-3")
+							</button>
+						</span>
+					}
+					if len(p.AvailableTags) > 0 {
+						<select
+							@change={ fmt.Sprintf("addSeriesTag(%q, $event.target.value)", p.Series.ShortID) }
+							class="select select-xs bg-base-200 w-auto"
+							aria-label="Add a tag"
+						>
+							<option value="">+ Add tag</option>
+							for _, opt := range p.AvailableTags {
+								<option value={ opt.Slug }>{ opt.Name }</option>
+							}
+						</select>
+					}
+					if len(p.Series.Tags) == 0 && len(p.AvailableTags) == 0 {
+						<span class="text-base-content/40 text-sm">No tags available — create one first.</span>
+					}
+				</div>
 			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Expected day"}) {
 				<span class="text-sm">{ subscriptionDetailField(p.ExpectedDay) }</span>

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -121,6 +121,17 @@ type SubscriptionDetailProps struct {
 
 	// Price-change history derived from members (oldest → newest change points).
 	PriceChanges []SubscriptionPriceChange
+
+	// AvailableTags is every tag in the vocabulary (slug + name), for the
+	// interactive tag editor's add-control. The template hides tags already on
+	// the series client-side.
+	AvailableTags []SubscriptionTagOption
+}
+
+// SubscriptionTagOption is one option in the detail page's add-tag picker.
+type SubscriptionTagOption struct {
+	Slug string
+	Name string
 }
 
 // SubscriptionMember is one linked charge in the detail timeline.

--- a/static/js/admin/components/subscriptions.js
+++ b/static/js/admin/components/subscriptions.js
@@ -37,6 +37,55 @@
           });
         },
 
+        // Interactive series-tag editing on the detail page. Add/remove go to
+        // the same REST endpoints the add_series_tag / remove_series_tag MCP
+        // tools wrap; CSRF is auto-injected by the global fetch wrapper. Reload
+        // on success to re-render the inherited tags + the add-options.
+        addSeriesTag: function (seriesId, slug) {
+          if (!slug) return;
+          this._tagOp(
+            'POST',
+            '/api/v1/series/' + encodeURIComponent(seriesId) + '/tags',
+            { tag_slug: slug },
+            'Tag added'
+          );
+        },
+
+        removeSeriesTag: function (seriesId, slug) {
+          this._tagOp(
+            'DELETE',
+            '/api/v1/series/' + encodeURIComponent(seriesId) + '/tags/' + encodeURIComponent(slug),
+            null,
+            'Tag removed'
+          );
+        },
+
+        _tagOp: function (method, url, body, okMsg) {
+          var opts = { method: method, headers: { Accept: 'application/json' } };
+          if (body) {
+            opts.headers['Content-Type'] = 'application/json';
+            opts.body = JSON.stringify(body);
+          }
+          fetch(url, opts)
+            .then(function (res) {
+              if (res.ok) {
+                toast(okMsg, 'success');
+                window.location.reload();
+                return;
+              }
+              restorePageState();
+              return res.json().then(function (data) {
+                toast((data.error && data.error.message) || 'Failed to update tags.');
+              }).catch(function () {
+                toast('Failed to update tags.');
+              });
+            })
+            .catch(function () {
+              restorePageState();
+              toast('Network error. Please try again.');
+            });
+        },
+
         // Search filter for the active-ledger rows (data-search haystack).
         matches: function (el) {
           if (!this.filter) return true;


### PR DESCRIPTION
Makes the **Recurring detail** Tags row interactive (it was read-only) — the first slice of #2. Each inherited tag is a chip with a ✕ remove, and an **"+ Add tag"** select offers the rest of the vocabulary. Add/remove call the already-shipped `POST`/`DELETE /series/{id}/tags` endpoints (the `add_series_tag`/`remove_series_tag` MCP tools' REST mirrors); CSRF is auto-injected; the page reloads on success so the members' inherited tags + the add-options re-render.

- Handler passes `AvailableTags` = the tag vocabulary minus tags already on the series.
- `subscriptionsList` Alpine factory gains `addSeriesTag` / `removeSeriesTag` / `_tagOp`.

### Validation
build+vet default/headless/lite; unit suite (incl. scripts-lint); browser-validated against `breadbox_test` — selecting a tag adds the chip and drops the option from the select; the ✕ removes the chip and restores the option.

<img src="https://i.img402.dev/2h5tj3wjwp.jpg" width="800" alt="Recurring detail — interactive tag editor">

Remaining for #2: reuse the transaction-row component for the linked-charges table + extract shared series components (type chip, renewal chip, confidence chip) into the /design sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
