### PR TITLE
feat(workflows): preset gallery page (/workflows)

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -191,6 +191,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Legacy /agents/runs and /agents/{slug}/runs 301-redirect.
 		r.Get("/agents", AgentRunsListPageHandler(svc, sm, tr, a.Config.DataDir))
 		r.Get("/agents/definitions", AgentsListPageHandler(svc, sm, tr))
+		r.Get("/workflows", WorkflowsGalleryPageHandler(svc, sm, tr))
 		r.Get("/agents/new", AgentFormPageHandler(svc, sm, tr))
 		// /agents/{slug} is the per-agent landing page (lifetime stats +
 		// last 10 runs); /agents/{slug}/edit remains the form, reachable
@@ -443,6 +444,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/agents/{slug}/update", UpdateAgentDefinitionAdminHandler(svc, sm))
 			r.Post("/agents/{slug}/delete", DeleteAgentDefinitionAdminHandler(svc, sm))
 			r.Post("/agents/{slug}/enable", EnableAgentAdminHandler(svc))
+			r.Post("/workflow-presets/{slug}/enable", EnableWorkflowPresetAdminHandler(svc))
 			r.Post("/agents/{slug}/disable", DisableAgentAdminHandler(svc))
 			r.Post("/agents/{slug}/run", RunAgentNowAdminHandler(a, svc))
 			r.Post("/agents/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -135,7 +135,7 @@ func pageSectionLabel(currentPage string) string {
 		return "Setup"
 	case "feed", "transactions", "accounts", "subscriptions", "reports":
 		return "Overview"
-	case "agents", "rules", "categories", "tags":
+	case "workflows", "agents", "rules", "categories", "tags":
 		return "Manage"
 	case "connections", "household", "logs":
 		return "System"

--- a/internal/admin/workflows_actions.go
+++ b/internal/admin/workflows_actions.go
@@ -1,0 +1,36 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"errors"
+	"net/http"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// EnableWorkflowPresetAdminHandler handles POST /-/workflow-presets/{slug}/enable.
+// It instantiates a workflow from the preset (enabled to run). Idempotent at the
+// gallery level: an already-enabled preset returns 200 so the page just refreshes
+// to show the run toggle. The instantiated workflow's run state is then toggled
+// via the existing /-/agents/{slug}/enable|disable endpoints.
+func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		wf, err := svc.EnableWorkflowFromPreset(r.Context(), slug, service.EnableWorkflowFromPresetParams{Enabled: true})
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrConflict):
+				writeJSON(w, http.StatusOK, map[string]any{"slug": slug, "already_enabled": true})
+			case errors.Is(err, service.ErrNotFound):
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow preset not found")
+			default:
+				writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_ENABLE_FAILED", err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, wf)
+	}
+}

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -1,0 +1,120 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components/pages"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// WorkflowsGalleryPageHandler renders GET /workflows — the codified preset
+// gallery. Presets come from the code registry (service.ListWorkflowPresets);
+// enabling one instantiates a workflow. Mirrors AgentsListPageHandler.
+func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var (
+			presets    []service.WorkflowPresetView
+			presetsErr error
+			status     *service.AgentSubsystemStatus
+			wg         sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() { defer wg.Done(); presets, presetsErr = svc.ListWorkflowPresets(ctx) }()
+		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
+		wg.Wait()
+
+		if presetsErr != nil {
+			http.Error(w, "failed to load workflow presets", http.StatusInternalServerError)
+			return
+		}
+
+		props := pages.WorkflowsGalleryProps{
+			Categories: groupWorkflowPresets(presets),
+			Status:     buildAgentsListStatus(status),
+			CSRFToken:  GetCSRFToken(r),
+		}
+
+		data := BaseTemplateData(r, sm, "workflows", "Workflows")
+		tr.RenderWithTempl(w, r, data, pages.WorkflowsGallery(props))
+	}
+}
+
+// groupWorkflowPresets buckets presets into category sections, preserving the
+// registry order for both categories and presets within them.
+func groupWorkflowPresets(views []service.WorkflowPresetView) []pages.WorkflowCategoryProps {
+	order := make([]string, 0)
+	byCat := make(map[string][]pages.WorkflowPresetCardProps)
+	for _, v := range views {
+		if _, seen := byCat[v.Category]; !seen {
+			order = append(order, v.Category)
+		}
+		card := pages.WorkflowPresetCardProps{
+			Slug:         v.Slug,
+			Name:         v.Name,
+			Description:  v.Description,
+			Icon:         v.Icon,
+			TriggerLabel: presetTriggerLabel(v),
+			ToolScope:    v.ToolScope,
+			Enabled:      v.Enabled,
+		}
+		if v.WorkflowSlug != nil {
+			card.WorkflowSlug = *v.WorkflowSlug
+		}
+		if v.WorkflowEnabled != nil {
+			card.WorkflowEnabled = *v.WorkflowEnabled
+		}
+		byCat[v.Category] = append(byCat[v.Category], card)
+	}
+	out := make([]pages.WorkflowCategoryProps, 0, len(order))
+	for _, cat := range order {
+		out = append(out, pages.WorkflowCategoryProps{
+			Name:    cat,
+			Icon:    workflowCategoryIcon(cat),
+			Presets: byCat[cat],
+		})
+	}
+	return out
+}
+
+func workflowCategoryIcon(category string) string {
+	switch category {
+	case "Categorization & Review":
+		return "sparkles"
+	case "Insights & Reports":
+		return "bar-chart-3"
+	case "Hygiene & Maintenance":
+		return "wrench"
+	case "Alerts & Anomalies":
+		return "bell"
+	default:
+		return "workflow"
+	}
+}
+
+// presetTriggerLabel renders a short human-readable trigger summary for a card.
+func presetTriggerLabel(v service.WorkflowPresetView) string {
+	if v.TriggerOnSyncComplete {
+		return "After each sync"
+	}
+	switch v.ScheduleCron {
+	case "":
+		return "Manual"
+	case "0 7 * * 1":
+		return "Weekly"
+	case "0 8 1 * *":
+		return "Monthly"
+	}
+	// Daily-ish heuristics for other crons; fall back to a generic label.
+	if strings.HasPrefix(v.ScheduleCron, "0 ") && strings.HasSuffix(v.ScheduleCron, " * * *") {
+		return "Daily"
+	}
+	return "Scheduled"
+}

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -63,6 +63,7 @@ templ Nav(p NavProps) {
 		}
 		<div class="bb-sidebar-section">Manage</div>
 		if p.IsEditor {
+			@navLink("/workflows", "workflow", "Workflows", navActive(p.CurrentPage, "workflows"))
 			@navLink("/agents", "bot-message-square", "Agents", navActive(p.CurrentPage, "agents"))
 		}
 		if p.IsAdmin {

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -1,0 +1,80 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// WorkflowsGallery is the /workflows preset gallery: codified, one-click
+// automations grouped by category. Enabling a preset instantiates a workflow;
+// an instantiated workflow shows a run toggle.
+templ WorkflowsGallery(p WorkflowsGalleryProps) {
+	<script src="/static/js/admin/components/workflows_gallery.js"></script>
+	<div
+		x-data="workflowsGallery"
+		data-csrf={ p.CSRFToken }
+		x-init="$store.shortcuts.setScope('workflows')"
+		x-destroy="$store.shortcuts.setScope('global')"
+	>
+		@components.PageHeader(components.PageHeaderProps{
+			Title:                "Workflows",
+			Subtitle:             "One-click AI automations that run on your Breadbox.",
+			SubtitleHideOnMobile: true,
+		})
+		if !p.Status.Ready {
+			<div role="alert" class="alert alert-warning rounded-xl mt-4 mb-2">
+				@components.LucideIcon("alert-triangle", "w-5 h-5 shrink-0")
+				<div class="flex-1">
+					<div class="font-semibold text-sm">Set up the agent runtime first</div>
+					<div class="text-xs opacity-80">Configure an Anthropic API key in Settings to actually run these workflows. You can still enable presets — they'll stay paused until the runtime is ready.</div>
+				</div>
+				<a href="/settings/agents" class="btn btn-sm btn-ghost">Configure</a>
+			</div>
+		}
+		<div class="mt-4 space-y-6">
+			for _, cat := range p.Categories {
+				@components.SettingsSection(components.SettingsSectionProps{
+					Icon:  cat.Icon,
+					Title: cat.Name,
+				}) {
+					for _, preset := range cat.Presets {
+						@components.SettingsRow(components.SettingsRowProps{
+							Label:   preset.Name,
+							Caption: preset.Description,
+						}) {
+							@workflowPresetControl(preset)
+						}
+					}
+				}
+			}
+		</div>
+	</div>
+}
+
+// workflowPresetControl is the state-dependent right-side control: an enable
+// button when the preset is available, a run toggle once it's instantiated.
+templ workflowPresetControl(preset WorkflowPresetCardProps) {
+	<div class="flex items-center gap-3">
+		<span class="hidden sm:inline-flex items-center gap-1 text-xs text-base-content/40">
+			@components.LucideIcon("clock", "w-3.5 h-3.5")
+			{ preset.TriggerLabel }
+		</span>
+		if preset.Enabled {
+			<input
+				type="checkbox"
+				class="toggle toggle-sm toggle-primary"
+				if preset.WorkflowEnabled {
+					checked
+				}
+				aria-label={ "Toggle " + preset.Name }
+				@change={ "toggleWorkflow('" + preset.WorkflowSlug + "', $event.target)" }
+			/>
+		} else {
+			<button
+				type="button"
+				class="btn btn-soft btn-sm gap-1.5"
+				@click={ "enablePreset('" + preset.Slug + "', $event.target)" }
+			>
+				@components.LucideIcon("plus", "w-4 h-4")
+				Enable
+			</button>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -1,0 +1,33 @@
+//go:build !headless && !lite
+
+package pages
+
+// WorkflowsGalleryProps is the view-model for the /workflows preset gallery.
+type WorkflowsGalleryProps struct {
+	Categories []WorkflowCategoryProps
+	// Status mirrors the agent runtime readiness (reused from agents_list_types).
+	Status    AgentSubsystemStatusProps
+	CSRFToken string
+}
+
+// WorkflowCategoryProps groups presets under a section header.
+type WorkflowCategoryProps struct {
+	Name    string
+	Icon    string // lucide section icon
+	Presets []WorkflowPresetCardProps
+}
+
+// WorkflowPresetCardProps is one preset row in the gallery.
+type WorkflowPresetCardProps struct {
+	Slug         string
+	Name         string
+	Description  string
+	Icon         string // lucide icon for the preset
+	TriggerLabel string // human-readable trigger summary ("After each sync", "Weekly")
+	ToolScope    string // "read_only" | "read_write" — drives a small "applies changes" hint
+
+	// Enablement state.
+	Enabled         bool   // the preset has been instantiated as a workflow
+	WorkflowSlug    string // slug of the instantiated workflow (when Enabled)
+	WorkflowEnabled bool   // the instantiated workflow's run toggle (when Enabled)
+}

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -1,0 +1,71 @@
+// Workflows gallery page factory. Enables presets (instantiate a workflow) and
+// toggles an instantiated workflow's run state. CSRF token is read from the
+// root element's data-csrf attribute. Registers via Alpine.data per the admin
+// page convention (see docs/design-system.md → "Alpine page components").
+document.addEventListener('alpine:init', function () {
+  Alpine.data('workflowsGallery', function () {
+    return {
+      csrfToken: '',
+
+      init: function () {
+        this.csrfToken = this.$el.dataset.csrf || '';
+      },
+
+      restorePageState: function () {
+        if (window.bbProgress) window.bbProgress.finish();
+        var main = document.querySelector('main');
+        if (main) {
+          main.style.opacity = '';
+          main.style.filter = '';
+          main.style.pointerEvents = '';
+        }
+      },
+
+      _post: function (url, body) {
+        return fetch(url, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'X-CSRF-Token': this.csrfToken,
+          },
+          body: body || '',
+        });
+      },
+
+      // Enable a preset: instantiate the workflow, then reload so the row swaps
+      // its "Enable" button for a run toggle.
+      enablePreset: function (slug, btn) {
+        var self = this;
+        if (btn) btn.disabled = true;
+        self._post('/-/workflow-presets/' + encodeURIComponent(slug) + '/enable')
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            window.location.reload();
+          })
+          .catch(function (e) {
+            console.error('enablePreset failed', e);
+            if (btn) btn.disabled = false;
+            self.restorePageState();
+          });
+      },
+
+      // Toggle an instantiated workflow's run state. Reuses the agent
+      // enable/disable endpoints (a workflow IS an agent_definition).
+      toggleWorkflow: function (workflowSlug, el) {
+        var self = this;
+        var enabled = el.checked;
+        var url = '/-/agents/' + encodeURIComponent(workflowSlug) + (enabled ? '/enable' : '/disable');
+        self._post(url)
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+          })
+          .catch(function (e) {
+            console.error('toggleWorkflow failed', e);
+            el.checked = !enabled; // revert
+            self.restorePageState();
+          });
+      },
+    };
+  });
+});


