### PR TITLE
fix(ui): add Recurring and Workflows to the command palette

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1891,8 +1891,10 @@
         // Overview
         { id: 'nav-feed', shortcutId: 'global.go.o', group: 'Overview', title: 'Feed', desc: 'Activity feed across the household', icon: 'rss', href: '/', keywords: 'home feed activity dashboard overview' },
         { id: 'nav-transactions', shortcutId: 'global.go.t', group: 'Overview', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
+        { id: 'nav-recurring', group: 'Overview', title: 'Recurring', desc: 'Recurring charges and subscriptions', icon: 'repeat', href: '/recurring', keywords: 'subscriptions series recurring charges bills memberships renewals monthly' },
         { id: 'nav-reports', group: 'Overview', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
         // Manage
+        { id: 'nav-workflows', group: 'Manage', title: 'Workflows', desc: 'Agent automations and runs', icon: 'workflow', href: '/workflows', keywords: 'workflows automations agents runs schedule cron presets gallery sdk' },
         { id: 'nav-agents', shortcutId: 'global.go.h', group: 'Manage', title: 'Agents', desc: 'Claude Agent SDK runs, prompt library, settings', icon: 'bot', href: '/agents', keywords: 'agent sdk runs prompts library wizard schedule cron mcp setup tools permissions' },
         { id: 'nav-agent-prompts', group: 'Manage', title: 'Prompt library', desc: 'Starter prompt templates for agents', icon: 'sparkles', href: '/agent-prompts', keywords: 'wizard prompt library template starter' },
         { id: 'nav-rules', shortcutId: 'global.go.u', group: 'Manage', title: 'Rules', desc: 'Auto-categorization rules', icon: 'list-filter', href: '/rules', keywords: 'automation patterns categorize labels organize' },


### PR DESCRIPTION
## What

The Cmd+K command palette's static item list (`commandPalette()` in `internal/templates/layout/base.html`) had drifted from the sidebar — it was missing two shipped features that now lead the sidebar's Overview and Manage sections:

- **Recurring** (`/recurring`) — added to **Overview**, between Transactions and Reports, with the `repeat` icon (mirrors the sidebar).
- **Workflows** (`/workflows`) — added to lead **Manage**, with the `workflow` icon.

Both are searchable by their titles/keywords (e.g. "subscriptions", "automations", "agents") and navigate to the correct routes.

## Why

The sidebar (`nav.templ`) lists both, but the palette didn't — so neither was reachable via Cmd+K. This just re-syncs the palette list with the live nav.

## Validation

Logged into a local build and opened the palette — both entries render in the correct groups with their icons:

<img src="https://i.img402.dev/3p6awjb411.jpg" width="800" alt="Command palette showing Recurring under Overview and Workflows under Manage">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
