### PR TITLE
feat(workflows): drawer governance — projected cost + first-enable consent

### DIFF
--- a/internal/admin/workflows_actions.go
+++ b/internal/admin/workflows_actions.go
@@ -20,6 +20,18 @@ func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := chi.URLParam(r, "slug")
 		_ = r.ParseForm()
+
+		// First-enable consent gate: until the household has acknowledged
+		// that workflows run Claude over their ledger (at cost), require an
+		// explicit consent=true on the enable. Server-side enforcement
+		// backs the drawer's disabled-until-checked button.
+		consented := svc.WorkflowsConsentAcknowledged(r.Context())
+		if !consented && r.FormValue("consent") != "true" {
+			writeError(w, http.StatusBadRequest, "CONSENT_REQUIRED",
+				"Acknowledge that workflows run Claude over your financial data before enabling.")
+			return
+		}
+
 		// Configure-drawer fields. enabled defaults to true (the drawer's
 		// "Enable" CTA), but the form can pass enabled=false to set up paused.
 		params := service.EnableWorkflowFromPresetParams{
@@ -42,6 +54,10 @@ func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
 				writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_ENABLE_FAILED", err.Error())
 			}
 			return
+		}
+		// Record the one-time consent on the first successful enable.
+		if !consented {
+			_ = svc.AcknowledgeWorkflowsConsent(r.Context())
 		}
 		writeJSON(w, http.StatusOK, wf)
 	}

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -24,11 +24,13 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			presets    []service.WorkflowPresetView
 			presetsErr error
 			status     *service.AgentSubsystemStatus
+			consented  bool
 			wg         sync.WaitGroup
 		)
-		wg.Add(2)
+		wg.Add(3)
 		go func() { defer wg.Done(); presets, presetsErr = svc.ListWorkflowPresets(ctx) }()
 		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
+		go func() { defer wg.Done(); consented = svc.WorkflowsConsentAcknowledged(ctx) }()
 		wg.Wait()
 
 		if presetsErr != nil {
@@ -37,9 +39,10 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 		}
 
 		props := pages.WorkflowsGalleryProps{
-			Categories: groupWorkflowPresets(presets),
-			Status:     buildAgentsListStatus(status),
-			CSRFToken:  GetCSRFToken(r),
+			Categories:          groupWorkflowPresets(presets),
+			Status:              buildAgentsListStatus(status),
+			CSRFToken:           GetCSRFToken(r),
+			ConsentAcknowledged: consented,
 		}
 
 		data := BaseTemplateData(r, sm, "workflows", "Workflows")
@@ -57,15 +60,16 @@ func groupWorkflowPresets(views []service.WorkflowPresetView) []pages.WorkflowCa
 			order = append(order, v.Category)
 		}
 		card := pages.WorkflowPresetCardProps{
-			Slug:          v.Slug,
-			Name:          v.Name,
-			Description:   v.Description,
-			Icon:          v.Icon,
-			TriggerLabel:  presetTriggerLabel(v),
-			ToolScope:     v.ToolScope,
-			ScheduleCron:  v.ScheduleCron,
-			TriggerOnSync: v.TriggerOnSyncComplete,
-			Enabled:       v.Enabled,
+			Slug:             v.Slug,
+			Name:             v.Name,
+			Description:      v.Description,
+			Icon:             v.Icon,
+			TriggerLabel:     presetTriggerLabel(v),
+			ToolScope:        v.ToolScope,
+			ScheduleCron:     v.ScheduleCron,
+			TriggerOnSync:    v.TriggerOnSyncComplete,
+			EstCostPerRunUSD: v.EstCostPerRunUSD,
+			Enabled:          v.Enabled,
 		}
 		if v.WorkflowSlug != nil {
 			card.WorkflowSlug = *v.WorkflowSlug

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -66,6 +66,14 @@ const (
 	// one. Default: "bottts-neutral" (robot identicons on a flat
 	// transparent background).
 	KeyAvatarAgentStyle = "avatar.dicebear_style_agent"
+
+	// KeyWorkflowsConsentAckAt records when the household first
+	// acknowledged that enabling a workflow runs Claude over their
+	// financial ledger (incurring Anthropic API cost). Stored as an
+	// RFC3339 timestamp; non-empty = acknowledged. Gates the consent
+	// checkbox in the workflow configure drawer — shown on first enable,
+	// hidden thereafter.
+	KeyWorkflowsConsentAckAt = "workflows.consent_acknowledged_at"
 )
 
 // AuthMode values for KeyAgentAuthMode.

--- a/internal/service/workflow_governance.go
+++ b/internal/service/workflow_governance.go
@@ -1,0 +1,32 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"breadbox/internal/appconfig"
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+)
+
+// WorkflowsConsentAcknowledged reports whether the household has already
+// acknowledged that enabling a workflow runs Claude over their financial
+// ledger (incurring Anthropic API cost). The acknowledgement is a
+// one-time, household-global gate — once given, the configure drawer
+// stops showing the consent checkbox. Best-effort: a read error reads as
+// "not acknowledged" so the safe (consent-required) path wins.
+func (s *Service) WorkflowsConsentAcknowledged(ctx context.Context) bool {
+	return appconfig.String(ctx, s.Queries, appconfig.KeyWorkflowsConsentAckAt, "") != ""
+}
+
+// AcknowledgeWorkflowsConsent records the household's first-enable consent
+// acknowledgement as an RFC3339 timestamp. Idempotent — re-acknowledging
+// just refreshes the timestamp.
+func (s *Service) AcknowledgeWorkflowsConsent(ctx context.Context) error {
+	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   appconfig.KeyWorkflowsConsentAckAt,
+		Value: pgconv.Text(time.Now().UTC().Format(time.RFC3339)),
+	})
+}

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -30,6 +30,12 @@ type WorkflowPreset struct {
 	MaxTurns              int    // 0 = DefaultAgentMaxTurns
 	ScheduleCron          string // empty = no cron
 	TriggerOnSyncComplete bool   // fire after each successful sync
+
+	// EstCostPerRunUSD is a rough per-run Anthropic-cost estimate, surfaced
+	// as a "projected cost" hint in the configure drawer so a self-hoster
+	// paying their own bill sees the order of magnitude before enabling.
+	// Deliberately approximate — actual cost is recorded per run.
+	EstCostPerRunUSD float64
 }
 
 // workflowPresets is the starter catalog. Order is the gallery display order.
