### PR TITLE
fix(ui): left-align name + role in the top-right avatar menu

### DIFF
--- a/internal/templates/components/topbar_user_menu.templ
+++ b/internal/templates/components/topbar_user_menu.templ
@@ -41,7 +41,7 @@ templ TopbarUserMenu(p SidebarUserMenuProps) {
 		style={ "position-anchor:" + anchorName }
 	>
 		<li>
-			<div class="flex flex-col gap-0.5 px-2.5 py-1.5 pointer-events-none">
+			<div class="flex flex-col items-start gap-0.5 px-2.5 py-1.5 pointer-events-none">
 				<span class="text-sm font-medium text-base-content truncate">{ navDisplayName(p.UserName, p.AdminUsername) }</span>
 				<span class="text-[0.65rem] text-base-content/40 truncate">{ p.RoleDisplay }</span>
 			</div>


### PR DESCRIPTION
The top-right avatar menu rendered the display name and role (**Administrator**) **centered horizontally**, out of line with the menu items beneath them. This left-aligns the header.

## Root cause

The popover header (`internal/templates/components/topbar_user_menu.templ`) used `flex flex-col` with no explicit `align-items`. DaisyUI's `.menu li > *` rule sets `align-items: center` through a 0-specificity `:where()` selector, and the Tailwind `flex`/`flex-col` utilities only set `display`/`flex-direction` — neither overrides `align-items` — so the daisy default won and centered the text. Adding `items-start` (`align-items: flex-start`) fixes it.

One-line change; verified in a real browser that the name + role now share the same left edge as the items below.

## Before / After

<table>
  <tr><th>Before (centered)</th><th>After (left-aligned)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/3q236ql8wy.jpg" width="400" alt="avatar menu — before, centered"></td>
    <td><img src="https://i.img402.dev/i0l1bnrvzy.jpg" width="400" alt="avatar menu — after, left-aligned"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
