### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -126,18 +126,11 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 			{Label: "Reports", Href: "/reports"},
 			{Label: "Report"},
 		}
-		renderReportDetail(w, r, tr, data, pages.ReportDetailProps{
+		tr.RenderWithTempl(w, r, data, pages.ReportDetail(pages.ReportDetailProps{
 			Report:      detail,
 			Breadcrumbs: breadcrumbs,
-		})
+		}))
 	}
-}
-
-// renderReportDetail mirrors renderSyncLogDetail / renderPromptBuilder:
-// hands the typed ReportDetailProps to the templ component and uses
-// RenderWithTempl to host it inside base.html.
-func renderReportDetail(w http.ResponseWriter, r *http.Request, tr *TemplateRenderer, data map[string]any, props pages.ReportDetailProps) {
-	tr.RenderWithTempl(w, r, data, pages.ReportDetail(props))
 }
 
 // MarkReportReadAdminHandler handles POST /-/reports/{id}/read.

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -130,7 +130,7 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 			UpcomingCount:  upcomingCount,
 			Candidates:     candidates,
 			Active:         active,
-			Users:          subscriptionUserFilters(ctx, a, usersWithSeries),
+			Users:          subscriptionUserFilters(userName, usersWithSeries),
 			Types:          subscriptionTypeFilters(typesPresent),
 		}
 
@@ -601,23 +601,22 @@ func subscriptionUserNames(ctx context.Context, a *app.App) map[string]string {
 }
 
 // subscriptionUserFilters builds the household-member filter chips from the
