### PR TITLE
feat(workflows): outbound notification sink — webhook config + test send

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -279,6 +279,10 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 			zero := 0.0
 			params.GlobalMaxBudgetUSD = &zero
 		}
+		if r.Form.Has("notify_webhook_url") {
+			v := strings.TrimSpace(r.FormValue("notify_webhook_url"))
+			params.NotifyWebhookURL = &v // empty clears; service validates http(s)
+		}
 
 		if _, err := svc.UpdateAgentSettings(r.Context(), params, a.Config.EncryptionKey, a.Config.DataDir); err != nil {
 			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/agents")
@@ -286,6 +290,20 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 		}
 		SetFlash(r.Context(), sm, "success", "Agent settings saved.")
 		http.Redirect(w, r, "/settings/agents", http.StatusSeeOther)
+	}
+}
+
+// NotifyTestAdminHandler handles POST /-/agents/notify-test — admin-only.
+// Fires a sample notification to the configured webhook so the operator can
+// verify wiring. Returns JSON {ok} or {ok:false, error} (rendered inline via
+// Alpine). 422 when unconfigured or the webhook errors.
+func NotifyTestAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := svc.SendTestNotification(r.Context()); err != nil {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"ok": false, "error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 	}
 }
 
@@ -461,4 +479,3 @@ func splitAllowedTools(raw string) []string {
 	}
 	return out
 }
-

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -46,6 +46,7 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			RuntimePath:           settings.RuntimePath,
 			TranscriptDir:         settings.TranscriptDir,
 			GlobalMaxBudgetUSDStr: formatOptionalBudget(settings.GlobalMaxBudgetUSD),
+			NotifyWebhookURL:      settings.NotifyWebhookURL,
 		}
 		if settings.SubscriptionToken != nil {
 			form.SubscriptionTokenDisplay = *settings.SubscriptionToken

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -549,6 +549,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			// smoke-test / cleanup cost money or touch the filesystem.
 			r.Post("/agents/settings", UpdateAgentSDKSettingsAdminHandler(a, svc, sm))
 			r.Post("/agents/test", SmokeTestAgentAdminHandler(a, svc))
+			r.Post("/agents/notify-test", NotifyTestAdminHandler(svc))
 			r.Post("/agents/cleanup", AgentCleanupAdminHandler(a, svc))
 		})
 	})

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -74,6 +74,13 @@ const (
 	// checkbox in the workflow configure drawer — shown on first enable,
 	// hidden thereafter.
 	KeyWorkflowsConsentAckAt = "workflows.consent_acknowledged_at"
+
+	// KeyNotifyWebhookURL is an optional outbound webhook URL. When set,
+	// Breadbox POSTs a JSON payload to it for workflow notifications (e.g.
+	// a report a workflow flagged). Empty = notifications disabled. The
+	// self-hoster controls the URL (point it at ntfy / Slack / Discord /
+	// an email bridge). http(s) only.
+	KeyNotifyWebhookURL = "notify.webhook_url"
 )
 
 // AuthMode values for KeyAgentAuthMode.

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -33,6 +34,7 @@ type AgentSettingsResponse struct {
 	GlobalMaxBudgetUSD *float64 `json:"global_max_budget_usd,omitempty"`
 	RuntimePath        string   `json:"runtime_path"`
 	TranscriptDir      string   `json:"transcript_dir"`
+	NotifyWebhookURL   string   `json:"notify_webhook_url"`
 }
 
 // UpdateAgentSettingsParams holds writable settings. Nil = don't touch;
@@ -45,6 +47,7 @@ type UpdateAgentSettingsParams struct {
 	GlobalMaxBudgetUSD *float64
 	RuntimePath        *string
 	TranscriptDir      *string
+	NotifyWebhookURL   *string
 }
 
 // GetAgentSettings reads agent.* keys from app_config, decrypts tokens,
@@ -68,6 +71,7 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte, dataDir s
 	// form showing the active path on a fresh install rather than blank.
 	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(dataDir))
 	globalBudget := readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)
+	notifyURL := appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, "")
 
 	return &AgentSettingsResponse{
 		AuthMode:           authMode,
@@ -77,6 +81,7 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte, dataDir s
 		GlobalMaxBudgetUSD: globalBudget,
 		RuntimePath:        runtimePath,
 		TranscriptDir:      transcriptDir,
+		NotifyWebhookURL:   notifyURL,
 	}, nil
 }
 