### PR DESCRIPTION
## Workflows sprint — PR 5a: the preset gallery page (`/workflows`)

The user-facing **front door** — a Mintlify-style gallery that renders the codified preset registry (PR 4a) grouped by category, each preset with a one-click enable. This is the heart of what you admired: *"a preset list of workflows users can just enable."*

<img src="https://i.img402.dev/i7y6sbd8dh.jpg" width="900" alt="Workflows gallery page — presets grouped by category with Enable buttons and a runtime-ready banner">

### What ships
- **New admin page** `GET /workflows` (`WorkflowsGalleryPageHandler`), mirroring the Agents list page: parallel-loads `ListWorkflowPresets` + `GetAgentSubsystemStatus`, groups presets by category, renders in the **Settings design language** (`PageHeader` → `SettingsSection` per category → `SettingsRow` per preset).
- **State-dependent control per row** — an **Enable** button when available (`POST /-/workflow-presets/{slug}/enable` → instantiate), a daisy **run toggle** once enabled (reuses the existing `/-/agents/{slug}/enable|disable`). A trigger label (*After each sync* / *Weekly* / *Monthly*) per row.
- **Runtime-ready banner** (`GetAgentSubsystemStatus`) — non-blocking: you can enable presets; they stay paused until the Anthropic key is configured.
- **"Workflows" nav entry** (lucide `workflow`, above Agents) + `pageSectionLabel` (satisfies `TestPageSectionCoversNav`). Alpine sidecar `workflows_gallery.js` (CSRF from `data-csrf`).
- **All daisy-first / existing components** — no new `bb-*` classes (per the design language).

### Validation
```
go build ./... / go vet ./... / go build -tags=lite ./...   PASS
unit: internal/admin (page_section) + pages (scripts_lint)  ok
make css                                                    ok
```
The screenshot above is a **real login → `/workflows` render** (headless Chrome via Playwright against the dedicated sprint test DB): 3 presets across 2 categories, the runtime banner, the Enable buttons. (Captured this way because the shared dev DB has cross-worktree migration conflicts and the browser MCPs need interactive approval unavailable in the autonomous loop.)

**Next slices:** the **configure drawer** (per-preset specialized options, Mintlify's right-side panel), the **runs-tab re-skin** (status filters + retrigger), and the `agents → workflows` rename (4b/4c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