-// users that actually own at least one series, sorted by name.
-func subscriptionUserFilters(ctx context.Context, a *app.App, owners map[string]bool) []pages.SubscriptionUserFilter {
+// users that actually own at least one series, sorted by name. Reuses the
+// name map already fetched for row rendering — no extra ListUsers query.
+func subscriptionUserFilters(userName map[string]string, owners map[string]bool) []pages.SubscriptionUserFilter {
 	if len(owners) < 2 {
 		return nil
 	}
-	users, _ := a.Queries.ListUsers(ctx)
 	var out []pages.SubscriptionUserFilter
-	for _, u := range users {
-		id := pgconv.FormatUUID(u.ID)
+	for id, name := range userName {
 		if !owners[id] {
 			continue
 		}
 		first := ""
-		if u.Name != "" {
-			first = u.Name[:1]
+		if name != "" {
+			first = name[:1]
 		}
-		out = append(out, pages.SubscriptionUserFilter{ID: id, Name: u.Name, First: first})
+		out = append(out, pages.SubscriptionUserFilter{ID: id, Name: name, First: first})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out

--- a/internal/templates/components/pages/design_reports_table_helpers.go
+++ b/internal/templates/components/pages/design_reports_table_helpers.go
@@ -14,77 +14,53 @@ import "breadbox/internal/templates/components"
 // components.ReportsList in the sandbox.
 func designReportRows() []components.ReportRowProps {
 	return []components.ReportRowProps{
-		designReportRowUnreadCritical(),
-		designReportRowUnreadWarning(),
-		designReportRowUnreadPlain(),
-		designReportRowReadPlain(),
-		designReportRowLongSummary(),
-		designReportRowReadCritical(),
-	}
-}
-
-func designReportRowUnreadCritical() components.ReportRowProps {
-	return components.ReportRowProps{
-		ID:       "rep_crit01",
-		Title:    "3 duplicate subscriptions found totaling $47/mo",
-		Priority: "critical",
-		Author:   "Subscription watchdog",
-		Time:     "12m ago",
-		IsRead:   false,
-	}
-}
-
-func designReportRowUnreadWarning() components.ReportRowProps {
-	return components.ReportRowProps{
-		ID:       "rep_warn01",
-		Title:    "Dining spend is 38% over your monthly target",
-		Priority: "warning",
-		Author:   "Budget coach",
-		Time:     "1h ago",
-		IsRead:   false,
-	}
-}
-
-func designReportRowUnreadPlain() components.ReportRowProps {
-	return components.ReportRowProps{
-		ID:       "rep_plain1",
-		Title:    "Weekly recap: 42 transactions categorized, all matched",
-		Priority: "",
-		Author:   "Daily recap",
-		Time:     "3h ago",
-		IsRead:   false,
-	}
-}
-
-func designReportRowReadPlain() components.ReportRowProps {
-	return components.ReportRowProps{
-		ID:       "rep_read01",
-		Title:    "Monthly statement reconciled — no discrepancies",
-		Priority: "",
-		Author:   "Reconciler",
-		Time:     "2d ago",
-		IsRead:   true,
-	}
-}
-
-func designReportRowLongSummary() components.ReportRowProps {
-	return components.ReportRowProps{
-		ID:       "rep_long01",
-		Title:    "Heads up: your travel-rewards card annual fee of $550 posts on the 14th, and based on this year's redemptions it may no longer pay for itself",
-		Priority: "warning",
-		Author:   "Rewards analyst",
-		Time:     "5h ago",
-		IsRead:   false,
-	}
-}
-
-func designReportRowReadCritical() components.ReportRowProps {
-	return components.ReportRowProps{
-		ID:       "rep_rc01",
-		Title:    "Unusual $1,240 charge from a new merchant",
-		Priority: "critical",
-		Author:   "Fraud sentry",
-		Time:     "3d ago",
-		IsRead:   true,
+		{
+			ID:       "rep_crit01",
+			Title:    "3 duplicate subscriptions found totaling $47/mo",
+			Priority: "critical",
+			Author:   "Subscription watchdog",
+			Time:     "12m ago",
+			IsRead:   false,
+		},
+		{
+			ID:       "rep_warn01",
+			Title:    "Dining spend is 38% over your monthly target",
+			Priority: "warning",
+			Author:   "Budget coach",
+			Time:     "1h ago",
+			IsRead:   false,
+		},
+		{
+			ID:       "rep_plain1",
+			Title:    "Weekly recap: 42 transactions categorized, all matched",
+			Priority: "",
+			Author:   "Daily recap",
+			Time:     "3h ago",
+			IsRead:   false,
+		},
+		{
+			ID:       "rep_read01",
+			Title:    "Monthly statement reconciled — no discrepancies",
+			Priority: "",
+			Author:   "Reconciler",
+			Time:     "2d ago",
+			IsRead:   true,
+		},
+		{
+			ID:       "rep_long01",
+			Title:    "Heads up: your travel-rewards card annual fee of $550 posts on the 14th, and based on this year's redemptions it may no longer pay for itself",
+			Priority: "warning",
+			Author:   "Rewards analyst",
+			Time:     "5h ago",
+			IsRead:   false,
+		},
+		{
+			ID:       "rep_rc01",
+			Title:    "Unusual $1,240 charge from a new merchant",
+			Priority: "critical",
+			Author:   "Fraud sentry",
+			Time:     "3d ago",
+			IsRead:   true,
+		},
 	}
 }


### PR DESCRIPTION
## Summary

Daily simplify-drift review of the 22 PRs merged in the last 24 hours. Three quality cleanups: one dead wrapper, one redundant DB query, one fixture-data inlining. No behavior changes.

## PRs reviewed

- #1631 — feat(recurring): `series reinfer-types` backfill for pre-type-feature series
- #1629 — feat(recurring): "Price ↑" badge on the ledger for rising-price series
- #1627 — feat(recurring): "Due in 30 days" upcoming-spend stat tile
- #1625 — refactor(recurring): extract shared series chips + /design section
- #1623 — feat(recurring): interactive series-tag editing on the detail page
- #1622 — feat(recurring): surface type in the UI (chip, filter, type-aware copy)
- #1619 — feat(recurring): structured type field (subscription|bill|loan|other), inferred + overridable
- #1617 — feat(recurring): rename Subscriptions → Recurring (umbrella; subscription becomes a type)
- #1614 — fix(ui): brand marks follow resolved theme, not raw OS preference
- #1613 — feat(series): recurring-series sprint — conditions, renewal-health, explain feed, rekey/split, UI chip
- #1612 — fix(ui): match Mintlify corner radii + darker outline hover fill
- #1611 — feat(ui): Mintlify-inspired theme — surface flip, warm-tinted neutrals, flat cards, tighter radius
- #1610 — fix(ui): render GitHub brand icon in the avatar menu
- #1609 — feat(series): retroactive apply for assign_series rule action
- #1608 — feat(series): tags on a series → linked transactions inherit them
- #1607 — feat(reports): redesign inbox + detail as a refined, reusable-component inbox
- #1606 — feat(series): assign_series rule action — auto-apply a series like a category (PR3)
- #1605 — feat: Recurring Series / Subscriptions (Beta)
- #1604 — feat(ui): collapsible icon-rail sidebar + static top navbar (Mintlify-style shell)
- #1603 — fix(ui): brand marks match Lucide icon weight (alpha-strip currentColor)
- #1602 — chore: simplify drift from PRs #1593–#1600 (previous run)
- #1601 — feat(settings): full-page Mintlify redesign — sidebar-extension rail, carded sections, one-click API keys

## Changes

- `internal/admin/reports.go:139` — inline `renderReportDetail`, a 1-line single-use wrapper, into its sole call site in `ReportDetailHandler`.
- `internal/admin/subscriptions.go:609` — drop a redundant `ListUsers` query on every `/recurring` page load. `subscriptionUserFilters` now takes the `userName` map already fetched for row rendering instead of re-querying.
- `internal/templates/components/pages/design_reports_table_helpers.go:26-90` — inline 6 single-use struct-literal wrapper functions (`designReportRowUnreadCritical`, …) into `designReportRows()`. Pure fixture data; ~65 lines of pass-through boilerplate removed.

## Findings skipped

- `haveExisting := matchErr == nil` in `internal/service/series.go:461` — reuse agent flagged it as redundant but it's used 3 times (467, 474, 540). Named bool is clearer than three inlined `matchErr == nil`.
- N+1 in `AddSeriesTag` / `RemoveSeriesTag` MCP+REST handlers (immediate `GetSeries` after mutation) — fixing it requires changing service-method signatures to return the modified row. Behavior-shaped refactor, out of simplify scope.
- New `Int4FromPtr` pgconv helper proposed by reuse agent — guardrails forbid introducing new abstractions in a simplify run.
- Altitude review came back clean.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`

https://claude.ai/code/session_01AqMxfdrURA8gbQ6Tf2SE14

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqMxfdrURA8gbQ6Tf2SE14)_