### PR TITLE
feat(recurring): `series reinfer-types` backfill for pre-type-feature series

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -148,6 +148,7 @@ A **connection** is a bank-side OAuth link (Plaid item, Teller enrollment, or CS
 | Command | Scope | Description |
 |---------|-------|-------------|
 | `breadbox series backfill` | L | One-time all-history recurring-series detection (populates merchant keys, surfaces subscription candidates) |
+| `breadbox series reinfer-types` | L | One-time re-inference of `type` for default-`subscription` series from member categories (for series detected before the type field) |
 
 ## CSV
 

--- a/internal/cli/series.go
+++ b/internal/cli/series.go
@@ -28,7 +28,14 @@ func AddSeriesCmd(root *cobra.Command) {
 			return runSeriesBackfill()
 		},
 	}
-	series.AddCommand(backfill)
+	reinferTypes := &cobra.Command{
+		Use:   "reinfer-types",
+		Short: "Re-infer the type of default-'subscription' series from member categories (one-time)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSeriesReinferTypes()
+		},
+	}
+	series.AddCommand(backfill, reinferTypes)
 	root.AddCommand(series)
 }
 
@@ -53,5 +60,29 @@ func runSeriesBackfill() error {
 	}
 	logger.Info("recurring-series backfill complete", "candidates", n)
 	fmt.Printf("Detected %d recurring-series candidate(s).\n", n)
+	return nil
+}
+
+func runSeriesReinferTypes() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	logger := newLogger(cfg)
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("connect to database: %w", err)
+	}
+	defer pool.Close()
+
+	svc := service.New(db.New(pool), pool, nil, logger)
+	n, err := svc.ReinferSeriesTypes(ctx)
+	if err != nil {
+		return fmt.Errorf("series reinfer-types: %w", err)
+	}
+	logger.Info("recurring-series type re-inference complete", "retyped", n)
+	fmt.Printf("Re-typed %d recurring series.\n", n)
 	return nil
 }

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -894,6 +894,36 @@ func (s *Service) SetSeriesType(ctx context.Context, idOrShort, seriesType strin
 	return &resp, nil
 }
 
+// ReinferSeriesTypes re-derives the type of every series still at the default
+// 'subscription' from its members' dominant category — a one-time backfill for
+// series detected before the type field existed (type is sticky-after-insert,
+// so they never re-type on their own). Series already typed bill/loan/other are
+// left untouched, and a series whose members still infer 'subscription' is a
+// no-op. Returns the number actually re-typed.
+func (s *Service) ReinferSeriesTypes(ctx context.Context) (int, error) {
+	rows, err := s.Queries.ListRecurringSeries(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list series: %w", err)
+	}
+	retyped := 0
+	for _, row := range rows {
+		if row.Type != SeriesTypeSubscription {
+			continue // already typed (non-default) — leave deliberate values alone
+		}
+		inferred := s.inferTypeFromMembers(ctx, s.Queries, row.ID)
+		if inferred == "" || inferred == row.Type {
+			continue
+		}
+		upd := updateParamsFromRow(row)
+		upd.Type = inferred
+		if _, err := s.Queries.UpdateRecurringSeries(ctx, upd); err != nil {
+			return retyped, fmt.Errorf("re-type series %s: %w", row.ShortID, err)
+		}
+		retyped++
+	}
+	return retyped, nil
+}
+
 // GetSeries returns a single series by short_id or uuid.
 func (s *Service) GetSeries(ctx context.Context, idOrShort string) (*SeriesResponse, error) {
 	id, err := s.resolveSeriesID(ctx, idOrShort)

--- a/internal/service/series_integration_test.go
+++ b/internal/service/series_integration_test.go
@@ -867,6 +867,85 @@ func TestSeriesType_InferenceStickyAndOverride(t *testing.T) {
 	}
 }
 
