### PR TITLE
fix(workflows): actionable run-error messages (no more opaque "exited with code 1")

### DIFF
--- a/internal/templates/components/pages/agent_runs_helpers.go
+++ b/internal/templates/components/pages/agent_runs_helpers.go
@@ -12,6 +12,12 @@ import "strings"
 // separate list because the failure modes differ: the only overlap
 // today is the startup orphan-cleanup message, which both subsystems
 // write verbatim and both want to surface as "safe to retry".
+//
+// The raw message is the typed RunError taxonomy from
+// internal/agent/errors.go rendered as "agent: <code>: <message>
+// [stderr=…]". Patterns match a lowercased substring and the FIRST
+// match wins, so order specific diagnostic text before the broad
+// "agent: <code>:" catches below it.
 func AgentRunFriendlyError(raw string) string {
 	lower := strings.ToLower(raw)
 	for _, m := range AgentRunFriendlyErrorMappings {
@@ -27,10 +33,66 @@ type agentRunErrorMapping struct {
 	message string
 }
 
+// AgentRunFriendlyErrorMappings translates the raw run error into a
+// one-line headline the operator can act on. The raw message stays
+// visible beneath it for bug reports, so these stay short and
+// action-oriented. Order matters — see AgentRunFriendlyError.
 var AgentRunFriendlyErrorMappings = []agentRunErrorMapping{
+	// ── Specific diagnostic text (match before the generic codes) ──
 	{
 		pattern: "interrupted by server restart",
 		message: "Interrupted by a server restart — safe to re-run.",
+	},
+	{
+		// The Claude Agent SDK's generic wrapper when the underlying
+		// `claude` runner exits non-zero without surfacing a reason.
+		// Stays an "unknown" code on purpose, but in practice this is
+		// almost always a credential the SDK rejected before printing
+		// anything — point the operator at auth without over-claiming.
+		pattern: "claude code process exited",
+		message: "The Claude runner exited before reporting a reason — most often an expired or invalid Anthropic credential. Re-check Settings → Workflows auth, then re-run.",
+	},
+	{
+		// Sidecar's zero-message branch (it stamps auth_error + this text).
+		pattern: "stream ended without yielding any messages",
+		message: "The run produced no output — usually an invalid Anthropic credential or a runner that failed to start. Re-check Settings → Workflows auth, then re-run.",
+	},
+	{
+		pattern: "breadbox-agent binary not found",
+		message: "The workflow runner isn't installed on this server. Install it (make agent-sidecar-install-user) and re-run.",
+	},
+	{
+		pattern: "another run is already in progress",
+		message: "Skipped — another run was already in progress. It'll run on the next trigger, or re-run now.",
+	},
+	// ── Typed RunError codes (broad fallbacks) ──
+	{
+		pattern: "agent: auth_error",
+		message: "Anthropic rejected the credential (invalid, expired, or wrong account). Rotate the API key or subscription token in Settings → Workflows, then re-run.",
+	},
+	{
+		pattern: "agent: api_error",
+		message: "Anthropic's API returned an error (overloaded or rate-limited). This is usually transient — re-run in a few minutes.",
+	},
+	{
+		pattern: "agent: network_error",
+		message: "Couldn't reach Anthropic (network, DNS, or TLS). Check the server's outbound connectivity, then re-run.",
+	},
+	{
+		pattern: "agent: tool_error",
+		message: "A tool call failed mid-run. Open the transcript below to see which one, then re-run once it's resolved.",
+	},
+	{
+		pattern: "agent: spec_invalid",
+		message: "Internal error — the run spec failed validation. This is a Breadbox bug, not a configuration issue; please report it.",
+	},
+	{
+		pattern: "agent: interrupted",
+		message: "Interrupted before finishing (server shutdown or cancellation) — safe to re-run.",
+	},
+	{
+		pattern: "exceeded budget cap",
+		message: "Stopped at the per-run budget cap. Raise the budget in the workflow's settings if it needs more room.",
 	},
 }
 

--- a/internal/templates/components/pages/agent_runs_helpers_test.go
+++ b/internal/templates/components/pages/agent_runs_helpers_test.go
@@ -2,7 +2,93 @@
 
 package pages
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestAgentRunFriendlyError(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		wantEmpty bool
+		// substr must appear in the friendly message when wantEmpty is false.
+		substr string
+	}{
+		{
+			name:   "opaque claude-code exit (the run Ricardo hit)",
+			raw:    "agent: unknown: Claude Code process exited with code 1",
+			substr: "expired or invalid Anthropic credential",
+		},
+		{
+			name:   "zero-message stream end",
+			raw:    "agent: auth_error: agent SDK stream ended without yielding any messages — likely an invalid auth credential",
+			substr: "no output",
+		},
+		{
+			name:   "typed auth_error",
+			raw:    "agent: auth_error: 401 unauthorized [stderr=…]",
+			substr: "rejected the credential",
+		},
+		{
+			name:   "typed api_error",
+			raw:    "agent: api_error: overloaded",
+			substr: "transient",
+		},
+		{
+			name:   "typed network_error",
+			raw:    "agent: network_error: fetch failed: ENOTFOUND",
+			substr: "outbound connectivity",
+		},
+		{
+			name:   "spec_invalid is a bug",
+			raw:    "agent: spec_invalid: zod parse failed",
+			substr: "Breadbox bug",
+		},
+		{
+			name:   "missing runner binary",
+			raw:    "agent: breadbox-agent binary not found",
+			substr: "isn't installed",
+		},
+		{
+			name:   "concurrency skip",
+			raw:    "agent: another run is already in progress",
+			substr: "another run was already in progress",
+		},
+		{
+			name:   "budget cap",
+			raw:    "agent: run exceeded budget cap",
+			substr: "budget cap",
+		},
+		{
+			name:   "server restart still mapped",
+			raw:    "run interrupted by server restart",
+			substr: "safe to re-run",
+		},
+		{
+			name:      "genuinely unknown falls through to raw",
+			raw:       "agent: unknown: some brand-new failure mode nobody mapped",
+			wantEmpty: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := AgentRunFriendlyError(c.raw)
+			if c.wantEmpty {
+				if got != "" {
+					t.Errorf("expected no friendly mapping, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("expected a friendly mapping for %q, got empty", c.raw)
+			}
+			if !strings.Contains(strings.ToLower(got), strings.ToLower(c.substr)) {
+				t.Errorf("friendly message %q does not contain %q", got, c.substr)
+			}
+		})
+	}
+}
 
 func TestFilterTranscriptForDisplay_DropsEmptyResult(t *testing.T) {
 	in := []TranscriptEvent{


### PR DESCRIPTION
Follow-up #3 from the Workflows feedback list: the run that failed with the opaque **`agent: unknown: Claude Code process exited with code 1`** told the operator nothing actionable.

## Diagnosis

The two-line friendly+raw error alert and the sidecar's stderr-capture already exist (shipped in #1517/#1519). The remaining gap was the **friendly-error mapping had exactly one entry** (`interrupted by server restart`), so every other failure — including the SDK's generic "process exited" wrapper — fell straight through to the raw typed-error string.

The retry-policy `code` stays honestly `unknown` for the opaque case (we genuinely can't tell auth from crash there), so the fix is purely in the **operator-facing headline**, which can hedge ("most often an expired credential") without lying about the code.

## Change

Expand `AgentRunFriendlyErrorMappings` to cover the taxonomy operators actually hit, ordered specific-diagnostic-text → broad `agent: <code>:` catches:

| Raw | Friendly headline (abridged) |
|---|---|
| `…Claude Code process exited with code 1` | "exited before reporting a reason — most often an expired/invalid credential. Re-check Settings → Workflows auth" |
| `…stream ended without yielding any messages` | "produced no output — usually an invalid credential or a runner that failed to start" |
| `agent: auth_error` | "Anthropic rejected the credential — rotate the key/token" |
| `agent: api_error` | "overloaded or rate-limited — usually transient, re-run shortly" |
| `agent: network_error` | "couldn't reach Anthropic — check outbound connectivity" |
| `agent: tool_error` | "a tool call failed — open the transcript" |
| `agent: spec_invalid` | "Breadbox bug, not config — please report" |
| `agent: interrupted` | "interrupted — safe to re-run" |
| `breadbox-agent binary not found` | "runner not installed — `make agent-sidecar-install-user`" |
| `another run is already in progress` | "skipped — another run was in progress" |
| `exceeded budget cap` | "stopped at the per-run budget cap" |

The raw message stays visible in the mono secondary line for bug reports. No retry-policy or rendering changes — `agentRunRowFromResponse` already routes both the run list and run-detail through this one helper.

## Validation

`go build ./...`, `go vet`, and the full `internal/templates/components/pages` test package pass. Added `TestAgentRunFriendlyError` (11 cases incl. the exact run-detail string + a "genuinely unknown falls through to raw" guard).

Screenshotted against **the actual run the user flagged** (`0JjCXUWQ`) on the play DB — it now renders the actionable headline with the raw line preserved beneath:

<img src="https://i.img402.dev/vv4s3q5u9a.jpg" width="800" alt="Run 0JjCXUWQ — actionable error headline with raw message beneath">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