@@ -50,6 +56,7 @@ var workflowPresets = []WorkflowPreset{
 		},
 		ToolScope:             "read_write",
 		TriggerOnSyncComplete: true,
+		EstCostPerRunUSD:      0.02, // short, efficient per-sync review
 	},
 	{
 		Slug:        "weekly-money-digest",
@@ -60,8 +67,9 @@ var workflowPresets = []WorkflowPreset{
 		PromptBlocks: []string{
 			"strategy-spending-report",
 		},
-		ToolScope:    "read_only",
-		ScheduleCron: "0 7 * * 1", // Mondays at 7:00
+		ToolScope:        "read_only",
+		ScheduleCron:     "0 7 * * 1", // Mondays at 7:00
+		EstCostPerRunUSD: 0.05,        // reads a week of activity for the digest
 	},
 	{
 		Slug:        "subscription-auditor",
@@ -73,8 +81,9 @@ var workflowPresets = []WorkflowPreset{
 			"strategy-anomaly-detection",
 			"merchant-analysis",
 		},
-		ToolScope:    "read_write",
-		ScheduleCron: "0 8 1 * *", // 1st of the month at 08:00
+		ToolScope:        "read_write",
+		ScheduleCron:     "0 8 1 * *", // 1st of the month at 08:00
+		EstCostPerRunUSD: 0.04,        // monthly recurring-charge scan
 	},
 }
 

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -164,3 +164,31 @@ func TestListAllAgentRuns_WorkflowsOnly(t *testing.T) {
 		t.Fatalf("WorkflowsOnly run slug = %q, want %q", only.Runs[0].AgentSlug, wf.Slug)
 	}
 }
