### PR TITLE
feat(workflows): disclose the model each run used on the run-detail page

### DIFF
--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -359,6 +359,7 @@ func agentRunRowFromResponse(run service.AgentRunResponse) pages.AgentRunRowProp
 		ShortID: run.ShortID,
 		Status:  run.Status,
 		Trigger: run.Trigger,
+		Model:   run.Model,
 	}
 	if t, err := time.Parse(time.RFC3339, run.StartedAt); err == nil {
 		row.StartedAt = t

--- a/internal/db/migrations/20260601055045_add_model_to_workflow_runs.sql
+++ b/internal/db/migrations/20260601055045_add_model_to_workflow_runs.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Snapshot the model each run was executed with. Lives on the run (not just
+-- the workflow definition) so historical runs disclose the model they
+-- actually used even after the definition's model is later changed, and so
+-- orphaned runs (definition deleted → agent_definition_id NULL) keep the
+-- fact. Pre-existing rows default to '' (unknown); the orchestrator stamps
+-- every new run at creation.
+ALTER TABLE workflow_runs ADD COLUMN model TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE workflow_runs DROP COLUMN model;

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -1,6 +1,6 @@
 -- name: CreateAgentRun :one
-INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
-VALUES ($1, $2, 'in_progress', NOW())
+INSERT INTO workflow_runs (agent_definition_id, "trigger", model, status, started_at)
+VALUES ($1, $2, $3, 'in_progress', NOW())
 RETURNING *;
 
 -- name: GetAgentRun :one

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -230,7 +230,7 @@ func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionRespon
 		if perr != nil {
 			return nil, fmt.Errorf("orchestrator: parse def id: %w", perr)
 		}
-		runRow, crerr := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+		runRow, crerr := o.svc.CreateAgentRunDB(ctx, defUUID, trigger, def.Model)
 		if crerr != nil {
 			return nil, fmt.Errorf("orchestrator: create ceiling-skipped run row: %w (ceiling: %v)", crerr, cerr)
 		}
@@ -245,7 +245,7 @@ func (o *Orchestrator) RunOrSkip(ctx context.Context, def *AgentDefinitionRespon
 		if perr != nil {
 			return nil, fmt.Errorf("orchestrator: parse def id: %w", perr)
 		}
-		runRow, crerr := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+		runRow, crerr := o.svc.CreateAgentRunDB(ctx, defUUID, trigger, def.Model)
 		if crerr != nil {
 			return nil, fmt.Errorf("orchestrator: create skipped run row: %w (acquire err: %v)", crerr, err)
 		}
@@ -346,7 +346,7 @@ func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionRespo
 		return nil, fmt.Errorf("orchestrator: parse def id: %w", err), nil
 	}
 
-	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger, def.Model)
 	if err != nil {
 		return nil, fmt.Errorf("orchestrator: create run row: %w", err), nil
 	}
@@ -449,7 +449,7 @@ func (o *Orchestrator) runLocked(ctx context.Context, def *AgentDefinitionRespon
 		return nil, fmt.Errorf("orchestrator: parse def id: %w", err)
 	}
 
-	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger)
+	runRow, err := o.svc.CreateAgentRunDB(ctx, defUUID, trigger, def.Model)
 	if err != nil {
 		return nil, fmt.Errorf("orchestrator: create run row: %w", err)
 	}

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -63,6 +63,12 @@ func TestOrchestratorRunNow_Success(t *testing.T) {
 		t.Errorf("SessionID = %v, want sess-test", runResp.SessionID)
 	}
 
+	// The model the run executed with is snapshotted onto the run at
+	// creation (not just the definition), so the runs page can disclose it.
+	if runResp.Model != def.Model {
+		t.Errorf("runResp.Model = %q, want %q (snapshot of def.Model)", runResp.Model, def.Model)
+	}
+
 	// Verify the row was persisted with the same fields.
 	persisted, err := svc.GetAgentRun(context.Background(), runResp.ShortID)
 	if err != nil {
@@ -70,6 +76,9 @@ func TestOrchestratorRunNow_Success(t *testing.T) {
 	}
 	if persisted.Status != agent.StatusSuccess {
 		t.Errorf("persisted Status = %q, want success", persisted.Status)
+	}
+	if persisted.Model != def.Model {
+		t.Errorf("persisted Model = %q, want %q", persisted.Model, def.Model)
 	}
 }
 

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -172,6 +172,9 @@ type AgentRunResponse struct {
 	// terminated, if any: "max_turns" | "max_budget" | nil. Lets the v2
 	// SPA flag "ran into the ceiling" runs separately from clean successes.
 	HitCap *string `json:"hit_cap,omitempty"`
+	// Model is the Claude model this run executed with, snapshotted at run
+	// creation. Empty for runs created before the snapshot column existed.
+	Model string `json:"model,omitempty"`
 }
 
 // AgentRunListResult is the paginated envelope for run lists.
