### PR TITLE
feat(series): TxRowCompact charge rows with a leading date column

### DIFF
--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -77,11 +77,16 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 				// Attach a bounded sample of the charges the detector grouped so
 				// the review card shows the evidence before the user confirms.
 				if mem, merr := svc.SeriesMembers(ctx, s.ShortID); merr == nil {
-					ev := subscriptionMembers(mem)
-					if len(ev) > subscriptionCandidateEvidenceMax {
-						ev = ev[:subscriptionCandidateEvidenceMax]
+					ids := make([]string, 0, len(mem))
+					for _, m := range mem {
+						ids = append(ids, m.ShortID)
 					}
-					row.Members = ev
+					if len(ids) > subscriptionCandidateEvidenceMax {
+						ids = ids[:subscriptionCandidateEvidenceMax]
+					}
+					if rows, rerr := svc.GetAdminTransactionRowsByIDs(ctx, ids); rerr == nil {
+						row.MemberRows = rows
+					}
 				}
 				candidates = append(candidates, row)
 				continue
@@ -185,6 +190,17 @@ func SubscriptionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 		if err != nil {
 			a.Logger.Error("series members", "error", err)
 		}
+		// Canonical transaction rows for the "Charges in this series" list,
+		// rendered via the shared TxRowCompact (carries its own date/account/
+		// category) — same row as the /transactions list.
+		memberIDs := make([]string, 0, len(members))
+		for _, m := range members {
+			memberIDs = append(memberIDs, m.ShortID)
+		}
+		memberRows, mrErr := svc.GetAdminTransactionRowsByIDs(ctx, memberIDs)
+		if mrErr != nil {
+			a.Logger.Error("series member rows", "error", mrErr)
+		}
 
 		// Tags: full vocabulary (seeds the shared picker), chip data for the
 		// tags currently on the series, and the legacy add-select options —
@@ -233,7 +249,7 @@ func SubscriptionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 			ExpectedDayValue:     derefInt(s.ExpectedDay),
 			CurrentCategoryID:    deref(s.CategoryID),
 			Categories:           flattenCategoryOptions(catTree, ""),
-			Members:              subscriptionMembers(members),
+			MemberRows:           memberRows,
 			PriceChanges:         subscriptionPriceChanges(members),
 			AvailableTags:        tagOptions,
 			TagChips:             tagChips,
@@ -1070,32 +1086,6 @@ func formatSubDate(s *string, layout string) string {
 		return *s
 	}
 	return t.Format(layout)
-}
-
-func subscriptionMembers(in []service.SeriesMember) []pages.SubscriptionMember {
-	out := make([]pages.SubscriptionMember, 0, len(in))
-	for _, m := range in {
-		name := m.Name
-		if m.MerchantName != nil && *m.MerchantName != "" {
-			name = *m.MerchantName
-		}
-		row := pages.SubscriptionMember{
-			ShortID:       m.ShortID,
-			Date:          formatSubDate(m.Date, "Jan 2, 2006"),
-			Name:          name,
-			Currency:      deref(m.Currency),
-			Pending:       m.Pending,
-			CategoryColor: m.CategoryColor,
-			CategoryIcon:  m.CategoryIcon,
-			TagCount:      m.TagCount,
-		}
-		if m.Amount != nil {
-			row.HasAmount = true
-			row.Amount = math.Abs(*m.Amount)
-		}
-		out = append(out, row)
-	}
-	return out
 }
 
 // subscriptionPriceChanges walks the members oldest→newest and records each

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -49,13 +49,14 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 			@components.SeriesFactStrip(p.Facts)
 		</div>
 		<!-- The actual charges linked to this series, rendered with the shared
