### PR TITLE
feat(workflows): gallery declutter (⋯ menu) + /agents redirects + clearer setup copy

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -198,8 +198,12 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// PageHeader. /agents?agent=<slug> filters the runs feed to one
 		// agent, which subsumes the old /agents/{slug}/runs route.
 		// Legacy /agents/runs and /agents/{slug}/runs 301-redirect.
-		r.Get("/agents", AgentRunsListPageHandler(svc, sm, tr, a.Config.DataDir))
-		r.Get("/agents/definitions", AgentsListPageHandler(svc, sm, tr))
+		// Legacy /agents page surface is retired — Workflows is the single
+		// automation home. The entry points 301-redirect to their Workflows
+		// equivalents (the hand-authored form pages below stay reachable by
+		// direct URL until the custom-workflow builder lands).
+		r.Get("/agents", redirectGET("/workflows/runs"))
+		r.Get("/agents/definitions", redirectGET("/workflows"))
 		r.Get("/workflows", WorkflowsGalleryPageHandler(svc, sm, tr))
 		r.Get("/workflows/runs", WorkflowRunsPageHandler(svc, sm, tr))
 		// Run detail lives under the Workflows surface; the legacy
@@ -211,10 +215,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// from the detail page's Edit button.
 		r.Get("/agents/{slug}", AgentDetailPageHandler(svc, sm, tr))
 		r.Get("/agents/{slug}/edit", AgentFormPageHandler(svc, sm, tr))