@@ -878,7 +881,7 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 		       r.duration_ms, r.total_cost_usd, r.input_tokens, r.output_tokens, r.cache_read_tokens,
 		       r.cache_creation_tokens, r.turn_count, r.max_turns_used, r.num_tool_calls,
 		       r.error_message, r.transcript_path, r.session_id,
-		       r.operator_note, r.prompt_prefix, r.hit_cap,
+		       r.operator_note, r.prompt_prefix, r.hit_cap, r.model,
 		       d.slug, d.name
 		FROM workflow_runs r
 		JOIN workflows d ON d.id = r.agent_definition_id
@@ -903,7 +906,7 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens,
 			&r.CacheCreationTokens, &r.TurnCount, &r.MaxTurnsUsed,
 			&r.NumToolCalls, &r.ErrorMessage, &r.TranscriptPath, &r.SessionID,
-			&r.OperatorNote, &r.PromptPrefix, &r.HitCap,
+			&r.OperatorNote, &r.PromptPrefix, &r.HitCap, &r.Model,
 			&slug, &name,
 		); scanErr != nil {
 			return nil, fmt.Errorf("scan agent run: %w", scanErr)
@@ -1019,11 +1022,15 @@ func (s *Service) notifyDefinitionChanged() {
 
 // --- Orchestrator-facing helpers (called by internal/service/agent_orchestrator.go) ---
 
-// CreateAgentRunDB inserts an in_progress run row.
-func (s *Service) CreateAgentRunDB(ctx context.Context, defID pgtype.UUID, trigger string) (db.WorkflowRun, error) {
+// CreateAgentRunDB inserts an in_progress run row. model is snapshotted onto
+// the run (not just the definition) so the run discloses the model it actually
+// executed with even after the definition's model changes — see the
+// add_model_to_workflow_runs migration.
+func (s *Service) CreateAgentRunDB(ctx context.Context, defID pgtype.UUID, trigger, model string) (db.WorkflowRun, error) {
 	return s.Queries.CreateAgentRun(ctx, db.CreateAgentRunParams{
 		AgentDefinitionID: defID,
 		Trigger:           trigger,
+		Model:             model,
 	})
 }
 
@@ -1464,6 +1471,7 @@ func agentRunFromRow(row db.WorkflowRun) AgentRunResponse {
 		OperatorNote:        pgconv.TextPtr(row.OperatorNote),
 		PromptPrefix:        pgconv.TextPtr(row.PromptPrefix),
 		HitCap:              pgconv.TextPtr(row.HitCap),
+		Model:               row.Model,
 	}
 }
 

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -31,6 +31,11 @@ type AgentRunRowProps struct {
 	Turns      int
 	Note       string
 
+	// Model is the Claude model this run executed with, snapshotted at
+	// run creation (e.g. "claude-opus-4-7"). Empty for runs predating the
+	// snapshot. Surfaced on the run-detail page, not the spare list row.
+	Model string
+
 	// ErrorMessage is the raw error_message column. Empty for non-errored
 	// runs. ErrorMessageFriendly is the operator-friendly translation;
 	// empty when no special mapping applies, in which case the raw message

--- a/internal/templates/components/pages/agent_form_types.go
+++ b/internal/templates/components/pages/agent_form_types.go
@@ -93,6 +93,27 @@ func DefaultAgentModelOptions() []AgentModelOption {
 	}
 }
 
+// AgentModelShortLabel returns a compact, human-friendly label for the
+// model a run executed with — e.g. "claude-opus-4-7" → "Opus 4.7". Used
+// on the run-detail page where the verbose form-option labels are too
+// long. Unknown/custom IDs fall back to the raw string so disclosure
+// stays honest; an empty model (runs predating the snapshot column)
+// returns "" so callers can omit the affordance entirely.
+func AgentModelShortLabel(model string) string {
+	switch model {
+	case "":
+		return ""
+	case "claude-opus-4-7":
+		return "Opus 4.7"
+	case "claude-sonnet-4-6":
+		return "Sonnet 4.6"
+	case "claude-haiku-4-5":
+		return "Haiku 4.5"
+	default:
+		return model
+	}
+}
+
 // fieldErr returns the validation message for a given field name, or empty
 // string when none. Used by the templ to conditionally render an inline
 // error paragraph without nil-map panics.

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -149,6 +149,13 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 					<span title={ p.Run.StartedAt.Format(time.RFC3339) }>{ formatAgentRunStarted(p.Run.StartedAt) }</span>
 					<span class="opacity-50">·</span>
 					<span x-ref="duration" class="tabular-nums">{ formatAgentRunDuration(p.Run.DurationMs) }</span>
+					if AgentModelShortLabel(p.Run.Model) != "" {
+						<span class="opacity-50">·</span>
+						<span class="inline-flex items-center gap-1" title={ "Model: " + p.Run.Model }>
+							@components.LucideIcon("cpu", "w-3 h-3")
+							{ AgentModelShortLabel(p.Run.Model) }
+						</span>
+					}
 					<span x-show="status==='in_progress'" x-cloak class="inline-flex items-center gap-1 text-primary">
 						<span class="loading loading-spinner loading-xs"></span>
 						<span class="text-[0.65rem] uppercase tracking-wider">live</span>
@@ -204,13 +211,14 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 }
 
 // agentRunSummaryStats is the compact at-a-glance strip directly under
-// the sticky header — status, duration, trigger, and cost in a daisy
-// `stats` block. It restates the four facts an operator scans for first
+// the sticky header — status, duration, trigger, model, and cost in a
+// daisy `stats` block. It restates the facts an operator scans for first
 // without making them hunt through the Usage card in the side panel.
-// daisy `stats` is the canonical home for these tiles per
-// .claude/rules/daisyui.md (the rule explicitly nominates `stats
-// stats-horizontal` for dashboard-tile clusters); cost reuses the same
-// canonical Amount renderer as the rest of the page.
+// The Model tile is omitted for runs predating the per-run model
+// snapshot (empty model). daisy `stats` is the canonical home for these
+// tiles per .claude/rules/daisyui.md (the rule explicitly nominates
+// `stats stats-horizontal` for dashboard-tile clusters); cost reuses the
+// same canonical Amount renderer as the rest of the page.
 templ agentRunSummaryStats(p AgentRunDetailProps) {
 	<div class="stats stats-horizontal bb-card w-full overflow-x-auto mb-4">
 		<div class="stat px-4 py-3">
@@ -233,6 +241,12 @@ templ agentRunSummaryStats(p AgentRunDetailProps) {
 				}
 			</div>
 		</div>
+		if AgentModelShortLabel(p.Run.Model) != "" {
+			<div class="stat px-4 py-3">
+				<div class="stat-title text-[0.65rem] uppercase tracking-wider">Model</div>
+				<div class="stat-value text-base font-semibold" title={ p.Run.Model }>{ AgentModelShortLabel(p.Run.Model) }</div>
+			</div>
+		}
 		<div class="stat px-4 py-3">
 			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Cost</div>
 			<div class="stat-value text-base font-semibold">


### PR DESCRIPTION
## Why

Workflow/agent runs only recorded the model on the **definition**, not on each run. So a run's detail page had no way to show which model it actually executed with — and as soon as the workflow's model was changed (or the definition deleted), the fact was gone. Disclosing the model per run is useful transparency, especially as households mix Opus / Sonnet / Haiku across workflows.

## What

**Snapshot the model onto the run at creation** (historically accurate, survives later edits and definition deletion):

- Migration adds `workflow_runs.model` (`TEXT NOT NULL DEFAULT ''`). Additive → shared-dev-DB safe; pre-existing runs read `''` and render no model.
- `CreateAgentRun` / `CreateAgentRunDB` persist `def.Model` at run start (the orchestrator already has the definition in scope at all four call sites; there is no per-run model override, so `def.Model` is the effective model).
- `AgentRunResponse` + `agentRunFromRow` + the `ListAllAgentRuns` scan carry the value through; `AgentRunRowProps` gains `Model`.

**Surface it on the run-detail page** (`/agents/runs/{id}`):

- The sticky header meta line gains a `· <model>` segment with a `cpu` icon.
- The summary `stats` strip gains a **Model** tile between Trigger and Cost.
- `AgentModelShortLabel` renders compact labels (`claude-opus-4-7` → "Opus 4.7"), falling back to the raw ID for custom models and to `""` (hidden) for pre-snapshot runs.

The deliberately-spare runs **list row** is left untouched (its doc comment already pushes secondary metadata to the detail page). Happy to add a subtle list-row indicator too if you'd prefer it visible at a glance.

## Screenshot

Run-detail page with the model disclosed in the header line and the new MODEL stat tile:

<img src="https://i.img402.dev/hxglhq3mrc.png" width="800" alt="Run detail — model disclosed in header line and a MODEL stat tile">

## Tests

- `TestOrchestratorRunNow_Success` extended to assert the run snapshots `def.Model` end-to-end (both the response and the persisted row).
- Full agent run / orchestrator / db suites pass against `breadbox_test`.
- `go build ./...` + `go vet ./...` clean.

## Notes

- Validated by rendering the real `pages.AgentRunDetail` templ output to HTML with a sample run and screenshotting it (no shared-DB mutation). The change reuses existing daisy `stat` classes — no new CSS.
- `internal/db/*.sql.go` is gitignored and regenerated in CI (`sqlc generate`), so only the `.sql` query + migration are committed.
