### PR TITLE
feat(workflows): per-status count badges on the Runs status tabs

### DIFF
--- a/internal/admin/workflows_runs_page.go
+++ b/internal/admin/workflows_runs_page.go
@@ -77,6 +77,14 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			}
 		}
 
+		// Status-tab badges respect the (finalized) workflow filter but not
+		// the status filter, so each tab shows its own tally. Best-effort.
+		counts, _ := svc.WorkflowRunStatusCounts(ctx, workflowSlug)
+		all := 0
+		for _, n := range counts {
+			all += n
+		}
+
 		props := pages.WorkflowRunsProps{
 			StatusFilter:   status,
 			WorkflowSlug:   workflowSlug,
@@ -86,6 +94,13 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			HasMore:        result.HasMore,
 			CSRFToken:      GetCSRFToken(r),
 			SubsystemReady: buildAgentsListStatus(subStatus).Ready,
+			Counts: pages.WorkflowRunStatusCounts{
+				All:        all,
+				Success:    counts["success"],
+				Error:      counts["error"],
+				InProgress: counts["in_progress"],
+				Skipped:    counts["skipped"],
+			},
 		}
 
 		props.Rows = make([]components.AgentRunRowProps, 0, len(result.Runs))

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -933,6 +933,46 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 	}, nil
 }
 
+// WorkflowRunStatusCounts returns a status→count map across preset-backed
+// workflow runs (source_template IS NOT NULL), optionally narrowed to one
+// workflow. Powers the count badges on the Workflows → Runs status tabs.
+// Same hand-rolled SQL pattern as ListAllAgentRuns.
+func (s *Service) WorkflowRunStatusCounts(ctx context.Context, workflowSlugOrID string) (map[string]int, error) {
+	where := []string{"d.source_template IS NOT NULL"}
+	args := []any{}
+	if workflowSlugOrID != "" {
+		def, err := s.resolveAgentDefinition(ctx, workflowSlugOrID)
+		if err != nil {
+			// Unknown filter → no counts (mirrors the runs page dropping a
+			// bad workflow filter rather than erroring).
+			return map[string]int{}, nil
+		}
+		where = append(where, "r.agent_definition_id = $1")
+		args = append(args, def.ID)
+	}
+	query := "SELECT r.status, COUNT(*) FROM agent_runs r " +
+		"JOIN agent_definitions d ON d.id = r.agent_definition_id WHERE " +
+		strings.Join(where, " AND ") + " GROUP BY r.status"
+	rows, err := s.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("workflow run status counts: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]int, 5)
+	for rows.Next() {
+		var status string
+		var n int
+		if err := rows.Scan(&status, &n); err != nil {
+			return nil, fmt.Errorf("scan status count: %w", err)
+		}
+		out[status] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate status counts: %w", err)
+	}
+	return out, nil
+}
+
 // AgentRunNoteMaxLen caps the operator note size both in the admin
 // textarea and on the server. Free-form text but bounded so we don't
 // accidentally host arbitrarily-large blobs.

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -192,3 +192,44 @@ func TestWorkflowPresetsHaveCostEstimates(t *testing.T) {
 		}
 	}
 }
