### PR TITLE
feat(workflows): Mintlify-style configure drawer for preset enable

### DIFF
--- a/internal/admin/workflows_actions.go
+++ b/internal/admin/workflows_actions.go
@@ -19,13 +19,25 @@ import (
 func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := chi.URLParam(r, "slug")
-		wf, err := svc.EnableWorkflowFromPreset(r.Context(), slug, service.EnableWorkflowFromPresetParams{Enabled: true})
+		_ = r.ParseForm()
+		// Configure-drawer fields. enabled defaults to true (the drawer's
+		// "Enable" CTA), but the form can pass enabled=false to set up paused.
+		params := service.EnableWorkflowFromPresetParams{
+			Enabled:                r.FormValue("enabled") != "false",
+			AdditionalInstructions: r.FormValue("additional_instructions"),
+		}
+		if cron := r.FormValue("schedule_cron"); cron != "" {
+			params.ScheduleCron = &cron
+		}
+		wf, err := svc.EnableWorkflowFromPreset(r.Context(), slug, params)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrConflict):
 				writeJSON(w, http.StatusOK, map[string]any{"slug": slug, "already_enabled": true})
 			case errors.Is(err, service.ErrNotFound):
 				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow preset not found")
+			case errors.Is(err, service.ErrInvalidParameter):
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			default:
 				writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_ENABLE_FAILED", err.Error())
 			}

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -57,13 +57,15 @@ func groupWorkflowPresets(views []service.WorkflowPresetView) []pages.WorkflowCa
 			order = append(order, v.Category)
 		}
 		card := pages.WorkflowPresetCardProps{
-			Slug:         v.Slug,
-			Name:         v.Name,
-			Description:  v.Description,
-			Icon:         v.Icon,
-			TriggerLabel: presetTriggerLabel(v),
-			ToolScope:    v.ToolScope,
-			Enabled:      v.Enabled,
+			Slug:          v.Slug,
+			Name:          v.Name,
+			Description:   v.Description,
+			Icon:          v.Icon,
+			TriggerLabel:  presetTriggerLabel(v),
+			ToolScope:     v.ToolScope,
+			ScheduleCron:  v.ScheduleCron,
+			TriggerOnSync: v.TriggerOnSyncComplete,
+			Enabled:       v.Enabled,
 		}
 		if v.WorkflowSlug != nil {
 			card.WorkflowSlug = *v.WorkflowSlug

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -157,7 +157,17 @@ type EnableWorkflowFromPresetParams struct {
 	// Enabled controls whether the instantiated workflow runs immediately.
 	// Defaults to false (instantiated but paused) so a household can review it.
 	Enabled bool
+	// ScheduleCron overrides the preset's default cron for scheduled presets
+	// (ignored for post-sync presets). nil = use the preset default.
+	ScheduleCron *string
+	// AdditionalInstructions, when non-empty, is appended to the composed base
+	// prompt every run — the household's per-workflow tuning, mirroring
+	// Mintlify's "additional prompt over the base prompt".
+	AdditionalInstructions string
 }
+
+// maxAdditionalInstructions caps the per-workflow instruction tuning.
+const maxAdditionalInstructions = 4000
 
 // EnableWorkflowFromPreset instantiates a workflow from a preset: it composes
 // the base prompt, applies the preset defaults, stamps source_template, and
@@ -185,6 +195,14 @@ func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, par
 	if err != nil {
 		return nil, err
 	}
+	// Append the household's per-workflow tuning to the base prompt.
+	instr := strings.TrimSpace(params.AdditionalInstructions)
+	if len(instr) > maxAdditionalInstructions {
+		return nil, fmt.Errorf("%w: additional instructions exceed %d chars", ErrInvalidParameter, maxAdditionalInstructions)
+	}
+	if instr != "" {
+		prompt = prompt + "\n\n## Additional instructions\n\n" + instr
+	}
 
 	create := CreateAgentDefinitionParams{
 		Name:                  preset.Name,
@@ -197,9 +215,16 @@ func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, par
 		TriggerOnSyncComplete: preset.TriggerOnSyncComplete,
 		SourceTemplate:        &preset.Slug,
 	}
-	if preset.ScheduleCron != "" {
+	// Scheduled presets accept a cron override; post-sync presets keep their
+	// event trigger (no cron).
+	if !preset.TriggerOnSyncComplete {
 		cron := preset.ScheduleCron
-		create.ScheduleCron = &cron
+		if params.ScheduleCron != nil && strings.TrimSpace(*params.ScheduleCron) != "" {
+			cron = strings.TrimSpace(*params.ScheduleCron)
+		}
+		if cron != "" {
+			create.ScheduleCron = &cron
+		}
 	}
 	return s.CreateAgentDefinition(ctx, create)
 }

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -5,6 +5,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"breadbox/internal/service"
@@ -78,5 +79,45 @@ func TestEnableWorkflowFromPreset(t *testing.T) {
 	// Unknown preset -> not found.
 	if _, err := svc.EnableWorkflowFromPreset(ctx, "no-such-preset", service.EnableWorkflowFromPresetParams{}); !errors.Is(err, service.ErrNotFound) {
 		t.Fatalf("unknown preset err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestEnableWorkflowFromPreset_WithConfig(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cron := "0 8 * * *"
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{
+		Enabled:                false,
+		ScheduleCron:           &cron,
+		AdditionalInstructions: "Focus on dining-out spend and call out anything unusual.",
+	})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	// Schedule override applied.
+	if wf.ScheduleCron == nil || *wf.ScheduleCron != cron {
+		t.Fatalf("schedule_cron = %v, want %q", wf.ScheduleCron, cron)
+	}
+	// Additional instructions appended to the composed base prompt.
+	if !strings.Contains(wf.Prompt, "Additional instructions") || !strings.Contains(wf.Prompt, "dining-out spend") {
+		t.Fatalf("prompt missing appended instructions; got %d chars", len(wf.Prompt))
+	}
+}
+
+func TestEnableWorkflowFromPreset_PostSyncIgnoresSchedule(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+	cron := "0 8 * * *"
+	// routine-reviewer is post-sync; a schedule override must be ignored.
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{ScheduleCron: &cron})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	if wf.ScheduleCron != nil {
+		t.Fatalf("post-sync preset got a schedule_cron = %v, want nil", *wf.ScheduleCron)
+	}
+	if !wf.TriggerOnSyncComplete {
+		t.Fatalf("routine-reviewer should trigger on sync")
 	}
 }

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -2,9 +2,9 @@ package pages
 
 import "breadbox/internal/templates/components"
 
-// WorkflowsGallery is the /workflows preset gallery: codified, one-click
-// automations grouped by category. Enabling a preset instantiates a workflow;
-// an instantiated workflow shows a run toggle.
+// WorkflowsGallery is the /workflows preset gallery: codified, configurable,
+// one-click automations grouped by category. "Set up" opens a right-side
+// configure drawer; enabling instantiates a workflow with a run toggle.
 templ WorkflowsGallery(p WorkflowsGalleryProps) {
 	<script src="/static/js/admin/components/workflows_gallery.js"></script>
 	<div
@@ -45,11 +45,31 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				}
 			}
 		</div>
