### PR TITLE
feat(workflows): expand gallery to 5 presets (Backlog Closer, Monthly Close)

### DIFF
--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -85,6 +85,35 @@ var workflowPresets = []WorkflowPreset{
 		ScheduleCron:     "0 8 1 * *", // 1st of the month at 08:00
 		EstCostPerRunUSD: 0.04,        // monthly recurring-charge scan
 	},
+	{
+		Slug:        "backlog-closer",
+		Name:        "Backlog Closer",
+		Category:    "Categorization & Review",
+		Icon:        "list-checks",
+		Description: "A weekly deep-clean of aged uncategorized transactions — thorough, and promotes repeat patterns to rules.",
+		PromptBlocks: []string{
+			"strategy-bulk-review",
+			"review-depth-thorough",
+			"category-system",
+		},
+		ToolScope:        "read_write",
+		ScheduleCron:     "0 7 * * 1", // Mondays at 07:00 (canonical "Weekly" — drawer-selectable)
+		EstCostPerRunUSD: 0.08,        // thorough pass over an accumulated backlog
+	},
+	{
+		Slug:        "monthly-close",
+		Name:        "Monthly Close",
+		Category:    "Insights & Reports",
+		Icon:        "calendar-check",
+		Description: "A month-end summary of where the money went — by category and top merchants.",
+		PromptBlocks: []string{
+			"strategy-spending-report",
+			"merchant-analysis",
+		},
+		ToolScope:        "read_only",
+		ScheduleCron:     "0 8 1 * *", // 1st of the month at 08:00 (canonical "Monthly" — drawer-selectable)
+		EstCostPerRunUSD: 0.07,        // a full month of activity + merchant breakdown
+	},
 }
 
 // WorkflowPresetView is a preset plus its enablement state, for the gallery.


### PR DESCRIPTION
Expands the preset gallery from 3 → 5, drawing two more from the design-doc's 16-preset catalog. Both compose from **existing, tested prompt blocks** (no new prompt content) and need no notification sink, so they're shippable now and "done right."

## New presets

- **Backlog Closer** (Categorization & Review) — a weekly deep-clean of aged uncategorized transactions; thorough, and promotes repeat patterns to rules. Composes `strategy-bulk-review` + `review-depth-thorough` + `category-system`. `read_write`, Weekly (Mon 7:00). The thorough/weekly counterpart to Routine Reviewer's efficient/post-sync pass.
- **Monthly Close** (Insights & Reports) — a month-end summary of where the money went, by category and top merchants. Composes `strategy-spending-report` + `merchant-analysis`. `read_only`, Monthly (1st, 8:00). The monthly companion to the Weekly Money Digest.

Both use **canonical drawer-selectable crons** (Weekly = Mon 7:00, Monthly = 1st 8:00) so the configure drawer's schedule select round-trips correctly and the trigger labels resolve ("Weekly"/"Monthly").

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
```

`TestWorkflowPresetsCompose` (eager-validation guard) passes for all 5 presets — confirming both new ones reference real prompt blocks and compose to a non-empty base prompt. Integration `ListWorkflowPresets` now returns 5.

## Screenshot

Gallery — 5 presets across 2 categories (Backlog Closer + Monthly Close are new):

<img src="https://i.img402.dev/3l9rlv3g67.jpg" width="800" alt="Workflows gallery with 5 presets">