@@ -127,6 +132,19 @@ func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettings
 			return nil, fmt.Errorf("set transcript_dir: %w", err)
 		}
 	}
+	if p.NotifyWebhookURL != nil {
+		// Empty clears the webhook (notifications off); a non-empty value
+		// must be a valid http(s) URL.
+		trimmed := strings.TrimSpace(*p.NotifyWebhookURL)
+		if trimmed != "" {
+			if err := validateNotifyURL(trimmed); err != nil {
+				return nil, err
+			}
+		}
+		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyWebhookURL, trimmed)); err != nil {
+			return nil, fmt.Errorf("set notify_webhook_url: %w", err)
+		}
+	}
 	return s.GetAgentSettings(ctx, encKey, dataDir)
 }
 
@@ -135,11 +153,11 @@ func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettings
 // onboarding hints, and (later) by the smoke-test endpoints to short-
 // circuit before charging a real API call.
 type AgentSubsystemStatus struct {
-	AuthMode        string `json:"auth_mode"`
-	AuthConfigured  bool   `json:"auth_configured"`
-	BinaryPresent   bool   `json:"binary_present"`
-	BinaryPath      string `json:"binary_path,omitempty"`
-	Ready           bool   `json:"ready"` // AuthConfigured && BinaryPresent
+	AuthMode       string `json:"auth_mode"`
+	AuthConfigured bool   `json:"auth_configured"`
+	BinaryPresent  bool   `json:"binary_present"`
+	BinaryPath     string `json:"binary_path,omitempty"`
+	Ready          bool   `json:"ready"` // AuthConfigured && BinaryPresent
 }
 
 // GetAgentSubsystemStatus inspects app_config + the filesystem to report

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -1,0 +1,96 @@
+//go:build !lite
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"breadbox/internal/appconfig"
+)
+
+// notifyHTTPClient is the shared client for outbound workflow notifications.
+// A short timeout keeps a slow/hung webhook from blocking the caller.
+var notifyHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// NotificationPayload is the JSON body POSTed to the configured notification
+// webhook. Shaped to be readable by generic sinks (ntfy, Slack-compatible
+// relays, email bridges) without per-provider formatting.
+type NotificationPayload struct {
+	Event    string `json:"event"`              // "test" | "report"
+	Title    string `json:"title"`              // short headline
+	Body     string `json:"body,omitempty"`     // longer text
+	Priority string `json:"priority,omitempty"` // info | warning | critical
+	Workflow string `json:"workflow,omitempty"` // originating workflow name
+	URL      string `json:"url,omitempty"`      // deep link back into Breadbox
+	SentAt   string `json:"sent_at"`            // RFC3339
+}
+
+// WorkflowNotificationConfigured reports whether an outbound webhook URL is set.
+func (s *Service) WorkflowNotificationConfigured(ctx context.Context) bool {
+	return strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, "")) != ""
+}
+
+// SendWorkflowNotification POSTs the payload as JSON to the configured
+// notification webhook. It is a no-op (returns nil) when no URL is
+// configured, so callers can fire unconditionally. The URL must be http(s).
+func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPayload) error {
+	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""))
+	if raw == "" {
+		return nil // notifications disabled — no-op
+	}
+	if err := validateNotifyURL(raw); err != nil {
+		return err
+	}
+	if p.SentAt == "" {
+		p.SentAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	body, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("marshal notification: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, raw, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build notification request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "breadbox-workflows")
+	resp, err := notifyHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("notification webhook: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("notification webhook returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// SendTestNotification fires a sample payload so an operator can verify their
+// webhook wiring from Settings. Returns ErrInvalidParameter when no URL is set.
+func (s *Service) SendTestNotification(ctx context.Context) error {
+	if !s.WorkflowNotificationConfigured(ctx) {
+		return fmt.Errorf("%w: no notification webhook URL configured", ErrInvalidParameter)
+	}
+	return s.SendWorkflowNotification(ctx, NotificationPayload{
+		Event:    "test",
+		Title:    "Breadbox workflow notification test",
+		Body:     "If you can see this, your workflow notification webhook is wired up correctly.",
+		Priority: "info",
+	})
+}
+
+// validateNotifyURL rejects anything that isn't a well-formed http(s) URL.
+func validateNotifyURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("%w: notification webhook URL must be a valid http(s) URL", ErrInvalidParameter)
+	}
+	return nil
+}

--- a/internal/service/notify_integration_test.go
+++ b/internal/service/notify_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+func TestSendWorkflowNotification(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Unconfigured → no-op, no error.
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Title: "x"}); err != nil {
+		t.Fatalf("unconfigured send should be a no-op, got %v", err)
+	}
+
+	var gotBody []byte
+	var gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotCT = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{NotifyWebhookURL: &srv.URL}, devEncKey, ""); err != nil {
+		t.Fatalf("set webhook: %v", err)
+	}
+	if !svc.WorkflowNotificationConfigured(ctx) {
+		t.Fatal("expected configured after setting URL")
+	}
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "Flagged charge", Priority: "warning"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("content-type = %q, want application/json", gotCT)
+	}
+	var p map[string]any
+	if err := json.Unmarshal(gotBody, &p); err != nil {
+		t.Fatalf("payload not JSON: %v (%s)", err, gotBody)
+	}
+	if p["title"] != "Flagged charge" || p["event"] != "report" {
+		t.Errorf("payload = %v, want title/event set", p)
+	}
+}

