### PR TITLE
fix(reports): resolve short_id on /reports/{id} so transcript links work

### DIFF
--- a/internal/db/queries/agent_reports.sql
+++ b/internal/db/queries/agent_reports.sql
@@ -6,6 +6,9 @@ RETURNING *;
 -- name: GetAgentReport :one
 SELECT * FROM agent_reports WHERE id = $1;
 
+-- name: GetAgentReportUUIDByShortID :one
+SELECT id FROM agent_reports WHERE short_id = $1;
+
 -- name: ListAgentReports :many
 SELECT * FROM agent_reports ORDER BY created_at DESC LIMIT $1;
 

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -238,11 +238,16 @@ func (s *Service) CountUnreadAgentReports(ctx context.Context) (int64, error) {
 	return s.Queries.CountUnreadAgentReports(ctx)
 }
 
-// GetAgentReport returns a single report by ID or short ID.
+// GetAgentReport returns a single report by ID or short ID. A malformed ID
+// (neither a UUID nor a short ID) is ErrInvalidParameter (400); a well-formed
+// reference to a nonexistent report is ErrNotFound (404).
 func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentReportResponse, error) {
 	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return AgentReportResponse{}, ErrNotFound
+		if errors.Is(err, ErrNotFound) {
+			return AgentReportResponse{}, ErrNotFound
+		}
+		return AgentReportResponse{}, fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
 	row, err := s.Queries.GetAgentReport(ctx, uid)
 	if err != nil {
@@ -260,7 +265,10 @@ func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentRep
 func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) error {
 	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return ErrNotFound
+		if errors.Is(err, ErrNotFound) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
 	// Use Pool.Exec directly to inspect rows affected — sqlc's :exec discards
 	// the CommandTag. The generated query has `AND read_at IS NULL`, so a
@@ -290,7 +298,10 @@ func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) erro
 func (s *Service) MarkAgentReportUnread(ctx context.Context, reportID string) error {
 	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return ErrNotFound
+		if errors.Is(err, ErrNotFound) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
 	tag, err := s.Pool.Exec(ctx,
 		"UPDATE agent_reports SET read_at = NULL WHERE id = $1", uid)
@@ -313,7 +324,10 @@ func (s *Service) MarkAllAgentReportsRead(ctx context.Context) error {
 func (s *Service) DeleteAgentReport(ctx context.Context, reportID string) error {
 	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return ErrNotFound
+		if errors.Is(err, ErrNotFound) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
 	tag, err := s.Pool.Exec(ctx, "DELETE FROM agent_reports WHERE id = $1", uid)
 	if err != nil {

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -238,11 +238,11 @@ func (s *Service) CountUnreadAgentReports(ctx context.Context) (int64, error) {
 	return s.Queries.CountUnreadAgentReports(ctx)
 }
 
-// GetAgentReport returns a single report by ID.
+// GetAgentReport returns a single report by ID or short ID.
 func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentReportResponse, error) {
-	uid, err := pgconv.ParseUUID(reportID)
+	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return AgentReportResponse{}, fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+		return AgentReportResponse{}, ErrNotFound
 	}
 	row, err := s.Queries.GetAgentReport(ctx, uid)
 	if err != nil {
@@ -258,9 +258,9 @@ func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentRep
 // report with the given ID exists. Returns nil (idempotent) if the report
 // exists but is already read.
 func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) error {
-	uid, err := pgconv.ParseUUID(reportID)
+	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+		return ErrNotFound
 	}
 	// Use Pool.Exec directly to inspect rows affected — sqlc's :exec discards
 	// the CommandTag. The generated query has `AND read_at IS NULL`, so a
@@ -288,9 +288,9 @@ func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) erro
 // MarkAgentReportUnread clears read_at on a single report, returning it to the
 // unread queue. Returns ErrNotFound if no report with the given ID exists.
 func (s *Service) MarkAgentReportUnread(ctx context.Context, reportID string) error {
-	uid, err := pgconv.ParseUUID(reportID)
+	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+		return ErrNotFound
 	}
 	tag, err := s.Pool.Exec(ctx,
 		"UPDATE agent_reports SET read_at = NULL WHERE id = $1", uid)
@@ -311,9 +311,9 @@ func (s *Service) MarkAllAgentReportsRead(ctx context.Context) error {
 // DeleteAgentReport hard-deletes a single report by ID. Returns ErrNotFound
 // if no report with the given ID exists.
 func (s *Service) DeleteAgentReport(ctx context.Context, reportID string) error {
-	uid, err := pgconv.ParseUUID(reportID)
+	uid, err := s.resolveAgentReportID(ctx, reportID)
 	if err != nil {
-		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+		return ErrNotFound
 	}
 	tag, err := s.Pool.Exec(ctx, "DELETE FROM agent_reports WHERE id = $1", uid)
 	if err != nil {

--- a/internal/service/reports_integration_test.go
+++ b/internal/service/reports_integration_test.go
@@ -291,6 +291,73 @@ func TestGetAgentReport_InvalidID(t *testing.T) {
 	}
 }
 
+// TestGetAgentReport_ByShortID guards the transcript "Reports" link, which
+// builds /reports/{short_id}. GetAgentReport must resolve a short ID, not only
+// a UUID.
+func TestGetAgentReport_ByShortID(t *testing.T) {
+	svc, _, _ := newService(t)
+	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
+
+	created, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "info", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("CreateAgentReport: %v", err)
+	}
+	if created.ShortID == "" {
+		t.Fatal("expected a non-empty ShortID")
+	}
+
+	got, err := svc.GetAgentReport(context.Background(), created.ShortID)
+	if err != nil {
+		t.Fatalf("GetAgentReport by short ID: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Errorf("short-ID lookup returned %q, want %q", got.ID, created.ID)
+	}
+	if got.ShortID != created.ShortID {
+		t.Errorf("short-ID lookup returned ShortID %q, want %q", got.ShortID, created.ShortID)
+	}
+}
+
+func TestMarkAgentReportRead_ByShortID(t *testing.T) {
+	svc, _, _ := newService(t)
+	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
+
+	created, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "info", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("CreateAgentReport: %v", err)
+	}
+
+	if err := svc.MarkAgentReportRead(context.Background(), created.ShortID); err != nil {
+		t.Fatalf("MarkAgentReportRead by short ID: %v", err)
+	}
+
+	count, err := svc.CountUnreadAgentReports(context.Background())
+	if err != nil {
+		t.Fatalf("CountUnreadAgentReports: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 unread after marking read by short ID, got %d", count)
+	}
+}
+
+func TestDeleteAgentReport_ByShortID(t *testing.T) {
+	svc, _, _ := newService(t)
+	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}
+
+	created, err := svc.CreateAgentReport(context.Background(), "Title", "Body", actor, "info", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("CreateAgentReport: %v", err)
+	}
+
+	if err := svc.DeleteAgentReport(context.Background(), created.ShortID); err != nil {
+		t.Fatalf("DeleteAgentReport by short ID: %v", err)
+	}
+
+	if _, err := svc.GetAgentReport(context.Background(), created.ID); err == nil {
+		t.Fatal("expected report to be gone after delete by short ID")
+	}
+}
+
 func TestCreateAgentReport_AllPriorities(t *testing.T) {
 	svc, _, _ := newService(t)
 	actor := service.Actor{Type: "agent", ID: "a1", Name: "Agent"}

--- a/internal/service/resolve.go
+++ b/internal/service/resolve.go
@@ -85,3 +85,8 @@ func (s *Service) resolveAnnotationID(ctx context.Context, idOrShort string) (pg
 func (s *Service) resolveSeriesID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
 	return s.resolveID(ctx, idOrShort, s.Queries.GetRecurringSeriesUUIDByShortID, ErrNotFound)
 }
+
+// resolveAgentReportID accepts either a UUID string or a short ID for an agent report.
+func (s *Service) resolveAgentReportID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+	return s.resolveID(ctx, idOrShort, s.Queries.GetAgentReportUUIDByShortID, ErrNotFound)
+}


### PR DESCRIPTION
## Problem

Agent run transcripts have a **Reports** section that links to each report the run produced. The link was broken — clicking it rendered "not found".

Root cause: the link is built as `/reports/{short_id}` (`agent_run_detail.templ`), but the report-detail handler only accepted UUIDs. `service.GetAgentReport` parsed the path param with `pgconv.ParseUUID`, which rejects an 8-char base62 short_id, so the handler bailed to the not-found page (and the REST `GET /api/v1/reports/{id}` failed).

This violated the project convention (CLAUDE.md / `.claude/rules/service.md`): *every service method that takes an entity ID should accept either a UUID or a short_id via `internal/service/resolve.go`*. Reports were the one entity that never got a resolver.

## Fix

- Add `GetAgentReportUUIDByShortID` sqlc query (`internal/db/queries/agent_reports.sql`).
- Add `resolveAgentReportID` to `internal/service/resolve.go`.
- Route `GetAgentReport`, `MarkAgentReportRead`, `MarkAgentReportUnread`, and `DeleteAgentReport` through the resolver so they accept **either** a UUID or a short_id.

Existing UUID-based links (the feed, the report table) keep working unchanged — the resolver handles both forms.

### Error-envelope contract preserved

The pinned contract in `error_envelope_integration_test.go` is honored exactly:

| Input | Result |
|---|---|
| valid short_id that exists | resolves → 200 |
| well-formed short_id / UUID that doesn't exist | `NOT_FOUND` (404) |
| malformed id (`not-a-uuid`) | `INVALID_PARAMETER` (400) |

The first commit briefly collapsed all resolver errors to 404, which broke `TestReports_MarkRead_InvalidID`; the second commit restores the 400-for-malformed distinction.

## Tests

- Added three service-layer integration tests (`reports_integration_test.go`) covering Get / MarkRead / Delete **by short_id**.
- The existing API error-envelope tests (`TestReports_MarkRead_NotFound` → 404, `TestReports_MarkRead_InvalidID` → 400) pass unchanged.

```
go test -tags integration -p 1 ./internal/api  -run TestReports_MarkRead   # PASS
go test -tags integration -p 1 ./internal/service -run AgentReport          # PASS (incl. 3 new short_id tests)
```

`go build ./...` and `go vet ./...` clean.

## Notes

- The sqlc-generated `internal/db/*.sql.go` is gitignored and regenerated in CI (`sqlc generate`), so only the `.sql` query is committed.
- No UI markup changed — the transcript link already used the short_id; the server just couldn't resolve it.
