### PR TITLE
feat(workflows): Runs tab — status filters, workflow filter, per-run re-run

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -192,6 +192,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/agents", AgentRunsListPageHandler(svc, sm, tr, a.Config.DataDir))
 		r.Get("/agents/definitions", AgentsListPageHandler(svc, sm, tr))
 		r.Get("/workflows", WorkflowsGalleryPageHandler(svc, sm, tr))
+		r.Get("/workflows/runs", WorkflowRunsPageHandler(svc, sm, tr))
 		r.Get("/agents/new", AgentFormPageHandler(svc, sm, tr))
 		// /agents/{slug} is the per-agent landing page (lifetime stats +
 		// last 10 runs); /agents/{slug}/edit remains the form, reachable

--- a/internal/admin/workflows_runs_page.go
+++ b/internal/admin/workflows_runs_page.go
@@ -1,0 +1,140 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/pages"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// workflowRunsPageLimit is the fixed page size for the Workflows runs
+// tab. Offset pagination (prev/next) steps by this amount.
+const workflowRunsPageLimit = 50
+
+// validWorkflowRunStatus whitelists the status filter values surfaced as
+// tabs; anything else is treated as "all".
+var validWorkflowRunStatus = map[string]bool{
+	"success":     true,
+	"error":       true,
+	"in_progress": true,
+	"skipped":     true,
+}
+
+// WorkflowRunsPageHandler renders GET /workflows/runs — the run history
+// scoped to preset-instantiated workflows. Reuses the cross-agent runs
+// query with WorkflowsOnly set, the shared AgentRunRow shape, and the
+// existing admin run-now endpoint for retrigger. Mirrors the layering
+// of AgentRunsListPageHandler but trimmed to the Workflows surface.
+func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		status := r.URL.Query().Get("status")
+		if !validWorkflowRunStatus[status] {
+			status = ""
+		}
+		workflowSlug := r.URL.Query().Get("workflow")
+		offset := 0
+		if v, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil && v > 0 {
+			offset = v
+		}
+
+		var (
+			presets   []service.WorkflowPresetView
+			subStatus *service.AgentSubsystemStatus
+			wg        sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() { defer wg.Done(); presets, _ = svc.ListWorkflowPresets(ctx) }()
+		go func() { defer wg.Done(); subStatus = svc.GetAgentSubsystemStatus(ctx) }()
+		wg.Wait()
+
+		params := service.AllAgentRunListParams{
+			Limit:         workflowRunsPageLimit,
+			Offset:        offset,
+			Status:        status,
+			AgentSlugOrID: workflowSlug,
+			WorkflowsOnly: true,
+		}
+		result, err := svc.ListAllAgentRuns(ctx, params)
+		if err != nil {
+			// Bad workflow filter slug → drop it rather than erroring the
+			// whole page (matches the admin "silently drop invalid
+			// filters" convention).
+			params.AgentSlugOrID = ""
+			workflowSlug = ""
+			result, err = svc.ListAllAgentRuns(ctx, params)
+			if err != nil {
+				tr.RenderError(w, r)
+				return
+			}
+		}
+
+		props := pages.WorkflowRunsProps{
+			StatusFilter:   status,
+			WorkflowSlug:   workflowSlug,
+			Options:        workflowRunFilterOptions(presets),
+			Limit:          workflowRunsPageLimit,
+			Offset:         offset,
+			HasMore:        result.HasMore,
+			CSRFToken:      GetCSRFToken(r),
+			SubsystemReady: buildAgentsListStatus(subStatus).Ready,
+		}
+
+		props.Rows = make([]components.AgentRunRowProps, 0, len(result.Runs))
+		runIDs := make([]string, 0, len(result.Runs))
+		for _, run := range result.Runs {
+			row := agentRunRowFromResponse(run.AgentRunResponse)
+			row.AgentSlug = run.AgentSlug
+			row.AgentName = run.AgentName
+			row.ShowAgent = true
+			props.Rows = append(props.Rows, row)
+			runIDs = append(runIDs, run.AgentRunResponse.ID)
+		}
+
+		// Batched report chips — best-effort; failure just drops the chips.
+		if reportMap, rerr := svc.ListReportSummariesForRunIDs(ctx, runIDs); rerr == nil {
+			for i := range props.Rows {
+				reps, ok := reportMap[runIDs[i]]
+				if !ok {
+					continue
+				}
+				props.Rows[i].Reports = make([]components.AgentRunReportRef, 0, len(reps))
+				for _, rep := range reps {
+					props.Rows[i].Reports = append(props.Rows[i].Reports, components.AgentRunReportRef{
+						ShortID:  rep.ShortID,
+						Title:    rep.Title,
+						Priority: rep.Priority,
+					})
+				}
+			}
+		}
+
+		data := BaseTemplateData(r, sm, "workflows", "Workflows")
+		tr.RenderWithTempl(w, r, data, pages.WorkflowRuns(props))
+	}
+}
+
+// workflowRunFilterOptions builds the workflow dropdown from the enabled
+// presets — each instantiated workflow's slug + name. Disabled presets
+// (never instantiated) can't have runs, so they're omitted.
+func workflowRunFilterOptions(presets []service.WorkflowPresetView) []pages.WorkflowRunFilterOption {
+	opts := make([]pages.WorkflowRunFilterOption, 0, len(presets))
+	for _, v := range presets {
+		if !v.Enabled || v.WorkflowSlug == nil {
+			continue
+		}
+		opts = append(opts, pages.WorkflowRunFilterOption{
+			Slug: *v.WorkflowSlug,
+			Name: v.Name,
+		})
+	}
+	return opts
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -59,28 +59,28 @@ var validAgentSlug = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$`
 
 // AgentDefinitionResponse is the API shape for an agent_definition row.
 type AgentDefinitionResponse struct {
-	ID              string           `json:"id"`
-	ShortID         string           `json:"short_id"`
-	Name            string           `json:"name"`
-	Slug            string           `json:"slug"`
-	Prompt          string           `json:"prompt"`
-	SystemPrompt    *string          `json:"system_prompt,omitempty"`
-	ScheduleCron    *string          `json:"schedule_cron,omitempty"`
-	ToolScope       string           `json:"tool_scope"`
-	AllowedTools    []string         `json:"allowed_tools"`
-	Model           string           `json:"model"`
-	MaxTurns        int              `json:"max_turns"`
-	MaxBudgetUSD    *float64         `json:"max_budget_usd,omitempty"`
-	Enabled               bool             `json:"enabled"`
-	QuietHoursStart       *string          `json:"quiet_hours_start,omitempty"`
-	QuietHoursEnd         *string          `json:"quiet_hours_end,omitempty"`
+	ID              string   `json:"id"`
+	ShortID         string   `json:"short_id"`
+	Name            string   `json:"name"`
+	Slug            string   `json:"slug"`
+	Prompt          string   `json:"prompt"`
+	SystemPrompt    *string  `json:"system_prompt,omitempty"`
+	ScheduleCron    *string  `json:"schedule_cron,omitempty"`
+	ToolScope       string   `json:"tool_scope"`
+	AllowedTools    []string `json:"allowed_tools"`
+	Model           string   `json:"model"`
+	MaxTurns        int      `json:"max_turns"`
+	MaxBudgetUSD    *float64 `json:"max_budget_usd,omitempty"`
+	Enabled         bool     `json:"enabled"`
+	QuietHoursStart *string  `json:"quiet_hours_start,omitempty"`
+	QuietHoursEnd   *string  `json:"quiet_hours_end,omitempty"`
 	// TriggerOnSyncComplete fires this agent after every successful sync
 	// (in addition to any cron schedule). Disabled by default.
-	TriggerOnSyncComplete bool             `json:"trigger_on_sync_complete"`
+	TriggerOnSyncComplete bool `json:"trigger_on_sync_complete"`
 	// SourceTemplate is the workflow-preset slug this definition was
 	// instantiated from, or nil if it was hand-authored.
-	SourceTemplate        *string          `json:"source_template,omitempty"`
-	LastRun               *AgentRunSummary `json:"last_run,omitempty"`
+	SourceTemplate *string          `json:"source_template,omitempty"`
+	LastRun        *AgentRunSummary `json:"last_run,omitempty"`
 	// CostStats30d is populated only by ListAgentDefinitions (the surface
 	// where users want to compare spend at a glance). Single-row
 	// GetAgentDefinition leaves it nil so the edit-page hot path doesn't
@@ -102,8 +102,8 @@ type AgentDefinitionResponse struct {
 	// non-skipped runs. Used by the admin UI to surface a warning when 2+
 	// recent runs hit a safety ceiling. List-only; nil when no run history.
 	RecentCapStats *AgentRecentCapStats `json:"recent_cap_stats,omitempty"`
-	CreatedAt        string  `json:"created_at"`
-	UpdatedAt        string  `json:"updated_at"`
+	CreatedAt      string               `json:"created_at"`
+	UpdatedAt      string               `json:"updated_at"`
 }
 
 // AgentRecentErrorStats is the "is this agent broken right now?" signal —
@@ -161,13 +161,13 @@ type AgentRunResponse struct {
 	// turns at run-start" would be clearer. Pair with turn_count to
 	// render "actual / cap". Until iter-33 this column erroneously
 	// mirrored turn_count, making every run look like it hit the cap.
-	MaxTurnsUsed        *int     `json:"max_turns_used,omitempty"`
-	NumToolCalls        *int     `json:"num_tool_calls,omitempty"`
-	ErrorMessage        *string  `json:"error_message,omitempty"`
-	TranscriptPath      *string  `json:"transcript_path,omitempty"`
-	SessionID           *string  `json:"session_id,omitempty"`
-	OperatorNote        *string  `json:"operator_note,omitempty"`
-	PromptPrefix        *string  `json:"prompt_prefix,omitempty"`
+	MaxTurnsUsed   *int    `json:"max_turns_used,omitempty"`
+	NumToolCalls   *int    `json:"num_tool_calls,omitempty"`
+	ErrorMessage   *string `json:"error_message,omitempty"`
+	TranscriptPath *string `json:"transcript_path,omitempty"`
+	SessionID      *string `json:"session_id,omitempty"`
+	OperatorNote   *string `json:"operator_note,omitempty"`
+	PromptPrefix   *string `json:"prompt_prefix,omitempty"`
 	// HitCap names the safety ceiling this run bumped into when it
 	// terminated, if any: "max_turns" | "max_budget" | nil. Lets the v2
 	// SPA flag "ran into the ceiling" runs separately from clean successes.
@@ -792,6 +792,11 @@ type AllAgentRunListParams struct {
 	HitCap        string
 	Start         *time.Time
 	End           *time.Time
+	// WorkflowsOnly restricts the result to runs whose definition was
+	// instantiated from a workflow preset (source_template IS NOT NULL).
+	// Powers the Workflows → Runs tab, which shows only preset-backed
+	// runs (not hand-authored agents). Default false = every definition.
+	WorkflowsOnly bool
 }
 
 // ListAllAgentRuns returns offset-paginated runs across every agent,
@@ -854,6 +859,11 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 		where = append(where, fmt.Sprintf("r.started_at <= $%d", idx))
 		args = append(args, *p.End)
 		idx++
+	}
+	if p.WorkflowsOnly {
+		// d is the agent_definitions JOIN below; preset-instantiated
+		// workflows carry a non-null source_template.
+		where = append(where, "d.source_template IS NOT NULL")
 	}
 
 	whereClause := ""
@@ -1362,26 +1372,26 @@ func agentIntFromInt4(n pgtype.Int4) *int {
 
 func agentDefinitionFromRow(row db.AgentDefinition, lastRun *AgentRunSummary) AgentDefinitionResponse {
 	return AgentDefinitionResponse{
-		ID:              pgconv.FormatUUID(row.ID),
-		ShortID:         row.ShortID,
-		Name:            row.Name,
-		Slug:            row.Slug,
-		Prompt:          row.Prompt,
-		SystemPrompt:    pgconv.TextPtr(row.SystemPrompt),
-		ScheduleCron:    pgconv.TextPtr(row.ScheduleCron),
-		ToolScope:       row.ToolScope,
-		AllowedTools:    agentAllowedToolsFromBytes(row.AllowedTools),
-		Model:           row.Model,
-		MaxTurns:        int(row.MaxTurns),
-		MaxBudgetUSD:    agentFloatFromNumeric(row.MaxBudgetUsd),
-		Enabled:         row.Enabled,
+		ID:                    pgconv.FormatUUID(row.ID),
+		ShortID:               row.ShortID,
+		Name:                  row.Name,
+		Slug:                  row.Slug,
+		Prompt:                row.Prompt,
+		SystemPrompt:          pgconv.TextPtr(row.SystemPrompt),
+		ScheduleCron:          pgconv.TextPtr(row.ScheduleCron),
+		ToolScope:             row.ToolScope,
+		AllowedTools:          agentAllowedToolsFromBytes(row.AllowedTools),
+		Model:                 row.Model,
+		MaxTurns:              int(row.MaxTurns),
+		MaxBudgetUSD:          agentFloatFromNumeric(row.MaxBudgetUsd),
+		Enabled:               row.Enabled,
 		QuietHoursStart:       pgconv.TextPtr(row.QuietHoursStart),
 		QuietHoursEnd:         pgconv.TextPtr(row.QuietHoursEnd),
 		TriggerOnSyncComplete: row.TriggerOnSyncComplete,
 		SourceTemplate:        pgconv.TextPtr(row.SourceTemplate),
 		LastRun:               lastRun,
-		CreatedAt:       pgconv.TimestampStr(row.CreatedAt),
-		UpdatedAt:       pgconv.TimestampStr(row.UpdatedAt),
+		CreatedAt:             pgconv.TimestampStr(row.CreatedAt),
+		UpdatedAt:             pgconv.TimestampStr(row.UpdatedAt),
 	}
 }
 

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -121,3 +121,46 @@ func TestEnableWorkflowFromPreset_PostSyncIgnoresSchedule(t *testing.T) {
 		t.Fatalf("routine-reviewer should trigger on sync")
 	}
 }
+
+func TestListAllAgentRuns_WorkflowsOnly(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	// A preset-instantiated workflow (source_template set) ...
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	// ... and a hand-authored agent (no source_template).
+	plain := mustCreateAgentDefinition(t, svc, "plain-agent-runs", true)
+
+	// One run apiece. short_id/id/started_at are DB-defaulted.
+	for _, defID := range []string{wf.ID, plain.ID} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO agent_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			defID); err != nil {
+			t.Fatalf("insert run for %s: %v", defID, err)
+		}
+	}
+
+	// Unfiltered: both runs.
+	all, err := svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListAllAgentRuns(all): %v", err)
+	}
+	if len(all.Runs) != 2 {
+		t.Fatalf("unfiltered = %d runs, want 2", len(all.Runs))
+	}
+
+	// WorkflowsOnly: just the preset-backed run.
+	only, err := svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{Limit: 50, WorkflowsOnly: true})
+	if err != nil {
+		t.Fatalf("ListAllAgentRuns(workflows): %v", err)
+	}
+	if len(only.Runs) != 1 {
+		t.Fatalf("WorkflowsOnly = %d runs, want 1", len(only.Runs))
+	}
+	if only.Runs[0].AgentSlug != wf.Slug {
+		t.Fatalf("WorkflowsOnly run slug = %q, want %q", only.Runs[0].AgentSlug, wf.Slug)
+	}
+}

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -46,6 +46,14 @@ type AgentRunRowProps struct {
 	// first. When present, the highest-priority report's title becomes
 	// the row's inline body line; extras collapse into a "+N" indicator.
 	Reports []AgentRunReportRef
+
+	// Actions is an optional trailing control rendered OUTSIDE the row's
+	// navigation anchor (its own daisy `list-row` grid column), so an
+	// interactive affordance like an OverflowMenu retrigger button won't
+	// nest inside the row link. nil = no actions cell (the default; the
+	// global /agents runs list renders identically to before). Used by
+	// the Workflows → Runs tab for a per-run "Re-run" menu.
+	Actions templ.Component
 }
 
 // AgentRunReportRef is the lightweight reference rendered on a row when
@@ -103,6 +111,11 @@ templ AgentRunRow(p AgentRunRowProps) {
 			</div>
 			@agentRunRowCost(p)
 		</a>
+		if p.Actions != nil {
+			<div class="shrink-0 self-center">
+				@p.Actions
+			</div>
+		}
 	</li>
 }
 

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -18,6 +18,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 			Subtitle:             "One-click AI automations that run on your Breadbox.",
 			SubtitleHideOnMobile: true,
 		})
+		@workflowsTabBar("gallery")
 		if !p.Status.Ready {
 			<div role="alert" class="alert alert-warning rounded-xl mt-4 mb-2">
 				@components.LucideIcon("alert-triangle", "w-5 h-5 shrink-0")

--- a/internal/templates/components/pages/workflows_runs.templ
+++ b/internal/templates/components/pages/workflows_runs.templ
@@ -1,0 +1,150 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// WorkflowRuns is the /workflows/runs tab: run history scoped to
+// preset-instantiated workflows, with a status TabBar, a workflow
+// filter, a per-run retrigger menu, and offset pagination. Shares the
+// Gallery/Runs shell with the preset gallery.
+templ WorkflowRuns(p WorkflowRunsProps) {
+	<script src="/static/js/admin/components/workflows_runs.js"></script>
+	<div
+		x-data="workflowsRuns"
+		data-csrf={ p.CSRFToken }
+		x-init="$store.shortcuts.setScope('workflows')"
+		x-destroy="$store.shortcuts.setScope('global')"
+	>
+		@components.PageHeader(components.PageHeaderProps{
+			Title:                "Workflows",
+			Subtitle:             "Run history across your enabled workflows.",
+			SubtitleHideOnMobile: true,
+		})
+		@workflowsTabBar("runs")
+		<div class="mt-4 space-y-4">
+			@workflowRunsFilters(p)
+			if len(p.Rows) == 0 {
+				@workflowRunsEmpty(p)
+			} else {
+				@components.AgentRunRowList() {
+					for _, r := range p.Rows {
+						@components.AgentRunRow(workflowRunRow(r, p.SubsystemReady))
+					}
+				}
+				@workflowRunsPagination(p)
+			}
+		</div>
+	</div>
+}
+
+// workflowRunsFilters renders the status TabBar (segmented box variant)
+// plus the workflow dropdown. Status switches via plain links (each
+// preserves the workflow filter); the workflow select is a GET form so
+// it works without JS and preserves the active status.
+templ workflowRunsFilters(p WorkflowRunsProps) {
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		@components.TabBar(components.TabBarProps{
+			Variant:   "box",
+			AriaLabel: "Filter runs by status",
+			Items: []components.TabBarItem{
+				{Label: "All", Href: workflowRunsHref("", p.WorkflowSlug), Active: p.StatusFilter == ""},
+				{Label: "Success", Href: workflowRunsHref("success", p.WorkflowSlug), Active: p.StatusFilter == "success"},
+				{Label: "Error", Href: workflowRunsHref("error", p.WorkflowSlug), Active: p.StatusFilter == "error"},
+				{Label: "In progress", Href: workflowRunsHref("in_progress", p.WorkflowSlug), Active: p.StatusFilter == "in_progress"},
+				{Label: "Skipped", Href: workflowRunsHref("skipped", p.WorkflowSlug), Active: p.StatusFilter == "skipped"},
+			},
+		})
+		if len(p.Options) > 0 {
+			<form method="GET" action="/workflows/runs" class="shrink-0">
+				<input type="hidden" name="status" value={ p.StatusFilter }/>
+				<select
+					name="workflow"
+					class="select select-sm bg-base-200 w-full sm:w-56"
+					onchange="this.form.submit()"
+					aria-label="Filter by workflow"
+				>
+					if p.WorkflowSlug == "" {
+						<option value="" selected>All workflows</option>
+					} else {
+						<option value="">All workflows</option>
+					}
+					for _, o := range p.Options {
+						if o.Slug == p.WorkflowSlug {
+							<option value={ o.Slug } selected>{ o.Name }</option>
+						} else {
+							<option value={ o.Slug }>{ o.Name }</option>
+						}
+					}
+				</select>
+			</form>
+		}
+	</div>
+}
+
+// workflowRunActions is the per-row trailing menu: re-run the workflow
+// now (disabled when the runtime isn't ready) or jump to the run detail.
+// retrigger() lives in workflows_runs.js and POSTs to the existing
+// admin run-now endpoint.
+templ workflowRunActions(slug, shortID string, ready bool) {
+	@components.OverflowMenu(components.OverflowMenuProps{
+		AriaLabel: "Run " + shortID + " actions",
+		Size:      "xs",
+		Items: []components.OverflowMenuItem{
+			{
+				Label:     "Re-run workflow",
+				Icon:      "refresh-cw",
+				OnClick:   "retrigger('" + slug + "')",
+				Disabled:  !ready,
+				AriaLabel: "Re-run this workflow now",
+			},
+			{
+				Label: "View run",
+				Icon:  "external-link",
+				Href:  templ.SafeURL("/agents/runs/" + shortID),
+			},
+		},
+	})
+}
+
+// workflowRunsEmpty is the no-runs / no-match card.
+templ workflowRunsEmpty(p WorkflowRunsProps) {
+	@components.EmptyState(components.EmptyStateProps{
+		Icon:    "history",
+		Title:   workflowRunsEmptyTitle(p),
+		Body:    "Runs appear here after a workflow fires — on its schedule, after a sync, or when you re-run it.",
+		Compact: true,
+		InCard:  true,
+	})
+}
+
+// workflowRunsPagination renders prev/next offset controls as a daisy
+// join, shown only when there's somewhere to page to.
+templ workflowRunsPagination(p WorkflowRunsProps) {
+	if p.Offset > 0 || p.HasMore {
+		<div class="flex justify-center pt-1">
+			<div class="join">
+				if p.Offset > 0 {
+					<a class="join-item btn btn-sm gap-1" href={ workflowRunsPageHref(p, -1) }>
+						@components.LucideIcon("chevron-left", "w-4 h-4")
+						Prev
+					</a>
+				} else {
+					<button class="join-item btn btn-sm gap-1" disabled>
+						@components.LucideIcon("chevron-left", "w-4 h-4")
+						Prev
+					</button>
+				}
+				if p.HasMore {
+					<a class="join-item btn btn-sm gap-1" href={ workflowRunsPageHref(p, 1) }>
+						Next
+						@components.LucideIcon("chevron-right", "w-4 h-4")
+					</a>
+				} else {
+					<button class="join-item btn btn-sm gap-1" disabled>
+						Next
+						@components.LucideIcon("chevron-right", "w-4 h-4")
+					</button>
+				}
+			</div>
+		</div>
+	}
+}

--- a/internal/templates/components/pages/workflows_runs_types.go
+++ b/internal/templates/components/pages/workflows_runs_types.go
@@ -1,0 +1,96 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"net/url"
+	"strconv"
+
+	"breadbox/internal/templates/components"
+
+	"github.com/a-h/templ"
+)
+
+// WorkflowRunsProps is the view-model for the /workflows/runs tab — the
+// run history scoped to preset-instantiated workflows. It reuses the
+// shared AgentRunRow shape for each row; the page adds a status TabBar,
+// a workflow filter, a per-run retrigger action, and offset pagination.
+type WorkflowRunsProps struct {
+	Rows         []components.AgentRunRowProps
+	StatusFilter string                    // "" | success | error | in_progress | skipped
+	WorkflowSlug string                    // active workflow filter ("" = all)
+	Options      []WorkflowRunFilterOption // workflow dropdown options (enabled workflows)
+	Limit        int
+	Offset       int
+	HasMore      bool
+	CSRFToken    string
+
+	// SubsystemReady gates the retrigger action — when the agent runtime
+	// isn't configured, the "Re-run" item renders disabled instead of
+	// firing a run that would only fail.
+	SubsystemReady bool
+}
+
+// WorkflowRunFilterOption is one entry in the workflow filter dropdown.
+type WorkflowRunFilterOption struct {
+	Slug string
+	Name string
+}
+
+// workflowRunRow attaches the per-row retrigger OverflowMenu to a base
+// run row. Kept as a Go helper (rather than inline templ) so the
+// handler can build plain AgentRunRowProps and the templ layer owns the
+// action wiring.
+func workflowRunRow(r components.AgentRunRowProps, ready bool) components.AgentRunRowProps {
+	r.Actions = workflowRunActions(r.AgentSlug, r.ShortID, ready)
+	return r
+}
+
+// workflowRunsHref builds a /workflows/runs URL preserving the status +
+// workflow filters. Used by the status TabBar so switching status keeps
+// the workflow filter, and vice versa.
+func workflowRunsHref(status, workflow string) templ.SafeURL {
+	return templ.SafeURL(workflowRunsURL(status, workflow, 0))
+}
+
+// workflowRunsPageHref steps the offset by one page in either direction
+// while preserving both filters. dir is -1 (prev) or +1 (next).
+func workflowRunsPageHref(p WorkflowRunsProps, dir int) templ.SafeURL {
+	limit := p.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	off := p.Offset + dir*limit
+	if off < 0 {
+		off = 0
+	}
+	return templ.SafeURL(workflowRunsURL(p.StatusFilter, p.WorkflowSlug, off))
+}
+
+func workflowRunsURL(status, workflow string, offset int) string {
+	q := url.Values{}
+	if status != "" {
+		q.Set("status", status)
+	}
+	if workflow != "" {
+		q.Set("workflow", workflow)
+	}
+	if offset > 0 {
+		q.Set("offset", strconv.Itoa(offset))
+	}
+	s := "/workflows/runs"
+	if enc := q.Encode(); enc != "" {
+		s += "?" + enc
+	}
+	return s
+}
+
+// workflowRunsEmptyTitle adapts the empty-state headline to whether a
+// filter is active, so a filtered-to-nothing view doesn't read as "no
+// runs ever".
+func workflowRunsEmptyTitle(p WorkflowRunsProps) string {
+	if p.StatusFilter != "" || p.WorkflowSlug != "" {
+		return "No runs match this filter"
+	}
+	return "No workflow runs yet"
+}

--- a/internal/templates/components/pages/workflows_shell.templ
+++ b/internal/templates/components/pages/workflows_shell.templ
@@ -1,0 +1,31 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// workflowsTabBar renders the Gallery / Runs two-tab nav shared between
+// /workflows (the preset gallery) and /workflows/runs (the run history).
+// Both pages mount it immediately under the PageHeader so the user can
+// switch between "browse & enable" and "what has run" without a trip to
+// the sidebar — mirrors the agents Runs/Agents shell.
+//
+// active is the slug of the current tab — "gallery" or "runs".
+templ workflowsTabBar(active string) {
+	@components.TabBar(components.TabBarProps{
+		Variant:   "border",
+		AriaLabel: "Workflows sections",
+		Items: []components.TabBarItem{
+			{
+				Label:  "Gallery",
+				Href:   "/workflows",
+				Icon:   "layout-grid",
+				Active: active == "gallery",
+			},
+			{
+				Label:  "Runs",
+				Href:   "/workflows/runs",
+				Icon:   "history",
+				Active: active == "runs",
+			},
+		},
+	})
+}

--- a/static/js/admin/components/workflows_runs.js
+++ b/static/js/admin/components/workflows_runs.js
@@ -1,0 +1,44 @@
+// Workflows runs tab factory. Provides the per-row "Re-run workflow"
+// action, which POSTs to the existing admin run-now endpoint (a workflow
+// IS an agent_definition) and reloads so the fresh in-progress run shows
+// at the top. CSRF token comes from the root element's data-csrf.
+document.addEventListener('alpine:init', function () {
+  Alpine.data('workflowsRuns', function () {
+    return {
+      csrfToken: '',
+
+      init: function () {
+        this.csrfToken = this.$el.dataset.csrf || '';
+      },
+
+      restorePageState: function () {
+        if (window.bbProgress) window.bbProgress.finish();
+        var main = document.querySelector('main');
+        if (main) {
+          main.style.opacity = '';
+          main.style.filter = '';
+          main.style.pointerEvents = '';
+        }
+      },
+
+      // Re-run the workflow now. Fires a fresh run of the underlying
+      // definition (no prompt override); on success reload to surface it.
+      retrigger: function (slug) {
+        var self = this;
+        fetch('/-/agents/' + encodeURIComponent(slug) + '/run', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'X-CSRF-Token': this.csrfToken },
+        })
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            window.location.reload();
+          })
+          .catch(function (e) {
+            console.error('retrigger failed', e);
+            self.restorePageState();
+          });
+      },
+    };
+  });
+});


### PR DESCRIPTION
Adds a **Runs tab** to the Workflows surface — run history scoped to preset-instantiated workflows, with status-filter tabs, a workflow filter, and a per-run **Re-run** action. Pairs with the gallery as a two-tab shell (Gallery / Runs).

## What changed

- **`GET /workflows/runs`** (`WorkflowRunsPageHandler`) — reuses the cross-agent runs query (`ListAllAgentRuns`) with a new `WorkflowsOnly` filter, the shared `AgentRunRow` shape, and batched report-chip enrichment. No new REST surface (so no OpenAPI/api-endpoints drift).
- **`AllAgentRunListParams.WorkflowsOnly`** (service) — additive filter: `WHERE d.source_template IS NOT NULL` on the existing `agent_definitions` join. Default false = unchanged `/agents` behavior.
- **Two-tab shell** — `workflowsTabBar` (Gallery / Runs) mounted under the header on both `/workflows` and `/workflows/runs`.
- **Status filter** — daisy `TabBar` (box variant): All / Success / Error / In progress / Skipped. Plain links that preserve the workflow filter.
- **Workflow filter** — a GET-form `<select>` of enabled workflows (works without JS, preserves the active status).
- **Per-run Re-run** — `AgentRunRow` gains an optional `Actions` slot rendered *outside* the row's nav anchor (its own `list-row` grid column, so it doesn't nest an interactive control in the link). The Workflows runs tab fills it with an `OverflowMenu` (Re-run workflow → `POST /-/agents/{slug}/run`; View run). `nil` everywhere else → `/agents` renders byte-identically.
- Offset pagination (prev/next), empty state, and a small `workflows_runs.js` Alpine factory for the retrigger POST.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. scripts_lint, pages, admin, OpenAPI-drift)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped !headless && !lite)
go vet  -tags=headless ./...   PASS
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Integration (dedicated `breadbox_test_wf` DB):

```
TestListAllAgentRuns_WorkflowsOnly   PASS  (seeds a workflow run + a plain-agent run; asserts only the workflow run returns under WorkflowsOnly)
TestEnableWorkflowFromPreset*        PASS
```

## Screenshots

Runs tab — status tabs, workflow filter, status-colored rows (error + skipped body lines), per-row kebab:

<img src="https://i.img402.dev/a2w7cnet3j.jpg" width="800" alt="Workflows runs tab">

Per-run Re-run menu open:

<img src="https://i.img402.dev/reqp07779a.jpg" width="800" alt="Workflows runs — retrigger menu">

Gallery with the new Gallery / Runs tab bar:

<img src="https://i.img402.dev/c14e7lozvu.jpg" width="800" alt="Workflows gallery with tab bar">
