### PR TITLE
feat(recurring): "Due in 30 days" upcoming-spend stat tile

### DIFF
--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -47,6 +47,9 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 		activeCount := 0
 		usersWithSeries := map[string]bool{}
 		typesPresent := map[string]bool{}
+		upcomingByCurrency := map[string]float64{}
+		var upcomingOrder []string
+		upcomingCount := 0
 
 		for _, s := range all {
 			// A rejected verdict ("Not a subscription") is a dismissal — it
@@ -79,6 +82,14 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 						currencyOrder = append(currencyOrder, cur)
 					}
 					monthlyByCurrency[cur] += monthlyEquivalent(s.Cadence, row.Amount)
+					// Upcoming spend: the next charge lands within the next 30 days.
+					if row.DaysUntilRenewal != nil && *row.DaysUntilRenewal >= 0 && *row.DaysUntilRenewal <= 30 {
+						if _, seen := upcomingByCurrency[cur]; !seen {
+							upcomingOrder = append(upcomingOrder, cur)
+						}
+						upcomingByCurrency[cur] += row.Amount
+						upcomingCount++
+					}
 				}
 			}
 		}
@@ -102,12 +113,21 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 				Amount:   monthlyByCurrency[cur],
 			})
 		}
+		var upcomingTotals []pages.SubscriptionMonthlyTotal
+		for _, cur := range upcomingOrder {
+			upcomingTotals = append(upcomingTotals, pages.SubscriptionMonthlyTotal{
+				Currency: cur,
+				Amount:   upcomingByCurrency[cur],
+			})
+		}
 
 		props := pages.SubscriptionsListProps{
 			CSRFToken:      GetCSRFToken(r),
 			ActiveCount:    activeCount,
 			CandidateCount: len(candidates),
 			MonthlyTotals:  monthlyTotals,
+			UpcomingTotals: upcomingTotals,
+			UpcomingCount:  upcomingCount,
 			Candidates:     candidates,
 			Active:         active,
 			Users:          subscriptionUserFilters(ctx, a, usersWithSeries),

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -57,14 +57,14 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 				</div>
 			</div>
 		}
-		<!-- Stat tiles: Active · Monthly-equivalent (per currency) · Candidates -->
+		<!-- Stat tiles: Active · Monthly-equivalent · Due in 30 days · Needs review -->
 		<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterUser === 'all'">
-			<div class="grid grid-cols-3 divide-x divide-base-300">
-				<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+			<div class="grid grid-cols-2 lg:grid-cols-4 gap-px bg-base-300">
+				<div class="bg-base-100 px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 					<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Active</div>
 					<div class="text-sm sm:text-2xl font-semibold tracking-tight truncate">{ fmt.Sprintf("%d", p.ActiveCount) }</div>
 				</div>
-				<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+				<div class="bg-base-100 px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 					<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Monthly equivalent</div>
 					if len(p.MonthlyTotals) == 0 {
 						<div class="text-sm sm:text-2xl font-semibold tracking-tight text-base-content/30 truncate">—</div>
@@ -85,7 +85,29 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 						</div>
 					}
 				</div>
-				<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+				<div class="bg-base-100 px-3 sm:px-5 py-3 sm:py-4 min-w-0">
+					<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1" title="Charges renewing in the next 30 days">Due in 30 days</div>
+					if len(p.UpcomingTotals) == 0 {
+						<div class="text-sm sm:text-2xl font-semibold tracking-tight text-base-content/30 truncate">—</div>
+					} else {
+						<div class="truncate">
+							for i, t := range p.UpcomingTotals {
+								<div class={ "truncate", templ.KV("mt-0.5", i > 0) }>
+									@components.Amount(components.AmountProps{
+										Value:  t.Amount,
+										Intent: components.AmountCost,
+										Class:  amountTileClass(i),
+									})
+									if len(p.UpcomingTotals) > 1 {
+										<span class="text-[0.6rem] sm:text-xs text-base-content/40 ml-1">{ t.Currency }</span>
+									}
+								</div>
+							}
+						</div>
+						<div class="text-[0.6rem] sm:text-xs text-base-content/40 mt-0.5 truncate">{ fmt.Sprintf("%d charge%s", p.UpcomingCount, plural(p.UpcomingCount)) }</div>
+					}
+				</div>
+				<div class="bg-base-100 px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 					<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Needs review</div>
 					<div class={ "text-sm sm:text-2xl font-semibold tracking-tight truncate", templ.KV("text-warning", p.CandidateCount > 0) }>{ fmt.Sprintf("%d", p.CandidateCount) }</div>
 				</div>
@@ -306,4 +328,12 @@ func amountTileClass(i int) string {
 		return "text-sm sm:text-2xl font-semibold tracking-tight"
 	}
 	return "text-xs sm:text-sm font-medium text-base-content/60"
+}
+
+// plural returns "s" unless n == 1.
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -13,6 +13,10 @@ type SubscriptionsListProps struct {
 	CandidateCount int
 	// Monthly-equivalent spend, one entry per currency (never summed across).
 	MonthlyTotals []SubscriptionMonthlyTotal
+	// Upcoming spend in the next 30 days — active series whose next charge lands
+	// within [0,30] days, summed per currency. UpcomingCount is how many.
+	UpcomingTotals []SubscriptionMonthlyTotal
+	UpcomingCount  int
 
 	// Household-member filter strip. Only rendered when len > 1.
 	Users []SubscriptionUserFilter


### PR DESCRIPTION
First part of #8 — a **"Due in 30 days"** upcoming-spend stat tile on /recurring. Sums the next charge of every active series whose renewal lands within the next 30 days (per currency) + the count. Complements "Monthly equivalent" (normalized) with the actual cash about to hit — meaningful once cadences are mixed (an annual renewal only lands in the 30-day window the month it's due).

The stat grid moves from 3-col `divide-x` to a **2-col (mobile) / 4-col (lg) `gap-px` hairline grid** so dividers survive the wrap.

### Validation
build+vet default/headless/lite; unit (templates + admin); browser-validated against `breadbox_test` — desktop 4-up + mobile 2×2 both render with clean dividers, "Due in 30 days $2,255.99 · 3 charges".

<img src="https://i.img402.dev/5vnawgdsxp.jpg" width="800" alt="/recurring — Due in 30 days stat tile">

Remaining for #8: a price-change badge on the ledger (the detail page already shows price-change history). Remaining for #2: tx-row reuse for linked charges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