+func TestReinferSeriesTypes(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	seedMerchant := func(name string, dates ...string) []string {
+		ids := make([]string, 0, len(dates))
+		for _, d := range dates {
+			txn := testutil.MustCreateTransaction(t, queries, acctID, name+"_"+d, name, 999, d)
+			ids = append(ids, txn.ShortID)
+		}
+		return ids
+	}
+	categorize := func(providerName, slug, display string) {
+		if _, err := pool.Exec(ctx, `INSERT INTO categories (slug, display_name) VALUES ($1,$2) ON CONFLICT (slug) DO NOTHING`, slug, display); err != nil {
+			t.Fatalf("ensure category: %v", err)
+		}
+		if _, err := pool.Exec(ctx, `UPDATE transactions SET category_id=(SELECT id FROM categories WHERE slug=$1) WHERE provider_name=$2`, slug, providerName); err != nil {
+			t.Fatalf("categorize: %v", err)
+		}
+	}
+
+	// A series detected BEFORE its members were categorized → defaults to
+	// subscription (inference at insert had no category signal).
+	mtg := seedMerchant("WF MTG", "2026-02-01", "2026-03-01", "2026-04-01")
+	mtgSeries, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		MerchantKey: "wfmtg", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: mtg,
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint mortgage: %v", err)
+	}
+	if mtgSeries.Type != service.SeriesTypeSubscription {
+		t.Fatalf("precondition: mortgage series should default to subscription, got %q", mtgSeries.Type)
+	}
+	// Now the members get categorized as a mortgage payment.
+	categorize("WF MTG", "loan_payments_mortgage_payment", "Mortgage")
+
+	// A series already explicitly typed bill — must NOT be re-typed.
+	pge := seedMerchant("PGE", "2026-02-03", "2026-03-03", "2026-04-03")
+	pgeSeries, err := svc.UpsertSeriesCandidate(ctx, service.SeriesUpsert{
+		MerchantKey: "pge", Cadence: service.SeriesCadenceMonthly,
+		Source: service.SeriesSourceDeterministic, MemberTxnIDs: pge,
+	}, service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint pge: %v", err)
+	}
+	if _, err := svc.SetSeriesType(ctx, pgeSeries.ShortID, service.SeriesTypeBill, service.Actor{Type: "user"}); err != nil {
+		t.Fatalf("set pge type: %v", err)
+	}
+	// Re-categorize PG&E members to loan (to prove the already-typed row is left alone).
+	categorize("PGE", "loan_payments_mortgage_payment", "Mortgage")
+
+	n, err := svc.ReinferSeriesTypes(ctx)
+	if err != nil {
+		t.Fatalf("ReinferSeriesTypes: %v", err)
+	}
+	if n < 1 {
+		t.Errorf("expected at least 1 series re-typed, got %d", n)
+	}
+
+	// The default-subscription mortgage series is now loan.
+	got, err := svc.GetSeries(ctx, mtgSeries.ShortID)
+	if err != nil {
+		t.Fatalf("get mortgage: %v", err)
+	}
+	if got.Type != service.SeriesTypeLoan {
+		t.Errorf("mortgage type after reinfer = %q, want loan", got.Type)
+	}
+	// The explicitly-typed bill series is untouched.
+	gotPge, err := svc.GetSeries(ctx, pgeSeries.ShortID)
+	if err != nil {
+		t.Fatalf("get pge: %v", err)
+	}
+	if gotPge.Type != service.SeriesTypeBill {
+		t.Errorf("explicitly-typed series was re-typed to %q; should stay bill", gotPge.Type)
+	}
+}
+
 func keysOf(m map[string]service.SeriesNearMiss) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
Closes a production gap in the type feature: series detected **before** the `type` field shipped are stuck at the default `subscription` (type is sticky-after-insert, so they never re-type on their own) — a mortgage detected last week renders as a "Subscription."

`ReinferSeriesTypes` re-derives the type of every still-default-`subscription` series from its members' dominant category. Already-typed (`bill`/`loan`/`other`) series are left untouched; a series whose members still infer `subscription` is a no-op. Exposed as **`breadbox series reinfer-types`** (L-scoped, one-time admin op, mirrors `series backfill`).

### Validation
build+vet default/headless/lite; unit; service+api+mcp integration on breadbox_test. New integration test: a default-`subscription` mortgage series (members categorized post-insert) re-types to `loan`; an explicitly-typed `bill` series is left untouched. Docs/cli-commands.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
