### PR TITLE
fix(deploy): run DB migrations explicitly on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,17 @@ jobs:
           # Prune unused images after the new one is live — without this,
           # every deploy leaves the old image behind and the dev box's disk
           # eventually fills to 100% (wedged the box once; see incident).
-          script: cd ${{ secrets.DEPLOY_PATH }} && docker compose pull && docker compose up -d && docker image prune -af
+          # Run migrations explicitly before `up -d`. Migrations run as a
+          # one-shot `migrate` service that `app` waits on (depends_on:
+          # condition: service_completed_successfully); but `docker compose up
+          # -d` reuses the previously-completed `migrate` container on redeploy
+          # and skips it, so new migrations never apply and the app boots
+          # failing /health/ready ("pending migrations detected: database is
+          # behind") — this wedged prod on the #1647 (workflows) deploy.
+          # `run --rm migrate` always spins a fresh one-off from the
+          # just-pulled image, applying the pending set every deploy (a failure
+          # aborts before the app is touched); `up -d`'s dependency is a no-op.
+          script: cd ${{ secrets.DEPLOY_PATH }} && docker compose pull && docker compose run --rm migrate && docker compose up -d && docker image prune -af
 
       - name: Verify health
         run: |


### PR DESCRIPTION
## Fix prod deploy: run DB migrations explicitly (it silently skips them on redeploy)

### Incident

Merging #1647 (Workflows) auto-deployed to `breadbox.exe.xyz` and the deploy's **Verify health** step failed all 5 attempts ([run 26718202769](https://github.com/canalesb93/breadbox/actions/runs/26718202769)). The site is up but unhealthy:

```json
GET https://breadbox.exe.xyz/health/ready  → 503
{"status":"not_ready","checks":{
  "database":{"status":"ok"},
  "migrations":{"status":"error","error":"pending migrations detected: database is behind"}}}
```

`/health/live` returns 200 — the app boots fine. The new binary's embedded migrations are simply **ahead of the prod DB**: the ~8 migrations #1647 shipped (the `agent_definitions`/`agent_runs` → `workflows`/`workflow_runs` `RENAME TABLE`, the `category_override` boolean→enum, `transactions.metadata`, `flagged_at`, etc.) were never applied.

### Root cause

`docker-compose.prod.yml` runs migrations as a one-shot `migrate` service that `app` waits on:

```yaml
app:
  depends_on:
    migrate:
      condition: service_completed_successfully
migrate:
  command: [migrate]   # breadbox migrate
  restart: "no"
```

The deploy script was:

```
docker compose pull && docker compose up -d && docker image prune -af
```

On a **redeploy**, `docker compose up -d` finds the previous `migrate` container already in `Exited (0)`, treats `service_completed_successfully` as already satisfied, and **does not re-run it** — so the freshly-pulled image's new migrations never execute. `app` starts against the stale schema and fails readiness. (Past deploys were fine because they carried no migrations; #1647 was the first migration-bearing deploy to hit this.)

### Fix

Add an explicit migration pass before `up -d`:

```
docker compose pull && docker compose run --rm migrate && docker compose up -d && docker image prune -af
```

`docker compose run --rm migrate` always creates a fresh one-off container from the just-pulled image and runs `breadbox migrate`, so pending migrations apply on every deploy regardless of Compose's dependency-recreation heuristics. With `set -e`/`&&` semantics, a failed migration now aborts the deploy **before** touching the running app (fail-safe), and — because `run` executes in the foreground — migration output is captured in the deploy log instead of being hidden inside `up -d`.

### Recovery

Merging this PR re-deploys with the corrected script, which applies the pending migrations and brings `/health/ready` back to 200. (Equivalent manual recovery on the box: `cd $DEPLOY_PATH && docker compose run --rm migrate && docker compose up -d`.) The #1647 migrations were verified to apply cleanly in timestamp order against the existing schema, so the migration pass itself is expected to succeed.

### Scope

One file: `.github/workflows/ci.yml` (deploy step). No Go/app changes.
