### PR TITLE
feat(workflows): rename agent_definitions/agent_runs tables to workflows/workflow_runs (PR4c)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -48,7 +48,7 @@ the full chain works:
   - SDK can reach Anthropic and produce a response
 
 No agent definition is registered, no MCP servers attached, no
-agent_runs row written. Cost is bounded to ~5¢ via the diagnostic
+workflow_runs row written. Cost is bounded to ~5¢ via the diagnostic
 budget cap.
 
 Exit codes:
@@ -70,7 +70,7 @@ Exit codes:
 		Short: "Trigger an immediate run of a named agent",
 		Long: `Run one agent end-to-end against the live system: mints a scoped API
 key, spawns the sidecar with the definition's prompt + schedule, calls
-the MCP server, persists the resulting agent_runs row, revokes the key.
+the MCP server, persists the resulting workflow_runs row, revokes the key.
 
 Equivalent to clicking "Run now" in the admin UI — useful for cron/shell
 automation or local debugging.

--- a/internal/db/agent_queries_integration_test.go
+++ b/internal/db/agent_queries_integration_test.go
@@ -26,7 +26,7 @@ func numericFromFloat(t *testing.T, v float64) pgtype.Numeric {
 	return n
 }
 
-func mustCreateDefinition(t *testing.T, q *db.Queries, slug string, enabled bool) db.AgentDefinition {
+func mustCreateDefinition(t *testing.T, q *db.Queries, slug string, enabled bool) db.Workflow {
 	t.Helper()
 	ctx := context.Background()
 	out, err := q.CreateAgentDefinition(ctx, db.CreateAgentDefinitionParams{
@@ -245,7 +245,7 @@ func TestDeleteAgentRunsOlderThan(t *testing.T) {
 	d := mustCreateDefinition(t, q, "qry-cleanup-"+t.Name(), true)
 	// Insert a deliberately-old completed run via direct SQL.
 	if _, err := pool.Exec(ctx, `
-		INSERT INTO agent_runs (agent_definition_id, "trigger", status, started_at, completed_at)
+		INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at, completed_at)
 		VALUES ($1, 'manual', 'success', NOW() - INTERVAL '31 days', NOW() - INTERVAL '31 days')
 	`, d.ID); err != nil {
 		t.Fatalf("insert old run: %v", err)

--- a/internal/db/agent_tables_integration_test.go
+++ b/internal/db/agent_tables_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration && !lite
 
-// Pins the agent_definitions / agent_runs schema shipped in the Claude
+// Pins the workflows / workflow_runs schema shipped in the Claude
 // Agent SDK sprint. These tables back the admin /agents UI and the
 // scheduled-runner; the integration check fails loudly if someone reverts
 // the migrations.
@@ -29,12 +29,12 @@ func TestAgentDefinitionsTable_Exists(t *testing.T) {
 		var exists bool
 		if err := pool.QueryRow(ctx, `
 			SELECT EXISTS (SELECT 1 FROM information_schema.columns
-				WHERE table_name='agent_definitions' AND column_name=$1)
+				WHERE table_name='workflows' AND column_name=$1)
 		`, col).Scan(&exists); err != nil {
 			t.Fatalf("information_schema scan for %s: %v", col, err)
 		}
 		if !exists {
-			t.Errorf("agent_definitions.%s column is missing", col)
+			t.Errorf("workflows.%s column is missing", col)
 		}
 	}
 }
@@ -44,7 +44,7 @@ func TestAgentDefinitionsToolScopeCheck_RejectsInvalid(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := pool.Exec(ctx, `
-		INSERT INTO agent_definitions (name, slug, prompt, tool_scope, allowed_tools)
+		INSERT INTO workflows (name, slug, prompt, tool_scope, allowed_tools)
 		VALUES ('bogus tool scope', 'bogus-tool-scope-`+uniqueSuffix(t)+`',
 		        'p', 'totally-invalid', '[]')
 	`)
@@ -63,7 +63,7 @@ func TestAgentDefinitionsToolScopeCheck_AcceptsValid(t *testing.T) {
 	for _, scope := range []string{"read_only", "read_write"} {
 		slug := "valid-" + scope + "-" + uniqueSuffix(t)
 		if _, err := pool.Exec(ctx, `