-		r.Get("/agents/runs/{shortId}", AgentRunDetailPageHandler(svc, sm, tr, a.Config.DataDir))
+		// A run detail is a workflow run — 301 to the canonical Workflows URL.
+		r.Get("/agents/runs/{shortId}", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/workflows/runs/"+chi.URLParam(r, "shortId"), http.StatusMovedPermanently)
+		})
 		r.Get("/agents/runs", func(w http.ResponseWriter, r *http.Request) {
 			// Preserve query params so bookmarked filter URLs still work.
-			target := "/agents"
+			target := "/workflows/runs"
 			if r.URL.RawQuery != "" {
 				target += "?" + r.URL.RawQuery
 			}
@@ -222,7 +229,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		})
 		r.Get("/agents/{slug}/runs", func(w http.ResponseWriter, r *http.Request) {
 			slug := chi.URLParam(r, "slug")
-			target := "/agents?agent=" + slug
+			target := "/workflows/runs?workflow=" + slug
 			if r.URL.RawQuery != "" {
 				target += "&" + r.URL.RawQuery
 			}

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -245,34 +245,13 @@ templ workflowPromptPreviewModal() {
 // enabled. Instantiating a workflow is admin-only — non-admins see the
 // "Set up" control disabled with an explanatory tooltip.
 templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
-	<div class="flex items-center gap-3">
-		<!-- F2: Preview internal prompt — read-only peek at the composed base prompt. -->
-		<button
-			type="button"
-			class="btn btn-ghost btn-xs gap-1.5 text-base-content/60"
-			@click={ "previewPrompt('" + preset.Slug + "', '" + preset.Name + "')" }
-		>
-			@components.LucideIcon("file-text", "w-3.5 h-3.5")
-			<span class="hidden sm:inline">Preview prompt</span>
-		</button>
+	<div class="flex items-center gap-2">
 		<span class="hidden sm:inline-flex items-center gap-1 text-xs text-base-content/40">
 			@components.LucideIcon("clock", "w-3.5 h-3.5")
 			{ preset.TriggerLabel }
 		</span>
 		if preset.Enabled {
 			@workflowLastRunLine(preset.LastRun)
-			if isAdmin {
-				<!-- F3: Reconfigure — re-open the configure drawer prefilled. Admin-only (mirrors enable). -->
-				<button
-					type="button"
-					class="btn btn-ghost btn-sm gap-1.5 text-base-content/70"
-					@click={ "openReconfigure('" + preset.WorkflowSlug + "', '" + preset.Name + "')" }
-					aria-label={ "Reconfigure " + preset.Name }
-				>
-					@components.LucideIcon("sliders-horizontal", "w-4 h-4")
-					<span class="hidden sm:inline">Reconfigure</span>
-				</button>
-			}
 			<button
 				type="button"
 				class="btn btn-soft btn-sm gap-1.5"
@@ -308,6 +287,12 @@ templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
 				</button>
 			</span>
 		}
+		<!-- Secondary actions (Preview prompt, Reconfigure) live in the overflow
+		     menu so the row stays uncluttered — one primary action + toggle inline. -->
+		@components.OverflowMenu(components.OverflowMenuProps{
+			AriaLabel: preset.Name + " actions",
+			Items:     presetMenuItems(preset, isAdmin),
+		})
 	</div>
 }
 
@@ -399,9 +384,12 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 					></textarea>
 					<div class="text-xs text-base-content/40 mt-1">Appended to the workflow's built-in prompt on every run.</div>
 				</div>
-				<label class="flex items-center gap-2 text-sm cursor-pointer">
-					<input type="checkbox" name="enabled" value="true" checked class="checkbox checkbox-sm"/>
-					Start running now
+				<label class="flex items-start gap-2 text-sm cursor-pointer">
+					<input type="checkbox" name="enabled" value="true" checked class="checkbox checkbox-sm mt-0.5"/>
+					<span>
+						Activate as soon as it's set up
+						<span class="block text-xs text-base-content/50">Leave unchecked to add it paused — you can turn it on anytime.</span>
+					</span>
 				</label>
 				if !consentAck {
 					<label class="flex items-start gap-2 text-xs cursor-pointer rounded-lg bg-base-200/60 p-3 border border-base-300">
@@ -415,12 +403,12 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 				if consentAck {
 					<button type="submit" class="btn btn-primary btn-sm gap-1.5">
 						@components.LucideIcon("zap", "w-4 h-4")
-						Enable workflow
+						Set up workflow
 					</button>
 				} else {
 					<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="!consent">
 						@components.LucideIcon("zap", "w-4 h-4")
-						Enable workflow
+						Set up workflow
 					</button>
 				}
 			</div>

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -3,8 +3,11 @@
 package pages
 
 import (
+	"fmt"
 	"strconv"
 	"time"
+
+	"breadbox/internal/templates/components"
 )
 
 // workflowCostStr formats a per-run cost estimate as a 2-decimal string
@@ -12,6 +15,27 @@ import (
 // reactive projectedCost() JS call).
 func workflowCostStr(c float64) string {
 	return strconv.FormatFloat(c, 'f', 2, 64)
+}
+
+// presetMenuItems builds the row's overflow ("⋯") menu — the secondary
+// actions moved out of the inline row to declutter it: Preview prompt
+// always, plus Reconfigure for an enabled workflow (admin only). The
+// OnClick strings invoke the workflowsGallery Alpine factory methods and
+// render inside the gallery's x-data root, so the handlers resolve.
+func presetMenuItems(preset WorkflowPresetCardProps, isAdmin bool) []components.OverflowMenuItem {
+	items := []components.OverflowMenuItem{{
+		Label:   "Preview prompt",
+		Icon:    "file-text",
+		OnClick: fmt.Sprintf("previewPrompt('%s', '%s')", preset.Slug, preset.Name),
+	}}
+	if preset.Enabled && isAdmin {
+		items = append(items, components.OverflowMenuItem{
+			Label:   "Reconfigure",
+			Icon:    "sliders-horizontal",
+			OnClick: fmt.Sprintf("openReconfigure('%s', '%s')", preset.WorkflowSlug, preset.Name),
+		})
+	}
+	return items
 }
 
 // WorkflowsGalleryProps is the view-model for the /workflows preset gallery.


### PR DESCRIPTION
First batch of follow-ups from your review of the improvements sprint. Three of the six items — the clear, low-risk ones. (Remaining: drawer options incl. model/cron #5, and the run-error-message improvement #3 — coming as separate PRs.)

## Changes

**#1/#2 — Retire the legacy `/agents` page surface** (`internal/admin/router.go`)
`/agents` → `/workflows/runs`, `/agents/definitions` → `/workflows`, `/agents/runs/{id}` → `/workflows/runs/{id}`, plus the `/agents/runs` + `/agents/{slug}/runs` aliases — all 301. The hand-authored form pages (`/agents/new`, `/agents/{slug}/edit`) stay reachable by direct URL until the custom-workflow builder lands.

**#4 — Declutter gallery rows** → the overflow-menu direction you picked. Preview prompt + Reconfigure move into a `⋯` `OverflowMenu`; one primary action (Run now / Set up) + the toggle stay inline.

**#6 — Disambiguate the setup drawer.** "Start running now" → **"Activate as soon as it's set up"** (+ "Leave unchecked to add it paused" caption); "Enable workflow" button → **"Set up workflow"**. No more enable-vs-run confusion.

## Validation
```
go build / vet / test (incl. gallery render + lucide lint)  PASS
go build -tags=headless / -tags=lite                        PASS
redirects: /agents* → 301 → /workflows*                     verified
browser: gallery + ⋯ menu + drawer, 0 console errors        verified
```

## Screenshots
**Decluttered rows + open `⋯` menu (Preview prompt · Reconfigure):**
<img src="https://i.img402.dev/bgpx8c8bjd.jpg" width="800" alt="Gallery with overflow menu open">

**Setup drawer — clearer copy:**
<img src="https://i.img402.dev/37wgs890d2.jpg" width="800" alt="Setup drawer with Activate/Set up workflow copy">
