### PR TITLE
feat(ui): move Settings entrypoint into the sidebar System section

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -72,14 +72,20 @@ templ Nav(p NavProps) {
 		if p.IsEditor {
 			@navLink("/tags", "tags", "Tags", navActive(p.CurrentPage, "tags"))
 		}
+		// System sits at the foot of the rail. The header renders for every
+		// role because Settings (account self-service at /settings/account) is
+		// available to all authenticated users — viewers included — so the
+		// section can't be gated behind IsEditor the way the connection/
+		// household/log admin tools are.
+		<div class="bb-sidebar-section">System</div>
 		if p.IsEditor {
-			<div class="bb-sidebar-section">System</div>
 			@navLinkBadge("/connections", "link", "Connections", navActive(p.CurrentPage, "connections"), p.ConnectionsAttention, "bb-nav-badge--warn", fmt.Sprintf("%d connections need attention", p.ConnectionsAttention))
 			if p.IsAdmin {
 				@navLink("/household", "users", "Household", navActive(p.CurrentPage, "household"))
 				@navLink("/logs", "scroll-text", "Logs", navActive(p.CurrentPage, "logs"))
 			}
 		}
+		@navLink("/settings/account", "settings", "Settings", navSettingsActive(p.CurrentPage))
 	</nav>
 	if p.NavUpdateAvailable && p.IsAdmin {
 		<a
@@ -160,6 +166,22 @@ templ navExternalLink(href, icon, label string) {
 
 func navActive(current, page string) string {
 	if current == page {
+		return "bb-sidebar-link--active"
+	}
+	return ""
+}
+
+// navSettingsActive lights the single Settings rail link on any /settings/*
+// tab. Each settings sub-page reports its own CurrentPage id rather than a
+// shared "settings" one (account → members.go; general/system/help →
+// settings.go; providers → providers.go; mcp → settings_agents.go;
+// agents-settings → agent_sdk_settings_page.go; api-keys → apikeys.go;
+// backups → backups.go), so a plain navActive(…, "settings") would never
+// match. Keep this set in sync with those handlers' currentPage values.
+func navSettingsActive(current string) string {
+	switch current {
+	case "account", "general", "system", "help", "providers",
+		"mcp", "agents-settings", "api-keys", "backups":
 		return "bb-sidebar-link--active"
 	}
 	return ""

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -200,7 +200,7 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "sidebar-user-menu",
 			Title:       "Sidebar user menu",
-			Description: "Consolidated identity + actions popover at the bottom of the sidebar. Trigger shows avatar + display name + role; popover holds Settings, Documentation, GitHub, an editor-only /design shortcut, and a destructive Sign out below an <hr> separator. Use components.SidebarUserMenu.",
+			Description: "Consolidated identity + actions popover at the bottom of the sidebar. Trigger shows avatar + display name + role; popover holds Documentation, GitHub, an editor-only /design shortcut, and a destructive Sign out below an <hr> separator. (Settings lives in the sidebar System section, not here.) Use components.SidebarUserMenu.",
 			Group:       "navigation",
 			Render:      func() templ.Component { return SectionSidebarUserMenu() },
 		},

--- a/internal/templates/components/sidebar_user_menu.templ
+++ b/internal/templates/components/sidebar_user_menu.templ
@@ -9,8 +9,8 @@ import (
 // popover at the bottom of the sidebar rail.
 //
 // Trigger: avatar + display name + role + chevron.
-// Popover: Settings / Documentation / GitHub / (Design system if editor)
-// / Sign out.
+// Popover: Documentation / GitHub / (Design system if editor) / Sign out.
+// (Settings lives in the sidebar System section now, not in this popover.)
 type SidebarUserMenuProps struct {
 	CurrentPage string
 

--- a/internal/templates/components/user_menu.templ
+++ b/internal/templates/components/user_menu.templ
@@ -9,20 +9,13 @@ package components
 // per-instance logoutFormID; userMenuItems fills the <li>s and
 // userMenuLogoutForm renders the matching hidden form as a <ul> sibling.
 
-// userMenuItems renders the shared action <li>s: Settings / Documentation /
-// GitHub / (Design system, editors only) / Sign out.
+// userMenuItems renders the shared action <li>s: Documentation / GitHub /
+// (Design system, editors only) / Sign out.
 //
-// Settings is a full page now (/settings/*, since #1601 retired the modal),
-// so it's a plain link to the account settings — works for every role
-// (RequireAuth), no Alpine/listener dependency, right-clickable.
+// Settings is no longer here — it moved back into the sidebar System section
+// (components.Nav) as a primary, one-click destination for every role. This
+// popover is now purely identity + external resources + sign out.
 templ userMenuItems(p SidebarUserMenuProps, logoutFormID string) {
-	<li>
-		<a href="/settings/account" @click="$el.closest('[popover]')?.hidePopover()">
-			@LucideIcon("settings", "w-3.5 h-3.5")
-			<span class="flex-1">Settings</span>
-		</a>
-	</li>
-	<hr class="border-base-300 my-1 mx-2"/>
 	<li>
 		<a
 			href="https://docs.breadbox.sh"


### PR DESCRIPTION
Moves the **Settings** entrypoint out of the avatar popover and back into the sidebar **System** section, where it reads as a primary destination rather than a profile action.

## What changed

- **`nav.templ`** — adds a `Settings` rail link at the foot of the System section (after Connections / Household / Logs). The `System` header now renders for **every** role, not just editors: `/settings/account` is `RequireAuth` (available to viewers too), so gating the whole section behind `IsEditor` would have hidden Settings from viewers. Connections / Household / Logs stay editor/admin-gated as before — a viewer simply sees `System → Settings`.
- **`navSettingsActive`** — new helper that lights the single rail link on *any* `/settings/*` tab. Each settings sub-page reports its own `CurrentPage` id (`account`, `general`, `system`, `help`, `providers`, `mcp`, `agents-settings`, `api-keys`, `backups`), so a plain `navActive(…, "settings")` would never fire. Kept in sync with the settings rail in `settings_page.templ`.
- **`user_menu.templ`** — drops the Settings item from the shared popover body (now **Documentation / GitHub / Design system / Sign out**). Doc comments on `SidebarUserMenu` and the `/design` sandbox entry updated to match. The popover body is shared by `TopbarUserMenu` (live top-right avatar) and the `/design` `SidebarUserMenu`, so both lose Settings in one place.

The mobile top-navbar avatar button (a separate affordance in `base.html`) still links to `/settings/account` and is left as-is.

## Validation

`templ generate` + `go build ./...` + `go vet ./...` + unit tests (`internal/templates/...`, `internal/admin/...`) all pass.

Screenshots to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
