### PR TITLE
feat(workflows): redesigned gallery — Mintlify-style rows, status tiles, drawer actions

### DIFF
--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -309,7 +309,7 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "workflow-preset-card",
 			Title:       "Workflow preset card",
-			Description: "The /workflows gallery tile (workflowPresetCard) — a leading status tile (gray → green once set up), name + clamped description, an overflow kebab for Reconfigure, and a bottom-aligned footer carrying run state + the primary action (Set up, or Run now + the run toggle). Flows in a 2-up grid; secondary actions live in the configure / reconfigure drawer.",
+			Description: "The /workflows gallery row (workflowPresetCard) — a clean Mintlify-style single line: a leading status tile (gray → green once set up; a red dot flags a failed last run), name + clamped description, and the run toggle + a settings gear. The gear opens the configure / reconfigure drawer, where Set up, Run now, Reconfigure, and Preview prompt all live. Flows in a 2-up grid.",
 			Group:       "data",
 			Render:      func() templ.Component { return SectionWorkflowPresetCard() },
 		},

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -307,6 +307,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionAgentRunRows() },
 		},
 		{
+			Slug:        "workflow-preset-card",
+			Title:       "Workflow preset card",
+			Description: "The /workflows gallery tile (workflowPresetCard) — a leading status tile (gray → green once set up), name + clamped description, an overflow kebab for Reconfigure, and a bottom-aligned footer carrying run state + the primary action (Set up, or Run now + the run toggle). Flows in a 2-up grid; secondary actions live in the configure / reconfigure drawer.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionWorkflowPresetCard() },
+		},
+		{
 			Slug:        "reports-table",
 			Title:       "Reports table",
 			Description: "components.ReportsTable + ReportTableRow + ReportPriorityBadge — the agent-reports index (/reports). A clean daisy table: Agent (name + time, primary dot for unread), Status (soft priority badge or em-dash), Summary (the title), and a trailing mark-read action. The whole row links to the report; the body lives on the detail page. The priority chip is reused on the report detail header.",

--- a/internal/templates/components/pages/design_workflow_cards.templ
+++ b/internal/templates/components/pages/design_workflow_cards.templ
@@ -1,0 +1,45 @@
+package pages
+
+// SectionWorkflowPresetCard renders the variants of the /workflows gallery
+// preset tile (workflowPresetCard): the leading status tile (gray → green
+// once set up), the name + clamped description, the Reconfigure overflow
+// kebab, and the bottom-aligned footer carrying run state on the left and
+// the primary action on the right. Each example uses the same
+// `grid grid-cols-1 lg:grid-cols-2` wrapper the live gallery does so the
+// 2-up layout reads true.
+//
+// The card's actions resolve against the workflowsGallery Alpine factory on
+// the live page; here they're stubbed by an inline x-data so the sandbox
+// stays self-contained (clicking a control is an inert no-op — no console
+// error, and no drawer since the drawers live at the gallery root).
+templ SectionWorkflowPresetCard() {
+	<div class="flex flex-col gap-6" x-data="{ open: '', runWorkflow() {}, toggleWorkflow() {}, openReconfigure() {}, previewPrompt() {} }">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>One preset tile in the <code>/workflows</code> gallery grid (<code>grid-cols-1 lg:grid-cols-2</code>). The leading icon tile carries set-up state — gray until configured, a green accent once a workflow exists.</li>
+				<li>Footer-left is run state: the trigger summary while un-configured; once set up, a last-run pill + relative time, or a muted "Not run yet". Footer-right is the primary action — Set up, or Run now + the run toggle.</li>
+				<li>Secondary actions (Preview prompt, Reconfigure) live in the configure / reconfigure drawer, not on the card. The ⋯ kebab shows only on an enabled card an admin can reconfigure, and is omitted otherwise.</li>
+			</ul>
+		</div>
+		@designExample("Not set up", "Gray tile, the trigger summary on the left, and a Set up button that opens the configure drawer. No kebab — there's nothing to reconfigure yet. Scheduled presets show their cadence; post-sync presets read \"After each sync\".") {
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+				@workflowPresetCard(designWFCardNotSetUp(), true)
+				@workflowPresetCard(designWFCardNotSetUpSync(), true)
+			</div>
+		}
+		@designExample("Set up — run states", "Green tile once configured. The footer reflects the latest run: success + relative time, an error pill, or a muted \"Not run yet\". The toggle on the right reflects enabled vs paused; the ⋯ kebab carries Reconfigure.") {
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+				@workflowPresetCard(designWFCardRunning(), true)
+				@workflowPresetCard(designWFCardPaused(), true)
+				@workflowPresetCard(designWFCardError(), true)
+				@workflowPresetCard(designWFCardNeverRun(), true)
+			</div>
+		}
+		@designExample("Non-admin", "Viewers can't instantiate a workflow: the Set up control is disabled with a lock + tooltip, and no kebab renders.") {
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+				@workflowPresetCard(designWFCardNotSetUp(), false)
+			</div>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_workflow_cards.templ
+++ b/internal/templates/components/pages/design_workflow_cards.templ
@@ -17,18 +17,18 @@ templ SectionWorkflowPresetCard() {
 		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
 			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
 			<ul class="space-y-1 list-disc pl-4">
-				<li>One preset tile in the <code>/workflows</code> gallery grid (<code>grid-cols-1 lg:grid-cols-2</code>). The leading icon tile carries set-up state — gray until configured, a green accent once a workflow exists.</li>
-				<li>Footer-left is run state: the trigger summary while un-configured; once set up, a last-run pill + relative time, or a muted "Not run yet". Footer-right is the primary action — Set up, or Run now + the run toggle.</li>
-				<li>Secondary actions (Preview prompt, Reconfigure) live in the configure / reconfigure drawer, not on the card. The ⋯ kebab shows only on an enabled card an admin can reconfigure, and is omitted otherwise.</li>
+				<li>One preset row in the <code>/workflows</code> gallery grid (<code>grid-cols-1 lg:grid-cols-2</code>) — a clean Mintlify-style single line: vertically-centered icon tile, name + two-line description, and the controls on the right.</li>
+				<li>The icon tile carries set-up state — gray until configured, a green accent once a workflow exists; a small red dot flags a failed last run.</li>
+				<li>Right side is just the run toggle + a settings gear. The gear opens the configure (not set up) / reconfigure (set up) drawer; Set up, Run now, Reconfigure, and Preview prompt all live in that drawer. A not-set-up toggle opens the setup drawer instead of flipping; non-admins get a disabled toggle.</li>
 			</ul>
 		</div>
-		@designExample("Not set up", "Gray tile, the trigger summary on the left, and a Set up button that opens the configure drawer. No kebab — there's nothing to reconfigure yet. Scheduled presets show their cadence; post-sync presets read \"After each sync\".") {
+		@designExample("Not set up", "Gray tile, name + description, and an off toggle + gear on the right — both open the configure drawer (you can't enable without picking a schedule + acknowledging cost). Scheduled and post-sync presets look identical here; the trigger is chosen in the drawer.") {
 			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
 				@workflowPresetCard(designWFCardNotSetUp(), true)
 				@workflowPresetCard(designWFCardNotSetUpSync(), true)
 			</div>
 		}
-		@designExample("Set up — run states", "Green tile once configured. The footer reflects the latest run: success + relative time, an error pill, or a muted \"Not run yet\". The toggle on the right reflects enabled vs paused; the ⋯ kebab carries Reconfigure.") {
+		@designExample("Set up — run states", "Green tile once configured. The run toggle (left of the gear) reflects enabled vs paused; the gear opens the reconfigure drawer (where Run now + Preview prompt live). A failed last run pins a small red dot to the tile corner — see Large Charge Sentinel.") {
 			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
 				@workflowPresetCard(designWFCardRunning(), true)
 				@workflowPresetCard(designWFCardPaused(), true)
@@ -36,7 +36,7 @@ templ SectionWorkflowPresetCard() {
 				@workflowPresetCard(designWFCardNeverRun(), true)
 			</div>
 		}
-		@designExample("Non-admin", "Viewers can't instantiate a workflow: the Set up control is disabled with a lock + tooltip, and no kebab renders.") {
+		@designExample("Non-admin", "Viewers can't instantiate a workflow: the toggle is disabled with a tooltip and no gear renders.") {
 			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
 				@workflowPresetCard(designWFCardNotSetUp(), false)
 			</div>

--- a/internal/templates/components/pages/design_workflow_cards_helpers.go
+++ b/internal/templates/components/pages/design_workflow_cards_helpers.go
@@ -1,0 +1,116 @@
+//go:build !headless && !lite
+
+package pages
+
+import "time"
+
+// design_workflow_cards_helpers.go holds the fixture props for the
+// SectionWorkflowPresetCard sandbox entry — the /workflows gallery tile
+// across its set-up / run states. Times use a shared `now` anchor so a
+// refresh doesn't reshuffle the relative-time labels mid-comparison.
+
+func designWFNow() time.Time                { return time.Now() }
+func designWFAgo(d time.Duration) time.Time { return designWFNow().Add(-d) }
+
+// designWFCardNotSetUp — a scheduled preset that hasn't been instantiated:
+// gray tile, trigger summary on the left, "Set up" on the right, no kebab.
+func designWFCardNotSetUp() WorkflowPresetCardProps {
+	return WorkflowPresetCardProps{
+		Slug:             "subscription-auditor",
+		Name:             "Subscription Auditor",
+		Description:      "Finds recurring charges and subscriptions, flagging price hikes and likely-forgotten ones.",
+		Icon:             "repeat",
+		TriggerLabel:     "Monthly",
+		ScheduleCron:     "0 8 1 * *",
+		EstCostPerRunUSD: 0.08,
+		Enabled:          false,
+	}
+}
+
+// designWFCardNotSetUpSync — a post-sync preset (no schedule), so the
+// trigger label reads "After each sync". Still gray / not set up.
+func designWFCardNotSetUpSync() WorkflowPresetCardProps {
+	return WorkflowPresetCardProps{
+		Slug:             "duplicate-charge-detector",
+		Name:             "Duplicate Charge Detector",
+		Description:      "Flags likely double-bills and gateway-retry duplicates so you can dispute them, right after each sync.",
+		Icon:             "copy",
+		TriggerLabel:     "After each sync",
+		TriggerOnSync:    true,
+		EstCostPerRunUSD: 0.03,
+		Enabled:          false,
+	}
+}
+
+// designWFCardRunning — set up + enabled, last run succeeded a few minutes
+// ago: green tile, success pill + relative time, Run now + a checked toggle,
+// and the Reconfigure kebab.
+func designWFCardRunning() WorkflowPresetCardProps {
+	return WorkflowPresetCardProps{
+		Slug:            "routine-reviewer",
+		Name:            "Routine Reviewer",
+		Description:     "Auto-categorizes newly-synced transactions and flags anything it's unsure about.",
+		Icon:            "sparkles",
+		TriggerLabel:    "After each sync",
+		TriggerOnSync:   true,
+		Enabled:         true,
+		WorkflowSlug:    "routine-reviewer",
+		WorkflowEnabled: true,
+		LastRun: &WorkflowLastRunProps{
+			ShortID:    "wf42ab7c",
+			Status:     "success",
+			FinishedAt: designWFAgo(7 * time.Minute),
+		},
+	}
+}
+
+// designWFCardPaused — set up but the run toggle is off (unchecked). Still
+// green (it's configured); the last successful run was a few days ago.
+func designWFCardPaused() WorkflowPresetCardProps {
+	c := designWFCardRunning()
+	c.Slug = "backlog-closer"
+	c.Name = "Backlog Closer"
+	c.Icon = "list-checks"
+	c.Description = "A weekly deep-clean of aged uncategorized transactions — thorough, and promotes repeat patterns to rules."
+	c.TriggerOnSync = false
+	c.TriggerLabel = "Weekly"
+	c.WorkflowSlug = "backlog-closer"
+	c.WorkflowEnabled = false
+	c.LastRun = &WorkflowLastRunProps{
+		ShortID:    "wf88dd2e",
+		Status:     "success",
+		FinishedAt: designWFAgo(3 * 24 * time.Hour),
+	}
+	return c
+}
+
+// designWFCardError — set up, last run failed: green tile, error pill.
+func designWFCardError() WorkflowPresetCardProps {
+	c := designWFCardRunning()
+	c.Slug = "large-charge-sentinel"
+	c.Name = "Large Charge Sentinel"
+	c.Icon = "trending-up"
+	c.Description = "Flags unusually large individual charges relative to your normal spending, right after each sync."
+	c.WorkflowSlug = "large-charge-sentinel"
+	c.LastRun = &WorkflowLastRunProps{
+		ShortID:    "wf11ee9f",
+		Status:     "error",
+		FinishedAt: designWFAgo(20 * time.Minute),
+	}
+	return c
+}
+
+// designWFCardNeverRun — set up but never run: green tile, muted
+// "Not run yet" instead of a last-run pill.
+func designWFCardNeverRun() WorkflowPresetCardProps {
+	c := designWFCardRunning()
+	c.Slug = "monthly-close"
+	c.Name = "Monthly Close"
+	c.Icon = "calendar-check"
+	c.Description = "A month-end summary of where the money went — by category and top merchants."
+	c.TriggerOnSync = false
+	c.TriggerLabel = "Monthly"
+	c.WorkflowSlug = "monthly-close"
+	c.LastRun = nil
+	return c
+}

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -133,6 +133,14 @@ templ workflowReconfigureDrawer() {
 					<div>
 						<div class="font-semibold leading-tight" x-text="reconfigure.name || 'Reconfigure workflow'"></div>
 						<div class="text-xs text-base-content/60 mt-1">Adjust how this workflow runs. Its base behavior stays the same.</div>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs gap-1 mt-2 -ml-1 text-base-content/70"
+							@click="previewPrompt(reconfigure.slug, reconfigure.name)"
+						>
+							@components.LucideIcon("file-text", "w-3.5 h-3.5")
+							Preview prompt
+						</button>
 					</div>
 				</div>
 				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
@@ -256,12 +264,14 @@ templ workflowPresetCard(preset WorkflowPresetCardProps, isAdmin bool) {
 				<div class="font-medium text-sm leading-tight">{ preset.Name }</div>
 				<div class="text-xs text-base-content/60 mt-1 line-clamp-2">{ preset.Description }</div>
 			</div>
-			<!-- Secondary actions (Preview prompt, Reconfigure) live in the
-			     overflow menu so the card front stays uncluttered. -->
-			@components.OverflowMenu(components.OverflowMenuProps{
-				AriaLabel: preset.Name + " actions",
-				Items:     presetMenuItems(preset, isAdmin),
-			})
+			<!-- Reconfigure (enabled + admin) is the only overflow action; the
+			     kebab is omitted entirely when there's nothing to put in it. -->
+			if len(presetMenuItems(preset, isAdmin)) > 0 {
+				@components.OverflowMenu(components.OverflowMenuProps{
+					AriaLabel: preset.Name + " actions",
+					Items:     presetMenuItems(preset, isAdmin),
+				})
+			}
 		</div>
 		<div class="flex items-center justify-between gap-2 mt-auto pt-1">
 			<div class="flex items-center gap-2 text-xs text-base-content/45 min-w-0">
@@ -368,6 +378,14 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 					<div>
 						<div class="font-semibold leading-tight">{ preset.Name }</div>
 						<div class="text-xs text-base-content/60 mt-1">{ preset.Description }</div>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs gap-1 mt-2 -ml-1 text-base-content/70"
+							@click={ "previewPrompt('" + preset.Slug + "', '" + preset.Name + "')" }
+						>
+							@components.LucideIcon("file-text", "w-3.5 h-3.5")
+							Preview prompt
+						</button>
 					</div>
 				</div>
 				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -55,21 +55,21 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				</div>
 			}
 		}
-		<div class="mt-4 space-y-6">
+		<div class="mt-5 space-y-8">
 			for _, cat := range p.Categories {
-				@components.SettingsSection(components.SettingsSectionProps{
-					Icon:  cat.Icon,
-					Title: cat.Name,
-				}) {
-					for _, preset := range cat.Presets {
-						@components.SettingsRow(components.SettingsRowProps{
-							Label:   preset.Name,
-							Caption: preset.Description,
-						}) {
-							@workflowPresetControl(preset, p.IsAdmin)
+				<section>
+					<!-- Section header sits on top, full-width; the presets below
+					     flow as a 2-up grid on desktop, single column on mobile. -->
+					<div class="flex items-center gap-2 mb-3 px-0.5">
+						@components.LucideIcon(cat.Icon, "w-4 h-4 text-base-content/55")
+						<h2 class="text-sm font-semibold">{ cat.Name }</h2>
+					</div>
+					<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+						for _, preset := range cat.Presets {
+							@workflowPresetCard(preset, p.IsAdmin)
 						}
-					}
-				}
+					</div>
+				</section>
 			}
 		</div>
 		<!-- Configure drawer: shared backdrop + one slide-over panel per available preset. -->
@@ -240,60 +240,104 @@ templ workflowPromptPreviewModal() {
 	</dialog>
 }
 
-// workflowPresetControl is the state-dependent right-side control: a "Set up"
-// button (opens the configure drawer) when available, a run toggle once
-// enabled. Instantiating a workflow is admin-only — non-admins see the
-// "Set up" control disabled with an explanatory tooltip.
-templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
-	<div class="flex items-center gap-2">
-		<span class="hidden sm:inline-flex items-center gap-1 text-xs text-base-content/40">
-			@components.LucideIcon("clock", "w-3.5 h-3.5")
-			{ preset.TriggerLabel }
-		</span>
-		if preset.Enabled {
-			@workflowLastRunLine(preset.LastRun)
-			<button
-				type="button"
-				class="btn btn-soft btn-sm gap-1.5"
-				@click={ "runWorkflow('" + preset.WorkflowSlug + "')" }
-				aria-label={ "Run " + preset.Name + " now" }
-			>
-				@components.LucideIcon("play", "w-4 h-4")
-				<span class="hidden sm:inline">Run now</span>
-			</button>
-			<input
-				type="checkbox"
-				class="toggle toggle-sm toggle-primary"
-				if preset.WorkflowEnabled {
-					checked
+// workflowPresetCard is one preset tile in the gallery grid: a leading
+// icon tile (gray, green-accented once set up), the name + description,
+// an overflow menu for secondary actions, and a bottom-aligned footer
+// carrying the run state on the left and the primary action(s) on the
+// right. Cards stretch to a uniform height per grid row (h-full + a
+// mt-auto footer) so the action rows line up across the 2-up layout.
+templ workflowPresetCard(preset WorkflowPresetCardProps, isAdmin bool) {
+	<div class="bb-card p-4 h-full flex flex-col gap-3">
+		<div class="flex items-start gap-3">
+			<div class={ presetTileClasses(preset.Enabled) }>
+				@components.LucideIcon(preset.Icon, "w-5 h-5")
+			</div>
+			<div class="flex-1 min-w-0">
+				<div class="font-medium text-sm leading-tight">{ preset.Name }</div>
+				<div class="text-xs text-base-content/60 mt-1 line-clamp-2">{ preset.Description }</div>
+			</div>
+			<!-- Secondary actions (Preview prompt, Reconfigure) live in the
+			     overflow menu so the card front stays uncluttered. -->
+			@components.OverflowMenu(components.OverflowMenuProps{
+				AriaLabel: preset.Name + " actions",
+				Items:     presetMenuItems(preset, isAdmin),
+			})
+		</div>
+		<div class="flex items-center justify-between gap-2 mt-auto pt-1">
+			<div class="flex items-center gap-2 text-xs text-base-content/45 min-w-0">
+				@workflowCardStatus(preset)
+			</div>
+			<div class="flex items-center gap-2 shrink-0">
+				if preset.Enabled {
+					<button
+						type="button"
+						class="btn btn-soft btn-sm gap-1.5"
+						@click={ "runWorkflow('" + preset.WorkflowSlug + "')" }
+						aria-label={ "Run " + preset.Name + " now" }
+					>
+						@components.LucideIcon("play", "w-4 h-4")
+						Run now
+					</button>
+					<input
+						type="checkbox"
+						class="toggle toggle-sm toggle-primary"
+						if preset.WorkflowEnabled {
+							checked
+						}
+						aria-label={ "Toggle " + preset.Name }
+						@change={ "toggleWorkflow('" + preset.WorkflowSlug + "', $event.target)" }
+					/>
+				} else if isAdmin {
+					<button
+						type="button"
+						class="btn btn-soft btn-sm gap-1.5"
+						@click={ "open='" + preset.Slug + "'" }
+					>
+						@components.LucideIcon("settings-2", "w-4 h-4")
+						Set up
+					</button>
+				} else {
+					<span class="tooltip tooltip-left" data-tip="Only admins can enable workflows">
+						<button type="button" class="btn btn-soft btn-sm gap-1.5" disabled>
+							@components.LucideIcon("lock", "w-4 h-4")
+							Set up
+						</button>
+					</span>
 				}
-				aria-label={ "Toggle " + preset.Name }
-				@change={ "toggleWorkflow('" + preset.WorkflowSlug + "', $event.target)" }
-			/>
-		} else if isAdmin {
-			<button
-				type="button"
-				class="btn btn-soft btn-sm gap-1.5"
-				@click={ "open='" + preset.Slug + "'" }
-			>
-				@components.LucideIcon("settings-2", "w-4 h-4")
-				Set up
-			</button>
+			</div>
+		</div>
+	</div>
+}
+
+// workflowCardStatus is the footer-left status line: when set up, the
+// last-run pill + relative time (or a muted "Not run yet"); otherwise the
+// trigger summary so an un-configured card still tells you when it would
+// run. Always visible — the grid gives each card room even on mobile.
+templ workflowCardStatus(preset WorkflowPresetCardProps) {
+	if preset.Enabled {
+		if preset.LastRun == nil {
+			<span class="text-base-content/35">Not run yet</span>
 		} else {
-			<span class="tooltip tooltip-left" data-tip="Only admins can enable workflows">
-				<button type="button" class="btn btn-soft btn-sm gap-1.5" disabled>
-					@components.LucideIcon("lock", "w-4 h-4")
-					Set up
-				</button>
+			<span class="inline-flex items-center gap-1.5 min-w-0">
+				@workflowRunStatusPill(preset.LastRun.Status)
+				if preset.LastRun.ShortID != "" {
+					<a
+						href={ templ.SafeURL(fmt.Sprintf("/workflows/runs/%s", preset.LastRun.ShortID)) }
+						class="text-base-content/60 hover:underline tabular-nums truncate"
+					>
+						{ workflowsRelativeTime(preset.LastRun.FinishedAt) }
+					</a>
+				} else {
+					<span class="text-base-content/60 tabular-nums truncate">{ workflowsRelativeTime(preset.LastRun.FinishedAt) }</span>
+				}
 			</span>
 		}
-		<!-- Secondary actions (Preview prompt, Reconfigure) live in the overflow
-		     menu so the row stays uncluttered — one primary action + toggle inline. -->
-		@components.OverflowMenu(components.OverflowMenuProps{
-			AriaLabel: preset.Name + " actions",
-			Items:     presetMenuItems(preset, isAdmin),
-		})
-	</div>
+	} else {
+		<span class="inline-flex items-center gap-1 truncate">
+			@components.LucideIcon("clock", "w-3.5 h-3.5 shrink-0")
+			{ preset.TriggerLabel }
+		</span>
+	}
 }
 
 // workflowConfigDrawer is the right-side slide-over for configuring + enabling
@@ -421,30 +465,6 @@ templ workflowScheduleOption(value, label, selected string) {
 		<option value={ value } selected>{ label }</option>
 	} else {
 		<option value={ value }>{ label }</option>
-	}
-}
-
-// workflowLastRunLine renders the inline "Last run" summary on an enabled
-// card: a status pill plus a relative-time link to the run-detail page. A nil
-// run (never run yet) renders a muted "Not run yet" so the card still reads as
-// enabled-but-idle rather than blank.
-templ workflowLastRunLine(run *WorkflowLastRunProps) {
-	if run == nil {
-		<span class="hidden md:inline text-xs text-base-content/30">Not run yet</span>
-	} else {
-		<span class="hidden md:inline-flex items-center gap-1.5 text-xs">
-			@workflowRunStatusPill(run.Status)
-			if run.ShortID != "" {
-				<a
-					href={ templ.SafeURL(fmt.Sprintf("/workflows/runs/%s", run.ShortID)) }
-					class="text-base-content/60 hover:underline tabular-nums"
-				>
-					{ workflowsRelativeTime(run.FinishedAt) }
-				</a>
-			} else {
-				<span class="text-base-content/60 tabular-nums">{ workflowsRelativeTime(run.FinishedAt) }</span>
-			}
-		</span>
 	}
 }
 

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -1,11 +1,6 @@
 package pages
 
-import (
-	"fmt"
-	"time"
-
-	"breadbox/internal/templates/components"
-)
+import "breadbox/internal/templates/components"
 
 // WorkflowsGallery is the /workflows preset gallery: codified, configurable,
 // one-click automations grouped by category. "Set up" opens a right-side
@@ -133,14 +128,6 @@ templ workflowReconfigureDrawer() {
 					<div>
 						<div class="font-semibold leading-tight" x-text="reconfigure.name || 'Reconfigure workflow'"></div>
 						<div class="text-xs text-base-content/60 mt-1">Adjust how this workflow runs. Its base behavior stays the same.</div>
-						<button
-							type="button"
-							class="btn btn-ghost btn-xs gap-1 mt-2 -ml-1 text-base-content/70"
-							@click="previewPrompt(reconfigure.slug, reconfigure.name)"
-						>
-							@components.LucideIcon("file-text", "w-3.5 h-3.5")
-							Preview prompt
-						</button>
 					</div>
 				</div>
 				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
@@ -180,9 +167,19 @@ templ workflowReconfigureDrawer() {
 					</div>
 				</template>
 				<div>
-					<div class="text-sm font-medium mb-1.5">
-						Additional instructions
-						<span class="text-base-content/40 font-normal">(optional)</span>
+					<div class="flex items-center justify-between gap-2 mb-1.5">
+						<div class="text-sm font-medium">
+							Additional instructions
+							<span class="text-base-content/40 font-normal">(optional)</span>
+						</div>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs gap-1 text-base-content/55"
+							@click="previewPrompt(reconfigure.slug, reconfigure.name)"
+						>
+							@components.LucideIcon("file-text", "w-3.5 h-3.5")
+							Preview prompt
+						</button>
 					</div>
 					<textarea
 						name="additional_instructions"
@@ -194,12 +191,23 @@ templ workflowReconfigureDrawer() {
 					<div class="text-xs text-base-content/40 mt-1">Appended to the workflow's built-in prompt on every run.</div>
 				</div>
 			</div>
-			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
-				<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
-				<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="reconfigure.loading">
-					@components.LucideIcon("save", "w-4 h-4")
-					Save changes
+			<div class="flex items-center justify-between gap-2 p-4 border-t border-base-300">
+				<button
+					type="button"
+					class="btn btn-soft btn-sm gap-1.5"
+					@click="runWorkflow(reconfigure.slug); open=''"
+					x-bind:disabled="reconfigure.loading"
+				>
+					@components.LucideIcon("play", "w-4 h-4")
+					Run now
 				</button>
+				<div class="flex items-center gap-2">
+					<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
+					<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="reconfigure.loading">
+						@components.LucideIcon("save", "w-4 h-4")
+						Save changes
+					</button>
+				</div>
 			</div>
 		</form>
 	</div>
@@ -248,104 +256,78 @@ templ workflowPromptPreviewModal() {
 	</dialog>
 }
 
-// workflowPresetCard is one preset tile in the gallery grid: a leading
-// icon tile (gray, green-accented once set up), the name + description,
-// an overflow menu for secondary actions, and a bottom-aligned footer
-// carrying the run state on the left and the primary action(s) on the
-// right. Cards stretch to a uniform height per grid row (h-full + a
-// mt-auto footer) so the action rows line up across the 2-up layout.
+// workflowPresetCard is one preset row in the gallery grid — a clean,
+// Mintlify-style single line: a vertically-centered icon tile (gray,
+// green once set up; a small red dot flags a failed last run), the name
+// + a two-line description, and the run toggle + a settings gear on the
+// right. Set up, Run now, Reconfigure, and Preview prompt all live in the
+// drawer the gear opens, so the row itself stays uncluttered.
 templ workflowPresetCard(preset WorkflowPresetCardProps, isAdmin bool) {
-	<div class="bb-card p-4 h-full flex flex-col gap-3">
-		<div class="flex items-start gap-3">
-			<div class={ presetTileClasses(preset.Enabled) }>
-				@components.LucideIcon(preset.Icon, "w-5 h-5")
-			</div>
-			<div class="flex-1 min-w-0">
-				<div class="font-medium text-sm leading-tight">{ preset.Name }</div>
-				<div class="text-xs text-base-content/60 mt-1 line-clamp-2">{ preset.Description }</div>
-			</div>
-			<!-- Reconfigure (enabled + admin) is the only overflow action; the
-			     kebab is omitted entirely when there's nothing to put in it. -->
-			if len(presetMenuItems(preset, isAdmin)) > 0 {
-				@components.OverflowMenu(components.OverflowMenuProps{
-					AriaLabel: preset.Name + " actions",
-					Items:     presetMenuItems(preset, isAdmin),
-				})
+	<div class="bb-card px-4 py-3 h-full flex items-center gap-3">
+		<div class={ presetTileClasses(preset.Enabled) }>
+			@components.LucideIcon(preset.Icon, "w-5 h-5")
+			if preset.LastRun != nil && preset.LastRun.Status == "error" {
+				<span
+					class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-error ring-2 ring-base-100"
+					title="Last run failed"
+				></span>
 			}
 		</div>
-		<div class="flex items-center justify-between gap-2 mt-auto pt-1">
-			<div class="flex items-center gap-2 text-xs text-base-content/45 min-w-0">
-				@workflowCardStatus(preset)
-			</div>
-			<div class="flex items-center gap-2 shrink-0">
-				if preset.Enabled {
-					<button
-						type="button"
-						class="btn btn-soft btn-sm gap-1.5"
-						@click={ "runWorkflow('" + preset.WorkflowSlug + "')" }
-						aria-label={ "Run " + preset.Name + " now" }
-					>
-						@components.LucideIcon("play", "w-4 h-4")
-						Run now
-					</button>
-					<input
-						type="checkbox"
-						class="toggle toggle-sm toggle-primary"
-						if preset.WorkflowEnabled {
-							checked
-						}
-						aria-label={ "Toggle " + preset.Name }
-						@change={ "toggleWorkflow('" + preset.WorkflowSlug + "', $event.target)" }
-					/>
-				} else if isAdmin {
-					<button
-						type="button"
-						class="btn btn-soft btn-sm gap-1.5"
-						@click={ "open='" + preset.Slug + "'" }
-					>
-						@components.LucideIcon("settings-2", "w-4 h-4")
-						Set up
-					</button>
-				} else {
-					<span class="tooltip tooltip-left" data-tip="Only admins can enable workflows">
-						<button type="button" class="btn btn-soft btn-sm gap-1.5" disabled>
-							@components.LucideIcon("lock", "w-4 h-4")
-							Set up
-						</button>
-					</span>
-				}
-			</div>
+		<div class="flex-1 min-w-0">
+			<div class="font-medium text-sm leading-tight">{ preset.Name }</div>
+			<div class="text-xs text-base-content/60 mt-0.5 line-clamp-2">{ preset.Description }</div>
+		</div>
+		<div class="flex items-center gap-1 shrink-0">
+			@workflowCardControls(preset, isAdmin)
 		</div>
 	</div>
 }
 
-// workflowCardStatus is the footer-left status line: when set up, the
-// last-run pill + relative time (or a muted "Not run yet"); otherwise the
-// trigger summary so an un-configured card still tells you when it would
-// run. Always visible — the grid gives each card room even on mobile.
-templ workflowCardStatus(preset WorkflowPresetCardProps) {
+// workflowCardControls is the right-side cluster: the run toggle + a gear
+// that opens the configure (not set up) / reconfigure (set up) drawer —
+// the Mintlify shape, two controls, no buttons or kebab. A not-set-up
+// toggle opens the setup drawer instead of flipping (you can't enable
+// without choosing a schedule + acknowledging cost); non-admins get a
+// disabled toggle with a tooltip.
+templ workflowCardControls(preset WorkflowPresetCardProps, isAdmin bool) {
 	if preset.Enabled {
-		if preset.LastRun == nil {
-			<span class="text-base-content/35">Not run yet</span>
-		} else {
-			<span class="inline-flex items-center gap-1.5 min-w-0">
-				@workflowRunStatusPill(preset.LastRun.Status)
-				if preset.LastRun.ShortID != "" {
-					<a
-						href={ templ.SafeURL(fmt.Sprintf("/workflows/runs/%s", preset.LastRun.ShortID)) }
-						class="text-base-content/60 hover:underline tabular-nums truncate"
-					>
-						{ workflowsRelativeTime(preset.LastRun.FinishedAt) }
-					</a>
-				} else {
-					<span class="text-base-content/60 tabular-nums truncate">{ workflowsRelativeTime(preset.LastRun.FinishedAt) }</span>
-				}
-			</span>
+		<input
+			type="checkbox"
+			class="toggle toggle-sm toggle-primary"
+			if preset.WorkflowEnabled {
+				checked
+			}
+			aria-label={ "Toggle " + preset.Name }
+			@change={ "toggleWorkflow('" + preset.WorkflowSlug + "', $event.target)" }
+		/>
+		if isAdmin {
+			<button
+				type="button"
+				class="btn btn-ghost btn-sm btn-square text-base-content/55"
+				@click={ "openReconfigure('" + preset.WorkflowSlug + "', '" + preset.Name + "')" }
+				aria-label={ "Configure " + preset.Name }
+			>
+				@components.LucideIcon("settings", "w-4 h-4")
+			</button>
 		}
+	} else if isAdmin {
+		<input
+			type="checkbox"
+			class="toggle toggle-sm"
+			@click.prevent={ "open='" + preset.Slug + "'" }
+			aria-label={ "Set up " + preset.Name }
+		/>
+		<button
+			type="button"
+			class="btn btn-ghost btn-sm btn-square text-base-content/55"
+			@click={ "open='" + preset.Slug + "'" }
+			aria-label={ "Set up " + preset.Name }
+		>
+			@components.LucideIcon("settings", "w-4 h-4")
+		</button>
 	} else {
-		<span class="inline-flex items-center gap-1 truncate">
-			@components.LucideIcon("clock", "w-3.5 h-3.5 shrink-0")
-			{ preset.TriggerLabel }
+		<span class="tooltip tooltip-left" data-tip="Only admins can enable workflows">
+			<input type="checkbox" class="toggle toggle-sm" disabled aria-label={ "Toggle " + preset.Name }/>
 		</span>
 	}
 }
@@ -378,14 +360,6 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 					<div>
 						<div class="font-semibold leading-tight">{ preset.Name }</div>
 						<div class="text-xs text-base-content/60 mt-1">{ preset.Description }</div>
-						<button
-							type="button"
-							class="btn btn-ghost btn-xs gap-1 mt-2 -ml-1 text-base-content/70"
-							@click={ "previewPrompt('" + preset.Slug + "', '" + preset.Name + "')" }
-						>
-							@components.LucideIcon("file-text", "w-3.5 h-3.5")
-							Preview prompt
-						</button>
 					</div>
 				</div>
 				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
@@ -434,9 +408,19 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 					</div>
 				}
 				<div>
-					<div class="text-sm font-medium mb-1.5">
-						Additional instructions
-						<span class="text-base-content/40 font-normal">(optional)</span>
+					<div class="flex items-center justify-between gap-2 mb-1.5">
+						<div class="text-sm font-medium">
+							Additional instructions
+							<span class="text-base-content/40 font-normal">(optional)</span>
+						</div>
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs gap-1 text-base-content/55"
+							@click={ "previewPrompt('" + preset.Slug + "', '" + preset.Name + "')" }
+						>
+							@components.LucideIcon("file-text", "w-3.5 h-3.5")
+							Preview prompt
+						</button>
 					</div>
 					<textarea
 						name="additional_instructions"
@@ -483,45 +467,5 @@ templ workflowScheduleOption(value, label, selected string) {
 		<option value={ value } selected>{ label }</option>
 	} else {
 		<option value={ value }>{ label }</option>
-	}
-}
-
-// workflowRunStatusPill mirrors agentsListStatusPill — a soft daisy badge per
-// run status. Kept local so the pages package stays self-contained and the
-// gallery doesn't depend on the agents-list table's render helpers.
-templ workflowRunStatusPill(status string) {
-	switch status {
-		case "success":
-			<span class="badge badge-soft badge-success badge-xs">success</span>
-		case "error":
-			<span class="badge badge-soft badge-error badge-xs">error</span>
-		case "in_progress":
-			<span class="badge badge-soft badge-info badge-xs">running</span>
-		case "skipped":
-			<span class="badge badge-ghost badge-xs">skipped</span>
-		default:
-			<span class="badge badge-ghost badge-xs">{ status }</span>
-	}
-}
-
-// workflowsRelativeTime renders a compact "N ago" string for the last-run
-// line. Thin local copy of agentsListRelativeTime (same algorithm) so the
-// gallery doesn't reach across page files for a single helper.
-func workflowsRelativeTime(t time.Time) string {
-	if t.IsZero() {
-		return ""
-	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		return fmt.Sprintf("%dm ago", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh ago", int(d.Hours()))
-	case d < 7*24*time.Hour:
-		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
-	default:
-		return t.Format("Jan 2")
 	}
 }

--- a/internal/templates/components/pages/workflows_gallery_render_test.go
+++ b/internal/templates/components/pages/workflows_gallery_render_test.go
@@ -182,6 +182,48 @@ func TestT15WorkflowsGalleryGridAndTiles(t *testing.T) {
 	if !strings.Contains(html, "Preview prompt") || !strings.Contains(html, "previewPrompt(") {
 		t.Error("expected the Preview prompt affordance inside the drawer (button + handler)")
 	}
+
+	// The cleaned-up row uses a settings gear (not a ⋯ kebab) as the
+	// drawer entry point.
+	if !strings.Contains(html, "lucide-settings") {
+		t.Error("expected a settings gear (lucide-settings) on the row")
+	}
+	if strings.Contains(html, "lucide-ellipsis") {
+		t.Error("expected no ⋯ kebab on the row (replaced by the gear)")
+	}
+}
+
+// TestT15WorkflowsGalleryLastRunErrorDot asserts a failed last run pins a
+// red status dot to the icon tile, and a clean run does not.
+func TestT15WorkflowsGalleryLastRunErrorDot(t *testing.T) {
+	base := WorkflowsGalleryProps{
+		CSRFToken: "csrf",
+		IsAdmin:   true,
+		Status:    AgentSubsystemStatusProps{Ready: true},
+	}
+	mk := func(status string) string {
+		props := base
+		props.Categories = []WorkflowCategoryProps{{
+			Name: "Cat", Icon: "sparkles",
+			Presets: []WorkflowPresetCardProps{{
+				Slug: "p", Name: "P", Description: "d", Icon: "sparkles",
+				Enabled: true, WorkflowSlug: "p", WorkflowEnabled: true,
+				LastRun: &WorkflowLastRunProps{ShortID: "r1", Status: status},
+			}},
+		}}
+		var buf strings.Builder
+		if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		return buf.String()
+	}
+
+	if !strings.Contains(mk("error"), "bg-error") {
+		t.Error("expected a red status dot (bg-error) on a card whose last run errored")
+	}
+	if strings.Contains(mk("success"), "bg-error") {
+		t.Error("did not expect a red status dot on a card whose last run succeeded")
+	}
 }
 
 // TestT15WorkflowsGalleryEnabledPresetRendersToggle asserts that a preset

--- a/internal/templates/components/pages/workflows_gallery_render_test.go
+++ b/internal/templates/components/pages/workflows_gallery_render_test.go
@@ -143,6 +143,41 @@ func TestT15WorkflowsGalleryRenders(t *testing.T) {
 	}
 }
 
+// TestT15WorkflowsGalleryGridAndTiles asserts the redesigned gallery layout:
+// presets flow in a 2-up grid (single column on mobile), and each card's
+// leading icon tile is gray by default but green-accented once the preset is
+// set up. The T15 fixture has both an enabled and a disabled preset, so both
+// tile states must appear.
+func TestT15WorkflowsGalleryGridAndTiles(t *testing.T) {
+	props := T15buildGalleryProps()
+
+	var buf strings.Builder
+	if err := WorkflowsGallery(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("WorkflowsGallery.Render returned error: %v", err)
+	}
+	html := buf.String()
+
+	// 2-up grid on desktop, single column on mobile.
+	if !strings.Contains(html, "grid-cols-1") || !strings.Contains(html, "lg:grid-cols-2") {
+		t.Error("expected a single-column / 2-up-desktop grid wrapper (grid-cols-1 lg:grid-cols-2)")
+	}
+
+	// Green-accented tile for the enabled preset (uncategorized-review).
+	if !strings.Contains(html, "bg-success/15") {
+		t.Error("expected a green-accent icon tile (bg-success/15) for the enabled preset")
+	}
+	// Gray tile for the disabled presets.
+	if !strings.Contains(html, "bg-base-200") {
+		t.Error("expected a gray icon tile (bg-base-200) for disabled presets")
+	}
+
+	// The card surfaces the preset's own icon — e.g. "tag" for Smart
+	// Categorizer renders as a lucide-tag SVG.
+	if !strings.Contains(html, "lucide-tag") {
+		t.Error("expected the preset icon (lucide-tag) to render in its card tile")
+	}
+}
+
 // TestT15WorkflowsGalleryEnabledPresetRendersToggle asserts that a preset
 // marked Enabled=true renders a toggle checkbox rather than the "Set up" button.
 func TestT15WorkflowsGalleryEnabledPresetRendersToggle(t *testing.T) {

--- a/internal/templates/components/pages/workflows_gallery_render_test.go
+++ b/internal/templates/components/pages/workflows_gallery_render_test.go
@@ -176,6 +176,12 @@ func TestT15WorkflowsGalleryGridAndTiles(t *testing.T) {
 	if !strings.Contains(html, "lucide-tag") {
 		t.Error("expected the preset icon (lucide-tag) to render in its card tile")
 	}
+
+	// Preview prompt now lives inside the configure/reconfigure drawer, not
+	// the card ⋯ menu. The button + its handler should be present (admin view).
+	if !strings.Contains(html, "Preview prompt") || !strings.Contains(html, "previewPrompt(") {
+		t.Error("expected the Preview prompt affordance inside the drawer (button + handler)")
+	}
 }
 
 // TestT15WorkflowsGalleryEnabledPresetRendersToggle asserts that a preset
@@ -267,6 +273,11 @@ func TestT15WorkflowsGalleryNonAdminDisablesSetUp(t *testing.T) {
 	// Non-admin: no configure drawer should be rendered (drawers are admin-only).
 	if strings.Contains(html, "submitDrawer") {
 		t.Error("expected no configure drawer (submitDrawer) for non-admin user")
+	}
+	// Preview prompt lives only inside the (admin-only) drawer now, so a
+	// non-admin sees no Preview prompt affordance at all.
+	if strings.Contains(html, "Preview prompt") {
+		t.Error("expected no Preview prompt affordance for non-admin (it lives in the admin-only drawer)")
 	}
 }
 

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -30,17 +30,15 @@ func presetTileClasses(enabled bool) string {
 	return base + "bg-base-200 text-base-content/55"
 }
 
-// presetMenuItems builds the row's overflow ("⋯") menu — the secondary
-// actions moved out of the inline row to declutter it: Preview prompt
-// always, plus Reconfigure for an enabled workflow (admin only). The
-// OnClick strings invoke the workflowsGallery Alpine factory methods and
-// render inside the gallery's x-data root, so the handlers resolve.
+// presetMenuItems builds a card's overflow ("⋯") menu. Preview prompt now
+// lives inside the configure / reconfigure drawer (it's a setup-time concern),
+// so the only menu action is Reconfigure for an already-enabled workflow that
+// the viewer can edit. The slice is empty for un-enabled presets and for
+// non-admins — the card guards on len() and skips the kebab entirely. The
+// OnClick string invokes the workflowsGallery Alpine factory and renders inside
+// the gallery's x-data root, so the handler resolves.
 func presetMenuItems(preset WorkflowPresetCardProps, isAdmin bool) []components.OverflowMenuItem {
-	items := []components.OverflowMenuItem{{
-		Label:   "Preview prompt",
-		Icon:    "file-text",
-		OnClick: fmt.Sprintf("previewPrompt('%s', '%s')", preset.Slug, preset.Name),
-	}}
+	var items []components.OverflowMenuItem
 	if preset.Enabled && isAdmin {
 		items = append(items, components.OverflowMenuItem{
 			Label:   "Reconfigure",

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -3,11 +3,8 @@
 package pages
 
 import (
-	"fmt"
 	"strconv"
 	"time"
-
-	"breadbox/internal/templates/components"
 )
 
 // workflowCostStr formats a per-run cost estimate as a 2-decimal string
@@ -22,31 +19,14 @@ func workflowCostStr(c float64) string {
 // has been set up as a workflow, so a glance down the grid reads which
 // automations are live. The shape (size, rounding, centering) is shared
 // across both states.
+// The tile is `relative` so an enabled card can pin a small status dot
+// (last-run error) to its corner.
 func presetTileClasses(enabled bool) string {
-	const base = "flex items-center justify-center w-10 h-10 rounded-xl shrink-0 "
+	const base = "relative flex items-center justify-center w-10 h-10 rounded-xl shrink-0 "
 	if enabled {
 		return base + "bg-success/15 text-success"
 	}
 	return base + "bg-base-200 text-base-content/55"
-}
-
-// presetMenuItems builds a card's overflow ("⋯") menu. Preview prompt now
-// lives inside the configure / reconfigure drawer (it's a setup-time concern),
-// so the only menu action is Reconfigure for an already-enabled workflow that
-// the viewer can edit. The slice is empty for un-enabled presets and for
-// non-admins — the card guards on len() and skips the kebab entirely. The
-// OnClick string invokes the workflowsGallery Alpine factory and renders inside
-// the gallery's x-data root, so the handler resolves.
-func presetMenuItems(preset WorkflowPresetCardProps, isAdmin bool) []components.OverflowMenuItem {
-	var items []components.OverflowMenuItem
-	if preset.Enabled && isAdmin {
-		items = append(items, components.OverflowMenuItem{
-			Label:   "Reconfigure",
-			Icon:    "sliders-horizontal",
-			OnClick: fmt.Sprintf("openReconfigure('%s', '%s')", preset.WorkflowSlug, preset.Name),
-		})
-	}
-	return items
 }
 
 // WorkflowsGalleryProps is the view-model for the /workflows preset gallery.

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -17,6 +17,19 @@ func workflowCostStr(c float64) string {
 	return strconv.FormatFloat(c, 'f', 2, 64)
 }
 
+// presetTileClasses returns the classes for a preset card's leading
+// icon tile. Gray (neutral) by default; a green accent once the preset
+// has been set up as a workflow, so a glance down the grid reads which
+// automations are live. The shape (size, rounding, centering) is shared
+// across both states.
+func presetTileClasses(enabled bool) string {
+	const base = "flex items-center justify-center w-10 h-10 rounded-xl shrink-0 "
+	if enabled {
+		return base + "bg-success/15 text-success"
+	}
+	return base + "bg-base-200 text-base-content/55"
+}
+
 // presetMenuItems builds the row's overflow ("⋯") menu — the secondary
 // actions moved out of the inline row to declutter it: Preview prompt
 // always, plus Reconfigure for an enabled workflow (admin only). The


### PR DESCRIPTION
Reshapes the Workflows preset gallery based on hands-on feedback — three items, all addressed here.

## What changed

**1. 2-up card grid (was a settings-style vertical stack)** — each category renders its header *on top* (full width), then its presets flow as a 2-column grid on desktop and a single column on mobile. More scannable and product-y than the old `SettingsSection`/`SettingsRow` stack, whose section identity sat in a left gutter rather than on top.

**2. Status icon tiles** — every card gets a leading icon tile: **gray by default, green accent once the preset is set up**, so a glance down the grid reads which automations are live.

**3. Preview prompt moved into the drawer** — it's a setup-time concern, so it's out of the per-card ⋯ menu and now lives under the header of both the configure (set up) and reconfigure drawers. The ⋯ menu now carries only Reconfigure (enabled + admin), so the kebab is omitted entirely on un-configured cards — one menu on the single enabled card instead of one per row. The preview modal still opens over the drawer.

Cards stretch to a uniform height per grid row (`h-full` + a `mt-auto` footer) so the run state (left) and primary action (right) line up; descriptions line-clamp to two lines.

Pure markup restructure — the `workflowsGallery` Alpine factory and every handler (set up / run now / toggle / preview / reconfigure) are untouched.

### Design notes
- **Green tile** keys off `preset.Enabled` (instantiated as a workflow), not the run toggle — so a set-up-but-paused workflow still reads as "configured" (green) while the toggle separately controls run state.
- **Preview prompt is now admin-gated** — a direct consequence of housing it in the (admin-only) setup drawer. Easy to re-expose to viewers if you'd rather keep it universal.

## Validation

`go build ./...`, `go vet ./...`, and the full `internal/templates/components/pages` package tests pass — including a new `TestT15WorkflowsGalleryGridAndTiles` (asserts the `grid-cols-1 lg:grid-cols-2` wrapper + both tile states + the in-drawer Preview prompt) and a non-admin negative guard (no Preview prompt outside the admin drawer). Validated live against the play DB (real workflows, one enabled) — zero console errors.

<table>
  <tr><th>Desktop — 2-up grid</th><th>Mobile — single column</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/r4ar5wxy88.jpg" width="460" alt="Workflows gallery — desktop 2-up grid with status tiles"></td>
    <td><img src="https://i.img402.dev/9vvvzy6gml.jpg" width="240" alt="Workflows gallery — mobile single column"></td>
  </tr>
  <tr><th>Setup drawer — Preview prompt in header</th><th>Preview modal over the drawer</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/w417wbklma.jpg" width="460" alt="Setup drawer with Preview prompt button; only the enabled card has a kebab"></td>
    <td><img src="https://i.img402.dev/xacu7xsdu9.jpg" width="460" alt="Preview prompt modal opening over the setup drawer"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Design sandbox

The new card is now sandboxified at **`/design/c/workflow-preset-card`** (group: data) with its full variant matrix — not-set-up, the set-up run states (success / paused / error / never-run), and the non-admin lockout — so reviewers can compare states without standing up data. Registered in `DesignSections()`; the design smoke test renders it.

<img src="https://i.img402.dev/udzos6mvxp.jpg" width="800" alt="Workflow preset card — /design sandbox variant matrix">


---

## Update — Mintlify-style rows

Reshaped the rows to the clean Mintlify reference: a single line with a vertically-centered icon tile, name + two-line description, and just the **run toggle + a settings gear** on the right. The footer, Run-now button, inline status pill, trigger-label line, and ⋯ kebab are gone from the row.

- **Gear** opens the configure (not set up) / reconfigure (set up) drawer. A not-set-up toggle opens the setup drawer instead of flipping (no enable without a schedule + cost ack).
- **Run now** moved into the reconfigure drawer, **bottom-left** of the footer.
- **Preview prompt** moved beside the **"Additional instructions"** label, where you're tuning the prompt.
- A small **red dot** on the tile flags a failed last run (see Routine Reviewer / Large Charge Sentinel), so failures still surface on an otherwise status-free row.

<table>
  <tr><th>Gallery — clean rows</th><th>Reconfigure drawer (Run now ↙, Preview by instructions)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/p7wmo9ch3m.jpg" width="420" alt="Workflows gallery — Mintlify-style single rows, toggle + gear"></td>
    <td><img src="https://i.img402.dev/9l2ilkk8u2.jpg" width="420" alt="Reconfigure drawer — Run now bottom-left, Preview prompt by Additional instructions"></td>
  </tr>
  <tr><th>Setup drawer</th><th>/design sandbox — updated</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/se5iq5mcfn.jpg" width="420" alt="Setup drawer — Preview prompt by Additional instructions"></td>
    <td><img src="https://i.img402.dev/7dziapp12u.jpg" width="420" alt="Design sandbox — new single-row variant matrix"></td>
  </tr>
</table>
