### PR TITLE
feat(ui): shared Drawer slide-over primitive + /design sandbox, migrate Workflows

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -59,7 +59,7 @@ Always use the daisy component (with our standard overlays only):
 | `toast` | `toast toast-center toast-bottom` | One toast pattern. |
 | `tooltip` | `tooltip tooltip-top` + `data-tip="…"` | Don't roll your own tooltip. |
 | `loading` | `loading loading-spinner loading-xs/sm/md` | Only `loading-spinner` in practice — acceptable. |
-| `drawer` | `drawer lg:drawer-open` | Single use in `base.html`. |
+| `drawer` | `drawer lg:drawer-open` | Sidebar layout — single use in `base.html`. For a right-side slide-over sheet use `components.Drawer`, NOT this. |
 | `steps` | `steps steps-horizontal` | Wizard progress. CSV import should be on this. |
 | `tabs` | `tabs tabs-border` (or `tabs-box` for filter-tabs) | **Adopt — currently 0 callers.** |
 | `stat` / `stats` | `stats stats-horizontal` | **Adopt for dashboard tiles — currently 0 callers.** |
@@ -98,6 +98,14 @@ These exist because daisy doesn't cover the case. Keep using them; do
 If you find yourself wanting to write a new `bb-*` class that
 overlaps with daisy, **stop**: either adopt the daisy primitive or
 write a templ component that wraps it.
