### PR TITLE
feat(workflows): admin-only enable — gate preset instantiation by role

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -445,7 +445,12 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/agents/{slug}/update", UpdateAgentDefinitionAdminHandler(svc, sm))
 			r.Post("/agents/{slug}/delete", DeleteAgentDefinitionAdminHandler(svc, sm))
 			r.Post("/agents/{slug}/enable", EnableAgentAdminHandler(svc))
-			r.Post("/workflow-presets/{slug}/enable", EnableWorkflowPresetAdminHandler(svc))
+			// Instantiating a NEW autonomous workflow from a preset is the
+			// high-authority act (it authorizes recurring AI spend on shared
+			// household data), so it's admin-only — RequireAdmin upgrades this
+			// one route above the surrounding editor group. Managing an
+			// already-instantiated workflow's run state stays editor.
+			r.With(RequireAdmin(sm)).Post("/workflow-presets/{slug}/enable", EnableWorkflowPresetAdminHandler(svc))
 			r.Post("/agents/{slug}/disable", DisableAgentAdminHandler(svc))
 			r.Post("/agents/{slug}/run", RunAgentNowAdminHandler(a, svc))
 			r.Post("/agents/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -66,6 +66,7 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			CSRFToken:           GetCSRFToken(r),
 			ConsentAcknowledged: consented,
 			Spend:               buildWorkflowSpendBanner(spend),
+			IsAdmin:             IsAdmin(sm, r),
 		}
 
 		data := BaseTemplateData(r, sm, "workflows", "Workflows")

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -61,7 +61,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 							Label:   preset.Name,
 							Caption: preset.Description,
 						}) {
-							@workflowPresetControl(preset)
+							@workflowPresetControl(preset, p.IsAdmin)
 						}
 					}
 				}
@@ -80,10 +80,14 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 			class="fixed inset-0 bg-black/40 z-40"
 			@click="open=''"
 		></div>
-		for _, cat := range p.Categories {
-			for _, preset := range cat.Presets {
-				if !preset.Enabled {
-					@workflowConfigDrawer(preset, p.ConsentAcknowledged)
+		// Drawers exist only for the admin who can actually submit them; a
+		// non-admin can't open one (the "Set up" control is disabled).
+		if p.IsAdmin {
+			for _, cat := range p.Categories {
+				for _, preset := range cat.Presets {
+					if !preset.Enabled {
+						@workflowConfigDrawer(preset, p.ConsentAcknowledged)
+					}
 				}
 			}
 		}
@@ -91,8 +95,10 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 }
 
 // workflowPresetControl is the state-dependent right-side control: a "Set up"
-// button (opens the configure drawer) when available, a run toggle once enabled.
-templ workflowPresetControl(preset WorkflowPresetCardProps) {
+// button (opens the configure drawer) when available, a run toggle once
+// enabled. Instantiating a workflow is admin-only — non-admins see the
+// "Set up" control disabled with an explanatory tooltip.
+templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
 	<div class="flex items-center gap-3">
 		<span class="hidden sm:inline-flex items-center gap-1 text-xs text-base-content/40">
 			@components.LucideIcon("clock", "w-3.5 h-3.5")
@@ -108,7 +114,7 @@ templ workflowPresetControl(preset WorkflowPresetCardProps) {
 				aria-label={ "Toggle " + preset.Name }
 				@change={ "toggleWorkflow('" + preset.WorkflowSlug + "', $event.target)" }
 			/>
-		} else {
+		} else if isAdmin {
 			<button
 				type="button"
 				class="btn btn-soft btn-sm gap-1.5"
@@ -117,6 +123,13 @@ templ workflowPresetControl(preset WorkflowPresetCardProps) {
 				@components.LucideIcon("settings-2", "w-4 h-4")
 				Set up
 			</button>
+		} else {
+			<span class="tooltip tooltip-left" data-tip="Only admins can enable workflows">
+				<button type="button" class="btn btn-soft btn-sm gap-1.5" disabled>
+					@components.LucideIcon("lock", "w-4 h-4")
+					Set up
+				</button>
+			</span>
 		}
 	</div>
 }

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -23,6 +23,9 @@ type WorkflowsGalleryProps struct {
 	ConsentAcknowledged bool
 	// Spend drives the optional top-of-gallery spend-ceiling banner.
 	Spend WorkflowSpendBanner
+	// IsAdmin gates the "Set up" action: instantiating a workflow from a
+	// preset is admin-only. Non-admins see a disabled control + hint.
+	IsAdmin bool
 }
 
 // WorkflowSpendBanner is the gallery's spend-ceiling state: shown when a


### PR DESCRIPTION
Adds **admin-only enable** (PR6b-ii slice): instantiating a workflow from a preset — the act that authorizes recurring AI spend on shared household data — is now admin-only. Closes the design-doc §4.3 authorization gap (no RBAC on who can turn on Apply-mode automation).

## What changed

- **Route gate** — `/-/workflow-presets/{slug}/enable` is wrapped with `RequireAdmin` (it sits in the editor group; `r.With(RequireAdmin(sm))` upgrades just this route, so editors get 403, admins pass).
- **UI gate** — the gallery passes `IsAdmin` to props. For non-admins the per-preset **"Set up"** control renders **disabled with a lock icon + tooltip** ("Only admins can enable workflows"), and the configure drawers aren't rendered at all (nothing they could submit) — so there are no confusing 403s.
- **Scope** — admin-only applies to *instantiating* a new workflow. Managing an already-instantiated workflow's run state (the run toggle) stays editor — a deliberate, narrow line: creating autonomous automation is the high-authority act; toggling a vetted one is routine.

Completes the governance arc: consent (#1630) → spend ceiling (#1632) → debounce (#1633) → ceiling banner (#1634) → access control (this).

**Deferred to PR6b-ii tail:** dependent-exclusion in report presets.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. scripts_lint, pages, admin, OpenAPI-drift — route is admin /-/* so no drift)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Live behavior confirmed with a throwaway editor account (since deleted): the editor gallery renders all "Set up" buttons disabled/locked; the admin gallery is unchanged.

## Screenshots

Non-admin (editor) — "Set up" disabled with lock:

<img src="https://i.img402.dev/yo6k1k5k1o.jpg" width="800" alt="Gallery as editor — Set up disabled (admin-only)">

Admin — normal "Set up":

<img src="https://i.img402.dev/f4cv9o7ggo.jpg" width="800" alt="Gallery as admin — Set up enabled">