+
+func TestWorkflowRunStatusCounts(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	plain := mustCreateAgentDefinition(t, svc, "plain-counts", true)
+
+	ins := func(defID, status string) {
+		if _, e := pool.Exec(ctx,
+			`INSERT INTO agent_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			defID, status); e != nil {
+			t.Fatalf("insert run: %v", e)
+		}
+	}
+	ins(wf.ID, "success")
+	ins(wf.ID, "success")
+	ins(wf.ID, "error")
+	ins(wf.ID, "skipped")
+	ins(plain.ID, "success") // not a workflow → excluded
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts: %v", err)
+	}
+	if counts["success"] != 2 || counts["error"] != 1 || counts["skipped"] != 1 {
+		t.Fatalf("counts = %v, want success:2 error:1 skipped:1 (plain excluded)", counts)
+	}
+
+	// Filtered to the one workflow — same tally.
+	scoped, err := svc.WorkflowRunStatusCounts(ctx, wf.Slug)
+	if err != nil {
+		t.Fatalf("scoped counts: %v", err)
+	}
+	if scoped["success"] != 2 {
+		t.Fatalf("scoped success = %d, want 2", scoped["success"])
+	}
+}

--- a/internal/templates/components/pages/workflows_runs.templ
+++ b/internal/templates/components/pages/workflows_runs.templ
@@ -46,11 +46,11 @@ templ workflowRunsFilters(p WorkflowRunsProps) {
 			Variant:   "box",
 			AriaLabel: "Filter runs by status",
 			Items: []components.TabBarItem{
-				{Label: "All", Href: workflowRunsHref("", p.WorkflowSlug), Active: p.StatusFilter == ""},
-				{Label: "Success", Href: workflowRunsHref("success", p.WorkflowSlug), Active: p.StatusFilter == "success"},
-				{Label: "Error", Href: workflowRunsHref("error", p.WorkflowSlug), Active: p.StatusFilter == "error"},
-				{Label: "In progress", Href: workflowRunsHref("in_progress", p.WorkflowSlug), Active: p.StatusFilter == "in_progress"},
-				{Label: "Skipped", Href: workflowRunsHref("skipped", p.WorkflowSlug), Active: p.StatusFilter == "skipped"},
+				{Label: "All", Href: workflowRunsHref("", p.WorkflowSlug), Active: p.StatusFilter == "", Count: workflowCountPtr(p.Counts.All)},
+				{Label: "Success", Href: workflowRunsHref("success", p.WorkflowSlug), Active: p.StatusFilter == "success", Count: workflowCountPtr(p.Counts.Success)},
+				{Label: "Error", Href: workflowRunsHref("error", p.WorkflowSlug), Active: p.StatusFilter == "error", Count: workflowCountPtr(p.Counts.Error)},
+				{Label: "In progress", Href: workflowRunsHref("in_progress", p.WorkflowSlug), Active: p.StatusFilter == "in_progress", Count: workflowCountPtr(p.Counts.InProgress)},
+				{Label: "Skipped", Href: workflowRunsHref("skipped", p.WorkflowSlug), Active: p.StatusFilter == "skipped", Count: workflowCountPtr(p.Counts.Skipped)},
 			},
 		})
 		if len(p.Options) > 0 {

--- a/internal/templates/components/pages/workflows_runs_types.go
+++ b/internal/templates/components/pages/workflows_runs_types.go
@@ -29,6 +29,28 @@ type WorkflowRunsProps struct {
 	// isn't configured, the "Re-run" item renders disabled instead of
 	// firing a run that would only fail.
 	SubsystemReady bool
+
+	// Counts drives the per-status badges on the status tabs (respecting
+	// the active workflow filter, ignoring the active status filter).
+	Counts WorkflowRunStatusCounts
+}
+
+// WorkflowRunStatusCounts holds the run tally per status tab.
+type WorkflowRunStatusCounts struct {
+	All        int
+	Success    int
+	Error      int
+	InProgress int
+	Skipped    int
+}
+
+// workflowCountPtr adapts a count to TabBarItem.Count (*int), collapsing
+// zero to nil so empty-status tabs render no badge.
+func workflowCountPtr(n int) *int {
+	if n == 0 {
+		return nil
+	}
+	return &n
 }
 
 // WorkflowRunFilterOption is one entry in the workflow filter dropdown.


### PR DESCRIPTION
Adds **per-status count badges** to the Workflows → Runs status tabs, completing the Mintlify "runs tab with status filters + counts" bar. At a glance you see the run distribution (All 7 · Success 4 · Error 1 · In progress 1 · Skipped 1) without clicking through each filter.

## What changed

- New `Service.WorkflowRunStatusCounts(ctx, workflowSlugOrID)` — a `status → count` tally over preset-backed workflow runs (`source_template IS NOT NULL`), optionally narrowed to one workflow. Same hand-rolled-SQL pattern as `ListAllAgentRuns`.
- The runs handler computes counts (respecting the active workflow filter, ignoring the active status filter so each tab shows its own tally) and sets `TabBarItem.Count` on each status tab. Counts of 0 render no badge (`workflowCountPtr` collapses to nil).
- The `TabBar` already supports `Count *int` badges — no component change needed.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. scripts_lint, pages, admin)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Integration (`breadbox_test_wf`):

```
TestWorkflowRunStatusCounts   PASS  (counts by status; non-workflow runs excluded; workflow-scoped tally correct)
```

## Screenshot

Runs tab — status tabs with count badges (All 7 · Success 4 · Error 1 · In progress 1 · Skipped 1):

<img src="https://i.img402.dev/37h3t88xjx.jpg" width="800" alt="Workflows runs tab with per-status count badges">
