### PR TITLE
feat(workflows): autonomous improvements — 10 features + 20 test units (32-agent fan-out)

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -97,6 +97,15 @@ List all categories in the 2-level hierarchy. Returns slug, display name, parent
 
 Export the full category tree as TSV. Useful for backup or transfer.
 
+### list_workflows (Read)
+
+List the household's automation layer. Returns two arrays:
+
+- `workflows` — the enabled, preset-backed Workflows. Each row carries `name`, `slug`, `preset` (the workflow-preset slug it was instantiated from), `enabled` (a workflow can be instantiated but paused), `trigger` (`sync` = after each successful sync \| `schedule` = cron \| `manual`), `schedule_cron` (when `trigger=schedule`), `tool_scope` (`read_only` \| `read_write`), and `last_run_status` + `last_run_at` (omitted when the workflow has never run).
+- `presets` — the full catalog of available presets it could enable. Each row carries `slug`, `name`, `category`, `description`, `tool_scope`, `trigger`, default `schedule_cron`, and `enabled` (true when already instantiated as a workflow).
+
+Read this to see what runs automatically before proposing new rules or reports — an existing workflow may already cover the task. Hand-authored agents (no source preset) are excluded; enabling or configuring a workflow is an admin-UI action (the `/workflows` gallery), not an MCP write.
+
 ---
 
 ## Categorization Tools

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,509 @@
+# Breadbox Workflows Specification
+
+## Overview
+
+Workflows are scheduled, event-driven Claude Agent SDK runs that operate on the household's financial data via Breadbox MCP. Each workflow is a code-defined preset from a curated gallery — one click in the admin UI instantiates it, and it fires automatically from that point forward (after each bank sync, on a cron schedule, or on demand).
+
+Workflows replaced the earlier hand-authored "Agents" product surface. Underlying data lives in the `workflows` table (renamed from `agent_definitions`) and `workflow_runs` (renamed from `agent_runs`); Go service code uses `AgentDefinitionResponse` / `AgentRunResponse` as its shared types. The UI and REST surface are entirely Workflows-branded.
+
+---
+
+## Table of Contents
+
+1. [Preset Registry Model](#1-preset-registry-model)
+2. [Database Schema](#2-database-schema)
+3. [Governance Gates](#3-governance-gates)
+4. [Admin UI Surfaces](#4-admin-ui-surfaces)
+5. [Route Catalog](#5-route-catalog)
+6. [Runtime — Orchestrator and Scheduler](#6-runtime--orchestrator-and-scheduler)
+7. [Actor Identity and API Key Lifecycle](#7-actor-identity-and-api-key-lifecycle)
+8. [Notification Sink](#8-notification-sink)
+9. [REST API Surface](#9-rest-api-surface)
+10. [Configuration Keys](#10-configuration-keys)
+
+---
+
+## 1. Preset Registry Model
+
+### Philosophy
+
+Presets are **code-defined, not database-seeded**. The catalog lives in `internal/service/workflow_presets.go` as a Go slice (`workflowPresets`). The gallery page renders directly from this slice — no DB read required to show available presets. A database row (`workflows` table) only exists once the household *enables* a preset, which calls `EnableWorkflowFromPreset`. This means:
+
+- Adding a new preset to the registry immediately appears in every deployment's gallery.
+- Removing a preset from the registry does not delete any existing instantiated workflow row; the household's history is preserved.
+- The same preset cannot be enabled twice (`ErrConflict` on a second enable attempt).
+
+### WorkflowPreset struct
+
+```go
+type WorkflowPreset struct {
+    Slug        string // stable identifier; also the slug of the instantiated workflow
+    Name        string // user-facing title shown in the gallery
+    Category    string // gallery grouping (e.g., "Categorization & Review")
+    Icon        string // lucide icon name
+    Description string // one-line gallery card copy
+
+    // PromptBlocks are IDs of prompt-block files (filenames under prompts/agents/
+    // sans .md) composed in order into the workflow's base prompt.
+    PromptBlocks []string
+
+    // Run configuration applied when the preset is enabled.
+    ToolScope             string  // "read_only" | "read_write"
+    Model                 string  // empty = DefaultAgentModel
+    MaxTurns              int     // 0 = DefaultAgentMaxTurns (10)
+    ScheduleCron          string  // empty = no cron; post-sync presets omit this
+    TriggerOnSyncComplete bool    // fire after each successful sync
+
+    // EstCostPerRunUSD is a rough per-run Anthropic-cost estimate surfaced
+    // in the configure drawer as a transparency hint.
+    EstCostPerRunUSD float64
+
+    // Options are preset-specific configuration choices rendered as selects
+    // in the configure drawer. Each chosen choice's Directive is appended
+    // to the composed prompt.
+    Options []WorkflowPresetOption
+}
+```
+
+### Prompt composition
+
+Each preset declares one or more `PromptBlocks` — references to Markdown files under `prompts/agents/` (e.g., `"strategy-routine-review"`, `"category-system"`). `composePresetPrompt` loads those blocks once at process start (via `sync.OnceValues`), validates that every referenced ID exists (a typo fails at unit-test time, not at a user's first run), and concatenates them in order into a single base prompt.
+
+After block concatenation:
+
+1. **Option directives** — each preset option resolves to a choice (submitted value or the option's `Default`). Non-empty `Directive` values are appended under a Markdown heading named for the option's `Label`.
+2. **Additional instructions** — the household's per-workflow tuning (`AdditionalInstructions`, capped at 4,000 characters) is appended under `## Additional instructions`. This mirrors Mintlify's "additional prompt over the base prompt" model.
+
+### EnableWorkflowFromPreset
+
+```go
+func (s *Service) EnableWorkflowFromPreset(
+    ctx context.Context,
+    slug string,
+    params EnableWorkflowFromPresetParams,
+) (*AgentDefinitionResponse, error)
+```
+
+Steps:
+
+1. Lookup the preset by slug — `ErrNotFound` when absent.
+2. Check for an existing `workflows` row with `source_template = slug` — `ErrConflict` on a duplicate enable.
+3. Compose the base prompt from `PromptBlocks`.
+4. Resolve and append option directives.
+5. Append additional instructions if provided.
+6. Call `CreateAgentDefinition` with `SourceTemplate: &slug` stamped on the row.
+
+The `source_template` column is the durable link between a live `workflows` row and the code-defined preset it was instantiated from. `ListWorkflowPresets` uses it to annotate the catalog with enablement state (slug, enabled toggle state) for the gallery view.
+
+### Preset catalog
+
+The starter catalog (order = gallery display order):
+
+| Slug | Category | Trigger | Tool scope | Est. cost/run |
+|---|---|---|---|---|
+| `routine-reviewer` | Categorization & Review | After each sync | `read_write` | $0.02 |
+| `weekly-money-digest` | Insights & Reports | Weekly (Mon 07:00) | `read_only` | $0.05 |
+| `subscription-auditor` | Insights & Reports | Monthly (1st, 08:00) | `read_write` | $0.04 |
+| `backlog-closer` | Categorization & Review | Weekly (Mon 07:00) | `read_write` | $0.08 |
+| `monthly-close` | Insights & Reports | Monthly (1st, 08:00) | `read_only` | $0.07 |
+
+### Preset options
+
+The shared `applyModeOption` is currently the only option type, used by the two `read_write` categorization presets:
+
+| Key | Choices | Default |
+|---|---|---|
+| `apply_mode` | `auto` (apply categories), `flag_only` (review only, no writes) | `auto` |
+
+When `flag_only` is chosen, a directive is appended to the prompt that explicitly prohibits calling `update_transactions` to write a category. The service validates submitted choices against the declared set; unknown values fall back to the option's `Default`.
+
+---
+
+## 2. Database Schema
+
+### `workflows` table (formerly `agent_definitions`)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID` | Primary key (auto-gen) |
+| `short_id` | `TEXT` | 8-char base62 alias (trigger-generated) |
+| `slug` | `TEXT` | URL-safe identifier; unique; matches preset slug |
+| `name` | `TEXT` | Display name |
+| `prompt` | `TEXT` | Fully-composed prompt (base blocks + option directives + additional instructions) |
+| `tool_scope` | `TEXT` | `read_only` or `read_write` |
+| `model` | `TEXT` | Model override; empty = server default |
+| `max_turns` | `INT` | Per-run turn cap; default 10 |
+| `max_budget_usd` | `NUMERIC(10,4)` | Per-run cost cap; default 1.00 |
+| `enabled` | `BOOLEAN` | Run toggle; false = instantiated but paused |
+| `schedule_cron` | `TEXT` | Cron expression; NULL = no cron |
+| `trigger_on_sync_complete` | `BOOLEAN` | Fire after each successful sync |
+| `quiet_hours_start` | `TEXT` | "HH:MM" 24h; NULL disables window |
+| `quiet_hours_end` | `TEXT` | "HH:MM" 24h |
+| `source_template` | `TEXT` | Preset slug this row was instantiated from; NULL = hand-authored |
+| `created_at` | `TIMESTAMPTZ` | |
+| `updated_at` | `TIMESTAMPTZ` | |
+
+### `workflow_runs` table (formerly `agent_runs`)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID` | Primary key |
+| `short_id` | `TEXT` | 8-char base62 alias |
+| `agent_definition_id` | `UUID` | FK -> `workflows.id`; `SET NULL` on delete (history preserved) |
+| `trigger` | `TEXT` | `manual` \| `cron` \| `webhook` |
+| `status` | `TEXT` | `in_progress` \| `success` \| `error` \| `skipped` |
+| `started_at` | `TIMESTAMPTZ` | |
+| `completed_at` | `TIMESTAMPTZ` | NULL while in progress |
+| `error_message` | `TEXT` | NULL on success |
+| `total_cost_usd` | `NUMERIC(10,4)` | Actual cost recorded by the sidecar |
+| `total_tokens` | `INT` | |
+| `max_turns_used` | `INT` | Snapshot of the definition's `max_turns` at run time |
+| `hit_cap` | `TEXT` | `max_turns` \| `max_budget` \| NULL |
+| `operator_note` | `TEXT` | Admin-editable annotation (PATCH endpoint) |
+| `prompt_prefix` | `TEXT` | Per-run prefix prepended to the prompt |
+
+The `source_template IS NOT NULL` predicate on the `workflows` join is the standard filter distinguishing workflow runs (preset-backed) from hand-authored agent runs in `ListAllAgentRuns` and `WorkflowRunStatusCounts`.
+
+---
+
+## 3. Governance Gates
+
+### 3.1 First-enable consent
+
+Enabling any workflow sends Claude over the household's financial ledger at the Anthropic API's cost. Before the first enable, the configure drawer requires an explicit consent checkbox:
+
+- **Server-side check:** `EnableWorkflowPresetAdminHandler` calls `svc.WorkflowsConsentAcknowledged(ctx)` before processing the request. When the household has not yet acknowledged and the form omits `consent=true`, the handler returns HTTP 400 `CONSENT_REQUIRED`.
+- **One-time acknowledgement:** On the first successful `EnableWorkflowFromPreset` call, `AcknowledgeWorkflowsConsent` writes the current UTC timestamp to `app_config[workflows.consent_acknowledged_at]`. Subsequent enables skip the consent checkbox.
+- **Read path:** `WorkflowsConsentAcknowledged` checks for a non-empty value in that key; a read error returns `false` (safe default: consent required).
+
+### 3.2 Household spend ceiling
+
+A configurable 30-day rolling spend ceiling (`app_config[agent.global_max_budget_usd]`) blocks new runs once the window total exceeds the cap:
+
+- **Window:** `HouseholdCeilingWindow = 30 x 24h` rolling from `time.Now()`.
+- **Measurement:** `HouseholdCostSince` sums `total_cost_usd` across all non-skipped runs started within the window.
+- **Enforcement:** `Orchestrator.checkHouseholdCeiling` is called at the top of both `RunNow` (manual) and `RunOrSkip` (cron/webhook). For cron fires, a ceiling-blocked run still leaves a `skipped` row so the history shows what was missed.
+- **Gallery banner:** `buildWorkflowSpendBanner` derives the gallery's spend state — a warning appears at >= 80% of the ceiling; an error banner ("Workflows paused") appears once spending meets or exceeds the cap.
+- **No ceiling (nil or <= 0):** No enforcement is applied.
+
+### 3.3 Post-sync debounce
+
+`trigger_on_sync_complete` presets fire via `Orchestrator.FireSyncCompleteAgents`, which is called from the sync engine's `OnSyncComplete` hook after every successful sync. Because a webhook burst or rapid manual re-sync could fan out multiple runs within minutes, each definition is debounced:
+
+- **Window:** `PostSyncDebounceWindow = 15 minutes`.
+- **Check:** `RecentRunExistsForDefinition` queries `workflow_runs` for a non-skipped run started within the window for that definition.
+- **Effect:** A debounced trigger is a silent skip — no `skipped` row, no log spam. The next actual run still picks up all transactions synced since it last ran, so no coverage is lost.
+
+### 3.4 Admin-only enablement
+
+Instantiating a workflow from a preset is restricted to admin users:
+
+- The router mounts `EnableWorkflowPresetAdminHandler` under `r.With(RequireAdmin(sm))`.
+- Non-admin users can view the gallery but the "Set up" button renders disabled with an explanatory tooltip.
+- Once instantiated, the workflow's run toggle (`enable`/`disable`) is accessible to any logged-in editor.
+
+### 3.5 Per-run safety caps
+
+Each `workflows` row carries:
+
+- `max_turns` — the Claude SDK halts the run cleanly after this many tool-call turns. Default: 10. Hit cap records `hit_cap = "max_turns"`.
+- `max_budget_usd` — the sidecar aborts mid-run when accumulated cost reaches this value. Default: $1.00. Hit cap records `hit_cap = "max_budget"`.
+
+The household spend ceiling (see §3.2) is a separate, server-side gate evaluated before the run starts. Per-run caps are enforced inside the sidecar.
+
+### 3.6 Quiet hours
+
+Each workflow can declare a quiet window (`quiet_hours_start`, `quiet_hours_end`, both "HH:MM" 24-hour strings). The scheduler skips cron fires that would land inside the window and reschedules to the first minute after the window closes. Post-sync and manual runs are not affected by quiet hours.
+
+---
+
+## 4. Admin UI Surfaces
+
+### 4.1 Gallery — `/workflows`
+
+**Handler:** `WorkflowsGalleryPageHandler` (`internal/admin/workflows_gallery_page.go`)
+**Template:** `pages.WorkflowsGallery` (`internal/templates/components/pages/workflows_gallery.templ`)
+**Alpine factory:** `workflowsGallery` (`static/js/admin/components/workflows_gallery.js`)
+
+The gallery renders the preset catalog grouped by category. Each category becomes a `SettingsSection`; each preset becomes a `SettingsRow`. The right-side control is state-dependent:
+
+- **Not yet enabled:** A "Set up" button opens the preset's configure drawer (admin only; disabled with tooltip for non-admins).
+- **Enabled + active:** A toggle switch (enabled/running). Toggling calls `/-/workflows/{slug}/enable` or `/-/workflows/{slug}/disable`.
+- **Enabled + paused:** The toggle shows the paused state; enabling resumes it.
+
+**Top-of-page banners:**
+
+- **Runtime not ready:** Shown when `GetAgentSubsystemStatus` returns `Ready = false` (no auth token configured, or sidecar binary not found). Links to Settings -> Agents.
+- **Spend ceiling warning / over:** Derived from `HouseholdSpendStatus`. Warning at >= 80%; error banner with "Workflows paused" copy once over.
+
+**Configure drawer:** A right-side slide-over panel (one per available preset, rendered only for admins). Contents:
+
+- Preset description and trigger summary.
+- **Schedule selector** (scheduled presets only): cron preset dropdown (Weekly / Monthly / Daily); post-sync presets skip this field.
+- **Per-preset option selects** (e.g., "Apply mode" for categorization presets).
+- **Additional instructions** textarea: the household's tuning appended to the base prompt.
+- **Projected cost hint:** Computed reactively by `projectedCost(cron, estPerRun, postSync)` in the Alpine factory. For scheduled presets this is `estPerRun x runs/month`; for post-sync it shows the per-run cost estimate.
+- **Consent checkbox** (first-enable only; hidden once `ConsentAcknowledged`).
+- **"Enable" CTA:** Submits the drawer form to `POST /-/workflow-presets/{slug}/enable`. On success, reloads the page so the row shows the run toggle.
+
+### 4.2 Runs tab — `/workflows/runs`
+
+**Handler:** `WorkflowRunsPageHandler` (`internal/admin/workflows_runs_page.go`)
+**Template:** `pages.WorkflowRuns` (`internal/templates/components/pages/workflows_runs.templ`)
+**Alpine factory:** `workflowsRuns` (`static/js/admin/components/workflows_runs.js`)
+
+The runs tab shows offset-paginated run history scoped to preset-backed workflows (`source_template IS NOT NULL`). Features:
+
+- **Status tabs:** All / Success / Error / In Progress / Skipped — each tab carries a count badge derived from `WorkflowRunStatusCounts`.
+- **Workflow filter dropdown:** Narrows to one instantiated workflow. The dropdown lists only enabled presets (those with a `workflows` row).
+- **Run rows:** Reuse the shared `components.AgentRunRow` shape — status badge, trigger chip, cost, duration, per-run report links (chips loaded via `ListReportSummariesForRunIDs`).
+- **Overflow menu:** Each row has a "Re-run" action (fires `POST /-/workflows/{slug}/run`); gated on `SubsystemReady`.
+- **Offset pagination:** Prev / Next links step by 50 rows (`workflowRunsPageLimit`), preserving the active status and workflow filters.
+
+### 4.3 Run detail — `/workflows/runs/{shortId}`
+
+Reuses the existing `AgentRunDetailPageHandler` (shared with the agents surface). Shows the full NDJSON transcript streamed from disk, the operator note PATCH form, and linked reports.
+
+### 4.4 Tab bar
+
+Both `/workflows` and `/workflows/runs` share a two-tab nav bar rendered by `workflowsTabBar("gallery"|"runs")` — Gallery (layout-grid icon) and Runs (history icon). The tab bar sits immediately under the page header.
+
+---
+
+## 5. Route Catalog
+
+### Admin page routes (session-cookie auth)
+
+| Method | Path | Guard | Handler |
+|---|---|---|---|
+| GET | `/workflows` | Editor | `WorkflowsGalleryPageHandler` |
+| GET | `/workflows/runs` | Editor | `WorkflowRunsPageHandler` |
+| GET | `/workflows/runs/{shortId}` | Editor | `AgentRunDetailPageHandler` |
+| GET | `/workflows/runs/{shortId}/live` | Editor | `AgentRunLiveHandler` |
+
+### Admin action routes (`/-/` prefix, session-cookie auth)
+
+| Method | Path | Guard | Action |
+|---|---|---|---|
+| POST | `/-/workflow-presets/{slug}/enable` | **Admin** | Instantiate a workflow from a preset |
+| POST | `/-/workflows/{slug}/enable` | Editor | Flip `enabled = true` on an instantiated workflow |
+| POST | `/-/workflows/{slug}/disable` | Editor | Flip `enabled = false` |
+| POST | `/-/workflows/{slug}/run` | Editor | Trigger an immediate manual run (async) |
+| POST | `/-/workflows/runs/{shortId}/note` | Editor | Set/clear the operator note on a run |
+| POST | `/-/workflows/settings` | Admin | Update agent subsystem settings |
+| POST | `/-/workflows/test` | Admin | Smoke-test the agent runtime |
+| POST | `/-/workflows/notify-test` | Admin | Fire a test notification to the configured webhook |
+| POST | `/-/workflows/cleanup` | Admin | Run the agent cleanup pass on demand |
+
+### REST API routes (`/api/v1/`, API-key auth)
+
+Full details in `docs/api-endpoints.md`. Summary of the Workflows surface:
+
+| Method | Path | Scope | Description |
+|---|---|---|---|
+| GET | `/workflows` | R | List all workflow definitions with last_run inlined |
+| GET | `/workflows/{slug}` | R | One definition; accepts slug, short_id, or UUID |
+| POST | `/workflows` | W | Create a hand-authored workflow definition |
+| PATCH | `/workflows/{slug}` | W | Partial update |
+| DELETE | `/workflows/{slug}` | W | Delete definition; historical runs preserved |
+| POST | `/workflows/{slug}/enable` | W | Flip enabled = true |
+| POST | `/workflows/{slug}/disable` | W | Flip enabled = false |
+| POST | `/workflows/{slug}/run` | W | Trigger an immediate run |
+| GET | `/workflows/{slug}/runs` | R | Per-definition run history |
+| GET | `/workflows/runs` | R | Cross-definition run history |
+| GET | `/workflows/runs/{shortId}` | R | One run detail |
+| PATCH | `/workflows/runs/{shortId}` | W | Set/clear operator note |
+| GET | `/workflows/runs/{shortId}/transcript` | R | NDJSON transcript stream |
+| GET | `/workflows/runs/recent-errors` | R | Errored runs in the last N hours |
+| GET | `/workflows/settings` | R | Agent subsystem config (tokens masked) |
+| PUT | `/workflows/settings` | W | Update settings |
+| GET | `/workflows/status` | R | Cheap readiness probe |
+| POST | `/workflows/test` | W | Smoke test |
+| POST | `/workflows/cleanup` | W | Cleanup pass on demand |
+| GET | `/workflows/prompt-blocks` | R | Parsed prompt-block library |
+| GET | `/workflow-presets` | R | Preset catalog with enabled-state annotations |
+| POST | `/workflow-presets/{slug}/enable` | W | Instantiate a workflow from a preset |
+
+---
+
+## 6. Runtime — Orchestrator and Scheduler
+
+### 6.1 Orchestrator
+
+`Orchestrator` (`internal/service/agent_orchestrator.go`) drives one workflow run end-to-end. It owns:
+
+1. **Household ceiling check** — before acquiring the semaphore.
+2. **Concurrency semaphore** — `agent.Semaphore` (configurable via `agent.max_concurrent`, default 1).
+3. **Run row creation** — `CreateAgentRunDB` writes the `workflow_runs` row with `status = in_progress`.
+4. **API key mint** — `MintRunAPIKey` creates a scoped `api_keys` row with `actor_type = 'agent'` (see §7).
+5. **JobSpec assembly** — `AssembleJobSpec` reads auth tokens from `app_config` (AES-256-GCM encrypted), resolves the sidecar binary path, and builds the `agent.JobSpec` the runner needs.
+6. **Sidecar invocation** — `runner.Run(ctx, spec)` execs `breadbox-agent` (the TypeScript Claude Agent SDK sidecar), passes it the MCP config, Anthropic credential, and full prompt. The sidecar connects to Breadbox MCP via stdio using the minted run key.
+7. **Row completion** — on sidecar exit, marks the run `success` or `error` with actual cost, token count, and cap signal.
+8. **API key revocation** — always, in a `defer` with a fresh `context.Background()` timeout so cancellation of the parent context cannot prevent revocation.
+
+#### Run entry points
+
+| Method | When used | Leaves skipped row? |
+|---|---|---|
+| `RunNow` / `RunNowWith` | Manual "Run now" from the admin UI or REST API (synchronous) | No — returns `ErrConcurrencyLocked` to caller |
+| `RunNowAsyncWith` | "Run now" button (returns immediately; sidecar runs in goroutine) | No |
+| `RunOrSkip` | Cron and webhook triggers | Yes — `status = skipped` when semaphore full or ceiling reached |
+| `FireSyncCompleteAgents` | Post-sync event (called from `OnSyncComplete` hook) | No — debounced fires are silent no-ops |
+
+### 6.2 Scheduler
+
+`AgentScheduler` (`internal/service/agent_scheduler.go`) wraps `robfig/cron` and registers one cron entry per enabled, scheduled workflow definition. On `Reload`, it tears down all existing entries and re-registers from the database. This is triggered by `NotifyDefinitionChanged` after any CRUD mutation on a workflow definition.
+
+Cron fires call `RunOrSkip` and respect quiet hours — a fire scheduled inside the quiet window is skipped with a log entry; the scheduler reschedules to the first minute after the window ends.
+
+### 6.3 Sync hook
+
+`Orchestrator.FireSyncCompleteAgents` is wired to `sync.Engine.OnSyncComplete` in `serve.go`. The sync engine has no knowledge of the agents/workflows package (no import cycle). When called:
+
+1. Queries `ListAgentDefinitionsForSyncWebhook` for enabled definitions with `trigger_on_sync_complete = true`.
+2. Applies the debounce check (see §3.3).
+3. Dispatches each definition in its own goroutine, calling `RunOrSkip` with `trigger = "webhook"`.
+
+### 6.4 Panic recovery
+
+`RunNowAsyncWith` wraps the goroutine body in a `recover()` block. A panic from any downstream code (sidecar NDJSON parser, DB driver, slog handler) is caught, logged with the full stack trace, and the run row is marked errored. The concurrency slot is always released.
+
+---
+
+## 7. Actor Identity and API Key Lifecycle
+
+### Mint-and-revoke
+
+Every workflow run creates a scoped `api_keys` row at start and revokes it at completion. The key is never exposed to callers.
+
+```go
+// MintRunAPIKey — called by Orchestrator before sidecar exec
+s.CreateAPIKey(ctx, CreateAPIKeyParams{
+    Name:              fmt.Sprintf("agent:%s:%s", def.Slug, runShortID),
+    Scope:             scope, // "read_only" or "full_access"
+    ActorType:         "agent",
+    ActorName:         def.Name,
+    AgentDefinitionID: def.ID,
+})
+```
+
+- `ActorType = "agent"` distinguishes workflow writes in the activity timeline from human edits.
+- `ActorName = def.Name` (the workflow's display name, e.g., "Routine Reviewer") is stamped on every write the run makes.
+- `AgentDefinitionID` is the durable link: `ResolveAgentSlugForActor` / `GetAgentIdentityByApiKeyID` resolve any agent actor to its definition for name and avatar rendering.
+- The key name (`agent:<slug>:<runShortID>`) is the audit trail in `api_keys`; the per-run row in `workflow_runs` does not store the plaintext key.
+
+Revocation always uses a fresh `context.WithTimeout(context.Background(), 10*time.Second)` so a cancelled parent (user closed the run-now request, server shutdown) does not prevent the revoke.
+
+### Attribution
+
+The sidecar receives the minted run key as `BREADBOX_API_KEY`. `runMCPStdio` (`internal/cli/mcp.go`) binds it as the actor floor via `ValidateAPIKey`. `MCPServer.rebindActorFromClientInfo` is gated on `AgentRunShortIDFromContext(ctx) == ""` — it upgrades anonymous clients but never clobbers a real run key, so workflow runs are always attributed to their specific definition regardless of the Claude SDK's generic `clientInfo`.
+
+### Tool scope
+
+- `read_only` definitions mint a `read_only`-scoped key, restricting the sidecar to read MCP tools only.
+- `read_write` definitions mint a `full_access`-scoped key, allowing the sidecar to call update tools (e.g., `update_transactions`, `create_transaction_rule`).
+
+---
+
+## 8. Notification Sink
+
+Workflows can fire an outbound JSON webhook when noteworthy events occur (typically when a run submits a report via `submit_report`).
+
+### Configuration
+
+The webhook URL is stored in `app_config[notify.webhook_url]` (plaintext, http(s) only). It is set from Settings -> Agents (the `POST /-/workflows/settings` handler writes `NotifyWebhookURL`). A "Send test" button (`POST /-/workflows/notify-test`) fires a sample payload to verify the wiring.
+
+### NotificationPayload
+
+```go
+type NotificationPayload struct {
+    Event    string `json:"event"`              // "test" | "report"
+    Title    string `json:"title"`
+    Body     string `json:"body,omitempty"`
+    Priority string `json:"priority,omitempty"` // info | warning | critical
+    Workflow string `json:"workflow,omitempty"` // originating workflow name
+    URL      string `json:"url,omitempty"`      // deep link back into Breadbox
+    SentAt   string `json:"sent_at"`            // RFC3339
+}
+```
+
+### Delivery
+
+`SendWorkflowNotification` is a no-op when no URL is configured — callers fire unconditionally without a nil-check. The request uses a 10-second timeout (`notifyHTTPClient`) and sets `Content-Type: application/json` and `User-Agent: breadbox-workflows`. Any HTTP 3xx+ response is treated as an error.
+
+The sink is generic by design: it works with ntfy, Slack-compatible relay bridges, Discord webhooks (via a formatter), and email bridges without per-provider formatting in Breadbox.
+
+---
+
+## 9. REST API Surface
+
+### Authentication
+
+All `/api/v1/workflows/*` and `/api/v1/workflow-presets/*` endpoints share the same API key middleware as the rest of the REST API (`X-API-Key` header). Scope requirements follow the table in §5 (read-only keys cannot call write endpoints).
+
+### Workflows list — GET /api/v1/workflows
+
+Returns a bare JSON array of `AgentDefinitionResponse` objects, each with `last_run` inlined. The `source_template` field identifies preset-backed workflows; null means hand-authored.
+
+### Preset gallery — GET /api/v1/workflow-presets
+
+Returns an annotated catalog: each preset carries `enabled`, `workflow_slug` (when instantiated), and `workflow_enabled` (the instantiated workflow's run toggle). The gallery UI reads this endpoint client-side for reactive enable-state.
+
+### Enable preset — POST /api/v1/workflow-presets/{slug}/enable
+
+Enforces the same consent gate as the admin action route. Accepts the same form fields:
+
+| Field | Default | Notes |
+|---|---|---|
+| `consent` | — | Required on first enable when consent not yet recorded |
+| `enabled` | `"true"` | Pass `"false"` to instantiate paused |
+| `schedule_cron` | preset default | Scheduled presets only |
+| `additional_instructions` | `""` | Capped at 4,000 characters |
+| `<option.Key>` | option.Default | One field per preset option (e.g., `apply_mode`) |
+
+Returns 409 `CONFLICT` when already enabled; 404 `NOT_FOUND` for an unknown slug; 400 for invalid parameters; 200 with the new `AgentDefinitionResponse` on success.
+
+### Run history — GET /api/v1/workflows/runs
+
+Cross-definition run history. Each row includes `agent_slug` and `agent_name` from the joined `workflows` row for deep-link and attribution display. Supports these query parameters: `status`, `trigger`, `hit_cap` (`max_turns`/`max_budget`/`any`), `start`, `end`, `agent` (slug to narrow to one definition), `limit` (max 200), `offset`.
+
+### Settings
+
+`GET /api/v1/workflows/settings` returns `AgentSettingsResponse`. Token fields (`subscription_token`, `anthropic_api_key`) are returned as masked display strings (e.g., `"sk-ant-oat01-XXXXXXXXX****wxyz"`); plaintext never leaves the server.
+
+`PUT /api/v1/workflows/settings` accepts partial updates. Nil fields are unchanged; an empty string for token fields clears the stored encrypted value.
+
+---
+
+## 10. Configuration Keys
+
+All keys are stored in the `app_config` table and read at runtime via `appconfig.*` helpers.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `agent.auth_mode` | string | `"subscription"` | `"subscription"` (Claude OAuth token) or `"api_key"` (Anthropic API key) |
+| `agent.subscription_token` | string (encrypted) | — | Claude OAuth token (`sk-ant-oat01-...`) |
+| `agent.anthropic_api_key` | string (encrypted) | — | Anthropic API key (`sk-ant-...`) |
+| `agent.max_concurrent` | int | `1` | Server-wide cap on simultaneous workflow runs |
+| `agent.global_max_budget_usd` | float | — | 30-day rolling household spend ceiling; empty = no cap |
+| `agent.runtime_path` | string | — | Absolute path to `breadbox-agent` binary; empty = auto-discover |
+| `agent.transcript_dir` | string | — | Directory for per-run NDJSON transcripts; falls back to `agent.DefaultTranscriptDir()` |
+| `agent.run_retention_days` | int | `30` | Days to keep completed `workflow_runs` rows; 0 = disabled |
+| `workflows.consent_acknowledged_at` | RFC3339 | — | Non-empty = household has given first-enable consent |
+| `notify.webhook_url` | string | — | Outbound webhook URL for workflow notifications; empty = disabled |
+
+Token values (`agent.subscription_token`, `agent.anthropic_api_key`) are AES-256-GCM encrypted at rest via `appconfig.ReadEncrypted` / `appconfig.WriteEncrypted`, using the server's `ENCRYPTION_KEY`.
+
+---
+
+## Relationship to the Agents Surface
+
+Workflows and hand-authored Agents share the same underlying data layer:
+
+- Both use the `workflows` table (formerly `agent_definitions`) and `workflow_runs` table (formerly `agent_runs`).
+- The orchestrator, scheduler, and sidecar are shared. There is one concurrency semaphore for all runs regardless of origin.
+- Workflows are distinguished by `source_template IS NOT NULL`; hand-authored agents have `source_template = NULL`.
+- The Settings -> Agents page (`/settings/agents`) configures the shared subsystem (Anthropic credentials, concurrency cap, global budget ceiling, notification webhook, runtime path) for both surfaces.
+- The `/agents` admin page (agent definitions list and form) remains the management surface for hand-authored agents; `/workflows` is the gallery surface for preset-backed ones.
+
+Going forward, the recommended path for new automations is the preset gallery, which provides composed prompts, estimated costs, and configured defaults out of the box.

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -5,6 +5,8 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"sync"
+	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -37,8 +39,33 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			http.Error(w, "Failed to load agent settings: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		status := svc.GetAgentSubsystemStatus(ctx)
-		spend, _ := svc.HouseholdSpendStatus(ctx) // best-effort; display only
+
+		// Read-only overview inputs fetched concurrently — each is
+		// best-effort (display only), so a single query hiccup degrades the
+		// relevant tile rather than failing the page.
+		var (
+			status *service.AgentSubsystemStatus
+			spend  service.HouseholdSpendStatus
+			defs   []service.AgentDefinitionResponse
+			runs   *service.AgentRunListWithAgentResult
+			wg     sync.WaitGroup
+		)
+		wg.Add(4)
+		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
+		go func() { defer wg.Done(); spend, _ = svc.HouseholdSpendStatus(ctx) }()
+		go func() { defer wg.Done(); defs, _ = svc.ListAgentDefinitions(ctx) }()
+		go func() {
+			defer wg.Done()
+			// Trailing-7-day, preset-backed runs only. Bounded limit keeps the
+			// read cheap; 7-day volume sits well under this in practice.
+			start := time.Now().Add(-7 * 24 * time.Hour)
+			runs, _ = svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{
+				Limit:         200,
+				WorkflowsOnly: true,
+				Start:         &start,
+			})
+		}()
+		wg.Wait()
 
 		form := pages.AgentSDKSettingsFormFields{
 			AuthMode:              settings.AuthMode,
@@ -67,18 +94,14 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 		}
 
 		props := pages.AgentSDKSettingsProps{
-			Form:        form,
-			FieldErrors: map[string]string{},
-			FormError:   formError,
-			FormSuccess: formSuccess,
-			Status: pages.AgentSDKStatusProps{
-				Ready:          status.Ready,
-				AuthConfigured: status.AuthConfigured,
-				BinaryPresent:  status.BinaryPresent,
-				BinaryPath:     status.BinaryPath,
-			},
+			Form:                 form,
+			FieldErrors:          map[string]string{},
+			FormError:            formError,
+			FormSuccess:          formSuccess,
+			Status:               buildAgentSDKStatus(status),
 			CSRFToken:            GetCSRFToken(r),
 			HouseholdSpend30dStr: formatHouseholdSpend(spend),
+			Overview:             buildAgentSDKOverview(spend, defs, runs),
 		}
 
 		data := BaseTemplateData(r, sm, "agents-settings", "Workflows settings")
@@ -106,4 +129,131 @@ func formatHouseholdSpend(s service.HouseholdSpendStatus) string {
 		return spent + " of $" + strconv.FormatFloat(*s.CeilingUSD, 'f', 2, 64)
 	}
 	return spent
+}
+
+// buildAgentSDKStatus maps the service readiness struct to the page's
+// status-panel props. Nil-safe — a nil status (the service method always
+// returns a value in practice) renders as "not ready".
+func buildAgentSDKStatus(s *service.AgentSubsystemStatus) pages.AgentSDKStatusProps {
+	if s == nil {
+		return pages.AgentSDKStatusProps{}
+	}
+	return pages.AgentSDKStatusProps{
+		Ready:          s.Ready,
+		AuthConfigured: s.AuthConfigured,
+		BinaryPresent:  s.BinaryPresent,
+		BinaryPath:     s.BinaryPath,
+	}
+}
+
+// agentSDKRunStatusOrder fixes the display order + labels + daisy tones of
+// the 7-day run breakdown so the templ never switches on the raw status.
+// Mirrors the canonical run-status enum (see CLAUDE.md "Sync status" +
+// the agents subsystem's added "skipped").
+var agentSDKRunStatusOrder = []struct {
+	Status string
+	Label  string
+	Tone   string
+}{
+	{"success", "Succeeded", "success"},
+	{"error", "Failed", "error"},
+	{"in_progress", "In progress", "info"},
+	{"skipped", "Skipped", "neutral"},
+}
+
+// buildAgentSDKOverview derives the read-only "Workflows overview" panel
+// from already-fetched data. Everything is best-effort: a nil/empty input
+// degrades the relevant tile rather than erroring.
+//
+//   - EnabledCount counts enabled preset-backed workflows (source_template
+//     set) so it lines up with the gallery's notion of a "workflow".
+//   - Spend mirrors HouseholdSpendStatus (the rolling 30-day window) and
+//     reuses its ceiling for the percent-of-cap hint.
+//   - The 7-day run breakdown is bucketed from the bounded run list.
+//   - NextRun is the soonest NextFireAt across enabled workflows; the
+//     service already computes NextFireAt (quiet-hours-aware) per definition.
+func buildAgentSDKOverview(
+	spend service.HouseholdSpendStatus,
+	defs []service.AgentDefinitionResponse,
+	runs *service.AgentRunListWithAgentResult,
+) pages.AgentSDKOverviewProps {
+	now := time.Now()
+	out := pages.AgentSDKOverviewProps{}
+
+	// Enabled workflow count + soonest next-fire.
+	var nextAt time.Time
+	var nextName string
+	for i := range defs {
+		d := defs[i]
+		if !d.Enabled || d.SourceTemplate == nil {
+			continue
+		}
+		out.EnabledCount++
+		if d.NextFireAt == nil {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, *d.NextFireAt)
+		if err != nil || !t.After(now) {
+			continue
+		}
+		if nextAt.IsZero() || t.Before(nextAt) {
+			nextAt = t
+			nextName = d.Name
+		}
+	}
+	if !nextAt.IsZero() {
+		out.HasNextRun = true
+		out.NextRunWhenStr = nextAt.Local().Format("Jan 2, 15:04")
+		out.NextRunRelStr = agentSDKUntil(nextAt.Sub(now))
+		out.NextRunWorkflow = nextName
+	}
+
+	// Spend tile.
+	out.Spend30dStr = "$" + strconv.FormatFloat(spend.SpentUSD, 'f', 2, 64)
+	if spend.CeilingUSD != nil && *spend.CeilingUSD > 0 {
+		ceiling := *spend.CeilingUSD
+		out.SpendVsCeilingStr = "of $" + strconv.FormatFloat(ceiling, 'f', 2, 64) + " ceiling"
+		pct := int(spend.SpentUSD / ceiling * 100)
+		if pct < 0 {
+			pct = 0
+		}
+		out.SpendPctStr = strconv.Itoa(pct) + "%"
+		out.SpendOverCeiling = spend.SpentUSD >= ceiling
+	} else {
+		out.SpendVsCeilingStr = "no ceiling set"
+	}
+
+	// 7-day run breakdown, in fixed display order.
+	counts := map[string]int{}
+	if runs != nil {
+		for i := range runs.Runs {
+			counts[runs.Runs[i].Status]++
+			out.Runs7dTotal++
+		}
+	}
+	for _, sc := range agentSDKRunStatusOrder {
+		out.Runs7dByStatus = append(out.Runs7dByStatus, pages.AgentSDKRunStatusCount{
+			Status: sc.Status,
+			Label:  sc.Label,
+			Count:  counts[sc.Status],
+			Tone:   sc.Tone,
+		})
+	}
+
+	return out
+}
+
+// agentSDKUntil renders a short, forward-looking duration hint ("in 2h",
+// "in 3d") for the next-run row. Sub-minute resolves to "imminently".
+func agentSDKUntil(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "imminently"
+	case d < time.Hour:
+		return "in " + strconv.Itoa(int(d.Minutes())) + "m"
+	case d < 24*time.Hour:
+		return "in " + strconv.Itoa(int(d.Hours())) + "h"
+	default:
+		return "in " + strconv.Itoa(int(d.Hours()/24)) + "d"
+	}
 }

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -480,6 +480,17 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/workflows/{slug}/disable", DisableAgentAdminHandler(svc))
 			r.Post("/workflows/{slug}/run", RunAgentNowAdminHandler(a, svc))
 			r.Post("/workflows/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))
+
+			// Preview the composed internal base prompt for a preset (read-only JSON).
+			r.Get("/workflows/{slug}/prompt", WorkflowPromptPreviewAdminHandler(svc))
+			// Reconfigure an already-enabled workflow (schedule, additional
+			// instructions, options). GET returns the live config to prefill
+			// the configure drawer; POST re-composes the prompt + schedule.
+			// Both are admin-only — RequireAdmin upgrades them above the
+			// surrounding editor group, mirroring the preset-enable guard,
+			// because a reconfigure re-authorizes recurring AI spend behavior.
+			r.With(RequireAdmin(sm)).Get("/workflows/{slug}/config", WorkflowConfigAdminHandler(svc))
+			r.With(RequireAdmin(sm)).Post("/workflows/{slug}/reconfigure", ReconfigureWorkflowAdminHandler(svc))
 		})
 
 		// Admin-only API routes.

--- a/internal/admin/workflows_actions_handler_test.go
+++ b/internal/admin/workflows_actions_handler_test.go
@@ -1,0 +1,233 @@
+//go:build integration && !headless && !lite
+
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// T6_routerWithPresetSlug registers EnableWorkflowPresetAdminHandler on a
+// minimal chi router with the {slug} param wired, bypassing RequireAdmin
+// middleware for handler-level coverage.
+func T6_routerWithPresetSlug(svc *service.Service) *chi.Mux {
+	r := chi.NewRouter()
+	r.Post("/-/workflow-presets/{slug}/enable", EnableWorkflowPresetAdminHandler(svc))
+	return r
+}
+
+// T6_postPresetEnable fires a POST /-/workflow-presets/{slug}/enable with the
+// supplied form values and returns the recorded response.
+func T6_postPresetEnable(t *testing.T, svc *service.Service, slug string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	r := T6_routerWithPresetSlug(svc)
+	req := httptest.NewRequest(http.MethodPost, "/-/workflow-presets/"+slug+"/enable",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// T6_mustDecodeError decodes the standard {"error":{"code","message"}} envelope.
+func T6_mustDecodeError(t *testing.T, body []byte) (code, message string) {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("T6: decode error envelope: %v (body=%s)", err, body)
+	}
+	return env.Error.Code, env.Error.Message
+}
+
+// T6_TestEnableWorkflowPreset_ConsentRequired verifies that the consent gate
+// returns 400 CONSENT_REQUIRED when consent has not been previously given and
+// the form does not supply consent=true.
+func T6_TestEnableWorkflowPreset_ConsentRequired(t *testing.T) {
+	svc := newTestSvc(t)
+
+	// No consent=true and consent not yet acknowledged in DB.
+	w := T6_postPresetEnable(t, svc, "routine-reviewer", url.Values{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("T6: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	code, msg := T6_mustDecodeError(t, w.Body.Bytes())
+	if code != "CONSENT_REQUIRED" {
+		t.Errorf("T6: error.code = %q, want CONSENT_REQUIRED", code)
+	}
+	if msg == "" {
+		t.Error("T6: error.message should not be empty")
+	}
+}
+
+// T6_TestEnableWorkflowPreset_UnknownSlug verifies that an unrecognised preset
+// slug returns 404 NOT_FOUND even when consent=true is provided.
+func T6_TestEnableWorkflowPreset_UnknownSlug(t *testing.T) {
+	svc := newTestSvc(t)
+
+	// Acknowledge consent first so the slug-lookup path is exercised.
+	if err := svc.AcknowledgeWorkflowsConsent(t.Context()); err != nil {
+		t.Fatalf("T6: AcknowledgeWorkflowsConsent: %v", err)
+	}
+
+	w := T6_postPresetEnable(t, svc, "no-such-preset", url.Values{
+		"consent": {"true"},
+	})
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("T6: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+	code, _ := T6_mustDecodeError(t, w.Body.Bytes())
+	if code != "NOT_FOUND" {
+		t.Errorf("T6: error.code = %q, want NOT_FOUND", code)
+	}
+}
+
+// T6_TestEnableWorkflowPreset_Success verifies that enabling a valid preset
+// with consent=true returns 200 and a workflow response body containing the
+// correct slug.
+func T6_TestEnableWorkflowPreset_Success(t *testing.T) {
+	svc := newTestSvc(t)
+
+	w := T6_postPresetEnable(t, svc, "routine-reviewer", url.Values{
+		"consent": {"true"},
+		"enabled": {"false"}, // start paused so no scheduler interference
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T6: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp service.AgentDefinitionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("T6: decode response: %v (body=%s)", err, w.Body.String())
+	}
+	if resp.Slug != "routine-reviewer" {
+		t.Errorf("T6: resp.Slug = %q, want %q", resp.Slug, "routine-reviewer")
+	}
+
+	// Consent should now be persisted: the handler calls
+	// AcknowledgeWorkflowsConsent after the first successful enable.
+	if !svc.WorkflowsConsentAcknowledged(t.Context()) {
+		t.Error("T6: consent should be acknowledged after first successful enable")
+	}
+}
+
+// T6_TestEnableWorkflowPreset_AlreadyEnabled verifies that enabling a preset
+// that has already been instantiated returns 200 with already_enabled:true
+// (idempotent gallery behaviour — the page just refreshes the tile state).
+func T6_TestEnableWorkflowPreset_AlreadyEnabled(t *testing.T) {
+	svc := newTestSvc(t)
+
+	// First enable directly via the service (bypassing the HTTP handler).
+	if _, err := svc.EnableWorkflowFromPreset(t.Context(), "backlog-closer",
+		service.EnableWorkflowFromPresetParams{Enabled: false}); err != nil {
+		t.Fatalf("T6: first EnableWorkflowFromPreset: %v", err)
+	}
+	// Mark consent as acknowledged so the handler skips the consent gate.
+	if err := svc.AcknowledgeWorkflowsConsent(t.Context()); err != nil {
+		t.Fatalf("T6: AcknowledgeWorkflowsConsent: %v", err)
+	}
+
+	// Second enable via the HTTP handler — should be idempotent (200 +
+	// already_enabled:true) rather than returning a conflict error.
+	w := T6_postPresetEnable(t, svc, "backlog-closer", url.Values{})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T6: expected 200 for double-enable, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("T6: decode body: %v", err)
+	}
+	alreadyEnabled, _ := body["already_enabled"].(bool)
+	if !alreadyEnabled {
+		t.Errorf("T6: expected already_enabled:true in response, got %v", body)
+	}
+	slug, _ := body["slug"].(string)
+	if slug != "backlog-closer" {
+		t.Errorf("T6: expected slug=backlog-closer in response, got %q", slug)
+	}
+}
+
+// T6_TestEnableWorkflowPreset_ConsentAlreadyAcknowledged verifies that once
+// consent has been recorded in the DB, subsequent enables do NOT require
+// consent=true in the form body — the gate is a one-time check.
+func T6_TestEnableWorkflowPreset_ConsentAlreadyAcknowledged(t *testing.T) {
+	svc := newTestSvc(t)
+
+	// Pre-seed consent acknowledgement.
+	if err := svc.AcknowledgeWorkflowsConsent(t.Context()); err != nil {
+		t.Fatalf("T6: AcknowledgeWorkflowsConsent: %v", err)
+	}
+
+	// Enable without consent=true — the gate must be bypassed.
+	w := T6_postPresetEnable(t, svc, "weekly-money-digest", url.Values{
+		"enabled": {"false"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("T6: expected 200 when consent already given, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp service.AgentDefinitionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("T6: decode response: %v", err)
+	}
+	if resp.Slug != "weekly-money-digest" {
+		t.Errorf("T6: resp.Slug = %q, want %q", resp.Slug, "weekly-money-digest")
+	}
+}
+
+// T6_TestEnableWorkflowPreset_InstructionsTooLong verifies that
+// additional_instructions exceeding 4000 chars returns 400 INVALID_PARAMETER.
+// This exercises the ErrInvalidParameter → INVALID_PARAMETER error branch.
+func T6_TestEnableWorkflowPreset_InstructionsTooLong(t *testing.T) {
+	svc := newTestSvc(t)
+
+	if err := svc.AcknowledgeWorkflowsConsent(t.Context()); err != nil {
+		t.Fatalf("T6: AcknowledgeWorkflowsConsent: %v", err)
+	}
+
+	// 4001 bytes of 'x' — one byte over the maxAdditionalInstructions cap.
+	oversized := strings.Repeat("x", 4001)
+	w := T6_postPresetEnable(t, svc, "routine-reviewer", url.Values{
+		"additional_instructions": {oversized},
+		"enabled":                 {"false"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("T6: expected 400 for oversized instructions, got %d: %s", w.Code, w.Body.String())
+	}
+	code, _ := T6_mustDecodeError(t, w.Body.Bytes())
+	if code != "INVALID_PARAMETER" {
+		t.Errorf("T6: error.code = %q, want INVALID_PARAMETER", code)
+	}
+}
+
+// TestT6WorkflowActionsHandler is the single exported entry-point that runs
+// all T6 sub-tests. The admin package's TestMain (tags_integration_test.go)
+// sets up and tears down the DB; sub-tests are independent — each calls
+// newTestSvc(t) for a fresh service instance sharing the connection pool.
+func TestT6WorkflowActionsHandler(t *testing.T) {
+	t.Run("ConsentRequired", T6_TestEnableWorkflowPreset_ConsentRequired)
+	t.Run("UnknownSlug", T6_TestEnableWorkflowPreset_UnknownSlug)
+	t.Run("Success", T6_TestEnableWorkflowPreset_Success)
+	t.Run("AlreadyEnabled", T6_TestEnableWorkflowPreset_AlreadyEnabled)
+	t.Run("ConsentAlreadyAcknowledged", T6_TestEnableWorkflowPreset_ConsentAlreadyAcknowledged)
+	t.Run("InstructionsTooLong", T6_TestEnableWorkflowPreset_InstructionsTooLong)
+}

--- a/internal/admin/workflows_card_actions_test.go
+++ b/internal/admin/workflows_card_actions_test.go
@@ -1,0 +1,100 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// strPtrF1 is a tiny local helper to take the address of a string literal in
+// table cases. Prefixed to avoid clashing with sibling test helpers.
+func strPtrF1(s string) *string { return &s }
+
+// TestF1GalleryBuildWorkflowLastRun covers the pure mapping from a service run
+// summary to the gallery card's last-run view: nil passthrough, the
+// CompletedAt-over-StartedAt preference, the in-progress fallback to StartedAt,
+// and graceful handling of an unparseable timestamp (zero FinishedAt, status
+// still carried).
+func TestF1GalleryBuildWorkflowLastRun(t *testing.T) {
+	t.Run("nil run returns nil", func(t *testing.T) {
+		if got := buildWorkflowLastRun(nil); got != nil {
+			t.Fatalf("buildWorkflowLastRun(nil) = %+v, want nil", got)
+		}
+	})
+
+	t.Run("prefers CompletedAt", func(t *testing.T) {
+		run := &service.AgentRunSummary{
+			ShortID:     "run12345",
+			Status:      "success",
+			StartedAt:   "2026-05-31T10:00:00Z",
+			CompletedAt: strPtrF1("2026-05-31T10:05:00Z"),
+		}
+		got := buildWorkflowLastRun(run)
+		if got == nil {
+			t.Fatal("buildWorkflowLastRun returned nil for a non-nil run")
+		}
+		if got.ShortID != "run12345" || got.Status != "success" {
+			t.Fatalf("identity not carried: %+v", got)
+		}
+		if got.FinishedAt.IsZero() {
+			t.Fatal("FinishedAt is zero; expected the parsed CompletedAt")
+		}
+		if got.FinishedAt.Format("15:04") != "10:05" {
+			t.Fatalf("FinishedAt = %s, want CompletedAt (10:05)", got.FinishedAt.Format("15:04"))
+		}
+	})
+
+	t.Run("falls back to StartedAt when not completed", func(t *testing.T) {
+		run := &service.AgentRunSummary{
+			ShortID:   "inprog01",
+			Status:    "in_progress",
+			StartedAt: "2026-05-31T09:30:00Z",
+			// CompletedAt nil — an in-progress run.
+		}
+		got := buildWorkflowLastRun(run)
+		if got == nil {
+			t.Fatal("buildWorkflowLastRun returned nil")
+		}
+		if got.FinishedAt.IsZero() {
+			t.Fatal("FinishedAt is zero; expected the parsed StartedAt")
+		}
+		if got.FinishedAt.Format("15:04") != "09:30" {
+			t.Fatalf("FinishedAt = %s, want StartedAt (09:30)", got.FinishedAt.Format("15:04"))
+		}
+	})
+
+	t.Run("empty CompletedAt string falls back to StartedAt", func(t *testing.T) {
+		run := &service.AgentRunSummary{
+			Status:      "success",
+			StartedAt:   "2026-05-31T08:00:00Z",
+			CompletedAt: strPtrF1(""), // present but empty — must not win
+		}
+		got := buildWorkflowLastRun(run)
+		if got == nil || got.FinishedAt.IsZero() {
+			t.Fatalf("expected StartedAt fallback, got %+v", got)
+		}
+		if got.FinishedAt.Format("15:04") != "08:00" {
+			t.Fatalf("FinishedAt = %s, want StartedAt (08:00)", got.FinishedAt.Format("15:04"))
+		}
+	})
+
+	t.Run("unparseable timestamp leaves zero time but carries status", func(t *testing.T) {
+		run := &service.AgentRunSummary{
+			ShortID:   "badtime0",
+			Status:    "error",
+			StartedAt: "not-a-timestamp",
+		}
+		got := buildWorkflowLastRun(run)
+		if got == nil {
+			t.Fatal("buildWorkflowLastRun returned nil")
+		}
+		if !got.FinishedAt.IsZero() {
+			t.Fatalf("FinishedAt = %v, want zero for unparseable input", got.FinishedAt)
+		}
+		if got.Status != "error" || got.ShortID != "badtime0" {
+			t.Fatalf("status/short id not carried on parse failure: %+v", got)
+		}
+	})
+}

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
@@ -33,6 +34,29 @@ func buildWorkflowSpendBanner(s service.HouseholdSpendStatus) pages.WorkflowSpen
 	}
 }
 
+// buildWorkflowLastRun maps a service run summary (string RFC3339 timestamps)
+// into the gallery card's last-run view. Prefers CompletedAt; falls back to
+// StartedAt for an in-progress run so the relative time still renders. A
+// timestamp that won't parse leaves FinishedAt zero — workflowsRelativeTime
+// then renders an empty string, which is fine (the status pill still shows).
+func buildWorkflowLastRun(run *service.AgentRunSummary) *pages.WorkflowLastRunProps {
+	if run == nil {
+		return nil
+	}
+	out := &pages.WorkflowLastRunProps{
+		ShortID: run.ShortID,
+		Status:  run.Status,
+	}
+	when := run.StartedAt
+	if run.CompletedAt != nil && *run.CompletedAt != "" {
+		when = *run.CompletedAt
+	}
+	if t, err := time.Parse(time.RFC3339, when); err == nil {
+		out.FinishedAt = t
+	}
+	return out
+}
+
 // WorkflowsGalleryPageHandler renders GET /workflows — the codified preset
 // gallery. Presets come from the code registry (service.ListWorkflowPresets);
 // enabling one instantiates a workflow. Mirrors AgentsListPageHandler.
@@ -46,13 +70,17 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			status     *service.AgentSubsystemStatus
 			consented  bool
 			spend      service.HouseholdSpendStatus
+			lastRuns   map[string]*service.AgentRunSummary
 			wg         sync.WaitGroup
 		)
-		wg.Add(4)
+		wg.Add(5)
 		go func() { defer wg.Done(); presets, presetsErr = svc.ListWorkflowPresets(ctx) }()
 		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
 		go func() { defer wg.Done(); consented = svc.WorkflowsConsentAcknowledged(ctx) }()
 		go func() { defer wg.Done(); spend, _ = svc.HouseholdSpendStatus(ctx) }()
+		// Last-run summaries are a soft enrichment: a query hiccup drops the
+		// per-card "Last run" line but doesn't fail the gallery.
+		go func() { defer wg.Done(); lastRuns, _ = svc.GetEnabledWorkflowLastRuns(ctx) }()
 		wg.Wait()
 
 		if presetsErr != nil {
@@ -61,7 +89,7 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 		}
 
 		props := pages.WorkflowsGalleryProps{
-			Categories:          groupWorkflowPresets(presets),
+			Categories:          groupWorkflowPresets(presets, lastRuns),
 			Status:              buildAgentsListStatus(status),
 			CSRFToken:           GetCSRFToken(r),
 			ConsentAcknowledged: consented,
@@ -75,8 +103,11 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 }
 
 // groupWorkflowPresets buckets presets into category sections, preserving the
-// registry order for both categories and presets within them.
-func groupWorkflowPresets(views []service.WorkflowPresetView) []pages.WorkflowCategoryProps {
+// registry order for both categories and presets within them. lastRuns maps an
+// instantiated workflow's slug → its most-recent run summary (nil/absent when a
+// preset isn't enabled or has never run); it drives the per-card "Last run"
+// line.
+func groupWorkflowPresets(views []service.WorkflowPresetView, lastRuns map[string]*service.AgentRunSummary) []pages.WorkflowCategoryProps {
 	order := make([]string, 0)
 	byCat := make(map[string][]pages.WorkflowPresetCardProps)
 	for _, v := range views {
@@ -97,6 +128,9 @@ func groupWorkflowPresets(views []service.WorkflowPresetView) []pages.WorkflowCa
 		}
 		if v.WorkflowSlug != nil {
 			card.WorkflowSlug = *v.WorkflowSlug
+			if run := lastRuns[*v.WorkflowSlug]; run != nil {
+				card.LastRun = buildWorkflowLastRun(run)
+			}
 		}
 		if v.WorkflowEnabled != nil {
 			card.WorkflowEnabled = *v.WorkflowEnabled

--- a/internal/admin/workflows_prompt_handler.go
+++ b/internal/admin/workflows_prompt_handler.go
@@ -1,0 +1,33 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"errors"
+	"net/http"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// WorkflowPromptPreviewAdminHandler handles GET /-/workflows/{slug}/prompt.
+// It returns the fully composed base prompt for a preset as JSON
+// {slug, title, prompt}, powering the gallery's "Preview prompt" modal. Read-
+// only — it reads the code-defined preset registry, instantiates nothing.
+func WorkflowPromptPreviewAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		preview, err := svc.ComposeWorkflowPrompt(r.Context(), slug)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound):
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow preset not found")
+			default:
+				writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_PROMPT_FAILED", err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, preview)
+	}
+}

--- a/internal/admin/workflows_reconfigure_handler.go
+++ b/internal/admin/workflows_reconfigure_handler.go
@@ -1,0 +1,84 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"errors"
+	"net/http"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// WorkflowConfigAdminHandler handles GET /-/workflows/{slug}/config. It
+// returns the live configuration of an already-enabled workflow (schedule,
+// additional-instructions tail, chosen options) so the gallery can re-open
+// the configure drawer prefilled for a reconfigure. Read-only — no consent
+// gate. 404s when the slug isn't an enabled, preset-instantiated workflow.
+func WorkflowConfigAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		cfg, err := svc.GetWorkflowConfig(r.Context(), slug)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound), errors.Is(err, service.ErrInvalidState):
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
+			default:
+				writeError(w, http.StatusInternalServerError, "WORKFLOW_CONFIG_FAILED", err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, cfg)
+	}
+}
+
+// ReconfigureWorkflowAdminHandler handles POST /-/workflows/{slug}/reconfigure.
+// It re-composes the configurable layers of an already-enabled workflow
+// (schedule, additional-instructions tail, chosen options) without touching
+// its run-state toggle or base prompt. Admin-only (the router pins this above
+// the surrounding editor group), mirroring the preset-enable guard — a
+// reconfigure re-authorizes recurring AI spend behavior on shared data.
+func ReconfigureWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		_ = r.ParseForm()
+
+		params := service.UpdateWorkflowConfigParams{
+			AdditionalInstructions: r.FormValue("additional_instructions"),
+		}
+		if cron := r.FormValue("schedule_cron"); cron != "" {
+			params.ScheduleCron = &cron
+		}
+		// Any non-control form field is a preset-specialized option (e.g.
+		// apply_mode); the service validates each against the preset's
+		// declared options and falls back to the default for unknown keys.
+		// Same control-key set as the enable handler, minus enable-only
+		// fields (enabled/consent) that don't apply to a reconfigure.
+		control := map[string]bool{
+			"schedule_cron":           true,
+			"additional_instructions": true,
+			"_csrf":                   true,
+		}
+		params.Options = map[string]string{}
+		for key := range r.Form {
+			if !control[key] {
+				params.Options[key] = r.FormValue(key)
+			}
+		}
+
+		wf, err := svc.UpdateWorkflowConfig(r.Context(), slug, params)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound), errors.Is(err, service.ErrInvalidState):
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
+			case errors.Is(err, service.ErrInvalidParameter):
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			default:
+				writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_RECONFIGURE_FAILED", err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, wf)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -170,6 +170,7 @@ func NewRootCmd(version string) *cobra.Command {
 	AddCategoriesCmd(root)
 	AddTagsCmd(root)
 	AddRulesCmd(root)
+	AddWorkflowsCmd(root)
 	AddReportsCmd(root)
 	AddConnectionsCmd(root)
 	AddSyncCmd(root)

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -1,0 +1,189 @@
+// Package cli — workflows noun group.
+//
+// `breadbox workflows ...` is a tag-free, HTTP-driven shell over the
+// /api/v1/workflows surface (the subsystem formerly called "agents"). Like
+// every other noun command it resolves a *client.Client via the persistent
+// pre-run and renders through the shared output formatter, so it works
+// against a local or remote breadbox over the network and compiles into the
+// lite CLI build.
+//
+// Subcommands:
+//   - list     GET /api/v1/workflows         configured workflows
+//   - runs     GET /api/v1/workflows/runs     the cross-workflow run feed
+//   - presets  GET /api/v1/workflow-presets   the code-defined gallery catalog
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddWorkflowsCmd registers `breadbox workflows` and its children.
+func AddWorkflowsCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "workflows",
+		Short: "Inspect configured workflows, their runs, and the preset gallery",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newWorkflowsListCmd())
+	cmd.AddCommand(newWorkflowsRunsCmd())
+	cmd.AddCommand(newWorkflowsPresetsCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newWorkflowsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured workflows",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			wfs, err := c.ListWorkflows(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return renderWorkflowsList(flags, wfs)
+		},
+	}
+}
+
+func newWorkflowsRunsCmd() *cobra.Command {
+	var (
+		workflow string
+		status   string
+		trigger  string
+		offset   int
+	)
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "List the cross-workflow run feed (offset-paginated)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.ListWorkflowRuns(cmd.Context(), client.WorkflowRunListParams{
+				Workflow: workflow,
+				Status:   status,
+				Trigger:  trigger,
+				Limit:    flags.Limit,
+				Offset:   offset,
+			})
+			if err != nil {
+				return err
+			}
+			return renderWorkflowRuns(flags, res)
+		},
+	}
+	cmd.Flags().StringVar(&workflow, "workflow", "", "filter to one workflow (slug, short_id, or uuid)")
+	cmd.Flags().StringVar(&status, "status", "", "filter by status (success|error|in_progress|skipped|timeout)")
+	cmd.Flags().StringVar(&trigger, "trigger", "", "filter by trigger (cron|manual|webhook)")
+	cmd.Flags().IntVar(&offset, "offset", 0, "row offset for the next page (pair with --limit)")
+	return cmd
+}
+
+func newWorkflowsPresetsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "presets",
+		Short: "List the code-defined workflow preset gallery",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			presets, err := c.ListWorkflowPresets(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return renderWorkflowPresets(flags, presets)
+		},
+	}
+}
+
+// --- rendering helpers ---
+
+func renderWorkflowsList(flags *FlagBag, wfs []client.Workflow) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, wfs)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(wfs))
+		for _, w := range wfs {
+			items = append(items, w)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SLUG", "NAME", "SCOPE", "MODEL", "ENABLED", "SCHEDULE"})
+		for _, w := range wfs {
+			tbl.AddRow(w.Slug, w.Name, w.ToolScope, w.Model, boolYN(w.Enabled), workflowSchedule(w.ScheduleCron))
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderWorkflowRuns(flags *FlagBag, res *client.WorkflowRunListResult) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, res)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(res.Runs))
+		for _, r := range res.Runs {
+			items = append(items, r)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "WORKFLOW", "STATUS", "TRIGGER", "STARTED", "COST"})
+		for _, r := range res.Runs {
+			tbl.AddRow(r.ShortID, r.WorkflowSlug, r.Status, r.Trigger, r.StartedAt, formatCostPtr(r.TotalCostUSD))
+		}
+		if err := tbl.Flush(); err != nil {
+			return err
+		}
+		if res.HasMore {
+			fmt.Fprintf(os.Stderr, "(more rows; pass --offset %d to continue)\n", res.Offset+len(res.Runs))
+		}
+		return nil
+	}
+}
+
+func renderWorkflowPresets(flags *FlagBag, presets []client.WorkflowPreset) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, presets)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(presets))
+		for _, p := range presets {
+			items = append(items, p)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SLUG", "NAME", "CATEGORY", "ENABLED"})
+		for _, p := range presets {
+			tbl.AddRow(p.Slug, p.Name, p.Category, boolYN(p.Enabled))
+		}
+		return tbl.Flush()
+	}
+}
+
+// workflowSchedule renders a workflow's cron, falling back to "manual" when
+// no schedule is set — matching `breadbox agent list`'s column semantics.
+func workflowSchedule(cron *string) string {
+	if cron == nil || *cron == "" {
+		return "manual"
+	}
+	return *cron
+}
+
+// formatCostPtr renders an optional USD cost, returning "-" for nil.
+func formatCostPtr(f *float64) string {
+	if f == nil {
+		return "-"
+	}
+	return fmt.Sprintf("$%.4f", *f)
+}

--- a/internal/cli/workflows_test.go
+++ b/internal/cli/workflows_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"testing"
+)
+
+// TestWorkflowSchedule_Manual asserts a nil or empty cron renders as the
+// "manual" sentinel, matching the `breadbox agent list` column semantics.
+func TestWorkflowSchedule_Manual(t *testing.T) {
+	empty := ""
+	cron := "0 9 * * *"
+	cases := []struct {
+		name string
+		in   *string
+		want string
+	}{
+		{"nil cron", nil, "manual"},
+		{"empty cron", &empty, "manual"},
+		{"real cron passes through", &cron, "0 9 * * *"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workflowSchedule(tc.in); got != tc.want {
+				t.Fatalf("workflowSchedule(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatCostPtr renders an optional USD cost with a stable 4-decimal
+// format and a "-" placeholder for nil.
+func TestFormatCostPtr(t *testing.T) {
+	cost := 0.1234
+	if got := formatCostPtr(nil); got != "-" {
+		t.Errorf("formatCostPtr(nil) = %q, want -", got)
+	}
+	if got := formatCostPtr(&cost); got != "$0.1234" {
+		t.Errorf("formatCostPtr(&0.1234) = %q, want $0.1234", got)
+	}
+}
+
+// TestWorkflowsCmd_Subcommands verifies the noun group wires exactly the
+// three read subcommands (list, runs, presets) and that `runs` exposes the
+// filter/pagination flags the global feed supports. Argument/flag wiring is
+// the contract scripts depend on, so pin it down.
+func TestWorkflowsCmd_Subcommands(t *testing.T) {
+	root := NewRootCmd("test")
+	wf, _, err := root.Find([]string{"workflows"})
+	if err != nil {
+		t.Fatalf("find workflows: %v", err)
+	}
+	if wf == nil || wf.Name() != "workflows" {
+		t.Fatalf("workflows command not registered on root")
+	}
+
+	want := map[string]bool{"list": false, "runs": false, "presets": false}
+	for _, sub := range wf.Commands() {
+		if _, ok := want[sub.Name()]; ok {
+			want[sub.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("workflows subcommand %q not registered", name)
+		}
+	}
+
+	runs, _, err := wf.Find([]string{"runs"})
+	if err != nil {
+		t.Fatalf("find workflows runs: %v", err)
+	}
+	for _, flag := range []string{"workflow", "status", "trigger", "offset"} {
+		if runs.Flags().Lookup(flag) == nil {
+			t.Errorf("workflows runs missing --%s flag", flag)
+		}
+	}
+}

--- a/internal/client/workflows.go
+++ b/internal/client/workflows.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Workflow mirrors the subset of service.AgentDefinitionResponse the CLI
+// renders. Workflows are the instantiated rows behind the gallery presets
+// (the table was renamed from agent_definitions). The REST surface still
+// lives under /api/v1/workflows. --json passes the decoded struct through,
+// so the fields kept here are the ones a self-hoster commonly inspects.
+type Workflow struct {
+	ID             string  `json:"id"`
+	ShortID        string  `json:"short_id"`
+	Name           string  `json:"name"`
+	Slug           string  `json:"slug"`
+	ToolScope      string  `json:"tool_scope"`
+	Model          string  `json:"model"`
+	ScheduleCron   *string `json:"schedule_cron,omitempty"`
+	Enabled        bool    `json:"enabled"`
+	SourceTemplate *string `json:"source_template,omitempty"`
+	NextFireAt     *string `json:"next_fire_at,omitempty"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+}
+
+// ListWorkflows fetches every configured workflow. GET /api/v1/workflows
+// returns a bare JSON array (no pagination envelope).
+func (c *Client) ListWorkflows(ctx context.Context) ([]Workflow, error) {
+	var out []Workflow
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/workflows", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// WorkflowRun mirrors the per-row shape of GET /api/v1/workflows/runs —
+// every run carries its parent workflow's slug + name so the global feed
+// can label each row without an extra fetch. The wire keys are still
+// agent_slug / agent_name (the table rename didn't touch the run payload).
+type WorkflowRun struct {
+	ShortID      string   `json:"short_id"`
+	WorkflowSlug string   `json:"agent_slug"`
+	WorkflowName string   `json:"agent_name"`
+	Trigger      string   `json:"trigger"`
+	Status       string   `json:"status"`
+	StartedAt    string   `json:"started_at"`
+	CompletedAt  *string  `json:"completed_at,omitempty"`
+	DurationMs   *int     `json:"duration_ms,omitempty"`
+	TotalCostUSD *float64 `json:"total_cost_usd,omitempty"`
+	TurnCount    *int     `json:"turn_count,omitempty"`
+	HitCap       *string  `json:"hit_cap,omitempty"`
+	ErrorMessage *string  `json:"error_message,omitempty"`
+}
+
+// WorkflowRunListResult is the paginated envelope returned by
+// GET /api/v1/workflows/runs (offset-based, not cursor).
+type WorkflowRunListResult struct {
+	Runs    []WorkflowRun `json:"runs"`
+	Limit   int           `json:"limit"`
+	Offset  int           `json:"offset"`
+	HasMore bool          `json:"has_more"`
+}
+
+// WorkflowRunListParams carries the supported query params for the global
+// runs feed. Zero values are omitted from the request.
+type WorkflowRunListParams struct {
+	Workflow string // slug/short_id/uuid filter (sent as ?agent=)
+	Status   string
+	Trigger  string
+	Limit    int
+	Offset   int
+}
+
+// ListWorkflowRuns fetches a page of the cross-workflow run feed.
+func (c *Client) ListWorkflowRuns(ctx context.Context, p WorkflowRunListParams) (*WorkflowRunListResult, error) {
+	q := url.Values{}
+	if p.Workflow != "" {
+		q.Set("agent", p.Workflow)
+	}
+	if p.Status != "" {
+		q.Set("status", p.Status)
+	}
+	if p.Trigger != "" {
+		q.Set("trigger", p.Trigger)
+	}
+	if p.Limit > 0 {
+		q.Set("limit", strconv.Itoa(p.Limit))
+	}
+	if p.Offset > 0 {
+		q.Set("offset", strconv.Itoa(p.Offset))
+	}
+	path := "/api/v1/workflows/runs"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out WorkflowRunListResult
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// WorkflowPreset mirrors the gallery template shape from
+// GET /api/v1/workflow-presets. The server-side WorkflowPreset struct has
+// no JSON tags, so its exported fields serialize with capitalized keys
+// (Slug, Name, Category, Icon, Description); the annotation fields added by
+// WorkflowPresetView do carry tags. Mirror both exactly.
+type WorkflowPreset struct {
+	Slug        string `json:"Slug"`
+	Name        string `json:"Name"`
+	Category    string `json:"Category"`
+	Icon        string `json:"Icon"`
+	Description string `json:"Description"`
+	// Enabled is true when this preset has been instantiated as a workflow.
+	Enabled bool `json:"enabled"`
+	// WorkflowSlug is the slug of the instantiated workflow (when Enabled).
+	WorkflowSlug *string `json:"workflow_slug,omitempty"`
+	// WorkflowEnabled is the instantiated workflow's own enabled toggle
+	// (a workflow can be instantiated but paused). Nil when not instantiated.
+	WorkflowEnabled *bool `json:"workflow_enabled,omitempty"`
+}
+
+// ListWorkflowPresets fetches the code-defined gallery catalog annotated
+// with per-preset enablement state. GET /api/v1/workflow-presets returns a
+// bare JSON array.
+func (c *Client) ListWorkflowPresets(ctx context.Context) ([]WorkflowPreset, error) {
+	var out []WorkflowPreset
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/workflow-presets", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/mcp/flag_tool_response_shape_integration_test.go
+++ b/internal/mcp/flag_tool_response_shape_integration_test.go
@@ -1,0 +1,328 @@
+//go:build integration && !lite
+
+package mcp
+
+// Regression harness for the flag_transaction / unflag_transaction MCP tool
+// response shapes (T18).
+//
+// The goals mirror response_shapes_integration_test.go: lock the JSON envelope
+// every caller / SDK generator relies on. The asserts are intentionally loose on
+// values but strict on shape — if someone renames `flagged` → `is_flagged`, or
+// drops `transaction_id` from the envelope, the test breaks in the same PR.
+//
+// Coverage:
+//   - flag_transaction: required keys present (transaction_id, flagged=true)
+//   - flag_transaction with reason: reason recorded as a comment annotation
+//   - unflag_transaction: required keys present (transaction_id, flagged=false)
+//   - flag_transaction -> GetTransaction: flagged_at reflected in side-effect
+//   - unflag_transaction side-effect: flagged_at cleared (nil)
+//   - Missing transaction_id: error envelope returned
+//   - Missing transaction row: error envelope returned
+//   - StructuredContent / TextContent parity (via decodeToolResult)
+//   - query_transactions(flagged=true) surfaces only the flagged row
+
+import (
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// T18FlagFreshTxn creates a fresh transaction on the seeded primary account
+// and returns its UUID string. Keeps the test bodies from duplicating fixture
+// plumbing and avoids naming collisions with the shared seedFixtures txn used
+// by other parallel suites.
+func T18FlagFreshTxn(t *testing.T, f *fixtures) string {
+	t.Helper()
+	// Reuse the queries handle from the fixture server to stay within the same
+	// truncated DB state seedFixtures created.
+	q := f.svc.svc.Queries
+	accts, err := f.svc.svc.ListAccounts(f.ctx, nil)
+	if err != nil || len(accts) == 0 {
+		t.Fatalf("T18FlagFreshTxn: ListAccounts: err=%v n=%d", err, len(accts))
+	}
+	var primaryShort string
+	for _, a := range accts {
+		if a.Name == "Primary Credit Card" {
+			primaryShort = a.ShortID
+			break
+		}
+	}
+	if primaryShort == "" {
+		t.Fatalf("T18FlagFreshTxn: could not find Primary Credit Card in accounts")
+	}
+	primaryUUID, err := q.GetAccountUUIDByShortID(f.ctx, primaryShort)
+	if err != nil {
+		t.Fatalf("T18FlagFreshTxn: GetAccountUUIDByShortID: %v", err)
+	}
+	txn := testutil.MustCreateTransaction(t, q, primaryUUID, "txn_t18_flag", "T18 Merchant", 7700, "2026-04-20")
+	return formatUUIDTest(t, txn.ID)
+}
+
+// TestT18FlagTransactionResponseShape pins the flag_transaction tool's JSON
+// envelope: required keys transaction_id and flagged=true must both be present
+// for every successful call. Also locks the StructuredContent / TextContent
+// parity contract (enforced by decodeToolResult).
+func TestT18FlagTransactionResponseShape(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	res, _, err := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: txnID,
+	})
+	out := decodeToolResult[map[string]any](t, "T18:flag_transaction", res, err)
+
+	requireKeys(t, "T18:flag_transaction", out, "transaction_id", "flagged")
+
+	if flagged, _ := out["flagged"].(bool); !flagged {
+		t.Errorf("T18:flag_transaction: flagged=%v, want true", out["flagged"])
+	}
+	if tid, _ := out["transaction_id"].(string); tid == "" {
+		t.Errorf("T18:flag_transaction: transaction_id is empty")
+	}
+}
+
+// TestT18FlagTransactionSideEffect asserts that flagging a transaction actually
+// sets flagged_at in the DB. A MCP wrapper that returned the success envelope
+// without calling the service would look correct in the tool response but fail
+// here when we read back the transaction.
+func TestT18FlagTransactionSideEffect(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	// Confirm baseline: fresh transaction is unflagged.
+	before, err := f.svc.svc.GetTransaction(f.ctx, txnID)
+	if err != nil {
+		t.Fatalf("T18:side-effect: GetTransaction before: %v", err)
+	}
+	if before.FlaggedAt != nil {
+		t.Fatalf("T18:side-effect: fresh transaction FlaggedAt=%v, want nil", *before.FlaggedAt)
+	}
+
+	flagRes, _, flagErr := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: txnID,
+	})
+	decodeToolResult[map[string]any](t, "T18:flag_transaction side-effect", flagRes, flagErr)
+
+	after, err := f.svc.svc.GetTransaction(f.ctx, txnID)
+	if err != nil {
+		t.Fatalf("T18:side-effect: GetTransaction after: %v", err)
+	}
+	if after.FlaggedAt == nil {
+		t.Fatalf("T18:side-effect: FlaggedAt is nil after flag_transaction — wrapper likely dropped the service call")
+	}
+}
+
+// TestT18FlagTransactionWithReason ensures that passing a non-empty reason
+// persists it as a comment annotation on the transaction timeline. The flag
+// tool doc says "recorded as a comment annotation"; this test locks that the
+// MCP wrapper actually forwards the reason string to the service.
+func TestT18FlagTransactionWithReason(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	const reason = "T18: amount looks high for this merchant"
+
+	flagRes, _, flagErr := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: txnID,
+		Reason:        reason,
+	})
+	decodeToolResult[map[string]any](t, "T18:flag_with_reason", flagRes, flagErr)
+
+	// The reason should surface as a comment annotation on the timeline.
+	anns, err := f.svc.svc.ListAnnotations(f.ctx, txnID, service.ListAnnotationsParams{})
+	if err != nil {
+		t.Fatalf("T18:flag_with_reason: ListAnnotations: %v", err)
+	}
+	var foundReason bool
+	for _, a := range anns {
+		if a.Content == reason {
+			foundReason = true
+			break
+		}
+	}
+	if !foundReason {
+		t.Errorf("T18:flag_with_reason: reason %q not found in annotations; got %d annotation(s)", reason, len(anns))
+	}
+}
+
+// TestT18UnflagTransactionResponseShape pins the unflag_transaction tool's JSON
+// envelope: required keys transaction_id and flagged=false must both be present.
+// Also locks the StructuredContent / TextContent parity contract.
+func TestT18UnflagTransactionResponseShape(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	// Flag first so there is something to unflag.
+	flagRes, _, flagErr := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: txnID,
+	})
+	decodeToolResult[map[string]any](t, "T18:unflag setup flag", flagRes, flagErr)
+
+	res, _, err := f.svc.handleUnflagTransaction(f.ctx, nil, unflagTransactionInput{
+		TransactionID: txnID,
+	})
+	out := decodeToolResult[map[string]any](t, "T18:unflag_transaction", res, err)
+
+	requireKeys(t, "T18:unflag_transaction", out, "transaction_id", "flagged")
+
+	if flagged, _ := out["flagged"].(bool); flagged {
+		t.Errorf("T18:unflag_transaction: flagged=%v, want false", out["flagged"])
+	}
+	if tid, _ := out["transaction_id"].(string); tid == "" {
+		t.Errorf("T18:unflag_transaction: transaction_id is empty")
+	}
+}
+
+// TestT18UnflagTransactionSideEffect asserts that unflag_transaction actually
+// clears flagged_at in the DB. A wrapper that returned flagged=false without
+// calling the service would be silently broken.
+func TestT18UnflagTransactionSideEffect(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	// Seed a flag first via the tool handler.
+	flagRes, _, flagErr := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: txnID,
+	})
+	decodeToolResult[map[string]any](t, "T18:unflag side-effect: flag setup", flagRes, flagErr)
+
+	// Confirm it is now flagged in the DB.
+	mid, err := f.svc.svc.GetTransaction(f.ctx, txnID)
+	if err != nil {
+		t.Fatalf("T18:unflag side-effect: GetTransaction mid: %v", err)
+	}
+	if mid.FlaggedAt == nil {
+		t.Fatalf("T18:unflag side-effect: FlaggedAt is nil after flag — seeding failed")
+	}
+
+	// Now unflag via the MCP tool handler.
+	unflagRes, _, unflagErr := f.svc.handleUnflagTransaction(f.ctx, nil, unflagTransactionInput{
+		TransactionID: txnID,
+	})
+	decodeToolResult[map[string]any](t, "T18:unflag side-effect", unflagRes, unflagErr)
+
+	after, err := f.svc.svc.GetTransaction(f.ctx, txnID)
+	if err != nil {
+		t.Fatalf("T18:unflag side-effect: GetTransaction after: %v", err)
+	}
+	if after.FlaggedAt != nil {
+		t.Errorf("T18:unflag side-effect: FlaggedAt=%v after unflag, want nil — wrapper likely dropped the service call", *after.FlaggedAt)
+	}
+}
+
+// TestT18UnflagIdempotent asserts that unflagging an already-unflagged
+// transaction succeeds without error (the tool doc says "No-op if it isn't
+// flagged"). The response shape contract still holds.
+func TestT18UnflagIdempotent(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	// txnID is already unflagged — calling unflag must succeed.
+	res, _, err := f.svc.handleUnflagTransaction(f.ctx, nil, unflagTransactionInput{
+		TransactionID: txnID,
+	})
+	out := decodeToolResult[map[string]any](t, "T18:unflag_idempotent", res, err)
+	requireKeys(t, "T18:unflag_idempotent", out, "transaction_id", "flagged")
+}
+
+// TestT18FlagMissingTransactionID asserts that omitting transaction_id returns
+// the error envelope (IsError=true) rather than a 500 or a nil crash.
+func TestT18FlagMissingTransactionID(t *testing.T) {
+	f := seedFixtures(t)
+
+	res, _, _ := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: "",
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("T18:flag_missing_id: expected error envelope for empty transaction_id, got %+v", res)
+	}
+}
+
+// TestT18UnflagMissingTransactionID mirrors the same contract for the unflag
+// tool.
+func TestT18UnflagMissingTransactionID(t *testing.T) {
+	f := seedFixtures(t)
+
+	res, _, _ := f.svc.handleUnflagTransaction(f.ctx, nil, unflagTransactionInput{
+		TransactionID: "",
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("T18:unflag_missing_id: expected error envelope for empty transaction_id, got %+v", res)
+	}
+}
+
+// TestT18FlagNonexistentTransaction asserts that a syntactically valid but
+// non-existent ID returns the error envelope instead of a nil result or panic.
+func TestT18FlagNonexistentTransaction(t *testing.T) {
+	f := seedFixtures(t)
+
+	res, _, _ := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: "zzzzzzzz",
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("T18:flag_nonexistent: expected error envelope for unknown transaction, got %+v", res)
+	}
+}
+
+// TestT18QueryTransactionsFlaggedFilter exercises query_transactions with
+// flagged=true after seeding a flagged and an unflagged transaction. The
+// filter must return only the flagged row — locking that the flagged_at field
+// is actually populated and filterable by agents using the MCP tool.
+func TestT18QueryTransactionsFlaggedFilter(t *testing.T) {
+	f := seedFixtures(t)
+	txnID := T18FlagFreshTxn(t, f)
+
+	// Flag the fresh txn via the tool handler.
+	flagRes, _, flagErr := f.svc.handleFlagTransaction(f.ctx, nil, flagTransactionInput{
+		TransactionID: txnID,
+	})
+	decodeToolResult[map[string]any](t, "T18:query_flagged: flag setup", flagRes, flagErr)
+
+	// Resolve the short_id so we can look for it in both result sets.
+	flaggedRecord, err := f.svc.svc.GetTransaction(f.ctx, txnID)
+	if err != nil {
+		t.Fatalf("T18:query_flagged: GetTransaction: %v", err)
+	}
+	flaggedShort := flaggedRecord.ShortID
+
+	// query_transactions(flagged=true) — must include our flagged txn.
+	tru := true
+	flaggedQRes, _, flaggedQErr := f.svc.handleQueryTransactions(f.ctx, nil, queryTransactionsInput{
+		Flagged: &tru,
+		Limit:   500,
+	})
+	flaggedQOut := decodeToolResult[map[string]any](t, "T18:query_flagged", flaggedQRes, flaggedQErr)
+	requireKeys(t, "T18:query_flagged", flaggedQOut, "transactions", "has_more", "limit")
+
+	flaggedTxns := asArray(t, "T18:query_flagged.transactions", flaggedQOut["transactions"])
+	if len(flaggedTxns) == 0 {
+		t.Fatal("T18:query_flagged: expected at least the flagged transaction, got 0 rows")
+	}
+	var foundInFlagged bool
+	for _, raw := range flaggedTxns {
+		row := asObject(t, "T18:query_flagged row", raw)
+		requireKeys(t, "T18:query_flagged row", row, "id")
+		if id, _ := row["id"].(string); id == flaggedShort {
+			foundInFlagged = true
+		}
+	}
+	if !foundInFlagged {
+		t.Errorf("T18:query_flagged: short_id %q not found in flagged=true result set", flaggedShort)
+	}
+
+	// query_transactions(flagged=false) — the flagged txn must NOT appear.
+	fls := false
+	unflaggedQRes, _, unflaggedQErr := f.svc.handleQueryTransactions(f.ctx, nil, queryTransactionsInput{
+		Flagged: &fls,
+		Limit:   500,
+	})
+	unflaggedQOut := decodeToolResult[map[string]any](t, "T18:query_unflagged", unflaggedQRes, unflaggedQErr)
+	unflaggedTxns := asArray(t, "T18:query_unflagged.transactions", unflaggedQOut["transactions"])
+	for _, raw := range unflaggedTxns {
+		row := asObject(t, "T18:query_unflagged row", raw)
+		if id, _ := row["id"].(string); id == flaggedShort {
+			t.Errorf("T18:query_unflagged: flagged transaction %q appeared in flagged=false result set", flaggedShort)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -371,6 +371,10 @@ func (s *MCPServer) buildToolRegistry() {
 			Description: "List transaction rules with their conditions, actions, and pipeline stage. Mirror of breadbox://rules. Filter by category_slug, enabled, or search by name. Read this before authoring new rules to avoid duplicates.",
 		}, s.handleListTransactionRules, s),
 		makeToolDefLogged(ToolSpec{
+			Name: "list_workflows", Title: "List Workflows", Classification: ToolRead,
+			Description: "List the household's automation layer: the `workflows` it has enabled (each carries name, slug, trigger sync|schedule|manual, schedule_cron, tool_scope, the source `preset` it was instantiated from, plus last_run_status + last_run_at), and the full catalog of available `presets` it could enable (slug, name, category, description, tool_scope, trigger, default schedule_cron, and whether it's already enabled). Read this to see what runs automatically before suggesting new rules or reports — an existing workflow may already cover the task. Enabling/configuring workflows is an admin-UI action (the /workflows gallery), not an MCP write.",
+		}, s.handleListWorkflows, s),
+		makeToolDefLogged(ToolSpec{
 			Name: "list_series", Title: "List Subscriptions", Classification: ToolRead,
 			Description: "List detected recurring series (subscriptions). Optional status filter (active|candidate|paused|cancelled). Each row carries cadence, expected_amount + iso_currency_code (never sum across currencies), next_expected_date, occurrence_count, confidence (auto|confirmed|rejected), and detection_signals — the raw evidence the detector used (interval_cv, amount_branch, merchant_key_is_fallback). Read status=candidate to find series awaiting a confirm/reject verdict; calibrate from the signals before deciding.",
 		}, s.handleListSeries, s),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -144,6 +144,7 @@ func TestToolRegistryScopeContract(t *testing.T) {
 		"list_series",
 		"get_series",
 		"explain_series_candidates",
+		"list_workflows",
 	}
 	if len(readNames) != len(wantReads) {
 		t.Errorf("read tool count = %d, want %d (got %v)", len(readNames), len(wantReads), readNames)

--- a/internal/mcp/workflows_tool.go
+++ b/internal/mcp/workflows_tool.go
@@ -1,0 +1,39 @@
+//go:build !lite
+
+package mcp
+
+import (
+	"context"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// list_workflows surfaces the household's automation layer to an agent: the
+// enabled, preset-backed Workflows (name, slug, trigger, source preset, last
+// run status) plus the full catalog of available presets it could enable. It
+// is read-only and reshapes the same service paths the admin /workflows
+// gallery uses (Service.ListWorkflowsForMCP → ListAgentDefinitions +
+// ListWorkflowPresets), so an agent can answer "what runs automatically here,
+// and what else is on offer?" without an HTTP round-trip.
+
+// listWorkflowsInput takes no parameters — the result is the full picture
+// (enabled workflows + every preset). An empty input struct keeps the tool's
+// schema minimal, matching the other zero-arg reference reads (list_categories,
+// list_users) in tools_reads.go.
+type listWorkflowsInput struct {
+}
+
+// handleListWorkflows returns the enabled-workflows + available-presets
+// payload. Mirrors the tool-shaped envelope of the other reference reads: a
+// single jsonResult that runs through compactIDs. The views carry slug-only
+// identity (no UUIDs), so compaction is a no-op here — but routing through
+// jsonResult keeps the dual TextContent/StructuredContent contract consistent
+// with every other tool.
+func (s *MCPServer) handleListWorkflows(_ context.Context, _ *mcpsdk.CallToolRequest, _ listWorkflowsInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	result, err := s.svc.ListWorkflowsForMCP(ctx)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(result)
+}

--- a/internal/service/agent_settings_notify_url_unit_test.go
+++ b/internal/service/agent_settings_notify_url_unit_test.go
@@ -1,0 +1,367 @@
+//go:build !lite
+
+package service
+
+// T17-settings-notify-url: unit tests for the pure (no-DB) logic in
+// agent_settings.go that handles NotifyWebhookURL -- validation, masking,
+// trimming -- and the related helpers maskToken / lastN / readOptionalFloat.
+//
+// No DB is required: every function under test is either pure or accepts
+// an appconfig.Reader that we satisfy with a lightweight stub.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/db"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// ---------------------------------------------------------------------------
+// Stub appconfig.Reader for readOptionalFloat tests
+// ---------------------------------------------------------------------------
+
+// T17fakeReader is a minimal appconfig.Reader that returns a pre-canned value
+// for exactly one key or an error when instructed. It satisfies the interface
+// GetAppConfig(ctx, key) (db.AppConfig, error).
+type T17fakeReader struct {
+	key   string
+	value string // stored value
+	found bool   // if false, simulates a missing row (returns error)
+}
+
+func (r *T17fakeReader) GetAppConfig(_ context.Context, key string) (db.AppConfig, error) {
+	if !r.found || key != r.key {
+		return db.AppConfig{}, errors.New("not found")
+	}
+	return db.AppConfig{
+		Key:   r.key,
+		Value: pgtype.Text{String: r.value, Valid: r.value != "" || r.found},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// maskToken
+// ---------------------------------------------------------------------------
+
+func TestT17MaskToken_EmptyReturnsNil(t *testing.T) {
+	if got := maskToken(""); got != nil {
+		t.Errorf("maskToken(\"\") = %q, want nil", *got)
+	}
+}
+
+func TestT17MaskToken_ShortToken(t *testing.T) {
+	// Token <= 20 chars: bullets + last 4 chars
+	token := "abc123"
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("maskToken returned nil for non-empty token")
+	}
+	// last 4 of "abc123" is "c123"
+	want := "\u2022\u2022\u2022\u2022c123"
+	if *got != want {
+		t.Errorf("maskToken(%q) = %q, want %q", token, *got, want)
+	}
+}
+
+func TestT17MaskToken_ExactlyFourChars(t *testing.T) {
+	token := "abcd"
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("maskToken returned nil for non-empty token")
+	}
+	// len("abcd") = 4 <= 20 -- bullets + last 4 = bullets + "abcd"
+	want := "\u2022\u2022\u2022\u2022abcd"
+	if *got != want {
+		t.Errorf("maskToken(%q) = %q, want %q", token, *got, want)
+	}
+}
+
+func TestT17MaskToken_TwentyCharsExact(t *testing.T) {
+	// Exactly 20 chars: short path (<=20): bullets + last 4
+	token := "12345678901234567890" // len=20
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("maskToken returned nil for non-empty token")
+	}
+	want := "\u2022\u2022\u2022\u20227890"
+	if *got != want {
+		t.Errorf("maskToken(%q) = %q, want %q", token, *got, want)
+	}
+}
+
+func TestT17MaskToken_TwentyOneChars(t *testing.T) {
+	// Exactly 21 chars: long path (>20): first 16 + bullets + last 4
+	token := "123456789012345678901" // len=21
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("maskToken returned nil for non-empty token")
+	}
+	// first 16 = "1234567890123456"
+	// last 4 of "123456789012345678901" = "8901"
+	want := "1234567890123456" + "\u2022\u2022\u2022\u2022" + "8901"
+	if *got != want {
+		t.Errorf("maskToken(%q) = %q, want %q", token, *got, want)
+	}
+}
+
+func TestT17MaskToken_LongAPIKey(t *testing.T) {
+	// Simulate a realistic Anthropic API key (~60 chars)
+	token := "sk-ant-api01-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("maskToken returned nil for non-empty token")
+	}
+	// Must start with first 16 chars of the key
+	if (*got)[:16] != token[:16] {
+		t.Errorf("maskToken prefix = %q, want %q", (*got)[:16], token[:16])
+	}
+	// Must end with last 4 chars of the key
+	suffix := (*got)[len(*got)-4:]
+	wantSuffix := token[len(token)-4:]
+	if suffix != wantSuffix {
+		t.Errorf("maskToken suffix = %q, want %q", suffix, wantSuffix)
+	}
+}
+
+func TestT17MaskToken_SubscriptionToken(t *testing.T) {
+	// Simulate a Claude subscription token (>20 chars)
+	token := "sk-ant-oat01-xyzXYZ9876"
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("maskToken returned nil for non-empty token")
+	}
+	// Long path: first16 + bullets + last4
+	want := token[:16] + "\u2022\u2022\u2022\u2022" + token[len(token)-4:]
+	if *got != want {
+		t.Errorf("maskToken(%q) = %q, want %q", token, *got, want)
+	}
+}
+
+// maskToken must never return the full plaintext token.
+func TestT17MaskToken_NeverExposeFullPlaintext(t *testing.T) {
+	token := "sk-ant-api01-SUPERSECRET12345678"
+	got := maskToken(token)
+	if got == nil {
+		t.Fatal("unexpected nil")
+	}
+	if *got == token {
+		t.Error("maskToken returned full plaintext token -- must never happen")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// lastN
+// ---------------------------------------------------------------------------
+
+func TestT17LastN_Empty(t *testing.T) {
+	if got := lastN("", 4); got != "" {
+		t.Errorf("lastN(%q, 4) = %q, want %q", "", got, "")
+	}
+}
+
+func TestT17LastN_ShorterThanN(t *testing.T) {
+	if got := lastN("ab", 4); got != "ab" {
+		t.Errorf("lastN(%q, 4) = %q, want %q", "ab", got, "ab")
+	}
+}
+
+func TestT17LastN_EqualToN(t *testing.T) {
+	if got := lastN("abcd", 4); got != "abcd" {
+		t.Errorf("lastN(%q, 4) = %q, want %q", "abcd", got, "abcd")
+	}
+}
+
+func TestT17LastN_LongerThanN(t *testing.T) {
+	if got := lastN("12345678", 4); got != "5678" {
+		t.Errorf("lastN(%q, 4) = %q, want %q", "12345678", got, "5678")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateNotifyURL (coverage beyond notify_test.go, focused on the settings
+// path which trims whitespace before calling this validator)
+// ---------------------------------------------------------------------------
+
+func TestT17ValidateNotifyURL_Valid(t *testing.T) {
+	cases := []string{
+		"https://ntfy.sh/breadbox",
+		"http://localhost:8080/webhook",
+		"https://hooks.slack.com/services/T0/B0/xxx",
+		"https://discord.com/api/webhooks/123/abc",
+		"http://192.168.1.10:9000/hooks/breadbox",
+	}
+	for _, u := range cases {
+		if err := validateNotifyURL(u); err != nil {
+			t.Errorf("validateNotifyURL(%q) = %v, want nil", u, err)
+		}
+	}
+}
+
+func TestT17ValidateNotifyURL_Invalid(t *testing.T) {
+	cases := []string{
+		"",                    // empty
+		"ftp://x.com/hook",   // wrong scheme
+		"notaurl",             // no scheme
+		"javascript:alert(1)", // dangerous scheme
+		"https://",            // no host
+		"//example.com",       // protocol-relative (no scheme)
+		"mailto:x@x.com",     // email URI
+	}
+	for _, u := range cases {
+		if err := validateNotifyURL(u); err == nil {
+			t.Errorf("validateNotifyURL(%q) = nil, want error", u)
+		}
+	}
+}
+
+// The settings path trims whitespace before validating. Verify that the
+// already-trimmed URL is what gets validated (mirrors the
+// trimmed := strings.TrimSpace(*p.NotifyWebhookURL) path in UpdateAgentSettings).
+func TestT17ValidateNotifyURL_TrimmedInputs(t *testing.T) {
+	cases := []struct {
+		name    string
+		trimmed string
+		wantErr bool
+	}{
+		{
+			name:    "valid https URL passes",
+			trimmed: "https://ntfy.sh/topic",
+			wantErr: false,
+		},
+		{
+			name:    "slack webhook passes",
+			trimmed: "https://hooks.slack.com/services/x",
+			wantErr: false,
+		},
+		// Whitespace-only input collapses to empty after trim.
+		// UpdateAgentSettings skips validateNotifyURL when trimmed == "",
+		// but the empty string itself must fail if accidentally passed through.
+		{
+			name:    "empty string (whitespace collapsed) fails",
+			trimmed: "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNotifyURL(tc.trimmed)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateNotifyURL(%q) = nil, want error", tc.trimmed)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateNotifyURL(%q) = %v, want nil", tc.trimmed, err)
+			}
+		})
+	}
+}
+
+// validateNotifyURL must wrap ErrInvalidParameter so callers can use errors.Is.
+func TestT17ValidateNotifyURL_WrapsErrInvalidParameter(t *testing.T) {
+	err := validateNotifyURL("ftp://bad.example.com")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrInvalidParameter) {
+		t.Errorf("validateNotifyURL error does not wrap ErrInvalidParameter: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readOptionalFloat -- pure when appconfig.Reader is stubbed
+// ---------------------------------------------------------------------------
+
+func TestT17ReadOptionalFloat_MissingKey(t *testing.T) {
+	r := &T17fakeReader{key: "x", found: false}
+	got := readOptionalFloat(context.Background(), r, "x")
+	if got != nil {
+		t.Errorf("readOptionalFloat(missing) = %v, want nil", *got)
+	}
+}
+
+func TestT17ReadOptionalFloat_EmptyValue(t *testing.T) {
+	r := &T17fakeReader{key: "x", value: "", found: true}
+	got := readOptionalFloat(context.Background(), r, "x")
+	if got != nil {
+		t.Errorf("readOptionalFloat(empty) = %v, want nil", *got)
+	}
+}
+
+func TestT17ReadOptionalFloat_ValidFloat(t *testing.T) {
+	r := &T17fakeReader{key: "agent.global_max_budget_usd", value: "12.5000", found: true}
+	got := readOptionalFloat(context.Background(), r, "agent.global_max_budget_usd")
+	if got == nil {
+		t.Fatal("readOptionalFloat returned nil, want 12.5")
+	}
+	if *got != 12.5 {
+		t.Errorf("readOptionalFloat = %v, want 12.5", *got)
+	}
+}
+
+func TestT17ReadOptionalFloat_IntegerValue(t *testing.T) {
+	r := &T17fakeReader{key: "k", value: "100", found: true}
+	got := readOptionalFloat(context.Background(), r, "k")
+	if got == nil {
+		t.Fatal("readOptionalFloat returned nil, want 100")
+	}
+	if *got != 100 {
+		t.Errorf("readOptionalFloat = %v, want 100", *got)
+	}
+}
+
+func TestT17ReadOptionalFloat_ZeroValue(t *testing.T) {
+	r := &T17fakeReader{key: "k", value: "0", found: true}
+	got := readOptionalFloat(context.Background(), r, "k")
+	if got == nil {
+		t.Fatal("readOptionalFloat returned nil, want 0")
+	}
+	if *got != 0 {
+		t.Errorf("readOptionalFloat = %v, want 0", *got)
+	}
+}
+
+func TestT17ReadOptionalFloat_UnparseableValue(t *testing.T) {
+	r := &T17fakeReader{key: "k", value: "not-a-float", found: true}
+	got := readOptionalFloat(context.Background(), r, "k")
+	if got != nil {
+		t.Errorf("readOptionalFloat(unparseable) = %v, want nil", *got)
+	}
+}
+
+func TestT17ReadOptionalFloat_WrongKey(t *testing.T) {
+	// Reader has key "a" but we ask for "b" -- should return nil.
+	r := &T17fakeReader{key: "a", value: "5.5", found: true}
+	got := readOptionalFloat(context.Background(), r, "b")
+	if got != nil {
+		t.Errorf("readOptionalFloat(wrong key) = %v, want nil", *got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// appconfigParam helper
+// ---------------------------------------------------------------------------
+
+func TestT17AppconfigParam_BuildsCorrectly(t *testing.T) {
+	p := appconfigParam("notify.webhook_url", "https://ntfy.sh/test")
+	if p.Key != "notify.webhook_url" {
+		t.Errorf("Key = %q, want %q", p.Key, "notify.webhook_url")
+	}
+	if !p.Value.Valid {
+		t.Error("Value.Valid = false, want true")
+	}
+	if p.Value.String != "https://ntfy.sh/test" {
+		t.Errorf("Value.String = %q, want %q", p.Value.String, "https://ntfy.sh/test")
+	}
+}
+
+func TestT17AppconfigParam_EmptyValue(t *testing.T) {
+	// Clearing a webhook URL stores an empty string (notifications off).
+	p := appconfigParam("notify.webhook_url", "")
+	if !p.Value.Valid {
+		t.Error("Value.Valid = false, want true even for empty string")
+	}
+	if p.Value.String != "" {
+		t.Errorf("Value.String = %q, want empty", p.Value.String)
+	}
+}

--- a/internal/service/category_override_precedence_extra_integration_test.go
+++ b/internal/service/category_override_precedence_extra_integration_test.go
@@ -1,0 +1,559 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// T13 — extra precedence-ladder cases for category_override (user > agent > rule).
+//
+// These tests complement TestCategoryOverridePrecedence in
+// category_override_precedence_integration_test.go with edge cases not covered
+// there. Each test is independently named with the "T13" prefix to avoid
+// collisions with sibling tests that run in the same DB.
+//
+// Coverage:
+//   1. Rule skips 'agent'-level rows — rules write only where override='none'.
+//   2. Rule skips 'user'-locked rows — set_category UPDATE is gated on 'none'.
+//   3. Agent batch on multiple 'none' rows — each op lands with status=ok.
+//   4. Skipped agent write in abort-mode batch — skip != error; batch continues.
+//   5. Unlock reopens a user-locked row to agent writes.
+//   6. Hit count counts ALL condition matches regardless of override level.
+
+// TestT13_ruleSkipsAgentRow proves that ApplyRuleRetroactively does NOT
+// overwrite a row at category_override='agent'. The set_category UPDATE in the
+// retroactive pipeline filters WHERE category_override='none' only.
+func TestT13_ruleSkipsAgentRow(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	// Build fixture: user -> connection -> account with unique external IDs.
+	user := testutil.MustCreateUser(t, queries, "T13rsa-user")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "T13rsa-conn-1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "T13rsa-acct-1", "T13 Checking")
+	acctID := acct.ID
+
+	testutil.MustCreateCategory(t, queries, "t13rsa_agent_cat", "T13 Agent Cat")
+	testutil.MustCreateCategory(t, queries, "t13rsa_rule_cat", "T13 Rule Cat")
+
+	// Two transactions with the same provider-name prefix.
+	txnAgent := testutil.MustCreateTransaction(t, queries, acctID, "t13rsa_agent_row", "Bean & Brew", 600, "2026-04-01")
+	txnNone := testutil.MustCreateTransaction(t, queries, acctID, "t13rsa_none_row", "Bean & Brew Fresh", 700, "2026-04-02")
+
+	// Stamp the first transaction as agent-level override via UpdateTransactions.
+	agent := service.Actor{Type: "agent", ID: "t13rsa-agent", Name: "T13rsa Agent"}
+	res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txnAgent.ShortID, CategorySlug: strPtr("t13rsa_agent_cat")},
+		},
+		Actor: agent,
+	})
+	if err != nil || res[0].Status != "ok" {
+		t.Fatalf("stamp agent: err=%v status=%q", err, res[0].Status)
+	}
+
+	// Create a rule that matches both transactions by name substring.
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name: "T13rsa Rule",
+		Conditions: service.Condition{
+			Field: "provider_name",
+			Op:    "contains",
+			Value: "Bean & Brew",
+		},
+		CategorySlug: "t13rsa_rule_cat",
+		Priority:     10,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	count, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	// Both rows match the condition (hit-count semantics: count ALL matches).
+	if count != 2 {
+		t.Errorf("hit count=%d, want 2 (both condition matches)", count)
+	}
+
+	// The agent-level row must NOT have been re-categorised by the rule.
+	var agentSlug, agentOverride string
+	if err := pool.QueryRow(ctx, `
+		SELECT c.slug, t.category_override
+		FROM transactions t JOIN categories c ON c.id = t.category_id
+		WHERE t.provider_transaction_id = 't13rsa_agent_row'
+	`).Scan(&agentSlug, &agentOverride); err != nil {
+		t.Fatalf("query agent row: %v", err)
+	}
+	if agentSlug != "t13rsa_agent_cat" {
+		t.Errorf("agent row category=%q, want t13rsa_agent_cat (rule must not overwrite agent override)", agentSlug)
+	}
+	if agentOverride != service.CategoryOverrideAgent {
+		t.Errorf("agent row override=%q, want agent", agentOverride)
+	}
+
+	// The 'none' row must have picked up the rule category.
+	var noneSlug string
+	if err := pool.QueryRow(ctx, `
+		SELECT c.slug FROM transactions t JOIN categories c ON c.id = t.category_id
+		WHERE t.provider_transaction_id = 't13rsa_none_row'
+	`).Scan(&noneSlug); err != nil {
+		t.Fatalf("query none row: %v", err)
+	}
+	if noneSlug != "t13rsa_rule_cat" {
+		t.Errorf("none row category=%q, want t13rsa_rule_cat", noneSlug)
+	}
+	_ = txnNone
+}
+
+// TestT13_ruleSkipsUserRow proves that a rule never overwrites a 'user'-locked
+// row. The set_category UPDATE in ApplyRuleRetroactively is gated on
+// category_override='none'.
+func TestT13_ruleSkipsUserRow(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	u := testutil.MustCreateUser(t, queries, "T13rsu-user")
+	c := testutil.MustCreateConnection(t, queries, u.ID, "T13rsu-conn-1")
+	a := testutil.MustCreateAccount(t, queries, c.ID, "T13rsu-acct-1", "T13 Savings")
+	acctID := a.ID
+
+	testutil.MustCreateCategory(t, queries, "t13rsu_user_cat", "T13 User Cat")
+	testutil.MustCreateCategory(t, queries, "t13rsu_rule_cat", "T13 Rule Cat 2")
+
+	txnUser := testutil.MustCreateTransaction(t, queries, acctID, "t13rsu_user_row", "Trader Joes", 3000, "2026-04-01")
+	txnNone := testutil.MustCreateTransaction(t, queries, acctID, "t13rsu_none_row", "Trader Joes Express", 500, "2026-04-02")
+
+	// Lock the first transaction at user level.
+	userActor := service.Actor{Type: "user", ID: "t13rsu-user", Name: "T13rsu User"}
+	res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txnUser.ShortID, CategorySlug: strPtr("t13rsu_user_cat")},
+		},
+		Actor: userActor,
+	})
+	if err != nil || res[0].Status != "ok" {
+		t.Fatalf("user lock: err=%v status=%q", err, res[0].Status)
+	}
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name: "T13rsu Rule",
+		Conditions: service.Condition{
+			Field: "provider_name",
+			Op:    "contains",
+			Value: "Trader Joes",
+		},
+		CategorySlug: "t13rsu_rule_cat",
+		Priority:     10,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	count, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	// Both rows match the condition; hit count = 2.
+	if count != 2 {
+		t.Errorf("hit count=%d, want 2", count)
+	}
+
+	// User-locked row must keep its user category and 'user' override.
+	var userSlug, userOverride string
+	if err := pool.QueryRow(ctx, `
+		SELECT c.slug, t.category_override
+		FROM transactions t JOIN categories c ON c.id = t.category_id
+		WHERE t.provider_transaction_id = 't13rsu_user_row'
+	`).Scan(&userSlug, &userOverride); err != nil {
+		t.Fatalf("query user row: %v", err)
+	}
+	if userSlug != "t13rsu_user_cat" {
+		t.Errorf("user row category=%q, want t13rsu_user_cat (rule must not overwrite user lock)", userSlug)
+	}
+	if userOverride != service.CategoryOverrideUser {
+		t.Errorf("user row override=%q, want user", userOverride)
+	}
+
+	// The 'none' row must have the rule category.
+	var noneSlug string
+	if err := pool.QueryRow(ctx, `
+		SELECT c.slug FROM transactions t JOIN categories c ON c.id = t.category_id
+		WHERE t.provider_transaction_id = 't13rsu_none_row'
+	`).Scan(&noneSlug); err != nil {
+		t.Fatalf("query none row: %v", err)
+	}
+	if noneSlug != "t13rsu_rule_cat" {
+		t.Errorf("none row category=%q, want t13rsu_rule_cat", noneSlug)
+	}
+	_ = txnNone
+}
+
+// TestT13_agentBatchOnMultipleNoneRows confirms that an agent batch on several
+// 'none' rows all succeed with status=ok; each row lands at override=agent.
+func TestT13_agentBatchOnMultipleNoneRows(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	u := testutil.MustCreateUser(t, queries, "T13ab-user")
+	c := testutil.MustCreateConnection(t, queries, u.ID, "T13ab-conn-1")
+	a := testutil.MustCreateAccount(t, queries, c.ID, "T13ab-acct-1", "T13 Batch Checking")
+	acctID := a.ID
+
+	testutil.MustCreateCategory(t, queries, "t13ab_batch_cat", "T13 Batch Cat")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acctID, "t13ab_txn1", "Lyft A", 1000, "2026-04-01")
+	txn2 := testutil.MustCreateTransaction(t, queries, acctID, "t13ab_txn2", "Lyft B", 1200, "2026-04-02")
+	txn3 := testutil.MustCreateTransaction(t, queries, acctID, "t13ab_txn3", "Lyft C", 900, "2026-04-03")
+
+	agent := service.Actor{Type: "agent", ID: "t13ab-agent", Name: "T13 Batch Agent"}
+	results, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txn1.ShortID, CategorySlug: strPtr("t13ab_batch_cat")},
+			{TransactionID: txn2.ShortID, CategorySlug: strPtr("t13ab_batch_cat")},
+			{TransactionID: txn3.ShortID, CategorySlug: strPtr("t13ab_batch_cat")},
+		},
+		Actor: agent,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTransactions batch: %v", err)
+	}
+	for i, r := range results {
+		if r.Status != "ok" {
+			t.Errorf("op %d: status=%q, want ok", i, r.Status)
+		}
+	}
+
+	// Verify all three rows are at agent level.
+	for _, pair := range []struct {
+		shortID string
+		extID   string
+	}{
+		{txn1.ShortID, "t13ab_txn1"},
+		{txn2.ShortID, "t13ab_txn2"},
+		{txn3.ShortID, "t13ab_txn3"},
+	} {
+		got, err := svc.GetTransaction(ctx, pair.shortID)
+		if err != nil {
+			t.Fatalf("GetTransaction %s: %v", pair.extID, err)
+		}
+		if got.CategoryOverride != service.CategoryOverrideAgent {
+			t.Errorf("%s: override=%q, want agent", pair.extID, got.CategoryOverride)
+		}
+	}
+}
+
+// TestT13_agentSkippedInAbortBatch verifies that a skipped agent write (blocked
+// by a user lock) inside an abort-mode batch does NOT trigger the rollback path.
+// A skip is a normal outcome, not an error. Tags on the skipped op still apply.
+func TestT13_agentSkippedInAbortBatch(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	u := testutil.MustCreateUser(t, queries, "T13asab-user")
+	conn := testutil.MustCreateConnection(t, queries, u.ID, "T13asab-conn-1")
+	a := testutil.MustCreateAccount(t, queries, conn.ID, "T13asab-acct-1", "T13 Abort Checking")
+	acctID := a.ID
+
+	testutil.MustCreateCategory(t, queries, "t13asab_user_cat", "T13 Abort User Cat")
+	testutil.MustCreateCategory(t, queries, "t13asab_agent_cat", "T13 Abort Agent Cat")
+
+	txnLocked := testutil.MustCreateTransaction(t, queries, acctID, "t13asab_locked", "Amazon Prime", 1399, "2026-04-01")
+	txnFree := testutil.MustCreateTransaction(t, queries, acctID, "t13asab_free", "Amazon Fresh", 2599, "2026-04-02")
+
+	// Lock the first transaction at user level.
+	userActor := service.Actor{Type: "user", ID: "t13asab-user", Name: "T13asab User"}
+	res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txnLocked.ShortID, CategorySlug: strPtr("t13asab_user_cat")},
+		},
+		Actor: userActor,
+	})
+	if err != nil || res[0].Status != "ok" {
+		t.Fatalf("user lock: err=%v status=%q", err, res[0].Status)
+	}
+
+	// Agent abort-mode batch:
+	//   op[0]: tries to overwrite user lock -> skipped (NOT an error; batch continues).
+	//   op[1]: writes the free row -> ok.
+	agentActor := service.Actor{Type: "agent", ID: "t13asab-agent", Name: "T13asab Agent"}
+	results, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{
+				TransactionID: txnLocked.ShortID,
+				CategorySlug:  strPtr("t13asab_agent_cat"),
+				TagsToAdd:     []service.UpdateTransactionsTagOp{{Slug: "t13asab-lock-tag"}},
+			},
+			{
+				TransactionID: txnFree.ShortID,
+				CategorySlug:  strPtr("t13asab_agent_cat"),
+			},
+		},
+		OnError: "abort",
+		Actor:   agentActor,
+	})
+	if err != nil {
+		t.Fatalf("abort-mode batch: unexpected error=%v (skip must not trigger abort)", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// op[0]: skipped (agent blocked by user lock).
+	if results[0].Status != "skipped" {
+		t.Errorf("op[0] status=%q, want skipped", results[0].Status)
+	}
+
+	// op[1]: ok (free row).
+	if results[1].Status != "ok" {
+		t.Errorf("op[1] status=%q, want ok", results[1].Status)
+	}
+
+	// The locked row must still carry the user category.
+	lockedGot, err := svc.GetTransaction(ctx, txnLocked.ShortID)
+	if err != nil {
+		t.Fatalf("GetTransaction locked: %v", err)
+	}
+	if lockedGot.CategoryOverride != service.CategoryOverrideUser {
+		t.Errorf("locked override=%q, want user", lockedGot.CategoryOverride)
+	}
+	if lockedGot.Category == nil || lockedGot.Category.Slug == nil || *lockedGot.Category.Slug != "t13asab_user_cat" {
+		t.Errorf("locked category=%v, want t13asab_user_cat", lockedGot.Category)
+	}
+
+	// Tag from the skipped op must have been applied (tags apply even on skips).
+	var tagFound bool
+	for _, tg := range lockedGot.Tags {
+		if tg == "t13asab-lock-tag" {
+			tagFound = true
+		}
+	}
+	if !tagFound {
+		t.Errorf("tag t13asab-lock-tag missing from skipped op; tags=%v", lockedGot.Tags)
+	}
+
+	// The free row must be agent-categorised.
+	freeGot, err := svc.GetTransaction(ctx, txnFree.ShortID)
+	if err != nil {
+		t.Fatalf("GetTransaction free: %v", err)
+	}
+	if freeGot.CategoryOverride != service.CategoryOverrideAgent {
+		t.Errorf("free override=%q, want agent", freeGot.CategoryOverride)
+	}
+}
+
+// TestT13_unlockReopensRowToAgent validates that unlocking a user-locked row
+// (SetCategoryOverrideFlag false) resets category_override to 'none', which
+// lets a subsequent agent write succeed.
+func TestT13_unlockReopensRowToAgent(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	u := testutil.MustCreateUser(t, queries, "T13urra-user")
+	c := testutil.MustCreateConnection(t, queries, u.ID, "T13urra-conn-1")
+	a := testutil.MustCreateAccount(t, queries, c.ID, "T13urra-acct-1", "T13 Unlock Checking")
+	acctID := a.ID
+
+	testutil.MustCreateCategory(t, queries, "t13urra_user_cat", "T13 Unlock User Cat")
+	testutil.MustCreateCategory(t, queries, "t13urra_agent_cat", "T13 Unlock Agent Cat")
+
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t13urra_txn", "Netflix", 1599, "2026-04-01")
+
+	userActor := service.Actor{Type: "user", ID: "t13urra-user", Name: "T13urra User"}
+	agentActor := service.Actor{Type: "agent", ID: "t13urra-agent", Name: "T13urra Agent"}
+
+	// Step 1: User locks the row -> override=user.
+	if res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txn.ShortID, CategorySlug: strPtr("t13urra_user_cat")},
+		},
+		Actor: userActor,
+	}); err != nil || res[0].Status != "ok" {
+		t.Fatalf("user lock: err=%v status=%q", err, res[0].Status)
+	}
+	if got := mustOverride(t, svc, txn.ShortID); got != service.CategoryOverrideUser {
+		t.Fatalf("after user lock: override=%q, want user", got)
+	}
+
+	// Step 2: Agent write is blocked (user-locked) -> skipped.
+	if res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txn.ShortID, CategorySlug: strPtr("t13urra_agent_cat")},
+		},
+		Actor: agentActor,
+	}); err != nil || res[0].Status != "skipped" {
+		t.Fatalf("pre-unlock agent write: err=%v status=%q, want skipped", err, res[0].Status)
+	}
+
+	// Step 3: Unlock (binary flag -> none).
+	if err := svc.SetCategoryOverrideFlag(ctx, txn.ShortID, false, service.SystemActor()); err != nil {
+		t.Fatalf("SetCategoryOverrideFlag(false): %v", err)
+	}
+	if got := mustOverride(t, svc, txn.ShortID); got != service.CategoryOverrideNone {
+		t.Fatalf("after unlock: override=%q, want none", got)
+	}
+
+	// Step 4: Agent write now succeeds on the 'none' row.
+	if res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txn.ShortID, CategorySlug: strPtr("t13urra_agent_cat")},
+		},
+		Actor: agentActor,
+	}); err != nil || res[0].Status != "ok" {
+		t.Fatalf("post-unlock agent write: err=%v status=%q, want ok", err, res[0].Status)
+	}
+	if got := mustOverride(t, svc, txn.ShortID); got != service.CategoryOverrideAgent {
+		t.Errorf("after post-unlock agent write: override=%q, want agent", got)
+	}
+}
+
+// TestT13_agentCannotOverwriteUserLock is the focused assertion of the most
+// critical invariant: a user-locked row (override='user') is sacred -- an agent
+// write is skipped and the category remains unchanged.
+func TestT13_agentCannotOverwriteUserLock(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	u := testutil.MustCreateUser(t, queries, "T13acoul-user")
+	c := testutil.MustCreateConnection(t, queries, u.ID, "T13acoul-conn-1")
+	a := testutil.MustCreateAccount(t, queries, c.ID, "T13acoul-acct-1", "T13 Sacred Checking")
+	acctID := a.ID
+
+	testutil.MustCreateCategory(t, queries, "t13acoul_user_cat", "T13 Sacred User Cat")
+	testutil.MustCreateCategory(t, queries, "t13acoul_agent_cat", "T13 Sacred Agent Cat")
+
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t13acoul_txn", "Spotify", 999, "2026-04-01")
+
+	userActor := service.Actor{Type: "user", ID: "t13acoul-user", Name: "T13acoul User"}
+	agentActor := service.Actor{Type: "agent", ID: "t13acoul-agent", Name: "T13acoul Agent"}
+
+	// User locks the row.
+	if res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txn.ShortID, CategorySlug: strPtr("t13acoul_user_cat")},
+		},
+		Actor: userActor,
+	}); err != nil || res[0].Status != "ok" {
+		t.Fatalf("user lock: err=%v status=%q", err, res[0].Status)
+	}
+
+	// Agent attempts to overwrite -- must be skipped.
+	res, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
+		Operations: []service.UpdateTransactionsOp{
+			{TransactionID: txn.ShortID, CategorySlug: strPtr("t13acoul_agent_cat")},
+		},
+		Actor: agentActor,
+	})
+	if err != nil {
+		t.Fatalf("agent write: unexpected error=%v", err)
+	}
+	if res[0].Status != "skipped" {
+		t.Errorf("status=%q, want skipped -- user lock must be sacred", res[0].Status)
+	}
+
+	// Category and override must be unchanged.
+	got, err := svc.GetTransaction(ctx, txn.ShortID)
+	if err != nil {
+		t.Fatalf("GetTransaction: %v", err)
+	}
+	if got.CategoryOverride != service.CategoryOverrideUser {
+		t.Errorf("override=%q, want user (sacred lock)", got.CategoryOverride)
+	}
+	if got.Category == nil || got.Category.Slug == nil || *got.Category.Slug != "t13acoul_user_cat" {
+		t.Errorf("category=%v, want t13acoul_user_cat", got.Category)
+	}
+}
+
+// TestT13_ruleHitCountAllMatchesRegardlessOfOverride verifies that
+// ApplyRuleRetroactively counts ALL condition matches (including user-locked
+// rows) in the returned hit count. This is the sync-parity contract: the
+// counter reflects "how often this rule matches" not "how many rows changed."
+func TestT13_ruleHitCountAllMatchesRegardlessOfOverride(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	u := testutil.MustCreateUser(t, queries, "T13hc-user")
+	c := testutil.MustCreateConnection(t, queries, u.ID, "T13hc-conn-1")
+	a := testutil.MustCreateAccount(t, queries, c.ID, "T13hc-acct-1", "T13 HitCount Checking")
+	acctID := a.ID
+
+	testutil.MustCreateCategory(t, queries, "t13hc_user_cat", "T13 HitCount User Cat")
+	testutil.MustCreateCategory(t, queries, "t13hc_rule_cat", "T13 HitCount Rule Cat")
+
+	// Two transactions with exactly the same provider name -- one will be
+	// user-locked, the other stays at 'none'.
+	txnLocked := testutil.MustCreateTransaction(t, queries, acctID, "t13hc_locked", "Whole Foods Market", 4500, "2026-04-01")
+	testutil.MustCreateTransaction(t, queries, acctID, "t13hc_free", "Whole Foods Market", 6200, "2026-04-02")
+
+	// Lock the first row directly via pool (mirrors the approach in
+	// TestApplyRuleRetroactively_MatchesAndSkipsOverrides).
+	userCatRow, err := queries.GetCategoryBySlug(ctx, "t13hc_user_cat")
+	if err != nil {
+		t.Fatalf("GetCategoryBySlug: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		"UPDATE transactions SET category_id = $1, category_override = 'user' WHERE id = $2",
+		userCatRow.ID, txnLocked.ID,
+	); err != nil {
+		t.Fatalf("lock user row: %v", err)
+	}
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name: "T13hc Rule",
+		Conditions: service.Condition{
+			Field: "provider_name",
+			Op:    "eq",
+			Value: "Whole Foods Market",
+		},
+		CategorySlug: "t13hc_rule_cat",
+		Priority:     10,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	count, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	// Both rows match the condition, so hit count must be 2 (override level ignored).
+	if count != 2 {
+		t.Errorf("hit count=%d, want 2 (both condition matches regardless of override)", count)
+	}
+
+	// User-locked row must still have the user category.
+	var lockedSlug, lockedOverride string
+	if err := pool.QueryRow(ctx, `
+		SELECT c.slug, t.category_override
+		FROM transactions t JOIN categories c ON c.id = t.category_id
+		WHERE t.provider_transaction_id = 't13hc_locked'
+	`).Scan(&lockedSlug, &lockedOverride); err != nil {
+		t.Fatalf("query locked row: %v", err)
+	}
+	if lockedSlug != "t13hc_user_cat" {
+		t.Errorf("locked row category=%q, want t13hc_user_cat (rule must not overwrite user lock)", lockedSlug)
+	}
+	if lockedOverride != service.CategoryOverrideUser {
+		t.Errorf("locked row override=%q, want user", lockedOverride)
+	}
+
+	// Free row must have the rule category.
+	var freeSlug string
+	if err := pool.QueryRow(ctx, `
+		SELECT c.slug FROM transactions t JOIN categories c ON c.id = t.category_id
+		WHERE t.provider_transaction_id = 't13hc_free'
+	`).Scan(&freeSlug); err != nil {
+		t.Fatalf("query free row: %v", err)
+	}
+	if freeSlug != "t13hc_rule_cat" {
+		t.Errorf("free row category=%q, want t13hc_rule_cat", freeSlug)
+	}
+}

--- a/internal/service/enable_workflow_from_preset_extra_integration_test.go
+++ b/internal/service/enable_workflow_from_preset_extra_integration_test.go
@@ -1,0 +1,353 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestT14_ErrConflictOnSecondEnable verifies that enabling the same preset
+// a second time returns ErrConflict regardless of the params supplied on
+// the second call.
+func TestT14_ErrConflictOnSecondEnable(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// First enable must succeed.
+	first, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("T14: first enable: %v", err)
+	}
+	if first.SourceTemplate == nil || *first.SourceTemplate != "weekly-money-digest" {
+		t.Fatalf("T14: source_template = %v, want weekly-money-digest", first.SourceTemplate)
+	}
+
+	// Second enable with Enabled=true (different params) must still conflict.
+	_, err = svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{
+		Enabled: true,
+	})
+	if !errors.Is(err, service.ErrConflict) {
+		t.Fatalf("T14: second enable err = %v, want ErrConflict", err)
+	}
+	if !strings.Contains(err.Error(), "weekly-money-digest") {
+		t.Errorf("T14: ErrConflict message should include the preset slug, got: %q", err.Error())
+	}
+}
+
+// TestT14_ErrConflictDistinctPerPreset verifies that ErrConflict is scoped
+// to the specific preset: enabling preset A twice is a conflict, but enabling
+// preset B afterward succeeds.
+func TestT14_ErrConflictDistinctPerPreset(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Enable subscription-auditor.
+	_, err := svc.EnableWorkflowFromPreset(ctx, "subscription-auditor", service.EnableWorkflowFromPresetParams{})
+	if err != nil {
+		t.Fatalf("T14: enable subscription-auditor: %v", err)
+	}
+
+	// Second enable of subscription-auditor -> conflict.
+	_, err = svc.EnableWorkflowFromPreset(ctx, "subscription-auditor", service.EnableWorkflowFromPresetParams{})
+	if !errors.Is(err, service.ErrConflict) {
+		t.Fatalf("T14: expected ErrConflict for subscription-auditor second enable, got %v", err)
+	}
+
+	// monthly-close has not been enabled yet -- must succeed.
+	mc, err := svc.EnableWorkflowFromPreset(ctx, "monthly-close", service.EnableWorkflowFromPresetParams{})
+	if err != nil {
+		t.Fatalf("T14: enable monthly-close after conflict should succeed: %v", err)
+	}
+	if mc.Slug != "monthly-close" {
+		t.Fatalf("T14: monthly-close slug = %q, want monthly-close", mc.Slug)
+	}
+}
+
+// TestT14_OptionDirectivesAppendedToPrompt verifies that the chosen
+// WorkflowPresetOption Directive is appended to the stored prompt under a
+// heading labelled with the option Label, and that the "auto" default
+// choice (empty directive) appends nothing.
+func TestT14_OptionDirectivesAppendedToPrompt(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// routine-reviewer has applyModeOption (key "apply_mode").
+	// Choosing "flag_only" appends a FLAG ONLY directive under "## Apply mode".
+	flagOnly, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{
+		Options: map[string]string{"apply_mode": "flag_only"},
+	})
+	if err != nil {
+		t.Fatalf("T14: enable with flag_only: %v", err)
+	}
+	if !strings.Contains(flagOnly.Prompt, "## Apply mode") {
+		t.Errorf("T14: flag_only prompt missing '## Apply mode' heading; len=%d", len(flagOnly.Prompt))
+	}
+	if !strings.Contains(flagOnly.Prompt, "FLAG ONLY") {
+		t.Errorf("T14: flag_only prompt missing 'FLAG ONLY' directive; len=%d", len(flagOnly.Prompt))
+	}
+	if !strings.Contains(flagOnly.Prompt, "do NOT call update_transactions") {
+		t.Errorf("T14: flag_only prompt missing key directive text; len=%d", len(flagOnly.Prompt))
+	}
+
+	// backlog-closer also has applyModeOption. Choosing "auto" (the default)
+	// must NOT append any directive because the directive for "auto" is empty.
+	autoMode, err := svc.EnableWorkflowFromPreset(ctx, "backlog-closer", service.EnableWorkflowFromPresetParams{
+		Options: map[string]string{"apply_mode": "auto"},
+	})
+	if err != nil {
+		t.Fatalf("T14: enable backlog-closer with auto: %v", err)
+	}
+	if strings.Contains(autoMode.Prompt, "FLAG ONLY") {
+		t.Errorf("T14: auto prompt should not contain 'FLAG ONLY'")
+	}
+	// The heading itself is only present when a directive is appended.
+	if strings.Contains(autoMode.Prompt, "## Apply mode") {
+		t.Errorf("T14: auto prompt should not contain '## Apply mode' heading (no directive to wrap)")
+	}
+}
+
+// TestT14_UnknownOptionKeyFallsBackToDefault verifies that supplying an
+// unknown option key is silently ignored and the option falls back to its
+// Default choice. The "auto" default for applyModeOption has an empty
+// directive, so no FLAG ONLY text should appear.
+func TestT14_UnknownOptionKeyFallsBackToDefault(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// routine-reviewer expects key "apply_mode". We send a typo key.
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{
+		Options: map[string]string{"apply_modex": "flag_only"},
+	})
+	if err != nil {
+		t.Fatalf("T14: enable with unknown option key: %v", err)
+	}
+	// Default for applyModeOption is "auto" -- empty directive -- so FLAG ONLY must be absent.
+	if strings.Contains(wf.Prompt, "FLAG ONLY") {
+		t.Errorf("T14: unknown key should fall back to default (auto); prompt should not contain FLAG ONLY")
+	}
+	if len(wf.Prompt) == 0 {
+		t.Errorf("T14: prompt is empty after enabling with unknown option key")
+	}
+}
+
+// TestT14_ScheduleOverrideAppliedForScheduledPreset verifies that a non-nil
+// ScheduleCron override replaces the preset default for a cron-triggered preset.
+func TestT14_ScheduleOverrideAppliedForScheduledPreset(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// weekly-money-digest defaults to "0 7 * * 1". Override to daily at 09:00.
+	override := "0 9 * * *"
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{
+		ScheduleCron: &override,
+	})
+	if err != nil {
+		t.Fatalf("T14: enable with schedule override: %v", err)
+	}
+	if wf.ScheduleCron == nil {
+		t.Fatal("T14: schedule_cron is nil, expected the override")
+	}
+	if *wf.ScheduleCron != override {
+		t.Errorf("T14: schedule_cron = %q, want %q", *wf.ScheduleCron, override)
+	}
+	// post-sync trigger must be false for a purely cron-based preset.
+	if wf.TriggerOnSyncComplete {
+		t.Errorf("T14: weekly-money-digest should not trigger on sync complete")
+	}
+}
+
+// TestT14_NilScheduleOverrideKeepsPresetDefault verifies that when
+// ScheduleCron is nil the preset default cron is used unchanged.
+func TestT14_NilScheduleOverrideKeepsPresetDefault(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// subscription-auditor defaults to "0 8 1 * *".
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "subscription-auditor", service.EnableWorkflowFromPresetParams{
+		ScheduleCron: nil, // no override
+	})
+	if err != nil {
+		t.Fatalf("T14: enable subscription-auditor (no override): %v", err)
+	}
+	const presetDefault = "0 8 1 * *"
+	if wf.ScheduleCron == nil {
+		t.Fatal("T14: schedule_cron is nil, expected preset default")
+	}
+	if *wf.ScheduleCron != presetDefault {
+		t.Errorf("T14: schedule_cron = %q, want preset default %q", *wf.ScheduleCron, presetDefault)
+	}
+}
+
+// TestT14_EmptyStringScheduleOverrideKeepsPresetDefault verifies that an
+// empty-string ScheduleCron is treated the same as nil -- the preset default wins.
+func TestT14_EmptyStringScheduleOverrideKeepsPresetDefault(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	blank := ""
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{
+		ScheduleCron: &blank,
+	})
+	if err != nil {
+		t.Fatalf("T14: enable with empty-string override: %v", err)
+	}
+	const presetDefault = "0 7 * * 1"
+	if wf.ScheduleCron == nil {
+		t.Fatal("T14: schedule_cron is nil, expected preset default")
+	}
+	if *wf.ScheduleCron != presetDefault {
+		t.Errorf("T14: schedule_cron = %q, want preset default %q", *wf.ScheduleCron, presetDefault)
+	}
+}
+
+// TestT14_PostSyncPresetIgnoresScheduleOverride verifies that a schedule
+// override is silently ignored for a post-sync-triggered preset, which keeps
+// no cron schedule regardless.
+func TestT14_PostSyncPresetIgnoresScheduleOverride(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// routine-reviewer is post-sync (TriggerOnSyncComplete = true, no ScheduleCron).
+	override := "0 6 * * *"
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{
+		ScheduleCron: &override,
+	})
+	if err != nil {
+		t.Fatalf("T14: enable post-sync preset with schedule override: %v", err)
+	}
+	if wf.ScheduleCron != nil {
+		t.Errorf("T14: post-sync preset must have nil schedule_cron, got %q", *wf.ScheduleCron)
+	}
+	if !wf.TriggerOnSyncComplete {
+		t.Errorf("T14: routine-reviewer must have TriggerOnSyncComplete=true")
+	}
+}
+
+// TestT14_AdditionalInstructionsAppendedAfterOptionDirectives verifies that
+// AdditionalInstructions appears after option directives in the composed
+// prompt and is wrapped under its own heading.
+func TestT14_AdditionalInstructionsAppendedAfterOptionDirectives(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	const extraInstr = "Always add a comment when you flag a transaction."
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{
+		Options:                map[string]string{"apply_mode": "flag_only"},
+		AdditionalInstructions: extraInstr,
+	})
+	if err != nil {
+		t.Fatalf("T14: enable with directives + instructions: %v", err)
+	}
+	flagPos := strings.Index(wf.Prompt, "FLAG ONLY")
+	instrPos := strings.Index(wf.Prompt, extraInstr)
+	headingPos := strings.Index(wf.Prompt, "## Additional instructions")
+	if flagPos < 0 {
+		t.Fatal("T14: FLAG ONLY directive missing from prompt")
+	}
+	if headingPos < 0 {
+		t.Fatal("T14: '## Additional instructions' heading missing from prompt")
+	}
+	if instrPos < 0 {
+		t.Fatal("T14: additional instruction text missing from prompt")
+	}
+	// Additional instructions heading must come after the FLAG ONLY directive.
+	if headingPos < flagPos {
+		t.Errorf("T14: additional instructions heading (%d) appears before FLAG ONLY directive (%d)", headingPos, flagPos)
+	}
+}
+
+// TestT14_AdditionalInstructionsTooLong verifies that instructions exceeding
+// the limit are rejected with ErrInvalidParameter before any DB write occurs.
+func TestT14_AdditionalInstructionsTooLong(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// 4001 chars exceeds the maxAdditionalInstructions (4000) limit.
+	tooLong := strings.Repeat("x", 4001)
+	_, err := svc.EnableWorkflowFromPreset(ctx, "monthly-close", service.EnableWorkflowFromPresetParams{
+		AdditionalInstructions: tooLong,
+	})
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Fatalf("T14: oversized instructions err = %v, want ErrInvalidParameter", err)
+	}
+
+	// The preset must still be enable-able after the failed attempt (no partial write occurred).
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "monthly-close", service.EnableWorkflowFromPresetParams{})
+	if err != nil {
+		t.Fatalf("T14: enable after rejected attempt should succeed: %v", err)
+	}
+	if wf.Slug != "monthly-close" {
+		t.Errorf("T14: slug = %q, want monthly-close", wf.Slug)
+	}
+}
+
+// TestT14_GalleryReflectsEnabledAfterEnable verifies that ListWorkflowPresets
+// correctly marks a preset as enabled once EnableWorkflowFromPreset succeeds,
+// and that WorkflowSlug and WorkflowEnabled fields are populated.
+func TestT14_GalleryReflectsEnabledAfterEnable(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "backlog-closer", service.EnableWorkflowFromPresetParams{
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("T14: enable backlog-closer: %v", err)
+	}
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("T14: ListWorkflowPresets: %v", err)
+	}
+	var found bool
+	for _, v := range views {
+		if v.Slug != "backlog-closer" {
+			continue
+		}
+		found = true
+		if !v.Enabled {
+			t.Errorf("T14: gallery view for backlog-closer should be Enabled=true")
+		}
+		if v.WorkflowSlug == nil || *v.WorkflowSlug != wf.Slug {
+			t.Errorf("T14: gallery WorkflowSlug = %v, want %q", v.WorkflowSlug, wf.Slug)
+		}
+		if v.WorkflowEnabled == nil || !*v.WorkflowEnabled {
+			t.Errorf("T14: gallery WorkflowEnabled = %v, want true", v.WorkflowEnabled)
+		}
+	}
+	if !found {
+		t.Fatal("T14: backlog-closer not found in ListWorkflowPresets")
+	}
+}
+
+// TestT14_SourceTemplateStampedOnInstantiation verifies that the created
+// agent_definition carries source_template equal to the preset slug, and
+// that a hand-authored definition (no template) is not mistakenly tagged.
+func TestT14_SourceTemplateStampedOnInstantiation(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	preset, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{})
+	if err != nil {
+		t.Fatalf("T14: enable preset: %v", err)
+	}
+	if preset.SourceTemplate == nil {
+		t.Fatal("T14: SourceTemplate must be set on a preset-instantiated workflow")
+	}
+	if *preset.SourceTemplate != "weekly-money-digest" {
+		t.Errorf("T14: SourceTemplate = %q, want weekly-money-digest", *preset.SourceTemplate)
+	}
+
+	// Hand-authored definition must have nil SourceTemplate.
+	plain := mustCreateAgentDefinition(t, svc, "t14-plain-no-template", false)
+	if plain.SourceTemplate != nil {
+		t.Errorf("T14: hand-authored definition must have nil SourceTemplate, got %q", *plain.SourceTemplate)
+	}
+}

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -19,6 +19,11 @@ import (
 // A short timeout keeps a slow/hung webhook from blocking the caller.
 var notifyHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
+// notifyBodyMaxLen caps the report body carried in a notification payload.
+// Sinks like ntfy / Slack / push relays truncate or choke on multi-KB
+// bodies; the deep link in the payload carries the reader to the full text.
+const notifyBodyMaxLen = 480
+
 // NotificationPayload is the JSON body POSTed to the configured notification
 // webhook. Shaped to be readable by generic sinks (ntfy, Slack-compatible
 // relays, email bridges) without per-provider formatting.
@@ -30,6 +35,44 @@ type NotificationPayload struct {
 	Workflow string `json:"workflow,omitempty"` // originating workflow name
 	URL      string `json:"url,omitempty"`      // deep link back into Breadbox
 	SentAt   string `json:"sent_at"`            // RFC3339
+}
+
+// reportNotificationPayload maps a freshly-created report into the outbound
+// notification shape. Priority is normalized to the canonical info/warning/
+// critical set; an unknown value falls back to "info" so a sink that keys
+// behavior off priority never sees something unexpected. The body is
+// truncated — the URL deep link carries the reader to the full report.
+func reportNotificationPayload(r AgentReportResponse, workflow string) NotificationPayload {
+	return NotificationPayload{
+		Event:    "report",
+		Title:    r.Title,
+		Body:     truncateNotifyBody(r.Body),
+		Priority: normalizeNotifyPriority(r.Priority),
+		Workflow: workflow,
+		URL:      "/reports/" + r.ShortID,
+	}
+}
+
+// normalizeNotifyPriority clamps a report priority to the canonical
+// info/warning/critical set, defaulting to "info".
+func normalizeNotifyPriority(p string) string {
+	switch p {
+	case "warning", "critical":
+		return p
+	default:
+		return "info"
+	}
+}
+
+// truncateNotifyBody trims a report body to notifyBodyMaxLen runes, appending
+// an ellipsis when it had to cut. Rune-aware so a multibyte body never splits
+// mid-character.
+func truncateNotifyBody(body string) string {
+	r := []rune(body)
+	if len(r) <= notifyBodyMaxLen {
+		return body
+	}
+	return strings.TrimRight(string(r[:notifyBodyMaxLen]), " \t\n") + "…"
 }
 
 // WorkflowNotificationConfigured reports whether an outbound webhook URL is set.

--- a/internal/service/notify_on_report_integration_test.go
+++ b/internal/service/notify_on_report_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"breadbox/internal/service"
+)
+
+// f5notifyRecorder captures the JSON bodies POSTed to a stub notification
+// webhook. CreateAgentReport fires the notification asynchronously, so the
+// test side blocks on `received` to observe the POST deterministically and
+// inspects `count` to assert the no-fire cases.
+type f5notifyRecorder struct {
+	srv      *httptest.Server
+	received chan map[string]any
+	count    int32
+}
+
+func f5newNotifyRecorder(t *testing.T) *f5notifyRecorder {
+	t.Helper()
+	rec := &f5notifyRecorder{received: make(chan map[string]any, 4)}
+	rec.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&rec.count, 1)
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		_ = json.Unmarshal(body, &p)
+		// Stash the Content-Type so the assertion can confirm the JSON shape.
+		p["_content_type"] = r.Header.Get("Content-Type")
+		select {
+		case rec.received <- p:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(rec.srv.Close)
+	return rec
+}
+
+// await blocks until a webhook POST lands or the timeout elapses.
+func (rec *f5notifyRecorder) await(t *testing.T, timeout time.Duration) map[string]any {
+	t.Helper()
+	select {
+	case p := <-rec.received:
+		return p
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for notification webhook POST")
+		return nil
+	}
+}
+
+// expectNoFire settles briefly and asserts no webhook POST was made.
+func (rec *f5notifyRecorder) expectNoFire(t *testing.T, settle time.Duration) {
+	t.Helper()
+	select {
+	case p := <-rec.received:
+		t.Fatalf("expected no notification, but webhook fired with %v", p)
+	case <-time.After(settle):
+		if c := atomic.LoadInt32(&rec.count); c != 0 {
+			t.Fatalf("expected no webhook POST, got %d", c)
+		}
+	}
+}
+
+// TestF5NotifyOnReport_WorkflowReportFires proves an agent-authored report
+// POSTs a notification with the enriched payload shape.
+func TestF5NotifyOnReport_WorkflowReportFires(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	rec := f5newNotifyRecorder(t)
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{NotifyWebhookURL: &rec.srv.URL}, devEncKey, ""); err != nil {
+		t.Fatalf("set webhook: %v", err)
+	}
+
+	actor := service.Actor{Type: "agent", ID: "agent-f5", Name: "Subscriptions Watchdog"}
+	report, err := svc.CreateAgentReport(ctx,
+		"Recurring charge spike", "Netflix jumped from $15.49 to $22.99 this month.",
+		actor, "warning", []string{"subscriptions"}, "", "", "")
+	if err != nil {
+		t.Fatalf("CreateAgentReport: %v", err)
+	}
+
+	p := rec.await(t, 5*time.Second)
+	if p["_content_type"] != "application/json" {
+		t.Errorf("content-type = %v, want application/json", p["_content_type"])
+	}
+	if p["event"] != "report" {
+		t.Errorf("event = %v, want report", p["event"])
+	}
+	if p["title"] != "Recurring charge spike" {
+		t.Errorf("title = %v, want report title", p["title"])
+	}
+	if p["priority"] != "warning" {
+		t.Errorf("priority = %v, want warning", p["priority"])
+	}
+	if p["workflow"] != "Subscriptions Watchdog" {
+		t.Errorf("workflow = %v, want actor name", p["workflow"])
+	}
+	if p["body"] != "Netflix jumped from $15.49 to $22.99 this month." {
+		t.Errorf("body = %v, want report body", p["body"])
+	}
+	wantURL := "/reports/" + report.ShortID
+	if p["url"] != wantURL {
+		t.Errorf("url = %v, want %s", p["url"], wantURL)
+	}
+	if _, ok := p["sent_at"]; !ok {
+		t.Error("sent_at missing from payload")
+	}
+}
+
+// TestF5NotifyOnReport_NoWebhookNoOp proves that with no webhook configured,
+// creating a workflow report is a silent no-op (no POST attempted).
+func TestF5NotifyOnReport_NoWebhookNoOp(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// A recorder exists but is never wired into config — so nothing should
+	// reach it.
+	rec := f5newNotifyRecorder(t)
+
+	actor := service.Actor{Type: "agent", ID: "agent-f5", Name: "Watchdog"}
+	if _, err := svc.CreateAgentReport(ctx,
+		"No sink", "This report has nowhere to go.",
+		actor, "info", nil, "", "", ""); err != nil {
+		t.Fatalf("CreateAgentReport: %v", err)
+	}
+
+	rec.expectNoFire(t, 750*time.Millisecond)
+}
+
+// TestF5NotifyOnReport_OperatorReportNoFire proves an operator-submitted
+// report (actor.Type == "user") does NOT fire a notification even when a
+// webhook is configured — only workflow/agent reports notify.
+func TestF5NotifyOnReport_OperatorReportNoFire(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	rec := f5newNotifyRecorder(t)
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{NotifyWebhookURL: &rec.srv.URL}, devEncKey, ""); err != nil {
+		t.Fatalf("set webhook: %v", err)
+	}
+
+	actor := service.Actor{Type: "user", ID: "operator-1", Name: "Ricardo"}
+	if _, err := svc.CreateAgentReport(ctx,
+		"Manual note", "Operator-authored report, should stay silent.",
+		actor, "info", nil, "", "", ""); err != nil {
+		t.Fatalf("CreateAgentReport: %v", err)
+	}
+
+	rec.expectNoFire(t, 750*time.Millisecond)
+}

--- a/internal/service/notify_payload_shape_unit_test.go
+++ b/internal/service/notify_payload_shape_unit_test.go
@@ -1,0 +1,148 @@
+//go:build !lite
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// T4_unmarshal parses raw JSON into a map so each test can inspect
+// exactly which keys are present without relying on struct field defaults.
+func T4_unmarshal(t *testing.T, p NotificationPayload) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("T4: json.Marshal failed: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("T4: json.Unmarshal failed: %v", err)
+	}
+	return m
+}
+
+// T4_requireKey asserts a key is present in the map.
+func T4_requireKey(t *testing.T, m map[string]any, key string) {
+	t.Helper()
+	if _, ok := m[key]; !ok {
+		t.Errorf("T4: expected key %q to be present in JSON output", key)
+	}
+}
+
+// T4_refuseKey asserts a key is absent from the map (omitempty omitted it).
+func T4_refuseKey(t *testing.T, m map[string]any, key string) {
+	t.Helper()
+	if _, ok := m[key]; ok {
+		t.Errorf("T4: expected key %q to be omitted from JSON output (omitempty)", key)
+	}
+}
+
+// TestT4_NotificationPayload_RequiredKeysAlwaysPresent confirms that event,
+// title, and sent_at are always emitted regardless of other field values.
+func TestT4_NotificationPayload_RequiredKeysAlwaysPresent(t *testing.T) {
+	p := NotificationPayload{
+		Event:  "test",
+		Title:  "hello",
+		SentAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	m := T4_unmarshal(t, p)
+	T4_requireKey(t, m, "event")
+	T4_requireKey(t, m, "title")
+	T4_requireKey(t, m, "sent_at")
+}
+
+// TestT4_NotificationPayload_OmitemptyFieldsOmittedWhenBlank verifies that
+// body, priority, workflow, and url are omitted when their values are empty
+// strings.
+func TestT4_NotificationPayload_OmitemptyFieldsOmittedWhenBlank(t *testing.T) {
+	p := NotificationPayload{
+		Event:  "report",
+		Title:  "Monthly digest",
+		SentAt: time.Now().UTC().Format(time.RFC3339),
+		// Body, Priority, Workflow, URL intentionally left blank.
+	}
+	m := T4_unmarshal(t, p)
+	T4_refuseKey(t, m, "body")
+	T4_refuseKey(t, m, "priority")
+	T4_refuseKey(t, m, "workflow")
+	T4_refuseKey(t, m, "url")
+}
+
+// TestT4_NotificationPayload_OmitemptyFieldsPresentWhenSet verifies that the
+// optional fields are included when non-empty.
+func TestT4_NotificationPayload_OmitemptyFieldsPresentWhenSet(t *testing.T) {
+	p := NotificationPayload{
+		Event:    "report",
+		Title:    "Weekly digest",
+		Body:     "Here is your weekly summary.",
+		Priority: "info",
+		Workflow: "weekly-review",
+		URL:      "https://breadbox.example.com/workflows/runs/abc123",
+		SentAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	m := T4_unmarshal(t, p)
+	T4_requireKey(t, m, "event")
+	T4_requireKey(t, m, "title")
+	T4_requireKey(t, m, "sent_at")
+	T4_requireKey(t, m, "body")
+	T4_requireKey(t, m, "priority")
+	T4_requireKey(t, m, "workflow")
+	T4_requireKey(t, m, "url")
+}
+
+// TestT4_NotificationPayload_EventValueRoundtrip verifies the event string
+// value is preserved exactly through JSON serialisation.
+func TestT4_NotificationPayload_EventValueRoundtrip(t *testing.T) {
+	for _, event := range []string{"test", "report"} {
+		p := NotificationPayload{
+			Event:  event,
+			Title:  "title",
+			SentAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		m := T4_unmarshal(t, p)
+		if got, ok := m["event"].(string); !ok || got != event {
+			t.Errorf("T4: event = %v, want %q", m["event"], event)
+		}
+	}
+}
+
+// TestT4_NotificationPayload_SentAtIsRFC3339 checks that SentAt round-trips
+// as a valid RFC3339 timestamp.
+func TestT4_NotificationPayload_SentAtIsRFC3339(t *testing.T) {
+	now := time.Now().UTC()
+	p := NotificationPayload{
+		Event:  "test",
+		Title:  "ts check",
+		SentAt: now.Format(time.RFC3339),
+	}
+	m := T4_unmarshal(t, p)
+	raw, ok := m["sent_at"].(string)
+	if !ok {
+		t.Fatalf("T4: sent_at is not a string: %T", m["sent_at"])
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Errorf("T4: sent_at %q is not valid RFC3339: %v", raw, err)
+	}
+	// Truncate to second precision for comparison (RFC3339 has second resolution).
+	if !parsed.Equal(now.Truncate(time.Second)) {
+		t.Errorf("T4: sent_at round-trip mismatch: got %v, want %v", parsed, now.Truncate(time.Second))
+	}
+}
+
+// TestT4_NotificationPayload_TitleValueRoundtrip ensures the title is preserved
+// verbatim (no JSON escaping issues for typical headline text).
+func TestT4_NotificationPayload_TitleValueRoundtrip(t *testing.T) {
+	const want = "Breadbox workflow notification test"
+	p := NotificationPayload{
+		Event:  "test",
+		Title:  want,
+		SentAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	m := T4_unmarshal(t, p)
+	if got, ok := m["title"].(string); !ok || got != want {
+		t.Errorf("T4: title = %v, want %q", m["title"], want)
+	}
+}

--- a/internal/service/notify_send_recorder_integration_test.go
+++ b/internal/service/notify_send_recorder_integration_test.go
@@ -1,0 +1,170 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestT16NotifyNoOpWhenUnconfigured verifies that SendWorkflowNotification
+// returns nil without contacting any server when KeyNotifyWebhookURL is unset.
+func TestT16NotifyNoOpWhenUnconfigured(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// No webhook URL has been written to app_config — expect a silent no-op.
+	var called atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Deliberately do NOT set the URL in app_config.
+	err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{
+		Event: "test",
+		Title: "T16 no-op check",
+	})
+	if err != nil {
+		t.Fatalf("T16: unconfigured SendWorkflowNotification should return nil, got %v", err)
+	}
+	if called.Load() {
+		t.Fatal("T16: httptest server was called, but no URL was configured")
+	}
+}
+
+// TestT16NotifyPostsJSONWhenConfigured verifies that SendWorkflowNotification
+// makes a POST with the correct Content-Type and a well-formed JSON body
+// when KeyNotifyWebhookURL is set.
+func TestT16NotifyPostsJSONWhenConfigured(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	type captured struct {
+		method      string
+		contentType string
+		userAgent   string
+		body        []byte
+	}
+	var got captured
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.contentType = r.Header.Get("Content-Type")
+		got.userAgent = r.Header.Get("User-Agent")
+		got.body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Configure the webhook URL via UpdateAgentSettings (the canonical write path).
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+		NotifyWebhookURL: &srv.URL,
+	}, devEncKey, ""); err != nil {
+		t.Fatalf("T16: set webhook URL: %v", err)
+	}
+
+	payload := service.NotificationPayload{
+		Event:    "report",
+		Title:    "T16 test charge",
+		Body:     "A suspicious transaction was flagged.",
+		Priority: "warning",
+		Workflow: "routine-reviewer",
+	}
+	if err := svc.SendWorkflowNotification(ctx, payload); err != nil {
+		t.Fatalf("T16: SendWorkflowNotification: %v", err)
+	}
+
+	// Verify HTTP method.
+	if got.method != http.MethodPost {
+		t.Errorf("T16: method = %q, want POST", got.method)
+	}
+
+	// Verify Content-Type header.
+	if got.contentType != "application/json" {
+		t.Errorf("T16: Content-Type = %q, want application/json", got.contentType)
+	}
+
+	// Verify User-Agent header.
+	if !strings.Contains(got.userAgent, "breadbox") {
+		t.Errorf("T16: User-Agent = %q, want it to contain 'breadbox'", got.userAgent)
+	}
+
+	// Verify body is valid JSON and contains the expected fields.
+	var p map[string]any
+	if err := json.Unmarshal(got.body, &p); err != nil {
+		t.Fatalf("T16: response body is not valid JSON: %v (raw: %s)", err, got.body)
+	}
+	checks := map[string]any{
+		"event":    "report",
+		"title":    "T16 test charge",
+		"priority": "warning",
+		"workflow": "routine-reviewer",
+	}
+	for field, want := range checks {
+		if p[field] != want {
+			t.Errorf("T16: JSON field %q = %v, want %v", field, p[field], want)
+		}
+	}
+
+	// sent_at must be a non-empty RFC3339-ish string.
+	sentAt, ok := p["sent_at"].(string)
+	if !ok || sentAt == "" {
+		t.Errorf("T16: sent_at missing or not a string, got %v", p["sent_at"])
+	}
+}
+
+// TestT16NotifyErrorOnNon2xx verifies that SendWorkflowNotification returns a
+// non-nil error when the remote webhook responds with a non-2xx status code.
+func TestT16NotifyErrorOnNon2xx(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"bad_request_400", http.StatusBadRequest},
+		{"not_found_404", http.StatusNotFound},
+		{"server_error_500", http.StatusInternalServerError},
+		{"service_unavailable_503", http.StatusServiceUnavailable},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			// (Re-)configure the webhook URL for each sub-test.
+			if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+				NotifyWebhookURL: &srv.URL,
+			}, devEncKey, ""); err != nil {
+				t.Fatalf("T16: set webhook URL: %v", err)
+			}
+
+			err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{
+				Event: "test",
+				Title: "T16 error probe",
+			})
+			if err == nil {
+				t.Fatalf("T16: expected error for HTTP %d, got nil", tc.status)
+			}
+			// The error message should mention the status code.
+			if !strings.Contains(err.Error(), "HTTP") {
+				t.Errorf("T16: error %v does not mention HTTP status", err)
+			}
+		})
+	}
+}

--- a/internal/service/notify_url_validation_unit_test.go
+++ b/internal/service/notify_url_validation_unit_test.go
@@ -1,0 +1,74 @@
+//go:build !lite
+
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+// T3NotifyURLValid verifies that well-formed http and https URLs with a host
+// are accepted by validateNotifyURL.
+func TestT3NotifyURLValid(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"http with host", "http://example.com/hook"},
+		{"https with host", "https://ntfy.sh/topic"},
+		{"http with port", "http://localhost:9000/webhook"},
+		{"https with path and query", "https://hooks.example.com/services/x/y/z?token=abc"},
+		{"https IP host", "https://192.168.1.1/notify"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNotifyURL(tc.url)
+			if err != nil {
+				t.Errorf("validateNotifyURL(%q) = %v, want nil", tc.url, err)
+			}
+		})
+	}
+}
+
+// T3NotifyURLInvalid verifies that validateNotifyURL returns ErrInvalidParameter
+// for empty strings, URLs missing a scheme, ftp:// URLs, and host-less URLs.
+func TestT3NotifyURLInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"empty string", ""},
+		{"missing scheme bare host", "example.com/hook"},
+		{"missing scheme no slash", "example.com"},
+		{"ftp scheme", "ftp://example.com/resource"},
+		{"host-less https", "https://"},
+		{"host-less http", "http://"},
+		{"no scheme path only", "/just/a/path"},
+		{"javascript scheme", "javascript:alert(1)"},
+		{"file scheme", "file:///etc/passwd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNotifyURL(tc.url)
+			if err == nil {
+				t.Errorf("validateNotifyURL(%q) = nil, want error", tc.url)
+				return
+			}
+			if !errors.Is(err, ErrInvalidParameter) {
+				t.Errorf("validateNotifyURL(%q) error = %v, want errors.Is(err, ErrInvalidParameter) = true", tc.url, err)
+			}
+		})
+	}
+}
+
+// T3NotifyURLErrWrapping verifies that the error returned by validateNotifyURL
+// wraps ErrInvalidParameter so callers can use errors.Is for dispatch.
+func TestT3NotifyURLErrWrapping(t *testing.T) {
+	err := validateNotifyURL("ftp://example.com")
+	if err == nil {
+		t.Fatal("expected error for ftp scheme, got nil")
+	}
+	if !errors.Is(err, ErrInvalidParameter) {
+		t.Errorf("expected error to wrap ErrInvalidParameter, got: %v", err)
+	}
+}

--- a/internal/service/post_sync_debounce_integration_test.go
+++ b/internal/service/post_sync_debounce_integration_test.go
@@ -1,0 +1,141 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/service"
+)
+
+// TestT11_FireSyncCompleteAgents_DebounceWindow exercises the two-sided
+// post-sync debounce: a definition that ran within PostSyncDebounceWindow is
+// skipped row-lessly, while a definition whose last run is older than the
+// window IS dispatched on the same sync-complete event.
+//
+// Seeds two eligible agents (enabled=true, trigger_on_sync_complete=true):
+//   - "t11-within-window": last non-skipped run started at NOW()
+//     (squarely inside the debounce window)
+//   - "t11-outside-window": last non-skipped run started at
+//     NOW() - 2*PostSyncDebounceWindow (clearly outside the window)
+//
+// After FireSyncCompleteAgents fires, exactly one runner invocation is
+// expected -- the outside-window agent. The within-window agent is silently
+// coalesced: the debounce is intentionally row-less (design-doc section 4 --
+// a coalesced trigger is not a "missed" run worth a skipped row).
+func TestT11_FireSyncCompleteAgents_DebounceWindow(t *testing.T) {
+	svc, _, pool := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	ctx := context.Background()
+
+	// Both agents are eligible: enabled=true, trigger_on_sync_complete=true.
+	defInWindow := mustCreateWebhookAgent(t, svc, "t11-within-window", true, true)
+	defOutWindow := mustCreateWebhookAgent(t, svc, "t11-outside-window", true, true)
+
+	// Seed a recent non-skipped run for the within-window agent.
+	// started_at = NOW() places it squarely inside PostSyncDebounceWindow.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
+		 VALUES ($1, 'webhook', 'success', NOW())`,
+		defInWindow.ID,
+	); err != nil {
+		t.Fatalf("seed within-window run: %v", err)
+	}
+
+	// Seed an old non-skipped run for the outside-window agent.
+	// 2*PostSyncDebounceWindow ensures the row is well outside the boundary
+	// even under slow test-execution clock drift.
+	oldAge := 2 * service.PostSyncDebounceWindow
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
+		 VALUES ($1, 'webhook', 'success', NOW() - $2::interval)`,
+		defOutWindow.ID, oldAge.String(),
+	); err != nil {
+		t.Fatalf("seed outside-window run: %v", err)
+	}
+
+	// Channel buffered to 4 to catch unexpected extra fires without blocking.
+	fired := make(chan string, 4)
+	runner := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		fired <- spec.AgentDefinitionID
+		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
+	})
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+
+	orch.FireSyncCompleteAgents(ctx)
+
+	// Wait for exactly one fire: the outside-window agent.
+	var got []string
+	select {
+	case id := <-fired:
+		got = append(got, id)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout: expected one runner fire (outside-window agent); got none")
+	}
+
+	// Short tail to detect any unexpected second fire (within-window agent
+	// must be debounced row-lessly, not dispatched).
+	select {
+	case extraID := <-fired:
+		t.Fatalf("unexpected extra fire from agent %q; within-window agent should be coalesced silently", extraID)
+	case <-time.After(300 * time.Millisecond):
+		// pass -- no extras
+	}
+
+	// Confirm the single fire came from the outside-window agent.
+	if got[0] != defOutWindow.ID {
+		t.Errorf("fired agent ID = %q, want %q (outside-window agent)", got[0], defOutWindow.ID)
+	}
+}
+
+// TestT11_FireSyncCompleteAgents_SkippedRunDoesNotDebounce verifies that a
+// 'skipped' run inside PostSyncDebounceWindow does NOT anchor the debounce.
+// ExistsRecentRunForDefinition uses "status <> 'skipped'" in its WHERE
+// clause, so skipped rows are invisible to the check and the definition
+// remains eligible for dispatch on the next sync-complete event.
+func TestT11_FireSyncCompleteAgents_SkippedRunDoesNotDebounce(t *testing.T) {
+	svc, _, pool := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+	ctx := context.Background()
+
+	def := mustCreateWebhookAgent(t, svc, "t11-skip-no-debounce", true, true)
+
+	// Seed a skipped run inside the debounce window.
+	// A skipped status must NOT suppress the next sync-complete dispatch.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
+		 VALUES ($1, 'webhook', 'skipped', NOW())`,
+		def.ID,
+	); err != nil {
+		t.Fatalf("seed skipped run: %v", err)
+	}
+
+	fired := make(chan struct{}, 2)
+	runner := agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		fired <- struct{}{}
+		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
+	})
+	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
+
+	orch.FireSyncCompleteAgents(ctx)
+
+	// Must fire: skipped rows are excluded from the debounce predicate.
+	select {
+	case <-fired:
+		// pass -- correctly dispatched despite a skipped run being in the window
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: definition should have been dispatched (skipped-only run must not debounce)")
+	}
+
+	// No spurious double-fire expected.
+	select {
+	case <-fired:
+		t.Fatal("unexpected second fire")
+	case <-time.After(200 * time.Millisecond):
+		// pass
+	}
+}

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
@@ -124,7 +125,30 @@ func (s *Service) CreateAgentReport(ctx context.Context, title, body string, act
 		return AgentReportResponse{}, fmt.Errorf("create agent report: %w", err)
 	}
 
-	return agentReportFromRow(report), nil
+	resp := agentReportFromRow(report)
+
+	// Fan the report out to the operator's configured notification sink.
+	// Only workflow/agent-authored reports notify — an operator submitting
+	// a report from the dashboard doesn't need to be pinged about their own
+	// action. This is strictly best-effort: it runs async on a fresh,
+	// time-bounded context (the request ctx may already be cancelled by the
+	// time the webhook fires) and never blocks or fails report creation.
+	// SendWorkflowNotification is itself a no-op when no webhook is set, so
+	// the goroutine is cheap in the common (unconfigured) case.
+	if actor.Type == "agent" {
+		payload := reportNotificationPayload(resp, actor.Name)
+		go func() {
+			nctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := s.SendWorkflowNotification(nctx, payload); err != nil && s.Logger != nil {
+				s.Logger.Warn("workflow report notification failed",
+					"report_id", resp.ShortID,
+					"error", err)
+			}
+		}()
+	}
+
+	return resp, nil
 }
 
 // AgentRunReportSummary is the compact report-reference shape rendered

--- a/internal/service/spend_ceiling_enforcement_integration_test.go
+++ b/internal/service/spend_ceiling_enforcement_integration_test.go
@@ -1,0 +1,297 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"breadbox/internal/agent"
+	"breadbox/internal/service"
+)
+
+// T10 prefix — unique across all integration-test agents in this package.
+
+// T10_neverRunner returns a RunnerFunc that fails the test immediately if invoked.
+// Used to assert the runner is never called when the ceiling gate fires.
+func T10_neverRunner(t *testing.T) agent.Runner {
+	t.Helper()
+	return agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		t.Error("T10: runner must NOT be invoked when the household ceiling is reached")
+		return agent.RunResult{Status: agent.StatusSuccess}, nil
+	})
+}
+
+// T10_successRunner returns a RunnerFunc that succeeds instantly.
+// Used to prove that runs proceed normally when no ceiling is set (or spend is under it).
+func T10_successRunner() agent.Runner {
+	return agent.RunnerFunc(func(_ context.Context, _ agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
+		return agent.RunResult{Status: agent.StatusSuccess, TurnCount: 1, DurationMs: 5}, nil
+	})
+}
+
+// TestT10_SpendCeilingEnforcement_ManualRunReturnsError verifies that
+// RunNow returns ErrBudgetCeilingReached (without creating a run row) when
+// KeyAgentGlobalMaxBudgetUSD is set and the rolling 30-day spend has reached it.
+func TestT10_SpendCeilingEnforcement_ManualRunReturnsError(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "t10-manual-ceiling", true)
+
+	// Configure a $0.10 ceiling.
+	ceiling := 0.10
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+		GlobalMaxBudgetUSD: &ceiling,
+	}, encKey, ""); err != nil {
+		t.Fatalf("T10: set ceiling: %v", err)
+	}
+
+	// Seed two completed runs whose costs sum to $0.13 — over the ceiling.
+	for _, cost := range []string{"0.07", "0.06"} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+			 VALUES ($1, 'cron', 'success', $2, NOW())`,
+			def.ID, cost,
+		); err != nil {
+			t.Fatalf("T10: insert run: %v", err)
+		}
+	}
+
+	orch := service.NewOrchestrator(svc, T10_neverRunner(t), 1, encKey, slog.Default())
+
+	resp, err := orch.RunNow(ctx, def, "")
+	if !errors.Is(err, service.ErrBudgetCeilingReached) {
+		t.Fatalf("T10: RunNow err = %v, want ErrBudgetCeilingReached", err)
+	}
+	// RunNow returns nil resp when the ceiling gate fires — no row is created.
+	if resp != nil {
+		t.Errorf("T10: RunNow should return nil resp when ceiling fires (no row created), got %+v", resp)
+	}
+
+	// The error message must carry dollar-amount context so operators know the figures.
+	if !strings.Contains(err.Error(), "$") {
+		t.Errorf("T10: ceiling error should include dollar amounts, got: %v", err)
+	}
+}
+
+// TestT10_SpendCeilingEnforcement_CronPathLeavesSkippedRow verifies that
+// RunOrSkip (the cron/webhook path) creates a 'skipped' row with the ceiling
+// message as error_message when the 30-day spend is at or over the ceiling.
+func TestT10_SpendCeilingEnforcement_CronPathLeavesSkippedRow(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "t10-cron-ceiling", true)
+
+	// Configure a $0.05 ceiling.
+	ceiling := 0.05
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+		GlobalMaxBudgetUSD: &ceiling,
+	}, encKey, ""); err != nil {
+		t.Fatalf("T10: set ceiling: %v", err)
+	}
+
+	// Seed a run at exactly the ceiling amount. The gate condition is spent >= ceiling,
+	// so $0.05 spent against a $0.05 ceiling must block the next run.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		 VALUES ($1, 'cron', 'success', $2, NOW())`,
+		def.ID, "0.05",
+	); err != nil {
+		t.Fatalf("T10: insert run at ceiling: %v", err)
+	}
+
+	orch := service.NewOrchestrator(svc, T10_neverRunner(t), 1, encKey, slog.Default())
+
+	resp, err := orch.RunOrSkip(ctx, def, "cron")
+	if !errors.Is(err, service.ErrBudgetCeilingReached) {
+		t.Fatalf("T10: RunOrSkip err = %v, want ErrBudgetCeilingReached", err)
+	}
+	// RunOrSkip must always create a row — even for ceiling fires.
+	if resp == nil {
+		t.Fatal("T10: RunOrSkip must return a skipped run row, got nil")
+	}
+	if resp.Status != "skipped" {
+		t.Errorf("T10: resp.Status = %q, want skipped", resp.Status)
+	}
+	if resp.Trigger != "cron" {
+		t.Errorf("T10: resp.Trigger = %q, want cron", resp.Trigger)
+	}
+
+	// The row must be durable in the DB.
+	persisted, perr := svc.GetAgentRun(ctx, resp.ShortID)
+	if perr != nil {
+		t.Fatalf("T10: GetAgentRun: %v", perr)
+	}
+	if persisted.Status != "skipped" {
+		t.Errorf("T10: persisted Status = %q, want skipped", persisted.Status)
+	}
+	// The ceiling reason must surface in error_message so operators know why.
+	if persisted.ErrorMessage == nil {
+		t.Error("T10: persisted ErrorMessage should contain the ceiling reason, got nil")
+	} else if !strings.Contains(*persisted.ErrorMessage, "ceiling") &&
+		!strings.Contains(*persisted.ErrorMessage, "spend") &&
+		!strings.Contains(*persisted.ErrorMessage, "budget") {
+		t.Errorf("T10: persisted ErrorMessage = %q, expected ceiling/spend/budget language", *persisted.ErrorMessage)
+	}
+}
+
+// TestT10_SpendCeilingEnforcement_UnsetCeilingNoCap verifies that when
+// KeyAgentGlobalMaxBudgetUSD is not set (the default), RunNow succeeds even
+// with substantial 30-day spend — no artificial cap is applied.
+func TestT10_SpendCeilingEnforcement_UnsetCeilingNoCap(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "t10-unset-ceiling", true)
+
+	// Seed a large spend. If checkHouseholdCeiling correctly returns nil for
+	// an unset key, this spend must not block the run.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		 VALUES ($1, 'cron', 'success', $2, NOW())`,
+		def.ID, "999.99",
+	); err != nil {
+		t.Fatalf("T10: insert large-cost run: %v", err)
+	}
+
+	// Deliberately do NOT set GlobalMaxBudgetUSD — leave it unset.
+
+	orch := service.NewOrchestrator(svc, T10_successRunner(), 1, encKey, slog.Default())
+
+	resp, err := orch.RunNow(ctx, def, "")
+	if err != nil {
+		t.Fatalf("T10: RunNow with unset ceiling err = %v, want nil", err)
+	}
+	if resp == nil || resp.Status != agent.StatusSuccess {
+		t.Errorf("T10: expected success run, got resp=%v", resp)
+	}
+}
+
+// TestT10_SpendCeilingEnforcement_ZeroCeilingNoCap verifies that a ceiling
+// explicitly set to 0.0 is treated as "no limit" — runs are not blocked.
+// This is enforced by the `<= 0` guard in checkHouseholdCeiling.
+func TestT10_SpendCeilingEnforcement_ZeroCeilingNoCap(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "t10-zero-ceiling", true)
+
+	// Set the ceiling to 0.0 (explicit "no cap").
+	zeroCeiling := 0.0
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+		GlobalMaxBudgetUSD: &zeroCeiling,
+	}, encKey, ""); err != nil {
+		t.Fatalf("T10: set zero ceiling: %v", err)
+	}
+
+	// Seed spend that would block a naive zero-ceiling implementation.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		 VALUES ($1, 'cron', 'success', $2, NOW())`,
+		def.ID, "50.00",
+	); err != nil {
+		t.Fatalf("T10: insert run: %v", err)
+	}
+
+	orch := service.NewOrchestrator(svc, T10_successRunner(), 1, encKey, slog.Default())
+
+	resp, err := orch.RunNow(ctx, def, "")
+	if err != nil {
+		t.Fatalf("T10: RunNow with zero ceiling err = %v, want nil", err)
+	}
+	if resp == nil || resp.Status != agent.StatusSuccess {
+		t.Errorf("T10: expected success run with zero ceiling, got %v", resp)
+	}
+}
+
+// TestT10_SpendCeilingEnforcement_SpendUnderCeilingAllowsRun verifies that
+// when 30-day spend is below the configured ceiling, RunNow completes normally.
+func TestT10_SpendCeilingEnforcement_SpendUnderCeilingAllowsRun(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "t10-under-ceiling", true)
+
+	// Set a $1.00 ceiling — high enough that $0.10 spend is safely under it.
+	ceiling := 1.00
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+		GlobalMaxBudgetUSD: &ceiling,
+	}, encKey, ""); err != nil {
+		t.Fatalf("T10: set ceiling: %v", err)
+	}
+
+	// Seed $0.10 worth of runs — well under the $1.00 ceiling.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		 VALUES ($1, 'cron', 'success', $2, NOW())`,
+		def.ID, "0.10",
+	); err != nil {
+		t.Fatalf("T10: insert run: %v", err)
+	}
+
+	orch := service.NewOrchestrator(svc, T10_successRunner(), 1, encKey, slog.Default())
+
+	resp, err := orch.RunNow(ctx, def, "")
+	if err != nil {
+		t.Fatalf("T10: RunNow under ceiling err = %v, want nil", err)
+	}
+	if resp == nil || resp.Status != agent.StatusSuccess {
+		t.Errorf("T10: expected success run, got %v", resp)
+	}
+}
+
+// TestT10_SpendCeilingEnforcement_SkippedRunsExcludedFromSpend verifies that
+// skipped workflow_runs are NOT counted toward the 30-day spend ceiling.
+// Skipped rows never consumed API budget; including them would inflate the
+// spend figure and cause false ceiling fires. Mirrors HouseholdCostSince's
+// exclusion of status='skipped' rows.
+func TestT10_SpendCeilingEnforcement_SkippedRunsExcludedFromSpend(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+	encKey := seedSubscriptionAuth(t, svc)
+	def := mustCreateAgentDefinition(t, svc, "t10-skipped-excluded", true)
+
+	// $0.10 ceiling.
+	ceiling := 0.10
+	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
+		GlobalMaxBudgetUSD: &ceiling,
+	}, encKey, ""); err != nil {
+		t.Fatalf("T10: set ceiling: %v", err)
+	}
+
+	// Insert a skipped run with an inflated cost value. In practice skipped
+	// rows carry no real cost, but this explicitly guards the exclusion logic.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		 VALUES ($1, 'cron', 'skipped', $2, NOW())`,
+		def.ID, "5.00",
+	); err != nil {
+		t.Fatalf("T10: insert skipped run: %v", err)
+	}
+
+	// Also insert a small real-cost run well under the ceiling.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		 VALUES ($1, 'cron', 'success', $2, NOW())`,
+		def.ID, "0.02",
+	); err != nil {
+		t.Fatalf("T10: insert success run: %v", err)
+	}
+
+	// Effective spend = $0.02 (skipped $5.00 excluded). Ceiling = $0.10 —
+	// run must be allowed.
+	orch := service.NewOrchestrator(svc, T10_successRunner(), 1, encKey, slog.Default())
+
+	resp, err := orch.RunNow(ctx, def, "")
+	if err != nil {
+		t.Fatalf("T10: RunNow (skipped excluded) err = %v; skipped run must not count toward ceiling", err)
+	}
+	if resp == nil || resp.Status != agent.StatusSuccess {
+		t.Errorf("T10: expected success run, got %v", resp)
+	}
+}

--- a/internal/service/transaction_flag_filter_integration_test.go
+++ b/internal/service/transaction_flag_filter_integration_test.go
@@ -1,0 +1,316 @@
+//go:build integration && !lite
+
+// Integration tests for the flagged filter on transaction query/count (T21).
+// Specifically verifies that flagging a transaction makes it appear in the
+// ?flagged=true filter and affects CountTransactionsFiltered, and that
+// unflagging reverses both effects.
+//
+// The existing transaction_flag_integration_test.go (TestFlagTransaction) covers
+// single-transaction FlaggedAt field correctness and comment creation.
+// This file covers the multi-transaction COUNT and LIST filter semantics more
+// exhaustively, using the T21 prefix to avoid name collisions.
+//
+// Run with: make test-integration
+//
+// IMPORTANT: Do NOT use t.Parallel() — tests share a database and truncate between runs.
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// t21SeedFlagFixture creates a user → connection → account and three transactions.
+// Returns the service and an array of three short_id strings:
+// [0] and [1] are intended to be flagged, [2] remains unflagged in most tests.
+func t21SeedFlagFixture(t *testing.T) (svc *service.Service, txnIDs [3]string) {
+	t.Helper()
+	svc, queries, _ := newService(t)
+
+	user := testutil.MustCreateUser(t, queries, "T21Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "t21_item")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "t21_ext", "T21 Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "t21_flagged_1", "T21 Flagged Coffee", 500, "2025-03-10")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "t21_flagged_2", "T21 Flagged Lunch", 1200, "2025-03-11")
+	txn3 := testutil.MustCreateTransaction(t, queries, acct.ID, "t21_unflagged", "T21 Normal Dinner", 2500, "2025-03-12")
+
+	txnIDs[0] = txn1.ShortID
+	txnIDs[1] = txn2.ShortID
+	txnIDs[2] = txn3.ShortID
+	return svc, txnIDs
+}
+
+// TestT21_ListTransactions_FlaggedTrue verifies that only flagged transactions
+// appear in ListTransactions when Flagged=true.
+func TestT21_ListTransactions_FlaggedTrue(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	// Flag the first two transactions; leave the third unflagged.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "needs review", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn1): %v", err)
+	}
+	if err := svc.FlagTransaction(ctx, txnIDs[1], "", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn2): %v", err)
+	}
+
+	flaggedTrue := true
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=true): %v", err)
+	}
+
+	if len(result.Transactions) != 2 {
+		t.Errorf("expected 2 flagged transactions, got %d", len(result.Transactions))
+	}
+
+	// Verify FlaggedAt is populated on all returned rows.
+	for _, txn := range result.Transactions {
+		if txn.FlaggedAt == nil || *txn.FlaggedAt == "" {
+			t.Errorf("expected FlaggedAt to be set for transaction %s, got nil/empty", txn.ID)
+		}
+	}
+}
+
+// TestT21_ListTransactions_FlaggedFalse verifies that only unflagged transactions
+// appear in ListTransactions when Flagged=false.
+func TestT21_ListTransactions_FlaggedFalse(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	// Flag two; leave one unflagged.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn1): %v", err)
+	}
+	if err := svc.FlagTransaction(ctx, txnIDs[1], "", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn2): %v", err)
+	}
+
+	flaggedFalse := false
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &flaggedFalse})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=false): %v", err)
+	}
+
+	if len(result.Transactions) != 1 {
+		t.Errorf("expected 1 unflagged transaction, got %d", len(result.Transactions))
+	}
+
+	// The remaining transaction should have no FlaggedAt.
+	for _, txn := range result.Transactions {
+		if txn.FlaggedAt != nil && *txn.FlaggedAt != "" {
+			t.Errorf("expected FlaggedAt to be nil/empty for unflagged transaction %s, got %q", txn.ID, *txn.FlaggedAt)
+		}
+	}
+}
+
+// TestT21_CountTransactionsFiltered_FlaggedTrue verifies that
+// CountTransactionsFiltered returns the correct count before and after flagging
+// when Flagged=true.
+func TestT21_CountTransactionsFiltered_FlaggedTrue(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	flaggedTrue := true
+
+	// No flags yet — count should be 0.
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=true, before flag): %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 flagged before flagging, got %d", count)
+	}
+
+	// Flag the first two transactions.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "urgent", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn1): %v", err)
+	}
+	if err := svc.FlagTransaction(ctx, txnIDs[1], "", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn2): %v", err)
+	}
+
+	// Count should now be 2.
+	count, err = svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=true, after flag): %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 flagged after flagging two, got %d", count)
+	}
+}
+
+// TestT21_CountTransactionsFiltered_FlaggedFalse verifies that
+// CountTransactionsFiltered decrements when one transaction is flagged.
+func TestT21_CountTransactionsFiltered_FlaggedFalse(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	flaggedFalse := false
+
+	// No flags yet — all 3 are unflagged.
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedFalse})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=false, before flag): %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 unflagged before flagging, got %d", count)
+	}
+
+	// Flag one transaction.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn1): %v", err)
+	}
+
+	// Count should now be 2 unflagged.
+	count, err = svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedFalse})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=false, after flag): %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 unflagged after flagging one, got %d", count)
+	}
+}
+
+// TestT21_FlagFilter_UnflagReverses verifies that unflagging a transaction
+// removes it from the flagged filter and restores it to the unflagged filter.
+// This is the core reversal test: flag all → unflag one → check counts and lists.
+func TestT21_FlagFilter_UnflagReverses(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	// Flag all three transactions.
+	for i, id := range txnIDs {
+		if err := svc.FlagTransaction(ctx, id, "", actor); err != nil {
+			t.Fatalf("FlagTransaction(txn%d): %v", i, err)
+		}
+	}
+
+	// Confirm all 3 are flagged.
+	flaggedTrue := true
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered after flagging all: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 flagged after flagging all, got %d", count)
+	}
+
+	// Unflag the first transaction.
+	if err := svc.UnflagTransaction(ctx, txnIDs[0]); err != nil {
+		t.Fatalf("UnflagTransaction(txn1): %v", err)
+	}
+
+	// Flagged count should drop to 2.
+	count, err = svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=true, after unflag): %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 flagged after unflagging one, got %d", count)
+	}
+
+	// Unflagged count should be 1.
+	flaggedFalse := false
+	count, err = svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedFalse})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=false, after unflag): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 unflagged after unflagging one, got %d", count)
+	}
+
+	// ListTransactions(flagged=true) should return 2 transactions.
+	resultFlagged, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=true, after unflag): %v", err)
+	}
+	if len(resultFlagged.Transactions) != 2 {
+		t.Errorf("expected 2 flagged transactions after unflag, got %d", len(resultFlagged.Transactions))
+	}
+
+	// ListTransactions(flagged=false) should return 1 transaction.
+	resultUnflagged, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &flaggedFalse})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=false, after unflag): %v", err)
+	}
+	if len(resultUnflagged.Transactions) != 1 {
+		t.Errorf("expected 1 unflagged transaction after unflag, got %d", len(resultUnflagged.Transactions))
+	}
+}
+
+// TestT21_FlagFilter_NoFlagParam verifies that omitting the Flagged param
+// returns all transactions regardless of flag status (no filter applied).
+func TestT21_FlagFilter_NoFlagParam(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	// Flag one transaction, leave two unflagged.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "", actor); err != nil {
+		t.Fatalf("FlagTransaction(txn1): %v", err)
+	}
+
+	// No Flagged filter — should return all 3.
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{})
+	if err != nil {
+		t.Fatalf("ListTransactions(no flag filter): %v", err)
+	}
+	if len(result.Transactions) != 3 {
+		t.Errorf("expected 3 transactions when no flag filter, got %d", len(result.Transactions))
+	}
+
+	// CountTransactionsFiltered with no Flagged filter — should also count all 3.
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(no flag filter): %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected count 3 when no flag filter, got %d", count)
+	}
+}
+
+// TestT21_FlagFilter_Reflag verifies that re-flagging an already-flagged
+// transaction is idempotent (last-write-wins semantics) and doesn't double-count.
+func TestT21_FlagFilter_Reflag(t *testing.T) {
+	svc, txnIDs := t21SeedFlagFixture(t)
+	ctx := context.Background()
+	actor := service.SystemActor()
+
+	// Flag once.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "first pass", actor); err != nil {
+		t.Fatalf("FlagTransaction first: %v", err)
+	}
+
+	// Re-flag the same transaction.
+	if err := svc.FlagTransaction(ctx, txnIDs[0], "second pass", actor); err != nil {
+		t.Fatalf("FlagTransaction second (reflag): %v", err)
+	}
+
+	// Flagged count must still be exactly 1 — not 2.
+	flaggedTrue := true
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("CountTransactionsFiltered(flagged=true, after reflag): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 flagged after reflag (no double-count), got %d", count)
+	}
+
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{Flagged: &flaggedTrue})
+	if err != nil {
+		t.Fatalf("ListTransactions(flagged=true, after reflag): %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Errorf("expected 1 flagged transaction after reflag, got %d", len(result.Transactions))
+	}
+}

--- a/internal/service/transaction_metadata_scoped_ops_integration_test.go
+++ b/internal/service/transaction_metadata_scoped_ops_integration_test.go
@@ -1,0 +1,414 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// T12metaOf reads a transaction's metadata back as a map for assertions.
+// Named with T12 prefix to avoid collision with metaOf in the sibling file.
+func T12metaOf(t *testing.T, svc *service.Service, id string) map[string]any {
+	t.Helper()
+	resp, err := svc.GetTransaction(context.Background(), id)
+	if err != nil {
+		t.Fatalf("T12metaOf GetTransaction(%q): %v", id, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(resp.Metadata, &m); err != nil {
+		t.Fatalf("T12metaOf unmarshal metadata %q: %v", string(resp.Metadata), err)
+	}
+	return m
+}
+
+// TestT12_SetMetadata_ValueSizeCap verifies that a value exceeding 4 KiB is
+// rejected with ErrInvalidParameter.  The existing suite only validates key
+// constraints; this covers the value ceiling.
+func TestT12_SetMetadata_ValueSizeCap(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_valcap", "ValCap Co", 100, "2026-02-01")
+	id := txn.ShortID
+
+	// A 4096-char string serialises to 4098 bytes (chars + surrounding quotes) - over 4096-byte cap.
+	bigVal := strings.Repeat("x", 4096)
+	err := svc.SetTransactionMetadata(ctx, id, "big", bigVal)
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Fatalf("4096-char string: err = %v, want ErrInvalidParameter", err)
+	}
+
+	// A 4094-char string serialises to 4096 bytes (4094 chars + 2 quotes) - exactly at the cap.
+	okVal := strings.Repeat("y", 4094)
+	if err := svc.SetTransactionMetadata(ctx, id, "ok", okVal); err != nil {
+		t.Fatalf("4094-char string (serialised = 4096 bytes): %v", err)
+	}
+}
+
+// TestT12_ReplaceMetadata_ObjectSizeCap verifies that replacing the entire blob
+// with an object whose serialised size exceeds 8 KiB is rejected.
+func TestT12_ReplaceMetadata_ObjectSizeCap(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_objcap", "ObjCap Co", 200, "2026-02-02")
+	id := txn.ShortID
+
+	// Build an object whose JSON is comfortably over the 8 KiB ceiling.
+	// Each entry serialises to ~407 bytes; 30 entries ≈ 12 KiB (> 8192).
+	big := map[string]any{}
+	for i := 0; i < 30; i++ {
+		// Each key is ~100 chars + a unique suffix; each value is ~300 chars.
+		key := strings.Repeat("k", 100) + string(rune('a'+i))
+		big[key] = strings.Repeat("v", 300)
+	}
+	if err := svc.ReplaceTransactionMetadata(ctx, id, big); !errors.Is(err, service.ErrInvalidParameter) {
+		t.Fatalf("oversized object: err = %v, want ErrInvalidParameter", err)
+	}
+}
+
+// TestT12_ReplaceMetadata_KeyValidation confirms that ReplaceTransactionMetadata
+// enforces key constraints the same way SetTransactionMetadata does.
+func TestT12_ReplaceMetadata_KeyValidation(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_replkey", "ReplKey Co", 300, "2026-02-03")
+	id := txn.ShortID
+
+	// Empty key inside the replacement object.
+	if err := svc.ReplaceTransactionMetadata(ctx, id, map[string]any{"": "v"}); !errors.Is(err, service.ErrInvalidParameter) {
+		t.Fatalf("empty key in replace: err = %v, want ErrInvalidParameter", err)
+	}
+
+	// Overlong key inside the replacement object.
+	longKey := strings.Repeat("k", 200)
+	if err := svc.ReplaceTransactionMetadata(ctx, id, map[string]any{longKey: "v"}); !errors.Is(err, service.ErrInvalidParameter) {
+		t.Fatalf("long key in replace: err = %v, want ErrInvalidParameter", err)
+	}
+
+	// After both failures, metadata is still the original empty object.
+	if m := T12metaOf(t, svc, id); len(m) != 0 {
+		t.Fatalf("metadata unexpectedly mutated after validation failure: %v", m)
+	}
+}
+
+// TestT12_RemoveMetadata_MissingTransaction verifies that RemoveTransactionMetadata
+// returns ErrNotFound for a non-existent transaction -- the existing suite only
+// tests this path for SetTransactionMetadata.
+func TestT12_RemoveMetadata_MissingTransaction(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	err := svc.RemoveTransactionMetadata(ctx, "nonexistent_remove", "key")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Fatalf("RemoveTransactionMetadata(missing): err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestT12_ReplaceMetadata_MissingTransaction verifies that ReplaceTransactionMetadata
+// returns ErrNotFound for a non-existent transaction.
+func TestT12_ReplaceMetadata_MissingTransaction(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	err := svc.ReplaceTransactionMetadata(ctx, "nonexistent_replace", map[string]any{"k": "v"})
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Fatalf("ReplaceTransactionMetadata(missing): err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestT12_ClearMetadata_MissingTransaction verifies that ClearTransactionMetadata
+// returns ErrNotFound for a non-existent transaction.
+func TestT12_ClearMetadata_MissingTransaction(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	err := svc.ClearTransactionMetadata(ctx, "nonexistent_clear")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Fatalf("ClearTransactionMetadata(missing): err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestT12_SetMetadata_JSONValueTypes verifies that the scoped Set op correctly
+// round-trips diverse JSON value types: nested object, array, integer, float,
+// and null.
+func TestT12_SetMetadata_JSONValueTypes(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_jsontypes", "JSONTypes Co", 500, "2026-02-04")
+	id := txn.ShortID
+
+	type valueCase struct {
+		key      string
+		val      any
+		assertFn func(got any)
+	}
+	cases := []valueCase{
+		{
+			key: "nested",
+			val: map[string]any{"inner": "value"},
+			assertFn: func(got any) {
+				m, ok := got.(map[string]any)
+				if !ok || m["inner"] != "value" {
+					t.Errorf("nested: got %v (%T)", got, got)
+				}
+			},
+		},
+		{
+			key: "arr",
+			val: []any{float64(1), "two", false},
+			assertFn: func(got any) {
+				arr, ok := got.([]any)
+				if !ok || len(arr) != 3 {
+					t.Errorf("arr: got %v (%T)", got, got)
+				}
+			},
+		},
+		{
+			key: "intval",
+			val: float64(42),
+			assertFn: func(got any) {
+				if got != float64(42) {
+					t.Errorf("intval: got %v (%T)", got, got)
+				}
+			},
+		},
+		{
+			key: "floatval",
+			val: 3.14,
+			assertFn: func(got any) {
+				f, ok := got.(float64)
+				if !ok || f < 3.13 || f > 3.15 {
+					t.Errorf("floatval: got %v (%T)", got, got)
+				}
+			},
+		},
+		{
+			key: "nullval",
+			val: nil,
+			assertFn: func(got any) {
+				if got != nil {
+					t.Errorf("nullval: got %v (%T), want nil", got, got)
+				}
+			},
+		},
+	}
+
+	for _, c := range cases {
+		if err := svc.SetTransactionMetadata(ctx, id, c.key, c.val); err != nil {
+			t.Fatalf("SetTransactionMetadata(%q): %v", c.key, err)
+		}
+	}
+
+	m := T12metaOf(t, svc, id)
+	for _, c := range cases {
+		c.assertFn(m[c.key])
+	}
+}
+
+// TestT12_SetMetadata_IsolatesFirstClassFields verifies that scoped Set ops
+// never touch first-class transaction columns (amount, provider_name).
+func TestT12_SetMetadata_IsolatesFirstClassFields(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_iso", "ISO Merchant", 4200, "2026-02-05")
+	id := txn.ShortID
+
+	// Set a metadata key.
+	if err := svc.SetTransactionMetadata(ctx, id, "note", "business expense"); err != nil {
+		t.Fatalf("SetTransactionMetadata: %v", err)
+	}
+
+	// Read first-class fields directly from DB to avoid any service-layer
+	// mapping surprises.
+	var (
+		providerName string
+		amountRaw    string // NUMERIC comes back as text via ::text cast
+	)
+	if err := pool.QueryRow(ctx,
+		"SELECT provider_name, amount::text FROM transactions WHERE id = $1",
+		txn.ID,
+	).Scan(&providerName, &amountRaw); err != nil {
+		t.Fatalf("QueryRow first-class fields: %v", err)
+	}
+	if providerName != "ISO Merchant" {
+		t.Errorf("provider_name mutated: got %q, want %q", providerName, "ISO Merchant")
+	}
+	// amount stored as NUMERIC(12,2): 4200 cents -> 42.00
+	if amountRaw != "42.00" {
+		t.Errorf("amount mutated: got %q, want %q", amountRaw, "42.00")
+	}
+}
+
+// TestT12_ClearMetadata_Idempotent verifies that clearing an already-empty
+// metadata blob succeeds and leaves the column as an empty object.
+func TestT12_ClearMetadata_Idempotent(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_clearidm", "ClearIdm Co", 700, "2026-02-06")
+	id := txn.ShortID
+
+	// First clear on an already-empty blob.
+	if err := svc.ClearTransactionMetadata(ctx, id); err != nil {
+		t.Fatalf("ClearTransactionMetadata (first, empty): %v", err)
+	}
+	if m := T12metaOf(t, svc, id); len(m) != 0 {
+		t.Fatalf("after first clear: metadata = %v, want empty", m)
+	}
+
+	// Set a key, clear, then clear again.
+	if err := svc.SetTransactionMetadata(ctx, id, "x", 1); err != nil {
+		t.Fatalf("SetTransactionMetadata: %v", err)
+	}
+	if err := svc.ClearTransactionMetadata(ctx, id); err != nil {
+		t.Fatalf("ClearTransactionMetadata (after set): %v", err)
+	}
+	if err := svc.ClearTransactionMetadata(ctx, id); err != nil {
+		t.Fatalf("ClearTransactionMetadata (second, empty again): %v", err)
+	}
+	if m := T12metaOf(t, svc, id); len(m) != 0 {
+		t.Fatalf("after double-clear: metadata = %v, want empty", m)
+	}
+}
+
+// TestT12_MetadataOps_ShortIDResolution verifies that all four scoped ops
+// accept a short_id in place of a UUID.
+func TestT12_MetadataOps_ShortIDResolution(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_shortid", "ShortID Co", 800, "2026-02-07")
+	shortID := txn.ShortID
+
+	if len(shortID) != 8 {
+		t.Fatalf("expected 8-char short_id, got %q (len=%d)", shortID, len(shortID))
+	}
+
+	// Set via short_id.
+	if err := svc.SetTransactionMetadata(ctx, shortID, "s", "short"); err != nil {
+		t.Fatalf("SetTransactionMetadata(short_id): %v", err)
+	}
+
+	// Remove via short_id.
+	if err := svc.RemoveTransactionMetadata(ctx, shortID, "s"); err != nil {
+		t.Fatalf("RemoveTransactionMetadata(short_id): %v", err)
+	}
+
+	// Replace via short_id.
+	if err := svc.ReplaceTransactionMetadata(ctx, shortID, map[string]any{"r": true}); err != nil {
+		t.Fatalf("ReplaceTransactionMetadata(short_id): %v", err)
+	}
+
+	m := T12metaOf(t, svc, shortID)
+	if m["r"] != true {
+		t.Fatalf("after ReplaceTransactionMetadata(short_id): got %v", m)
+	}
+
+	// Clear via short_id.
+	if err := svc.ClearTransactionMetadata(ctx, shortID); err != nil {
+		t.Fatalf("ClearTransactionMetadata(short_id): %v", err)
+	}
+	if m := T12metaOf(t, svc, shortID); len(m) != 0 {
+		t.Fatalf("after ClearTransactionMetadata(short_id): %v", m)
+	}
+}
+
+// TestT12_ReplaceMetadata_NilEquivalentToEmpty verifies that nil and an empty
+// map produce the same result: an empty metadata object (not SQL NULL).
+func TestT12_ReplaceMetadata_NilEquivalentToEmpty(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_nil", "Nil Co", 900, "2026-02-08")
+	id := txn.ShortID
+
+	// Seed a key first.
+	if err := svc.SetTransactionMetadata(ctx, id, "tmp", 1); err != nil {
+		t.Fatalf("SetTransactionMetadata: %v", err)
+	}
+
+	// Replace with nil.
+	if err := svc.ReplaceTransactionMetadata(ctx, id, nil); err != nil {
+		t.Fatalf("ReplaceTransactionMetadata(nil): %v", err)
+	}
+
+	// metadata column must be the empty JSON object, not SQL NULL.
+	var raw []byte
+	if err := pool.QueryRow(ctx,
+		"SELECT metadata FROM transactions WHERE id = $1", txn.ID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("QueryRow metadata: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Fatalf("metadata after nil replace = %q, want %q", string(raw), "{}")
+	}
+}
+
+// TestT12_MetadataOps_NoBleedIntoOtherColumns confirms that performing all
+// four metadata ops does not mutate category_id or the transaction_tags join
+// table.
+func TestT12_MetadataOps_NoBleedIntoOtherColumns(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "t12_metaonly", "MetaOnly Co", 1100, "2026-02-09")
+	id := txn.ShortID
+
+	// Baseline: no category, no tags.
+	var catIDBase *string
+	var tagCountBase int
+	if err := pool.QueryRow(ctx,
+		`SELECT category_id::text,
+		        (SELECT COUNT(*) FROM transaction_tags WHERE transaction_id = t.id)
+		   FROM transactions t WHERE t.id = $1`,
+		txn.ID,
+	).Scan(&catIDBase, &tagCountBase); err != nil {
+		t.Fatalf("baseline query: %v", err)
+	}
+	if catIDBase != nil {
+		t.Fatalf("unexpected category before metadata ops: %v", *catIDBase)
+	}
+
+	// Perform all four scoped metadata ops.
+	if err := svc.SetTransactionMetadata(ctx, id, "flag", true); err != nil {
+		t.Fatalf("SetTransactionMetadata: %v", err)
+	}
+	if err := svc.RemoveTransactionMetadata(ctx, id, "flag"); err != nil {
+		t.Fatalf("RemoveTransactionMetadata: %v", err)
+	}
+	if err := svc.ReplaceTransactionMetadata(ctx, id, map[string]any{"a": 1}); err != nil {
+		t.Fatalf("ReplaceTransactionMetadata: %v", err)
+	}
+	if err := svc.ClearTransactionMetadata(ctx, id); err != nil {
+		t.Fatalf("ClearTransactionMetadata: %v", err)
+	}
+
+	// category_id and tag count must be unchanged after all ops.
+	var catIDAfter *string
+	var tagCountAfter int
+	if err := pool.QueryRow(ctx,
+		`SELECT category_id::text,
+		        (SELECT COUNT(*) FROM transaction_tags WHERE transaction_id = t.id)
+		   FROM transactions t WHERE t.id = $1`,
+		txn.ID,
+	).Scan(&catIDAfter, &tagCountAfter); err != nil {
+		t.Fatalf("after-ops query: %v", err)
+	}
+	if catIDAfter != nil {
+		t.Fatalf("category mutated by metadata ops: %v", *catIDAfter)
+	}
+	if tagCountAfter != tagCountBase {
+		t.Fatalf("tag count changed by metadata ops: %d -> %d", tagCountBase, tagCountAfter)
+	}
+}

--- a/internal/service/workflow_actions.go
+++ b/internal/service/workflow_actions.go
@@ -1,0 +1,32 @@
+//go:build !lite
+
+package service
+
+import "context"
+
+// GetEnabledWorkflowLastRuns returns the most-recent run for every workflow
+// instantiated from a preset, keyed by the workflow's slug. It reuses the
+// existing per-definition last-run query that ListAgentDefinitions already
+// inlines (GetLatestAgentRun via lastRunSummary) — there's no extra query
+// here, just a projection of the catalog into a slug → last-run map the
+// gallery can render per enabled card.
+//
+// Definitions with no run history (instantiated but never run) are omitted
+// from the map; callers treat a missing key as "never run". Only
+// preset-sourced definitions (SourceTemplate != nil) are included — the
+// gallery only renders cards for presets, so hand-authored agents are
+// irrelevant here.
+func (s *Service) GetEnabledWorkflowLastRuns(ctx context.Context) (map[string]*AgentRunSummary, error) {
+	defs, err := s.ListAgentDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]*AgentRunSummary, len(defs))
+	for _, d := range defs {
+		if d.SourceTemplate == nil || d.LastRun == nil {
+			continue
+		}
+		out[d.Slug] = d.LastRun
+	}
+	return out, nil
+}

--- a/internal/service/workflow_actions_integration_test.go
+++ b/internal/service/workflow_actions_integration_test.go
@@ -1,0 +1,103 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+)
+
+// f1MustInsertCompletedRun creates and completes a run for the given workflow
+// definition. Kept local (F1 prefix) so it can't collide with sibling test
+// helpers in the shared service_test package.
+func f1MustInsertCompletedRun(t *testing.T, q *db.Queries, defID pgtype.UUID) {
+	t.Helper()
+	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
+		AgentDefinitionID: defID,
+		Trigger:           "manual",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	var cost pgtype.Numeric
+	if err := cost.Scan("0.0100"); err != nil {
+		t.Fatalf("numeric scan: %v", err)
+	}
+	if _, err := q.CompleteAgentRun(context.Background(), db.CompleteAgentRunParams{
+		ID:                  run.ID,
+		Status:              "success",
+		DurationMs:          pgtype.Int4{Int32: 120, Valid: true},
+		TotalCostUsd:        cost,
+		InputTokens:         pgtype.Int4{Int32: 10, Valid: true},
+		OutputTokens:        pgtype.Int4{Int32: 5, Valid: true},
+		CacheReadTokens:     pgtype.Int4{Int32: 0, Valid: true},
+		CacheCreationTokens: pgtype.Int4{Int32: 0, Valid: true},
+		TurnCount:           pgtype.Int4{Int32: 1, Valid: true},
+		MaxTurnsUsed:        pgtype.Int4{Int32: 10, Valid: true},
+		NumToolCalls:        pgtype.Int4{Int32: 0, Valid: true},
+		TranscriptPath:      pgtype.Text{},
+		SessionID:           pgtype.Text{},
+	}); err != nil {
+		t.Fatalf("complete run: %v", err)
+	}
+}
+
+// TestF1GetEnabledWorkflowLastRuns verifies the gallery last-run projection:
+// a never-run workflow is absent from the map (callers treat that as "never
+// run"), and once a run exists it surfaces keyed by the workflow's slug with
+// the run's status carried through.
+func TestF1GetEnabledWorkflowLastRuns(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	// No workflows instantiated yet → empty map, no error.
+	runs, err := svc.GetEnabledWorkflowLastRuns(ctx)
+	if err != nil {
+		t.Fatalf("GetEnabledWorkflowLastRuns (empty): %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected no last-runs on a fresh DB, got %d", len(runs))
+	}
+
+	// Instantiate a workflow from a preset; it has no run history yet.
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	runs, err = svc.GetEnabledWorkflowLastRuns(ctx)
+	if err != nil {
+		t.Fatalf("GetEnabledWorkflowLastRuns (no runs): %v", err)
+	}
+	if _, ok := runs["routine-reviewer"]; ok {
+		t.Fatalf("workflow with no run history should be absent from the map")
+	}
+
+	// Record a completed run and re-query.
+	defID, err := pgconv.ParseUUID(wf.ID)
+	if err != nil {
+		t.Fatalf("parse workflow id: %v", err)
+	}
+	f1MustInsertCompletedRun(t, q, defID)
+
+	runs, err = svc.GetEnabledWorkflowLastRuns(ctx)
+	if err != nil {
+		t.Fatalf("GetEnabledWorkflowLastRuns (with run): %v", err)
+	}
+	last, ok := runs["routine-reviewer"]
+	if !ok || last == nil {
+		t.Fatalf("expected a last-run for routine-reviewer, got %+v", runs)
+	}
+	if last.Status != "success" {
+		t.Fatalf("last-run status = %q, want success", last.Status)
+	}
+	if last.ShortID == "" {
+		t.Fatal("last-run is missing its short_id")
+	}
+}

--- a/internal/service/workflow_governance_status_unit_test.go
+++ b/internal/service/workflow_governance_status_unit_test.go
@@ -1,0 +1,274 @@
+//go:build !lite
+
+package service
+
+import (
+	"fmt"
+	"testing"
+)
+
+// spendBand is the discrete classification that downstream consumers (e.g. the
+// gallery's spend banner) derive from a HouseholdSpendStatus. It mirrors the
+// logic in internal/admin/workflows_gallery_page.go::buildWorkflowSpendBanner
+// so that changes to either end are caught here.
+type spendBand int
+
+const (
+	// T5BandNone means no ceiling is configured (or ceiling <= 0); no warning shown.
+	T5BandNone spendBand = iota
+	// T5BandOK means spend is below 80% of the ceiling; banner hidden.
+	T5BandOK
+	// T5BandApproaching means spend is >=80% but <100% of the ceiling.
+	T5BandApproaching
+	// T5BandOver means spend has reached or exceeded the ceiling.
+	T5BandOver
+)
+
+// t5ClassifySpend derives the spend band from a HouseholdSpendStatus.
+// This is the pure projection that the gallery render layer performs;
+// keeping it here lets us unit-test the boundary conditions without a DB.
+func t5ClassifySpend(s HouseholdSpendStatus) spendBand {
+	if s.CeilingUSD == nil || *s.CeilingUSD <= 0 {
+		return T5BandNone
+	}
+	ceiling := *s.CeilingUSD
+	if s.SpentUSD >= ceiling {
+		return T5BandOver
+	}
+	pct := int(s.SpentUSD / ceiling * 100)
+	if pct >= 80 {
+		return T5BandApproaching
+	}
+	return T5BandOK
+}
+
+// t5fp is a convenience helper that returns a pointer to f.
+func t5fp(f float64) *float64 { return &f }
+
+// t5fmtFloat formats a float64 for use in test names.
+func t5fmtFloat(f float64) string {
+	if f == float64(int(f)) {
+		return fmt.Sprintf("%.0f", f)
+	}
+	return fmt.Sprintf("%.2f", f)
+}
+
+// TestT5SpendBand_NoCeiling verifies that when no ceiling is configured (nil
+// pointer or a non-positive value) the band is always None.
+func TestT5SpendBand_NoCeiling(t *testing.T) {
+	cases := []struct {
+		name   string
+		status HouseholdSpendStatus
+		want   spendBand
+	}{
+		{
+			name:   "nil ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 9999.99, CeilingUSD: nil},
+			want:   T5BandNone,
+		},
+		{
+			name:   "zero ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 5.00, CeilingUSD: t5fp(0)},
+			want:   T5BandNone,
+		},
+		{
+			name:   "negative ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 0, CeilingUSD: t5fp(-10.0)},
+			want:   T5BandNone,
+		},
+		{
+			name:   "nil ceiling zero spend",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 0, CeilingUSD: nil},
+			want:   T5BandNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := t5ClassifySpend(tc.status)
+			if got != tc.want {
+				t.Errorf("t5ClassifySpend(%+v) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestT5SpendBand_OK verifies that spend below the 80% threshold stays quiet.
+func TestT5SpendBand_OK(t *testing.T) {
+	cases := []struct {
+		name   string
+		status HouseholdSpendStatus
+		want   spendBand
+	}{
+		{
+			name:   "zero spend, $10 ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 0.00, CeilingUSD: t5fp(10.00)},
+			want:   T5BandOK,
+		},
+		{
+			name:   "50% of ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 5.00, CeilingUSD: t5fp(10.00)},
+			want:   T5BandOK,
+		},
+		{
+			name:   "79% of ceiling (just below approaching threshold)",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 7.90, CeilingUSD: t5fp(10.00)},
+			want:   T5BandOK,
+		},
+		{
+			name:   "1 cent spent vs large ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 0.01, CeilingUSD: t5fp(1000.00)},
+			want:   T5BandOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := t5ClassifySpend(tc.status)
+			if got != tc.want {
+				t.Errorf("t5ClassifySpend(%+v) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestT5SpendBand_Approaching verifies that spend at or above 80% but below
+// 100% of the ceiling is classified as Approaching.
+func TestT5SpendBand_Approaching(t *testing.T) {
+	cases := []struct {
+		name   string
+		status HouseholdSpendStatus
+		want   spendBand
+	}{
+		{
+			name:   "exactly 80% of ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 8.00, CeilingUSD: t5fp(10.00)},
+			want:   T5BandApproaching,
+		},
+		{
+			name:   "90% of ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 9.00, CeilingUSD: t5fp(10.00)},
+			want:   T5BandApproaching,
+		},
+		{
+			name:   "99% of ceiling (one cent below)",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 9.99, CeilingUSD: t5fp(10.00)},
+			want:   T5BandApproaching,
+		},
+		{
+			name:   "80% of a small ceiling ($0.08 of $0.10)",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 0.08, CeilingUSD: t5fp(0.10)},
+			want:   T5BandApproaching,
+		},
+		{
+			name:   "85% of a large ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 85.00, CeilingUSD: t5fp(100.00)},
+			want:   T5BandApproaching,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := t5ClassifySpend(tc.status)
+			if got != tc.want {
+				t.Errorf("t5ClassifySpend(%+v) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestT5SpendBand_Over verifies that spend at or above the ceiling is
+// classified as Over.
+func TestT5SpendBand_Over(t *testing.T) {
+	cases := []struct {
+		name   string
+		status HouseholdSpendStatus
+		want   spendBand
+	}{
+		{
+			name:   "exactly at ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 10.00, CeilingUSD: t5fp(10.00)},
+			want:   T5BandOver,
+		},
+		{
+			name:   "1 cent over ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 10.01, CeilingUSD: t5fp(10.00)},
+			want:   T5BandOver,
+		},
+		{
+			name:   "significantly over ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 50.00, CeilingUSD: t5fp(10.00)},
+			want:   T5BandOver,
+		},
+		{
+			name:   "over a small ceiling ($0.11 of $0.10)",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 0.11, CeilingUSD: t5fp(0.10)},
+			want:   T5BandOver,
+		},
+		{
+			name:   "over a large ceiling",
+			status: HouseholdSpendStatus{WindowDays: 30, SpentUSD: 100.01, CeilingUSD: t5fp(100.00)},
+			want:   T5BandOver,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := t5ClassifySpend(tc.status)
+			if got != tc.want {
+				t.Errorf("t5ClassifySpend(%+v) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestT5SpendBandBoundary_ExactThresholds exercises the precise boundary
+// transitions: 79%->OK, 80%->Approaching, 99%->Approaching, 100%->Over.
+// Uses a $100 ceiling so percentages map cleanly to dollar values.
+func TestT5SpendBandBoundary_ExactThresholds(t *testing.T) {
+	ceiling := t5fp(100.00)
+	cases := []struct {
+		spent float64
+		want  spendBand
+	}{
+		{0.00, T5BandOK},
+		{79.00, T5BandOK},
+		{79.99, T5BandOK}, // truncated int(79.99/100*100)=79, still OK
+		{80.00, T5BandApproaching},
+		{80.01, T5BandApproaching},
+		{99.00, T5BandApproaching},
+		{99.99, T5BandApproaching},
+		{100.00, T5BandOver},
+		{100.01, T5BandOver},
+		{150.00, T5BandOver},
+	}
+
+	for _, tc := range cases {
+		name := "spent=" + t5fmtFloat(tc.spent)
+		t.Run(name, func(t *testing.T) {
+			s := HouseholdSpendStatus{WindowDays: 30, SpentUSD: tc.spent, CeilingUSD: ceiling}
+			got := t5ClassifySpend(s)
+			if got != tc.want {
+				t.Errorf("t5ClassifySpend(spent=%.2f, ceiling=%.2f) = %v, want %v",
+					tc.spent, *ceiling, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestT5HouseholdSpendStatus_WindowDays verifies that the HouseholdCeilingWindow
+// constant encodes a 30-day rolling window, matching the WindowDays=30 the
+// settings UI displays. Both ends must agree so the copy "last 30 days" stays
+// accurate.
+func TestT5HouseholdSpendStatus_WindowDays(t *testing.T) {
+	const want = 30
+	got := int(HouseholdCeilingWindow.Hours() / 24)
+	if got != want {
+		t.Errorf("HouseholdCeilingWindow = %d days, want %d", got, want)
+	}
+
+	s := HouseholdSpendStatus{WindowDays: want}
+	if s.WindowDays != want {
+		t.Errorf("HouseholdSpendStatus.WindowDays = %d, want %d", s.WindowDays, want)
+	}
+}

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -81,6 +81,48 @@ var applyModeOption = WorkflowPresetOption{
 	},
 }
 
+// lookbackWindowOption is the shared "how far back to scan" choice for the
+// alerts/anomaly presets. The default (7 days) carries no directive — the base
+// strategy blocks already say "default: last 7 days"; the 30/90-day choices
+// append a directive that widens the window the run reasons over.
+var lookbackWindowOption = WorkflowPresetOption{
+	Key:     "lookback_window",
+	Label:   "Lookback window",
+	Help:    "How far back each run scans for anomalies.",
+	Default: "7",
+	Choices: []WorkflowPresetChoice{
+		{Value: "7", Label: "Last 7 days", Directive: ""},
+		{
+			Value:     "30",
+			Label:     "Last 30 days",
+			Directive: "LOOKBACK WINDOW — 30 DAYS: Scan the last 30 days, not the default 7. Wherever a step says \"last 7 days\", read it as \"last 30 days\". Establish baselines from the period immediately preceding the window so a one-month scan still has something to compare against.",
+		},
+		{
+			Value:     "90",
+			Label:     "Last 90 days",
+			Directive: "LOOKBACK WINDOW — 90 DAYS: Scan the last 90 days, not the default 7. Wherever a step says \"last 7 days\", read it as \"last 90 days\". This is a wide, catch-up sweep — prioritize the highest-signal findings and don't re-flag items a prior run already surfaced.",
+		},
+	},
+}
+
+// reportVerbosityOption is the shared "how much detail to write" choice for the
+// alerts/anomaly presets. Concise is the default (no directive); detailed
+// appends a directive asking for fuller evidence and reasoning in the report.
+var reportVerbosityOption = WorkflowPresetOption{
+	Key:     "report_verbosity",
+	Label:   "Report verbosity",
+	Help:    "How much detail each report carries.",
+	Default: "concise",
+	Choices: []WorkflowPresetChoice{
+		{Value: "concise", Label: "Concise — headline findings", Directive: ""},
+		{
+			Value:     "detailed",
+			Label:     "Detailed — full evidence",
+			Directive: "REPORT VERBOSITY — DETAILED: Write a thorough report. For every flagged item include the full evidence trail (amounts, dates, merchant, account, and the baseline you compared against) and a one-line rationale. Open with a short summary of what you scanned and the headline count, then the itemized findings. When nothing is flagged, still summarize what you checked and why the window is clean.",
+		},
+	},
+}
+
 // resolveOptionDirectives returns the prompt text to append for a preset's
 // chosen options. Each option resolves to a choice — the submitted value if
 // valid, otherwise the option's Default — and any non-empty Directive is
@@ -188,6 +230,57 @@ var workflowPresets = []WorkflowPreset{
 		ToolScope:        "read_only",
 		ScheduleCron:     "0 8 1 * *", // 1st of the month at 08:00 (canonical "Monthly" — drawer-selectable)
 		EstCostPerRunUSD: 0.07,        // a full month of activity + merchant breakdown
+	},
+
+	// ── Alerts & Anomalies ──────────────────────────────────────────────────
+	// Watchdogs that surface things worth a human's eyeballs. Each flags via a
+	// `needs-review` tag + a report and never recategorizes; the two read_write
+	// sentinels run after each sync for fast feedback, the read_only watch runs
+	// weekly. All three expose the shared Lookback window + Report verbosity
+	// options so a household can tune scan breadth and report detail.
+	{
+		Slug:        "large-charge-sentinel",
+		Name:        "Large Charge Sentinel",
+		Category:    "Alerts & Anomalies",
+		Icon:        "trending-up",
+		Description: "Flags unusually large individual charges relative to your normal spending, right after each sync.",
+		PromptBlocks: []string{
+			"strategy-large-charge-sentinel",
+			"merchant-analysis",
+		},
+		ToolScope:             "read_write", // tags flagged charges for human review
+		TriggerOnSyncComplete: true,
+		EstCostPerRunUSD:      0.03, // scans recent debits + a baseline pass per sync
+		Options:               []WorkflowPresetOption{lookbackWindowOption, reportVerbosityOption},
+	},
+	{
+		Slug:        "new-merchant-watch",
+		Name:        "New-Merchant Watch",
+		Category:    "Alerts & Anomalies",
+		Icon:        "store",
+		Description: "A weekly report of first-seen merchants — new subscriptions and one-off vendors you may not recognize.",
+		PromptBlocks: []string{
+			"strategy-anomaly-detection",
+			"merchant-analysis",
+		},
+		ToolScope:        "read_only", // reports only; never tags or recategorizes
+		ScheduleCron:     "0 7 * * 1", // Mondays at 07:00 (canonical "Weekly")
+		EstCostPerRunUSD: 0.04,        // a week of merchant-summary comparison
+		Options:          []WorkflowPresetOption{lookbackWindowOption, reportVerbosityOption},
+	},
+	{
+		Slug:        "duplicate-charge-detector",
+		Name:        "Duplicate Charge Detector",
+		Category:    "Alerts & Anomalies",
+		Icon:        "copy",
+		Description: "Flags likely double-bills and gateway-retry duplicates so you can dispute them, right after each sync.",
+		PromptBlocks: []string{
+			"strategy-duplicate-detection",
+		},
+		ToolScope:             "read_write", // tags suspected duplicates for review
+		TriggerOnSyncComplete: true,
+		EstCostPerRunUSD:      0.03, // pairwise scan over recent debits per sync
+		Options:               []WorkflowPresetOption{lookbackWindowOption, reportVerbosityOption},
 	},
 }
 

--- a/internal/service/workflow_presets_compose_unit_test.go
+++ b/internal/service/workflow_presets_compose_unit_test.go
@@ -1,0 +1,357 @@
+//go:build !lite
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+// T1-presets-compose: unit tests for the workflowPresets registry. No DB
+// required — all assertions operate on the in-process registry and the
+// embedded prompts.FS.
+
+// knownPresetCategories is the authoritative set of gallery category strings.
+// Update this list whenever a new category is added to workflow_presets.go.
+var knownPresetCategories = map[string]bool{
+	"Categorization & Review": true,
+	"Insights & Reports":      true,
+	"Alerts & Anomalies":      true,
+}
+
+// T1RegistryNonEmpty asserts that the preset registry contains at least one
+// entry (a totally empty registry is a silent broken build).
+func TestT1RegistryNonEmpty(t *testing.T) {
+	if len(workflowPresets) == 0 {
+		t.Fatal("T1: workflowPresets registry is empty")
+	}
+}
+
+// TestT1SlugsUniqueNonEmpty asserts that every preset has a non-empty Slug and
+// that no two presets share a Slug. Duplicate slugs would cause the second
+// enable to silently shadow the first in EnableWorkflowFromPreset.
+func TestT1SlugsUniqueNonEmpty(t *testing.T) {
+	seen := make(map[string]int) // slug → first index
+	for i, p := range workflowPresets {
+		if p.Slug == "" {
+			t.Errorf("T1: preset[%d] has empty Slug", i)
+			continue
+		}
+		if first, ok := seen[p.Slug]; ok {
+			t.Errorf("T1: duplicate Slug %q: first at index %d, also at index %d", p.Slug, first, i)
+		} else {
+			seen[p.Slug] = i
+		}
+	}
+}
+
+// TestT1NameNonEmpty asserts that every preset has a non-empty Name (the
+// user-facing gallery card title).
+func TestT1NameNonEmpty(t *testing.T) {
+	for i, p := range workflowPresets {
+		if strings.TrimSpace(p.Name) == "" {
+			t.Errorf("T1: preset[%d] (slug=%q) has empty Name", i, p.Slug)
+		}
+	}
+}
+
+// TestT1CategoryValid asserts that every preset's Category is one of the known
+// gallery grouping strings. An unexpected category won't appear in the
+// gallery unless the frontend also adds a column for it.
+func TestT1CategoryValid(t *testing.T) {
+	for _, p := range workflowPresets {
+		if !knownPresetCategories[p.Category] {
+			t.Errorf("T1: preset %q has unknown Category %q (known: %v)", p.Slug, p.Category, knownPresetCategoryList())
+		}
+	}
+}
+
+// TestT1TriggerValid asserts that every preset has at least one trigger defined
+// (TriggerOnSyncComplete=true OR a non-empty ScheduleCron). A preset with
+// neither trigger is registered but can never fire.
+func TestT1TriggerValid(t *testing.T) {
+	for _, p := range workflowPresets {
+		hasTrigger := p.TriggerOnSyncComplete || strings.TrimSpace(p.ScheduleCron) != ""
+		if !hasTrigger {
+			t.Errorf("T1: preset %q has no trigger (TriggerOnSyncComplete=false and ScheduleCron=%q)", p.Slug, p.ScheduleCron)
+		}
+	}
+}
+
+// TestT1TriggerMutuallyExclusive asserts that no preset mixes TriggerOnSyncComplete
+// and a ScheduleCron, since EnableWorkflowFromPreset ignores the schedule for
+// post-sync presets — a filled ScheduleCron on a post-sync preset is dead code
+// and signals a copy-paste error.
+func TestT1TriggerMutuallyExclusive(t *testing.T) {
+	for _, p := range workflowPresets {
+		if p.TriggerOnSyncComplete && strings.TrimSpace(p.ScheduleCron) != "" {
+			t.Errorf("T1: preset %q sets both TriggerOnSyncComplete and ScheduleCron=%q; EnableWorkflowFromPreset ignores the cron for post-sync presets", p.Slug, p.ScheduleCron)
+		}
+	}
+}
+
+// TestT1ToolScopeValid asserts that every preset's ToolScope is either "read_only"
+// or "read_write" — the two values accepted by CreateAgentDefinition.
+func TestT1ToolScopeValid(t *testing.T) {
+	for _, p := range workflowPresets {
+		switch p.ToolScope {
+		case "read_only", "read_write":
+			// valid
+		default:
+			t.Errorf("T1: preset %q has invalid ToolScope %q (want read_only or read_write)", p.Slug, p.ToolScope)
+		}
+	}
+}
+
+// TestT1PromptBlocksNonEmpty asserts that every preset declares at least one
+// prompt block. A preset with no blocks would compose an empty prompt.
+func TestT1PromptBlocksNonEmpty(t *testing.T) {
+	for _, p := range workflowPresets {
+		if len(p.PromptBlocks) == 0 {
+			t.Errorf("T1: preset %q declares no PromptBlocks", p.Slug)
+		}
+	}
+}
+
+// TestT1PromptBlocksExist asserts that every block ID named in every preset's
+// PromptBlocks list corresponds to a real file under prompts/agents/. An
+// unknown block ID would cause composePresetPrompt to return an error at
+// runtime (and EnableWorkflowFromPreset to fail for every household).
+func TestT1PromptBlocksExist(t *testing.T) {
+	blocks, err := loadPromptBlocks()
+	if err != nil {
+		t.Fatalf("T1: loadPromptBlocks: %v", err)
+	}
+	known := make(map[string]bool, len(blocks))
+	for _, b := range blocks {
+		known[b.ID] = true
+	}
+
+	for _, p := range workflowPresets {
+		for _, id := range p.PromptBlocks {
+			if !known[id] {
+				t.Errorf("T1: preset %q references unknown prompt block %q", p.Slug, id)
+			}
+		}
+	}
+}
+
+// TestT1ComposePromptNonEmpty asserts that every preset produces a
+// non-empty composed prompt. This is the critical invariant: if composition
+// succeeds but returns empty text the workflow runs with a blank system
+// prompt, defeating the entire preset mechanism.
+func TestT1ComposePromptNonEmpty(t *testing.T) {
+	for _, p := range workflowPresets {
+		got, err := composePresetPrompt(p.PromptBlocks)
+		if err != nil {
+			t.Errorf("T1: preset %q composePresetPrompt error: %v", p.Slug, err)
+			continue
+		}
+		if strings.TrimSpace(got) == "" {
+			t.Errorf("T1: preset %q composePresetPrompt returned empty prompt", p.Slug)
+		}
+	}
+}
+
+// TestT1ComposePromptContainsBlocks asserts that each block contributing to a
+// preset's composed prompt has non-trivial content (at least 10 non-whitespace
+// characters). A nearly-empty block file would silently degrade the prompt.
+func TestT1ComposePromptContainsBlocks(t *testing.T) {
+	blocks, err := loadPromptBlocks()
+	if err != nil {
+		t.Fatalf("T1: loadPromptBlocks: %v", err)
+	}
+	byID := make(map[string]string, len(blocks))
+	for _, b := range blocks {
+		byID[b.ID] = b.Content
+	}
+
+	for _, p := range workflowPresets {
+		for _, id := range p.PromptBlocks {
+			content, ok := byID[id]
+			if !ok {
+				// Already caught by TestT1PromptBlocksExist; skip to avoid redundant noise.
+				continue
+			}
+			if len(strings.TrimSpace(content)) < 10 {
+				t.Errorf("T1: preset %q block %q has suspiciously short content (%d chars)", p.Slug, id, len(strings.TrimSpace(content)))
+			}
+		}
+	}
+}
+
+// TestT1EstCostPositive asserts that every preset has a positive
+// EstCostPerRunUSD. The cost estimate is surfaced in the configure drawer so
+// a self-hoster sees the order of magnitude before enabling; a zero or
+// negative value means the hint is absent or misleading.
+func TestT1EstCostPositive(t *testing.T) {
+	for _, p := range workflowPresets {
+		if p.EstCostPerRunUSD <= 0 {
+			t.Errorf("T1: preset %q has non-positive EstCostPerRunUSD=%v", p.Slug, p.EstCostPerRunUSD)
+		}
+	}
+}
+
+// TestT1OptionsWellFormed asserts that every WorkflowPresetOption on every
+// preset is internally consistent: Key and Label are non-empty, at least one
+// Choice exists, Default matches a real choice Value, and every Choice has
+// a non-empty Value and Label.
+func TestT1OptionsWellFormed(t *testing.T) {
+	for _, p := range workflowPresets {
+		for oi, opt := range p.Options {
+			if strings.TrimSpace(opt.Key) == "" {
+				t.Errorf("T1: preset %q option[%d] has empty Key", p.Slug, oi)
+			}
+			if strings.TrimSpace(opt.Label) == "" {
+				t.Errorf("T1: preset %q option[%d] (key=%q) has empty Label", p.Slug, oi, opt.Key)
+			}
+			if len(opt.Choices) == 0 {
+				t.Errorf("T1: preset %q option[%d] (key=%q) has no Choices", p.Slug, oi, opt.Key)
+				continue
+			}
+			// Default must be a known choice Value.
+			defaultFound := false
+			for ci, ch := range opt.Choices {
+				if strings.TrimSpace(ch.Value) == "" {
+					t.Errorf("T1: preset %q option[%d] choice[%d] has empty Value", p.Slug, oi, ci)
+				}
+				if strings.TrimSpace(ch.Label) == "" {
+					t.Errorf("T1: preset %q option[%d] choice[%d] (value=%q) has empty Label", p.Slug, oi, ci, ch.Value)
+				}
+				if ch.Value == opt.Default {
+					defaultFound = true
+				}
+			}
+			if !defaultFound {
+				t.Errorf("T1: preset %q option[%d] (key=%q) Default=%q does not match any choice Value", p.Slug, oi, opt.Key, opt.Default)
+			}
+		}
+	}
+}
+
+// TestT1OptionKeyUniquenessPerPreset asserts that within a single preset,
+// no two options share the same Key. Duplicate keys would cause the last
+// one to silently shadow earlier ones in resolveOptionDirectives.
+func TestT1OptionKeyUniquenessPerPreset(t *testing.T) {
+	for _, p := range workflowPresets {
+		seen := make(map[string]int)
+		for oi, opt := range p.Options {
+			if first, ok := seen[opt.Key]; ok {
+				t.Errorf("T1: preset %q has duplicate option Key %q at indices %d and %d", p.Slug, opt.Key, first, oi)
+			} else {
+				seen[opt.Key] = oi
+			}
+		}
+	}
+}
+
+// TestT1ResolveOptionDirectivesDefault asserts that resolveOptionDirectives
+// does not panic and produces consistent output when called with a nil / empty
+// chosen map (i.e. every option falls back to its Default).
+func TestT1ResolveOptionDirectivesDefault(t *testing.T) {
+	for _, p := range workflowPresets {
+		// Should not panic regardless of Options length.
+		got := resolveOptionDirectives(p, nil)
+
+		// Also exercise with an explicit empty map.
+		got2 := resolveOptionDirectives(p, map[string]string{})
+		if got != got2 {
+			t.Errorf("T1: preset %q resolveOptionDirectives(nil) != resolveOptionDirectives({})", p.Slug)
+		}
+	}
+}
+
+// TestT1ResolveOptionDirectivesUnknownFallsBack asserts that an unknown choice
+// value triggers a fall-back to the option's Default rather than returning an
+// error or an empty directive when the default has one.
+func TestT1ResolveOptionDirectivesUnknownFallsBack(t *testing.T) {
+	for _, p := range workflowPresets {
+		chosen := make(map[string]string)
+		for _, opt := range p.Options {
+			chosen[opt.Key] = "definitely-not-a-real-choice-value"
+		}
+		// Must not panic. The result equals the output for the default selections.
+		withUnknown := resolveOptionDirectives(p, chosen)
+		withDefault := resolveOptionDirectives(p, nil)
+		if withUnknown != withDefault {
+			t.Errorf("T1: preset %q: resolveOptionDirectives with unknown value differs from default fallback", p.Slug)
+		}
+	}
+}
+
+// TestT1ComposePresetPromptWithFlagOnlyOption asserts that composing a preset
+// prompt for a preset that has an apply_mode option and choosing "flag_only"
+// appends the FLAG ONLY directive text. This validates the option/directive
+// pipeline end-to-end without a DB.
+func TestT1ComposePresetPromptWithFlagOnlyOption(t *testing.T) {
+	// Find a preset that has the apply_mode option (routine-reviewer and
+	// backlog-closer both do; we test the first one we encounter).
+	var target *WorkflowPreset
+	for i := range workflowPresets {
+		for _, opt := range workflowPresets[i].Options {
+			if opt.Key == "apply_mode" {
+				target = &workflowPresets[i]
+				break
+			}
+		}
+		if target != nil {
+			break
+		}
+	}
+	if target == nil {
+		t.Skip("T1: no preset with apply_mode option found; skipping directive test")
+	}
+
+	base, err := composePresetPrompt(target.PromptBlocks)
+	if err != nil {
+		t.Fatalf("T1: composePresetPrompt(%q): %v", target.Slug, err)
+	}
+
+	flagOnly := resolveOptionDirectives(*target, map[string]string{"apply_mode": "flag_only"})
+	auto := resolveOptionDirectives(*target, map[string]string{"apply_mode": "auto"})
+
+	// flag_only directive must be non-empty and must contain the canonical text.
+	if !strings.Contains(flagOnly, "FLAG ONLY") {
+		t.Errorf("T1: preset %q flag_only directive missing FLAG ONLY text; got: %q", target.Slug, flagOnly)
+	}
+	// auto directive must be empty (no extra text appended for the default choice).
+	if auto != "" {
+		t.Errorf("T1: preset %q auto directive should be empty, got: %q", target.Slug, auto)
+	}
+
+	// Combining base + flag_only must still be non-empty and > base alone.
+	full := base + flagOnly
+	if len(full) <= len(base) {
+		t.Errorf("T1: preset %q full prompt with flag_only should be longer than base alone", target.Slug)
+	}
+}
+
+// TestT1PresetBySlugRoundtrip asserts that every preset slug found in the
+// registry is retrievable by presetBySlug, and that presetBySlug returns
+// false for an invented slug.
+func TestT1PresetBySlugRoundtrip(t *testing.T) {
+	for _, p := range workflowPresets {
+		got, ok := presetBySlug(p.Slug)
+		if !ok {
+			t.Errorf("T1: presetBySlug(%q) returned ok=false", p.Slug)
+			continue
+		}
+		if got.Slug != p.Slug {
+			t.Errorf("T1: presetBySlug(%q) returned slug=%q", p.Slug, got.Slug)
+		}
+	}
+
+	if _, ok := presetBySlug("T1-invented-slug-that-does-not-exist"); ok {
+		t.Error("T1: presetBySlug returned ok=true for a non-existent slug")
+	}
+}
+
+// knownPresetCategoryList is a helper for error messages; returns a slice of
+// the known category strings.
+func knownPresetCategoryList() []string {
+	out := make([]string, 0, len(knownPresetCategories))
+	for k := range knownPresetCategories {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/service/workflow_presets_expansion_test.go
+++ b/internal/service/workflow_presets_expansion_test.go
@@ -1,0 +1,231 @@
+//go:build !lite
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file (unit-prefixed F4*) covers the F4-presets-and-options expansion:
+// the new "Alerts & Anomalies" category, the three new presets, and the two
+// new reusable options (Lookback window, Report verbosity). It does NOT touch
+// the DB — composition and option resolution are pure functions over the
+// embedded prompt-block FS.
+
+// f4ValidCategories is the set of gallery categories the registry is allowed to
+// use. Adding a category here is deliberate — the gallery's category-icon and
+// ordering code must keep up (internal/admin/workflows_gallery_page.go).
+var f4ValidCategories = map[string]bool{
+	"Categorization & Review": true,
+	"Insights & Reports":      true,
+	"Hygiene & Maintenance":   true,
+	"Alerts & Anomalies":      true,
+}
+
+// TestF4AllPresetsComposeValid is the broad guard over the WHOLE registry
+// (old presets + the new Alerts & Anomalies ones): every preset must have a
+// unique slug, a known category, a valid tool scope, a positive cost estimate,
+// a coherent trigger, and compose a non-empty base prompt from real blocks.
+func TestF4AllPresetsComposeValid(t *testing.T) {
+	if len(workflowPresets) == 0 {
+		t.Fatal("workflowPresets registry is empty")
+	}
+	slugs := map[string]bool{}
+	for _, p := range workflowPresets {
+		if p.Slug == "" {
+			t.Fatalf("preset %q (%s) has an empty slug", p.Name, p.Category)
+		}
+		if slugs[p.Slug] {
+			t.Errorf("duplicate preset slug %q", p.Slug)
+		}
+		slugs[p.Slug] = true
+
+		if p.Name == "" {
+			t.Errorf("preset %q has an empty name", p.Slug)
+		}
+		if !f4ValidCategories[p.Category] {
+			t.Errorf("preset %q has unknown category %q", p.Slug, p.Category)
+		}
+		if p.Icon == "" {
+			t.Errorf("preset %q has no icon", p.Slug)
+		}
+		if p.ToolScope != "read_only" && p.ToolScope != "read_write" {
+			t.Errorf("preset %q has invalid tool_scope %q", p.Slug, p.ToolScope)
+		}
+		if p.EstCostPerRunUSD <= 0 {
+			t.Errorf("preset %q has non-positive EstCostPerRunUSD %v", p.Slug, p.EstCostPerRunUSD)
+		}
+
+		// Trigger coherence: exactly one of post-sync OR a cron schedule.
+		if p.TriggerOnSyncComplete && p.ScheduleCron != "" {
+			t.Errorf("preset %q is both post-sync and cron-scheduled (%q)", p.Slug, p.ScheduleCron)
+		}
+		if !p.TriggerOnSyncComplete && p.ScheduleCron == "" {
+			t.Errorf("preset %q has no trigger (neither post-sync nor cron)", p.Slug)
+		}
+
+		// Prompt composition from real blocks → non-empty.
+		if len(p.PromptBlocks) == 0 {
+			t.Errorf("preset %q has no prompt blocks", p.Slug)
+			continue
+		}
+		prompt, err := composePresetPrompt(p.PromptBlocks)
+		if err != nil {
+			t.Errorf("preset %q failed to compose prompt: %v", p.Slug, err)
+			continue
+		}
+		if strings.TrimSpace(prompt) == "" {
+			t.Errorf("preset %q composed an empty prompt", p.Slug)
+		}
+	}
+}
+
+// TestF4AlertsCategoryPresets pins the three new presets to their intended
+// shape so a future edit that drifts the trust spectrum / trigger model fails
+// loudly: large-charge sentinel (read_write, post-sync), new-merchant watch
+// (read_only, weekly), duplicate detector (read_write, post-sync).
+func TestF4AlertsCategoryPresets(t *testing.T) {
+	want := map[string]struct {
+		scope    string
+		postSync bool
+		cron     string
+	}{
+		"large-charge-sentinel":     {scope: "read_write", postSync: true, cron: ""},
+		"new-merchant-watch":        {scope: "read_only", postSync: false, cron: "0 7 * * 1"},
+		"duplicate-charge-detector": {scope: "read_write", postSync: true, cron: ""},
+	}
+	got := map[string]bool{}
+	for _, p := range workflowPresets {
+		w, ok := want[p.Slug]
+		if !ok {
+			continue
+		}
+		got[p.Slug] = true
+		if p.Category != "Alerts & Anomalies" {
+			t.Errorf("%q category = %q, want Alerts & Anomalies", p.Slug, p.Category)
+		}
+		if p.ToolScope != w.scope {
+			t.Errorf("%q tool_scope = %q, want %q", p.Slug, p.ToolScope, w.scope)
+		}
+		if p.TriggerOnSyncComplete != w.postSync {
+			t.Errorf("%q TriggerOnSyncComplete = %v, want %v", p.Slug, p.TriggerOnSyncComplete, w.postSync)
+		}
+		if p.ScheduleCron != w.cron {
+			t.Errorf("%q ScheduleCron = %q, want %q", p.Slug, p.ScheduleCron, w.cron)
+		}
+		if p.EstCostPerRunUSD <= 0 {
+			t.Errorf("%q EstCostPerRunUSD = %v, want > 0", p.Slug, p.EstCostPerRunUSD)
+		}
+	}
+	for slug := range want {
+		if !got[slug] {
+			t.Errorf("expected preset %q in the registry, not found", slug)
+		}
+	}
+}
+
+// TestF4LookbackWindowOptionResolves proves the new Lookback window option
+// resolves directives: 7 (default) → no directive, 30/90 → a window directive,
+// and an unknown/blank value falls back to the default (no directive).
+func TestF4LookbackWindowOptionResolves(t *testing.T) {
+	preset := WorkflowPreset{Options: []WorkflowPresetOption{lookbackWindowOption}}
+
+	// Default value → no directive appended.
+	if d := resolveOptionDirectives(preset, map[string]string{"lookback_window": "7"}); strings.TrimSpace(d) != "" {
+		t.Errorf("lookback_window=7 should append no directive, got %q", d)
+	}
+	// Empty / unknown → falls back to default → no directive.
+	if d := resolveOptionDirectives(preset, map[string]string{"lookback_window": "bogus"}); strings.TrimSpace(d) != "" {
+		t.Errorf("unknown lookback_window should fall back to default (no directive), got %q", d)
+	}
+	if d := resolveOptionDirectives(preset, nil); strings.TrimSpace(d) != "" {
+		t.Errorf("missing lookback_window should fall back to default (no directive), got %q", d)
+	}
+	// 30 / 90 → a non-empty directive under the option's label heading.
+	for _, v := range []string{"30", "90"} {
+		d := resolveOptionDirectives(preset, map[string]string{"lookback_window": v})
+		if !strings.Contains(d, "## Lookback window") {
+			t.Errorf("lookback_window=%s missing the option heading, got %q", v, d)
+		}
+		if !strings.Contains(d, "LOOKBACK WINDOW") || !strings.Contains(d, v) {
+			t.Errorf("lookback_window=%s missing the window directive, got %q", v, d)
+		}
+	}
+}
+
+// TestF4ReportVerbosityOptionResolves proves the Report verbosity option:
+// concise (default) → no directive, detailed → a fuller-report directive.
+func TestF4ReportVerbosityOptionResolves(t *testing.T) {
+	preset := WorkflowPreset{Options: []WorkflowPresetOption{reportVerbosityOption}}
+
+	if d := resolveOptionDirectives(preset, map[string]string{"report_verbosity": "concise"}); strings.TrimSpace(d) != "" {
+		t.Errorf("report_verbosity=concise should append no directive, got %q", d)
+	}
+	if d := resolveOptionDirectives(preset, map[string]string{"report_verbosity": "detailed"}); !strings.Contains(d, "## Report verbosity") || !strings.Contains(d, "REPORT VERBOSITY — DETAILED") {
+		t.Errorf("report_verbosity=detailed missing the detailed directive, got %q", d)
+	}
+}
+
+// TestF4OptionsCombineOnAlertsPreset proves the two new options compose
+// together on a real registry preset: a 90-day detailed configuration appends
+// BOTH directives, in option order, after the base prompt.
+func TestF4OptionsCombineOnAlertsPreset(t *testing.T) {
+	preset, ok := presetBySlug("large-charge-sentinel")
+	if !ok {
+		t.Fatal("large-charge-sentinel preset missing from registry")
+	}
+	base, err := composePresetPrompt(preset.PromptBlocks)
+	if err != nil {
+		t.Fatalf("composePresetPrompt: %v", err)
+	}
+	dir := resolveOptionDirectives(preset, map[string]string{
+		"lookback_window":  "90",
+		"report_verbosity": "detailed",
+	})
+	full := base + dir
+
+	if !strings.Contains(full, "LOOKBACK WINDOW — 90 DAYS") {
+		t.Errorf("combined prompt missing the 90-day lookback directive")
+	}
+	if !strings.Contains(full, "REPORT VERBOSITY — DETAILED") {
+		t.Errorf("combined prompt missing the detailed-report directive")
+	}
+	// Lookback window is option[0] → its heading must precede Report verbosity's.
+	li := strings.Index(full, "## Lookback window")
+	ri := strings.Index(full, "## Report verbosity")
+	if li < 0 || ri < 0 || li > ri {
+		t.Errorf("option directives out of order: lookback@%d report@%d", li, ri)
+	}
+	// The base prompt is preserved ahead of the appended directives.
+	if !strings.HasPrefix(full, strings.TrimSpace(base)[:1]) || li <= 0 {
+		t.Errorf("base prompt should precede the appended option directives")
+	}
+}
+
+// TestF4NewPromptBlocksLoad proves the two new strategy blocks added for this
+// unit are present in the embedded library and carry non-empty content (so a
+// missing or empty file fails here, not at a household's run).
+func TestF4NewPromptBlocksLoad(t *testing.T) {
+	blocks, err := loadPromptBlocks()
+	if err != nil {
+		t.Fatalf("loadPromptBlocks: %v", err)
+	}
+	byID := map[string]PromptBlock{}
+	for _, b := range blocks {
+		byID[b.ID] = b
+	}
+	for _, id := range []string{"strategy-large-charge-sentinel", "strategy-duplicate-detection"} {
+		b, ok := byID[id]
+		if !ok {
+			t.Errorf("new prompt block %q not loaded from prompts/agents/", id)
+			continue
+		}
+		if strings.TrimSpace(b.Content) == "" {
+			t.Errorf("new prompt block %q has empty content", id)
+		}
+		if b.Group != GroupStrategy {
+			t.Errorf("new prompt block %q group = %q, want strategy", id, b.Group)
+		}
+	}
+}

--- a/internal/service/workflow_presets_options_unit_test.go
+++ b/internal/service/workflow_presets_options_unit_test.go
@@ -1,0 +1,322 @@
+//go:build !lite
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+// T2 prefix — unique to this unit (T2-options-resolve) so it never collides
+// with another parallel agent's test names.
+
+// T2_makeOptionPreset builds a minimal WorkflowPreset with the provided
+// options list, ready to pass to resolveOptionDirectives.
+func T2_makeOptionPreset(opts []WorkflowPresetOption) WorkflowPreset {
+	return WorkflowPreset{
+		Slug:    "t2-test-preset",
+		Name:    "T2 Test Preset",
+		Options: opts,
+	}
+}
+
+// T2_twoChoiceOption returns a WorkflowPresetOption with two choices:
+//   - "alpha" → Directive "Alpha directive text"
+//   - "beta"  → Directive "Beta directive text"
+//
+// Default is "alpha".
+func T2_twoChoiceOption(key string) WorkflowPresetOption {
+	return WorkflowPresetOption{
+		Key:     key,
+		Label:   "T2 Option Label",
+		Default: "alpha",
+		Choices: []WorkflowPresetChoice{
+			{Value: "alpha", Label: "Alpha", Directive: "Alpha directive text"},
+			{Value: "beta", Label: "Beta", Directive: "Beta directive text"},
+		},
+	}
+}
+
+// T2_emptyDirectiveOption returns a WorkflowPresetOption whose default choice
+// has an empty Directive (like applyModeOption's "auto").
+func T2_emptyDirectiveOption(key string) WorkflowPresetOption {
+	return WorkflowPresetOption{
+		Key:     key,
+		Label:   "T2 Silent Option",
+		Default: "silent",
+		Choices: []WorkflowPresetChoice{
+			{Value: "silent", Label: "Silent", Directive: ""},
+			{Value: "loud", Label: "Loud", Directive: "Loud directive text"},
+		},
+	}
+}
+
+// TestT2ResolveOptionDirectives_ValidChoice verifies that when a valid choice
+// value is supplied, the corresponding Directive is appended beneath a heading
+// that names the option's Label.
+func TestT2ResolveOptionDirectives_ValidChoice(t *testing.T) {
+	opt := T2_twoChoiceOption("mode")
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	result := resolveOptionDirectives(preset, map[string]string{"mode": "beta"})
+
+	if !strings.Contains(result, "Beta directive text") {
+		t.Errorf("expected Beta directive text in result, got: %q", result)
+	}
+	if strings.Contains(result, "Alpha directive text") {
+		t.Errorf("Alpha directive text should NOT appear for 'beta' choice, got: %q", result)
+	}
+	// The heading must name the option's Label.
+	if !strings.Contains(result, "## T2 Option Label") {
+		t.Errorf("expected '## T2 Option Label' heading in result, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_DefaultFallback verifies that when an unknown
+// value is submitted the function falls back to the option's Default value,
+// and that Default's Directive is appended accordingly.
+func TestT2ResolveOptionDirectives_DefaultFallback(t *testing.T) {
+	opt := T2_twoChoiceOption("mode")
+	// "alpha" is the Default; its Directive is "Alpha directive text".
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	result := resolveOptionDirectives(preset, map[string]string{"mode": "unknown-value"})
+
+	if !strings.Contains(result, "Alpha directive text") {
+		t.Errorf("expected Alpha directive text (default fallback), got: %q", result)
+	}
+	if strings.Contains(result, "Beta directive text") {
+		t.Errorf("Beta directive text should NOT appear when unknown key forces default, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_MissingKey verifies that when a chosen map
+// omits the option's key entirely, the function falls back to the Default.
+func TestT2ResolveOptionDirectives_MissingKey(t *testing.T) {
+	opt := T2_twoChoiceOption("mode")
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	// Pass an empty map — no key for "mode".
+	result := resolveOptionDirectives(preset, map[string]string{})
+
+	if !strings.Contains(result, "Alpha directive text") {
+		t.Errorf("expected Alpha directive text (missing-key default), got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_EmptySelection verifies that an empty chosen
+// map on a preset with NO options returns an empty string (the base prompt
+// is left untouched at the call site).
+func TestT2ResolveOptionDirectives_EmptySelection(t *testing.T) {
+	preset := T2_makeOptionPreset(nil)
+
+	result := resolveOptionDirectives(preset, map[string]string{})
+
+	if result != "" {
+		t.Errorf("expected empty string for preset with no options, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_EmptyStringChosenValue verifies that an
+// explicitly empty string value is treated as invalid and falls back to the
+// Default (mirrors what resolveOptionDirectives does via TrimSpace + loop).
+func TestT2ResolveOptionDirectives_EmptyStringChosenValue(t *testing.T) {
+	opt := T2_twoChoiceOption("mode")
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	result := resolveOptionDirectives(preset, map[string]string{"mode": ""})
+
+	// "" is not a valid choice value -> falls back to "alpha".
+	if !strings.Contains(result, "Alpha directive text") {
+		t.Errorf("expected Alpha directive text (empty-string fallback to default), got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_WhitespaceOnlyChosenValue verifies that
+// whitespace-only chosen values are trimmed and treated as invalid, falling
+// back to the Default.
+func TestT2ResolveOptionDirectives_WhitespaceOnlyChosenValue(t *testing.T) {
+	opt := T2_twoChoiceOption("mode")
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	result := resolveOptionDirectives(preset, map[string]string{"mode": "   "})
+
+	if !strings.Contains(result, "Alpha directive text") {
+		t.Errorf("expected Alpha directive text (whitespace trimmed to invalid -> default), got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_DefaultChoiceEmptyDirective verifies that
+// when the Default's Directive is empty (like applyModeOption's "auto"), no
+// heading or extra text is appended -- the result is an empty string.
+func TestT2ResolveOptionDirectives_DefaultChoiceEmptyDirective(t *testing.T) {
+	opt := T2_emptyDirectiveOption("verbosity")
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	// "silent" is the default and has an empty directive.
+	result := resolveOptionDirectives(preset, map[string]string{"verbosity": "silent"})
+
+	if result != "" {
+		t.Errorf("expected empty string for choice with empty Directive, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_NonDefaultChoiceWithDirective verifies that
+// choosing a non-default value whose Directive is non-empty appends both the
+// heading and the directive text.
+func TestT2ResolveOptionDirectives_NonDefaultChoiceWithDirective(t *testing.T) {
+	opt := T2_emptyDirectiveOption("verbosity")
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	result := resolveOptionDirectives(preset, map[string]string{"verbosity": "loud"})
+
+	if !strings.Contains(result, "Loud directive text") {
+		t.Errorf("expected 'Loud directive text', got: %q", result)
+	}
+	if !strings.Contains(result, "## T2 Silent Option") {
+		t.Errorf("expected '## T2 Silent Option' heading, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_MultipleOptions verifies that when a preset has
+// multiple options, ALL non-empty directives are appended in order.
+func TestT2ResolveOptionDirectives_MultipleOptions(t *testing.T) {
+	optA := WorkflowPresetOption{
+		Key:     "opt_a",
+		Label:   "Option A",
+		Default: "a1",
+		Choices: []WorkflowPresetChoice{
+			{Value: "a1", Label: "A1", Directive: "Directive from A"},
+			{Value: "a2", Label: "A2", Directive: ""},
+		},
+	}
+	optB := WorkflowPresetOption{
+		Key:     "opt_b",
+		Label:   "Option B",
+		Default: "b1",
+		Choices: []WorkflowPresetChoice{
+			{Value: "b1", Label: "B1", Directive: ""},
+			{Value: "b2", Label: "B2", Directive: "Directive from B"},
+		},
+	}
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{optA, optB})
+
+	result := resolveOptionDirectives(preset, map[string]string{
+		"opt_a": "a1", // has a directive
+		"opt_b": "b2", // has a directive
+	})
+
+	if !strings.Contains(result, "Directive from A") {
+		t.Errorf("expected 'Directive from A', got: %q", result)
+	}
+	if !strings.Contains(result, "Directive from B") {
+		t.Errorf("expected 'Directive from B', got: %q", result)
+	}
+	// Order: opt_a is first, so "Directive from A" must appear before "Directive from B".
+	idxA := strings.Index(result, "Directive from A")
+	idxB := strings.Index(result, "Directive from B")
+	if idxA >= idxB {
+		t.Errorf("expected opt_a directive before opt_b directive; idxA=%d idxB=%d in %q", idxA, idxB, result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_MultipleOptionsPartialEmpty verifies that when
+// one of multiple options resolves to a choice with an empty Directive, only
+// the non-empty directive is appended.
+func TestT2ResolveOptionDirectives_MultipleOptionsPartialEmpty(t *testing.T) {
+	optA := WorkflowPresetOption{
+		Key:     "opt_a",
+		Label:   "Option A",
+		Default: "a1",
+		Choices: []WorkflowPresetChoice{
+			{Value: "a1", Label: "A1", Directive: ""}, // empty directive
+		},
+	}
+	optB := WorkflowPresetOption{
+		Key:     "opt_b",
+		Label:   "Option B",
+		Default: "b1",
+		Choices: []WorkflowPresetChoice{
+			{Value: "b1", Label: "B1", Directive: "Only B has a directive"},
+		},
+	}
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{optA, optB})
+
+	result := resolveOptionDirectives(preset, map[string]string{
+		"opt_a": "a1",
+		"opt_b": "b1",
+	})
+
+	if strings.Contains(result, "## Option A") {
+		t.Errorf("Option A heading should not appear when its directive is empty, got: %q", result)
+	}
+	if !strings.Contains(result, "Only B has a directive") {
+		t.Errorf("expected 'Only B has a directive', got: %q", result)
+	}
+	if !strings.Contains(result, "## Option B") {
+		t.Errorf("expected '## Option B' heading, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_ApplyModeOptionAuto mirrors the real
+// applyModeOption with "auto" selection -- must return empty string (no
+// directive, just use the base prompt).
+func TestT2ResolveOptionDirectives_ApplyModeOptionAuto(t *testing.T) {
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{applyModeOption})
+
+	result := resolveOptionDirectives(preset, map[string]string{"apply_mode": "auto"})
+
+	if result != "" {
+		t.Errorf("auto apply_mode should produce no directive, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_ApplyModeOptionFlagOnly mirrors the real
+// applyModeOption with "flag_only" -- must append the suppress-categorization
+// directive under the "Apply mode" heading.
+func TestT2ResolveOptionDirectives_ApplyModeOptionFlagOnly(t *testing.T) {
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{applyModeOption})
+
+	result := resolveOptionDirectives(preset, map[string]string{"apply_mode": "flag_only"})
+
+	if !strings.Contains(result, "FLAG ONLY") {
+		t.Errorf("flag_only apply_mode should contain 'FLAG ONLY' directive, got: %q", result)
+	}
+	if !strings.Contains(result, "## Apply mode") {
+		t.Errorf("expected '## Apply mode' heading, got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_ApplyModeOptionMissingKeyDefaultsToAuto
+// verifies the real applyModeOption when no chosen value is provided --
+// "auto" is the default and has an empty directive, so result is empty.
+func TestT2ResolveOptionDirectives_ApplyModeOptionMissingKeyDefaultsToAuto(t *testing.T) {
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{applyModeOption})
+
+	result := resolveOptionDirectives(preset, nil)
+
+	if result != "" {
+		t.Errorf("missing key on applyModeOption should default to 'auto' (no directive), got: %q", result)
+	}
+}
+
+// TestT2ResolveOptionDirectives_OutputFormat verifies the exact leading format
+// of the appended text: "\n\n## <Label>\n\n<Directive>".
+func TestT2ResolveOptionDirectives_OutputFormat(t *testing.T) {
+	opt := WorkflowPresetOption{
+		Key:     "fmt_opt",
+		Label:   "Format Check",
+		Default: "fv",
+		Choices: []WorkflowPresetChoice{
+			{Value: "fv", Label: "Format Value", Directive: "The directive body"},
+		},
+	}
+	preset := T2_makeOptionPreset([]WorkflowPresetOption{opt})
+
+	result := resolveOptionDirectives(preset, map[string]string{"fmt_opt": "fv"})
+
+	want := "\n\n## Format Check\n\nThe directive body"
+	if result != want {
+		t.Errorf("output format mismatch\n  got:  %q\n  want: %q", result, want)
+	}
+}

--- a/internal/service/workflow_presets_view_mapping_integration_test.go
+++ b/internal/service/workflow_presets_view_mapping_integration_test.go
@@ -1,0 +1,297 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// T19ListWorkflowPresets_ReturnsRegistry verifies that ListWorkflowPresets
+// returns the full preset catalog (all registered presets surfaced as views),
+// and that on a fresh DB no preset is flagged as enabled.
+func T19ListWorkflowPresets_ReturnsRegistry(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+
+	// The registry must expose at least the five presets defined at launch.
+	if len(views) < 5 {
+		t.Fatalf("expected >=5 preset views, got %d", len(views))
+	}
+
+	// Every view must carry the basic metadata fields from the registry.
+	for _, v := range views {
+		if v.Slug == "" {
+			t.Errorf("preset view has empty Slug: %+v", v)
+		}
+		if v.Name == "" {
+			t.Errorf("preset %q has empty Name", v.Slug)
+		}
+		if v.Category == "" {
+			t.Errorf("preset %q has empty Category", v.Slug)
+		}
+		if v.Icon == "" {
+			t.Errorf("preset %q has empty Icon", v.Slug)
+		}
+		if v.Description == "" {
+			t.Errorf("preset %q has empty Description", v.Slug)
+		}
+	}
+
+	// On a fresh DB (nothing enabled) every view must have Enabled=false and
+	// both pointer fields nil.
+	for _, v := range views {
+		if v.Enabled {
+			t.Errorf("preset %q unexpectedly enabled on fresh DB", v.Slug)
+		}
+		if v.WorkflowSlug != nil {
+			t.Errorf("preset %q has non-nil WorkflowSlug on fresh DB", v.Slug)
+		}
+		if v.WorkflowEnabled != nil {
+			t.Errorf("preset %q has non-nil WorkflowEnabled on fresh DB", v.Slug)
+		}
+	}
+}
+
+// T19ListWorkflowPresets_EnabledPresetFlagged verifies that after enabling a
+// preset, ListWorkflowPresets marks that preset as enabled and surfaces the
+// instantiated workflow's slug and enabled toggle.
+func T19ListWorkflowPresets_EnabledPresetFlagged(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Confirm "routine-reviewer" is not yet enabled.
+	before, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets (before): %v", err)
+	}
+	for _, v := range before {
+		if v.Slug == "routine-reviewer" && v.Enabled {
+			t.Fatal("precondition: routine-reviewer already enabled on fresh DB")
+		}
+	}
+
+	// Enable the preset in the paused state.
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	// Now ListWorkflowPresets must show it as enabled.
+	after, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets (after): %v", err)
+	}
+
+	var found bool
+	for _, v := range after {
+		if v.Slug != "routine-reviewer" {
+			continue
+		}
+		found = true
+
+		if !v.Enabled {
+			t.Error("routine-reviewer view.Enabled = false, want true")
+		}
+		if v.WorkflowSlug == nil {
+			t.Fatal("routine-reviewer view.WorkflowSlug is nil")
+		}
+		if *v.WorkflowSlug != wf.Slug {
+			t.Errorf("view.WorkflowSlug = %q, want %q", *v.WorkflowSlug, wf.Slug)
+		}
+		if v.WorkflowEnabled == nil {
+			t.Fatal("routine-reviewer view.WorkflowEnabled is nil")
+		}
+		// We enabled it paused (Enabled=false), so WorkflowEnabled must reflect
+		// the instantiated definition's own enabled toggle (false).
+		if *v.WorkflowEnabled != wf.Enabled {
+			t.Errorf("view.WorkflowEnabled = %v, want %v", *v.WorkflowEnabled, wf.Enabled)
+		}
+	}
+
+	if !found {
+		t.Fatal("routine-reviewer not present in preset views")
+	}
+
+	// Every other preset must remain NOT enabled.
+	for _, v := range after {
+		if v.Slug == "routine-reviewer" {
+			continue
+		}
+		if v.Enabled {
+			t.Errorf("preset %q unexpectedly enabled after enabling only routine-reviewer", v.Slug)
+		}
+	}
+}
+
+// T19ListWorkflowPresets_WorkflowEnabledToggle verifies that WorkflowEnabled
+// tracks the instantiated workflow's own enabled toggle accurately (both true
+// and false states).
+func T19ListWorkflowPresets_WorkflowEnabledToggle(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Enable the preset in active state (Enabled: true).
+	_, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{Enabled: true})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset (active): %v", err)
+	}
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+
+	for _, v := range views {
+		if v.Slug != "weekly-money-digest" {
+			continue
+		}
+		if !v.Enabled {
+			t.Error("view.Enabled = false, want true")
+		}
+		if v.WorkflowEnabled == nil {
+			t.Fatal("view.WorkflowEnabled is nil")
+		}
+		if !*v.WorkflowEnabled {
+			t.Error("view.WorkflowEnabled = false, want true (enabled=true was passed)")
+		}
+		return
+	}
+	t.Fatal("weekly-money-digest not found in preset views")
+}
+
+// T19ListWorkflowPresets_OptionsAreSurfaced verifies that presets which carry
+// specialized options (e.g. the applyModeOption) expose those options in the
+// view so callers can render a configure drawer.
+func T19ListWorkflowPresets_OptionsAreSurfaced(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+
+	// "routine-reviewer" is defined with the applyModeOption.
+	for _, v := range views {
+		if v.Slug != "routine-reviewer" {
+			continue
+		}
+		if len(v.Options) == 0 {
+			t.Fatal("routine-reviewer has no options in the view")
+		}
+		var foundApplyMode bool
+		for _, opt := range v.Options {
+			if opt.Key == "apply_mode" {
+				foundApplyMode = true
+				if opt.Label == "" {
+					t.Error("apply_mode option has empty Label")
+				}
+				if len(opt.Choices) < 2 {
+					t.Errorf("apply_mode option has %d choices, want >=2", len(opt.Choices))
+				}
+				if opt.Default == "" {
+					t.Error("apply_mode option has empty Default")
+				}
+				// Every choice must have a non-empty Value and Label.
+				for _, ch := range opt.Choices {
+					if ch.Value == "" {
+						t.Errorf("apply_mode choice has empty Value: %+v", ch)
+					}
+					if ch.Label == "" {
+						t.Errorf("apply_mode choice %q has empty Label", ch.Value)
+					}
+				}
+			}
+		}
+		if !foundApplyMode {
+			t.Error("routine-reviewer is missing the apply_mode option")
+		}
+		return
+	}
+	t.Fatal("routine-reviewer not found in preset views")
+}
+
+// T19ListWorkflowPresets_NoOptionsPreset verifies that presets without
+// configured options surface an empty (not nil) Options slice, consistent
+// with the registry definition.
+func T19ListWorkflowPresets_NoOptionsPreset(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+
+	// "weekly-money-digest" is defined without options in the registry.
+	for _, v := range views {
+		if v.Slug != "weekly-money-digest" {
+			continue
+		}
+		// Options may be nil or empty — both are acceptable; the caller must not
+		// panic iterating over it. A non-zero length here would be wrong.
+		if len(v.Options) != 0 {
+			t.Errorf("weekly-money-digest has %d unexpected options", len(v.Options))
+		}
+		return
+	}
+	t.Fatal("weekly-money-digest not found in preset views")
+}
+
+// T19ListWorkflowPresets_OrderMatchesRegistry verifies that ListWorkflowPresets
+// returns views in the same order as the underlying registry (gallery display
+// order is stable, not DB-order).
+func T19ListWorkflowPresets_OrderMatchesRegistry(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+
+	// The first five presets in registry order are known at test time.
+	want := []string{
+		"routine-reviewer",
+		"weekly-money-digest",
+		"subscription-auditor",
+		"backlog-closer",
+		"monthly-close",
+	}
+	if len(views) < len(want) {
+		t.Fatalf("expected >=%d views, got %d", len(want), len(views))
+	}
+	for i, slug := range want {
+		if views[i].Slug != slug {
+			t.Errorf("views[%d].Slug = %q, want %q (registry order)", i, views[i].Slug, slug)
+		}
+	}
+}
+
+// T19ListWorkflowPresets_CostEstimatesSurfaced verifies that each view carries
+// a positive EstCostPerRunUSD from the registry.
+func T19ListWorkflowPresets_CostEstimatesSurfaced(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	views, err := svc.ListWorkflowPresets(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowPresets: %v", err)
+	}
+	if len(views) == 0 {
+		t.Fatal("expected at least one preset view")
+	}
+	for _, v := range views {
+		if v.EstCostPerRunUSD <= 0 {
+			t.Errorf("preset %q has non-positive EstCostPerRunUSD: %v", v.Slug, v.EstCostPerRunUSD)
+		}
+	}
+}

--- a/internal/service/workflow_prompt.go
+++ b/internal/service/workflow_prompt.go
@@ -1,0 +1,49 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"fmt"
+)
+
+// WorkflowPromptPreview is the composed base prompt for a preset, surfaced by
+// the admin "Preview internal prompt" affordance. It's the exact base prompt a
+// run starts from BEFORE per-workflow additional instructions are appended —
+// the composed prompt blocks plus each option's default-choice directive.
+type WorkflowPromptPreview struct {
+	Slug   string `json:"slug"`
+	Title  string `json:"title"`
+	Prompt string `json:"prompt"`
+}
+
+// ComposeWorkflowPrompt returns the fully composed base prompt for a preset:
+// the concatenated prompt blocks plus the directives for each option's DEFAULT
+// choice. It reuses composePresetPrompt + resolveOptionDirectives — the same
+// composition EnableWorkflowFromPreset performs — so the preview matches what a
+// freshly-enabled workflow would run with (sans the household's per-workflow
+// additional instructions, which are tuned at enable time).
+//
+// Passing a nil chosen map to resolveOptionDirectives makes every option fall
+// back to its Default, which is the correct "what you'd get out of the box"
+// preview.
+func (s *Service) ComposeWorkflowPrompt(ctx context.Context, slug string) (*WorkflowPromptPreview, error) {
+	preset, ok := presetBySlug(slug)
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown workflow preset %q", ErrNotFound, slug)
+	}
+
+	prompt, err := composePresetPrompt(preset.PromptBlocks)
+	if err != nil {
+		return nil, err
+	}
+	// Append each option's default-choice directive (nil map ⇒ all defaults),
+	// mirroring EnableWorkflowFromPreset's composition order.
+	prompt += resolveOptionDirectives(preset, nil)
+
+	return &WorkflowPromptPreview{
+		Slug:   preset.Slug,
+		Title:  preset.Name,
+		Prompt: prompt,
+	}, nil
+}

--- a/internal/service/workflow_reconfigure.go
+++ b/internal/service/workflow_reconfigure.go
@@ -1,0 +1,217 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// additionalInstructionsHeading is the prompt marker under which the
+// household's per-workflow tuning is appended. It must stay byte-identical
+// to the suffix written by EnableWorkflowFromPreset so a reconfigure can
+// split the tail back off and re-compose deterministically.
+const additionalInstructionsHeading = "\n\n## Additional instructions\n\n"
+
+// WorkflowConfigOption mirrors a preset's specialized option for the
+// reconfigure drawer: the option metadata (key/label/help/choices) plus
+// the currently-selected value derived from the live workflow's prompt.
+type WorkflowConfigOption struct {
+	Key      string                       `json:"key"`
+	Label    string                       `json:"label"`
+	Help     string                       `json:"help,omitempty"`
+	Selected string                       `json:"selected"`
+	Choices  []WorkflowConfigOptionChoice `json:"choices"`
+}
+
+// WorkflowConfigOptionChoice is one selectable value for an option.
+type WorkflowConfigOptionChoice struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+// WorkflowConfig is the current configuration of an already-enabled
+// workflow, shaped for the reconfigure drawer. It reports the live
+// schedule, the appended additional-instructions tail, and the chosen
+// value for each of the preset's specialized options — everything the
+// drawer needs to render prefilled.
+type WorkflowConfig struct {
+	// Slug is the workflow (and preset) slug.
+	Slug string `json:"slug"`
+	// Name is the workflow's display name.
+	Name string `json:"name"`
+	// TriggerOnSync is true for post-sync presets (schedule not editable).
+	TriggerOnSync bool `json:"trigger_on_sync"`
+	// ScheduleCron is the live cron for scheduled presets (empty for
+	// post-sync). The drawer's schedule select is seeded from this.
+	ScheduleCron string `json:"schedule_cron"`
+	// AdditionalInstructions is the per-workflow tuning currently appended
+	// to the composed base prompt (empty when none).
+	AdditionalInstructions string `json:"additional_instructions"`
+	// Options carries every preset option with its currently-selected value.
+	Options []WorkflowConfigOption `json:"options"`
+}
+
+// UpdateWorkflowConfigParams carries the reconfigure-drawer fields for an
+// already-enabled workflow. It mirrors the enable-time configurable surface:
+// schedule, additional-instructions tail, and chosen options. The base
+// prompt blocks are NOT editable here (they're the preset's identity); only
+// the household-tunable layers on top are.
+type UpdateWorkflowConfigParams struct {
+	// ScheduleCron overrides the schedule for scheduled presets. nil = leave
+	// the schedule untouched; ignored entirely for post-sync presets.
+	ScheduleCron *string
+	// AdditionalInstructions replaces the appended per-workflow tuning. An
+	// empty string clears it.
+	AdditionalInstructions string
+	// Options carries the chosen value for each of the preset's options
+	// (keyed by WorkflowPresetOption.Key). Unknown/missing keys fall back to
+	// the option's Default, matching enable-time semantics.
+	Options map[string]string
+}
+
+// presetForEnabledWorkflow resolves an enabled workflow by slug and returns
+// both the live definition and the preset it was instantiated from. It is
+// the shared guard for Get/UpdateWorkflowConfig: a workflow that wasn't
+// instantiated from a known preset (hand-authored, or a retired preset
+// slug) can't be reconfigured through this surface.
+func (s *Service) presetForEnabledWorkflow(ctx context.Context, slug string) (*AgentDefinitionResponse, WorkflowPreset, error) {
+	def, err := s.GetAgentDefinition(ctx, slug)
+	if err != nil {
+		// resolveAgentDefinition already returns ErrNotFound for an unknown slug.
+		return nil, WorkflowPreset{}, err
+	}
+	if def.SourceTemplate == nil {
+		return nil, WorkflowPreset{}, fmt.Errorf("%w: %q is not a preset-instantiated workflow", ErrInvalidState, slug)
+	}
+	preset, ok := presetBySlug(*def.SourceTemplate)
+	if !ok {
+		return nil, WorkflowPreset{}, fmt.Errorf("%w: workflow %q references unknown preset %q", ErrNotFound, slug, *def.SourceTemplate)
+	}
+	return def, preset, nil
+}
+
+// splitAdditionalInstructions separates a composed workflow prompt into its
+// body (base + option directives) and the appended additional-instructions
+// tail. Returns ("", body) when no tail marker is present. The marker is the
+// exact suffix EnableWorkflowFromPreset writes, so the round-trip is lossless.
+func splitAdditionalInstructions(prompt string) (instructions, body string) {
+	idx := strings.LastIndex(prompt, additionalInstructionsHeading)
+	if idx < 0 {
+		return "", prompt
+	}
+	body = prompt[:idx]
+	instructions = strings.TrimSpace(prompt[idx+len(additionalInstructionsHeading):])
+	return instructions, body
+}
+
+// deriveChosenOptions reverse-engineers which option choices are currently
+// active in a workflow's prompt body. A choice is detected by the presence
+// of its (non-empty) directive text; an option whose active choice has no
+// directive (the common "default/auto" case) resolves to its Default. This
+// reads the body rather than the full prompt so trailing additional
+// instructions can never be mistaken for a directive.
+func deriveChosenOptions(preset WorkflowPreset, body string) map[string]string {
+	chosen := make(map[string]string, len(preset.Options))
+	for _, opt := range preset.Options {
+		selected := opt.Default
+		for _, ch := range opt.Choices {
+			dir := strings.TrimSpace(ch.Directive)
+			if dir != "" && strings.Contains(body, dir) {
+				selected = ch.Value
+				break
+			}
+		}
+		chosen[opt.Key] = selected
+	}
+	return chosen
+}
+
+// GetWorkflowConfig returns the live configuration of an already-enabled
+// workflow for the reconfigure drawer: its schedule, the appended
+// additional-instructions tail, and the chosen value of each preset option,
+// all derived from the instantiated definition. Resolves by slug.
+func (s *Service) GetWorkflowConfig(ctx context.Context, slug string) (*WorkflowConfig, error) {
+	def, preset, err := s.presetForEnabledWorkflow(ctx, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	instructions, body := splitAdditionalInstructions(def.Prompt)
+	chosen := deriveChosenOptions(preset, body)
+
+	cfg := &WorkflowConfig{
+		Slug:                   def.Slug,
+		Name:                   def.Name,
+		TriggerOnSync:          def.TriggerOnSyncComplete,
+		AdditionalInstructions: instructions,
+	}
+	if def.ScheduleCron != nil {
+		cfg.ScheduleCron = *def.ScheduleCron
+	}
+	for _, opt := range preset.Options {
+		co := WorkflowConfigOption{
+			Key:      opt.Key,
+			Label:    opt.Label,
+			Help:     opt.Help,
+			Selected: chosen[opt.Key],
+		}
+		for _, ch := range opt.Choices {
+			co.Choices = append(co.Choices, WorkflowConfigOptionChoice{Value: ch.Value, Label: ch.Label})
+		}
+		cfg.Options = append(cfg.Options, co)
+	}
+	return cfg, nil
+}
+
+// composeWorkflowPrompt builds the full prompt for a preset from its base
+// blocks, the chosen options' directives, and the household's additional
+// instructions — byte-identical to what EnableWorkflowFromPreset assembles.
+// Centralizing the assembly here keeps enable and reconfigure in lockstep.
+func composeWorkflowPrompt(preset WorkflowPreset, options map[string]string, additionalInstructions string) (string, error) {
+	prompt, err := composePresetPrompt(preset.PromptBlocks)
+	if err != nil {
+		return "", err
+	}
+	prompt += resolveOptionDirectives(preset, options)
+	instr := strings.TrimSpace(additionalInstructions)
+	if len(instr) > maxAdditionalInstructions {
+		return "", fmt.Errorf("%w: additional instructions exceed %d chars", ErrInvalidParameter, maxAdditionalInstructions)
+	}
+	if instr != "" {
+		prompt = prompt + additionalInstructionsHeading + instr
+	}
+	return prompt, nil
+}
+
+// UpdateWorkflowConfig re-composes and persists the configurable layers of an
+// already-enabled workflow: schedule_cron (scheduled presets only), the
+// chosen options' directives, and the appended additional-instructions tail.
+// The base prompt blocks (the preset's identity) and run-state toggle are
+// untouched — toggling runs stays on the enable/disable endpoints. Resolves
+// by slug; returns the updated definition.
+func (s *Service) UpdateWorkflowConfig(ctx context.Context, slug string, params UpdateWorkflowConfigParams) (*AgentDefinitionResponse, error) {
+	_, preset, err := s.presetForEnabledWorkflow(ctx, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	prompt, err := composeWorkflowPrompt(preset, params.Options, params.AdditionalInstructions)
+	if err != nil {
+		return nil, err
+	}
+
+	update := UpdateAgentDefinitionParams{Prompt: &prompt}
+
+	// Scheduled presets accept a cron override; post-sync presets keep their
+	// event trigger (no cron), mirroring EnableWorkflowFromPreset.
+	if !preset.TriggerOnSyncComplete && params.ScheduleCron != nil {
+		cron := strings.TrimSpace(*params.ScheduleCron)
+		if cron != "" {
+			update.ScheduleCron = &cron
+		}
+	}
+
+	return s.UpdateAgentDefinition(ctx, slug, update)
+}

--- a/internal/service/workflow_reconfigure_integration_test.go
+++ b/internal/service/workflow_reconfigure_integration_test.go
@@ -1,0 +1,194 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestF3GetWorkflowConfig round-trips enable → GetWorkflowConfig: the live
+// config must reflect the schedule, additional instructions, and chosen
+// options the workflow was instantiated with.
+func TestF3GetWorkflowConfig(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cron := "0 8 1 * *"
+	if _, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{
+		Enabled:                false,
+		ScheduleCron:           &cron,
+		AdditionalInstructions: "Focus on dining-out spend.",
+	}); err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	cfg, err := svc.GetWorkflowConfig(ctx, "weekly-money-digest")
+	if err != nil {
+		t.Fatalf("GetWorkflowConfig: %v", err)
+	}
+	if cfg.Slug != "weekly-money-digest" {
+		t.Fatalf("slug = %q, want weekly-money-digest", cfg.Slug)
+	}
+	if cfg.TriggerOnSync {
+		t.Fatalf("weekly-money-digest is a scheduled preset; TriggerOnSync should be false")
+	}
+	if cfg.ScheduleCron != cron {
+		t.Fatalf("schedule_cron = %q, want %q", cfg.ScheduleCron, cron)
+	}
+	if cfg.AdditionalInstructions != "Focus on dining-out spend." {
+		t.Fatalf("additional_instructions = %q, want the enabled value", cfg.AdditionalInstructions)
+	}
+}
+
+// TestF3GetWorkflowConfig_DerivesOption confirms the chosen option (apply_mode)
+// is recovered from the instantiated workflow's prompt.
+func TestF3GetWorkflowConfig_DerivesOption(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if _, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{
+		Options: map[string]string{"apply_mode": "flag_only"},
+	}); err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	cfg, err := svc.GetWorkflowConfig(ctx, "routine-reviewer")
+	if err != nil {
+		t.Fatalf("GetWorkflowConfig: %v", err)
+	}
+	if cfg.TriggerOnSync != true {
+		t.Fatalf("routine-reviewer should be post-sync (TriggerOnSync=true)")
+	}
+	var found bool
+	for _, opt := range cfg.Options {
+		if opt.Key == "apply_mode" {
+			found = true
+			if opt.Selected != "flag_only" {
+				t.Fatalf("apply_mode selected = %q, want flag_only", opt.Selected)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("apply_mode option not present in config")
+	}
+}
+
+// TestF3UpdateWorkflowConfig re-composes an enabled workflow: a new schedule,
+// new option, and new additional instructions all land in the live row, and a
+// subsequent GetWorkflowConfig reflects them (a full edit round-trip).
+func TestF3UpdateWorkflowConfig(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Enable a categorization preset paused, auto apply mode, no instructions.
+	if _, err := svc.EnableWorkflowFromPreset(ctx, "backlog-closer", service.EnableWorkflowFromPresetParams{
+		Enabled: false,
+	}); err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	newCron := "0 8 * * *"
+	wf, err := svc.UpdateWorkflowConfig(ctx, "backlog-closer", service.UpdateWorkflowConfigParams{
+		ScheduleCron:           &newCron,
+		AdditionalInstructions: "Promote only 3+ occurrence patterns.",
+		Options:                map[string]string{"apply_mode": "flag_only"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorkflowConfig: %v", err)
+	}
+	if wf.ScheduleCron == nil || *wf.ScheduleCron != newCron {
+		t.Fatalf("schedule_cron = %v, want %q", wf.ScheduleCron, newCron)
+	}
+	if !strings.Contains(wf.Prompt, "FLAG ONLY") {
+		t.Fatalf("re-composed prompt missing the flag-only directive")
+	}
+	if !strings.Contains(wf.Prompt, "Promote only 3+ occurrence patterns.") {
+		t.Fatalf("re-composed prompt missing the new additional instructions")
+	}
+	// The run-state toggle is untouched by a reconfigure.
+	if wf.Enabled {
+		t.Fatalf("reconfigure should not flip the enabled toggle")
+	}
+
+	// GetWorkflowConfig reflects the new values.
+	cfg, err := svc.GetWorkflowConfig(ctx, "backlog-closer")
+	if err != nil {
+		t.Fatalf("GetWorkflowConfig after update: %v", err)
+	}
+	if cfg.ScheduleCron != newCron {
+		t.Fatalf("config schedule_cron = %q, want %q", cfg.ScheduleCron, newCron)
+	}
+	if cfg.AdditionalInstructions != "Promote only 3+ occurrence patterns." {
+		t.Fatalf("config additional_instructions = %q, want the updated value", cfg.AdditionalInstructions)
+	}
+	for _, opt := range cfg.Options {
+		if opt.Key == "apply_mode" && opt.Selected != "flag_only" {
+			t.Fatalf("config apply_mode = %q, want flag_only", opt.Selected)
+		}
+	}
+
+	// Clearing the additional instructions removes the tail.
+	if _, err := svc.UpdateWorkflowConfig(ctx, "backlog-closer", service.UpdateWorkflowConfigParams{
+		AdditionalInstructions: "",
+		Options:                map[string]string{"apply_mode": "auto"},
+	}); err != nil {
+		t.Fatalf("UpdateWorkflowConfig (clear): %v", err)
+	}
+	cfg, err = svc.GetWorkflowConfig(ctx, "backlog-closer")
+	if err != nil {
+		t.Fatalf("GetWorkflowConfig after clear: %v", err)
+	}
+	if cfg.AdditionalInstructions != "" {
+		t.Fatalf("additional_instructions = %q, want empty after clear", cfg.AdditionalInstructions)
+	}
+}
+
+// TestF3UpdateWorkflowConfig_PostSyncIgnoresSchedule confirms a schedule
+// override is ignored for a post-sync workflow (mirrors enable-time semantics).
+func TestF3UpdateWorkflowConfig_PostSyncIgnoresSchedule(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if _, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{}); err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	cron := "0 8 * * *"
+	wf, err := svc.UpdateWorkflowConfig(ctx, "routine-reviewer", service.UpdateWorkflowConfigParams{
+		ScheduleCron: &cron,
+	})
+	if err != nil {
+		t.Fatalf("UpdateWorkflowConfig: %v", err)
+	}
+	if wf.ScheduleCron != nil {
+		t.Fatalf("post-sync workflow got a schedule_cron = %v, want nil", *wf.ScheduleCron)
+	}
+	if !wf.TriggerOnSyncComplete {
+		t.Fatalf("routine-reviewer should still trigger on sync")
+	}
+}
+
+// TestF3WorkflowConfig_NotEnabled guards the not-an-enabled-preset paths:
+// an unknown slug is ErrNotFound; a hand-authored agent (no source_template)
+// is ErrInvalidState.
+func TestF3WorkflowConfig_NotEnabled(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if _, err := svc.GetWorkflowConfig(ctx, "no-such-workflow"); !errors.Is(err, service.ErrNotFound) {
+		t.Fatalf("GetWorkflowConfig(unknown) err = %v, want ErrNotFound", err)
+	}
+
+	// A hand-authored agent carries no source_template → not reconfigurable.
+	plain := mustCreateAgentDefinition(t, svc, "f3-plain-agent", true)
+	if _, err := svc.GetWorkflowConfig(ctx, plain.Slug); !errors.Is(err, service.ErrInvalidState) {
+		t.Fatalf("GetWorkflowConfig(hand-authored) err = %v, want ErrInvalidState", err)
+	}
+	if _, err := svc.UpdateWorkflowConfig(ctx, plain.Slug, service.UpdateWorkflowConfigParams{}); !errors.Is(err, service.ErrInvalidState) {
+		t.Fatalf("UpdateWorkflowConfig(hand-authored) err = %v, want ErrInvalidState", err)
+	}
+}

--- a/internal/service/workflow_reconfigure_test.go
+++ b/internal/service/workflow_reconfigure_test.go
@@ -1,0 +1,121 @@
+//go:build !lite
+
+package service
+
+import "testing"
+
+// F3ReconfigureChoiceWithDirective returns a preset whose single option has a
+// directive-bearing choice, so the decompose/derive round-trip can be tested
+// without a DB. It mirrors the shape of applyModeOption.
+func f3ReconfigurePresetFixture() WorkflowPreset {
+	return WorkflowPreset{
+		Slug:     "f3-recon-fixture",
+		Name:     "F3 Recon Fixture",
+		Category: "Test",
+		Options: []WorkflowPresetOption{
+			{
+				Key:     "apply_mode",
+				Label:   "Apply mode",
+				Default: "auto",
+				Choices: []WorkflowPresetChoice{
+					{Value: "auto", Label: "Auto", Directive: ""},
+					{Value: "flag_only", Label: "Flag only", Directive: "FLAG ONLY: do not categorize."},
+				},
+			},
+		},
+	}
+}
+
+func TestF3ReconfigureSplitAdditionalInstructions(t *testing.T) {
+	cases := []struct {
+		name      string
+		prompt    string
+		wantInstr string
+		wantBody  string
+	}{
+		{
+			name:      "no tail",
+			prompt:    "base prompt body",
+			wantInstr: "",
+			wantBody:  "base prompt body",
+		},
+		{
+			name:      "with tail",
+			prompt:    "base body" + additionalInstructionsHeading + "watch dining out",
+			wantInstr: "watch dining out",
+			wantBody:  "base body",
+		},
+		{
+			name:      "trims tail whitespace",
+			prompt:    "base" + additionalInstructionsHeading + "  spaced  \n",
+			wantInstr: "spaced",
+			wantBody:  "base",
+		},
+		{
+			name:      "last marker wins",
+			prompt:    "x" + additionalInstructionsHeading + "first" + additionalInstructionsHeading + "second",
+			wantInstr: "second",
+			wantBody:  "x" + additionalInstructionsHeading + "first",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotInstr, gotBody := splitAdditionalInstructions(tc.prompt)
+			if gotInstr != tc.wantInstr {
+				t.Errorf("instructions = %q, want %q", gotInstr, tc.wantInstr)
+			}
+			if gotBody != tc.wantBody {
+				t.Errorf("body = %q, want %q", gotBody, tc.wantBody)
+			}
+		})
+	}
+}
+
+func TestF3ReconfigureDeriveChosenOptions(t *testing.T) {
+	preset := f3ReconfigurePresetFixture()
+
+	// A body containing the flag_only directive resolves to flag_only.
+	flagBody := "base\n\n## Apply mode\n\nFLAG ONLY: do not categorize."
+	got := deriveChosenOptions(preset, flagBody)
+	if got["apply_mode"] != "flag_only" {
+		t.Fatalf("apply_mode = %q, want flag_only", got["apply_mode"])
+	}
+
+	// A body with no directive falls back to the option default (auto).
+	got = deriveChosenOptions(preset, "base prompt with no directives")
+	if got["apply_mode"] != "auto" {
+		t.Fatalf("apply_mode = %q, want auto (default)", got["apply_mode"])
+	}
+}
+
+func TestF3ReconfigureComposeWorkflowPrompt_TooLong(t *testing.T) {
+	preset := f3ReconfigurePresetFixture()
+	long := make([]byte, maxAdditionalInstructions+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	// composePresetPrompt will fail first on the empty block list of the
+	// fixture, so give the fixture a real block to isolate the length check.
+	preset.PromptBlocks = workflowPresets[0].PromptBlocks
+	if _, err := composeWorkflowPrompt(preset, nil, string(long)); err == nil {
+		t.Fatal("composeWorkflowPrompt accepted over-long additional instructions")
+	}
+}
+
+func TestF3ReconfigureComposeWorkflowPrompt_RoundTrip(t *testing.T) {
+	preset := f3ReconfigurePresetFixture()
+	preset.PromptBlocks = workflowPresets[0].PromptBlocks
+
+	prompt, err := composeWorkflowPrompt(preset, map[string]string{"apply_mode": "flag_only"}, "be brief")
+	if err != nil {
+		t.Fatalf("composeWorkflowPrompt: %v", err)
+	}
+
+	instr, body := splitAdditionalInstructions(prompt)
+	if instr != "be brief" {
+		t.Fatalf("round-trip instructions = %q, want %q", instr, "be brief")
+	}
+	if got := deriveChosenOptions(preset, body)["apply_mode"]; got != "flag_only" {
+		t.Fatalf("round-trip apply_mode = %q, want flag_only", got)
+	}
+}

--- a/internal/service/workflow_run_report_summary_integration_test.go
+++ b/internal/service/workflow_run_report_summary_integration_test.go
@@ -1,0 +1,331 @@
+//go:build integration && !lite
+
+// Integration tests for ListReportSummariesForRunIDs.
+// Prefix: T22
+// Run with: make test-integration
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// T22_mustCreateRunWithReports creates an agent definition + run, attaches
+// numReports agent reports to that run (via the agentRunShortID path in
+// CreateAgentReport), and returns the run UUID string and the list of created
+// report summaries in insertion order.
+func T22_mustCreateRunWithReports(
+	t *testing.T,
+	svc *service.Service,
+	q *db.Queries,
+	slug string,
+	priorities []string,
+) (runID string, reports []service.AgentRunReportSummary) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Create an agent definition so we can create a run.
+	def, err := svc.CreateAgentDefinition(ctx, service.CreateAgentDefinitionParams{
+		Name:   "T22 Agent " + slug,
+		Slug:   slug,
+		Prompt: "Test workflow for T22.",
+	})
+	if err != nil {
+		t.Fatalf("T22: CreateAgentDefinition(%q): %v", slug, err)
+	}
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		t.Fatalf("T22: parse def UUID: %v", err)
+	}
+
+	// Insert a run row.
+	run, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
+		AgentDefinitionID: defUUID,
+		Trigger:           "manual",
+	})
+	if err != nil {
+		t.Fatalf("T22: CreateAgentRun for %q: %v", slug, err)
+	}
+	runID = pgconv.FormatUUID(run.ID)
+
+	actor := service.Actor{Type: "agent", ID: def.ID, Name: "T22 Agent"}
+
+	// Create each report with a small sleep to ensure created_at ordering is
+	// deterministic — the ListReportSummariesForRunIDs query orders by
+	// created_at ASC so oldest-first matters.
+	for i, priority := range priorities {
+		title := slug + "-report-" + priority
+		report, cerr := svc.CreateAgentReport(ctx, title, "body", actor, priority, nil, "", "", run.ShortID)
+		if cerr != nil {
+			t.Fatalf("T22: CreateAgentReport[%d] for run %s: %v", i, slug, cerr)
+		}
+		reports = append(reports, service.AgentRunReportSummary{
+			ShortID:  report.ShortID,
+			Title:    report.Title,
+			Priority: report.Priority,
+		})
+		// Tiny sleep so created_at is strictly increasing across rows.
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	return runID, reports
+}
+
+// T22_mapKeys is a small test-only helper that returns the keys of a
+// map[string][]AgentRunReportSummary for diagnostic output.
+func T22_mapKeys(m map[string][]service.AgentRunReportSummary) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// T22TestListReportSummariesForRunIDs_RunWithReports verifies that a run
+// linked to multiple reports has all its summaries returned in oldest->newest
+// order with correct short_id, title, and priority.
+func T22TestListReportSummariesForRunIDs_RunWithReports(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	runID, wantReports := T22_mustCreateRunWithReports(
+		t, svc, q,
+		"t22-with-reports",
+		[]string{"info", "warning", "critical"},
+	)
+
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{runID})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs: %v", err)
+	}
+
+	summaries, ok := got[runID]
+	if !ok {
+		t.Fatalf("T22: run %q absent from result map; map keys = %v", runID, T22_mapKeys(got))
+	}
+	if len(summaries) != len(wantReports) {
+		t.Fatalf("T22: got %d summaries, want %d", len(summaries), len(wantReports))
+	}
+
+	// Verify oldest->newest order and field correctness.
+	for i, want := range wantReports {
+		s := summaries[i]
+		if s.ShortID != want.ShortID {
+			t.Errorf("T22: summaries[%d].ShortID = %q, want %q", i, s.ShortID, want.ShortID)
+		}
+		if s.Title != want.Title {
+			t.Errorf("T22: summaries[%d].Title = %q, want %q", i, s.Title, want.Title)
+		}
+		if s.Priority != want.Priority {
+			t.Errorf("T22: summaries[%d].Priority = %q, want %q", i, s.Priority, want.Priority)
+		}
+	}
+}
+
+// T22TestListReportSummariesForRunIDs_RunWithNoReports verifies that a run
+// that has no associated reports is absent from the result map (not present
+// with an empty slice).
+func T22TestListReportSummariesForRunIDs_RunWithNoReports(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	// Create a run but attach zero reports.
+	def, err := svc.CreateAgentDefinition(ctx, service.CreateAgentDefinitionParams{
+		Name:   "T22 Agent t22-no-reports",
+		Slug:   "t22-no-reports",
+		Prompt: "Test workflow with no reports.",
+	})
+	if err != nil {
+		t.Fatalf("T22: CreateAgentDefinition: %v", err)
+	}
+	defUUID, err := pgconv.ParseUUID(def.ID)
+	if err != nil {
+		t.Fatalf("T22: parse def UUID: %v", err)
+	}
+	run, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
+		AgentDefinitionID: defUUID,
+		Trigger:           "manual",
+	})
+	if err != nil {
+		t.Fatalf("T22: CreateAgentRun: %v", err)
+	}
+	runID := pgconv.FormatUUID(run.ID)
+
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{runID})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs: %v", err)
+	}
+	if _, present := got[runID]; present {
+		t.Errorf("T22: run with no reports should be absent from map, but it is present with %d entry(ies)", len(got[runID]))
+	}
+}
+
+// T22TestListReportSummariesForRunIDs_MixedBatch verifies that when multiple
+// run IDs are batched together, only runs that have reports appear in the
+// result and their summaries are independent of each other.
+func T22TestListReportSummariesForRunIDs_MixedBatch(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	// Run A: 2 reports.
+	runAID, wantA := T22_mustCreateRunWithReports(
+		t, svc, q,
+		"t22-mixed-a",
+		[]string{"info", "critical"},
+	)
+
+	// Run B: no reports.
+	defB, err := svc.CreateAgentDefinition(ctx, service.CreateAgentDefinitionParams{
+		Name:   "T22 Agent t22-mixed-b",
+		Slug:   "t22-mixed-b",
+		Prompt: "Run B has no reports.",
+	})
+	if err != nil {
+		t.Fatalf("T22: CreateAgentDefinition B: %v", err)
+	}
+	defBUUID, err := pgconv.ParseUUID(defB.ID)
+	if err != nil {
+		t.Fatalf("T22: parse defB UUID: %v", err)
+	}
+	runB, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
+		AgentDefinitionID: defBUUID,
+		Trigger:           "cron",
+	})
+	if err != nil {
+		t.Fatalf("T22: CreateAgentRun B: %v", err)
+	}
+	runBID := pgconv.FormatUUID(runB.ID)
+
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{runAID, runBID})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs: %v", err)
+	}
+
+	// Run A must be present with 2 summaries.
+	sumA, ok := got[runAID]
+	if !ok {
+		t.Fatalf("T22: run A absent from result map")
+	}
+	if len(sumA) != len(wantA) {
+		t.Fatalf("T22: run A: got %d summaries, want %d", len(sumA), len(wantA))
+	}
+	for i, want := range wantA {
+		if sumA[i].ShortID != want.ShortID {
+			t.Errorf("T22: run A summaries[%d].ShortID = %q, want %q", i, sumA[i].ShortID, want.ShortID)
+		}
+		if sumA[i].Priority != want.Priority {
+			t.Errorf("T22: run A summaries[%d].Priority = %q, want %q", i, sumA[i].Priority, want.Priority)
+		}
+	}
+
+	// Run B must be absent.
+	if _, present := got[runBID]; present {
+		t.Errorf("T22: run B (no reports) should be absent from map")
+	}
+}
+
+// T22TestListReportSummariesForRunIDs_EmptyInput verifies that passing an
+// empty run-ID slice returns an empty map without error.
+func T22TestListReportSummariesForRunIDs_EmptyInput(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs(empty): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("T22: expected empty map for empty input, got %d entries", len(got))
+	}
+}
+
+// T22TestListReportSummariesForRunIDs_InvalidUUIDsSkipped verifies that
+// malformed run IDs are silently skipped and no error is returned.
+func T22TestListReportSummariesForRunIDs_InvalidUUIDsSkipped(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{"not-a-uuid", "also-bad"})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs(bad UUIDs): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("T22: expected empty map for all-invalid UUIDs, got %d entries", len(got))
+	}
+}
+
+// T22TestListReportSummariesForRunIDs_UnknownRunID verifies that a valid UUID
+// that doesn't correspond to any run returns an empty map (not an error).
+func T22TestListReportSummariesForRunIDs_UnknownRunID(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	unknownID := "00000000-0000-0000-0000-000000000099"
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{unknownID})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs(unknown): %v", err)
+	}
+	if _, present := got[unknownID]; present {
+		t.Errorf("T22: unknown run ID should be absent from map")
+	}
+	if len(got) != 0 {
+		t.Errorf("T22: expected empty map, got %d entries", len(got))
+	}
+}
+
+// T22TestListReportSummariesForRunIDs_SingleReport verifies the single-report
+// case: the map entry has exactly one summary.
+func T22TestListReportSummariesForRunIDs_SingleReport(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	runID, wantReports := T22_mustCreateRunWithReports(
+		t, svc, q,
+		"t22-single-report",
+		[]string{"warning"},
+	)
+
+	got, err := svc.ListReportSummariesForRunIDs(ctx, []string{runID})
+	if err != nil {
+		t.Fatalf("T22: ListReportSummariesForRunIDs: %v", err)
+	}
+
+	summaries, ok := got[runID]
+	if !ok {
+		t.Fatalf("T22: run absent from result map")
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("T22: got %d summaries, want 1", len(summaries))
+	}
+	if summaries[0].ShortID != wantReports[0].ShortID {
+		t.Errorf("T22: ShortID = %q, want %q", summaries[0].ShortID, wantReports[0].ShortID)
+	}
+	if summaries[0].Title != wantReports[0].Title {
+		t.Errorf("T22: Title = %q, want %q", summaries[0].Title, wantReports[0].Title)
+	}
+	if summaries[0].Priority != "warning" {
+		t.Errorf("T22: Priority = %q, want %q", summaries[0].Priority, "warning")
+	}
+}
+
+// TestT22_ListReportSummariesForRunIDs is the top-level test function that
+// runs all T22 sub-tests. This is the entry point used by go test.
+func TestT22_ListReportSummariesForRunIDs(t *testing.T) {
+	t.Run("RunWithReports", T22TestListReportSummariesForRunIDs_RunWithReports)
+	t.Run("RunWithNoReports", T22TestListReportSummariesForRunIDs_RunWithNoReports)
+	t.Run("MixedBatch", T22TestListReportSummariesForRunIDs_MixedBatch)
+	t.Run("EmptyInput", T22TestListReportSummariesForRunIDs_EmptyInput)
+	t.Run("InvalidUUIDsSkipped", T22TestListReportSummariesForRunIDs_InvalidUUIDsSkipped)
+	t.Run("UnknownRunID", T22TestListReportSummariesForRunIDs_UnknownRunID)
+	t.Run("SingleReport", T22TestListReportSummariesForRunIDs_SingleReport)
+}
+
+// compile-time assertion: ensure pgtype is imported.
+var _ pgtype.UUID

--- a/internal/service/workflow_run_status_counts_integration_test.go
+++ b/internal/service/workflow_run_status_counts_integration_test.go
@@ -1,0 +1,318 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestT7WorkflowRunStatusCounts_EmptyDB verifies that an empty database returns
+// an empty map (not nil, no error) when no runs exist.
+func TestT7WorkflowRunStatusCounts_EmptyDB(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts on empty DB: %v", err)
+	}
+	if counts == nil {
+		t.Fatal("expected non-nil map, got nil")
+	}
+	if len(counts) != 0 {
+		t.Fatalf("expected empty map on empty DB, got %v", counts)
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_PlainAgentExcluded confirms that runs belonging
+// to a hand-authored agent (source_template IS NULL) are not counted even when
+// they share the same status values as a workflow run.
+func TestT7WorkflowRunStatusCounts_PlainAgentExcluded(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	plain := mustCreateAgentDefinition(t, svc, "t7-plain-excluded", true)
+
+	// Insert a run for the plain agent only — no preset-backed workflow exists.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'manual','success')`,
+		plain.ID); err != nil {
+		t.Fatalf("insert plain run: %v", err)
+	}
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Fatalf("expected empty counts (plain agent excluded), got %v", counts)
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_SinglePreset verifies per-status aggregation
+// across several runs for one preset-sourced workflow. Statuses with zero runs
+// must be absent from the returned map.
+func TestT7WorkflowRunStatusCounts_SinglePreset(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	ins := func(status string) {
+		t.Helper()
+		if _, e := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			wf.ID, status); e != nil {
+			t.Fatalf("insert run (status=%s): %v", status, e)
+		}
+	}
+
+	// Seed: 3 success, 2 error, 1 skipped — timeout and in_progress absent.
+	ins("success")
+	ins("success")
+	ins("success")
+	ins("error")
+	ins("error")
+	ins("skipped")
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts: %v", err)
+	}
+
+	if counts["success"] != 3 {
+		t.Errorf("success = %d, want 3", counts["success"])
+	}
+	if counts["error"] != 2 {
+		t.Errorf("error = %d, want 2", counts["error"])
+	}
+	if counts["skipped"] != 1 {
+		t.Errorf("skipped = %d, want 1", counts["skipped"])
+	}
+
+	// Statuses with zero runs must be absent — not returned as zero.
+	if _, ok := counts["timeout"]; ok {
+		t.Errorf("timeout should be absent (zero runs), got %d", counts["timeout"])
+	}
+	if _, ok := counts["in_progress"]; ok {
+		t.Errorf("in_progress should be absent (zero runs), got %d", counts["in_progress"])
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_AllStatuses seeds one run of every valid
+// status and checks that all five appear in the result.
+func TestT7WorkflowRunStatusCounts_AllStatuses(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	for _, status := range []string{"in_progress", "success", "error", "timeout", "skipped"} {
+		if _, e := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			wf.ID, status); e != nil {
+			t.Fatalf("insert run (status=%s): %v", status, e)
+		}
+	}
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts: %v", err)
+	}
+
+	for _, want := range []string{"in_progress", "success", "error", "timeout", "skipped"} {
+		if counts[want] != 1 {
+			t.Errorf("status %q: got %d, want 1 (counts=%v)", want, counts[want], counts)
+		}
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_ScopedBySlug verifies that filtering by slug
+// returns only that workflow's runs, leaving sibling-workflow runs excluded.
+func TestT7WorkflowRunStatusCounts_ScopedBySlug(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wfA, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset routine-reviewer: %v", err)
+	}
+	wfB, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset weekly-money-digest: %v", err)
+	}
+
+	ins := func(defID, status string) {
+		t.Helper()
+		if _, e := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			defID, status); e != nil {
+			t.Fatalf("insert run: %v", e)
+		}
+	}
+
+	// wfA: 2 success, 1 error.
+	ins(wfA.ID, "success")
+	ins(wfA.ID, "success")
+	ins(wfA.ID, "error")
+	// wfB: 1 success (must not bleed into wfA's scoped view).
+	ins(wfB.ID, "success")
+
+	// Unfiltered: wfA (2 success + 1 error) + wfB (1 success) = 3 success, 1 error.
+	all, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("unfiltered counts: %v", err)
+	}
+	if all["success"] != 3 {
+		t.Errorf("unfiltered success = %d, want 3", all["success"])
+	}
+	if all["error"] != 1 {
+		t.Errorf("unfiltered error = %d, want 1", all["error"])
+	}
+
+	// Scoped to wfA by slug: 2 success, 1 error — wfB's run excluded.
+	scoped, err := svc.WorkflowRunStatusCounts(ctx, wfA.Slug)
+	if err != nil {
+		t.Fatalf("scoped counts (slug): %v", err)
+	}
+	if scoped["success"] != 2 {
+		t.Errorf("scoped success = %d, want 2", scoped["success"])
+	}
+	if scoped["error"] != 1 {
+		t.Errorf("scoped error = %d, want 1", scoped["error"])
+	}
+	if len(scoped) != 2 {
+		t.Errorf("scoped map has %d entries, want 2 (success+error): %v", len(scoped), scoped)
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_ScopedByShortID verifies that the short_id
+// lookup path works as an alternative to slug-based filtering.
+func TestT7WorkflowRunStatusCounts_ScopedByShortID(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	if _, e := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron','success')`,
+		wf.ID); e != nil {
+		t.Fatalf("insert run: %v", e)
+	}
+
+	if wf.ShortID == "" {
+		t.Fatal("workflow short_id is empty — fixture broken")
+	}
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, wf.ShortID)
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts by short_id: %v", err)
+	}
+	if counts["success"] != 1 {
+		t.Errorf("success by short_id = %d, want 1 (counts=%v)", counts["success"], counts)
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_UnknownFilter verifies that an unrecognised
+// filter string returns an empty map rather than an error (mirrors the Runs
+// page behaviour of dropping a bad workflow filter gracefully).
+func TestT7WorkflowRunStatusCounts_UnknownFilter(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+
+	if _, e := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron','success')`,
+		wf.ID); e != nil {
+		t.Fatalf("insert run: %v", e)
+	}
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "no-such-workflow-slug")
+	if err != nil {
+		t.Fatalf("expected no error for unknown filter, got: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Fatalf("expected empty map for unknown filter, got %v", counts)
+	}
+}
+
+// TestT7WorkflowRunStatusCounts_MultiPreset verifies that the unscoped call
+// aggregates runs across multiple distinct preset-sourced workflows.
+func TestT7WorkflowRunStatusCounts_MultiPreset(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wfA, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset routine-reviewer: %v", err)
+	}
+	wfB, err := svc.EnableWorkflowFromPreset(ctx, "weekly-money-digest", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset weekly-money-digest: %v", err)
+	}
+	wfC, err := svc.EnableWorkflowFromPreset(ctx, "backlog-closer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset backlog-closer: %v", err)
+	}
+
+	ins := func(defID, status string) {
+		t.Helper()
+		if _, e := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			defID, status); e != nil {
+			t.Fatalf("insert run: %v", e)
+		}
+	}
+
+	ins(wfA.ID, "success")
+	ins(wfA.ID, "error")
+	ins(wfB.ID, "success")
+	ins(wfB.ID, "skipped")
+	ins(wfC.ID, "timeout")
+
+	// Also insert a plain agent run to confirm it stays excluded.
+	plain := mustCreateAgentDefinition(t, svc, "t7-multi-plain", true)
+	ins(plain.ID, "success")
+
+	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
+	if err != nil {
+		t.Fatalf("WorkflowRunStatusCounts: %v", err)
+	}
+
+	// Workflow-backed: 2 success, 1 error, 1 skipped, 1 timeout. Plain excluded.
+	if counts["success"] != 2 {
+		t.Errorf("success = %d, want 2", counts["success"])
+	}
+	if counts["error"] != 1 {
+		t.Errorf("error = %d, want 1", counts["error"])
+	}
+	if counts["skipped"] != 1 {
+		t.Errorf("skipped = %d, want 1", counts["skipped"])
+	}
+	if counts["timeout"] != 1 {
+		t.Errorf("timeout = %d, want 1", counts["timeout"])
+	}
+	if _, ok := counts["in_progress"]; ok {
+		t.Errorf("in_progress should be absent, got %d", counts["in_progress"])
+	}
+	total := counts["success"] + counts["error"] + counts["skipped"] + counts["timeout"]
+	if total != 5 {
+		t.Errorf("total workflow runs = %d, want 5 (plain excluded)", total)
+	}
+}

--- a/internal/service/workflow_runs_only_filter_integration_test.go
+++ b/internal/service/workflow_runs_only_filter_integration_test.go
@@ -1,0 +1,138 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestT8_WorkflowsOnly_PresetRunIncluded verifies that a run belonging to a
+// preset-instantiated workflow (source_template IS NOT NULL) is returned when
+// WorkflowsOnly=true.
+func TestT8_WorkflowsOnly_PresetRunIncluded(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+		wf.ID); err != nil {
+		t.Fatalf("insert preset run: %v", err)
+	}
+
+	result, err := svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{
+		Limit:         50,
+		WorkflowsOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("ListAllAgentRuns(WorkflowsOnly=true): %v", err)
+	}
+	if len(result.Runs) != 1 {
+		t.Fatalf("WorkflowsOnly=true: got %d runs, want 1", len(result.Runs))
+	}
+	if result.Runs[0].AgentSlug != wf.Slug {
+		t.Errorf("run agent_slug = %q, want %q", result.Runs[0].AgentSlug, wf.Slug)
+	}
+}
+
+// TestT8_WorkflowsOnly_NonPresetRunExcluded verifies that a run belonging to
+// a hand-authored agent (source_template IS NULL) is excluded when
+// WorkflowsOnly=true.
+func TestT8_WorkflowsOnly_NonPresetRunExcluded(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	plain := mustCreateAgentDefinition(t, svc, "t8-plain-agent", true)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+		plain.ID); err != nil {
+		t.Fatalf("insert plain run: %v", err)
+	}
+
+	result, err := svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{
+		Limit:         50,
+		WorkflowsOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("ListAllAgentRuns(WorkflowsOnly=true): %v", err)
+	}
+	if len(result.Runs) != 0 {
+		t.Fatalf("WorkflowsOnly=true with only a plain agent: got %d runs, want 0", len(result.Runs))
+	}
+}
+
+// TestT8_WorkflowsOnly_UnfilteredIncludesBoth verifies that when WorkflowsOnly
+// is false (the default), runs from both preset-backed workflows and
+// hand-authored agents appear in the result set.
+func TestT8_WorkflowsOnly_UnfilteredIncludesBoth(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	plain := mustCreateAgentDefinition(t, svc, "t8-plain-unfiltered", true)
+
+	for _, defID := range []string{wf.ID, plain.ID} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			defID); err != nil {
+			t.Fatalf("insert run for def %s: %v", defID, err)
+		}
+	}
+
+	result, err := svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{
+		Limit:         50,
+		WorkflowsOnly: false,
+	})
+	if err != nil {
+		t.Fatalf("ListAllAgentRuns(WorkflowsOnly=false): %v", err)
+	}
+	if len(result.Runs) != 2 {
+		t.Fatalf("unfiltered: got %d runs, want 2", len(result.Runs))
+	}
+}
+
+// TestT8_WorkflowsOnly_OnlyPresetRunsReturnedAmongMixed verifies the
+// WorkflowsOnly filter in a mixed environment: one preset workflow run and
+// one plain-agent run coexist; WorkflowsOnly=true returns exactly the preset
+// run with the correct slug.
+func TestT8_WorkflowsOnly_OnlyPresetRunsReturnedAmongMixed(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	wf, err := svc.EnableWorkflowFromPreset(ctx, "routine-reviewer", service.EnableWorkflowFromPresetParams{Enabled: false})
+	if err != nil {
+		t.Fatalf("EnableWorkflowFromPreset: %v", err)
+	}
+	plain := mustCreateAgentDefinition(t, svc, "t8-mixed-plain", true)
+
+	for _, defID := range []string{wf.ID, plain.ID} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			defID); err != nil {
+			t.Fatalf("insert run for def %s: %v", defID, err)
+		}
+	}
+
+	only, err := svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{
+		Limit:         50,
+		WorkflowsOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("ListAllAgentRuns(WorkflowsOnly=true): %v", err)
+	}
+	if len(only.Runs) != 1 {
+		t.Fatalf("WorkflowsOnly=true: got %d runs, want 1", len(only.Runs))
+	}
+	if only.Runs[0].AgentSlug != wf.Slug {
+		t.Errorf("filtered run slug = %q, want preset slug %q", only.Runs[0].AgentSlug, wf.Slug)
+	}
+}

--- a/internal/service/workflows_consent_integration_test.go
+++ b/internal/service/workflows_consent_integration_test.go
@@ -1,0 +1,66 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+)
+
+// T9ConsentInitiallyFalse verifies that on a fresh household (empty app_config
+// table) WorkflowsConsentAcknowledged returns false -- the safe path.
+func TestT9ConsentInitiallyFalse(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("T9: fresh household must not have acknowledged consent")
+	}
+}
+
+// T9ConsentAfterAckTrue verifies that after calling AcknowledgeWorkflowsConsent
+// the gate flips to true.
+func TestT9ConsentAfterAckTrue(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Precondition: not acknowledged.
+	if svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("T9: precondition failed: consent already acknowledged on fresh DB")
+	}
+
+	// Acknowledge.
+	if err := svc.AcknowledgeWorkflowsConsent(ctx); err != nil {
+		t.Fatalf("T9: AcknowledgeWorkflowsConsent: %v", err)
+	}
+
+	// Postcondition: acknowledged.
+	if !svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("T9: consent must be acknowledged after AcknowledgeWorkflowsConsent")
+	}
+}
+
+// T9ConsentIdempotent verifies that calling AcknowledgeWorkflowsConsent a
+// second time does not error and the gate remains true.
+func TestT9ConsentIdempotent(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// First acknowledgement.
+	if err := svc.AcknowledgeWorkflowsConsent(ctx); err != nil {
+		t.Fatalf("T9: first AcknowledgeWorkflowsConsent: %v", err)
+	}
+	if !svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("T9: consent not acknowledged after first call")
+	}
+
+	// Second acknowledgement -- must not error (idempotent).
+	if err := svc.AcknowledgeWorkflowsConsent(ctx); err != nil {
+		t.Fatalf("T9: second AcknowledgeWorkflowsConsent must be idempotent, got: %v", err)
+	}
+
+	// Gate must still be true.
+	if !svc.WorkflowsConsentAcknowledged(ctx) {
+		t.Fatal("T9: consent must remain acknowledged after idempotent second call")
+	}
+}

--- a/internal/service/workflows_list.go
+++ b/internal/service/workflows_list.go
@@ -1,0 +1,139 @@
+//go:build !lite
+
+package service
+
+import "context"
+
+// WorkflowMCPView is the compact, agent-facing shape of one enabled workflow.
+// It is a deliberate subset of AgentDefinitionResponse — just the fields an
+// agent needs to understand "what automation exists and how is it doing" —
+// so the list_workflows MCP tool stays lean on tokens. Hand-authored agents
+// (no source_template) are excluded; this surface is workflow-presets only.
+type WorkflowMCPView struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+	// Preset is the workflow-preset slug this workflow was instantiated from
+	// (source_template). Always set — non-preset agents are filtered out.
+	Preset string `json:"preset"`
+	// Enabled is the workflow's own run toggle (a workflow can be instantiated
+	// but paused).
+	Enabled bool `json:"enabled"`
+	// Trigger names how the workflow fires: "sync" (after each successful
+	// sync), "schedule" (cron), or "manual" (neither configured).
+	Trigger string `json:"trigger"`
+	// ScheduleCron is the cron expression when Trigger == "schedule"; nil
+	// otherwise.
+	ScheduleCron *string `json:"schedule_cron,omitempty"`
+	// ToolScope is the run's permission floor: "read_only" | "read_write".
+	ToolScope string `json:"tool_scope"`
+	// LastRunStatus is the status of the most recent run ("success" | "error"
+	// | "in_progress" | "skipped" | "timeout"), or nil when the workflow has
+	// never run.
+	LastRunStatus *string `json:"last_run_status,omitempty"`
+	// LastRunAt is the RFC3339 start time of the most recent run, or nil.
+	LastRunAt *string `json:"last_run_at,omitempty"`
+}
+
+// WorkflowPresetMCPView is the agent-facing shape of one available preset in
+// the gallery — what an agent could enable. Mirrors the subset of
+// WorkflowPresetView relevant to "what automations are available".
+type WorkflowPresetMCPView struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	ToolScope   string `json:"tool_scope"`
+	// Trigger names how the preset fires once enabled: "sync" | "schedule".
+	Trigger string `json:"trigger"`
+	// ScheduleCron is the preset's default cron when Trigger == "schedule".
+	ScheduleCron string `json:"schedule_cron,omitempty"`
+	// Enabled is true when this preset has already been instantiated as a
+	// workflow.
+	Enabled bool `json:"enabled"`
+}
+
+// WorkflowsMCPResult is the list_workflows tool payload: the household's
+// enabled workflows plus the full catalog of available presets.
+type WorkflowsMCPResult struct {
+	Workflows []WorkflowMCPView       `json:"workflows"`
+	Presets   []WorkflowPresetMCPView `json:"presets"`
+}
+
+// ListWorkflowsForMCP assembles the list_workflows MCP payload. It reuses the
+// existing ListWorkflowPresets (catalog + enablement state) and
+// ListAgentDefinitions (enabled workflow detail + last-run summary), reshaping
+// both into the compact agent-facing views. Hand-authored agents (no
+// source_template) are excluded — this is the Workflows surface.
+func (s *Service) ListWorkflowsForMCP(ctx context.Context) (*WorkflowsMCPResult, error) {
+	defs, err := s.ListAgentDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	workflows := make([]WorkflowMCPView, 0, len(defs))
+	for _, d := range defs {
+		// Only preset-instantiated workflows belong on this surface.
+		if d.SourceTemplate == nil {
+			continue
+		}
+		view := WorkflowMCPView{
+			Name:         d.Name,
+			Slug:         d.Slug,
+			Preset:       *d.SourceTemplate,
+			Enabled:      d.Enabled,
+			Trigger:      workflowTriggerLabel(d.TriggerOnSyncComplete, d.ScheduleCron),
+			ScheduleCron: d.ScheduleCron,
+			ToolScope:    d.ToolScope,
+		}
+		if d.LastRun != nil {
+			status := d.LastRun.Status
+			view.LastRunStatus = &status
+			startedAt := d.LastRun.StartedAt
+			view.LastRunAt = &startedAt
+		}
+		workflows = append(workflows, view)
+	}
+
+	views, err := s.ListWorkflowPresets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	presets := make([]WorkflowPresetMCPView, 0, len(views))
+	for _, v := range views {
+		presets = append(presets, WorkflowPresetMCPView{
+			Slug:         v.Slug,
+			Name:         v.Name,
+			Category:     v.Category,
+			Description:  v.Description,
+			ToolScope:    v.ToolScope,
+			Trigger:      workflowTriggerLabel(v.TriggerOnSyncComplete, ptrIfNotEmptyStr(v.ScheduleCron)),
+			ScheduleCron: v.ScheduleCron,
+			Enabled:      v.Enabled,
+		})
+	}
+
+	return &WorkflowsMCPResult{Workflows: workflows, Presets: presets}, nil
+}
+
+// workflowTriggerLabel collapses the (trigger_on_sync_complete, schedule_cron)
+// pair into a single label an agent can read: post-sync wins over a cron when
+// both are somehow set; "manual" when neither fires the workflow on its own.
+func workflowTriggerLabel(onSync bool, cron *string) string {
+	switch {
+	case onSync:
+		return "sync"
+	case cron != nil && *cron != "":
+		return "schedule"
+	default:
+		return "manual"
+	}
+}
+
+// ptrIfNotEmptyStr returns a pointer to s when non-empty, else nil. Local to
+// this file so the preset's plain-string ScheduleCron can reuse the shared
+// trigger-label helper.
+func ptrIfNotEmptyStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"breadbox/internal/templates/components"
@@ -44,11 +45,22 @@ templ AgentRunDetail(p AgentRunDetailProps) {
 		data-run-status={ p.Run.Status }
 		data-started-at={ p.Run.StartedAt.Format(time.RFC3339Nano) }
 		data-poll-seconds={ pollSeconds(p) }
+		data-workflow-slug={ p.Run.AgentSlug }
+		data-csrf={ p.CSRFToken }
 		x-init="$store.shortcuts.setScope('agent-run-detail'); init()"
 		x-destroy="$store.shortcuts.setScope('global')"
 	>
+		<!-- Effective prompt for the "Copy prompt" affordance. Rendered as a
+		     hidden <template> so the (potentially large) text never paints but
+		     is still readable by the Alpine factory. The per-run prefix is
+		     appended to the user prompt the same way the orchestrator
+		     assembles the run, so "Copy prompt" yields what the agent saw. -->
+		if effectiveRunPrompt(p) != "" {
+			<template x-ref="promptText">{ effectiveRunPrompt(p) }</template>
+		}
 		@components.BreadcrumbNav(agentRunDetailBreadcrumbs(p))
 		@agentRunDetailHeader(p)
+		@agentRunSummaryStats(p)
 		if p.Run.Status == "error" && p.Run.ErrorMessage != "" {
 			@agentRunErrorAlert(p.Run)
 		}
@@ -156,18 +168,120 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 					Jump to result
 				</button>
 			}
-			if p.Run.AgentSlug != "" {
-				<a
-					href={ templ.SafeURL("/agents?agent=" + p.Run.AgentSlug + "&run=1") }
+			if effectiveRunPrompt(p) != "" {
+				<button
+					type="button"
 					class="btn btn-sm btn-ghost gap-2"
-					title="Run this agent again"
+					title="Copy the prompt this run was given"
+					@click="copyPrompt()"
+					:class="copiedPrompt ? 'btn-success' : ''"
 				>
-					@components.LucideIcon("play", "w-4 h-4")
-					Re-run
-				</a>
+					<i data-lucide="clipboard" class="w-4 h-4" x-show="!copiedPrompt"></i>
+					<i data-lucide="check" class="w-4 h-4" x-show="copiedPrompt" x-cloak></i>
+					<span x-text="copiedPrompt ? 'Copied' : 'Copy prompt'"></span>
+				</button>
+			}
+			if p.Run.AgentSlug != "" {
+				<button
+					type="button"
+					class="btn btn-sm btn-primary gap-2"
+					title="Run this workflow again now"
+					@click="rerun()"
+					:disabled="rerunning"
+				>
+					<span x-show="!rerunning" class="contents">
+						@components.LucideIcon("play", "w-4 h-4")
+						Re-run
+					</span>
+					<span x-show="rerunning" x-cloak class="contents">
+						<span class="loading loading-spinner loading-xs"></span>
+						Starting…
+					</span>
+				</button>
 			}
 		</div>
 	</div>
+}
+
+// agentRunSummaryStats is the compact at-a-glance strip directly under
+// the sticky header — status, duration, trigger, and cost in a daisy
+// `stats` block. It restates the four facts an operator scans for first
+// without making them hunt through the Usage card in the side panel.
+// daisy `stats` is the canonical home for these tiles per
+// .claude/rules/daisyui.md (the rule explicitly nominates `stats
+// stats-horizontal` for dashboard-tile clusters); cost reuses the same
+// canonical Amount renderer as the rest of the page.
+templ agentRunSummaryStats(p AgentRunDetailProps) {
+	<div class="stats stats-horizontal bb-card w-full overflow-x-auto mb-4">
+		<div class="stat px-4 py-3">
+			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Status</div>
+			<div class="stat-value text-base font-semibold">
+				@agentRunSummaryStatus(p.Run.Status)
+			</div>
+		</div>
+		<div class="stat px-4 py-3">
+			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Duration</div>
+			<div class="stat-value text-base font-semibold tabular-nums">{ formatAgentRunDuration(p.Run.DurationMs) }</div>
+		</div>
+		<div class="stat px-4 py-3">
+			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Trigger</div>
+			<div class="stat-value text-base font-semibold capitalize">
+				if p.Run.Trigger != "" {
+					{ p.Run.Trigger }
+				} else {
+					<span class="text-base-content/40">—</span>
+				}
+			</div>
+		</div>
+		<div class="stat px-4 py-3">
+			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Cost</div>
+			<div class="stat-value text-base font-semibold">
+				@agentRunCost(p.Run.CostUSD, "font-semibold tabular-nums")
+			</div>
+		</div>
+	</div>
+}
+
+// agentRunSummaryStatus renders the run status as a soft badge for
+// terminal states. in_progress renders a small inline spinner + "running"
+// label rather than a badge — loading states never sit inside a daisy
+// badge (badges are reserved for terminal/categorical state).
+templ agentRunSummaryStatus(status string) {
+	switch status {
+		case "success":
+			<span class="badge badge-soft badge-success badge-sm">success</span>
+		case "error":
+			<span class="badge badge-soft badge-error badge-sm">error</span>
+		case "timeout":
+			<span class="badge badge-soft badge-error badge-sm">timeout</span>
+		case "skipped":
+			<span class="badge badge-ghost badge-sm">skipped</span>
+		case "in_progress":
+			<span class="inline-flex items-center gap-1.5 text-primary text-sm">
+				<span class="loading loading-spinner loading-xs"></span>
+				running
+			</span>
+		default:
+			<span class="text-base-content/40 text-sm">{ status }</span>
+	}
+}
+
+// effectiveRunPrompt assembles the prompt the "Copy prompt" affordance
+// hands to the operator: the user prompt the agent was given, with the
+// per-run operator prefix prepended when one was supplied (matching the
+// orchestrator's assembly order). Returns "" when neither is present, in
+// which case the Copy-prompt button is omitted entirely.
+func effectiveRunPrompt(p AgentRunDetailProps) string {
+	prefix := strings.TrimSpace(p.PromptPrefix)
+	body := strings.TrimSpace(p.Prompt)
+	switch {
+	case prefix != "" && body != "":
+		return prefix + "\n\n" + body
+	case prefix != "":
+		return prefix
+	default:
+		return body
+	}
 }
 
 // agentRunHeaderBackHref returns the "back" target for the sticky header.

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -33,11 +33,93 @@ templ AgentSDKSettings(p AgentSDKSettingsProps) {
 			</div>
 		}
 		<div class="space-y-6">
+			@agentSDKOverviewSection(p.Overview)
 			@agentSDKStatusSection(p.Status)
 			@agentSDKConfigSection(p)
 			@agentSDKDiagnosticsSection(p.CSRFToken)
 		</div>
 	</div>
+}
+
+// ---------------------------------------------------------------------
+// Overview (read-only)
+// ---------------------------------------------------------------------
+
+// agentSDKOverviewSection is a read-only at-a-glance panel: how many
+// workflows are live, rolling 30-day spend against the ceiling, the
+// trailing-7-day run breakdown, and the next scheduled run. Stat tiles
+// follow the Backups data-viz pattern (bb-card grid) rather than
+// SettingsRow, since they are data-viz, not editable controls.
+templ agentSDKOverviewSection(o AgentSDKOverviewProps) {
+	@components.SettingsSection(components.SettingsSectionProps{
+		Icon:    "layout-dashboard",
+		Title:   "Overview",
+		Caption: "Live workflows, spend, and recent run activity at a glance",
+	}) {
+		@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+			<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 w-full">
+				<div class="bb-card p-4">
+					<div class="text-xs text-base-content/40 mb-1">Enabled workflows</div>
+					<div class="text-2xl font-bold tabular-nums">{ strconv.Itoa(o.EnabledCount) }</div>
+				</div>
+				<div class="bb-card p-4">
+					<div class="text-xs text-base-content/40 mb-1">Spend (30d)</div>
+					<div class="text-2xl font-bold tabular-nums">{ o.Spend30dStr }</div>
+					<div class="text-xs mt-0.5 flex items-center gap-1.5">
+						<span class="text-base-content/40">{ o.SpendVsCeilingStr }</span>
+						if o.SpendPctStr != "" {
+							if o.SpendOverCeiling {
+								<span class="badge badge-soft badge-error badge-xs">{ o.SpendPctStr }</span>
+							} else {
+								<span class="badge badge-soft badge-neutral badge-xs">{ o.SpendPctStr }</span>
+							}
+						}
+					</div>
+				</div>
+				<div class="bb-card p-4">
+					<div class="text-xs text-base-content/40 mb-1">Runs (7d)</div>
+					<div class="text-2xl font-bold tabular-nums">{ strconv.Itoa(o.Runs7dTotal) }</div>
+					if o.Runs7dTotal > 0 {
+						<div class="flex flex-wrap items-center gap-1 mt-1.5">
+							for _, sc := range o.Runs7dByStatus {
+								if sc.Count > 0 {
+									<span class={ agentSDKBadgeClass(sc.Tone) } title={ sc.Label }>{ strconv.Itoa(sc.Count) } { sc.Label }</span>
+								}
+							}
+						</div>
+					} else {
+						<div class="text-xs text-base-content/40 mt-1.5">No runs this week</div>
+					}
+				</div>
+				<div class="bb-card p-4">
+					<div class="text-xs text-base-content/40 mb-1">Next run</div>
+					if o.HasNextRun {
+						<div class="text-lg font-semibold leading-tight">{ o.NextRunRelStr }</div>
+						<div class="text-xs text-base-content/40 mt-0.5">{ o.NextRunWhenStr }</div>
+						<div class="text-xs text-base-content/60 truncate mt-0.5" title={ o.NextRunWorkflow }>{ o.NextRunWorkflow }</div>
+					} else {
+						<div class="text-lg font-semibold leading-tight text-base-content/40">None scheduled</div>
+						<div class="text-xs text-base-content/40 mt-0.5">No enabled workflow has a schedule</div>
+					}
+				</div>
+			</div>
+		}
+	}
+}
+
+// agentSDKBadgeClass maps a daisy tone to the soft-badge class used in the
+// 7-day run breakdown. Keeps the tone-→class switch out of the markup.
+func agentSDKBadgeClass(tone string) string {
+	switch tone {
+	case "success":
+		return "badge badge-soft badge-success badge-xs"
+	case "error":
+		return "badge badge-soft badge-error badge-xs"
+	case "info":
+		return "badge badge-soft badge-info badge-xs"
+	default:
+		return "badge badge-soft badge-neutral badge-xs"
+	}
 }
 
 // ---------------------------------------------------------------------

--- a/internal/templates/components/pages/agent_sdk_settings_types.go
+++ b/internal/templates/components/pages/agent_sdk_settings_types.go
@@ -23,6 +23,52 @@ type AgentSDKSettingsProps struct {
 	// workflow runs, formatted for the spend-ceiling section (e.g. "$2.13
 	// of $20.00" when a ceiling is set, or "$2.13" with no cap).
 	HouseholdSpend30dStr string
+	// Overview is the read-only "Workflows overview" panel at the top of the
+	// page: enabled count, rolling spend vs ceiling, 7-day run breakdown, and
+	// the next scheduled run. Derived entirely server-side by the page
+	// handler from existing service methods — display only.
+	Overview AgentSDKOverviewProps
+}
+
+// AgentSDKOverviewProps drives the read-only "Workflows overview" section.
+// Everything here is pre-formatted by the page handler so the templ stays
+// free of arithmetic and nil-handling. All fields degrade gracefully: a
+// failed underlying query leaves the relevant field empty/zero and the
+// section renders the remaining tiles.
+type AgentSDKOverviewProps struct {
+	// EnabledCount is the number of enabled preset-backed workflows.
+	EnabledCount int
+	// Spend30dStr is the rolling-window spend, e.g. "$2.13".
+	Spend30dStr string
+	// SpendVsCeilingStr is the spend tile's caption: "of $20.00 ceiling"
+	// when a cap is set, "no ceiling" otherwise.
+	SpendVsCeilingStr string
+	// SpendPctStr is the percent-of-ceiling string ("11%") or "" when no
+	// ceiling is configured. SpendOverCeiling flags >= 100%.
+	SpendPctStr      string
+	SpendOverCeiling bool
+	// Runs7dTotal is the total run count in the trailing 7 days (every
+	// status). Runs7dByStatus holds the per-status breakdown in a fixed,
+	// display-ordered slice.
+	Runs7dTotal    int
+	Runs7dByStatus []AgentSDKRunStatusCount
+	// HasNextRun is false when nothing is scheduled (no enabled cron
+	// workflows). NextRun* describe the soonest upcoming scheduled run
+	// across all enabled workflows.
+	HasNextRun      bool
+	NextRunWhenStr  string // absolute local datetime, e.g. "May 31, 14:00"
+	NextRunRelStr   string // "in 2h", "in 3d" — short relative hint
+	NextRunWorkflow string // the workflow name that fires next
+}
+
+// AgentSDKRunStatusCount is one status bucket in the 7-day run breakdown.
+// Tone maps to a daisy badge tone ("success" | "error" | "info" |
+// "neutral") so the templ doesn't switch on the raw status string.
+type AgentSDKRunStatusCount struct {
+	Status string // canonical run status: success | error | in_progress | skipped
+	Label  string // display label, e.g. "Succeeded"
+	Count  int
+	Tone   string // daisy tone: success | error | info | neutral
 }
 
 // AgentSDKSettingsFormFields mirrors the writable settings exposed by

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -1,6 +1,11 @@
 package pages
 
-import "breadbox/internal/templates/components"
+import (
+	"fmt"
+	"time"
+
+	"breadbox/internal/templates/components"
+)
 
 // WorkflowsGallery is the /workflows preset gallery: codified, configurable,
 // one-click automations grouped by category. "Set up" opens a right-side
@@ -91,7 +96,148 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				}
 			}
 		}
+		<!-- F2: Preview-prompt modal — one shared daisy dialog filled on demand by previewPrompt(). -->
+		@workflowPromptPreviewModal()
+		// F3: one shared reconfigure drawer, hydrated by openReconfigure() from
+		// GET /-/workflows/{slug}/config. Admin-only (the link that opens it is).
+		if p.IsAdmin {
+			@workflowReconfigureDrawer()
+		}
 	</div>
+}
+
+// workflowReconfigureDrawer is the single, data-driven slide-over for
+// editing an already-enabled workflow's configurable layers (schedule,
+// options, additional instructions). Unlike workflowConfigDrawer (one
+// server-rendered panel per available preset), this drawer is hydrated at
+// runtime by openReconfigure() from GET /-/workflows/{slug}/config and
+// submits to POST /-/workflows/{slug}/reconfigure. It never touches the
+// run-state toggle or the base prompt.
+templ workflowReconfigureDrawer() {
+	<div
+		x-show="open === 'reconfigure'"
+		x-cloak
+		x-transition:enter="transition ease-out duration-200"
+		x-transition:enter-start="translate-x-full"
+		x-transition:enter-end="translate-x-0"
+		x-transition:leave="transition ease-in duration-150"
+		x-transition:leave-start="translate-x-0"
+		x-transition:leave-end="translate-x-full"
+		class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 border-l border-base-300 shadow-xl flex flex-col"
+		@keydown.escape.window="open=''"
+	>
+		<form class="flex flex-col h-full" @submit.prevent="submitReconfigure($event.target)">
+			<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300">
+				<div class="flex items-start gap-3">
+					@components.LucideIcon("sliders-horizontal", "w-5 h-5 mt-0.5 text-base-content/60 shrink-0")
+					<div>
+						<div class="font-semibold leading-tight" x-text="reconfigure.name || 'Reconfigure workflow'"></div>
+						<div class="text-xs text-base-content/60 mt-1">Adjust how this workflow runs. Its base behavior stays the same.</div>
+					</div>
+				</div>
+				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
+					@components.LucideIcon("x", "w-4 h-4")
+				</button>
+			</div>
+			<div x-show="reconfigure.loading" class="flex items-center gap-2 text-sm text-base-content/60 p-5">
+				<span class="loading loading-spinner loading-sm"></span>
+				Loading configuration…
+			</div>
+			<div x-show="!reconfigure.loading" x-cloak class="flex-1 overflow-y-auto p-5 space-y-5">
+				<div>
+					<div class="text-sm font-medium mb-1.5">When it runs</div>
+					<template x-if="reconfigure.triggerOnSync">
+						<div class="text-sm text-base-content/70 flex items-center gap-2">
+							@components.LucideIcon("refresh-cw", "w-4 h-4 text-base-content/50")
+							After each successful sync
+						</div>
+					</template>
+					<template x-if="!reconfigure.triggerOnSync">
+						<select name="schedule_cron" x-model="reconfigure.scheduleCron" class="select select-sm w-full">
+							<option value="0 8 * * *">Daily — 8:00 AM</option>
+							<option value="0 7 * * 1">Weekly — Monday 7:00 AM</option>
+							<option value="0 8 1 * *">Monthly — 1st, 8:00 AM</option>
+						</select>
+					</template>
+				</div>
+				<template x-for="opt in reconfigure.options" :key="opt.key">
+					<div>
+						<div class="text-sm font-medium mb-1.5" x-text="opt.label"></div>
+						<select :name="opt.key" x-model="opt.selected" class="select select-sm w-full">
+							<template x-for="ch in opt.choices" :key="ch.value">
+								<option :value="ch.value" x-text="ch.label"></option>
+							</template>
+						</select>
+						<div class="text-xs text-base-content/40 mt-1" x-show="opt.help" x-text="opt.help"></div>
+					</div>
+				</template>
+				<div>
+					<div class="text-sm font-medium mb-1.5">
+						Additional instructions
+						<span class="text-base-content/40 font-normal">(optional)</span>
+					</div>
+					<textarea
+						name="additional_instructions"
+						rows="4"
+						class="textarea textarea-bordered w-full text-sm"
+						placeholder="Anything specific this workflow should watch for, or how it should behave…"
+						x-model="reconfigure.additionalInstructions"
+					></textarea>
+					<div class="text-xs text-base-content/40 mt-1">Appended to the workflow's built-in prompt on every run.</div>
+				</div>
+			</div>
+			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
+				<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="reconfigure.loading">
+					@components.LucideIcon("save", "w-4 h-4")
+					Save changes
+				</button>
+			</div>
+		</form>
+	</div>
+}
+
+// workflowPromptPreviewModal is the shared read-only dialog that shows a
+// preset's fully composed internal base prompt. previewPrompt() in the
+// gallery factory opens it (dialog.showModal()) and fills previewTitle /
+// previewBody from GET /-/workflows/{slug}/prompt.
+templ workflowPromptPreviewModal() {
+	<dialog id="wf-prompt-preview" class="modal modal-bottom sm:modal-middle">
+		<div class="modal-box max-w-2xl">
+			<div class="flex items-start justify-between gap-3 mb-3">
+				<div class="flex items-start gap-2 min-w-0">
+					@components.LucideIcon("file-text", "w-5 h-5 mt-0.5 text-base-content/60 shrink-0")
+					<div class="min-w-0">
+						<h3 class="text-base font-semibold leading-tight truncate" x-text="previewTitle || 'Workflow prompt'"></h3>
+						<p class="text-xs text-base-content/60 mt-0.5">The built-in base prompt this workflow runs with, before any additional instructions.</p>
+					</div>
+				</div>
+				<form method="dialog">
+					<button class="btn btn-ghost btn-sm btn-square shrink-0" aria-label="Close">
+						@components.LucideIcon("x", "w-4 h-4")
+					</button>
+				</form>
+			</div>
+			<div x-show="previewLoading" class="flex items-center gap-2 text-sm text-base-content/60 py-6">
+				<span class="loading loading-spinner loading-sm"></span>
+				Loading prompt…
+			</div>
+			<pre
+				x-show="!previewLoading"
+				x-cloak
+				class="text-xs whitespace-pre-wrap break-words bg-base-200 rounded-xl p-4 max-h-[60vh] overflow-y-auto font-mono leading-relaxed"
+				x-text="previewBody"
+			></pre>
+			<div class="modal-action mt-4">
+				<form method="dialog">
+					<button class="btn btn-ghost btn-sm">Close</button>
+				</form>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button>close</button>
+		</form>
+	</dialog>
 }
 
 // workflowPresetControl is the state-dependent right-side control: a "Set up"
@@ -100,11 +246,42 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 // "Set up" control disabled with an explanatory tooltip.
 templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
 	<div class="flex items-center gap-3">
+		<!-- F2: Preview internal prompt — read-only peek at the composed base prompt. -->
+		<button
+			type="button"
+			class="btn btn-ghost btn-xs gap-1.5 text-base-content/60"
+			@click={ "previewPrompt('" + preset.Slug + "', '" + preset.Name + "')" }
+		>
+			@components.LucideIcon("file-text", "w-3.5 h-3.5")
+			<span class="hidden sm:inline">Preview prompt</span>
+		</button>
 		<span class="hidden sm:inline-flex items-center gap-1 text-xs text-base-content/40">
 			@components.LucideIcon("clock", "w-3.5 h-3.5")
 			{ preset.TriggerLabel }
 		</span>
 		if preset.Enabled {
+			@workflowLastRunLine(preset.LastRun)
+			if isAdmin {
+				<!-- F3: Reconfigure — re-open the configure drawer prefilled. Admin-only (mirrors enable). -->
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm gap-1.5 text-base-content/70"
+					@click={ "openReconfigure('" + preset.WorkflowSlug + "', '" + preset.Name + "')" }
+					aria-label={ "Reconfigure " + preset.Name }
+				>
+					@components.LucideIcon("sliders-horizontal", "w-4 h-4")
+					<span class="hidden sm:inline">Reconfigure</span>
+				</button>
+			}
+			<button
+				type="button"
+				class="btn btn-soft btn-sm gap-1.5"
+				@click={ "runWorkflow('" + preset.WorkflowSlug + "')" }
+				aria-label={ "Run " + preset.Name + " now" }
+			>
+				@components.LucideIcon("play", "w-4 h-4")
+				<span class="hidden sm:inline">Run now</span>
+			</button>
 			<input
 				type="checkbox"
 				class="toggle toggle-sm toggle-primary"
@@ -256,5 +433,69 @@ templ workflowScheduleOption(value, label, selected string) {
 		<option value={ value } selected>{ label }</option>
 	} else {
 		<option value={ value }>{ label }</option>
+	}
+}
+
+// workflowLastRunLine renders the inline "Last run" summary on an enabled
+// card: a status pill plus a relative-time link to the run-detail page. A nil
+// run (never run yet) renders a muted "Not run yet" so the card still reads as
+// enabled-but-idle rather than blank.
+templ workflowLastRunLine(run *WorkflowLastRunProps) {
+	if run == nil {
+		<span class="hidden md:inline text-xs text-base-content/30">Not run yet</span>
+	} else {
+		<span class="hidden md:inline-flex items-center gap-1.5 text-xs">
+			@workflowRunStatusPill(run.Status)
+			if run.ShortID != "" {
+				<a
+					href={ templ.SafeURL(fmt.Sprintf("/workflows/runs/%s", run.ShortID)) }
+					class="text-base-content/60 hover:underline tabular-nums"
+				>
+					{ workflowsRelativeTime(run.FinishedAt) }
+				</a>
+			} else {
+				<span class="text-base-content/60 tabular-nums">{ workflowsRelativeTime(run.FinishedAt) }</span>
+			}
+		</span>
+	}
+}
+
+// workflowRunStatusPill mirrors agentsListStatusPill — a soft daisy badge per
+// run status. Kept local so the pages package stays self-contained and the
+// gallery doesn't depend on the agents-list table's render helpers.
+templ workflowRunStatusPill(status string) {
+	switch status {
+		case "success":
+			<span class="badge badge-soft badge-success badge-xs">success</span>
+		case "error":
+			<span class="badge badge-soft badge-error badge-xs">error</span>
+		case "in_progress":
+			<span class="badge badge-soft badge-info badge-xs">running</span>
+		case "skipped":
+			<span class="badge badge-ghost badge-xs">skipped</span>
+		default:
+			<span class="badge badge-ghost badge-xs">{ status }</span>
+	}
+}
+
+// workflowsRelativeTime renders a compact "N ago" string for the last-run
+// line. Thin local copy of agentsListRelativeTime (same algorithm) so the
+// gallery doesn't reach across page files for a single helper.
+func workflowsRelativeTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	default:
+		return t.Format("Jan 2")
 	}
 }

--- a/internal/templates/components/pages/workflows_gallery_render_test.go
+++ b/internal/templates/components/pages/workflows_gallery_render_test.go
@@ -1,0 +1,300 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// T15buildGalleryProps returns a hand-built WorkflowsGalleryProps fixture
+// with two categories and three presets for render-testing the gallery.
+func T15buildGalleryProps() WorkflowsGalleryProps {
+	return WorkflowsGalleryProps{
+		CSRFToken:           "test-csrf-token",
+		ConsentAcknowledged: false,
+		IsAdmin:             true,
+		Status: AgentSubsystemStatusProps{
+			Ready:          false,
+			AuthConfigured: false,
+			BinaryPresent:  false,
+		},
+		Spend: WorkflowSpendBanner{Show: false},
+		Categories: []WorkflowCategoryProps{
+			{
+				Name: "Categorization & Review",
+				Icon: "sparkles",
+				Presets: []WorkflowPresetCardProps{
+					{
+						Slug:             "smart-categorizer",
+						Name:             "Smart Categorizer",
+						Description:      "Automatically categorizes new transactions using AI.",
+						Icon:             "tag",
+						TriggerLabel:     "After each sync",
+						TriggerOnSync:    true,
+						ScheduleCron:     "",
+						EstCostPerRunUSD: 0.02,
+						Enabled:          false,
+					},
+					{
+						Slug:             "uncategorized-review",
+						Name:             "Uncategorized Review",
+						Description:      "Flags uncategorized transactions for manual review.",
+						Icon:             "search",
+						TriggerLabel:     "Weekly",
+						TriggerOnSync:    false,
+						ScheduleCron:     "0 7 * * 1",
+						EstCostPerRunUSD: 0.05,
+						Enabled:          true,
+						WorkflowSlug:     "uncategorized-review",
+						WorkflowEnabled:  true,
+					},
+				},
+			},
+			{
+				Name: "Insights & Reports",
+				Icon: "bar-chart-3",
+				Presets: []WorkflowPresetCardProps{
+					{
+						Slug:             "monthly-summary",
+						Name:             "Monthly Summary",
+						Description:      "Generates a monthly spending summary report.",
+						Icon:             "file-text",
+						TriggerLabel:     "Monthly",
+						TriggerOnSync:    false,
+						ScheduleCron:     "0 8 1 * *",
+						EstCostPerRunUSD: 0.10,
+						Enabled:          false,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestT15WorkflowsGalleryRenders asserts the WorkflowsGallery templ component
+// renders without error and emits the key structural strings: preset titles,
+// the "Set up" affordance for disabled presets, and category section headers.
+// This is a pure templ render — no DB, no HTTP server.
+func TestT15WorkflowsGalleryRenders(t *testing.T) {
+	props := T15buildGalleryProps()
+
+	var buf strings.Builder
+	if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowsGallery.Render returned error: %v", err)
+	}
+
+	html := buf.String()
+	t.Logf("Rendered %d bytes", buf.Len())
+
+	// Category headers (section titles). templ HTML-escapes text, so an "&"
+	// in a category name renders as "&amp;" — compare against the escaped form.
+	for _, cat := range props.Categories {
+		want := strings.ReplaceAll(cat.Name, "&", "&amp;")
+		if !strings.Contains(html, want) {
+			t.Errorf("expected category header %q (escaped %q) to appear in rendered HTML", cat.Name, want)
+		}
+	}
+
+	// Preset names and descriptions.
+	for _, cat := range props.Categories {
+		for _, preset := range cat.Presets {
+			if !strings.Contains(html, preset.Name) {
+				t.Errorf("expected preset name %q to appear in rendered HTML", preset.Name)
+			}
+			if !strings.Contains(html, preset.Description) {
+				t.Errorf("expected preset description %q to appear in rendered HTML", preset.Description)
+			}
+		}
+	}
+
+	// "Set up" affordance: present for unenabled presets when IsAdmin=true.
+	if !strings.Contains(html, "Set up") {
+		t.Error(`expected "Set up" button text for unenabled presets (IsAdmin=true)`)
+	}
+
+	// Alpine component initialization.
+	if !strings.Contains(html, `x-data="workflowsGallery"`) {
+		t.Error(`expected Alpine x-data="workflowsGallery" attribute`)
+	}
+
+	// Gallery JS script tag.
+	if !strings.Contains(html, `src="/static/js/admin/components/workflows_gallery.js"`) {
+		t.Error(`expected workflows_gallery.js script tag`)
+	}
+
+	// Tab bar links.
+	if !strings.Contains(html, `href="/workflows"`) {
+		t.Error(`expected Gallery tab link href="/workflows"`)
+	}
+	if !strings.Contains(html, `href="/workflows/runs"`) {
+		t.Error(`expected Runs tab link href="/workflows/runs"`)
+	}
+
+	// Runtime-not-ready warning banner (Status.Ready=false).
+	if !strings.Contains(html, "Set up the agent runtime first") {
+		t.Error(`expected runtime-readiness warning when Status.Ready=false`)
+	}
+
+	// CSRF token is threaded into the data attribute.
+	if !strings.Contains(html, "test-csrf-token") {
+		t.Error("expected CSRF token to appear in rendered HTML (data-csrf attribute)")
+	}
+}
+
+// TestT15WorkflowsGalleryEnabledPresetRendersToggle asserts that a preset
+// marked Enabled=true renders a toggle checkbox rather than the "Set up" button.
+func TestT15WorkflowsGalleryEnabledPresetRendersToggle(t *testing.T) {
+	props := WorkflowsGalleryProps{
+		CSRFToken:           "csrf",
+		ConsentAcknowledged: true,
+		IsAdmin:             true,
+		Status:              AgentSubsystemStatusProps{Ready: true},
+		Categories: []WorkflowCategoryProps{
+			{
+				Name: "Categorization & Review",
+				Icon: "sparkles",
+				Presets: []WorkflowPresetCardProps{
+					{
+						Slug:            "enabled-preset",
+						Name:            "Enabled Preset",
+						Description:     "A preset that has already been enabled.",
+						Icon:            "check",
+						TriggerLabel:    "After each sync",
+						TriggerOnSync:   true,
+						Enabled:         true,
+						WorkflowSlug:    "enabled-preset",
+						WorkflowEnabled: true,
+					},
+				},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowsGallery.Render returned error: %v", err)
+	}
+	html := buf.String()
+
+	// Enabled preset renders a toggle, not a "Set up" button.
+	if !strings.Contains(html, `type="checkbox"`) {
+		t.Error("expected toggle checkbox for an enabled preset")
+	}
+	// The toggle should reference toggleWorkflow with the workflow's slug.
+	if !strings.Contains(html, "toggleWorkflow") {
+		t.Error("expected toggleWorkflow JS call for enabled preset control")
+	}
+}
+
+// TestT15WorkflowsGalleryNonAdminDisablesSetUp asserts that when IsAdmin=false
+// the "Set up" button is rendered in a disabled state with a tooltip.
+func TestT15WorkflowsGalleryNonAdminDisablesSetUp(t *testing.T) {
+	props := WorkflowsGalleryProps{
+		CSRFToken:           "csrf",
+		ConsentAcknowledged: false,
+		IsAdmin:             false, // non-admin
+		Status:              AgentSubsystemStatusProps{Ready: true},
+		Categories: []WorkflowCategoryProps{
+			{
+				Name: "Hygiene & Maintenance",
+				Icon: "wrench",
+				Presets: []WorkflowPresetCardProps{
+					{
+						Slug:          "cleanup-preset",
+						Name:          "Cleanup Preset",
+						Description:   "Cleans up duplicate entries.",
+						Icon:          "trash-2",
+						TriggerLabel:  "Weekly",
+						TriggerOnSync: false,
+						ScheduleCron:  "0 7 * * 1",
+						Enabled:       false,
+					},
+				},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowsGallery.Render returned error: %v", err)
+	}
+	html := buf.String()
+
+	// Non-admin: disabled "Set up" button with explanatory tooltip.
+	if !strings.Contains(html, "disabled") {
+		t.Error("expected disabled attribute on Set up button for non-admin user")
+	}
+	if !strings.Contains(html, "Only admins can enable workflows") {
+		t.Error("expected tooltip text 'Only admins can enable workflows' for non-admin user")
+	}
+	// Non-admin: no configure drawer should be rendered (drawers are admin-only).
+	if strings.Contains(html, "submitDrawer") {
+		t.Error("expected no configure drawer (submitDrawer) for non-admin user")
+	}
+}
+
+// TestT15WorkflowsGallerySpendBannerOver asserts the "spend ceiling reached"
+// error banner renders when Spend.Over=true.
+func TestT15WorkflowsGallerySpendBannerOver(t *testing.T) {
+	props := WorkflowsGalleryProps{
+		CSRFToken:           "csrf",
+		ConsentAcknowledged: true,
+		IsAdmin:             true,
+		Status:              AgentSubsystemStatusProps{Ready: true},
+		Spend: WorkflowSpendBanner{
+			Show:       true,
+			Over:       true,
+			SpentStr:   "$5.00",
+			CeilingStr: "$5.00",
+			PctStr:     "100%",
+		},
+		Categories: []WorkflowCategoryProps{},
+	}
+
+	var buf strings.Builder
+	if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowsGallery.Render returned error: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, "Workflows paused") {
+		t.Error("expected 'Workflows paused' error banner when spend ceiling is reached")
+	}
+	if !strings.Contains(html, "$5.00") {
+		t.Error("expected formatted spend amount in banner")
+	}
+}
+
+// TestT15WorkflowsGallerySpendBannerApproaching asserts the "approaching
+// ceiling" warning renders when Spend.Show=true but Spend.Over=false.
+func TestT15WorkflowsGallerySpendBannerApproaching(t *testing.T) {
+	props := WorkflowsGalleryProps{
+		CSRFToken:           "csrf",
+		ConsentAcknowledged: true,
+		IsAdmin:             true,
+		Status:              AgentSubsystemStatusProps{Ready: true},
+		Spend: WorkflowSpendBanner{
+			Show:       true,
+			Over:       false,
+			SpentStr:   "$4.10",
+			CeilingStr: "$5.00",
+			PctStr:     "82%",
+		},
+		Categories: []WorkflowCategoryProps{},
+	}
+
+	var buf strings.Builder
+	if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowsGallery.Render returned error: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, "Approaching spend ceiling") {
+		t.Error("expected 'Approaching spend ceiling' warning banner")
+	}
+	if !strings.Contains(html, "82%") {
+		t.Error("expected percentage used in approaching-ceiling banner")
+	}
+}

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -2,7 +2,10 @@
 
 package pages
 
-import "strconv"
+import (
+	"strconv"
+	"time"
+)
 
 // workflowCostStr formats a per-run cost estimate as a 2-decimal string
 // for the drawer's projected-cost hint (and as a literal arg into the
@@ -67,6 +70,22 @@ type WorkflowPresetCardProps struct {
 	Enabled         bool   // the preset has been instantiated as a workflow
 	WorkflowSlug    string // slug of the instantiated workflow (when Enabled)
 	WorkflowEnabled bool   // the instantiated workflow's run toggle (when Enabled)
+
+	// LastRun is the most recent run of the instantiated workflow, surfaced
+	// inline on enabled cards as a "Last run" status + relative time. nil when
+	// the workflow has never run (or isn't enabled). The "Run now" button uses
+	// WorkflowSlug; this only drives the status line.
+	LastRun *WorkflowLastRunProps
+}
+
+// WorkflowLastRunProps is the inline last-run summary on an enabled card: a
+// status pill plus a relative-time link to the run-detail page. FinishedAt is
+// the run's completion time (falling back to start time for in-progress runs),
+// rendered via workflowsRelativeTime.
+type WorkflowLastRunProps struct {
+	ShortID    string // run short_id — deep-links to /workflows/runs/{shortID} when set
+	Status     string // run status enum: success | error | in_progress | skipped
+	FinishedAt time.Time
 }
 
 // WorkflowPresetOptionProps is one specialized option (a single-select) in

--- a/internal/templates/components/pages/workflows_runs_render_test.go
+++ b/internal/templates/components/pages/workflows_runs_render_test.go
@@ -1,0 +1,230 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// T20WorkflowRunsRenderFixture builds a minimal WorkflowRunsProps with no run
+// rows so WorkflowRuns(p) exercises the status TabBar and the empty state.
+// Counts are intentionally non-zero so the badge-suppression branch
+// (workflowCountPtr) can be exercised; zero-count tabs yield no badge.
+func T20WorkflowRunsRenderFixture() WorkflowRunsProps {
+	return WorkflowRunsProps{
+		Rows:           nil,
+		StatusFilter:   "",
+		WorkflowSlug:   "",
+		Options:        nil,
+		Limit:          50,
+		Offset:         0,
+		HasMore:        false,
+		CSRFToken:      "csrf-test-token",
+		SubsystemReady: true,
+		Counts: WorkflowRunStatusCounts{
+			All:        12,
+			Success:    8,
+			Error:      2,
+			InProgress: 1,
+			Skipped:    1,
+		},
+	}
+}
+
+// TestT20WorkflowRunsStatusTabLabels asserts that all five status tabs render
+// with the expected human-readable labels: "All", "Success", "Error",
+// "In progress", and "Skipped". The TabBar is emitted by workflowRunsFilters
+// inside WorkflowRuns, so a single top-level render covers the whole path.
+func TestT20WorkflowRunsStatusTabLabels(t *testing.T) {
+	p := T20WorkflowRunsRenderFixture()
+
+	var buf strings.Builder
+	if err := WorkflowRuns(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowRuns render returned error: %v", err)
+	}
+	html := buf.String()
+
+	wantLabels := []string{"All", "Success", "Error", "In progress", "Skipped"}
+	for _, label := range wantLabels {
+		if !strings.Contains(html, label) {
+			t.Errorf("expected rendered HTML to contain tab label %q\nrendered (%d bytes):\n%s",
+				label, buf.Len(), html)
+		}
+	}
+}
+
+// TestT20WorkflowRunsStatusTabBarPresent asserts that the TabBar wrapper
+// element (role="tablist") with the correct aria-label is present in the
+// rendered output, confirming that workflowRunsFilters is called and
+// emits the daisy tablist shape.
+func TestT20WorkflowRunsStatusTabBarPresent(t *testing.T) {
+	p := T20WorkflowRunsRenderFixture()
+
+	var buf strings.Builder
+	if err := WorkflowRuns(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowRuns render returned error: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, `role="tablist"`) {
+		t.Error(`expected rendered HTML to contain role="tablist" from TabBar`)
+	}
+	if !strings.Contains(html, "Filter runs by status") {
+		t.Error(`expected rendered HTML to contain aria-label "Filter runs by status"`)
+	}
+}
+
+// TestT20WorkflowRunsEmptyState_NoFilter asserts that when there are no run
+// rows and no active status/workflow filter, the empty state renders with the
+// "no runs yet" headline. The workflowRunsEmpty helper uses EmptyState with
+// Compact=true and InCard=true, so only the Title field is rendered (the
+// compact body variant omits Body copy per the EmptyState design contract).
+func TestT20WorkflowRunsEmptyState_NoFilter(t *testing.T) {
+	p := T20WorkflowRunsRenderFixture()
+	// p.StatusFilter == "" and p.WorkflowSlug == "" → "No workflow runs yet"
+
+	var buf strings.Builder
+	if err := WorkflowRuns(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowRuns render returned error: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, "No workflow runs yet") {
+		t.Errorf("empty state (no filter): expected HTML to contain %q\nrendered (%d bytes):\n%s",
+			"No workflow runs yet", buf.Len(), html)
+	}
+
+	// The filtered headline must NOT appear when no filter is active.
+	if strings.Contains(html, "No runs match this filter") {
+		t.Error(`empty state (no filter): unexpected filtered headline "No runs match this filter"`)
+	}
+}
+
+// TestT20WorkflowRunsEmptyState_WithStatusFilter asserts that activating a
+// status filter changes the empty-state headline to the "no match" variant.
+// The body copy ("Runs appear here…") is passed to EmptyState.Body but is
+// intentionally not rendered in the compact variant (Compact=true, InCard=true).
+func TestT20WorkflowRunsEmptyState_WithStatusFilter(t *testing.T) {
+	p := T20WorkflowRunsRenderFixture()
+	p.StatusFilter = "error" // trigger the filtered-empty branch
+
+	var buf strings.Builder
+	if err := WorkflowRuns(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowRuns (status filter) render returned error: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, "No runs match this filter") {
+		t.Errorf("empty state (status=error): expected HTML to contain %q\nrendered (%d bytes):\n%s",
+			"No runs match this filter", buf.Len(), html)
+	}
+
+	// The no-filter headline must NOT appear when a filter is active.
+	if strings.Contains(html, "No workflow runs yet") {
+		t.Error(`empty state (status=error): unexpected no-filter headline "No workflow runs yet"`)
+	}
+}
+
+// TestT20WorkflowRunsEmptyState_WithWorkflowFilter mirrors the status-filter
+// case but exercises the workflow-slug branch of workflowRunsEmptyTitle.
+func TestT20WorkflowRunsEmptyState_WithWorkflowFilter(t *testing.T) {
+	p := T20WorkflowRunsRenderFixture()
+	p.WorkflowSlug = "weekly-review" // trigger the filtered-empty branch
+
+	var buf strings.Builder
+	if err := WorkflowRuns(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowRuns (workflow filter) render returned error: %v", err)
+	}
+	html := buf.String()
+
+	if !strings.Contains(html, "No runs match this filter") {
+		t.Errorf(`empty state (workflow filter): expected "No runs match this filter"`+"\nrendered (%d bytes):\n%s",
+			buf.Len(), html)
+	}
+	if strings.Contains(html, "No workflow runs yet") {
+		t.Error(`empty state (workflow filter): unexpected no-filter headline "No workflow runs yet"`)
+	}
+}
+
+// TestT20WorkflowRunsTabLinksPresent asserts that every status tab emits an
+// anchor href pointing at /workflows/runs with the expected query-string shape.
+// This confirms workflowRunsHref is wired correctly and no tab links to a
+// stale route.
+func TestT20WorkflowRunsTabLinksPresent(t *testing.T) {
+	p := T20WorkflowRunsRenderFixture()
+
+	var buf strings.Builder
+	if err := WorkflowRuns(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowRuns render returned error: %v", err)
+	}
+	html := buf.String()
+
+	wantHrefs := []string{
+		`href="/workflows/runs"`,
+		`href="/workflows/runs?status=success"`,
+		`href="/workflows/runs?status=error"`,
+		`href="/workflows/runs?status=in_progress"`,
+		`href="/workflows/runs?status=skipped"`,
+	}
+	for _, href := range wantHrefs {
+		if !strings.Contains(html, href) {
+			t.Errorf("expected rendered HTML to contain tab link %q\nrendered (%d bytes):\n%s",
+				href, buf.Len(), html)
+		}
+	}
+}
+
+// TestT20WorkflowCountPtr_ZeroCollapsesToNil guards the badge-suppression
+// helper: a count of zero must return nil (no badge rendered) whereas a
+// positive count must return a non-nil pointer with the correct value.
+func TestT20WorkflowCountPtr_ZeroCollapsesToNil(t *testing.T) {
+	if got := workflowCountPtr(0); got != nil {
+		t.Errorf("workflowCountPtr(0): expected nil, got %v", got)
+	}
+	if got := workflowCountPtr(5); got == nil {
+		t.Error("workflowCountPtr(5): expected non-nil pointer")
+	} else if *got != 5 {
+		t.Errorf("workflowCountPtr(5): expected *5, got *%d", *got)
+	}
+}
+
+// TestT20WorkflowRunsEmptyTitleFunc exercises workflowRunsEmptyTitle directly
+// to ensure the filter-presence logic is correct in isolation.
+func TestT20WorkflowRunsEmptyTitleFunc(t *testing.T) {
+	cases := []struct {
+		name   string
+		props  WorkflowRunsProps
+		wantSz string
+	}{
+		{
+			name:   "no_filter",
+			props:  WorkflowRunsProps{},
+			wantSz: "No workflow runs yet",
+		},
+		{
+			name:   "status_filter",
+			props:  WorkflowRunsProps{StatusFilter: "success"},
+			wantSz: "No runs match this filter",
+		},
+		{
+			name:   "workflow_slug_filter",
+			props:  WorkflowRunsProps{WorkflowSlug: "some-workflow"},
+			wantSz: "No runs match this filter",
+		},
+		{
+			name:   "both_filters",
+			props:  WorkflowRunsProps{StatusFilter: "error", WorkflowSlug: "some-workflow"},
+			wantSz: "No runs match this filter",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workflowRunsEmptyTitle(tc.props)
+			if got != tc.wantSz {
+				t.Errorf("workflowRunsEmptyTitle(%+v) = %q, want %q", tc.props, got, tc.wantSz)
+			}
+		})
+	}
+}

--- a/prompts/agents/strategy-duplicate-detection.md
+++ b/prompts/agents/strategy-duplicate-detection.md
@@ -1,0 +1,30 @@
+---
+title: Duplicate Charge Detection Strategy
+description: Find and flag likely duplicate charges (double-bills, retries, gateway repeats)
+icon: copy
+---
+
+You are hunting for DUPLICATE charges — the same payment hitting an account more than once. These are double-bills, payment-gateway retries, or a merchant charging twice for one order. Your job is to surface likely duplicates so a human can dispute or confirm them.
+
+OBJECTIVE: Flag pairs (or clusters) of transactions that look like the same charge billed more than once, with enough evidence that a human can act.
+
+STEP-BY-STEP:
+1. Read breadbox://overview for baseline context (accounts, users, currency, freshness).
+2. Pull recent debits over the lookback window (default: last 7 days): query_transactions with fields=core,category, sorted by date.
+3. Look for duplicate signatures — same account + same (or near-identical) merchant + same amount + same currency, within a 1–2 day window but DIFFERENT transaction IDs.
+4. If account links exist, cross-check list_transaction_matches: a legitimate cross-account match (a credit-card payment showing on both the card and the bank) is NOT a duplicate — only repeats on the SAME account are.
+5. Distinguish true duplicates from look-alikes:
+   - A genuine recurring charge (a daily coffee, a per-ride fare) bills the same amount repeatedly but is expected — do not flag.
+   - A pending + posted version of one charge is one transaction settling, not a duplicate.
+6. For each likely-duplicate cluster, tag the suspected extra charge(s) with `needs-review` via update_transactions, with a note naming the original it appears to duplicate. Do NOT delete or recategorize anything — flag only.
+7. Submit a report listing each suspected duplicate as a pair, [Name](/transactions/ID) for both sides, with the matching evidence (amount, merchant, dates, account).
+
+WHAT NOT TO FLAG:
+- Expected recurring charges of identical amount (subscriptions, transit fares, vending).
+- Same merchant, same day, but a clearly different amount.
+- A pending/posted pair for the same underlying charge.
+
+IMPORTANT:
+- Precision matters more than recall — a false "duplicate" alarm erodes trust fast.
+- Use priority='warning' when duplicates are flagged, 'info' when the window is clean.
+- Always show BOTH sides of a suspected duplicate and the evidence that links them.

--- a/prompts/agents/strategy-large-charge-sentinel.md
+++ b/prompts/agents/strategy-large-charge-sentinel.md
@@ -1,0 +1,30 @@
+---
+title: Large Charge Sentinel Strategy
+description: Flag unusually large individual charges that merit a human's attention
+icon: trending-up
+---
+
+You are a sentinel watching for unusually LARGE individual charges. Your single job is to surface big-ticket transactions that a family member should consciously confirm — never to nag about expected large bills.
+
+OBJECTIVE: Flag individual transactions whose amount is large enough, relative to the family's normal spending, to be worth a deliberate second look.
+
+STEP-BY-STEP:
+1. Read breadbox://overview for baseline context (accounts, users, currency, freshness).
+2. List the largest recent debits: query_transactions with sort_by=amount, sort_order=desc over the lookback window (default: last 7 days). Remember amount sign — positive = money out.
+3. Establish "normal" for context: transaction_summary with group_by=category gives a per-category baseline; merchant_summary surfaces a merchant's typical charge. A $400 grocery run is unusual; a $400 flight is not.
+4. For each candidate, decide whether it is genuinely out of pattern:
+   - Significantly above the typical charge for that merchant or category, OR
+   - A new large charge in a category that is normally small, OR
+   - A round-number or wire/transfer-shaped charge that looks like fraud risk.
+5. For anything worth a human's eyeballs, add a `needs-review` tag via update_transactions with an add_tags entry and a short note saying *why it is large* (the comparison, not just the dollar figure). Do NOT change the transaction's category.
+6. Submit a report linking every flagged charge with [Name](/transactions/ID).
+
+WHAT NOT TO FLAG:
+- Expected large recurring bills at their usual amount (rent, mortgage, tuition, insurance, car payment).
+- A large charge that matches that merchant's historical average.
+- Refunds or income (money in) — this sentinel is about outflows.
+
+IMPORTANT:
+- Quality over volume. A clean week with nothing flagged is a successful run — submit an `info` report saying so.
+- Use priority='warning' when items are flagged, 'critical' only for genuine fraud-shaped charges, 'info' when nothing crosses the bar.
+- Every flag must explain the comparison that made it "large" — "$X is N× this merchant's usual $Y".

--- a/static/js/admin/components/agent_run_detail.js
+++ b/static/js/admin/components/agent_run_detail.js
@@ -37,11 +37,18 @@ document.addEventListener('alpine:init', function () {
       pollTimer: null,
       allOpen: false,
       copiedRunId: false,
+      // Re-run + copy-prompt affordances in the sticky header.
+      workflowSlug: '',
+      csrfToken: '',
+      rerunning: false,
+      copiedPrompt: false,
 
       init: function () {
         var root = this.$el;
         this.shortId = root.dataset.runShortId || '';
         this.status = root.dataset.runStatus || '';
+        this.workflowSlug = root.dataset.workflowSlug || '';
+        this.csrfToken = root.dataset.csrf || '';
         this.pollSeconds = parseInt(root.dataset.pollSeconds || '0', 10);
         var startedAt = root.dataset.startedAt || '';
         if (startedAt) {
@@ -256,6 +263,87 @@ document.addEventListener('alpine:init', function () {
         // Brief highlight pulse so the eye catches where we landed.
         target.classList.add('bb-run-summary--flash');
         setTimeout(function () { target.classList.remove('bb-run-summary--flash'); }, 1200);
+      },
+
+      // restorePageState clears the global SPA progress bar + content
+      // fade after an async action fails. Required on every error path
+      // per .claude/rules/ui.md — without it the page stays blurred.
+      restorePageState: function () {
+        if (window.bbProgress) window.bbProgress.finish();
+        var main = document.querySelector('main');
+        if (main) {
+          main.style.opacity = '';
+          main.style.filter = '';
+          main.style.pointerEvents = '';
+        }
+      },
+
+      // copyPrompt copies the prompt this run was given (per-run prefix +
+      // user prompt, server-assembled into the hidden <template x-ref>).
+      // Mirrors copyRunId's copied-flag flip for the inline confirmation.
+      copyPrompt: function () {
+        var tpl = this.$refs.promptText;
+        if (!tpl) return;
+        // <template> content lives in .content; fall back to textContent
+        // for browsers that flatten it (none we target, but cheap).
+        var text = (tpl.content ? tpl.content.textContent : tpl.textContent) || '';
+        text = text.trim();
+        if (!text) return;
+        var self = this;
+        copyText(text).then(function (ok) {
+          if (!ok) return;
+          self.copiedPrompt = true;
+          window.dispatchEvent(new CustomEvent('bb-toast', {
+            detail: { message: 'Prompt copied', type: 'success' },
+          }));
+          setTimeout(function () { self.copiedPrompt = false; }, 1600);
+        });
+      },
+
+      // rerun fires a fresh run of this run's workflow via the canonical
+      // admin run-now endpoint (a workflow IS an agent_definition) and,
+      // on success, navigates to the new run's detail page so the
+      // operator watches it stream. No prompt override — this re-runs the
+      // workflow as configured. Concurrency / budget guards surface as a
+      // toast rather than a silent failure.
+      rerun: function () {
+        if (this.rerunning || !this.workflowSlug) return;
+        this.rerunning = true;
+        var self = this;
+        fetch('/-/workflows/' + encodeURIComponent(this.workflowSlug) + '/run', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Accept': 'application/json',
+            'X-CSRF-Token': this.csrfToken,
+          },
+        })
+          .then(function (res) {
+            return res.json().then(function (body) { return { ok: res.ok, body: body }; });
+          })
+          .then(function (r) {
+            if (!r.ok) {
+              var msg = (r.body && r.body.error && r.body.error.message) || 'Could not start the run.';
+              throw new Error(msg);
+            }
+            window.dispatchEvent(new CustomEvent('bb-toast', {
+              detail: { message: 'Run started', type: 'success' },
+            }));
+            var newId = r.body && r.body.short_id;
+            if (newId) {
+              window.location.href = '/workflows/runs/' + encodeURIComponent(newId);
+            } else {
+              window.location.reload();
+            }
+          })
+          .catch(function (err) {
+            self.rerunning = false;
+            self.restorePageState();
+            window.dispatchEvent(new CustomEvent('bb-toast', {
+              detail: { message: err.message || 'Could not start the run.', type: 'error' },
+            }));
+            console.warn('[agent run rerun]', err);
+          });
       },
     };
   });

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -10,6 +10,32 @@ document.addEventListener('alpine:init', function () {
       // (empty string = no drawer).
       open: '',
 
+      // --- F2: preview internal prompt -----------------------------------
+      // State for the "Preview prompt" modal: the composed base prompt is
+      // fetched on demand from /-/workflows/{slug}/prompt and rendered in a
+      // <pre>. previewLoading drives the in-modal spinner.
+      previewTitle: '',
+      previewBody: '',
+      previewLoading: false,
+      // -------------------------------------------------------------------
+
+      // --- F3: reconfigure an enabled workflow ---------------------------
+      // The single, data-driven reconfigure drawer is opened by re-using the
+      // same `open` slot with the special value 'reconfigure'. Its fields are
+      // hydrated from GET /-/workflows/{slug}/config so the drawer renders
+      // prefilled with the workflow's live schedule, options, and additional
+      // instructions. reconfigure.loading drives the in-drawer spinner.
+      reconfigure: {
+        loading: false,
+        slug: '',
+        name: '',
+        triggerOnSync: false,
+        scheduleCron: '',
+        additionalInstructions: '',
+        options: [], // [{ key, label, help, selected, choices: [{value,label}] }]
+      },
+      // -------------------------------------------------------------------
+
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
       },
@@ -87,6 +113,142 @@ document.addEventListener('alpine:init', function () {
             self.restorePageState();
           });
       },
+
+      // --- F1: run an enabled workflow now -------------------------------
+      // toast dispatches the global bb-toast event (handled in base.html).
+      toast: function (message, type) {
+        window.dispatchEvent(
+          new CustomEvent('bb-toast', { detail: { message: message, type: type || 'info' } })
+        );
+      },
+
+      // Run an enabled workflow on demand. The run is async server-side
+      // (202 Accepted returns the in_progress row immediately), so we show an
+      // optimistic "started" toast the instant the request is accepted rather
+      // than waiting on the run. Concurrency/budget/auth refusals come back as
+      // error envelopes — surface their message instead of the optimistic toast.
+      runWorkflow: function (workflowSlug) {
+        var self = this;
+        self.toast('Starting run…', 'info');
+        self._post('/-/workflows/' + encodeURIComponent(workflowSlug) + '/run')
+          .then(function (res) {
+            if (res.ok) {
+              self.toast('Workflow run started.', 'success');
+              return;
+            }
+            return res
+              .json()
+              .catch(function () {
+                return null;
+              })
+              .then(function (body) {
+                var msg = (body && body.error && body.error.message) || 'Could not start the run.';
+                self.toast(msg, 'error');
+              });
+          })
+          .catch(function (e) {
+            console.error('runWorkflow failed', e);
+            self.toast('Network error — could not start the run.', 'error');
+            self.restorePageState();
+          });
+      },
+      // -------------------------------------------------------------------
+
+      // --- F3: reconfigure an enabled workflow ---------------------------
+      // Open the shared reconfigure drawer prefilled with an enabled
+      // workflow's live config (schedule, options, additional instructions),
+      // fetched from GET /-/workflows/{slug}/config.
+      openReconfigure: function (slug, name) {
+        var self = this;
+        self.reconfigure.slug = slug;
+        self.reconfigure.name = name || slug;
+        self.reconfigure.loading = true;
+        self.reconfigure.options = [];
+        self.reconfigure.additionalInstructions = '';
+        self.reconfigure.scheduleCron = '';
+        self.reconfigure.triggerOnSync = false;
+        self.open = 'reconfigure';
+        fetch('/-/workflows/' + encodeURIComponent(slug) + '/config', {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+          })
+          .then(function (data) {
+            self.reconfigure.name = data.name || self.reconfigure.name;
+            self.reconfigure.triggerOnSync = !!data.trigger_on_sync;
+            self.reconfigure.scheduleCron = data.schedule_cron || '';
+            self.reconfigure.additionalInstructions = data.additional_instructions || '';
+            self.reconfigure.options = Array.isArray(data.options) ? data.options : [];
+          })
+          .catch(function (e) {
+            console.error('openReconfigure failed', e);
+            self.open = '';
+            self.restorePageState();
+          })
+          .finally(function () {
+            self.reconfigure.loading = false;
+          });
+      },
+
+      // Submit the reconfigure drawer: re-compose the workflow's schedule,
+      // options, and additional instructions via POST
+      // /-/workflows/{slug}/reconfigure, then reload to reflect the new
+      // trigger label. The run-state toggle is untouched by a reconfigure.
+      submitReconfigure: function (form) {
+        var self = this;
+        var slug = self.reconfigure.slug;
+        if (!slug) return;
+        var fd = new FormData(form);
+        var btn = form.querySelector('button[type="submit"]');
+        if (btn) btn.disabled = true;
+        self._post('/-/workflows/' + encodeURIComponent(slug) + '/reconfigure', new URLSearchParams(fd).toString())
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            window.location.reload();
+          })
+          .catch(function (e) {
+            console.error('submitReconfigure failed', e);
+            if (btn) btn.disabled = false;
+            self.restorePageState();
+          });
+      },
+      // -------------------------------------------------------------------
+
+      // --- F2: preview internal prompt -----------------------------------
+      // Open the shared "Preview prompt" dialog and fetch the preset's fully
+      // composed base prompt (read-only). The <dialog id="wf-prompt-preview">
+      // lives once in the gallery template; this opens it and fills the body.
+      previewPrompt: function (slug, name) {
+        var self = this;
+        self.previewTitle = name || slug;
+        self.previewBody = '';
+        self.previewLoading = true;
+        var dialog = document.getElementById('wf-prompt-preview');
+        if (dialog && typeof dialog.showModal === 'function') dialog.showModal();
+        fetch('/-/workflows/' + encodeURIComponent(slug) + '/prompt', {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+          })
+          .then(function (data) {
+            self.previewTitle = data.title || self.previewTitle;
+            self.previewBody = data.prompt || '';
+          })
+          .catch(function (e) {
+            console.error('previewPrompt failed', e);
+            self.previewBody = 'Could not load the prompt for this workflow. Please try again.';
+          })
+          .finally(function () {
+            self.previewLoading = false;
+          });
+      },
+      // -------------------------------------------------------------------
     };
   });
 });


### PR DESCRIPTION
## Workflows improvements — 32-agent autonomous fan-out

A fleet of isolated agents advanced the Workflows subsystem in parallel; each produced a validated, self-contained change, integrated here onto a fresh sprint branch off `main`. **58 files, +9,654 / −26** (41 new, 17 modified).

### Features (10)
- **Run now** + per-card **last-run status** on the gallery (F1)
- **Preview internal prompt** — `ComposeWorkflowPrompt` + `GET /-/workflows/{slug}/prompt` + modal (F2)
- **Reconfigure after setup** — `Get/UpdateWorkflowConfig` + `/config` + `/reconfigure` + prefilled drawer (F3)
- **Preset expansion** — new **Alerts & Anomalies** category (Large Charge Sentinel, New-Merchant Watch, Duplicate Charge Detector) + Lookback/Verbosity **options** (F4)
- **Notification auto-fire on report** — async best-effort, agent actors only, richer payload (F5)
- **CLI** `breadbox workflows` (list/runs) (F6)
- **MCP** read-only `list_workflows` tool (F7)
- **Run-detail** re-run / summary / copy-prompt (F8)
- **Settings** Workflows overview (enabled count, 30-day spend, recent runs) (F9)
- `docs/workflows.md` canonical spec (F10)

### Test coverage (20 new units)
Preset compose/options, notify URL/payload/send, governance status, consent, spend ceiling, post-sync debounce, metadata scoped ops, category-override precedence, enable-from-preset, run status counts, WorkflowsOnly filter, gallery/runs render, flag filter, run-report summaries.

### Integration fixes (cross-agent reconciliation during merge)
MCP read-tool contract (+`list_workflows`); T1 known-categories (+Alerts); lucide lint (run-detail play icon → `@LucideIcon`); T15 render-test HTML-escaping of `&` in category headers; T12 oversized-metadata sizing; T21 unused `ctx`.

### Validation (local)
```
go build / vet / test (unit)        PASS
go build -tags=headless / -tags=lite PASS   (CI-faithful)
integration suite (fresh DB)        30/31 packages PASS
```
The lone integration failure — `cli TestInit_NonInteractiveCreatesAdminAndKey` (`hosts.Get: no hosts configured`) — is a **pre-existing local-env issue** (stale `~/.config/breadbox/hosts.toml`), **confirmed to fail identically with this diff reverted**. CI runs in a clean env; this PR's run is the authoritative check.

### Notes
- The Workflow harness's per-agent worktree isolation silently fell back to the shared checkout; agents detected this and reconstructed clean per-unit diffs, which were merged sequentially with build gates + conflict resolution (only the gallery trio overlapped, additively).
- **Not merged** — this is a sprint branch for your review.
