### PR TITLE
feat(workflows): agents→workflows UI/nav consolidation (PR4b slice 1)

### DIFF
--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -277,7 +277,9 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 		}
 
 		title := "Run " + row.ShortID
-		data := BaseTemplateData(r, sm, "agents", title)
+		// Run detail is part of the Workflows surface now (reached from the
+		// Workflows → Runs tab), so it highlights the Workflows nav item.
+		data := BaseTemplateData(r, sm, "workflows", title)
 		tr.RenderWithTempl(w, r, data, pages.AgentRunDetail(props))
 	}
 }

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -81,7 +81,7 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			HouseholdSpend30dStr: formatHouseholdSpend(spend),
 		}
 
-		data := BaseTemplateData(r, sm, "agents-settings", "Agents settings")
+		data := BaseTemplateData(r, sm, "agents-settings", "Workflows settings")
 		data["CSRFToken"] = props.CSRFToken
 		data["Flash"] = nil
 		renderSettingsTab(tr, w, r, data, pages.SettingsTabAgents, pages.AgentSDKSettings(props))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -193,6 +193,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/agents/definitions", AgentsListPageHandler(svc, sm, tr))
 		r.Get("/workflows", WorkflowsGalleryPageHandler(svc, sm, tr))
 		r.Get("/workflows/runs", WorkflowRunsPageHandler(svc, sm, tr))
