### PR TITLE
feat(series): timeline link/unlink events + review-driven UI polish

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -726,7 +726,7 @@ CHECK (added_by_type IN ('user', 'agent', 'rule', 'system'))
 | `id` | `UUID` | No | `gen_random_uuid()` | Primary key. |
 | `short_id` | `TEXT` | No | trigger-generated | 8-character base62 alias. |
 | `transaction_id` | `UUID` | No | — | FK → `transactions(id)`. CASCADE DELETE. |
-| `kind` | `TEXT` | No | — | One of `comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`. |
+| `kind` | `TEXT` | No | — | One of `comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`, `sync_started`, `sync_updated`, `transaction_deleted`, `transaction_restored`, `series_assigned`, `series_unlinked`. |
 | `actor_type` | `TEXT` | No | — | `user`, `agent`, or `system`. |
 | `actor_id` | `TEXT` | Yes | `NULL` | Attribution ID (admin user ID, API key prefix, etc.). |
 | `actor_name` | `TEXT` | No | — | Display name of the actor. |

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -684,6 +684,7 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 		BandTone:        bandTone,
 		SignalSummary:   subscriptionSignalSummary(s),
 		SignalsJSON:     prettySignals(s.DetectionSignals),
+		SignalFacts:     subscriptionSignalFacts(s),
 		Source:          s.DetectionSource,
 		SourceLabel:     sourceLabel(s.DetectionSource),
 	}
@@ -860,6 +861,87 @@ func subscriptionSignalSummary(s service.SeriesResponse) string {
 		parts = append(parts, amountPhrase)
 	}
 	return strings.Join(parts, " · ")
+}
+
+// subscriptionSignalFacts parses detection_signals into labelled criteria for
+// the "Why detected" surface — a readable breakdown (charges seen, cadence,
+// timing regularity, amount pattern) instead of a raw JSON dump. Returns nil
+// when there are no signals (manual / agent-created series) so the card falls
+// back to a plain note.
+func subscriptionSignalFacts(s service.SeriesResponse) []pages.SubscriptionSignalFact {
+	sig, ok := decodeSignals(s.DetectionSignals)
+	if !ok {
+		return nil
+	}
+	occ := s.OccurrenceCount
+	if sig.OccurrenceCount > 0 {
+		occ = sig.OccurrenceCount
+	}
+	occTone := "neutral"
+	switch {
+	case occ >= 6:
+		occTone = "success"
+	case occ <= 3:
+		occTone = "warning"
+	}
+
+	cadence := sig.Cadence
+	if cadence == "" {
+		cadence = strings.ToLower(cadenceLabel(s.Cadence))
+	}
+
+	facts := []pages.SubscriptionSignalFact{
+		{Icon: "hash", Label: "Charges seen", Value: fmt.Sprintf("%d", occ), Tone: occTone},
+		{Icon: "calendar", Label: "Cadence", Value: cadence, Tone: "neutral"},
+	}
+
+	// Timing regularity from the interval coefficient of variation (0 = perfectly
+	// even spacing). Lower CV ⇒ stronger recurring signal.
+	regularity, regTone := intervalRegularity(sig.IntervalCV)
+	facts = append(facts, pages.SubscriptionSignalFact{
+		Icon: "activity", Label: "Timing", Value: regularity, Tone: regTone,
+	})
+
+	// Amount pattern from the detector's amount branch.
+	amountValue, amountTone := amountPattern(sig)
+	facts = append(facts, pages.SubscriptionSignalFact{
+		Icon: "dollar-sign", Label: "Amount", Value: amountValue, Tone: amountTone,
+	})
+	return facts
+}
+
+// intervalRegularity turns the interval coefficient of variation into a phrase +
+// tone. CV is stddev/mean of the gaps between charges.
+func intervalRegularity(cv float64) (string, string) {
+	switch {
+	case cv <= 0.0001:
+		return "Perfectly even spacing", "success"
+	case cv < 0.10:
+		return fmt.Sprintf("Very regular (±%.0f%%)", cv*100), "success"
+	case cv < 0.25:
+		return fmt.Sprintf("Regular (±%.0f%%)", cv*100), "success"
+	case cv < 0.50:
+		return fmt.Sprintf("Somewhat irregular (±%.0f%%)", cv*100), "warning"
+	default:
+		return fmt.Sprintf("Irregular (±%.0f%%)", cv*100), "neutral"
+	}
+}
+
+// amountPattern turns the detector's amount branch + spread into a phrase + tone.
+func amountPattern(sig subscriptionSignalsShape) (string, string) {
+	switch sig.AmountBranch {
+	case "monotonic_drift":
+		return "Rising over time", "warning"
+	case "tight":
+		if pct := (sig.AmountSpreadRatio - 1) * 100; pct >= 1 {
+			return fmt.Sprintf("Stable (±%.0f%%)", pct), "success"
+		}
+		return "Identical each time", "success"
+	case "":
+		return "—", "neutral"
+	default:
+		return "Variable", "neutral"
+	}
 }
 
 func prettySignals(raw json.RawMessage) string {

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1150,6 +1150,25 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			entry.ActorID = &id
 		}
 		return entry, true
