### PR TITLE
refine(ui): lucide asterisk icon in the theme-toggle kbd hint

### DIFF
--- a/internal/templates/components/theme_toggle.templ
+++ b/internal/templates/components/theme_toggle.templ
@@ -23,17 +23,28 @@ package components
 // three; btn-square reserves the box so there's no layout shift.
 //
 // The daisy tooltip surfaces the global "Toggle theme" shortcut (⇧ *,
-// registered in base.html) as a KbdCombo pill — the same blended-pill
-// shape the keyboard-shortcuts modal renders for this binding. It
-// replaces the old native :title so we don't stack a browser tooltip on
-// top of the CSS one; :aria-label still carries the live preference for
-// screen readers. KbdCombo self-hides on touch, where there's no hover.
+// registered in base.html) as a blended-pill kbd combo — the same shape
+// the keyboard-shortcuts modal renders for this binding. It replaces the
+// old native :title so we don't stack a browser tooltip on top of the CSS
+// one; :aria-label still carries the live preference for screen readers.
+//
+// The pill is composed inline rather than via KbdCombo("shift","*"):
+// KbdCombo can only render text glyphs, and the typographic '*' sits high
+// and reads small in a keycap. Reusing the same .bb-kbd-combo classes with
+// the centered lucide `asterisk` icon in the second cell reads cleaner
+// while staying visually identical to the shared component. Same two-layer
+// touch guard (hidden sm:inline-flex + x-show) so it disappears on touch.
 templ ThemeToggle() {
 	<div class="tooltip tooltip-bottom" x-data>
 		<div class="tooltip-content">
 			<span class="inline-flex items-center gap-1.5 whitespace-nowrap">
 				Toggle theme
-				@KbdCombo("shift", "*")
+				<span class="bb-kbd-combo hidden sm:inline-flex" x-show="!$store.device.isTouch">
+					<span class="bb-kbd-combo__key">{ kbdGlyph("shift") }</span>
+					<span class="bb-kbd-combo__key">
+						@LucideIcon("asterisk", "w-3 h-3")
+					</span>
+				</span>
 			</span>
 		</div>
 		<button


### PR DESCRIPTION
Follow-up to #1669. That PR shipped the theme-toggle hover hint, but an auto-merge race landed the **first** commit (typographic `*`) before the icon refinement could be incorporated — so this PR brings the icon swap in on its own.

## What

In the theme-toggle tooltip's kbd pill, render the `*` cell with the **lucide `asterisk` icon** instead of the typographic `*` character.

The `*` glyph sits high and reads small in a keycap; the icon is centered and balanced against the ⇧ glyph, reading like a deliberate keycap symbol. The pill is composed inline (reusing the canonical `.bb-kbd-combo` classes + the in-package `kbdGlyph("shift")` helper) because the shared `KbdCombo` component can only render text glyphs. The icon inherits `currentColor`, so the existing `.tooltip .bb-kbd-combo` tinting applies unchanged in both themes.

## Validation

`go build ./...`, `go vet`, `go test ./internal/templates/...` green; CSS rebuilt; rendered in a real browser (logged-in dashboard, hovered the topbar toggle).

<table>
  <tr><th>Before — typographic <code>*</code> (floats high)</th><th>After — lucide <code>asterisk</code> icon (centered)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/70i8v1r89k.png" width="380" alt="hint with typographic asterisk"></td>
    <td><img src="https://i.img402.dev/eqoice2dpv.png" width="380" alt="hint with lucide asterisk icon"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
