### PR TITLE
feat(workflows): household spend ceiling — enforce aggregate 30-day cap

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -181,6 +181,10 @@ func RunAgentNowAdminHandler(a *app.App, svc *service.Service) http.HandlerFunc 
 				writeError(w, http.StatusServiceUnavailable, "CONCURRENCY_LOCKED", "Another run is in progress")
 				return
 			}
+			if errors.Is(err, service.ErrBudgetCeilingReached) {
+				writeError(w, http.StatusTooManyRequests, "BUDGET_CEILING_REACHED", err.Error())
+				return
+			}
 			if errors.Is(err, agent.ErrAuthNotConfigured) {
 				writeError(w, http.StatusUnprocessableEntity, "AUTH_NOT_CONFIGURED", err.Error())
 				return

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -38,6 +38,7 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			return
 		}
 		status := svc.GetAgentSubsystemStatus(ctx)
+		spend, _ := svc.HouseholdSpendStatus(ctx) // best-effort; display only
 
 		form := pages.AgentSDKSettingsFormFields{
 			AuthMode:              settings.AuthMode,
@@ -75,7 +76,8 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 				BinaryPresent:  status.BinaryPresent,
 				BinaryPath:     status.BinaryPath,
 			},
-			CSRFToken: GetCSRFToken(r),
+			CSRFToken:            GetCSRFToken(r),
+			HouseholdSpend30dStr: formatHouseholdSpend(spend),
 		}
 
 		data := BaseTemplateData(r, sm, "agents-settings", "Agents settings")
@@ -93,4 +95,14 @@ func formatOptionalBudget(v *float64) string {
 		return ""
 	}
 	return strconv.FormatFloat(*v, 'f', 2, 64)
+}
+
+// formatHouseholdSpend renders the rolling-window spend as "$X.XX" or,
+// when a ceiling is set, "$X.XX of $Y.YY".
+func formatHouseholdSpend(s service.HouseholdSpendStatus) string {
+	spent := "$" + strconv.FormatFloat(s.SpentUSD, 'f', 2, 64)
+	if s.CeilingUSD != nil && *s.CeilingUSD > 0 {
+		return spent + " of $" + strconv.FormatFloat(*s.CeilingUSD, 'f', 2, 64)
+	}
+	return spent
 }

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -587,6 +587,11 @@ func RunAgentNowHandler(svc *service.Service, orch *service.Orchestrator) http.H
 				"Another agent run is in progress. Retry when it completes.")
 			return
 		}
+		if errors.Is(runErr, service.ErrBudgetCeilingReached) {
+			mw.WriteError(w, http.StatusTooManyRequests,
+				"BUDGET_CEILING_REACHED", runErr.Error())
+			return
+		}
 		if errors.Is(runErr, agent.ErrAuthNotConfigured) {
 			mw.WriteError(w, http.StatusUnprocessableEntity,
 				"AUTH_NOT_CONFIGURED",

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -230,3 +230,12 @@ SELECT
     ), 0)::float8 / 1000.0)::float8                        AS avg_duration_seconds
 FROM agent_runs
 WHERE agent_definition_id = $1;
+
+-- GetHouseholdCostSince sums total_cost_usd across ALL agent definitions
+-- for runs started at/after the given instant, excluding skipped rows.
+-- Powers the household spend-ceiling gate + the settings spend display.
+-- name: GetHouseholdCostSince :one
+SELECT COALESCE(SUM(total_cost_usd), 0)::numeric(12,4) AS total_cost_usd
+FROM agent_runs
+WHERE started_at >= sqlc.arg(since)
+  AND status != 'skipped';

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -43,6 +43,28 @@ func capFromRunErr(err error) string {
 	}
 }
 
