### PR TITLE
fix(ui): render arrow icon on /connections/new Continue button

### DIFF
--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -104,7 +104,8 @@ templ ConnectionNew(p ConnectionNewProps) {
 						</fieldset>
 						<div class="pt-2">
 							<button type="submit" class="btn btn-primary btn-sm">
-								Continue @components.LucideIcon("arrow-right", "w-4 h-4")
+								Continue
+								@components.LucideIcon("arrow-right", "w-4 h-4")
 							</button>
 						</div>
 					</form>

--- a/internal/templates/components/pages/connection_new_test.go
+++ b/internal/templates/components/pages/connection_new_test.go
@@ -1,0 +1,32 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestConnectionNewContinueIconRenders guards the Continue button on
+// /connections/new against the templ footgun where an "@components.LucideIcon"
+// call placed after text on the same line is parsed as a literal text node
+// instead of a component invocation — which leaked the raw templ source into
+// the rendered button. The icon must render as a real arrow-right SVG.
+func TestConnectionNewContinueIconRenders(t *testing.T) {
+	var sb strings.Builder
+	p := ConnectionNewProps{
+		HasPlaid: true,
+		Users:    []ConnectionNewUser{{ID: "u1", Name: "Alice"}},
+	}
+	if err := ConnectionNew(p).Render(context.Background(), &sb); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := sb.String()
+	if strings.Contains(out, "@components.LucideIcon") {
+		t.Fatalf("rendered output still leaks literal templ source for the icon")
+	}
+	if !strings.Contains(out, "lucide-arrow-right") {
+		t.Fatalf("rendered output missing the arrow-right svg icon")
+	}
+}


### PR DESCRIPTION
## What

The **Continue** button on `/connections/new` rendered the literal text
`@components.LucideIcon("arrow-right", "w-4 h-4")` instead of an arrow icon.

## Why

In `connection_new.templ` the icon call sat *after* the `Continue` text on the
same line:

```templ
<button type="submit" class="btn btn-primary btn-sm">
    Continue @components.LucideIcon("arrow-right", "w-4 h-4")
</button>
```

templ parses a text run up to the next tag/expression boundary, and an `@`
component call that follows inline text on the same line gets swallowed into the
text node — so it was emitted as a literal string rather than invoked. The
generated `_templ.go` confirmed it: the icon went out via `WriteString(...)`
instead of `components.LucideIcon(...).Render(ctx, ...)`. (The sibling buttons
on this page — Retry / Back — render fine because their icon call comes first.)

## Fix

Put the component call on its own line so templ parses it as an expression child:

```templ
<button type="submit" class="btn btn-primary btn-sm">
    Continue
    @components.LucideIcon("arrow-right", "w-4 h-4")
</button>
```

One line of template change. The regenerated `*_templ.go` now emits
`components.LucideIcon("arrow-right", "w-4 h-4").Render(ctx, …)`.

## Validation

- `go build ./...`, `go vet ./internal/templates/...` — clean.
- Added `connection_new_test.go`: renders `ConnectionNew` and asserts the output
  contains a real `lucide-arrow-right` SVG and **zero** leaked
  `@components.LucideIcon` literal. **PASS.**
- Rendered the component to standalone HTML and grepped it: `lucide-arrow-right`
  present, `@components.LucideIcon` count = 0.

> Note: a live browser screenshot could not be captured from this headless agent
> session (Chrome MCP and headless Chrome are both blocked by the sandbox /
> a running Chrome instance). The change is a one-line templ idiom fix verified
> by the render-assertion test above and the generated-code diff.
