### PR TITLE
feat(ui): hover-swap the sidebar collapse button icon

### DIFF
--- a/input.css
+++ b/input.css
@@ -899,6 +899,59 @@
     @apply flex-1 truncate;
   }
 
+  /* ── Collapse toggle: hover icon swap ──
+     The footer collapse button stacks three icons in one slot and
+     crossfades between them on hover so the swap reads as a morph, not a
+     hard cut: panel-left at rest, panel-left-close while expanded (the
+     click collapses), panel-left-open while collapsed (it expands). The
+     `.bb-sidebar-collapse__icons` wrapper is exactly one nav-icon wide so
+     the collapsed-rail centring geometry (which keys off a w-4 icon) is
+     preserved. All rules are scoped under `.bb-sidebar-collapse` so they
+     out-specify the generic `.bb-sidebar-link svg` opacity above. */
+  .bb-sidebar-collapse .bb-sidebar-collapse__icons {
+    @apply relative inline-flex items-center justify-center w-4 h-4 shrink-0;
+  }
+  .bb-sidebar-collapse .bb-sidebar-collapse__icon {
+    @apply absolute inset-0;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+  }
+  /* At rest only the panel-left icon shows; the two directional cues are
+     hidden. (0,2,0) out-specifies the generic `.bb-sidebar-link svg`
+     opacity:.5 above.) */
+  .bb-sidebar-collapse .bb-sidebar-collapse__icon--close,
+  .bb-sidebar-collapse .bb-sidebar-collapse__icon--open {
+    opacity: 0;
+    transform: scale(0.82);
+  }
+  /* On hover, take full ownership of all three icons' opacity: blank them
+     out first, then the state-specific rule below raises exactly one. This
+     blanket (0,3,0) is what beats the generic `.bb-sidebar-link:hover svg`
+     opacity:.7 (0,2,1) — without it that rule would leak a second icon in. */
+  .bb-sidebar-collapse:hover .bb-sidebar-collapse__icon {
+    opacity: 0;
+    transform: scale(0.82);
+  }
+  /* Expanded + hover → panel-left-close fades in. */
+  .bb-sidebar-collapse:hover .bb-sidebar-collapse__icon--close {
+    opacity: 0.7;
+    transform: none;
+  }
+  /* Collapsed + hover → panel-left-open instead (close stays hidden). */
+  html[data-sidebar="collapsed"] .bb-sidebar-collapse:hover .bb-sidebar-collapse__icon--close {
+    opacity: 0;
+    transform: scale(0.82);
+  }
+  html[data-sidebar="collapsed"] .bb-sidebar-collapse:hover .bb-sidebar-collapse__icon--open {
+    opacity: 0.7;
+    transform: none;
+  }
+  /* Reduced motion: keep the swap, drop the animation. */
+  @media (prefers-reduced-motion: reduce) {
+    .bb-sidebar-collapse .bb-sidebar-collapse__icon {
+      transition: none;
+    }
+  }
+
   /* ── Trailing loading spinner on mobile sidebar tap ──
      Injected by base.html's link-click handler. The visible spin is a
      CSS @keyframes rotate on an inline SVG (compositor-eligible so it

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -117,7 +117,15 @@ templ Nav(p NavProps) {
 			aria-label="Toggle sidebar"
 			title="Collapse sidebar"
 		>
-			@LucideIcon("panel-left", "")
+			// Three stacked icons crossfade on hover: panel-left at rest, then a
+			// directional cue — panel-left-close while expanded (the click will
+			// collapse), panel-left-open while collapsed (it will expand). The
+			// swap is driven entirely in CSS off :hover + html[data-sidebar].
+			<span class="bb-sidebar-collapse__icons">
+				@LucideIcon("panel-left", "bb-sidebar-collapse__icon bb-sidebar-collapse__icon--rest")
+				@LucideIcon("panel-left-close", "bb-sidebar-collapse__icon bb-sidebar-collapse__icon--close")
+				@LucideIcon("panel-left-open", "bb-sidebar-collapse__icon bb-sidebar-collapse__icon--open")
+			</span>
 			<span class="bb-sidebar-link__label">Collapse</span>
 		</button>
 	</div>


### PR DESCRIPTION
## Polish: hover-swap the sidebar collapse button icon

The footer collapse toggle showed a static `panel-left` icon regardless of state. On hover it now crossfades to a directional cue that previews the action:

- **Expanded → hover:** `panel-left-close` (the click will collapse the rail)
- **Collapsed → hover:** `panel-left-open` (the click will expand the rail)

Three icons are stacked in one fixed, nav-icon-sized slot and crossfaded with opacity + a subtle scale, so the swap reads as a morph rather than a hard cut. The whole state machine is pure CSS off `:hover` + `html[data-sidebar]` — the existing `bbToggleSidebar()` / tooltip JS is untouched.

### Visual

<table>
  <tr><th>Rest</th><th>Expanded + hover</th><th>Collapsed + hover</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/njgkyerwdq.png" width="240" alt="rest — panel-left"></td>
    <td><img src="https://i.img402.dev/nfhlpr7ygz.png" width="240" alt="expanded hover — panel-left-close"></td>
    <td><img src="https://i.img402.dev/zs5iyaqwzp.png" width="120" alt="collapsed hover — panel-left-open"></td>
  </tr>
</table>

### Notes

- A blanket `.bb-sidebar-collapse:hover .bb-sidebar-collapse__icon` rule (specificity `0,3,0`) takes full ownership of the three icons' opacity so the generic `.bb-sidebar-link:hover svg` rule (`0,2,1`) can't leak a second icon in.
- The icon slot is exactly one nav-icon wide (`w-4`), so the collapsed-rail centring geometry (which keys off a `w-4` icon) is preserved.
- `prefers-reduced-motion: reduce` keeps the swap but drops the animation.

### Validation

Verified in Chrome at 1280×800 via computed `opacity` across all three states (rest `panel-left`=0.5 / directional=0; expanded hover `panel-left-close`=0.7, others=0; collapsed hover `panel-left-open`=0.7, others=0) plus the screenshots above. `go vet` + `go test ./internal/templates/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