-			INSERT INTO agent_definitions (name, slug, prompt, tool_scope, allowed_tools)
+			INSERT INTO workflows (name, slug, prompt, tool_scope, allowed_tools)
 			VALUES ('valid scope', $1, 'p', $2, '[]')
 		`, slug, scope); err != nil {
 			t.Errorf("expected scope %q to be accepted: %v", scope, err)
@@ -87,12 +87,12 @@ func TestAgentRunsTable_Exists(t *testing.T) {
 		var exists bool
 		if err := pool.QueryRow(ctx, `
 			SELECT EXISTS (SELECT 1 FROM information_schema.columns
-				WHERE table_name='agent_runs' AND column_name=$1)
+				WHERE table_name='workflow_runs' AND column_name=$1)
 		`, col).Scan(&exists); err != nil {
 			t.Fatalf("information_schema scan for %s: %v", col, err)
 		}
 		if !exists {
-			t.Errorf("agent_runs.%s column is missing", col)
+			t.Errorf("workflow_runs.%s column is missing", col)
 		}
 	}
 }
@@ -102,7 +102,7 @@ func TestAgentRunsStatusCheck_RejectsInvalid(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := pool.Exec(ctx, `
-		INSERT INTO agent_runs ("trigger", status) VALUES ('manual', 'bogus')
+		INSERT INTO workflow_runs ("trigger", status) VALUES ('manual', 'bogus')
 	`)
 	if err == nil {
 		t.Fatal("expected CHECK violation for status='bogus', got nil")
@@ -119,7 +119,7 @@ func TestAgentRunsFK_SetNullOnDefinitionDelete(t *testing.T) {
 	slug := "fk-test-" + uniqueSuffix(t)
 	var defID pgtype.UUID
 	if err := pool.QueryRow(ctx, `
-		INSERT INTO agent_definitions (name, slug, prompt, allowed_tools)
+		INSERT INTO workflows (name, slug, prompt, allowed_tools)
 		VALUES ('fk test', $1, 'p', '[]')
 		RETURNING id
 	`, slug).Scan(&defID); err != nil {
@@ -128,20 +128,20 @@ func TestAgentRunsFK_SetNullOnDefinitionDelete(t *testing.T) {
 
 	var runID pgtype.UUID
 	if err := pool.QueryRow(ctx, `
-		INSERT INTO agent_runs (agent_definition_id, "trigger", status)
+		INSERT INTO workflow_runs (agent_definition_id, "trigger", status)
 		VALUES ($1, 'manual', 'success')
 		RETURNING id
 	`, defID).Scan(&runID); err != nil {
 		t.Fatalf("insert run: %v", err)
 	}
 
-	if _, err := pool.Exec(ctx, `DELETE FROM agent_definitions WHERE id = $1`, defID); err != nil {
+	if _, err := pool.Exec(ctx, `DELETE FROM workflows WHERE id = $1`, defID); err != nil {
 		t.Fatalf("delete definition: %v", err)
 	}
 
 	var orphanedDefID pgtype.UUID
 	if err := pool.QueryRow(ctx, `
-		SELECT agent_definition_id FROM agent_runs WHERE id = $1
+		SELECT agent_definition_id FROM workflow_runs WHERE id = $1
 	`, runID).Scan(&orphanedDefID); err != nil {
 		t.Fatalf("re-fetch run: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestAgentDefinitionsShortIDTrigger_Fires(t *testing.T) {
 	slug := "shortid-test-" + uniqueSuffix(t)
 	var shortID string
 	if err := pool.QueryRow(ctx, `
