### PR TITLE
feat(workflows): per-preset specialized options (Apply mode)

### DIFF
--- a/internal/admin/workflows_actions.go
+++ b/internal/admin/workflows_actions.go
@@ -41,6 +41,19 @@ func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
 		if cron := r.FormValue("schedule_cron"); cron != "" {
 			params.ScheduleCron = &cron
 		}
+		// Any non-control form field is a preset-specialized option (e.g.
+		// apply_mode); the service validates each against the preset's
+		// declared options and ignores unknown keys.
+		control := map[string]bool{
+			"enabled": true, "schedule_cron": true,
+			"additional_instructions": true, "consent": true, "_csrf": true,
+		}
+		params.Options = map[string]string{}
+		for key := range r.Form {
+			if !control[key] {
+				params.Options[key] = r.FormValue(key)
+			}
+		}
 		wf, err := svc.EnableWorkflowFromPreset(r.Context(), slug, params)
 		if err != nil {
 			switch {

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -101,6 +101,18 @@ func groupWorkflowPresets(views []service.WorkflowPresetView) []pages.WorkflowCa
 		if v.WorkflowEnabled != nil {
 			card.WorkflowEnabled = *v.WorkflowEnabled
 		}
+		for _, opt := range v.Options {
+			cardOpt := pages.WorkflowPresetOptionProps{
+				Key:     opt.Key,
+				Label:   opt.Label,
+				Help:    opt.Help,
+				Default: opt.Default,
+			}
+			for _, ch := range opt.Choices {
+				cardOpt.Choices = append(cardOpt.Choices, pages.WorkflowPresetChoiceProps{Value: ch.Value, Label: ch.Label})
+			}
+			card.Options = append(card.Options, cardOpt)
+		}
 		byCat[v.Category] = append(byCat[v.Category], card)
 	}
 	out := make([]pages.WorkflowCategoryProps, 0, len(order))

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -36,6 +36,79 @@ type WorkflowPreset struct {
 	// paying their own bill sees the order of magnitude before enabling.
 	// Deliberately approximate — actual cost is recorded per run.
 	EstCostPerRunUSD float64
+
+	// Options are this preset's specialized configuration choices, rendered
+	// as selects in the configure drawer (Mintlify "per-preset options").
+	// The chosen choice's Directive is appended to the composed prompt.
+	Options []WorkflowPresetOption
+}
+
+// WorkflowPresetOption is one preset-specific configuration choice (a
+// single-select). The chosen choice's Directive (if any) is appended to
+// the workflow's prompt under a heading named after the option's Label.
+type WorkflowPresetOption struct {
+	Key     string // form field name, e.g. "apply_mode"
+	Label   string // drawer label + prompt heading
+	Help    string // optional caption under the select
+	Default string // default choice Value
+	Choices []WorkflowPresetChoice
+}
+
+// WorkflowPresetChoice is one option value. Directive is the prompt text
+// appended when this choice is selected (empty = the default behavior,
+// no extra prompt).
+type WorkflowPresetChoice struct {
+	Value     string
+	Label     string
+	Directive string
+}
+
+// applyModeOption is the shared "auto-apply vs flag-only" choice for the
+// categorization presets. Auto is the default (no extra directive); flag-only
+// overrides the base prompt to suppress all category writes.
+var applyModeOption = WorkflowPresetOption{
+	Key:     "apply_mode",
+	Label:   "Apply mode",
+	Help:    "How it handles categories it's confident about.",
+	Default: "auto",
+	Choices: []WorkflowPresetChoice{
+		{Value: "auto", Label: "Auto-apply categories", Directive: ""},
+		{
+			Value:     "flag_only",
+			Label:     "Flag only — don't categorize",
+			Directive: "APPLY MODE — FLAG ONLY: Do NOT set, change, or clear any transaction category, and do NOT call update_transactions to write a category. Your job in this mode is review-and-flag only: flag transactions that need a human's attention (and leave a brief comment explaining why), but leave all categorization decisions to the user.",
+		},
+	},
+}
+
+// resolveOptionDirectives returns the prompt text to append for a preset's
+// chosen options. Each option resolves to a choice — the submitted value if
+// valid, otherwise the option's Default — and any non-empty Directive is
+// appended under a heading named for the option's Label.
+func resolveOptionDirectives(preset WorkflowPreset, chosen map[string]string) string {
+	var b strings.Builder
+	for _, opt := range preset.Options {
+		val := strings.TrimSpace(chosen[opt.Key])
+		valid := false
+		for _, ch := range opt.Choices {
+			if ch.Value == val {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			val = opt.Default
+		}
+		for _, ch := range opt.Choices {
+			if ch.Value == val && strings.TrimSpace(ch.Directive) != "" {
+				b.WriteString("\n\n## ")
+				b.WriteString(opt.Label)
+				b.WriteString("\n\n")
+				b.WriteString(ch.Directive)
+			}
+		}
+	}
+	return b.String()
 }
 
 // workflowPresets is the starter catalog. Order is the gallery display order.
@@ -57,6 +130,7 @@ var workflowPresets = []WorkflowPreset{
 		ToolScope:             "read_write",
 		TriggerOnSyncComplete: true,
 		EstCostPerRunUSD:      0.02, // short, efficient per-sync review
+		Options:               []WorkflowPresetOption{applyModeOption},
 	},
 	{
 		Slug:        "weekly-money-digest",
@@ -99,6 +173,7 @@ var workflowPresets = []WorkflowPreset{
 		ToolScope:        "read_write",
 		ScheduleCron:     "0 7 * * 1", // Mondays at 07:00 (canonical "Weekly" — drawer-selectable)
 		EstCostPerRunUSD: 0.08,        // thorough pass over an accumulated backlog
+		Options:          []WorkflowPresetOption{applyModeOption},
 	},
 	{
 		Slug:        "monthly-close",
@@ -202,6 +277,11 @@ type EnableWorkflowFromPresetParams struct {
 	// prompt every run — the household's per-workflow tuning, mirroring
 	// Mintlify's "additional prompt over the base prompt".
 	AdditionalInstructions string
+	// Options carries the chosen value for each of the preset's specialized
+	// options (keyed by WorkflowPresetOption.Key). Unknown/missing keys fall
+	// back to the option's Default. Chosen choices' Directives are appended
+	// to the composed prompt.
+	Options map[string]string
 }
 
 // maxAdditionalInstructions caps the per-workflow instruction tuning.
@@ -233,6 +313,9 @@ func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, par
 	if err != nil {
 		return nil, err
 	}
+	// Apply the preset's specialized options: each chosen choice's directive
+	// is appended to the base prompt (auto/default choices have no directive).
+	prompt += resolveOptionDirectives(preset, params.Options)
 	// Append the household's per-workflow tuning to the base prompt.
 	instr := strings.TrimSpace(params.AdditionalInstructions)
 	if len(instr) > maxAdditionalInstructions {

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -233,3 +233,28 @@ func TestWorkflowRunStatusCounts(t *testing.T) {
 		t.Fatalf("scoped success = %d, want 2", scoped["success"])
 	}
 }
+
+func TestEnableWorkflowFromPreset_ApplyModeOption(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// flag_only → the suppress-categorization directive lands in the prompt.
+	flag, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{
+		Options: map[string]string{"apply_mode": "flag_only"},
+	})
+	if err != nil {
+		t.Fatalf("enable flag_only: %v", err)
+	}
+	if !strings.Contains(flag.Prompt, "FLAG ONLY") || !strings.Contains(flag.Prompt, "Apply mode") {
+		t.Fatalf("flag_only prompt missing the apply-mode directive (%d chars)", len(flag.Prompt))
+	}
+
+	// Default (auto) on a different preset → no directive appended.
+	auto, err := svc.EnableWorkflowFromPreset(ctx, "backlog-closer", service.EnableWorkflowFromPresetParams{})
+	if err != nil {
+		t.Fatalf("enable default: %v", err)
+	}
+	if strings.Contains(auto.Prompt, "FLAG ONLY") {
+		t.Fatalf("auto (default) prompt should NOT contain the flag-only directive")
+	}
+}

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -192,6 +192,23 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 						></div>
 					}
 				</div>
+				for _, opt := range preset.Options {
+					<div>
+						<div class="text-sm font-medium mb-1.5">{ opt.Label }</div>
+						<select name={ opt.Key } class="select select-sm w-full">
+							for _, ch := range opt.Choices {
+								if ch.Value == opt.Default {
+									<option value={ ch.Value } selected>{ ch.Label }</option>
+								} else {
+									<option value={ ch.Value }>{ ch.Label }</option>
+								}
+							}
+						</select>
+						if opt.Help != "" {
+							<div class="text-xs text-base-content/40 mt-1">{ opt.Help }</div>
+						}
+					</div>
+				}
 				<div>
 					<div class="text-sm font-medium mb-1.5">
 						Additional instructions

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -59,8 +59,29 @@ type WorkflowPresetCardProps struct {
 	TriggerOnSync    bool    // true = post-sync event trigger (no schedule editing)
 	EstCostPerRunUSD float64 // rough per-run cost estimate for the projected-cost hint
 
+	// Options are the preset's specialized configuration selects, rendered
+	// in the configure drawer (e.g. apply-mode for categorization presets).
+	Options []WorkflowPresetOptionProps
+
 	// Enablement state.
 	Enabled         bool   // the preset has been instantiated as a workflow
 	WorkflowSlug    string // slug of the instantiated workflow (when Enabled)
 	WorkflowEnabled bool   // the instantiated workflow's run toggle (when Enabled)
+}
+
+// WorkflowPresetOptionProps is one specialized option (a single-select) in
+// the configure drawer.
+type WorkflowPresetOptionProps struct {
+	Key     string
+	Label   string
+	Help    string
+	Default string // default choice Value (pre-selected)
+	Choices []WorkflowPresetChoiceProps
+}
+
+// WorkflowPresetChoiceProps is one option value (the prompt Directive lives
+// server-side; the drawer only needs the value + label).
+type WorkflowPresetChoiceProps struct {
+	Value string
+	Label string
 }


### PR DESCRIPTION
Adds **per-preset specialized options** — the Mintlify signature where each preset surfaces its own tailored configuration in the drawer. Ships the framework plus its first option: an **Apply mode** (Auto-apply categories / Flag only) on the two categorization presets.

## What changed

- **Options framework** (registry) — `WorkflowPreset.Options []WorkflowPresetOption`, each a single-select whose chosen `Choice.Directive` is appended to the composed prompt under a heading named for the option. General-purpose: future presets just declare their own options.
- **Apply mode** on Routine Reviewer + Backlog Closer — `Auto-apply categories` (default, no extra prompt) vs `Flag only — don't categorize` (appends a directive that suppresses all category writes, so the agent reviews-and-flags only). Lets one preset serve both the confident and the cautious household without a separate "Flag-Only Reviewer".
- **Service** — `EnableWorkflowFromPresetParams.Options map[string]string`; `resolveOptionDirectives` validates each submitted value against the preset's choices (falling back to the default) and appends directives before the additional-instructions block.
- **Drawer UI** — renders each preset option as a labeled select (with help caption); the handler copies non-control form fields into `params.Options`.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. TestWorkflowPresetsCompose for all 5 presets)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Integration (`breadbox_test_wf`):

```
TestEnableWorkflowFromPreset_ApplyModeOption  PASS  (flag_only → directive in prompt; default → no directive)
```

## Screenshot

Routine Reviewer drawer with the new "Apply mode" option:

<img src="https://i.img402.dev/j545uxcql5.jpg" width="800" alt="Configure drawer with per-preset Apply mode option">