+// checkHouseholdCeiling enforces the household's aggregate spend ceiling
+// before a run starts. When KeyAgentGlobalMaxBudgetUSD is set and the
+// rolling 30-day spend has reached it, returns ErrBudgetCeilingReached
+// (wrapped with the spent/ceiling figures). No ceiling (unset or <= 0)
+// returns nil. A cost-sum query error fails OPEN — a transient DB hiccup
+// must not wedge every workflow run — and is logged.
+func (o *Orchestrator) checkHouseholdCeiling(ctx context.Context) error {
+	ceiling := readOptionalFloat(ctx, o.svc.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)
+	if ceiling == nil || *ceiling <= 0 {
+		return nil
+	}
+	spent, err := o.svc.HouseholdCostSince(ctx, time.Now().Add(-HouseholdCeilingWindow))
+	if err != nil {
+		o.logger.Warn("orchestrator: household ceiling check failed; allowing run", "error", err)
+		return nil
+	}
+	if spent >= *ceiling {
+		return fmt.Errorf("%w ($%.2f of $%.2f in 30 days)", ErrBudgetCeilingReached, spent, *ceiling)
+	}
+	return nil
+}
+
 // Orchestrator drives one agent run end-to-end: acquires concurrency,
 // mints a scoped API key, assembles the JobSpec, runs the sidecar, persists
 // the resulting agent_runs row, and revokes the key.