--- a/internal/service/notify_test.go
+++ b/internal/service/notify_test.go
@@ -1,0 +1,20 @@
+//go:build !lite
+
+package service
+
+import "testing"
+
+func TestValidateNotifyURL(t *testing.T) {
+	ok := []string{"https://ntfy.sh/topic", "http://localhost:8080/hook", "https://hooks.slack.com/services/x/y/z"}
+	for _, u := range ok {
+		if err := validateNotifyURL(u); err != nil {
+			t.Errorf("validateNotifyURL(%q) = %v, want nil", u, err)
+		}
+	}
+	bad := []string{"", "ftp://x", "notaurl", "javascript:alert(1)", "https://"}
+	for _, u := range bad {
+		if err := validateNotifyURL(u); err == nil {
+			t.Errorf("validateNotifyURL(%q) = nil, want error", u)
+		}
+	}
+}

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -243,6 +243,21 @@ templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 			}) {
 				<span class="text-sm tabular-nums text-base-content/80">{ p.HouseholdSpend30dStr }</span>
 			}
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Notification webhook",
+				Caption: "POST workflow notifications to this http(s) URL (ntfy / Slack / Discord / email bridge). Empty = off.",
+				For:     "notify_webhook_url",
+				Stack:   true,
+			}) {
+				<input
+					id="notify_webhook_url"
+					type="url"
+					name="notify_webhook_url"
+					value={ p.Form.NotifyWebhookURL }
+					placeholder="https://ntfy.sh/my-breadbox-topic"
+					class="bb-form-input font-mono w-full"
+				/>
+			}
 			if p.FieldErrors["max_concurrent"] != "" || p.FieldErrors["global_max_budget_usd"] != "" {
 				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 					if p.FieldErrors["max_concurrent"] != "" {
@@ -341,6 +356,40 @@ templ agentSDKDiagnosticsSection(csrfToken string) {
 					</span>
 				</button>
 			}
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Test notification",
+				Caption: "Sends a sample payload to the configured webhook",
+			}) {
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm"
+					@click="runNotifyTest()"
+					:disabled="notifyState === 'loading'"
+				>
+					<span x-show="notifyState !== 'loading'" class="flex items-center gap-1.5">
+						@components.LucideIcon("bell", "w-4 h-4") Send test
+					</span>
+					<span x-show="notifyState === 'loading'" x-cloak class="flex items-center gap-1.5">
+						<span class="loading loading-spinner loading-xs"></span> Sending…
+					</span>
+				</button>
+			}
+			<template x-if="notifyState === 'ok'">
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<div role="alert" class="alert alert-success alert-soft rounded-xl">
+						@components.LucideIcon("circle-check", "w-4 h-4")
+						<span>Test notification sent — check your webhook destination.</span>
+					</div>
+				}
+			</template>
+			<template x-if="notifyState === 'error' && notifyError">
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<div role="alert" class="alert alert-error alert-soft rounded-xl">
+						@components.LucideIcon("circle-x", "w-4 h-4")
+						<span x-text="'Test notification failed: ' + notifyError"></span>
+					</div>
+				}
+			</template>
 			<template x-if="smokeState === 'ok' && smokeResult">
 				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 					<div class="rounded-lg bg-base-200/60 p-4 space-y-2">

