### PR TITLE
feat(workflows): admin action routes /-/workflows/* + fix run-note save (PR4b slice 3)

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -413,6 +413,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// roles (an editor restriction would block dashboards that
 		// want to keep an eye on someone else's runs).
 		r.Get("/agents/runs/{shortId}/live", AgentRunLiveHandler(svc, sm, tr, a.Config.DataDir))
+		// Workflows-surface alias: the run-detail page (served at
+		// /workflows/runs/{shortId}) polls this. Same handler; the legacy
+		// /agents path above stays for the deferred hand-authored agent pages.
+		r.Get("/workflows/runs/{shortId}/live", AgentRunLiveHandler(svc, sm, tr, a.Config.DataDir))
 
 		// Editor+ API routes (categorization, tagging, access management).
 		r.Group(func(r chi.Router) {
@@ -457,6 +461,16 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/agents/{slug}/disable", DisableAgentAdminHandler(svc))
 			r.Post("/agents/{slug}/run", RunAgentNowAdminHandler(a, svc))
 			r.Post("/agents/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))
+
+			// Workflows-surface action aliases (canonical). The Workflows
+			// gallery (run toggle), runs tab (re-run), and run-detail page
+			// POST to these; the legacy /-/agents/* routes above resolve the
+			// same handlers and stay for the deferred hand-authored agent
+			// pages. Both sets collapse to one when that surface is removed.
+			r.Post("/workflows/{slug}/enable", EnableAgentAdminHandler(svc))
+			r.Post("/workflows/{slug}/disable", DisableAgentAdminHandler(svc))
+			r.Post("/workflows/{slug}/run", RunAgentNowAdminHandler(a, svc))
+			r.Post("/workflows/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))
 		})
 
 		// Admin-only API routes.
@@ -554,6 +568,14 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/agents/test", SmokeTestAgentAdminHandler(a, svc))
 			r.Post("/agents/notify-test", NotifyTestAdminHandler(svc))
 			r.Post("/agents/cleanup", AgentCleanupAdminHandler(a, svc))
+
+			// Workflows-surface aliases for the SDK settings + diagnostics
+			// (admin-only). The Workflows settings page posts here; the
+			// legacy /-/agents/* routes above remain for back-compat.
+			r.Post("/workflows/settings", UpdateAgentSDKSettingsAdminHandler(a, svc, sm))
+			r.Post("/workflows/test", SmokeTestAgentAdminHandler(a, svc))
+			r.Post("/workflows/notify-test", NotifyTestAdminHandler(svc))
+			r.Post("/workflows/cleanup", AgentCleanupAdminHandler(a, svc))
 		})
 	})
 

--- a/internal/admin/workflows_actions.go
+++ b/internal/admin/workflows_actions.go
@@ -15,7 +15,7 @@ import (
 // It instantiates a workflow from the preset (enabled to run). Idempotent at the
 // gallery level: an already-enabled preset returns 200 so the page just refreshes
 // to show the run toggle. The instantiated workflow's run state is then toggled
-// via the existing /-/agents/{slug}/enable|disable endpoints.
+// via the /-/workflows/{slug}/enable|disable endpoints.
 func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := chi.URLParam(r, "slug")

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -24,7 +24,7 @@ func appconfigParam(key, value string) db.SetAppConfigParams {
 	}
 }
 
-// AgentSettingsResponse is what GET /api/v1/agents/settings returns.
+// AgentSettingsResponse is what GET /api/v1/workflows/settings returns.
 // Token fields are masked when present; full plaintext never leaves the server.
 type AgentSettingsResponse struct {
 	AuthMode           string   `json:"auth_mode"`

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -24,7 +24,7 @@ import (
 //	└──────────────┴─────────────────────────────────────┘
 //
 // Live updates: when the run is in_progress, an Alpine factory
-// (`agentRunDetail`) polls `GET /-/agents/runs/{shortId}/live` every
+// (`agentRunDetail`) polls `GET /-/workflows/runs/{shortId}/live` every
 // 3 s and patches the transcript + stats panel HTML in-place. We no
 // longer emit `<meta http-equiv="refresh">` — full-page reloads kill
 // scroll position and any open <details> nodes.
@@ -221,7 +221,7 @@ func agentRunDetailBreadcrumbs(p AgentRunDetailProps) []components.Breadcrumb {
 
 // agentRunTranscriptCard is the left-column chat thread. The inner
 // `bb-run-thread` container is the x-ref="thread" target the Alpine
-// poller refreshes from /-/agents/runs/{id}/live.
+// poller refreshes from /-/workflows/runs/{id}/live.
 templ agentRunTranscriptCard(p AgentRunDetailProps) {
 	<div class="bb-card p-4">
 		<div class="flex items-center justify-between mb-3">
@@ -260,7 +260,7 @@ const agentRunTranscriptMaxEventsConst = 500
 
 // AgentRunTranscriptFragment renders just the inner transcript
 // (per-event blocks + empty-state placeholder). Exported so the
-// /-/agents/runs/{id}/live admin endpoint can render the fragment
+// /-/workflows/runs/{id}/live admin endpoint can render the fragment
 // without re-rendering the surrounding card chrome.
 templ AgentRunTranscriptFragment(p AgentRunDetailProps) {
 	@agentRunPromptIntro(p)
@@ -531,7 +531,7 @@ templ agentRunStatsCard(p AgentRunDetailProps) {
 
 // agentRunNoteCard renders the operator note as a click-to-edit block.
 // Default mode shows the note (or "Add a note…" placeholder); clicking
-// flips into a textarea that PATCHes /api/v1/agents/runs/{shortId} on
+// flips into a textarea that PATCHes /api/v1/workflows/runs/{shortId} on
 // save. No more full-page POST → reload.
 templ agentRunNoteCard(p AgentRunDetailProps) {
 	<div

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -10,7 +10,7 @@ import (
 // limits for Claude Agent SDK runs. Distinct from AgentsSettings
 // ("MCP Settings"). See .claude/rules/settings.md.
 //
-// All POST targets sit under /-/agents/* (admin-scoped). The handler
+// All POST targets sit under /-/workflows/* (admin-scoped). The handler
 // resolves masked credential display strings before render so the templ
 // stays free of nil-handling.
 templ AgentSDKSettings(p AgentSDKSettingsProps) {
@@ -113,7 +113,7 @@ templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 			Title:   "Configuration",
 			Caption: "Authentication, sidecar paths, and per-run limits",
 			Form: &components.SettingsSectionFormProps{
-				Action:    "/-/agents/settings",
+				Action:    "/-/workflows/settings",
 				CSRFToken: p.CSRFToken,
 			},
 			Footer: agentSDKConfigFooter(),

--- a/static/js/admin/components/agent_run_detail.js
+++ b/static/js/admin/components/agent_run_detail.js
@@ -1,4 +1,5 @@
-// Agent run detail Alpine component for /agents/runs/{shortId}.
+// Run detail Alpine component for /workflows/runs/{shortId}
+// (legacy alias: /agents/runs/{shortId}).
 //
 // Convention reference: docs/design-system.md → "Alpine page components".
 //
@@ -6,7 +7,7 @@
 //   - Live transcript polling for in_progress runs. Replaces the legacy
 //     `<meta http-equiv="refresh">` that lost scroll position and any
 //     open <details> nodes on every reload.
-//   - Inline-edit operator note (PATCH /api/v1/agents/runs/{id}, JSON
+//   - Inline-edit operator note (PATCH /api/v1/workflows/runs/{id}, JSON
 //     body). The session cookie + Origin check on the API side is what
 //     authorises the request — no separate CSRF token needed for the
 //     PATCH because /api/v1/* uses the same-host check.
@@ -102,7 +103,7 @@ document.addEventListener('alpine:init', function () {
 
       poll: function () {
         var self = this;
-        fetch('/-/agents/runs/' + encodeURIComponent(this.shortId) + '/live', {
+        fetch('/-/workflows/runs/' + encodeURIComponent(this.shortId) + '/live', {
           headers: { 'Accept': 'application/json' },
           credentials: 'same-origin',
         })
@@ -299,7 +300,7 @@ document.addEventListener('alpine:init', function () {
         this.error = '';
         var self = this;
         var trimmed = (this.draft || '').slice(0, 2000);
-        fetch('/api/v1/agents/runs/' + encodeURIComponent(this.shortId), {
+        fetch('/api/v1/workflows/runs/' + encodeURIComponent(this.shortId), {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
           credentials: 'same-origin',

--- a/static/js/admin/components/agent_sdk_settings.js
+++ b/static/js/admin/components/agent_sdk_settings.js
@@ -37,7 +37,7 @@ document.addEventListener('alpine:init', function () {
         this.smokeState = 'loading';
         this.smokeResult = null;
         this.smokeError = null;
-        this._post('/-/agents/test')
+        this._post('/-/workflows/test')
           .then(function (res) {
             return res.json().then(function (body) {
               return { ok: res.ok, status: res.status, body: body };
@@ -63,7 +63,7 @@ document.addEventListener('alpine:init', function () {
         this.cleanupState = 'loading';
         this.cleanupResult = null;
         this.cleanupError = null;
-        this._post('/-/agents/cleanup')
+        this._post('/-/workflows/cleanup')
           .then(function (res) {
             return res.json().then(function (body) {
               return { ok: res.ok, status: res.status, body: body };
@@ -88,7 +88,7 @@ document.addEventListener('alpine:init', function () {
         var self = this;
         this.notifyState = 'loading';
         this.notifyError = null;
-        this._post('/-/agents/notify-test')
+        this._post('/-/workflows/notify-test')
           .then(function (res) {
             return res.json().then(function (body) {
               return { ok: res.ok, status: res.status, body: body };

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -71,12 +71,12 @@ document.addEventListener('alpine:init', function () {
           });
       },
 
-      // Toggle an instantiated workflow's run state. Reuses the agent
+      // Toggle an instantiated workflow's run state via the Workflows
       // enable/disable endpoints (a workflow IS an agent_definition).
       toggleWorkflow: function (workflowSlug, el) {
         var self = this;
         var enabled = el.checked;
-        var url = '/-/agents/' + encodeURIComponent(workflowSlug) + (enabled ? '/enable' : '/disable');
+        var url = '/-/workflows/' + encodeURIComponent(workflowSlug) + (enabled ? '/enable' : '/disable');
         self._post(url)
           .then(function (res) {
             if (!res.ok) throw new Error('HTTP ' + res.status);

--- a/static/js/admin/components/workflows_runs.js
+++ b/static/js/admin/components/workflows_runs.js
@@ -25,7 +25,7 @@ document.addEventListener('alpine:init', function () {
       // definition (no prompt override); on success reload to surface it.
       retrigger: function (slug) {
         var self = this;
-        fetch('/-/agents/' + encodeURIComponent(slug) + '/run', {
+        fetch('/-/workflows/' + encodeURIComponent(slug) + '/run', {
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'X-CSRF-Token': this.csrfToken },


### PR DESCRIPTION
**PR 4b slice 3 — the internal admin action routes.** Completes the agents→workflows rename: the live Workflows surface now POSTs entirely to `/-/workflows/*` (and PATCHes `/api/v1/workflows/*`). This is the last slice of 4b (UI/nav landed in 4b-1, REST in 4b-2, DB tables in 4c).

Also fixes a **live bug introduced by 4b-2**: the run-detail note-save still PATCHed the now-deleted `/api/v1/agents/runs/{id}` and 404'd on every save.

## What changed

**Admin router** (`internal/admin/router.go`) — dual-registered 9 canonical `/-/workflows/*` action routes alongside the existing `/-/agents/*` ones (same handlers, same middleware groups):

| Group | Routes added |
|---|---|
| read-only (all roles) | `GET /-/workflows/runs/{shortId}/live` |
| editor+ | `POST /-/workflows/{slug}/enable` · `/disable` · `/run` · `POST /-/workflows/runs/{shortId}/note` |
| admin-only | `POST /-/workflows/settings` · `/test` · `/notify-test` · `/cleanup` |

The legacy `/-/agents/*` routes **stay** — the hand-authored agent pages (`/agents/definitions`, `/agents/new`, `/agents/{slug}/edit`) are still URL-reachable (deferred to the custom-workflow builder, per 4b-1) and their GET paths can't move to `/workflows/*` without colliding with the new gallery/runs pages. Both route sets resolve the same handlers and collapse to one when that surface is removed.

**Callers repointed to the canonical paths** (Workflows surface only):
- `workflows_gallery.js` — run toggle → `/-/workflows/{slug}/enable|disable`
- `workflows_runs.js` — re-run → `/-/workflows/{slug}/run`
- `agent_run_detail.js` — live poll → `/-/workflows/runs/{id}/live`; **note-save → `/api/v1/workflows/runs/{id}` (the bug fix)**
- `agent_sdk_settings.js` — smoke-test/cleanup/notify-test → `/-/workflows/*`
- `agent_sdk_settings.templ` — settings form `Action` → `/-/workflows/settings` (+ regen)

Plus doc-comment accuracy touch-ups across the run-detail/settings templ + JS and two Go godocs.

**MCP:** confirmed **zero** `agent_*` tools exist (`grep internal/mcp` is empty) — the "rename MCP tools" part of 4b-3 is a verified no-op.

**Not in this PR (external repo):** `breadbox-docs/guides/scheduled-agents.mdx:88` still says `/api/v1/agents/prompt-blocks` (now `/api/v1/workflows/prompt-blocks`) — tracked as a docs follow-up, separate repo/PR.

## Validation

```
go build ./...                 PASS
go vet ./...                   PASS
go test ./internal/{admin,templates/...,api,service}  PASS  (incl. scripts_lint)
go build -tags=headless ./...  PASS   (CI-faithful, stamped *_templ.go)
go build -tags=lite ./...      PASS   (CI-faithful)
```

**Functional smoke** (branch binary against an isolated clone of the dev DB with the workflows schema; logged-in admin + CSRF):

```
NEW /-/workflows/* routes
  GET  /-/workflows/runs/{id}/live        → 200
  POST /-/workflows/{slug}/disable        → 200
  POST /-/workflows/{slug}/enable         → 200
  POST /-/workflows/{bogus}/run           → 404 {"code":"AGENT_NOT_FOUND"}   (handler ran; no run triggered)
  POST /-/workflows/notify-test           → 422 "no webhook configured"      (handler ran; no egress)
negative control
  POST /-/workflows/zzz/not-a-real-action → 404 HTML page-not-found          (proves the above are real routes)
back-compat (hand-authored pages)
  GET  /-/agents/runs/{id}/live           → 200
  POST /-/agents/{slug}/disable|enable    → 200
note-save bug fix
  PATCH /api/v1/workflows/runs/{id}       → 200  (operator_note persisted, verified in DB)
  PATCH /api/v1/agents/runs/{id}          → 404  (old path gone — the bug this fixes)
```

No OpenAPI/api-endpoints change: admin `/-/*` routes are out of the public REST catalog by rule, and no new `/api/v1` route was added.

## Screenshots (surface renders healthy post-rename)

<table>
<tr><th>Gallery</th><th>Runs</th></tr>
<tr>
<td><img src="https://i.img402.dev/nxt6ivak9t.jpg" width="420" alt="Workflows gallery"></td>
<td><img src="https://i.img402.dev/h916ip0fo8.jpg" width="420" alt="Workflows runs tab"></td>
</tr>
</table>