@@ -130,6 +152,9 @@ func (o *Orchestrator) RunNow(ctx context.Context, def *AgentDefinitionResponse,
 // the agent edit page to dry-fire an unsaved prompt without mutating the
 // stored definition.
 func (o *Orchestrator) RunNowWith(ctx context.Context, def *AgentDefinitionResponse, ov RunOverrides) (*AgentRunResponse, error) {
+	if err := o.checkHouseholdCeiling(ctx); err != nil {
+		return nil, err
+	}
 	if err := o.sem.Acquire(ctx); err != nil {
 		return nil, err
 	}
@@ -184,6 +209,22 @@ func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
 // semaphore was full. Returns ErrConcurrencyLocked alongside the skipped
 // row so the scheduler can log appropriately.
 func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionResponse, trigger string) (*AgentRunResponse, error) {
+	// Household ceiling first — a cron fire that's over budget leaves a
+	// 'skipped' row (reason = the ceiling message) so the miss is visible.
+	if cerr := o.checkHouseholdCeiling(ctx); cerr != nil {
+		defUUID, perr := pgconv.ParseUUID(def.ID)
+		if perr != nil {
+			return nil, fmt.Errorf("orchestrator: parse def id: %w", perr)
+		}
+		runRow, crerr := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+		if crerr != nil {
+			return nil, fmt.Errorf("orchestrator: create ceiling-skipped run row: %w (ceiling: %v)", crerr, cerr)
+		}
+		_ = o.svc.MarkAgentRunSkippedDB(ctx, runRow.ID, cerr.Error())
+		resp := AgentRunFromRow(runRow)
+		resp.Status = "skipped"
+		return &resp, cerr
+	}
 	if err := o.sem.Acquire(ctx); err != nil {
 		// Leave a 'skipped' row so the run history shows the missed fire.
 		defUUID, perr := pgconv.ParseUUID(def.ID)
@@ -220,6 +261,9 @@ func (o *Orchestrator) RunNowAsyncWith(ctx context.Context, def *AgentDefinition
 	// instead of returning an in_progress row that's destined to fail.
 	binaryPath := appconfig.String(ctx, o.svc.Queries, appconfig.KeyAgentRuntimePath, "")
 	if _, err := agent.LocateBinary(binaryPath); err != nil {
+		return nil, err
+	}
+	if err := o.checkHouseholdCeiling(ctx); err != nil {
 		return nil, err
 	}
 

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -613,3 +613,65 @@ func TestOrchestratorRunNowAsyncWith_PanicInGoroutineIsRecovered(t *testing.T) {
 		t.Errorf("post-panic RunNow failed (semaphore leaked?): %v", err)
 	}
 }
+
+func TestHouseholdCostSince(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	def := mustCreateAgentDefinition(t, svc, "cost-since", true)
+
+	ins := func(status string, cost string, age string) {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO agent_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
+			 VALUES ($1,'cron',$2,$3, NOW() - $4::interval)`,
+			def.ID, status, cost, age)
+		if err != nil {
+			t.Fatalf("insert run: %v", err)
+		}
+	}
+	ins("success", "0.06", "1 hour")   // in window
+	ins("success", "0.04", "2 hours")  // in window
+	ins("skipped", "0.50", "1 hour")   // excluded: skipped
+	ins("success", "1.00", "60 days")  // excluded: outside window
+
+	spent, err := svc.HouseholdCostSince(ctx, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("HouseholdCostSince: %v", err)
+	}
+	if spent < 0.099 || spent > 0.101 {
+		t.Fatalf("spent = %v, want ~0.10 (skipped + out-of-window excluded)", spent)
+	}
+}
+
+func TestRunOrSkip_HouseholdCeiling(t *testing.T) {
+	svc, _, pool := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	ctx := context.Background()
+	def := mustCreateAgentDefinition(t, svc, "ceiling", true)
+
+	// Set a $0.10 household ceiling and push 30-day spend over it.
+	ceiling := 0.10
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{GlobalMaxBudgetUSD: &ceiling}, encKey, ""); err != nil {
+		t.Fatalf("set ceiling: %v", err)
+	}
+	for _, c := range []string{"0.07", "0.06"} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO agent_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
+			 VALUES ($1,'cron','success',$2, NOW())`, def.ID, c); err != nil {
+			t.Fatalf("insert run: %v", err)
+		}
+	}
+
+	noop := agent.RunnerFunc(func(ctx context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		t.Error("runner should NOT fire when over the household ceiling")
+		return agent.RunResult{Status: agent.StatusSuccess}, nil
+	})
+	orch := service.NewOrchestrator(svc, noop, 1, encKey, slog.Default())
+
+	resp, err := orch.RunOrSkip(ctx, def, "cron")
+	if !errors.Is(err, service.ErrBudgetCeilingReached) {
+		t.Fatalf("RunOrSkip err = %v, want ErrBudgetCeilingReached", err)
+	}
+	if resp == nil || resp.Status != "skipped" {
+		t.Fatalf("want a skipped row, got %+v", resp)
+	}
+}

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -24,4 +24,10 @@ var (
 	// hosted-link session) has passed its expiration. Distinct from
 	// ErrNotFound because the row still exists, just unusable.
 	ErrExpired = errors.New("expired")
+	// ErrBudgetCeilingReached signals the household's aggregate spend
+	// ceiling (KeyAgentGlobalMaxBudgetUSD, over a rolling 30-day window)
+	// has been hit, so further workflow runs are paused until spend ages
+	// out of the window or the ceiling is raised. Manual triggers map it
+	// to 429; cron triggers leave a 'skipped' row with the reason.
+	ErrBudgetCeilingReached = errors.New("household spend ceiling reached")
 )

--- a/internal/service/workflow_governance.go
+++ b/internal/service/workflow_governance.go
@@ -4,12 +4,53 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 )
+
+// HouseholdCeilingWindow is the rolling window over which the household
+// spend ceiling (KeyAgentGlobalMaxBudgetUSD) is measured. A rolling
+// window (vs a calendar month) avoids a reset-day spend spike.
+const HouseholdCeilingWindow = 30 * 24 * time.Hour
+
+// HouseholdCostSince sums total_cost_usd across every workflow/agent run
+// started at/after `since` (skipped rows excluded). Powers the spend
+// ceiling gate and the settings spend display.
+func (s *Service) HouseholdCostSince(ctx context.Context, since time.Time) (float64, error) {
+	raw, err := s.Queries.GetHouseholdCostSince(ctx, pgconv.Timestamptz(since))
+	if err != nil {
+		return 0, fmt.Errorf("household cost since %s: %w", since.Format(time.RFC3339), err)
+	}
+	v, _ := pgconv.NumericToFloat(raw)
+	return v, nil
+}
+
+// HouseholdSpendStatus is the rolling-window spend snapshot for the
+// settings display: how much has been spent in the window and the active
+// ceiling (nil = no cap).
+type HouseholdSpendStatus struct {
+	WindowDays int
+	SpentUSD   float64
+	CeilingUSD *float64
+}
+
+// HouseholdSpendStatus returns the current rolling-window spend + the
+// configured ceiling for display in agent/workflow settings.
+func (s *Service) HouseholdSpendStatus(ctx context.Context) (HouseholdSpendStatus, error) {
+	spent, err := s.HouseholdCostSince(ctx, time.Now().Add(-HouseholdCeilingWindow))
+	if err != nil {
+		return HouseholdSpendStatus{WindowDays: 30}, err
+	}
+	return HouseholdSpendStatus{
+		WindowDays: 30,
+		SpentUSD:   spent,
+		CeilingUSD: readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD),
+	}, nil
+}
 
 // WorkflowsConsentAcknowledged reports whether the household has already
 // acknowledged that enabling a workflow runs Claude over their financial

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -218,8 +218,8 @@ templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 				/>
 			}
 			@components.SettingsRow(components.SettingsRowProps{
-				Label:   "Global max budget",
-				Caption: "Optional USD ceiling per run. Leave empty for no global cap.",
+				Label:   "Household spend ceiling",
+				Caption: "Pause all workflow runs once 30-day spend reaches this (USD). Empty = no cap.",
 				For:     "global_max_budget_usd",
 			}) {
 				<div class="flex items-center gap-2">
@@ -236,6 +236,12 @@ templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 						class="input input-sm w-28"
 					/>
 				</div>
+			}
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Spent (last 30 days)",
+				Caption: "Rolling total across every workflow run; skipped runs excluded.",
+			}) {
+				<span class="text-sm tabular-nums text-base-content/80">{ p.HouseholdSpend30dStr }</span>
 			}
 			if p.FieldErrors["max_concurrent"] != "" || p.FieldErrors["global_max_budget_usd"] != "" {
 				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {

--- a/internal/templates/components/pages/agent_sdk_settings_types.go
+++ b/internal/templates/components/pages/agent_sdk_settings_types.go
@@ -19,6 +19,10 @@ type AgentSDKSettingsProps struct {
 	FormSuccess string
 	Status      AgentSDKStatusProps
 	CSRFToken   string
+	// HouseholdSpend30dStr is the read-only rolling 30-day spend across all
+	// workflow runs, formatted for the spend-ceiling section (e.g. "$2.13
+	// of $20.00" when a ceiling is set, or "$2.13" with no cap).
+	HouseholdSpend30dStr string
 }
 
 // AgentSDKSettingsFormFields mirrors the writable settings exposed by


### PR DESCRIPTION
Adds a **household spend ceiling** (PR6b, slice 1): an aggregate rolling-30-day cost cap across all workflow/agent runs, enforced before a run starts. Closes the "silent cost-amplification" gap the design doc §4 flags — a gallery that encourages many enabled workflows (several post-sync) could multiply runs with no aggregate ceiling on a self-hoster's Anthropic bill.

## What changed

- **Enforcement** — `Orchestrator.checkHouseholdCeiling` runs *before* `sem.Acquire` in all three entry points (`RunNowWith`, `RunNowAsyncWith`, `RunOrSkip`):
  - When `KeyAgentGlobalMaxBudgetUSD` is set (>0) and rolling-30-day spend has reached it:
    - **Cron** (`RunOrSkip`) leaves a `skipped` row whose reason is the ceiling message — the miss is visible in the runs feed.
    - **Manual** (`RunNowWith`/`RunNowAsyncWith`) returns `ErrBudgetCeilingReached` (no row); the admin + REST run handlers map it to **429 `BUDGET_CEILING_REACHED`**.
  - Unset / `<= 0` ceiling = no cap (unchanged behavior). A cost-sum query error **fails open** (logged) so a transient DB hiccup can't wedge every run.
- **The config is now actually enforced** — `KeyAgentGlobalMaxBudgetUSD` was fully wired as a settings field but read by nothing. Repurposed from the old (mislabeled, unused) "per-run" cap into the household 30-day ceiling.
- **New windowed query** `GetHouseholdCostSince` (sqlc) sums `total_cost_usd` across all definitions since an instant, excluding skipped rows → `Service.HouseholdCostSince` + `HouseholdSpendStatus`.
- **Settings UI** — re-captioned "Global max budget" → **"Household spend ceiling"** ("Pause all workflow runs once 30-day spend reaches this") and added a read-only **"Spent (last 30 days)"** row ("$X.XX of $Y.YY").

Scoped to the ceiling. **Deferred to PR6b follow-ups:** post-sync debounce, admin-only RBAC on enable, dependent-exclusion in report presets, and a near/over-ceiling banner on the gallery.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped !headless && !lite)
go vet  -tags=headless ./...   PASS
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Integration (`breadbox_test_wf`):

```
TestHouseholdCostSince          PASS  (sum excludes skipped + out-of-window rows)
TestRunOrSkip_HouseholdCeiling  PASS  (over ceiling → skipped row + ErrBudgetCeilingReached; runner never fires)
Orchestrator/RunOrSkip/RunNow*  PASS  (existing run paths unregressed)
```

## Screenshot

Agent/workflow settings — re-captioned ceiling + live 30-day spend ("$2.72 of $20.00"):

<img src="https://i.img402.dev/ob7xiaq57d.jpg" width="800" alt="Household spend ceiling + 30-day spend display in settings">