--- a/internal/templates/components/pages/agent_sdk_settings_types.go
+++ b/internal/templates/components/pages/agent_sdk_settings_types.go
@@ -36,6 +36,7 @@ type AgentSDKSettingsFormFields struct {
 	GlobalMaxBudgetUSDStr    string // string so empty means "no cap"
 	RuntimePath              string
 	TranscriptDir            string
+	NotifyWebhookURL         string // outbound notification webhook (empty = off)
 }
 
 // AgentSDKStatusProps mirrors service.AgentSubsystemStatus for the

--- a/static/js/admin/components/agent_sdk_settings.js
+++ b/static/js/admin/components/agent_sdk_settings.js
@@ -14,6 +14,8 @@ document.addEventListener('alpine:init', function () {
       cleanupState: 'idle',
       cleanupResult: null,
       cleanupError: null,
+      notifyState: 'idle',
+      notifyError: null,
 
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
@@ -79,6 +81,30 @@ document.addEventListener('alpine:init', function () {
           .catch(function (e) {
             self.cleanupError = (e && e.message) || 'Request failed';
             self.cleanupState = 'error';
+          });
+      },
+
+      runNotifyTest: function () {
+        var self = this;
+        this.notifyState = 'loading';
+        this.notifyError = null;
+        this._post('/-/agents/notify-test')
+          .then(function (res) {
+            return res.json().then(function (body) {
+              return { ok: res.ok, status: res.status, body: body };
+            });
+          })
+          .then(function (r) {
+            if (!r.ok || (r.body && r.body.ok === false)) {
+              self.notifyError = (r.body && r.body.error) || ('HTTP ' + r.status);
+              self.notifyState = 'error';
+              return;
+            }
+            self.notifyState = 'ok';
+          })
+          .catch(function (e) {
+            self.notifyError = (e && e.message) || 'Request failed';
+            self.notifyState = 'error';
           });
       },
     };


### PR DESCRIPTION
Adds an **outbound notification sink** — config + service + a user-triggered test send. This is the first slice of the design-doc's "minimal sink"; it unblocks (in a follow-up) the Alerts & Anomalies category and Sync Watchdog, which need a real delivery channel to be timely rather than dashboard-only.

**Scope note (safety):** this slice introduces *no automatic egress*. The server only POSTs when an admin clicks "Send test" against their own configured URL. Auto-firing on workflow reports is a deliberate follow-up.

## What changed

- **`notify` service** (`internal/service/notify.go`) — `SendWorkflowNotification(ctx, payload)` POSTs a JSON `NotificationPayload` (event/title/body/priority/workflow/url/sent_at) to the configured webhook; **no-op when unconfigured** so callers can fire unconditionally. `SendTestNotification` fires a sample. `validateNotifyURL` enforces http(s).
- **Config** — new `appconfig.KeyNotifyWebhookURL`; read/written through `GetAgentSettings`/`UpdateAgentSettings` (empty clears; non-empty validated). The self-hoster controls the URL (ntfy / Slack / Discord / an email bridge).
- **Settings UI** — a "Notification webhook" field in agent settings + a "Send test" button in Diagnostics (admin-only `POST /-/agents/notify-test`, JSON result rendered inline via the existing `agentSDKDiagnostics` Alpine factory).

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. TestValidateNotifyURL, scripts_lint)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

Integration (`breadbox_test_wf`):

```
TestSendWorkflowNotification  PASS  (no-op unconfigured; configured → POSTs JSON payload to an httptest recorder; content-type + body verified)
```

The new route is admin `/-/*` (not REST `/api/v1`), so no OpenAPI drift.

## Screenshots

Notification webhook field (agent settings):

<img src="https://i.img402.dev/sch8ozew0f.jpg" width="800" alt="Notification webhook field in settings">

Diagnostics — Send test:

<img src="https://i.img402.dev/gx9n5kbmjh.jpg" width="800" alt="Test notification button in diagnostics">