+		<!-- Configure drawer: shared backdrop + one slide-over panel per available preset. -->
+		<div
+			x-show="open"
+			x-cloak
+			x-transition:enter="transition-opacity ease-out duration-200"
+			x-transition:enter-start="opacity-0"
+			x-transition:enter-end="opacity-100"
+			x-transition:leave="transition-opacity ease-in duration-150"
+			x-transition:leave-start="opacity-100"
+			x-transition:leave-end="opacity-0"
+			class="fixed inset-0 bg-black/40 z-40"
+			@click="open=''"
+		></div>
+		for _, cat := range p.Categories {
+			for _, preset := range cat.Presets {
+				if !preset.Enabled {
+					@workflowConfigDrawer(preset)
+				}
+			}
+		}
 	</div>
 }
 
-// workflowPresetControl is the state-dependent right-side control: an enable
-// button when the preset is available, a run toggle once it's instantiated.
+// workflowPresetControl is the state-dependent right-side control: a "Set up"
+// button (opens the configure drawer) when available, a run toggle once enabled.
 templ workflowPresetControl(preset WorkflowPresetCardProps) {
 	<div class="flex items-center gap-3">
 		<span class="hidden sm:inline-flex items-center gap-1 text-xs text-base-content/40">
@@ -70,11 +90,95 @@ templ workflowPresetControl(preset WorkflowPresetCardProps) {
 			<button
 				type="button"
 				class="btn btn-soft btn-sm gap-1.5"
-				@click={ "enablePreset('" + preset.Slug + "', $event.target)" }
+				@click={ "open='" + preset.Slug + "'" }
 			>
-				@components.LucideIcon("plus", "w-4 h-4")
-				Enable
+				@components.LucideIcon("settings-2", "w-4 h-4")
+				Set up
 			</button>
 		}
 	</div>
+}
+
+// workflowConfigDrawer is the right-side slide-over for configuring + enabling
+// one preset: trigger/schedule, additional instructions, and run-now.
+templ workflowConfigDrawer(preset WorkflowPresetCardProps) {
+	<div
+		x-show={ "open === '" + preset.Slug + "'" }
+		x-cloak
+		x-transition:enter="transition ease-out duration-200"
+		x-transition:enter-start="translate-x-full"
+		x-transition:enter-end="translate-x-0"
+		x-transition:leave="transition ease-in duration-150"
+		x-transition:leave-start="translate-x-0"
+		x-transition:leave-end="translate-x-full"
+		class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 border-l border-base-300 shadow-xl flex flex-col"
+		@keydown.escape.window="open=''"
+	>
+		<form
+			class="flex flex-col h-full"
+			@submit.prevent={ "submitDrawer('" + preset.Slug + "', $event.target)" }
+		>
+			<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300">
+				<div class="flex items-start gap-3">
+					@components.LucideIcon(preset.Icon, "w-5 h-5 mt-0.5 text-base-content/60 shrink-0")
+					<div>
+						<div class="font-semibold leading-tight">{ preset.Name }</div>
+						<div class="text-xs text-base-content/60 mt-1">{ preset.Description }</div>
+					</div>
+				</div>
+				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
+					@components.LucideIcon("x", "w-4 h-4")
+				</button>
+			</div>
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				<div>
+					<div class="text-sm font-medium mb-1.5">When it runs</div>
+					if preset.TriggerOnSync {
+						<div class="text-sm text-base-content/70 flex items-center gap-2">
+							@components.LucideIcon("refresh-cw", "w-4 h-4 text-base-content/50")
+							After each successful sync
+						</div>
+					} else {
+						<select name="schedule_cron" class="select select-sm w-full">
+							@workflowScheduleOption("0 8 * * *", "Daily — 8:00 AM", preset.ScheduleCron)
+							@workflowScheduleOption("0 7 * * 1", "Weekly — Monday 7:00 AM", preset.ScheduleCron)
+							@workflowScheduleOption("0 8 1 * *", "Monthly — 1st, 8:00 AM", preset.ScheduleCron)
+						</select>
+					}
+				</div>
+				<div>
+					<div class="text-sm font-medium mb-1.5">
+						Additional instructions
+						<span class="text-base-content/40 font-normal">(optional)</span>
+					</div>
+					<textarea
+						name="additional_instructions"
+						rows="4"
+						class="textarea textarea-bordered w-full text-sm"
+						placeholder="Anything specific this workflow should watch for, or how it should behave…"
+					></textarea>
+					<div class="text-xs text-base-content/40 mt-1">Appended to the workflow's built-in prompt on every run.</div>
+				</div>
+				<label class="flex items-center gap-2 text-sm cursor-pointer">
+					<input type="checkbox" name="enabled" value="true" checked class="checkbox checkbox-sm"/>
+					Start running now
+				</label>
+			</div>
+			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
+				<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm gap-1.5">
+					@components.LucideIcon("zap", "w-4 h-4")
+					Enable workflow
+				</button>
+			</div>
+		</form>
+	</div>
+}
+
+templ workflowScheduleOption(value, label, selected string) {
+	if value == selected {
+		<option value={ value } selected>{ label }</option>
+	} else {
+		<option value={ value }>{ label }</option>
+	}
 }

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -25,6 +25,8 @@ type WorkflowPresetCardProps struct {
 	Icon         string // lucide icon for the preset
 	TriggerLabel string // human-readable trigger summary ("After each sync", "Weekly")
 	ToolScope    string // "read_only" | "read_write" — drives a small "applies changes" hint
+	ScheduleCron string // default cron for scheduled presets (empty for post-sync)
+	TriggerOnSync bool  // true = post-sync event trigger (no schedule editing)
 
 	// Enablement state.
 	Enabled         bool   // the preset has been instantiated as a workflow

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -6,6 +6,9 @@ document.addEventListener('alpine:init', function () {
   Alpine.data('workflowsGallery', function () {
     return {
       csrfToken: '',
+      // open holds the slug of the preset whose configure drawer is showing
+      // (empty string = no drawer).
+      open: '',
 
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
@@ -33,18 +36,24 @@ document.addEventListener('alpine:init', function () {
         });
       },
 
-      // Enable a preset: instantiate the workflow, then reload so the row swaps
-      // its "Enable" button for a run toggle.
-      enablePreset: function (slug, btn) {
+      // Submit the configure drawer: instantiate the workflow with the chosen
+      // schedule / instructions / run-now, then reload so the row swaps its
+      // "Set up" button for a run toggle.
+      submitDrawer: function (slug, form) {
         var self = this;
+        var fd = new FormData(form);
+        // An unchecked checkbox is omitted by FormData — make the intent explicit.
+        var box = form.querySelector('input[name="enabled"]');
+        if (box && !box.checked) fd.set('enabled', 'false');
+        var btn = form.querySelector('button[type="submit"]');
         if (btn) btn.disabled = true;
-        self._post('/-/workflow-presets/' + encodeURIComponent(slug) + '/enable')
+        self._post('/-/workflow-presets/' + encodeURIComponent(slug) + '/enable', new URLSearchParams(fd).toString())
           .then(function (res) {
             if (!res.ok) throw new Error('HTTP ' + res.status);
             window.location.reload();
           })
           .catch(function (e) {
-            console.error('enablePreset failed', e);
+            console.error('submitDrawer failed', e);
             if (btn) btn.disabled = false;
             self.restorePageState();
           });


### PR DESCRIPTION
Adds the Mintlify-style **configure drawer** to the Workflows gallery: "Set up" opens a right-side slide-over where you pick the schedule, add optional instructions, and choose whether to start running now — before the workflow is instantiated.

## What changed

- **`workflows_gallery.templ`** — "Enable" button → **"Set up"** that opens a per-preset slide-over (`workflowConfigDrawer`) with a shared dimming backdrop. The drawer carries:
  - **When it runs** — a schedule `<select>` (Daily / Weekly / Monthly) for scheduled presets, or a read-only "After each successful sync" line for post-sync presets.
  - **Additional instructions** (optional) — a textarea appended to the workflow's built-in prompt on every run.
  - **Start running now** — a checkbox; unchecked sets the workflow up paused.
  - A Cancel / **Enable workflow** footer.
- **`EnableWorkflowFromPresetParams`** (service) now accepts `Enabled`, `ScheduleCron` (override, ignored for post-sync presets), and `AdditionalInstructions` (capped at 4000 chars, appended under an `## Additional instructions` heading).
- **`EnableWorkflowPresetAdminHandler`** parses the drawer form and maps `ErrConflict` → 200 `already_enabled`, `ErrNotFound` → 404, `ErrInvalidParameter` → 400.
- **`workflows_gallery.js`** — `submitDrawer(slug, form)` serializes the form (making the unchecked checkbox explicit) and POSTs to `/-/workflow-presets/{slug}/enable`, then reloads so the row swaps "Set up" for the run toggle.

## Validation

```
go build ./...        PASS
go vet ./...          PASS
go test ./...         PASS (unit; incl. scripts_lint + page_section)
go build -tags=lite   PASS (CI-faithful: templ files deleted first)
make css              PASS
```

Integration (against a dedicated `breadbox_test_wf` DB):

```
TestEnableWorkflowFromPreset                     PASS
TestEnableWorkflowFromPreset_WithConfig          PASS  (schedule override + instructions appended)
TestEnableWorkflowFromPreset_PostSyncIgnoresSchedule  PASS  (post-sync preset ignores schedule override)
TestWorkflowPresets*                             PASS
```

## Screenshots

Post-sync preset (Routine Reviewer) — fixed "After each successful sync":

<img src="https://i.img402.dev/cz8h2c8idc.jpg" width="800" alt="Workflows configure drawer — post-sync preset">

Scheduled preset (Weekly Money Digest) — schedule select:

<img src="https://i.img402.dev/zpa3rwa8m6.jpg" width="800" alt="Workflows configure drawer — scheduled preset with schedule select">
