### PR TITLE
feat(admin): dev-instance quick-login button on the login page

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -21,12 +21,13 @@ import (
 // handler and the template stay decoupled from the html/template
 // renderer. Called by every branch of LoginHandler that needs to show
 // the form (GET + error paths).
-func renderLogin(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager, username, errMsg string) {
+func renderLogin(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager, username, errMsg string, devLogin bool) {
 	props := pages.LoginProps{
-		PageTitle: "Sign In",
-		CSRFToken: GenerateCSRFToken(r.Context(), sm),
-		Username:  username,
-		Error:     errMsg,
+		PageTitle:    "Sign In",
+		CSRFToken:    GenerateCSRFToken(r.Context(), sm),
+		Username:     username,
+		Error:        errMsg,
+		ShowDevLogin: devLogin,
 	}
 	if f := GetFlash(r.Context(), sm); f != nil {
 		props.FlashType = f.Type
@@ -68,15 +69,16 @@ var ValidRoles = map[string]bool{
 var dummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), 12)
 
 // LoginHandler returns an http.HandlerFunc that handles GET and POST /login.
-// Single table lookup against auth_accounts.
-func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRenderer) http.HandlerFunc {
+// Single table lookup against auth_accounts. devLogin, when true (set only for
+// ENVIRONMENT=local), renders the one-tap quick-login button on the form.
+func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRenderer, devLogin bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			if sm.GetString(r.Context(), sessionKeyAccountID) != "" {
 				http.Redirect(w, r, "/", http.StatusSeeOther)
 				return
 			}
-			renderLogin(w, r, sm, "", "")
+			renderLogin(w, r, sm, "", "", devLogin)
 			return
 		}
 
@@ -85,12 +87,12 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRender
 		password := r.FormValue("password")
 
 		if username == "" || password == "" {
-			renderLogin(w, r, sm, username, "Invalid email or password")
+			renderLogin(w, r, sm, username, "Invalid email or password", devLogin)
 			return
 		}
 
 		renderLoginError := func() {
-			renderLogin(w, r, sm, username, "Invalid email or password")
+			renderLogin(w, r, sm, username, "Invalid email or password", devLogin)
 		}
 
 		// Single table lookup.
@@ -105,7 +107,7 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRender
 		// Account exists but no password set yet — tell user to use setup link.
 		if account.HashedPassword == nil {
 			bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
-			renderLogin(w, r, sm, username, "Your account hasn't been set up yet. Ask your administrator for a setup link.")
+			renderLogin(w, r, sm, username, "Your account hasn't been set up yet. Ask your administrator for a setup link.", devLogin)
 			return
 		}
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -34,11 +34,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 	r.Get("/avatars/preview/{seed}", AvatarPreviewHandler())
 	r.Get("/avatars/{id}", AvatarHandler(a))
 
-	// Unauthenticated routes.
+	// Unauthenticated routes. devLogin gates the one-tap quick-login button
+	// on the form: shown only for ENVIRONMENT=local, never docker/prod.
+	devLogin := a.Config.Environment == "local"
 	r.Group(func(r chi.Router) {
 		r.Use(OAuthLoginReturnMiddleware(sm))
-		r.Get("/login", LoginHandler(sm, a.Queries, tr))
-		r.Post("/login", LoginHandler(sm, a.Queries, tr))
+		r.Get("/login", LoginHandler(sm, a.Queries, tr, devLogin))
+		r.Post("/login", LoginHandler(sm, a.Queries, tr, devLogin))
 	})
 	r.Post("/logout", LogoutHandler(sm))
 

--- a/internal/templates/components/pages/login.templ
+++ b/internal/templates/components/pages/login.templ
@@ -62,5 +62,20 @@ templ Login(p LoginProps) {
 				@components.LucideIcon("arrow-right", "w-4 h-4 ml-1")
 			</button>
 		</form>
+		if p.ShowDevLogin {
+			<div class="divider text-xs text-base-content/40 my-6">Dev instance</div>
+			<form method="POST" action="/login">
+				if p.CSRFToken != "" {
+					<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+				}
+				<input type="hidden" name="username" value="admin@example.com"/>
+				<input type="hidden" name="password" value="password"/>
+				<input type="hidden" name="remember_me" value="1"/>
+				<button type="submit" class="btn btn-soft btn-block h-12 gap-2 font-medium">
+					@components.LucideIcon("terminal", "w-4 h-4")
+					Sign in as admin@example.com
+				</button>
+			</form>
+		}
 	}
 }

--- a/internal/templates/components/pages/login_types.go
+++ b/internal/templates/components/pages/login_types.go
@@ -12,4 +12,8 @@ type LoginProps struct {
 	Error     string
 	FlashType string
 	FlashMsg  string
+	// ShowDevLogin renders a one-tap quick-login button that posts the
+	// seeded dev credentials (admin@example.com / password). Set only when
+	// the server runs with ENVIRONMENT=local — never in docker/prod.
+	ShowDevLogin bool
 }


### PR DESCRIPTION
Adds a dev-instance-only quick-login button to the login page so local development doesn't require typing `admin@example.com` / `password` every time.

## What

A one-tap **"Sign in as admin@example.com"** button renders below the normal login form, under a "Dev instance" divider. Tapping it signs in with the seeded dev credentials and lands on the dashboard.

<img src="https://i.img402.dev/pltit1wxmq.jpg" width="760" alt="Login page with dev quick-login button">

## How it's gated (re: "maybe using an env var?")

No new env var — it reuses the existing **`ENVIRONMENT`** config flag (`internal/config`), which already defaults to `local` and is set to `docker` in production. The button only renders when `Environment == "local"`, so it can never appear in the prod Docker image.

## Implementation

- `LoginProps.ShowDevLogin` — new bool on the templ props (`login_types.go`).
- `login.templ` — a separate `<form method="POST" action="/login">` with the credentials as hidden fields, shown only when `ShowDevLogin`. Pure HTML, **no JS and no new auth code path** — it posts to the existing login handler.
- `auth.go` — `LoginHandler` / `renderLogin` take a `devLogin bool` and thread it into the props.
- `router.go` — computes `devLogin := a.Config.Environment == "local"` and passes it to the login routes.

The `/login` POST route is unauthenticated and not behind CSRF middleware, so the secondary form needs no extra plumbing (the CSRF token is still included for consistency).

## Validation

- `go build ./...`, `go vet ./internal/admin/... ./internal/templates/...`, and `go test ./internal/templates/...` pass.
- Ran the server with `ENVIRONMENT=local` and confirmed in a real browser: the button renders, and clicking it authenticates as admin@example.com and redirects to the Feed dashboard (screenshot above).