+**Right-side slide-over → `components.Drawer`.** Daisy's `drawer` is
+the sidebar layout (the one in `base.html`), not a right-anchored
+sheet. For focused inline create/edit flows use the shared
+`components.Drawer` + `DrawerHeader` + `DrawerFooter` templ
+components, opened via the global `$store.drawers` store. Don't
+hand-roll the backdrop+panel+slide chrome again — see
+`/design/c/drawers` and `docs/design-system.md`.
+
 
 ## Anti-patterns (actively being removed)
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -181,6 +181,59 @@ The Go server already serves `static/` via `http.FileServer`. The generated CSS 
 </div>
 ```
 
+### Drawer / slide-over (`components.Drawer`)
+
+The canonical **right-side slide-over** for focused create/edit flows
+that shouldn't take over the whole page or fight for room inside a
+modal. Backdrop + sliding panel + `DrawerHeader` (icon · title ·
+subtitle · close) + scrollable body + `DrawerFooter` (sticky actions).
+Reach for it for **simple inline edits** (rename, reconfigure, set up)
+where a full page is too heavy and a centered modal is too cramped for
+a vertical form.
+
+Why a templ component and not daisy: DaisyUI's `drawer` is the
+**sidebar layout** primitive (the one in `base.html`) — it's not a
+right-anchored sheet. This is the justified extension; don't hand-roll
+a fifth copy of the chrome.
+
+Open/close is driven by the global `$store.drawers` Alpine store
+(defined in `layout/base.html`) keyed by the `ID` you pass. Only one
+drawer is open at a time, so many `Drawer` instances can sit on one
+page and only the matching one + its backdrop show. Escape and a
+backdrop click both close; body scroll is locked while open.
+
+```go
+// Trigger — from markup or JS:
+//   <button @click="$store.drawers.open('edit-note')">Edit</button>
+//   Alpine.store('drawers').open('edit-note')
+
+@components.Drawer(components.DrawerProps{ID: "edit-note", Title: "Edit note"}) {
+    <form class="flex flex-col h-full" @submit.prevent="save($event.target)">
+        @components.DrawerHeader(components.DrawerHeaderProps{
+            Icon:     "pencil",
+            Title:    "Edit note",
+            Subtitle: "A focused edit surface.",
+        })
+        <div class="flex-1 overflow-y-auto p-5 space-y-5">
+            <textarea name="note" class="textarea w-full" rows="4"></textarea>
+        </div>
+        @components.DrawerFooter() {
+            <button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+        }
+    </form>
+}
+```
+
+`DrawerProps.Size` maps to panel max-width: `sm`→`max-w-sm`,
+`md`→`max-w-md` (default), `lg`→`max-w-lg`, `xl`→`max-w-2xl`. For a
+header set at runtime (a drawer hydrated by JS), pass
+`DrawerHeaderProps.TitleExpr` / `SubtitleExpr` (Alpine `x-text`
+expressions) instead of the static strings. Live variants:
+`/design/c/drawers`. Reference call sites: the Workflows gallery's
+**Set up** / **Configure** / **Reconfigure** flows
+(`workflows_gallery.templ`).
+
 ### Page Header (`.bb-page-header`)
 
 Every top-level admin page opens with a `.bb-page-header` row: the `<h1 class="bb-page-title">` (plus optional subtitle) on the left, and an optional **primary action** on the right (Save, Create, Sync All, Reconcile, Add Member, etc.).

--- a/internal/templates/components/drawer.templ
+++ b/internal/templates/components/drawer.templ
@@ -1,0 +1,159 @@
+package components
+
+// Drawer is the shared right-side slide-over ("sheet") — a focused
+// create/edit surface that slides in over a scrim without navigating
+// away from the page. It standardises the chrome that the Workflows
+// gallery hand-rolled twice (Set up / Configure / Reconfigure): the
+// backdrop, the sliding panel, sizing, the slide+fade transitions,
+// Escape-to-close, and body scroll-lock.
+//
+// Open/close is driven by the global `drawers` Alpine store (defined in
+// layout/base.html), keyed by the ID passed here. Open from anywhere —
+// a button, a row action, a JS factory:
+//
+//	<button @click="$store.drawers.open('edit-category')">Edit</button>
+//	Alpine.store('drawers').open('edit-category')   // from JS
+//
+// Only one drawer is open at a time (the store holds a single active
+// id), so multiple Drawer instances can coexist on a page and only the
+// matching one — plus its backdrop — shows.
+//
+// The component owns only the shell; the panel's contents are yours via
+// children. Compose them with DrawerHeader (icon + title + close) and
+// DrawerFooter (sticky action row) for the standard shape, or render
+// anything. A form that wraps header+body+footer works — make it the
+// direct child and give it `class="flex flex-col h-full"`.
+//
+// Example — a simple edit form:
+//
+//	@components.Drawer(components.DrawerProps{ID: "edit-note", Title: "Edit note"}) {
+//		<form class="flex flex-col h-full" @submit.prevent="save($event.target)">
+//			@components.DrawerHeader(components.DrawerHeaderProps{Icon: "pencil", Title: "Edit note"})
+//			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+//				<textarea name="note" class="textarea w-full" rows="4"></textarea>
+//			</div>
+//			@components.DrawerFooter() {
+//				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+//				<button type="submit" class="btn btn-primary btn-sm">Save</button>
+//			}
+//		</form>
+//	}
+type DrawerProps struct {
+	// ID uniquely names this drawer for the store. Required — it's the
+	// value you pass to $store.drawers.open('<id>').
+	ID string
+	// Title is the accessible name (aria-label) of the dialog. The
+	// visible title is whatever DrawerHeader (or your children) render;
+	// for a drawer with a dynamic header, pass a stable generic label
+	// here (e.g. "Reconfigure workflow") for assistive tech.
+	Title string
+	// Size maps to the panel max-width:
+	//   "sm" → max-w-sm, "md" → max-w-md (default), "lg" → max-w-lg,
+	//   "xl" → max-w-2xl.
+	Size string
+	// Class adds extra classes to the panel (rare — most callers don't
+	// need this).
+	Class string
+}
+
+templ Drawer(p DrawerProps) {
+	<div x-data class="contents">
+		<!-- scrim -->
+		<div
+			x-show={ "$store.drawers.is('" + p.ID + "')" }
+			x-cloak
+			x-transition:enter="transition-opacity ease-out duration-200"
+			x-transition:enter-start="opacity-0"
+			x-transition:enter-end="opacity-100"
+			x-transition:leave="transition-opacity ease-in duration-150"
+			x-transition:leave-start="opacity-100"
+			x-transition:leave-end="opacity-0"
+			class="fixed inset-0 bg-black/40 z-40"
+			@click="$store.drawers.close()"
+			aria-hidden="true"
+		></div>
+		<!-- panel -->
+		<div
+			x-show={ "$store.drawers.is('" + p.ID + "')" }
+			x-cloak
+			x-transition:enter="transition ease-out duration-200"
+			x-transition:enter-start="translate-x-full"
+			x-transition:enter-end="translate-x-0"
+			x-transition:leave="transition ease-in duration-150"
+			x-transition:leave-start="translate-x-0"
+			x-transition:leave-end="translate-x-full"
+			@keydown.escape.window="$store.drawers.close()"
+			role="dialog"
+			aria-modal="true"
+			if p.Title != "" {
+				aria-label={ p.Title }
+			}
+			class={ "fixed inset-y-0 right-0 z-50 w-full bg-base-100 border-l border-base-300 shadow-xl flex flex-col " + drawerSizeClass(p.Size) + " " + p.Class }
+		>
+			{ children... }
+		</div>
+	</div>
+}
+
+// drawerSizeClass maps the Size prop to a Tailwind max-width. Default
+// ("" or "md") is max-w-md (28rem) — the right width for a single-column
+// edit form. Use "lg"/"xl" only when the content genuinely needs it.
+func drawerSizeClass(size string) string {
+	switch size {
+	case "sm":
+		return "max-w-sm"
+	case "lg":
+		return "max-w-lg"
+	case "xl":
+		return "max-w-2xl"
+	default:
+		return "max-w-md"
+	}
+}
+
+// DrawerHeaderProps configures the standard drawer header: an optional
+// lucide icon, a title, an optional subtitle, and a close button wired
+// to $store.drawers.close(). For a header whose text is set at runtime
+// (a drawer hydrated by JS), pass TitleExpr / SubtitleExpr — Alpine
+// x-text expressions that take precedence over the static strings.
+type DrawerHeaderProps struct {
+	Icon         string
+	Title        string
+	TitleExpr    string // Alpine x-text expression; overrides Title
+	Subtitle     string
+	SubtitleExpr string // Alpine x-text expression; overrides Subtitle
+}
+
+templ DrawerHeader(p DrawerHeaderProps) {
+	<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300 shrink-0">
+		<div class="flex items-start gap-3 min-w-0">
+			if p.Icon != "" {
+				@LucideIcon(p.Icon, "w-5 h-5 mt-0.5 text-base-content/60 shrink-0")
+			}
+			<div class="min-w-0">
+				if p.TitleExpr != "" {
+					<div class="font-semibold leading-tight truncate" x-text={ p.TitleExpr }></div>
+				} else {
+					<div class="font-semibold leading-tight">{ p.Title }</div>
+				}
+				if p.SubtitleExpr != "" {
+					<div class="text-xs text-base-content/60 mt-1" x-text={ p.SubtitleExpr }></div>
+				} else if p.Subtitle != "" {
+					<div class="text-xs text-base-content/60 mt-1">{ p.Subtitle }</div>
+				}
+			</div>
+		</div>
+		<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="$store.drawers.close()" aria-label="Close">
+			@LucideIcon("x", "w-4 h-4")
+		</button>
+	</div>
+}
+
+// DrawerFooter is the sticky bottom action row of a drawer — a hairline
+// top border and right-aligned actions (Cancel + a primary). Place your
+// buttons as children.
+templ DrawerFooter() {
+	<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300 shrink-0">
+		{ children... }
+	</div>
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -784,6 +784,82 @@ templ SectionModals() {
 	</div>
 }
 
+// ─── Drawer (slide-over) ───────────────────────────────────────────────
+
+// SectionDrawer demos the shared components.Drawer slide-over. The
+// section root carries x-data so the trigger buttons' @click bind in
+// both the full gallery and the standalone embed; $store.drawers is
+// defined globally in layout/base.html and is present in both. Only one
+// drawer opens at a time, so all the demo panels can render at once.
+templ SectionDrawer() {
+	<div x-data class="flex flex-col gap-6">
+		@designExample("Anatomy", "Backdrop + sliding panel + DrawerHeader (icon · title · subtitle · close) + scrollable body + DrawerFooter (sticky actions). Opened via the global $store.drawers store keyed by id; Escape and a backdrop click close it.") {
+			<button type="button" class="btn btn-primary btn-sm gap-1.5" @click="$store.drawers.open('ds-drawer-edit')">
+				@components.LucideIcon("pencil", "w-4 h-4")
+				Open edit drawer
+			</button>
+			@components.Drawer(components.DrawerProps{ID: "ds-drawer-edit", Title: "Edit category"}) {
+				<form class="flex flex-col h-full" @submit.prevent="$store.drawers.close()">
+					@components.DrawerHeader(components.DrawerHeaderProps{
+						Icon:     "pencil",
+						Title:    "Edit category",
+						Subtitle: "A focused edit surface — no full-page navigation.",
+					})
+					<div class="flex-1 overflow-y-auto p-5 space-y-5">
+						<div>
+							<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="ds-drawer-name">Name</label>
+							<input id="ds-drawer-name" type="text" class="input w-full" placeholder="e.g. Groceries" value="Groceries"/>
+						</div>
+						<div>
+							<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="ds-drawer-note">Note</label>
+							<textarea id="ds-drawer-note" class="textarea w-full" rows="4" placeholder="Optional description…"></textarea>
+						</div>
+					</div>
+					@components.DrawerFooter() {
+						<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+						<button type="submit" class="btn btn-primary btn-sm gap-1.5">
+							@components.LucideIcon("check", "w-4 h-4")
+							Save
+						</button>
+					}
+				</form>
+			}
+		}
+		@designExample("Sizes", "Size prop → panel max-width: sm (max-w-sm) · md (max-w-md, default) · lg (max-w-lg) · xl (max-w-2xl). Default md fits a single-column edit form — pick the smallest the content reads well in.") {
+			<div class="flex flex-wrap items-center gap-2">
+				<button type="button" class="btn btn-sm" @click="$store.drawers.open('ds-drawer-sm')">sm</button>
+				<button type="button" class="btn btn-sm" @click="$store.drawers.open('ds-drawer-md')">md (default)</button>
+				<button type="button" class="btn btn-sm" @click="$store.drawers.open('ds-drawer-lg')">lg</button>
+				<button type="button" class="btn btn-sm" @click="$store.drawers.open('ds-drawer-xl')">xl</button>
+			</div>
+			@components.Drawer(components.DrawerProps{ID: "ds-drawer-sm", Title: "Small", Size: "sm"}) {
+				@designDrawerSizeBody("Small", "max-w-sm")
+			}
+			@components.Drawer(components.DrawerProps{ID: "ds-drawer-md", Title: "Medium", Size: "md"}) {
+				@designDrawerSizeBody("Medium", "max-w-md (default)")
+			}
+			@components.Drawer(components.DrawerProps{ID: "ds-drawer-lg", Title: "Large", Size: "lg"}) {
+				@designDrawerSizeBody("Large", "max-w-lg")
+			}
+			@components.Drawer(components.DrawerProps{ID: "ds-drawer-xl", Title: "Extra large", Size: "xl"}) {
+				@designDrawerSizeBody("Extra large", "max-w-2xl")
+			}
+		}
+	</div>
+}
+
+// designDrawerSizeBody is the shared body for the Drawer "Sizes" demo —
+// a header naming the size, a sentence, and a close button.
+templ designDrawerSizeBody(label, width string) {
+	@components.DrawerHeader(components.DrawerHeaderProps{Icon: "panel-right", Title: label + " drawer", Subtitle: width})
+	<div class="flex-1 overflow-y-auto p-5">
+		<p class="text-sm text-base-content/70">This panel is <span class="font-mono">{ width }</span>.</p>
+	</div>
+	@components.DrawerFooter() {
+		<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Close</button>
+	}
+}
+
 // ─── Loading & skeletons ───────────────────────────────────────────────
 
 templ SectionLoading() {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -364,6 +364,13 @@ func DesignSections() []DesignSection {
 			Group:       "feedback",
 			Render:      func() templ.Component { return SectionModals() },
 		},
+		{
+			Slug:        "drawers",
+			Title:       "Drawer (slide-over)",
+			Description: "Right-side slide-over sheet for focused create/edit flows without leaving the page — backdrop + sliding panel + DrawerHeader + scrollable body + DrawerFooter. Opened from anywhere via $store.drawers.open('<id>'). Drives the Workflows Set up / Configure / Reconfigure flows; reach for it for simple inline edits instead of a full page or a cramped modal.",
+			Group:       "feedback",
+			Render:      func() templ.Component { return SectionDrawer() },
+		},
 
 		// ── Patterns ────────────────────────────────────────────────
 		{

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -248,7 +248,7 @@ templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
 			<button
 				type="button"
 				class="btn btn-soft btn-sm gap-1.5"
-				@click={ "open='" + preset.Slug + "'" }
+				@click={ "$store.drawers.open('wf-config-" + preset.Slug + "')" }
 			>
 				@components.LucideIcon("settings-2", "w-4 h-4")
 				Set up

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -72,19 +72,8 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				}
 			}
 		</div>
-		<!-- Configure drawer: shared backdrop + one slide-over panel per available preset. -->
-		<div
-			x-show="open"
-			x-cloak
-			x-transition:enter="transition-opacity ease-out duration-200"
-			x-transition:enter-start="opacity-0"
-			x-transition:enter-end="opacity-100"
-			x-transition:leave="transition-opacity ease-in duration-150"
-			x-transition:leave-start="opacity-100"
-			x-transition:leave-end="opacity-0"
-			class="fixed inset-0 bg-black/40 z-40"
-			@click="open=''"
-		></div>
+		<!-- Configure drawer: one components.Drawer slide-over per available preset. -->
+		<!-- Each Drawer renders its own backdrop + panel via the shared $store.drawers store. -->
 		// Drawers exist only for the admin who can actually submit them; a
 		// non-admin can't open one (the "Set up" control is disabled).
 		if p.IsAdmin {
@@ -114,31 +103,16 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 // submits to POST /-/workflows/{slug}/reconfigure. It never touches the
 // run-state toggle or the base prompt.
 templ workflowReconfigureDrawer() {
-	<div
-		x-show="open === 'reconfigure'"
-		x-cloak
-		x-transition:enter="transition ease-out duration-200"
-		x-transition:enter-start="translate-x-full"
-		x-transition:enter-end="translate-x-0"
-		x-transition:leave="transition ease-in duration-150"
-		x-transition:leave-start="translate-x-0"
-		x-transition:leave-end="translate-x-full"
-		class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 border-l border-base-300 shadow-xl flex flex-col"
-		@keydown.escape.window="open=''"
-	>
+	@components.Drawer(components.DrawerProps{
+		ID:    "wf-reconfigure",
+		Title: "Reconfigure workflow",
+	}) {
 		<form class="flex flex-col h-full" @submit.prevent="submitReconfigure($event.target)">
-			<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300">
-				<div class="flex items-start gap-3">
-					@components.LucideIcon("sliders-horizontal", "w-5 h-5 mt-0.5 text-base-content/60 shrink-0")
-					<div>
-						<div class="font-semibold leading-tight" x-text="reconfigure.name || 'Reconfigure workflow'"></div>
-						<div class="text-xs text-base-content/60 mt-1">Adjust how this workflow runs. Its base behavior stays the same.</div>
-					</div>
-				</div>
-				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
-					@components.LucideIcon("x", "w-4 h-4")
-				</button>
-			</div>
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:      "sliders-horizontal",
+				TitleExpr: "reconfigure.name || 'Reconfigure workflow'",
+				Subtitle:  "Adjust how this workflow runs. Its base behavior stays the same.",
+			})
 			<div x-show="reconfigure.loading" class="flex items-center gap-2 text-sm text-base-content/60 p-5">
 				<span class="loading loading-spinner loading-sm"></span>
 				Loading configuration…
@@ -186,15 +160,15 @@ templ workflowReconfigureDrawer() {
 					<div class="text-xs text-base-content/40 mt-1">Appended to the workflow's built-in prompt on every run.</div>
 				</div>
 			</div>
-			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
-				<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
 				<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="reconfigure.loading">
 					@components.LucideIcon("save", "w-4 h-4")
 					Save changes
 				</button>
-			</div>
+			}
 		</form>
-	</div>
+	}
 }
 
 // workflowPromptPreviewModal is the shared read-only dialog that shows a
@@ -316,35 +290,20 @@ templ workflowPresetControl(preset WorkflowPresetCardProps, isAdmin bool) {
 // run-now, and (on first enable) a consent acknowledgement. consentAck=true
 // hides the consent gate once the household has already acknowledged.
 templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
-	<div
-		x-show={ "open === '" + preset.Slug + "'" }
-		x-cloak
-		x-transition:enter="transition ease-out duration-200"
-		x-transition:enter-start="translate-x-full"
-		x-transition:enter-end="translate-x-0"
-		x-transition:leave="transition ease-in duration-150"
-		x-transition:leave-start="translate-x-0"
-		x-transition:leave-end="translate-x-full"
-		class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 border-l border-base-300 shadow-xl flex flex-col"
-		@keydown.escape.window="open=''"
-	>
+	@components.Drawer(components.DrawerProps{
+		ID:    "wf-config-" + preset.Slug,
+		Title: "Set up " + preset.Name,
+	}) {
 		<form
 			x-data={ "{ cron: '" + preset.ScheduleCron + "', consent: false }" }
 			class="flex flex-col h-full"
 			@submit.prevent={ "submitDrawer('" + preset.Slug + "', $event.target)" }
 		>
-			<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300">
-				<div class="flex items-start gap-3">
-					@components.LucideIcon(preset.Icon, "w-5 h-5 mt-0.5 text-base-content/60 shrink-0")
-					<div>
-						<div class="font-semibold leading-tight">{ preset.Name }</div>
-						<div class="text-xs text-base-content/60 mt-1">{ preset.Description }</div>
-					</div>
-				</div>
-				<button type="button" class="btn btn-ghost btn-sm btn-square shrink-0" @click="open=''" aria-label="Close">
-					@components.LucideIcon("x", "w-4 h-4")
-				</button>
-			</div>
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     preset.Icon,
+				Title:    preset.Name,
+				Subtitle: preset.Description,
+			})
 			<div class="flex-1 overflow-y-auto p-5 space-y-5">
 				<div>
 					<div class="text-sm font-medium mb-1.5">When it runs</div>
@@ -410,8 +369,8 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 					</label>
 				}
 			</div>
-			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
-				<button type="button" class="btn btn-ghost btn-sm" @click="open=''">Cancel</button>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
 				if consentAck {
 					<button type="submit" class="btn btn-primary btn-sm gap-1.5">
 						@components.LucideIcon("zap", "w-4 h-4")
@@ -423,9 +382,9 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 						Enable workflow
 					</button>
 				}
-			</div>
+			}
 		</form>
-	</div>
+	}
 }
 
 templ workflowScheduleOption(value, label, selected string) {

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -160,6 +160,33 @@
   </script>
 
   <script>
+    // Alpine store: $store.drawers
+    //
+    // Drives the shared right-side slide-over (components.Drawer). One
+    // drawer is open at a time, keyed by the id passed to the component.
+    // Open from anywhere — a button, a row action, a page factory:
+    //   <button @click="$store.drawers.open('edit-note')">Edit</button>
+    //   Alpine.store('drawers').open('edit-note')   // from JS
+    // close() is also bound to Escape + backdrop click by the component.
+    // Body scroll is locked while a drawer is open so the page behind it
+    // doesn't scroll under the panel.
+    document.addEventListener('alpine:init', function() {
+      Alpine.store('drawers', {
+        active: null,
+        is: function(id) { return this.active === id; },
+        open: function(id) {
+          this.active = id;
+          document.documentElement.style.overflow = 'hidden';
+        },
+        close: function() {
+          this.active = null;
+          document.documentElement.style.overflow = '';
+        },
+      });
+    });
+  </script>
+
+  <script>
     // Alpine store: $store.theme
     //
     // Single source of truth for the theme preference, shared by every

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -6,9 +6,11 @@ document.addEventListener('alpine:init', function () {
   Alpine.data('workflowsGallery', function () {
     return {
       csrfToken: '',
-      // open holds the slug of the preset whose configure drawer is showing
-      // (empty string = no drawer).
-      open: '',
+      // Drawer open/close is owned by the global $store.drawers store
+      // (see layout/base.html). The configure drawers are keyed
+      // 'wf-config-<presetSlug>'; the shared reconfigure drawer is
+      // 'wf-reconfigure'. open()/close() are called from the template
+      // (Set up / Cancel / Escape / backdrop) and from openReconfigure().
 
       // --- F2: preview internal prompt -----------------------------------
       // State for the "Preview prompt" modal: the composed base prompt is
@@ -167,7 +169,7 @@ document.addEventListener('alpine:init', function () {
         self.reconfigure.additionalInstructions = '';
         self.reconfigure.scheduleCron = '';
         self.reconfigure.triggerOnSync = false;
-        self.open = 'reconfigure';
+        Alpine.store('drawers').open('wf-reconfigure');
         fetch('/-/workflows/' + encodeURIComponent(slug) + '/config', {
           credentials: 'same-origin',
           headers: { Accept: 'application/json' },
@@ -185,7 +187,7 @@ document.addEventListener('alpine:init', function () {
           })
           .catch(function (e) {
             console.error('openReconfigure failed', e);
-            self.open = '';
+            Alpine.store('drawers').close();
             self.restorePageState();
           })
           .finally(function () {


### PR DESCRIPTION
## What

"Sandboxify" the right-side slide-over drawers used on `/workflows` into one reusable, documented design-system component, so we can reach for it for **simple inline edits** across the admin instead of hand-rolling the chrome each time.

Before this, the same backdrop + sliding panel + header + footer was hand-written **twice** in `workflows_gallery.templ` (the per-preset **Set up / Configure** drawer and the shared **Reconfigure** drawer), with open/close state living in a bespoke `open` field on the page factory. This PR extracts that into `components.Drawer` and a global `$store.drawers` store, demos it in the `/design` sandbox, and migrates the Workflows call sites onto it.

## Changes

- **`components.Drawer` + `DrawerHeader` + `DrawerFooter`** (`internal/templates/components/drawer.templ`) — backdrop scrim + sliding panel + header (icon · title · subtitle · close) + scrollable body + sticky footer. Slide/fade transitions, Escape + backdrop-click close, body scroll-lock. `Size` prop → `sm`/`md` (default)/`lg`/`xl`. `DrawerHeaderProps.TitleExpr`/`SubtitleExpr` for runtime-hydrated headers.
- **Global `$store.drawers` Alpine store** (`base.html`) — `open('<id>')` / `close()` / `is('<id>')`, one drawer open at a time, keyed by id. Lives next to `$store.device` / `$store.theme`.
- **`/design` sandbox** — new "Drawer (slide-over)" section (anatomy + sizes) so the primitive is reviewable in isolation at `/design/c/drawers`.
- **Workflows migration** — both drawers + the `Set up` trigger now use `components.Drawer` and `$store.drawers`; removed the duplicated backdrop/panel chrome and the bespoke `open` page state.
- **Docs** — `docs/design-system.md` Drawer section + `daisyui.md` note (daisy's `drawer` is the **sidebar layout** only; use `components.Drawer` for right-side sheets — don't hand-roll a fifth copy).

## Why a templ component, not daisy

DaisyUI's `drawer` is the sidebar layout primitive (the one in `base.html`); it is *not* a right-anchored sheet. Per `.claude/rules/daisyui.md` this is a justified extension authored as a templ component (typed, testable) rather than a `bb-*` class.

## Merged latest `main`

Merged `origin/main` (incl. #1653 "gallery declutter — overflow menu", #1654, #1652). #1653 rewrote `workflowPresetControl`; the auto-merge silently kept its `Set up` button still pointing at the removed `open` state — fixed in a follow-up commit so the configure drawer actually opens. Verified by re-running the browser capture against a clean build.

## Validation

Logged in and exercised both surfaces in headless Chrome — drawers slide in correctly, **zero console errors**.

**Workflows — "Set up" configure drawer** (`/workflows`)

<img src="https://i.img402.dev/gll9mcvxvv.jpg" width="800" alt="Workflows Set up configure drawer open">

**`/design` sandbox — Drawer (slide-over) section**

<img src="https://i.img402.dev/1lo7q4ypcl.jpg" width="800" alt="Design sandbox Drawer section, edit drawer open">

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- `templ generate` + `make css` clean; no `templ fmt` churn on unrelated files.
- Browser: Set up drawer on `/workflows` and the `/design/c/drawers` edit drawer both open/close via button, Escape, and backdrop click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
