### PR TITLE
feat(ui): reshape daisyUI toggle into an iOS-style switch

### DIFF
--- a/input.css
+++ b/input.css
@@ -1499,9 +1499,83 @@
     transition: background-color 0.12s ease;
   }
 
-  /* ── Toggle transitions ── */
+  /* ── iOS-style toggle ──────────────────────────────────────────────
+   * Reshapes daisyUI 5's .toggle into an Apple/iOS switch: a full-pill,
+   * borderless track, a filled gray "off" state (base-300 — which maps
+   * almost exactly onto Apple's #E9E9EA light / #39393D dark), an
+   * Apple-green "on" state, and a white CIRCULAR knob carrying Apple's
+   * two-layer drop shadow. The knob slide reuses daisy's existing grid-
+   * column swap (1fr/0fr → 0fr/1fr); we only retune the easing to an
+   * iOS spring curve.
+   *
+   * `!important` mirrors the existing .toggle/.btn/.modal-box overrides:
+   * daisyUI emits `.toggle{…}` / `.toggle:checked{…}` in a component
+   * sublayer that wins over our @layer components on cascade order, so
+   * the declarations that must beat daisy carry !important. Color
+   * modifiers (toggle-primary, toggle-success, …) stay live by
+   * reassigning --bb-toggle-on instead of hard-coding the on color. */
   .toggle {
-    transition: background-color 0.2s ease, border-color 0.2s ease !important;
+    --bb-toggle-on: #34c759; /* Apple system green */
+    --bb-toggle-ease: cubic-bezier(0.32, 0.72, 0, 1);
+    border-color: transparent !important;
+    background-color: var(--color-base-300) !important;
+    border-radius: 999px !important;
+    box-shadow: none !important;
+    transition:
+      background-color 0.25s var(--bb-toggle-ease),
+      grid-template-columns 0.25s var(--bb-toggle-ease) !important;
+  }
+
+  /* Knob: white circle + Apple's two-layer shadow, in both states. */
+  .toggle::before {
+    border-radius: 999px !important;
+    background-color: #fff !important;
+    box-shadow:
+      0 3px 8px oklch(0 0 0 / 0.15),
+      0 1px 1px oklch(0 0 0 / 0.16) !important;
+    outline: none !important;
+    transition:
+      translate 0.25s var(--bb-toggle-ease),
+      inset-inline-start 0.25s var(--bb-toggle-ease) !important;
+  }
+
+  /* On state — track turns green; knob stays white and slides right
+     (the grid-column swap that slides it is daisy's, left intact). */
+  .toggle:checked,
+  .toggle[aria-checked="true"],
+  .toggle:has(> input:checked) {
+    background-color: var(--bb-toggle-on) !important;
+  }
+  .toggle:checked::before,
+  .toggle[aria-checked="true"]::before,
+  .toggle:has(> input:checked)::before {
+    background-color: #fff !important;
+  }
+
+  /* Color modifiers keep working by re-pointing the on color. */
+  .toggle-primary {
+    --bb-toggle-on: var(--color-primary);
+  }
+  .toggle-secondary {
+    --bb-toggle-on: var(--color-secondary);
+  }
+  .toggle-accent {
+    --bb-toggle-on: var(--color-accent);
+  }
+  .toggle-neutral {
+    --bb-toggle-on: var(--color-neutral);
+  }
+  .toggle-info {
+    --bb-toggle-on: var(--color-info);
+  }
+  .toggle-success {
+    --bb-toggle-on: var(--color-success);
+  }
+  .toggle-warning {
+    --bb-toggle-on: var(--color-warning);
+  }
+  .toggle-error {
+    --bb-toggle-on: var(--color-error);
   }
 
   /* ── Select/Input focus transitions ── */

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -379,6 +379,14 @@ templ SectionFormControls() {
 					<span class="label-text">Auto-sync</span>
 				</label>
 				<label class="label cursor-pointer gap-2">
+					<input type="checkbox" class="toggle"/>
+					<span class="label-text">Notifications</span>
+				</label>
+				<label class="label cursor-pointer gap-2">
+					<input type="checkbox" class="toggle toggle-primary" checked/>
+					<span class="label-text">Primary tone</span>
+				</label>
+				<label class="label cursor-pointer gap-2">
 					<input type="radio" name="ds-radio-1" class="radio" checked/>
 					<span class="label-text">Daily</span>
 				</label>


### PR DESCRIPTION
## What

Reshapes the daisyUI `toggle` into an **Apple / iOS-style switch**.

The theme sets `--radius-selector: 0.375rem` (6px), so daisyUI rendered `.toggle` as a *rounded rectangle* with a colored border and a white-track / dark-knob "on" state — nothing like Apple's pill switch. This overrides `.toggle` in `input.css` into a faithful iOS switch:

- **Full-pill, borderless track** (`border-radius: 999px`, transparent border)
- **Gray "off" fill** using `var(--color-base-300)` — which maps almost exactly onto Apple's `#E9E9EA` (light) / `#39393D` (dark)
- **Apple system-green "on" fill** (`#34C759`)
- **White circular knob** carrying Apple's two-layer drop shadow
- **iOS spring easing** (`cubic-bezier(0.32, 0.72, 0, 1)`) on the slide — daisy's existing grid-column swap still does the sliding

Color modifiers stay live via a `--bb-toggle-on` variable, so `toggle-primary` / `toggle-success` / etc. keep recoloring the "on" track (see the dark "Primary tone" switch below). The targeted `!important` mirrors the existing `.toggle` / `.btn` / `.modal-box` overrides — daisyUI emits its component rules in a sublayer that otherwise wins on cascade order.

Off / On / Primary variants are surfaced in the `/design` sandbox (Form controls → Checkbox / toggle / radio).

## Evidence

`/design` → Form controls. Left→right: `toggle` (on), `toggle` (off), `toggle toggle-primary` (on).

**Light**

<img src="https://i.img402.dev/f1umpody8u.jpg" width="820" alt="iOS-style toggle — light">

**Dark**

<img src="https://i.img402.dev/286vb47ldl.jpg" width="820" alt="iOS-style toggle — dark">

`getComputedStyle` confirms: off-track `border-radius: 999px`, `border-color: transparent`, `background: base-300`; on-track `background: rgb(52,199,89)` (`#34C759`); knob `border-radius: 999px`, white, two-layer shadow.

## Notes

- CSS-only + one `/design` sandbox edit. `styles.css` and `*_templ.go` are gitignored build artifacts — CI rebuilds them.
- `go build ./...`, `go vet ./...`, and `go test ./internal/templates/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
