### PR TITLE
fix(deploy): allow out-of-order migrations + revert #1650's broken migrate step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,17 +416,16 @@ jobs:
           # Prune unused images after the new one is live — without this,
           # every deploy leaves the old image behind and the dev box's disk
           # eventually fills to 100% (wedged the box once; see incident).
-          # Run migrations explicitly before `up -d`. Migrations run as a
-          # one-shot `migrate` service that `app` waits on (depends_on:
-          # condition: service_completed_successfully); but `docker compose up
-          # -d` reuses the previously-completed `migrate` container on redeploy
-          # and skips it, so new migrations never apply and the app boots
-          # failing /health/ready ("pending migrations detected: database is
-          # behind") — this wedged prod on the #1647 (workflows) deploy.
-          # `run --rm migrate` always spins a fresh one-off from the
-          # just-pulled image, applying the pending set every deploy (a failure
-          # aborts before the app is touched); `up -d`'s dependency is a no-op.
-          script: cd ${{ secrets.DEPLOY_PATH }} && docker compose pull && docker compose run --rm migrate && docker compose up -d && docker image prune -af
+          # The deployed docker-compose.yml runs the app as
+          #   command: sh -c "/app/breadbox migrate && /app/breadbox serve"
+          # so migrations apply automatically each time the container (re)starts
+          # — there is NO separate `migrate` compose service on the box. Do NOT
+          # add `docker compose run --rm migrate` here: it fails with "no such
+          # service: migrate" and aborts the deploy (the reverted #1650 did
+          # exactly this). Just pull the new image and recreate; the entrypoint
+          # migrates. Prune unused images afterward — otherwise the dev box's
+          # disk fills to 100% (it wedged the box once).
+          script: cd ${{ secrets.DEPLOY_PATH }} && docker compose pull && docker compose up -d && docker image prune -af
 
       - name: Verify health
         run: |

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -58,7 +58,18 @@ func migrateDB(databaseURL string) error {
 		return fmt.Errorf("set dialect: %w", err)
 	}
 
-	if err := goose.Up(sqlDB, "migrations"); err != nil {
+	// WithAllowMissing: apply out-of-order ("missing") migrations instead of
+	// aborting. Breadbox runs several feature sprints in parallel, each on its
+	// own branch; two sprints can pick migration timestamps that interleave, so
+	// after both merge a lower-timestamped migration can land *after* a
+	// higher-timestamped one is already applied. Plain goose.Up treats that as
+	// "found N missing migrations before current version" and refuses to run,
+	// which crash-loops the app on deploy (the #1647 Workflows incident:
+	// versions 20260531062826/070344/074239 were behind the already-applied
+	// recurring_series_type 20260531074852). Migrations here are additive-only
+	// (.claude/rules/migrations.md), so applying a straggler out of order is
+	// safe — far better than wedging the deploy.
+	if err := goose.Up(sqlDB, "migrations", goose.WithAllowMissing()); err != nil {
 		return fmt.Errorf("run migrations: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Fix the post-#1647 prod crash loop: allow out-of-order migrations + revert #1650's broken deploy step

Two fixes for the outage that followed #1647 (Workflows) merging to `main`.

### What happened

Merging #1647 auto-deployed to `breadbox.exe.xyz` and the app went into a **crash loop** — `/health/ready` 503, the post-deploy health check failed ([run 26718202769](https://github.com/canalesb93/breadbox/actions/runs/26718202769)), and the box stayed down. Verified from the container logs:

```
error: run migrations: found 3 missing migrations before current version 20260531074852:
	20260531062826 transaction_metadata.sql
	20260531070344 category_override_enum.sql
	20260531074239 transaction_flagged_at.sql
```

The recurring-series sprint's `recurring_series_type` migration (`20260531074852`) was applied on an earlier deploy. The Workflows sprint then merged migrations with **lower** timestamps (`…062826`, `…070344`, `…074239`, plus `…081609` and the `…120000` agent→workflows rename). Plain `goose.Up` treats lower-than-current-max migrations as "missing" and **refuses to run** — so the container's `migrate && serve` entrypoint never reached `serve` and crash-looped on every boot.

This is structural to running feature sprints in parallel: independent branches pick interleaving timestamps, and after both merge the order is no longer monotonic.

### Change 1 — `goose.WithAllowMissing()` (the durable fix)

`internal/cli/migrate.go`: apply out-of-order ("missing") migrations instead of aborting. Breadbox migrations are additive-only (`.claude/rules/migrations.md`), so applying a straggler out of order is safe — far better than wedging the deploy. Goose's documented remedy for exactly this error. The single call site is shared by `breadbox migrate` and `serve`'s auto-migrate, so both the entrypoint and the explicit command get it.

### Change 2 — revert #1650's deploy-script step

#1650 added `docker compose run --rm migrate` to the deploy script. It was written against the repo's `docker-compose.prod.yml` (which defines a one-shot `migrate` service) — but **the deploy script runs with no `-f`, so the box uses its own `docker-compose.yml`**, whose services are only `db` + `breadbox`, and whose `breadbox` container already auto-migrates via `command: sh -c "/app/breadbox migrate && /app/breadbox serve"`. So `docker compose run --rm migrate` fails with `no such service: migrate` and **aborts every deploy** (#1650's own Deploy job failed on this; it never actually deployed). Restored to `docker compose pull && docker compose up -d && docker image prune -af` with a guard comment so it isn't reintroduced.

### Prod status

**Already recovered** (with VM owner's authorization). After a full `pg_dump`, the 5 pending migrations were applied in version order inside one transaction and recorded in `goose_db_version`; the app was restarted and now boots clean:

```
goose: no migrations to run. current version: 20260531120000
migrations applied successfully → breadbox starting → /health/ready 200
```

`https://breadbox.exe.xyz/health/ready` returns 200; container is `Up (healthy)`. This PR prevents recurrence and unbreaks future deploys.

### Possible follow-up (not in this PR)

A CI check that fails a PR whose new migration timestamp is earlier than the latest migration already on `main` would catch the collision at authoring time. `WithAllowMissing` is the runtime safety net; that would be the upstream guard. Happy to add separately.

### Validation

```
go build ./...            PASS
go vet ./...              PASS
go test ./internal/cli/   ok
```

Scope: 2 files — `internal/cli/migrate.go`, `.github/workflows/ci.yml`. No schema changes.
