### PR TITLE
fix(workflows): render the "Preview prompt" modal as markdown, not raw source

### DIFF
--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -6,6 +6,13 @@ import "breadbox/internal/templates/components"
 // one-click automations grouped by category. "Set up" opens a right-side
 // configure drawer; enabling instantiates a workflow with a run toggle.
 templ WorkflowsGallery(p WorkflowsGalleryProps) {
+	// marked + DOMPurify + the shared bbRenderMarkdown helper power the
+	// "Preview prompt" modal, which renders the composed base prompt as
+	// markdown (same pipeline as reports / agent-run prompts) rather than
+	// dumping the raw source.
+	<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
+	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
+	<script src="/static/js/admin/markdown.js"></script>
 	<script src="/static/js/admin/components/workflows_gallery.js"></script>
 	<div
 		x-data="workflowsGallery"
@@ -210,12 +217,14 @@ templ workflowPromptPreviewModal() {
 				<span class="loading loading-spinner loading-sm"></span>
 				Loading prompt…
 			</div>
-			<pre
+			<!-- Rendered as markdown via bbRenderMarkdown() in previewPrompt();
+			     x-ref lets the factory target this element after the async fetch. -->
+			<div
 				x-show="!previewLoading"
 				x-cloak
-				class="text-xs whitespace-pre-wrap break-words bg-base-200 rounded-xl p-4 max-h-[60vh] overflow-y-auto font-mono leading-relaxed"
-				x-text="previewBody"
-			></pre>
+				x-ref="previewBody"
+				class="bb-prose text-sm bg-base-200 rounded-xl p-4 max-h-[60vh] overflow-y-auto break-words"
+			></div>
 			<div class="modal-action mt-4">
 				<form method="dialog">
 					<button class="btn btn-ghost btn-sm">Close</button>

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -14,8 +14,9 @@ document.addEventListener('alpine:init', function () {
 
       // --- F2: preview internal prompt -----------------------------------
       // State for the "Preview prompt" modal: the composed base prompt is
-      // fetched on demand from /-/workflows/{slug}/prompt and rendered in a
-      // <pre>. previewLoading drives the in-modal spinner.
+      // fetched on demand from /-/workflows/{slug}/prompt and rendered as
+      // markdown (via bbRenderMarkdown) into the x-ref="previewBody" element.
+      // previewLoading drives the in-modal spinner.
       previewTitle: '',
       previewBody: '',
       previewLoading: false,
@@ -248,7 +249,28 @@ document.addEventListener('alpine:init', function () {
           })
           .finally(function () {
             self.previewLoading = false;
+            self.renderPreviewBody();
           });
+      },
+
+      // Render the fetched base prompt as markdown into the preview element.
+      // The body arrives async and the modal is reused across opens, so we
+      // clear bbRenderMarkdown's idempotency flag (data-markdown-rendered)
+      // before re-pointing data-markdown at the new content. Falls back to
+      // plain text if the shared renderer isn't loaded.
+      renderPreviewBody: function () {
+        var self = this;
+        self.$nextTick(function () {
+          var el = self.$refs.previewBody;
+          if (!el) return;
+          el.removeAttribute('data-markdown-rendered');
+          el.setAttribute('data-markdown', self.previewBody || '');
+          if (typeof window.bbRenderMarkdown === 'function') {
+            window.bbRenderMarkdown(el);
+          } else {
+            el.textContent = self.previewBody || '';
+          }
+        });
       },
       // -------------------------------------------------------------------
     };


### PR DESCRIPTION
## What

The Workflows gallery's **"Preview prompt"** modal was dumping each workflow's composed base prompt as **raw markdown source** in a monospace `<pre>` — literal `##`, `**`, backticks and all. Every other place that shows the same kind of content (reports, transaction comments, agent-run system/user/prefix prompts) renders it as markdown through the shared `bbRenderMarkdown` pipeline. This brings the workflows preview in line.

## Why it was raw

`workflows_gallery.templ` rendered the fetched prompt with:

```html
<pre class="… font-mono …" x-text="previewBody"></pre>
```

`x-text` writes plain text, so markdown was never parsed. The shared renderer (`static/js/admin/markdown.js`, marked + DOMPurify) wasn't even loaded on this page.

## Change

- **`workflows_gallery.templ`** — load `marked` + `DOMPurify` + `markdown.js` (same tags/integrity hashes as `report_detail.templ`); replace the `<pre x-text>` with a `<div class="bb-prose" x-ref="previewBody">` target.
- **`workflows_gallery.js`** — after the async `GET /-/workflows/{slug}/prompt` resolves, render the body via a new `renderPreviewBody()` helper that points `data-markdown` at the prompt and calls `window.bbRenderMarkdown(el)`. Because the modal is reused across opens and the body arrives async, it clears `bbRenderMarkdown`'s idempotency flag (`data-markdown-rendered`) before each render, and falls back to plain text if the shared renderer isn't present.

No server-side or API changes — the `/-/workflows/{slug}/prompt` endpoint is unchanged; only how the client displays its response.

## Verification

- `templ generate` + `go build ./...` + `go vet ./...` — clean.
- `go test ./internal/templates/...` (incl. the `scripts_lint_test` inline-`<script>` guard) — pass.
- Validated live in a real browser against this branch (`make dev` server, `BREADBOX_DEV_RELOAD=1`): opened **Workflows → Routine Reviewer → Set up → Preview prompt**. The modal now renders the base prompt as markdown — bold section labels (`OBJECTIVE`, `STEP-BY-STEP`, `RULES IN ROUTINE MODE`), proper paragraph spacing, proportional prose font — with no leftover `#`/`*`/backtick markers. (No embedded screenshot: the pre-allowed Chrome DevTools MCP was disconnected in this session and the fallback extension's save-to-disk didn't surface a file path; the rendering was confirmed live + zoomed.)

## Audit note

This was the **only** spot in the app rendering known-markdown content raw. One borderline case — agent-run transcript **system** events (`agent_run_detail.templ`) render as plain text — was left as-is, since those are technical status lines, not authored markdown. Everything else (reports, comments, agent prompts, prompt-builder preview) already renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
