### PR TITLE
feat(workflows): gallery spend-ceiling banner (paused / approaching)

### DIFF
--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -12,6 +13,25 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 )
+
+// buildWorkflowSpendBanner derives the gallery's spend-ceiling banner from
+// the rolling-window spend status. No ceiling (unset or <= 0) → no banner.
+// Shown at >= 80% of the ceiling; "Over" once spend reaches it (runs paused).
+func buildWorkflowSpendBanner(s service.HouseholdSpendStatus) pages.WorkflowSpendBanner {
+	if s.CeilingUSD == nil || *s.CeilingUSD <= 0 {
+		return pages.WorkflowSpendBanner{}
+	}
+	ceiling := *s.CeilingUSD
+	pct := int(s.SpentUSD / ceiling * 100)
+	over := s.SpentUSD >= ceiling
+	return pages.WorkflowSpendBanner{
+		Show:       over || pct >= 80,
+		Over:       over,
+		SpentStr:   "$" + strconv.FormatFloat(s.SpentUSD, 'f', 2, 64),
+		CeilingStr: "$" + strconv.FormatFloat(ceiling, 'f', 2, 64),
+		PctStr:     strconv.Itoa(pct) + "%",
+	}
+}
 
 // WorkflowsGalleryPageHandler renders GET /workflows — the codified preset
 // gallery. Presets come from the code registry (service.ListWorkflowPresets);
@@ -25,12 +45,14 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			presetsErr error
 			status     *service.AgentSubsystemStatus
 			consented  bool
+			spend      service.HouseholdSpendStatus
 			wg         sync.WaitGroup
 		)
-		wg.Add(3)
+		wg.Add(4)
 		go func() { defer wg.Done(); presets, presetsErr = svc.ListWorkflowPresets(ctx) }()
 		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
 		go func() { defer wg.Done(); consented = svc.WorkflowsConsentAcknowledged(ctx) }()
+		go func() { defer wg.Done(); spend, _ = svc.HouseholdSpendStatus(ctx) }()
 		wg.Wait()
 
 		if presetsErr != nil {
@@ -43,6 +65,7 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			Status:              buildAgentsListStatus(status),
 			CSRFToken:           GetCSRFToken(r),
 			ConsentAcknowledged: consented,
+			Spend:               buildWorkflowSpendBanner(spend),
 		}
 
 		data := BaseTemplateData(r, sm, "workflows", "Workflows")

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -29,6 +29,27 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				<a href="/settings/agents" class="btn btn-sm btn-ghost">Configure</a>
 			</div>
 		}
+		if p.Spend.Show {
+			if p.Spend.Over {
+				<div role="alert" class="alert alert-error rounded-xl mt-4 mb-2">
+					@components.LucideIcon("octagon-x", "w-5 h-5 shrink-0")
+					<div class="flex-1">
+						<div class="font-semibold text-sm">Workflows paused — spend ceiling reached</div>
+						<div class="text-xs opacity-80">30-day spend { p.Spend.SpentStr } has reached your ceiling ({ p.Spend.CeilingStr }). New runs are paused until spend ages out of the window or you raise the ceiling.</div>
+					</div>
+					<a href="/settings/agents" class="btn btn-sm btn-ghost">Adjust</a>
+				</div>
+			} else {
+				<div role="alert" class="alert alert-warning rounded-xl mt-4 mb-2">
+					@components.LucideIcon("alert-triangle", "w-5 h-5 shrink-0")
+					<div class="flex-1">
+						<div class="font-semibold text-sm">Approaching spend ceiling</div>
+						<div class="text-xs opacity-80">{ p.Spend.PctStr } used — { p.Spend.SpentStr } of { p.Spend.CeilingStr } in the last 30 days.</div>
+					</div>
+					<a href="/settings/agents" class="btn btn-sm btn-ghost">Adjust</a>
+				</div>
+			}
+		}
 		<div class="mt-4 space-y-6">
 			for _, cat := range p.Categories {
 				@components.SettingsSection(components.SettingsSectionProps{

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -21,6 +21,20 @@ type WorkflowsGalleryProps struct {
 	// workflows run Claude over their ledger. When false, each configure
 	// drawer shows a required consent checkbox gating the Enable button.
 	ConsentAcknowledged bool
+	// Spend drives the optional top-of-gallery spend-ceiling banner.
+	Spend WorkflowSpendBanner
+}
+
+// WorkflowSpendBanner is the gallery's spend-ceiling state: shown when a
+// ceiling is set and 30-day spend is at/over 80% of it. Over=true means
+// runs are currently paused (spent >= ceiling); otherwise it's an
+// "approaching" warning. Strings are preformatted ("$2.72", "85%").
+type WorkflowSpendBanner struct {
+	Show       bool
+	Over       bool
+	SpentStr   string
+	CeilingStr string
+	PctStr     string
 }
 
 // WorkflowCategoryProps groups presets under a section header.


### PR DESCRIPTION
Surfaces the **household spend ceiling state on the Workflows gallery** (PR6b-ii slice). The ceiling enforcement (#1632) silently skips/429s runs when 30-day spend is over budget; this gives the user a visible reason at the top of the gallery instead of just wondering why nothing fires.

## What changed

- The gallery handler loads `HouseholdSpendStatus` (4th parallel load) and derives a `WorkflowSpendBanner`:
  - **Over** (spent ≥ ceiling) → red "Workflows paused — spend ceiling reached" alert with the spent/ceiling figures + an **Adjust** link to settings.
  - **Approaching** (≥ 80% of ceiling) → amber "Approaching spend ceiling — N% used" alert.
  - No ceiling set (or < 80% used) → no banner.
- Pure surfacing of the existing ceiling state — no new enforcement, no schema, no new routes. Reuses `Service.HouseholdSpendStatus` from #1632.

**Deferred to PR6b-ii follow-ups:** admin-only enable RBAC, dependent-exclusion in report presets.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. scripts_lint, pages, admin)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Live behavior confirmed: with $2.72 30-day spend, a $2.00 ceiling renders the paused banner; a $3.20 ceiling renders "85% used" approaching.

## Screenshots

Over ceiling — workflows paused:

<img src="https://i.img402.dev/kefyqbx884.jpg" width="800" alt="Gallery — over spend ceiling, workflows paused">

Approaching ceiling (≥80%):

<img src="https://i.img402.dev/yf8rwy4gwu.jpg" width="800" alt="Gallery — approaching spend ceiling">