+		// Run detail lives under the Workflows surface; the legacy
+		// /agents/runs/{shortId} route below still resolves the same handler.
+		r.Get("/workflows/runs/{shortId}", AgentRunDetailPageHandler(svc, sm, tr, a.Config.DataDir))
 		r.Get("/agents/new", AgentFormPageHandler(svc, sm, tr))
 		// /agents/{slug} is the per-agent landing page (lifetime stats +
 		// last 10 runs); /agents/{slug}/edit remains the form, reachable

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -64,7 +64,6 @@ templ Nav(p NavProps) {
 		<div class="bb-sidebar-section">Manage</div>
 		if p.IsEditor {
 			@navLink("/workflows", "workflow", "Workflows", navActive(p.CurrentPage, "workflows"))
-			@navLink("/agents", "bot-message-square", "Agents", navActive(p.CurrentPage, "agents"))
 		}
 		if p.IsAdmin {
 			@navLink("/rules", "zap", "Rules", navActive(p.CurrentPage, "rules"))

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -206,11 +206,11 @@ templ agentRunErrorAlert(run AgentRunRowProps) {
 // name › <short ID>. The agent crumb links to /agents?agent=<slug> (the
 // filtered feed) so consecutive runs stay in scope.
 func agentRunDetailBreadcrumbs(p AgentRunDetailProps) []components.Breadcrumb {
-	out := []components.Breadcrumb{{Label: "Agents", Href: "/agents"}}
+	out := []components.Breadcrumb{{Label: "Runs", Href: "/workflows/runs"}}
 	if p.Run.AgentSlug != "" {
 		out = append(out, components.Breadcrumb{
 			Label: runDetailAgentDisplay(p.Run),
-			Href:  "/agents?agent=" + p.Run.AgentSlug,
+			Href:  "/workflows/runs?workflow=" + p.Run.AgentSlug,
 		})
 	}
 	out = append(out, components.Breadcrumb{Label: p.Run.ShortID})

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -17,8 +17,8 @@ templ AgentSDKSettings(p AgentSDKSettingsProps) {
 	<script src="/static/js/admin/components/agent_sdk_settings.js"></script>
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
-			Title:    "Agents",
-			Subtitle: "Auth, sidecar binary, and execution limits for Claude Agent SDK runs",
+			Title:    "Workflows",
+			Subtitle: "Authentication, runtime, and spend controls that govern your workflow runs",
 		})
 		if p.FormError != "" {
 			<div role="alert" class="alert alert-error alert-soft mb-4 rounded-xl">

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -298,17 +298,17 @@ templ gsStep5(p GettingStartedProps) {
 				</div>
 				<div class="flex items-center gap-2 sm:hidden">
 					if p.HasAPIKey {
-						<a href="/agent-prompts" class="btn btn-ghost btn-sm">View Agents</a>
+						<a href="/workflows" class="btn btn-ghost btn-sm">View workflows</a>
 					} else {
-						<a href="/agent-prompts" class="btn btn-primary btn-sm">Set Up Agents</a>
+						<a href="/workflows" class="btn btn-primary btn-sm">Set up workflows</a>
 					}
 				</div>
 			</div>
 			<div class="hidden sm:flex flex-shrink-0">
 				if p.HasAPIKey {
-					<a href="/agent-prompts" class="btn btn-ghost btn-sm">View Agents</a>
+					<a href="/workflows" class="btn btn-ghost btn-sm">View workflows</a>
 				} else {
-					<a href="/agent-prompts" class="btn btn-primary btn-sm">Set Up Agents</a>
+					<a href="/workflows" class="btn btn-primary btn-sm">Set up workflows</a>
 				}
 			</div>
 		</div>

--- a/internal/templates/components/pages/settings_page.templ
+++ b/internal/templates/components/pages/settings_page.templ
@@ -57,7 +57,7 @@ templ settingsPageRail(p SettingsPageProps) {
 				@settingsRailItem(p, "system", "cpu", "System")
 				<div class="bb-settings-rail__group-label">Integrations</div>
 				@settingsRailItem(p, "providers", "plug", "Providers")
-				@settingsRailItem(p, "agents", "sparkles", "Agents")
+				@settingsRailItem(p, "agents", "sparkles", "Workflows")
 				@settingsRailItem(p, "mcp", "brand:model-context-protocol", "MCP")
 			}
 			if p.IsEditor {

--- a/internal/templates/components/pages/workflows_runs.templ
+++ b/internal/templates/components/pages/workflows_runs.templ
@@ -99,7 +99,7 @@ templ workflowRunActions(slug, shortID string, ready bool) {
 			{
 				Label: "View run",
 				Icon:  "external-link",
-				Href:  templ.SafeURL("/agents/runs/" + shortID),
+				Href:  templ.SafeURL("/workflows/runs/" + shortID),
 			},
 		},
 	})


### PR DESCRIPTION
**PR4b, slice 1 — the agents→workflows UI/nav consolidation.** Makes "Workflows" the single user-facing automation surface, per the design decision that Workflows replaces Agents (with the hand-authored agent CRUD hidden/deferred to a future custom-workflow builder). Pre-release, so the nav change is acceptable.

## What changed

- **Removed the "Agents" sidebar nav item** — "Workflows" is now the sole automation entry under Manage. The `/agents/*` hand-authored pages stay fully functional and reachable by URL (the deferred custom-workflow-builder surface), just out of primary nav.
- **Run detail unified under Workflows** — added `GET /workflows/runs/{shortId}` (same handler; legacy `/agents/runs/{shortId}` still resolves), repointed the runs-tab "View run" link, switched the page's nav highlight to Workflows, and reworked the breadcrumb to **Runs → /workflows/runs** (the per-workflow crumb now links `/workflows/runs?workflow=…`).
- **Settings** — the rail item + tab header rename "Agents" → **"Workflows"** (subtitle now "Authentication, runtime, and spend controls that govern your workflow runs"); the page title "Agents settings" → "Workflows settings". Route `/settings/agents` is unchanged so existing links (the gallery spend-ceiling banners) keep working.
- **Onboarding** — getting-started "View/Set Up Agents" buttons → "View/Set up workflows", pointing at `/workflows`.

**Deferred to follow-up slices:** REST `/api/v1/agents/*` → `/workflows/*`, the `/-/agents/*` action-route names (internal, not user-visible), and the docs. The internal DB tables + Go identifiers stay `agent_*`.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit; incl. scripts_lint, page_section, admin)
go build -tags=headless ./...  PASS   (CI-faithful: templ stamped)
go build -tags=lite ./...      PASS   (CI-faithful: templ deleted first)
make css                       PASS
```

No test asserts on the "Agents" nav/title strings, so nothing breaks. Verified live: the sidebar has zero `/agents` links; `/settings/agents` rail + header read "Workflows".

## Screenshots

Sidebar — "Workflows" is the single automation nav item (no more "Agents"):

<img src="https://i.img402.dev/qdn48kpy6n.jpg" width="800" alt="Sidebar with Workflows, no Agents">

Settings — rail item + header renamed to "Workflows":

<img src="https://i.img402.dev/4d8igg0rrv.jpg" width="800" alt="Workflows settings tab">
