### PR TITLE
feat(workflows): post-sync debounce — coalesce rapid syncs to one run

### DIFF
--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -239,3 +239,14 @@ SELECT COALESCE(SUM(total_cost_usd), 0)::numeric(12,4) AS total_cost_usd
 FROM agent_runs
 WHERE started_at >= sqlc.arg(since)
   AND status != 'skipped';
+
+-- ExistsRecentRunForDefinition reports whether a non-skipped run for the
+-- given definition started at/after `since`. Powers the post-sync
+-- debounce: N rapid syncs within the window coalesce to one run.
+-- name: ExistsRecentRunForDefinition :one
+SELECT EXISTS(
+    SELECT 1 FROM agent_runs
+    WHERE agent_definition_id = sqlc.arg(definition_id)
+      AND started_at >= sqlc.arg(since)
+      AND status <> 'skipped'
+) AS run_exists;

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -171,6 +171,12 @@ func (o *Orchestrator) RunNowWith(ctx context.Context, def *AgentDefinitionRespo
 // Runs each agent in its own goroutine so the sync engine returns
 // immediately. Concurrency is bounded by the orchestrator's existing
 // semaphore (iter-29 default: 3) — excess fires roll into skipped rows.
+//
+// Post-sync debounce: a definition that already ran (non-skipped) within
+// PostSyncDebounceWindow is skipped silently here, so N rapid syncs
+// coalesce to one run instead of fanning out (the design-doc §4
+// cost-amplification trap). The debounce is intentionally row-less — a
+// coalesced trigger isn't a "missed" run worth a skipped row.
 func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
 	// Use a fresh context for the lookup — the incoming ctx is the sync
 	// engine's, and a cancelled webhook request or timed-out sync would
@@ -190,8 +196,16 @@ func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
 	}
 	o.logger.Info("orchestrator: dispatching sync-webhook agents",
 		"agent_count", len(defs))
+	debounceSince := time.Now().Add(-PostSyncDebounceWindow)
 	for i := range defs {
 		def := defs[i] // capture range value before goroutine
+		// Debounce: skip a definition that already ran recently. Fail open
+		// — an EXISTS query error must not suppress the run.
+		if recent, derr := o.svc.RecentRunExistsForDefinition(lookupCtx, def.ID, debounceSince); derr == nil && recent {
+			o.logger.Info("orchestrator: debouncing sync-webhook agent (ran within window)",
+				"agent", def.Slug, "window", PostSyncDebounceWindow.String())
+			continue
+		}
 		go func() {
 			// New ctx with timeout so a stuck run doesn't outlive shutdown.
 			runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/internal/service/agent_webhook_trigger_test.go
+++ b/internal/service/agent_webhook_trigger_test.go
@@ -107,3 +107,35 @@ func mustCreateWebhookAgent(t *testing.T, svc *service.Service, slug string, ena
 	}
 	return def
 }
+
+// TestFireSyncCompleteAgents_DebouncesRecentRun confirms the post-sync
+// hook coalesces: an eligible agent that already ran (non-skipped) within
+// PostSyncDebounceWindow is NOT dispatched again on a fresh sync-complete.
+func TestFireSyncCompleteAgents_DebouncesRecentRun(t *testing.T) {
+	svc, _, pool := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateWebhookAgent(t, svc, "wh-debounce", true, true)
+
+	// A recent non-skipped run anchors the debounce window.
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO agent_runs (agent_definition_id,"trigger",status,started_at)
+		 VALUES ($1,'webhook','success', NOW())`, def.ID); err != nil {
+		t.Fatalf("seed recent run: %v", err)
+	}
+
+	fired := make(chan struct{}, 2)
+	runner := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		fired <- struct{}{}
+		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
+	})
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+
+	orch.FireSyncCompleteAgents(context.Background())
+
+	select {
+	case <-fired:
+		t.Fatal("runner fired for an agent that ran within the debounce window")
+	case <-time.After(300 * time.Millisecond):
+		// pass — debounced, no dispatch
+	}
+}

--- a/internal/service/workflow_governance.go
+++ b/internal/service/workflow_governance.go
@@ -17,6 +17,27 @@ import (
 // window (vs a calendar month) avoids a reset-day spend spike.
 const HouseholdCeilingWindow = 30 * 24 * time.Hour
 
+// PostSyncDebounceWindow coalesces rapid post-sync triggers: when a
+// workflow already ran (non-skipped) within this window, a fresh
+// sync-complete event for it is debounced rather than fanning out to
+// another run. Sync can fire frequently (webhook bursts, manual
+// re-syncs); the next run still picks up everything synced since, so
+// coalescing loses no coverage. Hardcoded — not a knob users tune.
+const PostSyncDebounceWindow = 15 * time.Minute
+
+// RecentRunExistsForDefinition reports whether a non-skipped run for the
+// definition started at/after `since`. Drives the post-sync debounce.
+func (s *Service) RecentRunExistsForDefinition(ctx context.Context, defID string, since time.Time) (bool, error) {
+	uid, err := pgconv.ParseUUID(defID)
+	if err != nil {
+		return false, fmt.Errorf("recent run exists: parse def id: %w", err)
+	}
+	return s.Queries.ExistsRecentRunForDefinition(ctx, db.ExistsRecentRunForDefinitionParams{
+		DefinitionID: uid,
+		Since:        pgconv.Timestamptz(since),
+	})
+}
+
 // HouseholdCostSince sums total_cost_usd across every workflow/agent run
 // started at/after `since` (skipped rows excluded). Powers the spend
 // ceiling gate and the settings spend display.


### PR DESCRIPTION
Adds **post-sync debounce** (PR6b-ii, slice 1): when a workflow already ran (non-skipped) within a 15-minute window, a fresh sync-complete event for it is coalesced rather than fanning out to another run. Closes the design-doc §4 cost-amplification trap — sync can fire frequently (webhook bursts, manual re-syncs), and several post-sync workflows multiplying runs is a silent spend amplifier on a self-hoster's Anthropic bill. Pairs with the household spend ceiling (#1632).

## What changed

- **`FireSyncCompleteAgents`** now skips a definition that ran (non-skipped) within `PostSyncDebounceWindow` (15 min), logging `debouncing sync-webhook agent`. The skip is **row-less** — a coalesced trigger isn't a "missed" run worth a skipped row. Fails **open**: an EXISTS-query error never suppresses a run.
- New sqlc query **`ExistsRecentRunForDefinition`** (def_id, since → bool, excludes skipped) + `Service.RecentRunExistsForDefinition`.
- Coverage is preserved by design — the next run still picks up everything synced since the last one, so coalescing rapid syncs loses nothing.

Cron runs are unaffected (they fire on a fixed schedule, not in bursts). The window is hardcoded — not a knob users tune.

**Deferred to PR6b-ii follow-ups:** admin-only enable RBAC, dependent-exclusion in report presets, gallery over-ceiling banner.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
```

Integration (`breadbox_test_wf`):

```
TestFireSyncCompleteAgents_DebouncesRecentRun   PASS  (recent run → no dispatch)
TestFireSyncCompleteAgents_OnlyFiresEligible    PASS  (no recent run → fires; unregressed)
TestFireSyncCompleteAgents_NoEligibleAgents_NoOp PASS
```

Backend-only change — no UI, no screenshot.