+
+func TestWorkflowsConsent(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("fresh household should not have acknowledged consent")
+	}
+	if err := svc.AcknowledgeWorkflowsConsent(ctx); err != nil {
+		t.Fatalf("AcknowledgeWorkflowsConsent: %v", err)
+	}
+	if !svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("consent should be acknowledged after AcknowledgeWorkflowsConsent")
+	}
+}
+
+func TestWorkflowPresetsHaveCostEstimates(t *testing.T) {
+	svc, _, _ := newService(t)
+	views, err := svc.ListWorkflowPresets(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+	for _, v := range views {
+		if v.EstCostPerRunUSD <= 0 {
+			t.Errorf("preset %q has non-positive EstCostPerRunUSD %v", v.Slug, v.EstCostPerRunUSD)
+		}
+	}
+}

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -62,7 +62,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 		for _, cat := range p.Categories {
 			for _, preset := range cat.Presets {
 				if !preset.Enabled {
-					@workflowConfigDrawer(preset)
+					@workflowConfigDrawer(preset, p.ConsentAcknowledged)
 				}
 			}
 		}
@@ -101,8 +101,10 @@ templ workflowPresetControl(preset WorkflowPresetCardProps) {
 }
 
 // workflowConfigDrawer is the right-side slide-over for configuring + enabling
-// one preset: trigger/schedule, additional instructions, and run-now.
-templ workflowConfigDrawer(preset WorkflowPresetCardProps) {
+// one preset: trigger/schedule, projected cost, additional instructions,
+// run-now, and (on first enable) a consent acknowledgement. consentAck=true
+// hides the consent gate once the household has already acknowledged.
+templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 	<div
 		x-show={ "open === '" + preset.Slug + "'" }
 		x-cloak
@@ -116,6 +118,7 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps) {
 		@keydown.escape.window="open=''"
 	>
 		<form
+			x-data={ "{ cron: '" + preset.ScheduleCron + "', consent: false }" }
 			class="flex flex-col h-full"
 			@submit.prevent={ "submitDrawer('" + preset.Slug + "', $event.target)" }
 		>
@@ -139,12 +142,20 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps) {
 							@components.LucideIcon("refresh-cw", "w-4 h-4 text-base-content/50")
 							After each successful sync
 						</div>
+						<div class="text-xs text-base-content/45 mt-1.5 flex items-center gap-1">
+							@components.LucideIcon("circle-dollar-sign", "w-3.5 h-3.5")
+							{ "≈ $" + workflowCostStr(preset.EstCostPerRunUSD) + " per run" }
+						</div>
 					} else {
-						<select name="schedule_cron" class="select select-sm w-full">
+						<select name="schedule_cron" x-model="cron" class="select select-sm w-full">
 							@workflowScheduleOption("0 8 * * *", "Daily — 8:00 AM", preset.ScheduleCron)
 							@workflowScheduleOption("0 7 * * 1", "Weekly — Monday 7:00 AM", preset.ScheduleCron)
 							@workflowScheduleOption("0 8 1 * *", "Monthly — 1st, 8:00 AM", preset.ScheduleCron)
 						</select>
+						<div
+							class="text-xs text-base-content/45 mt-1.5 flex items-center gap-1"
+							x-text={ "projectedCost(cron, " + workflowCostStr(preset.EstCostPerRunUSD) + ", false)" }
+						></div>
 					}
 				</div>
 				<div>
@@ -164,13 +175,26 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps) {
 					<input type="checkbox" name="enabled" value="true" checked class="checkbox checkbox-sm"/>
 					Start running now
 				</label>
+				if !consentAck {
+					<label class="flex items-start gap-2 text-xs cursor-pointer rounded-lg bg-base-200/60 p-3 border border-base-300">
+						<input type="checkbox" name="consent" value="true" x-model="consent" class="checkbox checkbox-xs mt-0.5"/>
+						<span class="text-base-content/70">I understand this runs Claude over my household's financial data via the Anthropic API, which incurs usage cost.</span>
+					</label>
+				}
 			</div>
 			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
 				<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
-				<button type="submit" class="btn btn-primary btn-sm gap-1.5">
-					@components.LucideIcon("zap", "w-4 h-4")
-					Enable workflow
-				</button>
+				if consentAck {
+					<button type="submit" class="btn btn-primary btn-sm gap-1.5">
+						@components.LucideIcon("zap", "w-4 h-4")
+						Enable workflow
+					</button>
+				} else {
+					<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="!consent">
+						@components.LucideIcon("zap", "w-4 h-4")
+						Enable workflow
+					</button>
+				}
 			</div>
 		</form>
 	</div>

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -2,12 +2,25 @@
 
 package pages
 
+import "strconv"
+
+// workflowCostStr formats a per-run cost estimate as a 2-decimal string
+// for the drawer's projected-cost hint (and as a literal arg into the
+// reactive projectedCost() JS call).
+func workflowCostStr(c float64) string {
+	return strconv.FormatFloat(c, 'f', 2, 64)
+}
+
 // WorkflowsGalleryProps is the view-model for the /workflows preset gallery.
 type WorkflowsGalleryProps struct {
 	Categories []WorkflowCategoryProps
 	// Status mirrors the agent runtime readiness (reused from agents_list_types).
 	Status    AgentSubsystemStatusProps
 	CSRFToken string
+	// ConsentAcknowledged is true once the household has acknowledged that
+	// workflows run Claude over their ledger. When false, each configure
+	// drawer shows a required consent checkbox gating the Enable button.
+	ConsentAcknowledged bool
 }
 
 // WorkflowCategoryProps groups presets under a section header.
@@ -19,14 +32,15 @@ type WorkflowCategoryProps struct {
 
 // WorkflowPresetCardProps is one preset row in the gallery.
 type WorkflowPresetCardProps struct {
-	Slug         string
-	Name         string
-	Description  string
-	Icon         string // lucide icon for the preset
-	TriggerLabel string // human-readable trigger summary ("After each sync", "Weekly")
-	ToolScope    string // "read_only" | "read_write" — drives a small "applies changes" hint
-	ScheduleCron string // default cron for scheduled presets (empty for post-sync)
-	TriggerOnSync bool  // true = post-sync event trigger (no schedule editing)
+	Slug             string
+	Name             string
+	Description      string
+	Icon             string  // lucide icon for the preset
+	TriggerLabel     string  // human-readable trigger summary ("After each sync", "Weekly")
+	ToolScope        string  // "read_only" | "read_write" — drives a small "applies changes" hint
+	ScheduleCron     string  // default cron for scheduled presets (empty for post-sync)
+	TriggerOnSync    bool    // true = post-sync event trigger (no schedule editing)
+	EstCostPerRunUSD float64 // rough per-run cost estimate for the projected-cost hint
 
 	// Enablement state.
 	Enabled         bool   // the preset has been instantiated as a workflow

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -36,6 +36,18 @@ document.addEventListener('alpine:init', function () {
         });
       },
 
+      // projectedCost returns the drawer's reactive cost hint for a scheduled
+      // preset: estPerRun × the chosen cadence's runs/month. Cadences map to a
+      // rough monthly run count (daily≈30, weekly≈4.3, monthly=1). Approximate
+      // by design — it's an order-of-magnitude transparency cue, not a quote.
+      projectedCost: function (cron, estPerRun, postSync) {
+        var est = Number(estPerRun) || 0;
+        if (postSync) return '≈ $' + est.toFixed(2) + ' per run';
+        var perMonth = { '0 8 * * *': 30, '0 7 * * 1': 4.3, '0 8 1 * *': 1 }[cron] || 4.3;
+        var runs = Math.round(perMonth);
+        return '≈ $' + (est * perMonth).toFixed(2) + '/mo · ' + runs + (runs === 1 ? ' run' : ' runs');
+      },
+
       // Submit the configure drawer: instantiate the workflow with the chosen
       // schedule / instructions / run-now, then reload so the row swaps its
       // "Set up" button for a run toggle.


### PR DESCRIPTION
Adds **governance to the configure drawer** (PR6, slice 1): a projected-cost hint and a first-enable consent acknowledgement — so a self-hoster paying their own Anthropic bill sees the cost order-of-magnitude and explicitly consents before a workflow starts running Claude over their ledger.

## What changed

- **Projected cost** — each preset carries a rough `EstCostPerRunUSD`; the drawer shows a dim cost hint under "When it runs":
  - Scheduled presets: a **reactive** "≈ $X/mo · N runs" that updates as you change the schedule (`projectedCost(cron, est, …)` maps cadence → runs/month: daily≈30, weekly≈4.3, monthly=1).
  - Post-sync presets: "≈ $X per run" (run frequency follows syncs).
- **First-enable consent** — until the household acknowledges (once), the drawer shows a required checkbox ("I understand this runs Claude over my household's financial data … which incurs usage cost") that **gates the Enable button** (Alpine `:disabled` until checked). The acknowledgement is stored household-global in `app_config` (`workflows.consent_acknowledged_at`); after the first enable the checkbox no longer appears.
- **Server-side enforcement** — `EnableWorkflowPresetAdminHandler` rejects an enable with `400 CONSENT_REQUIRED` when consent isn't acknowledged and the form lacks `consent=true`, and records the ack on the first successful enable. The UI gate is backed, not just cosmetic.
- New `Service.WorkflowsConsentAcknowledged` / `AcknowledgeWorkflowsConsent` (`workflow_governance.go`) + appconfig key.

Scoped to the drawer governance. **Deferred to PR6 follow-ups:** the household daily/monthly spend ceiling (the `agent.global_max_budget_usd` key already exists to build on), post-sync debounce, admin-only RBAC, and dependent-exclusion in report presets.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. scripts_lint, pages, admin)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped !headless && !lite)
go vet  -tags=headless ./...   PASS
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Integration (`breadbox_test_wf`):

```
TestWorkflowsConsent                  PASS  (unacked → AcknowledgeWorkflowsConsent → acked)
TestWorkflowPresetsHaveCostEstimates  PASS  (every preset has a positive EstCostPerRunUSD)
TestEnableWorkflowFromPreset*         PASS
```

Live behavior confirmed in the browser: scheduled drawer shows "≈ $0.21/mo · 4 runs" with Enable **disabled**; checking consent **enables** it; post-sync drawer shows "≈ $0.02 per run".

## Screenshots

Scheduled preset — projected cost + consent gate (Enable disabled):

<img src="https://i.img402.dev/xiaf0rn29a.jpg" width="800" alt="Workflow drawer — cost + consent gate, Enable disabled">

After acknowledging — Enable enabled:

<img src="https://i.img402.dev/ua61nh1jhc.jpg" width="800" alt="Workflow drawer — consent checked, Enable enabled">

Post-sync preset — per-run cost:

<img src="https://i.img402.dev/3bo2ft9b0o.jpg" width="800" alt="Workflow drawer — post-sync per-run cost">