-		INSERT INTO agent_definitions (name, slug, prompt, allowed_tools)
+		INSERT INTO workflows (name, slug, prompt, allowed_tools)
 		VALUES ('shortid', $1, 'p', '[]')
 		RETURNING short_id
 	`, slug).Scan(&shortID); err != nil {

--- a/internal/db/migrations/20260531120000_rename_agent_tables_to_workflows.sql
+++ b/internal/db/migrations/20260531120000_rename_agent_tables_to_workflows.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Rename the agent_* tables to workflow_* to match the user-facing
+-- "Workflows" product (the UI rename landed in PR4b). Pre-release, so a
+-- breaking RENAME is acceptable. PostgreSQL auto-updates the dependent
+-- FK constraints (agent_runs.agent_definition_id, agent_reports.agent_run_id,
+-- api_keys.agent_definition_id), indexes, and short_id triggers to follow
+-- the renamed tables — only the table identifiers change here. FK COLUMN
+-- names are intentionally left as-is to bound the change.
+ALTER TABLE agent_definitions RENAME TO workflows;
+ALTER TABLE agent_runs RENAME TO workflow_runs;
+
+-- +goose Down
+ALTER TABLE workflow_runs RENAME TO agent_runs;
+ALTER TABLE workflows RENAME TO agent_definitions;

--- a/internal/db/queries/agent_definitions.sql
+++ b/internal/db/queries/agent_definitions.sql
@@ -1,5 +1,5 @@
 -- name: CreateAgentDefinition :one
-INSERT INTO agent_definitions (
+INSERT INTO workflows (
     name, slug, prompt, system_prompt, schedule_cron,
     tool_scope, allowed_tools, model, max_turns, max_budget_usd, enabled,
     quiet_hours_start, quiet_hours_end, trigger_on_sync_complete, source_template
@@ -8,25 +8,25 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 RETURNING *;
 
 -- name: GetAgentDefinition :one
-SELECT * FROM agent_definitions WHERE id = $1;
+SELECT * FROM workflows WHERE id = $1;
 
 -- name: GetAgentDefinitionByShortID :one
-SELECT * FROM agent_definitions WHERE short_id = $1;
+SELECT * FROM workflows WHERE short_id = $1;
 
 -- name: GetAgentDefinitionBySlug :one
-SELECT * FROM agent_definitions WHERE slug = $1;
+SELECT * FROM workflows WHERE slug = $1;
 
 -- name: ListAgentDefinitions :many
-SELECT * FROM agent_definitions
+SELECT * FROM workflows
 ORDER BY created_at DESC;
 
 -- name: ListEnabledAgentDefinitions :many
-SELECT * FROM agent_definitions
+SELECT * FROM workflows
 WHERE enabled = TRUE
 ORDER BY created_at DESC;
 
 -- name: UpdateAgentDefinition :one
-UPDATE agent_definitions
+UPDATE workflows
 SET name                     = $2,
     slug                     = $3,
     prompt                   = $4,
@@ -48,16 +48,16 @@ RETURNING *;
 -- name: ListAgentDefinitionsForSyncWebhook :many
 -- Used by the post-sync hook to find agents that should fire after a
 -- successful sync. Filtered by the partial index for cheap lookup.
-SELECT * FROM agent_definitions
+SELECT * FROM workflows
 WHERE enabled = TRUE AND trigger_on_sync_complete = TRUE
 ORDER BY created_at DESC;
 
 -- name: SetAgentDefinitionEnabled :one
-UPDATE agent_definitions
+UPDATE workflows
 SET enabled    = $2,
     updated_at = NOW()
 WHERE id = $1
 RETURNING *;
 
 -- name: DeleteAgentDefinition :execrows
-DELETE FROM agent_definitions WHERE id = $1;
+DELETE FROM workflows WHERE id = $1;

--- a/internal/db/queries/agent_reports.sql
+++ b/internal/db/queries/agent_reports.sql
@@ -28,7 +28,7 @@ UPDATE agent_reports SET read_at = NOW() WHERE read_at IS NULL;
 DELETE FROM agent_reports WHERE id = $1;
 
 -- name: ListReportSummariesForRunIDs :many
--- Returns short report summaries for a batch of agent_runs UUIDs.
+-- Returns short report summaries for a batch of workflow_runs UUIDs.
 -- Powers the AgentRunRow chip on the runs landing — operators see
 -- "this run produced these reports" at a glance.
 SELECT

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -1,33 +1,33 @@
 -- name: CreateAgentRun :one
-INSERT INTO agent_runs (agent_definition_id, "trigger", status, started_at)
+INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
 VALUES ($1, $2, 'in_progress', NOW())
 RETURNING *;
 
 -- name: GetAgentRun :one
-SELECT * FROM agent_runs WHERE id = $1;
+SELECT * FROM workflow_runs WHERE id = $1;
 
 -- name: GetAgentRunByShortID :one
-SELECT * FROM agent_runs WHERE short_id = $1;
+SELECT * FROM workflow_runs WHERE short_id = $1;
 
 -- name: GetLatestAgentRun :one
-SELECT * FROM agent_runs
+SELECT * FROM workflow_runs
 WHERE agent_definition_id = $1
 ORDER BY started_at DESC
 LIMIT 1;
 
 -- name: ListAgentRuns :many
-SELECT * FROM agent_runs
+SELECT * FROM workflow_runs
 WHERE agent_definition_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListRecentAgentRuns :many
-SELECT * FROM agent_runs
+SELECT * FROM workflow_runs
 ORDER BY started_at DESC
 LIMIT $1 OFFSET $2;
 
 -- name: CompleteAgentRun :one
-UPDATE agent_runs
+UPDATE workflow_runs
 SET status                = $2,
     completed_at          = NOW(),
     duration_ms           = $3,
@@ -46,7 +46,7 @@ WHERE id = $1
 RETURNING *;
 
 -- name: MarkAgentRunError :exec
-UPDATE agent_runs
+UPDATE workflow_runs
 SET status          = 'error',
     completed_at    = NOW(),
     duration_ms     = (EXTRACT(EPOCH FROM (NOW() - started_at)) * 1000)::INTEGER,
@@ -55,7 +55,7 @@ SET status          = 'error',
 WHERE id = $1;
 
 -- name: MarkAgentRunSkipped :exec
-UPDATE agent_runs
+UPDATE workflow_runs
 SET status        = 'skipped',
     completed_at  = NOW(),
     error_message = $2
@@ -74,7 +74,7 @@ WITH ranked AS (
                PARTITION BY agent_definition_id
                ORDER BY started_at DESC
            ) AS rn
-    FROM agent_runs
+    FROM workflow_runs
     WHERE agent_definition_id IS NOT NULL
       AND status != 'skipped'
 )
@@ -96,7 +96,7 @@ WITH ranked AS (
                PARTITION BY agent_definition_id
                ORDER BY started_at DESC
            ) AS rn
-    FROM agent_runs
+    FROM workflow_runs
     WHERE agent_definition_id IS NOT NULL
       AND status != 'skipped'
 )
@@ -116,14 +116,14 @@ SELECT
     agent_definition_id,
     COUNT(*)::int                                        AS run_count,
     COALESCE(SUM(total_cost_usd), 0)::numeric(10,4)      AS total_cost_usd
-FROM agent_runs
+FROM workflow_runs
 WHERE agent_definition_id IS NOT NULL
   AND started_at >= NOW() - INTERVAL '30 days'
   AND status != 'skipped'
 GROUP BY agent_definition_id;
 
 -- name: SetAgentRunNote :one
-UPDATE agent_runs
+UPDATE workflow_runs
 SET operator_note = $2
 WHERE id = $1
 RETURNING *;
@@ -141,8 +141,8 @@ SELECT r.short_id      AS run_short_id,
        r.hit_cap       AS hit_cap,
        d.slug          AS agent_slug,
        d.name          AS agent_name
-FROM agent_runs r
-JOIN agent_definitions d ON d.id = r.agent_definition_id
+FROM workflow_runs r
+JOIN workflows d ON d.id = r.agent_definition_id
 WHERE r.status = 'error'
   AND r.started_at >= NOW() - ($1::int * INTERVAL '1 hour')
 ORDER BY r.started_at DESC
@@ -152,7 +152,7 @@ LIMIT $2::int;
 -- Set the operator-supplied prompt prefix for a "run now" trigger. Called
 -- immediately after CreateAgentRun + before AssembleJobSpec so the prefix
 -- is captured in the audit trail even if the run fails to assemble.
-UPDATE agent_runs
+UPDATE workflow_runs
 SET prompt_prefix = $2
 WHERE id = $1;
 
@@ -162,7 +162,7 @@ WHERE id = $1;
 -- max_turns or budget_exceeded via the returned RunResult error. Returns
 -- the updated row so AgentRunFromRow can rebuild the response with the
 -- new field populated.
-UPDATE agent_runs
+UPDATE workflow_runs
 SET hit_cap = $2
 WHERE id = $1
 RETURNING *;
@@ -174,26 +174,26 @@ RETURNING *;
 -- Run now dialog to pre-fill the operator's prior context.
 SELECT DISTINCT ON (agent_definition_id)
        agent_definition_id, prompt_prefix
-FROM agent_runs
+FROM workflow_runs
 WHERE agent_definition_id IS NOT NULL
   AND prompt_prefix IS NOT NULL
   AND prompt_prefix <> ''
 ORDER BY agent_definition_id, started_at DESC;
 
 -- name: CleanupOrphanedAgentRuns :execresult
-UPDATE agent_runs
+UPDATE workflow_runs
 SET status        = 'error',
     error_message = 'interrupted by server restart',
     completed_at  = NOW()
 WHERE status = 'in_progress';
 
 -- name: DeleteAgentRunsOlderThan :execresult
-DELETE FROM agent_runs
+DELETE FROM workflow_runs
 WHERE started_at < $1
   AND status != 'in_progress';
 
 -- name: CountInProgressAgentRuns :one
-SELECT COUNT(*) FROM agent_runs WHERE status = 'in_progress';
+SELECT COUNT(*) FROM workflow_runs WHERE status = 'in_progress';
 
 -- name: GetAgentRunsExtraStats30d :one
 -- Cross-agent 30-day rollup of error count + average duration. Powers
@@ -206,7 +206,7 @@ SELECT
     (COALESCE(AVG(duration_ms) FILTER (
         WHERE status != 'skipped' AND duration_ms IS NOT NULL
     ), 0)::float8 / 1000.0)::float8                      AS avg_duration_seconds
-FROM agent_runs
+FROM workflow_runs
 WHERE started_at >= NOW() - INTERVAL '30 days';
 
 -- name: GetAgentLifetimeStats :one
@@ -228,7 +228,7 @@ SELECT
     (COALESCE(AVG(duration_ms) FILTER (
         WHERE status != 'skipped' AND duration_ms IS NOT NULL
     ), 0)::float8 / 1000.0)::float8                        AS avg_duration_seconds
-FROM agent_runs
+FROM workflow_runs
 WHERE agent_definition_id = $1;
 
 -- GetHouseholdCostSince sums total_cost_usd across ALL agent definitions
@@ -236,7 +236,7 @@ WHERE agent_definition_id = $1;
 -- Powers the household spend-ceiling gate + the settings spend display.
 -- name: GetHouseholdCostSince :one
 SELECT COALESCE(SUM(total_cost_usd), 0)::numeric(12,4) AS total_cost_usd
-FROM agent_runs
+FROM workflow_runs
 WHERE started_at >= sqlc.arg(since)
   AND status != 'skipped';
 
@@ -245,7 +245,7 @@ WHERE started_at >= sqlc.arg(since)
 -- debounce: N rapid syncs within the window coalesce to one run.
 -- name: ExistsRecentRunForDefinition :one
 SELECT EXISTS(
-    SELECT 1 FROM agent_runs
+    SELECT 1 FROM workflow_runs
     WHERE agent_definition_id = sqlc.arg(definition_id)
       AND started_at >= sqlc.arg(since)
       AND status <> 'skipped'

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -15,7 +15,7 @@ SELECT * FROM api_keys WHERE key_hash = $1;
 -- back to parsing the slug from the key name).
 SELECT ad.id, ad.short_id, ad.name, ad.slug
 FROM api_keys ak
-JOIN agent_definitions ad ON ad.id = ak.agent_definition_id
+JOIN workflows ad ON ad.id = ak.agent_definition_id
 WHERE ak.id = $1;
 
 -- name: GetApiKeyByPrefix :one

--- a/internal/service/agent_cleanup_now_test.go
+++ b/internal/service/agent_cleanup_now_test.go
@@ -47,7 +47,7 @@ func TestRunCleanupNow(t *testing.T) {
 	defUUID, _ := pgconv.ParseUUID(def.ID)
 	mustInsertCompletedRun(t, q, defUUID, "0.01")
 	if _, err := pool.Exec(ctx,
-		`UPDATE agent_runs SET started_at = $1, completed_at = $1
+		`UPDATE workflow_runs SET started_at = $1, completed_at = $1
 		 WHERE agent_definition_id = $2`,
 		time.Now().AddDate(0, 0, -40), defUUID); err != nil {
 		t.Fatalf("backdate first row: %v", err)

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -621,7 +621,7 @@ func TestHouseholdCostSince(t *testing.T) {
 
 	ins := func(status string, cost string, age string) {
 		_, err := pool.Exec(ctx,
-			`INSERT INTO agent_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
 			 VALUES ($1,'cron',$2,$3, NOW() - $4::interval)`,
 			def.ID, status, cost, age)
 		if err != nil {
@@ -655,7 +655,7 @@ func TestRunOrSkip_HouseholdCeiling(t *testing.T) {
 	}
 	for _, c := range []string{"0.07", "0.06"} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO agent_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
 			 VALUES ($1,'cron','success',$2, NOW())`, def.ID, c); err != nil {
 			t.Fatalf("insert run: %v", err)
 		}

--- a/internal/service/agent_recent_errors_test.go
+++ b/internal/service/agent_recent_errors_test.go
@@ -45,7 +45,7 @@ func TestListRecentErroredAgentRuns_OnlyRecentErrors(t *testing.T) {
 			}
 		}
 		if _, err := pool.Exec(ctx,
-			`UPDATE agent_runs SET started_at = $1 WHERE id = $2`,
+			`UPDATE workflow_runs SET started_at = $1 WHERE id = $2`,
 			startedAt, row.ID); err != nil {
 			t.Fatalf("backdate: %v", err)
 		}

--- a/internal/service/agent_webhook_trigger_test.go
+++ b/internal/service/agent_webhook_trigger_test.go
@@ -118,7 +118,7 @@ func TestFireSyncCompleteAgents_DebouncesRecentRun(t *testing.T) {
 
 	// A recent non-skipped run anchors the debounce window.
 	if _, err := pool.Exec(context.Background(),
-		`INSERT INTO agent_runs (agent_definition_id,"trigger",status,started_at)
+		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status,started_at)
 		 VALUES ($1,'webhook','success', NOW())`, def.ID); err != nil {
 		t.Fatalf("seed recent run: %v", err)
 	}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -24,7 +24,7 @@ import (
 )
 
 // DefaultAgentModel is the model used when a definition omits one.
-// claude-opus-4-7 is the latest Opus (matches the agent_definitions
+// claude-opus-4-7 is the latest Opus (matches the workflows
 // migration default).
 const DefaultAgentModel = "claude-opus-4-7"
 
@@ -48,7 +48,7 @@ var defaultAgentSystemPrompt = func() string {
 // DefaultAgentMaxTurns is the per-run turn cap when a definition omits one.
 const DefaultAgentMaxTurns = 10
 
-// DefaultAgentMaxBudgetUSD mirrors the agent_definitions migration default.
+// DefaultAgentMaxBudgetUSD mirrors the workflows migration default.
 // The column is NOT NULL, so we always send a value to sqlc.
 const DefaultAgentMaxBudgetUSD = 1.0
 
@@ -676,7 +676,7 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 		       cache_creation_tokens, turn_count, max_turns_used, num_tool_calls,
 		       error_message, transcript_path, session_id,
 		       operator_note, prompt_prefix, hit_cap
-		FROM agent_runs
+		FROM workflow_runs
 		WHERE %s
 		ORDER BY started_at DESC
 		LIMIT $%d OFFSET $%d`,
@@ -690,7 +690,7 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 
 	var out []AgentRunResponse
 	for rows.Next() {
-		var r db.AgentRun
+		var r db.WorkflowRun
 		if scanErr := rows.Scan(
 			&r.ID, &r.ShortID, &r.AgentDefinitionID, &r.Trigger, &r.Status,
 			&r.StartedAt, &r.CompletedAt, &r.DurationMs, &r.TotalCostUsd,
@@ -800,7 +800,7 @@ type AllAgentRunListParams struct {
 }
 
 // ListAllAgentRuns returns offset-paginated runs across every agent,
-// joined against agent_definitions so each row carries the agent's slug
+// joined against workflows so each row carries the agent's slug
 // and name. Powers the cross-agent global runs view.
 //
 // Same hand-rolled SQL pattern as ListAgentRuns — composable WHERE
@@ -861,7 +861,7 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 		idx++
 	}
 	if p.WorkflowsOnly {
-		// d is the agent_definitions JOIN below; preset-instantiated
+		// d is the workflows JOIN below; preset-instantiated
 		// workflows carry a non-null source_template.
 		where = append(where, "d.source_template IS NOT NULL")
 	}
@@ -880,8 +880,8 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 		       r.error_message, r.transcript_path, r.session_id,
 		       r.operator_note, r.prompt_prefix, r.hit_cap,
 		       d.slug, d.name
-		FROM agent_runs r
-		JOIN agent_definitions d ON d.id = r.agent_definition_id
+		FROM workflow_runs r
+		JOIN workflows d ON d.id = r.agent_definition_id
 		%s
 		ORDER BY r.started_at DESC
 		LIMIT $%d OFFSET $%d`,
@@ -895,7 +895,7 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 
 	var out []AgentRunWithAgentResponse
 	for rows.Next() {
-		var r db.AgentRun
+		var r db.WorkflowRun
 		var slug, name string
 		if scanErr := rows.Scan(
 			&r.ID, &r.ShortID, &r.AgentDefinitionID, &r.Trigger, &r.Status,
@@ -950,8 +950,8 @@ func (s *Service) WorkflowRunStatusCounts(ctx context.Context, workflowSlugOrID 
 		where = append(where, "r.agent_definition_id = $1")
 		args = append(args, def.ID)
 	}
-	query := "SELECT r.status, COUNT(*) FROM agent_runs r " +
-		"JOIN agent_definitions d ON d.id = r.agent_definition_id WHERE " +
+	query := "SELECT r.status, COUNT(*) FROM workflow_runs r " +
+		"JOIN workflows d ON d.id = r.agent_definition_id WHERE " +
 		strings.Join(where, " AND ") + " GROUP BY r.status"
 	rows, err := s.Pool.Query(ctx, query, args...)
 	if err != nil {
@@ -1020,7 +1020,7 @@ func (s *Service) notifyDefinitionChanged() {
 // --- Orchestrator-facing helpers (called by internal/service/agent_orchestrator.go) ---
 
 // CreateAgentRunDB inserts an in_progress run row.
-func (s *Service) CreateAgentRunDB(ctx context.Context, defID pgtype.UUID, trigger string) (db.AgentRun, error) {
+func (s *Service) CreateAgentRunDB(ctx context.Context, defID pgtype.UUID, trigger string) (db.WorkflowRun, error) {
 	return s.Queries.CreateAgentRun(ctx, db.CreateAgentRunParams{
 		AgentDefinitionID: defID,
 		Trigger:           trigger,
@@ -1058,7 +1058,7 @@ func (s *Service) SetAgentRunPromptPrefixDB(ctx context.Context, runID pgtype.UU
 // Called by the orchestrator after CompleteAgentRunDB when the runner
 // surfaces ErrMaxTurnsReached / ErrBudgetExceeded. cap must be one of
 // "max_turns", "max_budget" — the DB CHECK rejects others.
-func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, cap string) (db.AgentRun, error) {
+func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, cap string) (db.WorkflowRun, error) {
 	return s.Queries.SetAgentRunHitCap(ctx, db.SetAgentRunHitCapParams{
 		ID:     runID,
 		HitCap: pgtype.Text{String: cap, Valid: cap != ""},
@@ -1081,7 +1081,7 @@ func (s *Service) SetAgentRunHitCapDB(ctx context.Context, runID pgtype.UUID, ca
 // Sidecar crashes (e.g. exit 127) attach full stderr to result.Err,
 // which can easily reach several KB — capped at runErrorMessageMax to
 // keep the column readable in the UI and bounded in size.
-func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult, maxTurnsCap int) (db.AgentRun, error) {
+func (s *Service) CompleteAgentRunDB(ctx context.Context, runID pgtype.UUID, result agent.RunResult, maxTurnsCap int) (db.WorkflowRun, error) {
 	costPtr := result.TotalCostUSD
 	errMsg := truncateRunError(result.Err)
 	return s.Queries.CompleteAgentRun(ctx, db.CompleteAgentRunParams{
@@ -1122,7 +1122,7 @@ func truncateRunError(err error) string {
 
 // AgentRunFromRow is exported so the orchestrator (same package) can build
 // API responses from raw db rows.
-func AgentRunFromRow(row db.AgentRun) AgentRunResponse {
+func AgentRunFromRow(row db.WorkflowRun) AgentRunResponse {
 	return agentRunFromRow(row)
 }
 
@@ -1267,22 +1267,22 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 
 // --- internal helpers ---
 
-func (s *Service) resolveAgentDefinition(ctx context.Context, slugOrID string) (db.AgentDefinition, error) {
+func (s *Service) resolveAgentDefinition(ctx context.Context, slugOrID string) (db.Workflow, error) {
 	if slugOrID == "" {
-		return db.AgentDefinition{}, ErrNotFound
+		return db.Workflow{}, ErrNotFound
 	}
 	// Try slug first.
 	if row, err := s.Queries.GetAgentDefinitionBySlug(ctx, slugOrID); err == nil {
 		return row, nil
 	} else if !errors.Is(err, pgx.ErrNoRows) {
-		return db.AgentDefinition{}, fmt.Errorf("get by slug: %w", err)
+		return db.Workflow{}, fmt.Errorf("get by slug: %w", err)
 	}
 	// Try short_id (8 chars).
 	if len(slugOrID) == 8 {
 		if row, err := s.Queries.GetAgentDefinitionByShortID(ctx, slugOrID); err == nil {
 			return row, nil
 		} else if !errors.Is(err, pgx.ErrNoRows) {
-			return db.AgentDefinition{}, fmt.Errorf("get by short_id: %w", err)
+			return db.Workflow{}, fmt.Errorf("get by short_id: %w", err)
 		}
 	}
 	// Try UUID.
@@ -1290,31 +1290,31 @@ func (s *Service) resolveAgentDefinition(ctx context.Context, slugOrID string) (
 		if row, err := s.Queries.GetAgentDefinition(ctx, u); err == nil {
 			return row, nil
 		} else if !errors.Is(err, pgx.ErrNoRows) {
-			return db.AgentDefinition{}, fmt.Errorf("get by uuid: %w", err)
+			return db.Workflow{}, fmt.Errorf("get by uuid: %w", err)
 		}
 	}
-	return db.AgentDefinition{}, ErrNotFound
+	return db.Workflow{}, ErrNotFound
 }
 
-func (s *Service) resolveAgentRun(ctx context.Context, shortIDOrUUID string) (db.AgentRun, error) {
+func (s *Service) resolveAgentRun(ctx context.Context, shortIDOrUUID string) (db.WorkflowRun, error) {
 	if shortIDOrUUID == "" {
-		return db.AgentRun{}, ErrNotFound
+		return db.WorkflowRun{}, ErrNotFound
 	}
 	if len(shortIDOrUUID) == 8 {
 		if row, err := s.Queries.GetAgentRunByShortID(ctx, shortIDOrUUID); err == nil {
 			return row, nil
 		} else if !errors.Is(err, pgx.ErrNoRows) {
-			return db.AgentRun{}, fmt.Errorf("get run by short_id: %w", err)
+			return db.WorkflowRun{}, fmt.Errorf("get run by short_id: %w", err)
 		}
 	}
 	if u, err := pgconv.ParseUUID(shortIDOrUUID); err == nil {
 		if row, err := s.Queries.GetAgentRun(ctx, u); err == nil {
 			return row, nil
 		} else if !errors.Is(err, pgx.ErrNoRows) {
-			return db.AgentRun{}, fmt.Errorf("get run by uuid: %w", err)
+			return db.WorkflowRun{}, fmt.Errorf("get run by uuid: %w", err)
 		}
 	}
-	return db.AgentRun{}, ErrNotFound
+	return db.WorkflowRun{}, ErrNotFound
 }
 
 func (s *Service) lastRunSummary(ctx context.Context, defID pgtype.UUID) (*AgentRunSummary, error) {
@@ -1410,7 +1410,7 @@ func agentIntFromInt4(n pgtype.Int4) *int {
 	return &v
 }
 
-func agentDefinitionFromRow(row db.AgentDefinition, lastRun *AgentRunSummary) AgentDefinitionResponse {
+func agentDefinitionFromRow(row db.Workflow, lastRun *AgentRunSummary) AgentDefinitionResponse {
 	return AgentDefinitionResponse{
 		ID:                    pgconv.FormatUUID(row.ID),
 		ShortID:               row.ShortID,
@@ -1435,7 +1435,7 @@ func agentDefinitionFromRow(row db.AgentDefinition, lastRun *AgentRunSummary) Ag
 	}
 }
 
-func agentRunFromRow(row db.AgentRun) AgentRunResponse {
+func agentRunFromRow(row db.WorkflowRun) AgentRunResponse {
 	var defID *string
 	if row.AgentDefinitionID.Valid {
 		s := pgconv.FormatUUID(row.AgentDefinitionID)
@@ -1467,7 +1467,7 @@ func agentRunFromRow(row db.AgentRun) AgentRunResponse {
 	}
 }
 
-func agentRunSummaryFromRow(row db.AgentRun) AgentRunSummary {
+func agentRunSummaryFromRow(row db.WorkflowRun) AgentRunSummary {
 	return AgentRunSummary{
 		ShortID:      row.ShortID,
 		Status:       row.Status,

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -137,7 +137,7 @@ func TestListAllAgentRuns_WorkflowsOnly(t *testing.T) {
 	// One run apiece. short_id/id/started_at are DB-defaulted.
 	for _, defID := range []string{wf.ID, plain.ID} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO agent_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
 			defID); err != nil {
 			t.Fatalf("insert run for %s: %v", defID, err)
 		}
@@ -205,7 +205,7 @@ func TestWorkflowRunStatusCounts(t *testing.T) {
 
 	ins := func(defID, status string) {
 		if _, e := pool.Exec(ctx,
-			`INSERT INTO agent_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
 			defID, status); e != nil {
 			t.Fatalf("insert run: %v", e)
 		}


### PR DESCRIPTION
**PR4c — the breaking DB-table rename** `agent_definitions` → `workflows`, `agent_runs` → `workflow_runs`. Completes the agents→workflows rename at the storage layer so the schema matches the product. Ricardo approved; pre-release, so a breaking `RENAME TABLE` is acceptable.

## What changed

- **Migration** (`20260531120000_rename_agent_tables_to_workflows.sql`) — two `ALTER TABLE … RENAME TO` statements (with a reversing Down). PostgreSQL auto-updates the dependent **FK constraints** (`agent_runs.agent_definition_id`, `agent_reports.agent_run_id`, `api_keys.agent_definition_id`), indexes, and short_id triggers to follow the renamed tables. **FK column names are intentionally left as-is** (`agent_definition_id`, `agent_run_id`) to bound the change.
- **Queries** — the four query files (`agent_definitions.sql`, `agent_runs.sql`, `agent_reports.sql`, `api_keys.sql`) and the hand-rolled dynamic SQL in `service/agents.go` now reference `workflows`/`workflow_runs`.
- **sqlc** regenerates the base models as **`db.Workflow`** / **`db.WorkflowRun`** (the bare `db.AgentDefinition`/`db.AgentRun` model types are renamed across all 21 call sites). The sqlc *method* names (`GetAgentRun`, `CreateAgentDefinitionParams`, …) and the service-layer types (`AgentRunResponse`, etc.) are unchanged — only the storage-model identifiers moved, keeping the diff atomic and bounded.

No REST/MCP route or API-surface change (those are the separate 4b-2/4b-3 slices), so no OpenAPI drift.

## Safety — shared dev DB

`RENAME TABLE` is destructive to concurrent readers of the old names. I validated **only** against the dedicated `breadbox_test_wf` DB and CI's fresh DBs — the shared dev `breadbox` DB was **not** migrated (verified: it still has `agent_definitions`/`agent_runs`), so other worktrees/running servers are unaffected. Applying this to the shared dev DB should be done when those are idle.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./...                  PASS (unit)
go build -tags=headless ./...  PASS   (CI-faithful)
go build -tags=lite ./...      PASS   (CI-faithful: templ + generated db files removed)
```

Integration (against `breadbox_test_wf` with the rename applied) — every package that touches these tables, all green on the new schema:

```
internal/db       ok   (schema + sqlc queries)
internal/service  ok   (agents/workflows/orchestrator/notify/governance)
internal/api      ok
internal/mcp      ok
internal/admin    ok
```

No UI change — pure internal storage rename, so no screenshot.