-		     transaction-row component (same row used across the app) so you can
-		     see — and click into — exactly what's included before confirming. -->
-		if len(p.Members) > 0 {
+		     TxRowCompact (same row used across the app — carries its own date,
+		     account + category) so you can see and click into exactly what's
+		     included before confirming. -->
+		if len(p.MemberRows) > 0 {
 			<div class="mt-5">
-				@seriesPanelHeader("receipt", "Charges in this series", fmt.Sprintf("%d linked", len(p.Members)), nil)
-				<div class="bb-card p-3 sm:p-4">
-					for _, m := range p.Members {
+				@seriesPanelHeader("receipt", "Charges in this series", fmt.Sprintf("%d linked", len(p.MemberRows)), nil)
+				<div class="bb-card p-2 sm:p-3">
+					for _, m := range p.MemberRows {
 						@seriesChargeRow(m)
 					}
 				</div>

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -3,6 +3,7 @@ package pages
 import (
 	"fmt"
 
+	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
 
@@ -218,16 +219,16 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 			</div>
 		</div>
 		<!-- Evidence: the charges this candidate was detected from. -->
-		if len(s.Members) > 0 {
+		if len(s.MemberRows) > 0 {
 			<div class="mt-3 pt-3 border-t border-base-200">
 				<div class="text-[0.7rem] uppercase tracking-wider text-base-content/40 mb-1">Based on these charges</div>
 				<div>
-					for _, m := range s.Members {
+					for _, m := range s.MemberRows {
 						@seriesChargeRow(m)
 					}
 				</div>
-				if s.OccurrenceCount > len(s.Members) {
-					<div class="text-xs text-base-content/40 mt-1.5 pl-1">+ { fmt.Sprintf("%d", s.OccurrenceCount-len(s.Members)) } more</div>
+				if s.OccurrenceCount > len(s.MemberRows) {
+					<div class="text-xs text-base-content/40 mt-1.5 pl-1">+ { fmt.Sprintf("%d", s.OccurrenceCount-len(s.MemberRows)) } more</div>
 				}
 			</div>
 		}
@@ -252,24 +253,15 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 	</div>
 }
 
-// seriesChargeRow renders one member charge via the shared TxRowFeed row with a
-// leading date column. Shared by the Needs-review candidate evidence list and
-// the "Charges in this series" list on the detail page so both read identically.
-templ seriesChargeRow(m SubscriptionMember) {
-	<div class="flex items-center gap-2 py-0.5">
-		<span class="text-xs text-base-content/45 tabular-nums w-20 shrink-0">{ m.Date }</span>
+// seriesChargeRow renders one linked charge as a leading date column + the
+// shared TxRowCompact (date suppressed — the left column carries it). Shared by
+// the Needs-review candidate evidence and the detail-page "Charges in this
+// series" list so both read identically.
+templ seriesChargeRow(tx service.AdminTransactionRow) {
+	<div class="flex items-center gap-2">
+		<span class="text-xs text-base-content/45 tabular-nums w-24 shrink-0 text-right">{ seriesChargeDate(tx.Date) }</span>
 		<div class="flex-1 min-w-0">
-			@components.TxRowFeed(components.TxRowFeedProps{
-				ShortID:       m.ShortID,
-				Description:   m.Name,
-				Amount:        m.Amount,
-				Currency:      m.Currency,
-				Pending:       m.Pending,
-				CategoryColor: m.CategoryColor,
-				CategoryIcon:  m.CategoryIcon,
-				TagCount:      m.TagCount,
-				Dimmed:        true,
-			})
+			@components.TxRowCompactNoDate(tx)
 		</div>
 	</div>
 }

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -3,6 +3,8 @@
 package pages
 
 import (
+	"time"
+
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
@@ -115,10 +117,11 @@ type SubscriptionRow struct {
 	// itself but kept for parity / future per-row display.
 	MonthlyEquiv float64
 
-	// Members holds a bounded sample of the linked charges, populated only for
-	// candidates so the review card can show the evidence the detector grouped
-	// before the user commits to confirming.
-	Members []SubscriptionMember
+	// MemberRows holds a bounded sample of the linked charges as canonical
+	// transaction rows (rendered via the shared TxRowCompact), populated only
+	// for candidates so the review card shows the evidence — account, category,
+	// date — before the user commits to confirming.
+	MemberRows []service.AdminTransactionRow
 
 	// Filter support.
 	UserID    string // formatted UUID, "" for shared/household
@@ -152,8 +155,10 @@ type SubscriptionDetailProps struct {
 	// Categories is the full vocabulary for the suggested-category <select>.
 	Categories []SubscriptionCategoryOption
 
-	// Linked charges, newest first.
-	Members []SubscriptionMember
+	// Linked charges (newest first) as canonical transaction rows, rendered
+	// with the shared TxRowCompact so the "Charges in this series" list reads
+	// identically to the /transactions list.
+	MemberRows []service.AdminTransactionRow
 
 	// Price-change history derived from members (oldest → newest change points).
 	PriceChanges []SubscriptionPriceChange
@@ -233,6 +238,15 @@ type SubscriptionSignalFact struct {
 	Label string // "Timing regularity"
 	Value string // "Very regular (±4%)"
 	Tone  string // success | warning | neutral
+}
+
+// seriesChargeDate formats an AdminTransactionRow.Date ("2006-01-02") as the
+// leading date label in the series charge list ("Jan 2, 2006"); raw on parse fail.
+func seriesChargeDate(s string) string {
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t.Format("Jan 2, 2006")
+	}
+	return s
 }
 
 // subscriptionSignalFactClass maps a signal-fact tone to the value text color.

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -11,6 +11,17 @@ import (
 // (dashboard recent txns, rule detail tables). No selection, no inline
 // category picker, no expand panel. Mirrors the "tx-row-compact" partial.
 templ TxRowCompact(tx service.AdminTransactionRow) {
+	@txRowCompactBody(tx, false)
+}
+
+// TxRowCompactNoDate is TxRowCompact without the trailing date — used where a
+// separate leading date column already carries it (e.g. the recurring-series
+// "Charges in this series" list, which emphasises chronology in a left column).
+templ TxRowCompactNoDate(tx service.AdminTransactionRow) {
+	@txRowCompactBody(tx, true)
+}
+
+templ txRowCompactBody(tx service.AdminTransactionRow, hideDate bool) {
 	<a href={ templ.SafeURL("/transactions/" + tx.ID) } class="bb-tx-row-compact flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
 		<!-- Category avatar. Categorised rows render the coloured circle;
 		     uncategorised rows render the neutral `circle-off` glyph. Owner
@@ -54,7 +65,8 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 			</div>
 		</div>
 		<!-- Date + Amount. Pending rows get a small clock icon left of the
-		     amount plus a softer glyph color; row height stays stable. -->
+		     amount plus a softer glyph color; row height stays stable. The date
+		     is suppressed when a caller provides its own date column. -->
 		<div class="shrink-0 text-right flex flex-col items-end gap-0.5">
 			<div class="flex items-center justify-end gap-1">
 				if tx.Pending {
@@ -66,7 +78,9 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 					Class:   "text-sm font-semibold",
 				})
 			</div>
-			<span class="text-[0.65rem] text-base-content/40 tabular-nums">{ relativeDate(tx.Date) }</span>
+			if !hideDate {
+				<span class="text-[0.65rem] text-base-content/40 tabular-nums">{ relativeDate(tx.Date) }</span>
+			}
 		</div>
 	</a>
 }


### PR DESCRIPTION
## Recurring series — `TxRowCompact` charge rows with a leading date

Recovers the two commits that were stranded after #1662 merged at its 2-commit head (the `TxRowCompact` switch + the leading-date column never made it in).

The **"Charges in this series"** list on the detail page and the **needs-review candidate evidence** now render the canonical **`TxRowCompact`** — category avatar (+ owner badge), name, **account · category** meta, comment count, amount — fed by `GetAdminTransactionRowsByIDs`, so they read identically to the `/transactions` list.

Per the latest feedback, the **date sits in a leading left-hand column** (`May 15, 2026`), and `TxRowCompact`'s own below-amount date is suppressed via a new **`TxRowCompactNoDate`** variant (shares one body with `TxRowCompact`; existing callers — dashboard, rule detail, `/design` sandbox — are unchanged).

### Validation
Built + verified server-side on a live `breadbox_demo` instance: detail page renders 3 `bb-tx-row-compact` rows, 3 leading date columns (`May 15, 2026 / Apr 15, 2026 / Mar 15, 2026`), and **zero** below-amount date spans.

Default / headless / lite build + vet clean; templates + admin render tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