+
+	case "series_assigned", "series_unlinked":
+		// Recurring-series membership: actor is the user/agent who linked, or
+		// the system (detection). Summary is the canonical sentence built by
+		// EnrichAnnotations; both kinds collapse to a single "series" type
+		// (the icon is identical and the Summary differentiates the verb).
+		entry := service.ActivityEntry{
+			Type:               "series",
+			Timestamp:          a.CreatedAt,
+			ActorName:          a.ActorName,
+			ActorType:          a.ActorType,
+			ActorAvatarVersion: a.ActorAvatarVersion,
+			Summary:            a.Summary,
+		}
+		if a.ActorID != nil && *a.ActorID != "" {
+			id := *a.ActorID
+			entry.ActorID = &id
+		}
+		return entry, true
 	}
 	return service.ActivityEntry{}, false
 }

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -360,7 +360,8 @@ func UnlinkSeriesTransactionHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		txID := chi.URLParam(r, "txid")
-		s, err := svc.UnlinkSeriesTransactions(r.Context(), id, []string{txID})
+		actor := service.ActorFromContext(r.Context())
+		s, err := svc.UnlinkSeriesTransactions(r.Context(), id, []string{txID}, actor)
 		if err != nil {
 			writeServiceError(w, err, "Series or transaction not found", "Failed to unlink transaction")
 			return

--- a/internal/db/migrations/20260531130000_annotations_series_kinds.sql
+++ b/internal/db/migrations/20260531130000_annotations_series_kinds.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- Extend the annotations.kind CHECK constraint to recognise recurring-series
+-- membership events on the activity timeline:
+--   - series_assigned: written when a transaction is linked to a recurring
+--     series (manual assign, detection auto-link, or manual create).
+--   - series_unlinked: written when a transaction is detached from a series.
+--
+-- Drop + add run in goose's per-migration transaction so the table is never
+-- without a constraint. Additive in the shared-DB sense: the new constraint
+-- only WIDENS the allowed set, so older `breadbox serve` processes (which never
+-- write the new kinds) keep working before they pick up the emitting code.
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated',
+    'transaction_deleted',
+    'transaction_restored',
+    'series_assigned',
+    'series_unlinked'
+  ));
+
+-- +goose Down
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated',
+    'transaction_deleted',
+    'transaction_restored'
+  ));

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -164,7 +164,8 @@ func (s *MCPServer) handleUnlinkSeriesTransactions(ctx context.Context, _ *mcpsd
 	if input.ID == "" || len(input.TransactionIDs) == 0 {
 		return errorResult(fmt.Errorf("id and transaction_ids are required")), nil, nil
 	}
-	series, err := s.svc.UnlinkSeriesTransactions(context.Background(), input.ID, input.TransactionIDs)
+	actor := service.ActorFromContext(ctx)
+	series, err := s.svc.UnlinkSeriesTransactions(context.Background(), input.ID, input.TransactionIDs, actor)
 	if err != nil {
 		if errors.Is(err, service.ErrNotFound) {
 			return errorResult(fmt.Errorf("series not found")), nil, nil

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -17,7 +17,7 @@ import (
 
 type listAnnotationsInput struct {
 	TransactionID string   `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
-	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category, sync. Empty = all kinds. Pass ['comment'] for the comment-only timeline. Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied|started|updated) for the specific event. Pass ['sync'] to see initial-import + pending-flip rows."`
+	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category, sync, series. Empty = all kinds. Pass ['comment'] for the comment-only timeline. Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied|started|updated|linked|unlinked) for the specific event. Pass ['series'] to see recurring-series link/unlink events."`
 	ActorTypes    []string `json:"actor_types,omitempty" jsonschema:"Optional actor-type filter: any of user, agent, system. Empty = all actors. Pass ['user'] for the canonical 'any human input?' check — drops rule churn and prior agent activity in one filter. Combine with kinds for fine-grained slices."`
 	Since         string   `json:"since,omitempty" jsonschema:"Optional RFC3339 timestamp; return only annotations whose created_at is strictly after this time. Lets an agent that already saw the timeline once skip to the new tail. Malformed timestamps are rejected with a clear error."`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Optional cap on returned rows — returns the most recent N (timeline tail) in chronological order. 0 (default) = full timeline; max 200; negative is rejected. Pair with since to bound a delta read."`
@@ -134,6 +134,7 @@ var mcpAnnotationKinds = map[string][]string{
 	"tag":      {"tag_added", "tag_removed"},
 	"category": {"category_set"},
 	"sync":     {"sync_started", "sync_updated"},
+	"series":   {"series_assigned", "series_unlinked"},
 }
 
 // mapAnnotationKinds translates the agent-facing generic kinds into the raw DB
@@ -149,7 +150,7 @@ func mapAnnotationKinds(kinds []string) ([]string, error) {
 	for _, k := range kinds {
 		raw, ok := mcpAnnotationKinds[k]
 		if !ok {
-			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category, sync", k)
+			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category, sync, series", k)
 		}
 		for _, r := range raw {
 			if seen[r] {
@@ -253,13 +254,13 @@ func toMCPAnnotation(a service.Annotation) mcpAnnotation {
 		// Surface the rule's short_id as `rule_id` (canonical handle for
 		// agents). Falls back to the FK column's UUID for raw rows where
 		// enrichment hasn't populated RuleShortID yet.
-		RuleID:        ruleHandle(a),
-		ActorType:     a.ActorType,
-		ActorID:       a.ActorID,
-		ActorName:     a.ActorName,
-		SessionID:     a.SessionID,
-		Payload:       a.Payload,
-		CreatedAt:     a.CreatedAt,
+		RuleID:    ruleHandle(a),
+		ActorType: a.ActorType,
+		ActorID:   a.ActorID,
+		ActorName: a.ActorName,
+		SessionID: a.SessionID,
+		Payload:   a.Payload,
+		CreatedAt: a.CreatedAt,
 	}
 }
 

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -270,9 +270,37 @@ func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) An
 		a.Subject = a.ActorName
 		from, to := readStatusChange(a.Payload)
 		a.Summary = formatSyncUpdatedSummary(a.ActorName, from, to)
+
+	case "series_assigned", "series_unlinked":
+		seriesName, _ := a.Payload["series_name"].(string)
+		if a.Kind == "series_assigned" {
+			a.Action = "linked"
+		} else {
+			a.Action = "unlinked"
+		}
+		a.Subject = seriesName
+		a.Summary = formatSeriesMembershipSummary(a.ActorName, a.Action, seriesName)
 	}
 
 	return a
+}
+
+// formatSeriesMembershipSummary renders the timeline sentence for a
+// series_assigned / series_unlinked row, e.g. "Alice linked this to Netflix" /
+// "Linked to Netflix" (system). Mirrors the other system-row sentence shapes.
+func formatSeriesMembershipSummary(actor, action, seriesName string) string {
+	if seriesName == "" {
+		seriesName = "a recurring series"
+	}
+	verb, capVerb, prep := "linked", "Linked", "to"
+	if action == "unlinked" {
+		verb, capVerb, prep = "unlinked", "Unlinked", "from"
+	}
+	if actor == "" {
+		// System-attributed (detection): no actor name.
+		return capVerb + " " + prep + " " + seriesName
+	}
+	return actor + " " + verb + " this " + prep + " " + seriesName
 }
 
 // formatDeletedCommentSummary renders the tombstone sentence shown in place

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -237,7 +237,7 @@ func (s *Service) AssignSeries(ctx context.Context, in AssignSeriesInput, actor 
 	var resp *SeriesResponse
 	switch {
 	case in.SeriesID != nil && strings.TrimSpace(*in.SeriesID) != "":
-		linked, err := s.linkSeriesMembers(ctx, *in.SeriesID, in.TransactionIDs)
+		linked, err := s.linkSeriesMembers(ctx, *in.SeriesID, in.TransactionIDs, actor)
 		if err != nil {
 			return nil, err
 		}
@@ -365,7 +365,7 @@ func (s *Service) AssignSeriesFromRuleTx(ctx context.Context, tx pgx.Tx, txnID p
 // linkSeriesMembers back-links transactions to an existing series (NULL-fill
 // only) and recomputes its rollups, in one transaction. Used by the
 // existing-series branch of AssignSeries.
-func (s *Service) linkSeriesMembers(ctx context.Context, idOrShort string, memberIDsOrShorts []string) (*SeriesResponse, error) {
+func (s *Service) linkSeriesMembers(ctx context.Context, idOrShort string, memberIDsOrShorts []string, actor Actor) (*SeriesResponse, error) {
 	id, err := s.resolveSeriesID(ctx, idOrShort)
 	if err != nil {
 		return nil, err
@@ -390,6 +390,11 @@ func (s *Service) linkSeriesMembers(ctx context.Context, idOrShort string, membe
 		return nil, fmt.Errorf("get series: %w", err)
 	}
 	if len(memberIDs) > 0 {
+		// Newly-linked subset (before the NULL-fill) drives the timeline event.
+		newlyLinked, err := unlinkedMemberSubset(ctx, tx, memberIDs)
+		if err != nil {
+			return nil, err
+		}
 		if _, err := qtx.BackLinkSeriesMembers(ctx, db.BackLinkSeriesMembersParams{
 			SeriesID:       row.ID,
 			TransactionIds: memberIDs,
@@ -401,6 +406,9 @@ func (s *Service) linkSeriesMembers(ctx context.Context, idOrShort string, membe
 			Column2:  memberIDs,
 		}); err != nil {
 			return nil, fmt.Errorf("apply series tags to members: %w", err)
+		}
+		if err := emitSeriesMembershipAnnotations(ctx, qtx, annotationKindSeriesAssigned, newlyLinked, row.ShortID, row.Name, actor); err != nil {
+			return nil, fmt.Errorf("emit series_assigned annotations: %w", err)
 		}
 	}
 	occCount, lastAmount, lastSeen, err := s.seriesRollup(ctx, qtx, row.ID)
@@ -548,6 +556,13 @@ func (s *Service) UpsertSeriesCandidate(ctx context.Context, in SeriesUpsert, ac
 	// 4. Back-link member transactions (NULL-fill only) and materialize the
 	// series' tags onto the freshly-linked members (NULL-fill via ON CONFLICT).
 	if len(memberIDs) > 0 {
+		// Only the charges actually linked by this call (currently series-less)
+		// get a timeline event — a re-detect NULL-fills already-linked members
+		// and must not re-emit.
+		newlyLinked, err := unlinkedMemberSubset(ctx, tx, memberIDs)
+		if err != nil {
+			return nil, err
+		}
 		if _, err := qtx.BackLinkSeriesMembers(ctx, db.BackLinkSeriesMembersParams{
 			SeriesID:       base.ID,
 			TransactionIds: memberIDs,
@@ -559,6 +574,9 @@ func (s *Service) UpsertSeriesCandidate(ctx context.Context, in SeriesUpsert, ac
 			Column2:  memberIDs,
 		}); err != nil {
 			return nil, fmt.Errorf("apply series tags to members: %w", err)
+		}
+		if err := emitSeriesMembershipAnnotations(ctx, qtx, annotationKindSeriesAssigned, newlyLinked, base.ShortID, base.Name, actor); err != nil {
+			return nil, fmt.Errorf("emit series_assigned annotations: %w", err)
 		}
 	}
 
@@ -1157,7 +1175,7 @@ func (s *Service) updateSeriesInTx(ctx context.Context, qtx *db.Queries, id pgty
 // SplitSeries), and recomputes the series' rollups + projected next charge. It
 // refuses if any listed transaction isn't a current member, so an unlink can
 // neither silently no-op nor touch a charge that belongs to another series.
-func (s *Service) UnlinkSeriesTransactions(ctx context.Context, idOrShort string, memberIDsOrShorts []string) (*SeriesResponse, error) {
+func (s *Service) UnlinkSeriesTransactions(ctx context.Context, idOrShort string, memberIDsOrShorts []string, actor Actor) (*SeriesResponse, error) {
 	if len(memberIDsOrShorts) == 0 {
 		return nil, fmt.Errorf("%w: at least one transaction to unlink is required", ErrInvalidParameter)
 	}
@@ -1213,6 +1231,11 @@ func (s *Service) UnlinkSeriesTransactions(ctx context.Context, idOrShort string
 		 WHERE transaction_id = ANY($1::uuid[]) AND added_by_type = 'system' AND added_by_id = $2`,
 		memberIDs, row.ShortID); err != nil {
 		return nil, fmt.Errorf("strip series tags from unlinked members: %w", err)
+	}
+
+	// Timeline event on each detached charge (all confirmed members above).
+	if err := emitSeriesMembershipAnnotations(ctx, qtx, annotationKindSeriesUnlinked, memberIDs, row.ShortID, row.Name, actor); err != nil {
+		return nil, fmt.Errorf("emit series_unlinked annotations: %w", err)
 	}
 
 	updated, err := s.applyRollup(ctx, qtx, row.ID)
@@ -1474,6 +1497,68 @@ func (s *Service) resolveTransactionIDs(ctx context.Context, idsOrShorts []strin
 		out = append(out, id)
 	}
 	return out, nil
+}
+
+// Annotation kinds for recurring-series membership events on the transaction
+// activity timeline (see internal/db/migrations/*_annotations_series_kinds.sql).
+const (
+	annotationKindSeriesAssigned = "series_assigned"
+	annotationKindSeriesUnlinked = "series_unlinked"
+)
+
+// unlinkedMemberSubset returns the subset of ids whose transactions are not yet
+// in any series (series_id IS NULL). Used so series_assigned annotations are
+// emitted only for charges the back-link actually links — never re-emitted on a
+// deterministic re-detect, which NULL-fills already-linked members.
+func unlinkedMemberSubset(ctx context.Context, tx pgx.Tx, ids []pgtype.UUID) ([]pgtype.UUID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := tx.Query(ctx,
+		`SELECT id FROM transactions WHERE id = ANY($1::uuid[]) AND series_id IS NULL AND deleted_at IS NULL`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("query unlinked members: %w", err)
+	}
+	defer rows.Close()
+	var out []pgtype.UUID
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan unlinked member: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// emitSeriesMembershipAnnotations writes one series_assigned / series_unlinked
+// annotation per affected transaction, atomic with the surrounding tx (q is the
+// tx-scoped *db.Queries). The payload carries the series short_id + name so the
+// timeline can render and deep-link the sentence.
+func emitSeriesMembershipAnnotations(ctx context.Context, q *db.Queries, kind string, txnIDs []pgtype.UUID, seriesShortID, seriesName string, actor Actor) error {
+	if len(txnIDs) == 0 {
+		return nil
+	}
+	if actor.Type == "" {
+		actor = SystemActor()
+	}
+	payload := map[string]interface{}{
+		"series_id":   seriesShortID,
+		"series_name": seriesName,
+	}
+	for _, txnID := range txnIDs {
+		if err := writeAnnotation(ctx, q, writeAnnotationParams{
+			TransactionID: txnID,
+			Kind:          kind,
+			ActorType:     normalizeAnnotationActorType(actor.Type),
+			ActorID:       actor.ID,
+			ActorName:     actor.Name,
+			Payload:       payload,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // dedupeUUIDs returns ids with duplicate values removed, preserving order.

--- a/internal/service/series_edit_integration_test.go
+++ b/internal/service/series_edit_integration_test.go
@@ -140,7 +140,7 @@ func TestUnlinkSeriesTransactions_DetachAndRollup(t *testing.T) {
 	}
 
 	// Unlink the most-recent charge (2026-04-15, members[2]).
-	updated, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{members[2]})
+	updated, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{members[2]}, service.SystemActor())
 	if err != nil {
 		t.Fatalf("UnlinkSeriesTransactions: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestUnlinkSeriesTransactions_DetachAndRollup(t *testing.T) {
 
 	// Unlinking a transaction that isn't a member errors (doesn't touch others).
 	loose := testutil.MustCreateTransaction(t, queries, acctID, "LOOSE", "Loose Co", 100, "2026-01-01")
-	if _, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{loose.ShortID}); err == nil {
+	if _, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{loose.ShortID}, service.SystemActor()); err == nil {
 		t.Error("expected unlinking a non-member to error")
 	}
 }
@@ -196,7 +196,7 @@ func TestUnlinkSeriesTransactions_StripsInheritedTags(t *testing.T) {
 		t.Fatal("precondition: dropped charge should carry both tags")
 	}
 
-	if _, err := svc.UnlinkSeriesTransactions(ctx, series.ShortID, []string{drop.ShortID}); err != nil {
+	if _, err := svc.UnlinkSeriesTransactions(ctx, series.ShortID, []string{drop.ShortID}, actor); err != nil {
 		t.Fatalf("UnlinkSeriesTransactions: %v", err)
 	}
 
@@ -284,7 +284,7 @@ func TestUnlinkSeriesTransactions_DuplicateIDs(t *testing.T) {
 		t.Fatalf("mint: %v", err)
 	}
 
-	updated, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{members[2], members[2]})
+	updated, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{members[2], members[2]}, service.SystemActor())
 	if err != nil {
 		t.Fatalf("UnlinkSeriesTransactions with duplicate id: %v", err)
 	}
@@ -327,6 +327,47 @@ func TestAssignSeries_FailIfExists(t *testing.T) {
 		MerchantKey: "netflix", CreateIfMissing: true, Confirm: true, FailIfExists: true, Name: "Netflix",
 	}, user); !errors.Is(err, service.ErrConflict) {
 		t.Errorf("strict create over a rejected series: err = %v, want ErrConflict", err)
+	}
+}
+
+// TestSeriesMembershipAnnotations proves the timeline events: linking members
+// emits one series_assigned per newly-linked charge, a re-detect does NOT
+// re-emit (NULL-fill only), and unlinking emits series_unlinked.
+func TestSeriesMembershipAnnotations(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	_, members := seedRecurring(t, queries, "SPOTIFY", []string{"2026-02-15", "2026-03-15", "2026-04-15"})
+
+	countKind := func(kind string) int {
+		var n int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM annotations WHERE kind = $1`, kind).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", kind, err)
+		}
+		return n
+	}
+
+	created, err := svc.UpsertSeriesCandidate(ctx, spotifyUpsert(members), service.SystemActor())
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if got := countKind("series_assigned"); got != 3 {
+		t.Errorf("series_assigned after mint = %d, want 3 (one per linked member)", got)
+	}
+
+	// A deterministic re-detect NULL-fills already-linked members → no re-emit.
+	if _, err := svc.UpsertSeriesCandidate(ctx, spotifyUpsert(members), service.SystemActor()); err != nil {
+		t.Fatalf("re-detect: %v", err)
+	}
+	if got := countKind("series_assigned"); got != 3 {
+		t.Errorf("series_assigned after re-detect = %d, want 3 (must not re-emit)", got)
+	}
+
+	// Unlinking a member emits exactly one series_unlinked.
+	if _, err := svc.UnlinkSeriesTransactions(ctx, created.ShortID, []string{members[2]}, service.Actor{Type: "user", Name: "Tester"}); err != nil {
+		t.Fatalf("unlink: %v", err)
+	}
+	if got := countKind("series_unlinked"); got != 1 {
+		t.Errorf("series_unlinked after unlink = %d, want 1", got)
 	}
 }
 

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -48,6 +48,19 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 		<div class="mt-5">
 			@components.SeriesFactStrip(p.Facts)
 		</div>
+		<!-- The actual charges linked to this series, rendered with the shared
+		     transaction-row component (same row used across the app) so you can
+		     see — and click into — exactly what's included before confirming. -->
+		if len(p.Members) > 0 {
+			<div class="mt-5">
+				@seriesPanelHeader("receipt", "Charges in this series", fmt.Sprintf("%d linked", len(p.Members)), nil)
+				<div class="bb-card p-3 sm:p-4">
+					for _, m := range p.Members {
+						@seriesChargeRow(m)
+					}
+				</div>
+			</div>
+		}
 		@seriesEditDrawer(p)
 		@seriesLinkModal()
 	</div>

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -173,9 +173,13 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 				<div class="flex items-center gap-2 flex-wrap">
 					<a href={ templ.SafeURL("/recurring/" + s.ShortID) } class="text-sm font-semibold text-base-content truncate hover:underline">{ s.Name }</a>
 					@components.SeriesTypeChip(s.TypeLabel, "xs")
-					@components.SeriesConfidenceChip(s.ConfidenceBand, s.BandTone)
 				</div>
-				<div class="text-xs text-base-content/50 mt-1">{ s.SignalSummary }</div>
+				<!-- Detection strength reads with the rationale, not as a second
+				     pill in the title (the title carries the type chip only). -->
+				<div class="flex items-center gap-1.5 text-xs text-base-content/50 mt-1">
+					@components.SeriesConfidenceChip(s.ConfidenceBand, s.BandTone)
+					<span>{ s.SignalSummary }</span>
+				</div>
 				<button
 					type="button"
 					@click="why = !why"
@@ -186,7 +190,21 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 					</span>
 					Why detected?
 				</button>
-				<pre x-show="why" x-cloak class="mt-2 text-[0.7rem] leading-relaxed bg-base-200/50 rounded-lg p-3 overflow-x-auto text-base-content/70">{ s.SignalsJSON }</pre>
+				<div x-show="why" x-cloak class="mt-2 rounded-lg bg-base-200/50 p-3">
+					if len(s.SignalFacts) > 0 {
+						<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+							for _, f := range s.SignalFacts {
+								<div class="flex items-center gap-2 text-xs min-w-0">
+									@components.LucideIcon(f.Icon, "w-3.5 h-3.5 text-base-content/40 shrink-0")
+									<span class="text-base-content/50 shrink-0">{ f.Label }</span>
+									<span class={ "font-medium ml-auto text-right truncate", subscriptionSignalFactClass(f.Tone) }>{ f.Value }</span>
+								</div>
+							}
+						</div>
+					} else {
+						<p class="text-xs text-base-content/50">No detection signals recorded — created manually or by an agent.</p>
+					}
+				</div>
 			</div>
 			<div class="text-right shrink-0">
 				if s.HasAmount {
@@ -205,7 +223,7 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 				<div class="text-[0.7rem] uppercase tracking-wider text-base-content/40 mb-1">Based on these charges</div>
 				<div>
 					for _, m := range s.Members {
-						@seriesEvidenceCharge(m)
+						@seriesChargeRow(m)
 					}
 				</div>
 				if s.OccurrenceCount > len(s.Members) {
@@ -234,9 +252,10 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 	</div>
 }
 
-// seriesEvidenceCharge renders one member charge (read-only) via the shared
-// TxRowFeed row — used inside a candidate card's evidence list.
-templ seriesEvidenceCharge(m SubscriptionMember) {
+// seriesChargeRow renders one member charge via the shared TxRowFeed row with a
+// leading date column. Shared by the Needs-review candidate evidence list and
+// the "Charges in this series" list on the detail page so both read identically.
+templ seriesChargeRow(m SubscriptionMember) {
 	<div class="flex items-center gap-2 py-0.5">
 		<span class="text-xs text-base-content/45 tabular-nums w-20 shrink-0">{ m.Date }</span>
 		<div class="flex-1 min-w-0">

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -100,7 +100,11 @@ type SubscriptionRow struct {
 	ConfidenceBand string // "High" | "Medium" | "Low"
 	BandTone       string // success | warning | neutral
 	SignalSummary  string // "11 charges · monthly · ±0% spread"
-	SignalsJSON    string // pretty-printed detection_signals for the disclosure
+	SignalsJSON    string // pretty-printed detection_signals (raw fallback)
+	// SignalFacts is the parsed "Why detected" surface: the raw detection_signals
+	// rendered as labelled criteria (charges seen, cadence, timing regularity,
+	// amount pattern) instead of a raw JSON blob.
+	SignalFacts []SubscriptionSignalFact
 
 	Source       string // deterministic | agent | user | rule
 	SourceLabel  string
@@ -219,6 +223,28 @@ type SubscriptionMember struct {
 	CategoryColor *string
 	CategoryIcon  *string
 	TagCount      int
+}
+
+// SubscriptionSignalFact is one parsed detection criterion for the "Why
+// detected" surface — a labelled, human-readable reading of a single
+// detection_signals field (replaces the raw JSON dump).
+type SubscriptionSignalFact struct {
+	Icon  string // lucide name
+	Label string // "Timing regularity"
+	Value string // "Very regular (±4%)"
+	Tone  string // success | warning | neutral
+}
+
+// subscriptionSignalFactClass maps a signal-fact tone to the value text color.
+func subscriptionSignalFactClass(tone string) string {
+	switch tone {
+	case "success":
+		return "text-success"
+	case "warning":
+		return "text-warning"
+	default:
+		return "text-base-content/80"
+	}
 }
 
 // SubscriptionPriceChange marks a point where the charge amount changed.

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -461,6 +461,8 @@ templ txdSystemSentence(e service.ActivityEntry) {
 		@txdRuleSentence(e)
 	} else if e.Type == "sync" {
 		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
+	} else if e.Type == "series" {
+		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
 	} else if e.Type == "tag" {
 		if e.ActorName != "" {
 			@txdActorInline(e)
@@ -555,6 +557,10 @@ templ txdSystemIcon(e service.ActivityEntry) {
 	} else if e.Type == "sync" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
 			@components.LucideIcon("landmark", "w-3 h-3 text-base-content opacity-60")
+		</span>
+	} else if e.Type == "series" {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-info/15 ring-4 ring-base-100" aria-hidden="true">
+			@components.LucideIcon("repeat", "w-3 h-3 text-info")
 		</span>
 	} else if e.Type == "review" {
 		<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", txdReviewBg(e.ReviewStatus) } aria-hidden="true">

--- a/internal/templates/components/series_detail_panels.templ
+++ b/internal/templates/components/series_detail_panels.templ
@@ -51,18 +51,18 @@ templ SeriesDetectionPanel(p SeriesDetectionProps) {
 				{ p.StrengthLabel }
 			</span>
 		</div>
-		<p class="text-base sm:text-lg leading-relaxed text-base-content/70">
-			Matches charges from <code class="font-mono text-sm bg-base-200 text-base-content/80 rounded px-1.5 py-0.5">{ p.MerchantKey }</code>
+		<p class="text-sm leading-relaxed text-base-content/70">
+			Matches charges from <code class="font-mono text-xs bg-base-200 text-base-content/80 rounded px-1.5 py-0.5">{ p.MerchantKey }</code>
 			if p.HasAmount {
-				near <span class="font-semibold text-base-content">{ p.AmountText }</span> <span class="text-base-content/45">(±{ p.ToleranceText })</span>,
+				near <span class="font-medium text-base-content">{ p.AmountText }</span> <span class="text-base-content/45">(±{ p.ToleranceText })</span>,
 			} else {
 				,
 			}
 			if p.DayPhrase != "" {
-				<span class="font-semibold text-base-content">{ p.CadencePhrase }</span>
-				<span class="font-semibold text-base-content">{ p.DayPhrase }.</span>
+				<span class="font-medium text-base-content">{ p.CadencePhrase }</span>
+				<span class="font-medium text-base-content">{ p.DayPhrase }.</span>
 			} else {
-				<span class="font-semibold text-base-content">{ p.CadencePhrase }.</span>
+				<span class="font-medium text-base-content">{ p.CadencePhrase }.</span>
 			}
 		</p>
 		if p.Window != nil {


### PR DESCRIPTION
## Recurring series — polish: timeline events + review-driven UI tweaks

Follow-up to #1659. Two cohesive pieces.

### 1. `series_assigned` / `series_unlinked` activity-timeline events

When a transaction is linked to a recurring series (manual assign, detection auto-link, or manual create) or unlinked, emit a system-event annotation so it shows on the transaction's activity timeline — closing the "I can't tell, from a charge, what series it feeds" gap.

- Migration widens the `annotations.kind` CHECK (additive — only widens the allowed set; older servers keep working).
- Emit is **atomic** with the link/unlink transaction (reuses `writeAnnotation` with the tx-scoped queries). `series_assigned` fires **only for the newly-linked subset** (charges currently series-less), so a deterministic re-detect — which NULL-fills already-linked members — never re-emits.
- Threaded `actor` through `linkSeriesMembers` + `UnlinkSeriesTransactions` (REST + MCP callers updated) so the event is attributed to the user/agent who acted, or the system on detection.
- Enrich builds the sentence; `transaction_detail` renders a repeat-icon row; admin maps the kinds to a `series` activity entry; MCP `list_annotations` gains a `series` kind group.

Note: rule-driven assignment (`AssignSeriesFromRuleTx`, sync hot path) is intentionally left un-emitting for now to avoid churn inside the sync transaction — follow-up.

### 2. UI feedback on the recurring surfaces

Five review-driven tweaks:

- **(a)** Detection summary ("Matches charges from …") calmed to body-copy scale so it no longer out-shouts the surface.
- **(b)** Detail page gains a **"Charges in this series"** list rendered with the shared transaction-row component, so you can see — and click into — exactly which charges are included before confirming.
- **(c)** The needs-review evidence and the new detail list now share one `seriesChargeRow` (the common `TxRowFeed`), so both read identically.
- **(d)** **"Why detected?"** now renders **parsed criteria** (charges seen, cadence, timing regularity from `interval_cv`, amount pattern) as labelled, tone-coded rows instead of a raw JSON dump — with a plain-note fallback for manually/agent-created series.
- **(e)** Needs-review card title de-cluttered: only the type chip stays inline; the detection-strength chip moves down to the rationale line.

### Validation

Validated server-side against a live instance on real data (`breadbox_demo`): the needs-review page renders the parsed "Why detected" criteria ("Very regular (±4%)", "Identical each time", "Charges seen", "Timing") with the raw `<pre>` gone; the detail page renders "Charges in this series — 3 linked" via 3 shared `bb-tx-row-feed` rows, the calmed detection sentence (no `text-lg`), and no double-currency.

_Automated screenshots weren't captured this run — the Chrome DevTools MCP disconnected mid-session — so the checks above are server-rendered-HTML assertions rather than images._

### Tests & build

`TestSeriesMembershipAnnotations` (one event per linked charge, no re-emit on re-detect, one on unlink) + the existing edit/unlink/collision/atomic-patch tests. Service + api + mcp + admin + templates suites green; default / headless / lite build + vet clean; migration applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
