### PR TITLE
refactor(recurring): extract shared series chips + /design section

### DIFF
--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -210,6 +210,36 @@ templ SectionBadges() {
 	</div>
 }
 
+templ SectionRecurringChips() {
+	<div class="flex flex-col gap-6">
+		@designExample("Type (SeriesTypeChip)", "Structured recurring type — quiet metadata badge. size \"xs\" on dense ledger rows, \"sm\" on the detail header/config.") {
+			<div class="flex flex-wrap items-center gap-2">
+				@components.SeriesTypeChip("Subscription", "xs")
+				@components.SeriesTypeChip("Bill", "xs")
+				@components.SeriesTypeChip("Loan", "xs")
+				@components.SeriesTypeChip("Other", "xs")
+				@components.SeriesTypeChip("Loan", "sm")
+			</div>
+		}
+		@designExample("Renewal health (SeriesRenewalChip)", "Attention chip for an active series' next charge. Only due-soon / overdue / stale earn one; type-aware copy (bill/loan \"Lapsed?\" vs subscription \"Likely cancelled\"). Empty label renders nothing.") {
+			<div class="flex flex-wrap items-center gap-2">
+				@components.SeriesRenewalChip("Due tomorrow", "info")
+				@components.SeriesRenewalChip("Renews in 5d", "info")
+				@components.SeriesRenewalChip("5d overdue", "warning")
+				@components.SeriesRenewalChip("Likely cancelled", "error")
+				@components.SeriesRenewalChip("Lapsed?", "error")
+			</div>
+		}
+		@designExample("Detection confidence (SeriesConfidenceChip)", "Candidate detection band, derived from detection_signals. success / warning / neutral by band.") {
+			<div class="flex flex-wrap items-center gap-2">
+				@components.SeriesConfidenceChip("High", "success")
+				@components.SeriesConfidenceChip("Medium", "warning")
+				@components.SeriesConfidenceChip("Low", "neutral")
+			</div>
+		}
+	</div>
+}
+
 // ─── Alerts ────────────────────────────────────────────────────────────
 
 templ SectionAlerts() {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -258,6 +258,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionBadges() },
 		},
 		{
+			Slug:        "recurring-chips",
+			Title:       "Recurring chips",
+			Description: "Shared chips for the Recurring (recurring-series) surfaces: SeriesTypeChip (type), SeriesRenewalChip (renewal health), SeriesConfidenceChip (detection band). Used across the ledger, candidate cards, and detail page.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionRecurringChips() },
+		},
+		{
 			Slug:        "tags",
 			Title:       "Tags",
 			Description: "Pill-shaped colored tags — bb-tag, bb-tag-sm, bb-tag-lg, bb-tag-ghost, bb-tag-add.",

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -26,9 +26,9 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 		<!-- Status + verdict toolbar -->
 		<div class="flex items-center flex-wrap gap-2 mb-6">
 			<span class={ "badge badge-soft badge-sm", "badge-" + p.Series.StatusTone }>{ p.Series.StatusLabel }</span>
-			<span class="badge badge-ghost badge-sm">{ p.Series.TypeLabel }</span>
+			@components.SeriesTypeChip(p.Series.TypeLabel, "sm")
 			if p.Series.Status == "candidate" {
-				<span class={ "badge badge-soft badge-sm", "badge-" + p.Series.BandTone }>{ p.Series.ConfidenceBand } confidence</span>
+				@components.SeriesConfidenceChip(p.Series.ConfidenceBand, p.Series.BandTone)
 			}
 			<div class="flex-1"></div>
 			switch p.Series.Status {
@@ -51,7 +51,7 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 			Title: "Details",
 		}) {
 			@components.SettingsRow(components.SettingsRowProps{Label: "Type", Caption: "Subscription, bill, loan, or other"}) {
-				<span class="badge badge-soft badge-neutral badge-sm">{ p.Series.TypeLabel }</span>
+				@components.SeriesTypeChip(p.Series.TypeLabel, "sm")
 			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Cadence"}) {
 				<span class="text-sm">{ p.Series.CadenceLabel }</span>
@@ -107,9 +107,7 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 			@components.SettingsRow(components.SettingsRowProps{Label: "Next renewal"}) {
 				<span class="text-sm inline-flex items-center gap-2">
 					{ subscriptionDetailField(p.NextExpected) }
-					if p.Series.RenewalLabel != "" {
-						<span class={ "badge badge-soft badge-xs", "badge-" + p.Series.RenewalTone }>{ p.Series.RenewalLabel }</span>
-					}
+					@components.SeriesRenewalChip(p.Series.RenewalLabel, p.Series.RenewalTone)
 				</span>
 			}
 			@components.SettingsRow(components.SettingsRowProps{Label: "Last seen"}) {

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -169,8 +169,8 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 			<div class="min-w-0 flex-1">
 				<div class="flex items-center gap-2 flex-wrap">
 					<span class="text-sm font-semibold text-base-content truncate">{ s.Name }</span>
-					<span class="badge badge-ghost badge-xs">{ s.TypeLabel }</span>
-					<span class={ "badge badge-soft badge-sm", "badge-" + s.BandTone }>{ s.ConfidenceBand } confidence</span>
+					@components.SeriesTypeChip(s.TypeLabel, "xs")
+					@components.SeriesConfidenceChip(s.ConfidenceBand, s.BandTone)
 				</div>
 				<div class="text-xs text-base-content/50 mt-1">{ s.SignalSummary }</div>
 				<button
@@ -257,7 +257,7 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 				<div class="min-w-0">
 					<div class="flex items-center gap-2 min-w-0">
 						<span class="text-sm font-medium truncate text-base-content">{ s.Name }</span>
-						<span class="badge badge-ghost badge-xs shrink-0">{ s.TypeLabel }</span>
+						@components.SeriesTypeChip(s.TypeLabel, "xs")
 					</div>
 					if s.CategoryName != "" {
 						<div class="text-xs text-base-content/40 truncate">{ s.CategoryName }</div>
@@ -276,9 +276,7 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 		<td>
 			<span class="inline-flex items-center gap-1.5 flex-wrap">
 				<span class={ "badge badge-soft badge-sm", "badge-" + s.StatusTone }>{ s.StatusLabel }</span>
-				if s.RenewalLabel != "" {
-					<span class={ "badge badge-soft badge-xs", "badge-" + s.RenewalTone }>{ s.RenewalLabel }</span>
-				}
+				@components.SeriesRenewalChip(s.RenewalLabel, s.RenewalTone)
 			</span>
 		</td>
 		<td class="text-right">

--- a/internal/templates/components/series_chips.templ
+++ b/internal/templates/components/series_chips.templ
@@ -1,0 +1,31 @@
+package components
+
+// Shared chips for the Recurring (recurring-series) surfaces — the list ledger,
+// candidate cards, and the detail page. Extracted here so the three series
+// surfaces render identical chips; showcased in the /design sandbox under
+// "Recurring chips". They take plain strings (not a row struct) so they stay
+// decoupled from the admin page types.
+
+// SeriesTypeChip renders the structured recurring type (Subscription / Bill /
+// Loan / Other) as a quiet metadata badge. size is the daisy badge size token
+// ("xs" on dense rows, "sm" on the detail header / config grid).
+templ SeriesTypeChip(label, size string) {
+	<span class={ "badge badge-ghost shrink-0", "badge-" + size }>{ label }</span>
+}
+
+// SeriesRenewalChip renders the renewal-health attention chip (e.g. "Renews in
+// 3d", "5d overdue", "Lapsed?"). tone is a daisy color token (info / warning /
+// error). Renders nothing when label is empty — only the states a user should
+// act on earn a chip, so callers can drop the surrounding guard.
+templ SeriesRenewalChip(label, tone string) {
+	if label != "" {
+		<span class={ "badge badge-soft badge-xs", "badge-" + tone }>{ label }</span>
+	}
+}
+
+// SeriesConfidenceChip renders a candidate's detection-confidence band
+// ("High confidence" etc.). tone is the daisy color for the band
+// (success / warning / neutral).
+templ SeriesConfidenceChip(band, tone string) {
+	<span class={ "badge badge-soft badge-sm", "badge-" + tone }>{ band } confidence</span>
+}


### PR DESCRIPTION
Second slice of #2 — extracts the repeated Recurring chip markup into three shared templ components and lands them in the **/design sandbox** (the daisyui sandbox-first rule).

- `SeriesTypeChip(label, size)` — quiet type metadata badge (`badge-ghost`); `xs` on dense rows, `sm` on the detail header/config.
- `SeriesRenewalChip(label, tone)` — renewal-health attention chip; renders nothing on an empty label so callers drop the `if` guard.
- `SeriesConfidenceChip(band, tone)` — candidate detection band.

All 7 call sites in `subscriptions_list.templ` + `subscription_detail.templ` now use the components (behavior-preserving; the detail "Type" row normalizes `soft-neutral` → `ghost` for consistency). New `/design` section **"Recurring chips"** (data group) with the variant matrix.

### Validation
build+vet default/headless/lite; unit (templates + admin, incl. the design smoke test that renders every section); browser-validated `/design/c/recurring-chips` (below) and `/recurring` (no regression — chips render identically via the components).

<img src="https://i.img402.dev/6lhqg0aups.jpg" width="800" alt="/design — Recurring chips section">

Remaining for #2: reuse the transaction-row component for the linked-charges table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
