### PR TITLE
feat(recurring): "Price ↑" badge on the ledger for rising-price series

### DIFF
--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -235,6 +235,9 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 	row.TypeLabel = recurringTypeLabel(s.Type)
 	row.RenewalLabel, row.RenewalTone = subscriptionRenewal(s)
 	row.DaysUntilRenewal = s.DaysUntilRenewal
+	if sig, ok := decodeSignals(s.DetectionSignals); ok {
+		row.PriceChanged = sig.AmountBranch == "monotonic_drift"
+	}
 	if s.LastAmount != nil {
 		row.HasAmount = true
 		row.Amount = math.Abs(*s.LastAmount)

--- a/internal/admin/subscriptions_renewal_test.go
+++ b/internal/admin/subscriptions_renewal_test.go
@@ -61,3 +61,27 @@ func TestRecurringTypeLabel(t *testing.T) {
 		}
 	}
 }
+
+// TestSubscriptionRow_PriceChanged verifies the ledger price-change flag is
+// derived from detection_signals.amount_branch == "monotonic_drift".
+func TestSubscriptionRow_PriceChanged(t *testing.T) {
+	empty := map[string]string{}
+	drift := subscriptionRow(service.SeriesResponse{
+		Type: service.SeriesTypeSubscription, Status: service.SeriesStatusActive,
+		DetectionSignals: []byte(`{"amount_branch":"monotonic_drift"}`),
+	}, empty, empty)
+	if !drift.PriceChanged {
+		t.Error("expected PriceChanged=true for monotonic_drift signals")
+	}
+	tight := subscriptionRow(service.SeriesResponse{
+		Type: service.SeriesTypeSubscription, Status: service.SeriesStatusActive,
+		DetectionSignals: []byte(`{"amount_branch":"tight"}`),
+	}, empty, empty)
+	if tight.PriceChanged {
+		t.Error("expected PriceChanged=false for tight-band signals")
+	}
+	none := subscriptionRow(service.SeriesResponse{Type: service.SeriesTypeSubscription, Status: service.SeriesStatusActive}, empty, empty)
+	if none.PriceChanged {
+		t.Error("expected PriceChanged=false when there are no detection signals")
+	}
+}

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -299,6 +299,12 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 			<span class="inline-flex items-center gap-1.5 flex-wrap">
 				<span class={ "badge badge-soft badge-sm", "badge-" + s.StatusTone }>{ s.StatusLabel }</span>
 				@components.SeriesRenewalChip(s.RenewalLabel, s.RenewalTone)
+				if s.PriceChanged {
+					<span class="badge badge-soft badge-warning badge-xs gap-1" title="Price has been rising">
+						@components.LucideIcon("trending-up", "w-3 h-3")
+						Price
+					</span>
+				}
 			</span>
 		</td>
 		<td class="text-right">

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -74,6 +74,10 @@ type SubscriptionRow struct {
 	// overdue), nil when there's no projection. Drives the ledger's
 	// renewal-urgency sort. Active series only.
 	DaysUntilRenewal *int
+	// PriceChanged flags a series the detector saw steadily raising its price
+	// (detection_signals amount_branch == "monotonic_drift") — surfaced as a
+	// "Price ↑" chip on the ledger. The detail page shows the full from→to history.
+	PriceChanged bool
 
 	HasAmount bool
 	Amount    float64 // last_amount in dollars


### PR DESCRIPTION
Completes **#8** — a **"↗ Price"** chip on the /recurring ledger for any tracked series the detector saw steadily raising its price (`detection_signals.amount_branch == "monotonic_drift"`). An at-a-glance "this one's getting more expensive" signal in the Status cell; the detail page already shows the full from→to price-change history.

`SubscriptionRow.PriceChanged` is derived in `subscriptionRow` from the decoded signals.

### Validation
build+vet default/headless/lite; unit (`TestSubscriptionRow_PriceChanged` — drift→true, tight/none→false); browser-validated against `breadbox_test` — only the `monotonic_drift` series shows the chip.

<img src="https://i.img402.dev/0z1gcfkwrc.jpg" width="800" alt="/recurring ledger — Price-rising chip on Netflix">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
