### PR TITLE
feat(workflows): settings rename + configure-drawer polish (14 fixes)

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -232,7 +232,7 @@ func UpdateAgentRunNoteAdminHandler(svc *service.Service, sm *scs.SessionManager
 func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
-			FlashRedirect(w, r, sm, "error", "Invalid form data.", "/settings/agents")
+			FlashRedirect(w, r, sm, "error", "Invalid form data.", "/settings/workflows")
 			return
 		}
 
@@ -263,7 +263,7 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 		if v := strings.TrimSpace(r.FormValue("max_concurrent")); v != "" {
 			n, err := strconv.Atoi(v)
 			if err != nil || n < 1 || n > 50 {
-				FlashRedirect(w, r, sm, "error", "Max concurrent must be a whole number between 1 and 50.", "/settings/agents")
+				FlashRedirect(w, r, sm, "error", "Max concurrent must be a whole number between 1 and 50.", "/settings/workflows")
 				return
 			}
 			params.MaxConcurrent = &n
@@ -271,7 +271,7 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 		if v := strings.TrimSpace(r.FormValue("global_max_budget_usd")); v != "" {
 			f, err := strconv.ParseFloat(v, 64)
 			if err != nil || f < 0 {
-				FlashRedirect(w, r, sm, "error", "Global max budget must be a non-negative number.", "/settings/agents")
+				FlashRedirect(w, r, sm, "error", "Global max budget must be a non-negative number.", "/settings/workflows")
 				return
 			}
 			params.GlobalMaxBudgetUSD = &f
@@ -285,11 +285,11 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 		}
 
 		if _, err := svc.UpdateAgentSettings(r.Context(), params, a.Config.EncryptionKey, a.Config.DataDir); err != nil {
-			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/agents")
+			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/workflows")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Agent settings saved.")
-		http.Redirect(w, r, "/settings/agents", http.StatusSeeOther)
+		http.Redirect(w, r, "/settings/workflows", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -15,8 +14,8 @@ import (
 	"github.com/alexedwards/scs/v2"
 )
 
-// AgentSDKSettingsPageHandler serves GET /settings/agents (or wherever
-// router.go wires it) — the v1 admin "Agents settings" tab for the
+// AgentSDKSettingsPageHandler serves GET /settings/workflows (or wherever
+// router.go wires it) — the v1 admin "Workflows settings" tab for the
 // Claude Agent SDK runner. Distinct from the existing MCP settings page
 // at /settings/mcp (which lives in agents_settings.templ and configures
 // MCP server instructions / tool toggles).
@@ -40,31 +39,17 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			return
 		}
 
-		// Read-only overview inputs fetched concurrently — each is
-		// best-effort (display only), so a single query hiccup degrades the
-		// relevant tile rather than failing the page.
+		// Status + rolling spend fetched concurrently — each is best-effort
+		// (display only), so a single query hiccup degrades the relevant
+		// element rather than failing the page.
 		var (
 			status *service.AgentSubsystemStatus
 			spend  service.HouseholdSpendStatus
-			defs   []service.AgentDefinitionResponse
-			runs   *service.AgentRunListWithAgentResult
 			wg     sync.WaitGroup
 		)
-		wg.Add(4)
+		wg.Add(2)
 		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
 		go func() { defer wg.Done(); spend, _ = svc.HouseholdSpendStatus(ctx) }()
-		go func() { defer wg.Done(); defs, _ = svc.ListAgentDefinitions(ctx) }()
-		go func() {
-			defer wg.Done()
-			// Trailing-7-day, preset-backed runs only. Bounded limit keeps the
-			// read cheap; 7-day volume sits well under this in practice.
-			start := time.Now().Add(-7 * 24 * time.Hour)
-			runs, _ = svc.ListAllAgentRuns(ctx, service.AllAgentRunListParams{
-				Limit:         200,
-				WorkflowsOnly: true,
-				Start:         &start,
-			})
-		}()
 		wg.Wait()
 
 		form := pages.AgentSDKSettingsFormFields{
@@ -101,13 +86,12 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			Status:               buildAgentSDKStatus(status),
 			CSRFToken:            GetCSRFToken(r),
 			HouseholdSpend30dStr: formatHouseholdSpend(spend),
-			Overview:             buildAgentSDKOverview(spend, defs, runs),
 		}
 
-		data := BaseTemplateData(r, sm, "agents-settings", "Workflows settings")
+		data := BaseTemplateData(r, sm, "workflows-settings", "Workflows settings")
 		data["CSRFToken"] = props.CSRFToken
 		data["Flash"] = nil
-		renderSettingsTab(tr, w, r, data, pages.SettingsTabAgents, pages.AgentSDKSettings(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabWorkflows, pages.AgentSDKSettings(props))
 	}
 }
 
@@ -143,117 +127,5 @@ func buildAgentSDKStatus(s *service.AgentSubsystemStatus) pages.AgentSDKStatusPr
 		AuthConfigured: s.AuthConfigured,
 		BinaryPresent:  s.BinaryPresent,
 		BinaryPath:     s.BinaryPath,
-	}
-}
-
-// agentSDKRunStatusOrder fixes the display order + labels + daisy tones of
-// the 7-day run breakdown so the templ never switches on the raw status.
-// Mirrors the canonical run-status enum (see CLAUDE.md "Sync status" +
-// the agents subsystem's added "skipped").
-var agentSDKRunStatusOrder = []struct {
-	Status string
-	Label  string
-	Tone   string
-}{
-	{"success", "Succeeded", "success"},
-	{"error", "Failed", "error"},
-	{"in_progress", "In progress", "info"},
-	{"skipped", "Skipped", "neutral"},
-}
-
-// buildAgentSDKOverview derives the read-only "Workflows overview" panel
-// from already-fetched data. Everything is best-effort: a nil/empty input
-// degrades the relevant tile rather than erroring.
-//
-//   - EnabledCount counts enabled preset-backed workflows (source_template
-//     set) so it lines up with the gallery's notion of a "workflow".
-//   - Spend mirrors HouseholdSpendStatus (the rolling 30-day window) and
-//     reuses its ceiling for the percent-of-cap hint.
-//   - The 7-day run breakdown is bucketed from the bounded run list.
-//   - NextRun is the soonest NextFireAt across enabled workflows; the
-//     service already computes NextFireAt (quiet-hours-aware) per definition.
-func buildAgentSDKOverview(
-	spend service.HouseholdSpendStatus,
-	defs []service.AgentDefinitionResponse,
-	runs *service.AgentRunListWithAgentResult,
-) pages.AgentSDKOverviewProps {
-	now := time.Now()
-	out := pages.AgentSDKOverviewProps{}
-
-	// Enabled workflow count + soonest next-fire.
-	var nextAt time.Time
-	var nextName string
-	for i := range defs {
-		d := defs[i]
-		if !d.Enabled || d.SourceTemplate == nil {
-			continue
-		}
-		out.EnabledCount++
-		if d.NextFireAt == nil {
-			continue
-		}
-		t, err := time.Parse(time.RFC3339, *d.NextFireAt)
-		if err != nil || !t.After(now) {
-			continue
-		}
-		if nextAt.IsZero() || t.Before(nextAt) {
-			nextAt = t
-			nextName = d.Name
-		}
-	}
-	if !nextAt.IsZero() {
-		out.HasNextRun = true
-		out.NextRunWhenStr = nextAt.Local().Format("Jan 2, 15:04")
-		out.NextRunRelStr = agentSDKUntil(nextAt.Sub(now))
-		out.NextRunWorkflow = nextName
-	}
-
-	// Spend tile.
-	out.Spend30dStr = "$" + strconv.FormatFloat(spend.SpentUSD, 'f', 2, 64)
-	if spend.CeilingUSD != nil && *spend.CeilingUSD > 0 {
-		ceiling := *spend.CeilingUSD
-		out.SpendVsCeilingStr = "of $" + strconv.FormatFloat(ceiling, 'f', 2, 64) + " ceiling"
-		pct := int(spend.SpentUSD / ceiling * 100)
-		if pct < 0 {
-			pct = 0
-		}
-		out.SpendPctStr = strconv.Itoa(pct) + "%"
-		out.SpendOverCeiling = spend.SpentUSD >= ceiling
-	} else {
-		out.SpendVsCeilingStr = "no ceiling set"
-	}
-
-	// 7-day run breakdown, in fixed display order.
-	counts := map[string]int{}
-	if runs != nil {
-		for i := range runs.Runs {
-			counts[runs.Runs[i].Status]++
-			out.Runs7dTotal++
-		}
-	}
-	for _, sc := range agentSDKRunStatusOrder {
-		out.Runs7dByStatus = append(out.Runs7dByStatus, pages.AgentSDKRunStatusCount{
-			Status: sc.Status,
-			Label:  sc.Label,
-			Count:  counts[sc.Status],
-			Tone:   sc.Tone,
-		})
-	}
-
-	return out
-}
-
-// agentSDKUntil renders a short, forward-looking duration hint ("in 2h",
-// "in 3d") for the next-run row. Sub-minute resolves to "imminently".
-func agentSDKUntil(d time.Duration) string {
-	switch {
-	case d < time.Minute:
-		return "imminently"
-	case d < time.Hour:
-		return "in " + strconv.Itoa(int(d.Minutes())) + "m"
-	case d < 24*time.Hour:
-		return "in " + strconv.Itoa(int(d.Hours())) + "h"
-	default:
-		return "in " + strconv.Itoa(int(d.Hours()/24)) + "d"
 	}
 }

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -359,9 +359,11 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// review guidelines, report format, and per-tool toggles. POST
 		// targets remain at /-/mcp-settings/* (registered below).
 		r.Get("/settings/mcp", AgentsSettingsHandler(svc, mcpServer, sm, tr))
-		// Agent SDK settings — Claude Agent SDK auth, sidecar, and run
+		// Workflow runtime settings — Claude Agent SDK auth, sidecar, and run
 		// ceilings. Admin-only because tokens are sensitive and runs cost.
-		r.Get("/settings/agents", AgentSDKSettingsPageHandler(a, svc, sm, tr))
+		r.Get("/settings/workflows", AgentSDKSettingsPageHandler(a, svc, sm, tr))
+		// Back-compat: the tab used to live at /settings/agents.
+		r.Get("/settings/agents", redirectGET("/settings/workflows"))
 		r.Get("/agents-settings", redirectGET("/settings/mcp"))
 		r.Get("/mcp-getting-started", redirectGET("/agent-prompts"))
 		r.Get("/agent-wizard", redirectGET("/agent-prompts"))

--- a/internal/admin/workflows_cron_handler.go
+++ b/internal/admin/workflows_cron_handler.go
@@ -8,14 +8,18 @@ import (
 	"breadbox/internal/service"
 )
 
-// WorkflowCronPreviewAdminHandler handles GET /-/workflows/cron-preview?cron=<expr>.
+// WorkflowCronPreviewAdminHandler handles
+// GET /-/workflows/cron-preview?cron=<expr>&tz=<IANA>.
 // It returns {valid, description} for the configure drawer's live schedule
 // preview — a human-readable rendering of a cron expression (e.g.
-// "At 08:00 AM, only on Monday"). Read-only; validates with the same parser
-// the scheduler uses so the preview agrees with what will actually run.
+// "At 08:00 AM, only on Monday"). When a `tz` (the viewer's IANA timezone)
+// is supplied, the times are localized to it, since the scheduler fires cron
+// in the server's timezone. Read-only; validates with the same parser the
+// scheduler uses so the preview agrees with what will actually run.
 func WorkflowCronPreviewAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		valid, desc := svc.DescribeCron(r.URL.Query().Get("cron"))
+		q := r.URL.Query()
+		valid, desc := svc.DescribeCronInTZ(q.Get("cron"), q.Get("tz"))
 		writeJSON(w, http.StatusOK, map[string]any{
 			"valid":       valid,
 			"description": desc,

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -247,7 +247,7 @@ func runAgentTest(parent context.Context) error {
 		case errors.Is(err, agent.ErrAuthNotConfigured):
 			fmt.Fprintln(os.Stdout, "  ✗ auth          not configured")
 			fmt.Fprintln(os.Stdout, "")
-			fmt.Fprintln(os.Stdout, "Open the admin Settings → Agents (/settings/agents) and paste an Anthropic credential.")
+			fmt.Fprintln(os.Stdout, "Open the admin Settings → Agents (/settings/workflows) and paste an Anthropic credential.")
 			fmt.Fprintln(os.Stdout, "For a subscription token: run `claude setup-token` on any machine, then paste the sk-ant-oat01-… into Settings.")
 			return silentlyFail(err)
 		case errors.Is(err, agent.ErrBinaryNotFound):

--- a/internal/service/cron_describe.go
+++ b/internal/service/cron_describe.go
@@ -3,7 +3,9 @@
 package service
 
 import (
+	"strconv"
 	"strings"
+	"time"
 
 	lcron "github.com/lnquy/cron"
 	rcron "github.com/robfig/cron/v3"
@@ -49,4 +51,129 @@ func (s *Service) DescribeCron(expr string) (valid bool, description string) {
 		return true, "Custom schedule"
 	}
 	return true, desc
+}
+
+// DescribeCronInTZ is DescribeCron localized to a viewer's IANA timezone
+// (e.g. "America/Los_Angeles"). The scheduler fires cron in the server's
+// local time, so the raw expression's times are server-local; this shifts
+// them into the viewer's zone before rendering, so the preview matches the
+// clock the viewer is actually reading.
+//
+//   - tzName empty or unknown → falls back to DescribeCron (server-local).
+//   - viewer tz == server tz (the common dev case) → identical to
+//     DescribeCron, no suffix.
+//   - shift representable (single hour:minute, no day-of-month constraint a
+//     midnight-wrap would invalidate) → times shifted, " (your time)" suffix.
+//   - shift not representable (lists/ranges/steps in the time fields, or a
+//     monthly schedule that would wrap past midnight) → described as-is with
+//     a " (server time)" suffix so the frame is never ambiguous.
+func (s *Service) DescribeCronInTZ(expr, tzName string) (valid bool, description string) {
+	valid, description = s.DescribeCron(expr)
+	if !valid {
+		return valid, description
+	}
+	tzName = strings.TrimSpace(tzName)
+	if tzName == "" {
+		return valid, description
+	}
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		return valid, description // unknown tz → server-local, unlabeled
+	}
+
+	// Offset delta (viewer − server) at now. Using the current instant keeps
+	// this DST-correct for the near-term schedule the user is editing.
+	now := time.Now()
+	_, serverOff := now.Zone()
+	_, viewerOff := now.In(loc).Zone()
+	deltaMin := (viewerOff - serverOff) / 60
+	if deltaMin == 0 {
+		return valid, description // same wall clock — nothing to convert
+	}
+
+	if shifted, ok := shiftCronTimeFields(strings.TrimSpace(expr), deltaMin); ok {
+		if d, derr := cronDescriptor.ToDescription(shifted, lcron.Locale_en); derr == nil && strings.TrimSpace(d) != "" {
+			return true, d + " (your time)"
+		}
+	}
+	// Couldn't safely convert — keep the server-time wording but label it.
+	return true, description + " (server time)"
+}
+
+// shiftCronTimeFields shifts a standard 5-field cron's time-of-day by
+// deltaMin minutes, carrying any midnight wrap into the day-of-week set.
+// It returns ok=true only for the representable case: minute and hour are
+// each a single integer (every built-in preset plus the common custom
+// schedule). A wrap is only applied when the schedule is day-of-week based
+// (dom and month are "*"); a day-of-month constrained schedule that would
+// wrap returns ok=false so the caller can fall back rather than silently
+// move, say, a "1st of the month" run onto a different day.
+func shiftCronTimeFields(expr string, deltaMin int) (string, bool) {
+	f := strings.Fields(expr)
+	if len(f) != 5 {
+		return "", false
+	}
+	minute, okM := singleCronInt(f[0])
+	hour, okH := singleCronInt(f[1])
+	if !okM || !okH {
+		return "", false
+	}
+	total := hour*60 + minute + deltaMin
+	dayDelta := 0
+	for total < 0 {
+		total += 1440
+		dayDelta--
+	}
+	for total >= 1440 {
+		total -= 1440
+		dayDelta++
+	}
+	f[0] = strconv.Itoa(total % 60)
+	f[1] = strconv.Itoa(total / 60)
+
+	if dayDelta != 0 {
+		dom, month, dow := f[2], f[3], f[4]
+		if dom != "*" || month != "*" {
+			return "", false // monthly/dom-constrained + wrap → too risky
+		}
+		if dow != "*" { // "*" is daily — a wrap leaves it daily
+			shifted, ok := shiftCronDow(dow, dayDelta)
+			if !ok {
+				return "", false
+			}
+			f[4] = shifted
+		}
+	}
+	return strings.Join(f, " "), true
+}
+
+// singleCronInt parses a cron field that is a single non-negative integer
+// (no "*", list, range, or step). Returns ok=false for anything else.
+func singleCronInt(field string) (int, bool) {
+	n, err := strconv.Atoi(field)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// shiftCronDow shifts a day-of-week field (a single value or comma list of
+// integers, 0/7 = Sunday) by dayDelta days, wrapping within the week. Only
+// numeric values are handled; named days (MON, TUE…), ranges, and steps
+// return ok=false so the caller falls back to a labeled server-time render.
+func shiftCronDow(field string, dayDelta int) (string, bool) {
+	parts := strings.Split(field, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n < 0 || n > 7 {
+			return "", false
+		}
+		if n == 7 {
+			n = 0 // normalize Sunday
+		}
+		shifted := ((n+dayDelta)%7 + 7) % 7
+		out = append(out, strconv.Itoa(shifted))
+	}
+	return strings.Join(out, ","), true
 }

--- a/internal/service/cron_describe_test.go
+++ b/internal/service/cron_describe_test.go
@@ -35,3 +35,52 @@ func TestDescribeCron(t *testing.T) {
 		})
 	}
 }
+
+// TestShiftCronTimeFields covers the timezone-shift logic that backs
+// DescribeCronInTZ. It is a pure function of (expr, deltaMinutes) so it's
+// deterministic regardless of the test host's local timezone.
+func TestShiftCronTimeFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		expr   string
+		delta  int
+		want   string
+		wantOk bool
+	}{
+		// Daily, no midnight wrap: 08:00 +2h → 10:00, still daily.
+		{"daily +2h", "0 8 * * *", 120, "0 10 * * *", true},
+		// Daily, negative shift staying same day: 08:00 −3h → 05:00.
+		{"daily -3h", "0 8 * * *", -180, "0 5 * * *", true},
+		// Half-hour offset (e.g. UTC→IST +5:30): minute shifts too.
+		{"daily +5h30", "0 8 * * *", 330, "30 13 * * *", true},
+		// Weekly, wrap forward past midnight bumps the weekday: Mon 23:00
+		// +2h → Tue 01:00 (dow 1 → 2).
+		{"weekly wrap forward", "0 23 * * 1", 120, "0 1 * * 2", true},
+		// Weekly, wrap backward before midnight: Mon 01:00 −2h → Sun 23:00
+		// (dow 1 → 0).
+		{"weekly wrap backward", "0 1 * * 1", -120, "0 23 * * 0", true},
+		// Sunday normalization: dow 7 (Sunday) wrapping forward → Mon (1).
+		{"sunday wrap", "0 23 * * 7", 120, "0 1 * * 1", true},
+		// Multi-day list wraps each member: Tue,Thu 23:00 +2h → Wed,Fri.
+		{"multi-dow wrap", "0 23 * * 2,4", 120, "0 1 * * 3,5", true},
+		// No wrap, weekday untouched: Mon 08:00 +2h → Mon 10:00.
+		{"weekly no wrap", "0 8 * * 1", 120, "0 10 * * 1", true},
+		// Monthly with a wrap is not representable → fall back.
+		{"monthly wrap not ok", "0 23 1 * *", 120, "", false},
+		// Step minute is not a single integer → fall back.
+		{"step minute not ok", "*/15 * * * *", 120, "", false},
+		// Range hour is not a single integer → fall back.
+		{"range hour not ok", "0 8-10 * * *", 120, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := shiftCronTimeFields(c.expr, c.delta)
+			if ok != c.wantOk {
+				t.Fatalf("shiftCronTimeFields(%q, %d) ok=%v, want %v (got=%q)", c.expr, c.delta, ok, c.wantOk, got)
+			}
+			if c.wantOk && got != c.want {
+				t.Errorf("shiftCronTimeFields(%q, %d) = %q, want %q", c.expr, c.delta, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/templates/components/drawer.templ
+++ b/internal/templates/components/drawer.templ
@@ -82,7 +82,7 @@ templ Drawer(p DrawerProps) {
 			x-transition:leave="transition ease-in duration-150"
 			x-transition:leave-start="translate-x-0"
 			x-transition:leave-end="translate-x-full"
-			@keydown.escape.window="$store.drawers.close()"
+			@keydown.escape.window="if (!document.querySelector('dialog[open]')) $store.drawers.close()"
 			role="dialog"
 			aria-modal="true"
 			if p.Title != "" {

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -183,13 +183,13 @@ func navActive(current, page string) string {
 // tab. Each settings sub-page reports its own CurrentPage id rather than a
 // shared "settings" one (account → members.go; general/system/help →
 // settings.go; providers → providers.go; mcp → settings_agents.go;
-// agents-settings → agent_sdk_settings_page.go; api-keys → apikeys.go;
+// workflows-settings → agent_sdk_settings_page.go; api-keys → apikeys.go;
 // backups → backups.go), so a plain navActive(…, "settings") would never
 // match. Keep this set in sync with those handlers' currentPage values.
 func navSettingsActive(current string) string {
 	switch current {
 	case "account", "general", "system", "help", "providers",
-		"mcp", "agents-settings", "api-keys", "backups":
+		"mcp", "workflows-settings", "api-keys", "backups":
 		return "bb-sidebar-link--active"
 	}
 	return ""

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -33,7 +33,6 @@ templ AgentSDKSettings(p AgentSDKSettingsProps) {
 			</div>
 		}
 		<div class="space-y-6">
-			@agentSDKOverviewSection(p.Overview)
 			@agentSDKStatusSection(p.Status)
 			@agentSDKConfigSection(p)
 			@agentSDKDiagnosticsSection(p.CSRFToken)
@@ -42,90 +41,8 @@ templ AgentSDKSettings(p AgentSDKSettingsProps) {
 }
 
 // ---------------------------------------------------------------------
-// Overview (read-only)
-// ---------------------------------------------------------------------
-
-// agentSDKOverviewSection is a read-only at-a-glance panel: how many
-// workflows are live, rolling 30-day spend against the ceiling, the
-// trailing-7-day run breakdown, and the next scheduled run. Stat tiles
-// follow the Backups data-viz pattern (bb-card grid) rather than
-// SettingsRow, since they are data-viz, not editable controls.
-templ agentSDKOverviewSection(o AgentSDKOverviewProps) {
-	@components.SettingsSection(components.SettingsSectionProps{
-		Icon:    "layout-dashboard",
-		Title:   "Overview",
-		Caption: "Live workflows, spend, and recent run activity at a glance",
-	}) {
-		@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-			<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 w-full">
-				<div class="bb-card p-4">
-					<div class="text-xs text-base-content/40 mb-1">Enabled workflows</div>
-					<div class="text-2xl font-bold tabular-nums">{ strconv.Itoa(o.EnabledCount) }</div>
-				</div>
-				<div class="bb-card p-4">
-					<div class="text-xs text-base-content/40 mb-1">Spend (30d)</div>
-					<div class="text-2xl font-bold tabular-nums">{ o.Spend30dStr }</div>
-					<div class="text-xs mt-0.5 flex items-center gap-1.5">
-						<span class="text-base-content/40">{ o.SpendVsCeilingStr }</span>
-						if o.SpendPctStr != "" {
-							if o.SpendOverCeiling {
-								<span class="badge badge-soft badge-error badge-xs">{ o.SpendPctStr }</span>
-							} else {
-								<span class="badge badge-soft badge-neutral badge-xs">{ o.SpendPctStr }</span>
-							}
-						}
-					</div>
-				</div>
-				<div class="bb-card p-4">
-					<div class="text-xs text-base-content/40 mb-1">Runs (7d)</div>
-					<div class="text-2xl font-bold tabular-nums">{ strconv.Itoa(o.Runs7dTotal) }</div>
-					if o.Runs7dTotal > 0 {
-						<div class="flex flex-wrap items-center gap-1 mt-1.5">
-							for _, sc := range o.Runs7dByStatus {
-								if sc.Count > 0 {
-									<span class={ agentSDKBadgeClass(sc.Tone) } title={ sc.Label }>{ strconv.Itoa(sc.Count) } { sc.Label }</span>
-								}
-							}
-						</div>
-					} else {
-						<div class="text-xs text-base-content/40 mt-1.5">No runs this week</div>
-					}
-				</div>
-				<div class="bb-card p-4">
-					<div class="text-xs text-base-content/40 mb-1">Next run</div>
-					if o.HasNextRun {
-						<div class="text-lg font-semibold leading-tight">{ o.NextRunRelStr }</div>
-						<div class="text-xs text-base-content/40 mt-0.5">{ o.NextRunWhenStr }</div>
-						<div class="text-xs text-base-content/60 truncate mt-0.5" title={ o.NextRunWorkflow }>{ o.NextRunWorkflow }</div>
-					} else {
-						<div class="text-lg font-semibold leading-tight text-base-content/40">None scheduled</div>
-						<div class="text-xs text-base-content/40 mt-0.5">No enabled workflow has a schedule</div>
-					}
-				</div>
-			</div>
-		}
-	}
-}
-
-// agentSDKBadgeClass maps a daisy tone to the soft-badge class used in the
-// 7-day run breakdown. Keeps the tone-→class switch out of the markup.
-func agentSDKBadgeClass(tone string) string {
-	switch tone {
-	case "success":
-		return "badge badge-soft badge-success badge-xs"
-	case "error":
-		return "badge badge-soft badge-error badge-xs"
-	case "info":
-		return "badge badge-soft badge-info badge-xs"
-	default:
-		return "badge badge-soft badge-neutral badge-xs"
-	}
-}
-
-// ---------------------------------------------------------------------
 // Status
 // ---------------------------------------------------------------------
-
 templ agentSDKStatusSection(s AgentSDKStatusProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "activity",
@@ -187,7 +104,6 @@ func agentSDKBinaryCaption(s AgentSDKStatusProps) string {
 // ---------------------------------------------------------------------
 // Configuration form
 // ---------------------------------------------------------------------
-
 templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 	<div x-data={ "{ authMode: " + jsString(p.Form.AuthMode) + " }" }>
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -206,44 +122,46 @@ templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 				Stack:   true,
 			}) {
 				<div class="space-y-3">
-					<label class="flex items-start gap-3 p-3 rounded-xl ring-1 ring-base-content/10 cursor-pointer hover:bg-base-200/50 transition-colors" :class="authMode === 'subscription' && 'bg-base-200/60 ring-primary/40'">
-						<input
-							type="radio"
-							name="auth_mode"
-							value="subscription"
-							class="radio radio-sm radio-primary mt-0.5 shrink-0"
-							x-model="authMode"
-							if p.Form.AuthMode == "subscription" {
-								checked
-							}
-						/>
-						@components.BrandIcon("claude", "w-5 h-5 mt-0.5 shrink-0")
-						<div class="min-w-0 flex-1">
-							<div class="text-sm font-medium">Subscription token <span class="badge badge-soft badge-success badge-xs ml-1">recommended</span></div>
-							<div class="text-xs text-base-content/50 mt-0.5">Generate from <code class="text-xs">claude setup-token</code>. Charges your Claude Pro / Max subscription.</div>
-						</div>
-					</label>
-					<div x-show="authMode === 'subscription'" x-cloak class="pl-9">
+					<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+						<label class="flex items-start gap-3 p-3 rounded-xl ring-1 ring-base-content/10 cursor-pointer hover:bg-base-200/50 transition-colors" :class="authMode === 'subscription' && 'bg-base-200/60 ring-primary/40'">
+							<input
+								type="radio"
+								name="auth_mode"
+								value="subscription"
+								class="radio radio-sm radio-primary mt-0.5 shrink-0"
+								x-model="authMode"
+								if p.Form.AuthMode == "subscription" {
+									checked
+								}
+							/>
+							@components.BrandIcon("claude", "w-5 h-5 mt-0.5 shrink-0")
+							<div class="min-w-0 flex-1">
+								<div class="text-sm font-medium">Subscription token <span class="badge badge-soft badge-success badge-xs ml-1">recommended</span></div>
+								<div class="text-xs text-base-content/50 mt-0.5">Generate from <code class="text-xs">claude setup-token</code>. Charges your Claude Pro / Max subscription.</div>
+							</div>
+						</label>
+						<label class="flex items-start gap-3 p-3 rounded-xl ring-1 ring-base-content/10 cursor-pointer hover:bg-base-200/50 transition-colors" :class="authMode === 'api_key' && 'bg-base-200/60 ring-primary/40'">
+							<input
+								type="radio"
+								name="auth_mode"
+								value="api_key"
+								class="radio radio-sm radio-primary mt-0.5 shrink-0"
+								x-model="authMode"
+								if p.Form.AuthMode == "api_key" {
+									checked
+								}
+							/>
+							@components.BrandIcon("anthropic", "w-5 h-5 mt-0.5 shrink-0")
+							<div class="min-w-0 flex-1">
+								<div class="text-sm font-medium">API key</div>
+								<div class="text-xs text-base-content/50 mt-0.5">From <a class="link link-hover" href="https://console.anthropic.com" target="_blank" rel="noopener noreferrer">console.anthropic.com</a> — pay-as-you-go.</div>
+							</div>
+						</label>
+					</div>
+					<div x-show="authMode === 'subscription'" x-cloak>
 						@agentSDKMaskedInput("subscription_token", "Subscription token", p.Form.SubscriptionTokenDisplay, p.FieldErrors["subscription_token"])
 					</div>
-					<label class="flex items-start gap-3 p-3 rounded-xl ring-1 ring-base-content/10 cursor-pointer hover:bg-base-200/50 transition-colors" :class="authMode === 'api_key' && 'bg-base-200/60 ring-primary/40'">
-						<input
-							type="radio"
-							name="auth_mode"
-							value="api_key"
-							class="radio radio-sm radio-primary mt-0.5 shrink-0"
-							x-model="authMode"
-							if p.Form.AuthMode == "api_key" {
-								checked
-							}
-						/>
-						@components.BrandIcon("anthropic", "w-5 h-5 mt-0.5 shrink-0")
-						<div class="min-w-0 flex-1">
-							<div class="text-sm font-medium">API key</div>
-							<div class="text-xs text-base-content/50 mt-0.5">From <a class="link link-hover" href="https://console.anthropic.com" target="_blank" rel="noopener noreferrer">console.anthropic.com</a> — pay-as-you-go.</div>
-						</div>
-					</label>
-					<div x-show="authMode === 'api_key'" x-cloak class="pl-9">
+					<div x-show="authMode === 'api_key'" x-cloak>
 						@agentSDKMaskedInput("anthropic_api_key", "Anthropic API key", p.Form.AnthropicAPIKeyDisplay, p.FieldErrors["anthropic_api_key"])
 					</div>
 				</div>
@@ -394,7 +312,6 @@ templ agentSDKMaskedInput(name, label, maskedDisplay, fieldErr string) {
 // ---------------------------------------------------------------------
 // Diagnostics
 // ---------------------------------------------------------------------
-
 templ agentSDKDiagnosticsSection(csrfToken string) {
 	<div x-data="agentSDKDiagnostics" data-csrf={ csrfToken }>
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -413,7 +330,8 @@ templ agentSDKDiagnosticsSection(csrfToken string) {
 					:disabled="smokeState === 'loading'"
 				>
 					<span x-show="smokeState !== 'loading'" class="flex items-center gap-1.5">
-						@components.LucideIcon("zap", "w-4 h-4") Run smoke test
+						@components.LucideIcon("zap", "w-4 h-4")
+						Run smoke test
 					</span>
 					<span x-show="smokeState === 'loading'" x-cloak class="flex items-center gap-1.5">
 						<span class="loading loading-spinner loading-xs"></span> Running…
@@ -431,7 +349,8 @@ templ agentSDKDiagnosticsSection(csrfToken string) {
 					:disabled="cleanupState === 'loading'"
 				>
 					<span x-show="cleanupState !== 'loading'" class="flex items-center gap-1.5">
-						@components.LucideIcon("broom", "w-4 h-4") Run cleanup
+						@components.LucideIcon("broom", "w-4 h-4")
+						Run cleanup
 					</span>
 					<span x-show="cleanupState === 'loading'" x-cloak class="flex items-center gap-1.5">
 						<span class="loading loading-spinner loading-xs"></span> Cleaning…
@@ -449,7 +368,8 @@ templ agentSDKDiagnosticsSection(csrfToken string) {
 					:disabled="notifyState === 'loading'"
 				>
 					<span x-show="notifyState !== 'loading'" class="flex items-center gap-1.5">
-						@components.LucideIcon("bell", "w-4 h-4") Send test
+						@components.LucideIcon("bell", "w-4 h-4")
+						Send test
 					</span>
 					<span x-show="notifyState === 'loading'" x-cloak class="flex items-center gap-1.5">
 						<span class="loading loading-spinner loading-xs"></span> Sending…

--- a/internal/templates/components/pages/agent_sdk_settings_types.go
+++ b/internal/templates/components/pages/agent_sdk_settings_types.go
@@ -23,52 +23,6 @@ type AgentSDKSettingsProps struct {
 	// workflow runs, formatted for the spend-ceiling section (e.g. "$2.13
 	// of $20.00" when a ceiling is set, or "$2.13" with no cap).
 	HouseholdSpend30dStr string
-	// Overview is the read-only "Workflows overview" panel at the top of the
-	// page: enabled count, rolling spend vs ceiling, 7-day run breakdown, and
-	// the next scheduled run. Derived entirely server-side by the page
-	// handler from existing service methods — display only.
-	Overview AgentSDKOverviewProps
-}
-
-// AgentSDKOverviewProps drives the read-only "Workflows overview" section.
-// Everything here is pre-formatted by the page handler so the templ stays
-// free of arithmetic and nil-handling. All fields degrade gracefully: a
-// failed underlying query leaves the relevant field empty/zero and the
-// section renders the remaining tiles.
-type AgentSDKOverviewProps struct {
-	// EnabledCount is the number of enabled preset-backed workflows.
-	EnabledCount int
-	// Spend30dStr is the rolling-window spend, e.g. "$2.13".
-	Spend30dStr string
-	// SpendVsCeilingStr is the spend tile's caption: "of $20.00 ceiling"
-	// when a cap is set, "no ceiling" otherwise.
-	SpendVsCeilingStr string
-	// SpendPctStr is the percent-of-ceiling string ("11%") or "" when no
-	// ceiling is configured. SpendOverCeiling flags >= 100%.
-	SpendPctStr      string
-	SpendOverCeiling bool
-	// Runs7dTotal is the total run count in the trailing 7 days (every
-	// status). Runs7dByStatus holds the per-status breakdown in a fixed,
-	// display-ordered slice.
-	Runs7dTotal    int
-	Runs7dByStatus []AgentSDKRunStatusCount
-	// HasNextRun is false when nothing is scheduled (no enabled cron
-	// workflows). NextRun* describe the soonest upcoming scheduled run
-	// across all enabled workflows.
-	HasNextRun      bool
-	NextRunWhenStr  string // absolute local datetime, e.g. "May 31, 14:00"
-	NextRunRelStr   string // "in 2h", "in 3d" — short relative hint
-	NextRunWorkflow string // the workflow name that fires next
-}
-
-// AgentSDKRunStatusCount is one status bucket in the 7-day run breakdown.
-// Tone maps to a daisy badge tone ("success" | "error" | "info" |
-// "neutral") so the templ doesn't switch on the raw status string.
-type AgentSDKRunStatusCount struct {
-	Status string // canonical run status: success | error | in_progress | skipped
-	Label  string // display label, e.g. "Succeeded"
-	Count  int
-	Tone   string // daisy tone: success | error | info | neutral
 }
 
 // AgentSDKSettingsFormFields mirrors the writable settings exposed by

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -127,7 +127,7 @@ templ agentsListStatusBanner(s AgentSubsystemStatusProps) {
 				{ agentsListMissingLabel(s) }
 			</div>
 		</div>
-		<a href="/settings/agents" class="btn btn-sm btn-ghost">Configure</a>
+		<a href="/settings/workflows" class="btn btn-sm btn-ghost">Configure</a>
 	</div>
 }
 

--- a/internal/templates/components/pages/settings_page.templ
+++ b/internal/templates/components/pages/settings_page.templ
@@ -57,7 +57,7 @@ templ settingsPageRail(p SettingsPageProps) {
 				@settingsRailItem(p, "system", "cpu", "System")
 				<div class="bb-settings-rail__group-label">Integrations</div>
 				@settingsRailItem(p, "providers", "plug", "Providers")
-				@settingsRailItem(p, "agents", "sparkles", "Workflows")
+				@settingsRailItem(p, "workflows", "sparkles", "Workflows")
 				@settingsRailItem(p, "mcp", "brand:model-context-protocol", "MCP")
 			}
 			if p.IsEditor {

--- a/internal/templates/components/pages/settings_tabs.go
+++ b/internal/templates/components/pages/settings_tabs.go
@@ -19,7 +19,7 @@ const (
 	SettingsTabGeneral   = components.SettingsModalTabGeneral
 	SettingsTabSystem    = components.SettingsModalTabSystem
 	SettingsTabProviders = components.SettingsModalTabProviders
-	SettingsTabAgents    = components.SettingsModalTabAgents
+	SettingsTabWorkflows = components.SettingsModalTabWorkflows
 	SettingsTabMCP       = components.SettingsModalTabMCP
 	SettingsTabAccess    = components.SettingsModalTabAccess
 	SettingsTabBackups   = components.SettingsModalTabBackups

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -33,7 +33,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 					<div class="font-semibold text-sm">Set up the agent runtime first</div>
 					<div class="text-xs opacity-80">Configure an Anthropic API key in Settings to actually run these workflows. You can still enable presets — they'll stay paused until the runtime is ready.</div>
 				</div>
-				<a href="/settings/agents" class="btn btn-sm btn-ghost">Configure</a>
+				<a href="/settings/workflows" class="btn btn-sm btn-ghost">Configure</a>
 			</div>
 		}
 		if p.Spend.Show {
@@ -44,7 +44,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 						<div class="font-semibold text-sm">Workflows paused — spend ceiling reached</div>
 						<div class="text-xs opacity-80">30-day spend { p.Spend.SpentStr } has reached your ceiling ({ p.Spend.CeilingStr }). New runs are paused until spend ages out of the window or you raise the ceiling.</div>
 					</div>
-					<a href="/settings/agents" class="btn btn-sm btn-ghost">Adjust</a>
+					<a href="/settings/workflows" class="btn btn-sm btn-ghost">Adjust</a>
 				</div>
 			} else {
 				<div role="alert" class="alert alert-warning rounded-xl mt-4 mb-2">
@@ -53,7 +53,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 						<div class="font-semibold text-sm">Approaching spend ceiling</div>
 						<div class="text-xs opacity-80">{ p.Spend.PctStr } used — { p.Spend.SpentStr } of { p.Spend.CeilingStr } in the last 30 days.</div>
 					</div>
-					<a href="/settings/agents" class="btn btn-sm btn-ghost">Adjust</a>
+					<a href="/settings/workflows" class="btn btn-sm btn-ghost">Adjust</a>
 				</div>
 			}
 		}
@@ -126,11 +126,11 @@ templ workflowReconfigureDrawer() {
 				<template x-for="opt in reconfigure.options" :key="opt.key">
 					<div>
 						<div class="text-sm font-medium mb-1.5" x-text="opt.label"></div>
-						<select :name="opt.key" x-model="opt.selected" class="select select-sm w-full">
+						<div class="join w-full rounded-lg overflow-hidden">
 							<template x-for="ch in opt.choices" :key="ch.value">
-								<option :value="ch.value" x-text="ch.label"></option>
+								<input type="radio" :name="opt.key" :value="ch.value" x-model="opt.selected" :aria-label="ch.label" class="join-item btn btn-sm flex-1 checked:btn-primary"/>
 							</template>
-						</select>
+						</div>
 						<div class="text-xs text-base-content/40 mt-1" x-show="opt.help" x-text="opt.help"></div>
 					</div>
 				</template>
@@ -146,7 +146,7 @@ templ workflowReconfigureDrawer() {
 							@click="previewPrompt(reconfigure.slug, reconfigure.name)"
 						>
 							@components.LucideIcon("file-text", "w-3.5 h-3.5")
-							Preview prompt
+							Workflow prompt
 						</button>
 					</div>
 					<textarea
@@ -185,7 +185,7 @@ templ workflowReconfigureDrawer() {
 // gallery factory opens it (dialog.showModal()) and fills previewTitle /
 // previewBody from GET /-/workflows/{slug}/prompt.
 templ workflowPromptPreviewModal() {
-	<dialog id="wf-prompt-preview" class="modal modal-bottom sm:modal-middle">
+	<dialog id="wf-prompt-preview" class="modal modal-bottom sm:modal-middle" @keydown.c="if (!$event.metaKey && !$event.ctrlKey) copyPrompt()">
 		<div class="modal-box max-w-2xl">
 			<div class="flex items-start justify-between gap-3 mb-3">
 				<div class="flex items-start gap-2 min-w-0">
@@ -214,6 +214,17 @@ templ workflowPromptPreviewModal() {
 				class="bb-prose text-sm bg-base-200 rounded-xl p-4 max-h-[60vh] overflow-y-auto break-words"
 			></div>
 			<div class="modal-action mt-4">
+				<button type="button" class="btn btn-sm gap-2" :class="previewCopied ? 'btn-success' : 'btn-primary'" @click="copyPrompt()">
+					<span x-show="!previewCopied" class="inline-flex items-center gap-2">
+						@components.LucideIcon("copy", "w-4 h-4")
+						Copy
+						@components.Kbd("c")
+					</span>
+					<span x-show="previewCopied" x-cloak class="inline-flex items-center gap-2">
+						@components.LucideIcon("check", "w-4 h-4")
+						Copied
+					</span>
+				</button>
 				<form method="dialog">
 					<button class="btn btn-ghost btn-sm">Close</button>
 				</form>
@@ -262,7 +273,7 @@ templ workflowCardControls(preset WorkflowPresetCardProps, isAdmin bool) {
 	if preset.Enabled {
 		<input
 			type="checkbox"
-			class="toggle toggle-sm toggle-primary"
+			class="toggle toggle-sm"
 			if preset.WorkflowEnabled {
 				checked
 			}
@@ -317,7 +328,7 @@ templ workflowTriggerFields(triggerVar, cronVar string) {
 		<div class="grid grid-cols-2 gap-2">
 			<label class="cursor-pointer">
 				<input type="radio" name="trigger_on_sync" value="false" x-model={ triggerVar } @change={ "describeCron(" + cronVar + ")" } class="peer sr-only"/>
-				<div class="rounded-xl border border-base-300 p-3 h-full transition-colors peer-checked:border-success peer-checked:bg-success/5">
+				<div class="rounded-xl border border-base-300 p-3 h-full transition-colors peer-checked:border-primary peer-checked:bg-primary/5">
 					<div class="flex items-center gap-2">
 						@components.LucideIcon("calendar-clock", "w-4 h-4 text-base-content/60")
 						<span class="text-sm font-medium">Custom schedule</span>
@@ -327,7 +338,7 @@ templ workflowTriggerFields(triggerVar, cronVar string) {
 			</label>
 			<label class="cursor-pointer">
 				<input type="radio" name="trigger_on_sync" value="true" x-model={ triggerVar } class="peer sr-only"/>
-				<div class="rounded-xl border border-base-300 p-3 h-full transition-colors peer-checked:border-success peer-checked:bg-success/5">
+				<div class="rounded-xl border border-base-300 p-3 h-full transition-colors peer-checked:border-primary peer-checked:bg-primary/5">
 					<div class="flex items-center gap-2">
 						@components.LucideIcon("refresh-cw", "w-4 h-4 text-base-content/60")
 						<span class="text-sm font-medium">After each sync</span>
@@ -367,8 +378,8 @@ templ workflowTriggerFields(triggerVar, cronVar string) {
 templ workflowCronPill(cronVar, value, label string) {
 	<button
 		type="button"
-		class="btn btn-xs btn-soft"
-		x-bind:class={ cronVar + " === '" + value + "' ? 'btn-success' : ''" }
+		class="btn btn-sm"
+		x-bind:class={ cronVar + " === '" + value + "' ? 'btn-primary' : 'btn-soft'" }
 		@click={ cronVar + " = '" + value + "'; describeCron(" + cronVar + ")" }
 	>
 		{ label }
@@ -392,24 +403,19 @@ templ workflowModelField(modelVar string) {
 // cap (max_budget_usd) and turn cap (max_turns). Collapsed by default. Bound to
 // budgetVar / turnsVar (the corresponding form fields).
 templ workflowAdvancedFields(turnsVar, budgetVar string) {
-	<div x-data="{ advOpen: false }" class="border-t border-base-200 pt-3">
-		<button type="button" class="flex items-center gap-1.5 text-sm font-medium text-base-content/70 w-full" @click="advOpen = !advOpen">
+	<div class="border-t border-base-200 pt-3">
+		<div class="flex items-center gap-1.5 text-sm font-medium text-base-content/70 mb-2">
 			@components.LucideIcon("sliders-horizontal", "w-3.5 h-3.5")
 			Advanced
-			<span class="ml-auto transition-transform" x-bind:class="advOpen ? 'rotate-90' : ''">
-				@components.LucideIcon("chevron-right", "w-4 h-4 text-base-content/40")
-			</span>
-		</button>
-		<div x-show="advOpen" x-cloak x-collapse class="space-y-3 pt-3">
+		</div>
+		<div class="grid grid-cols-2 gap-3">
 			<div>
-				<div class="text-sm font-medium mb-1.5">Max cost per run (USD)</div>
+				<div class="text-sm font-medium mb-1.5">Max cost / run (USD)</div>
 				<input type="number" name="max_budget_usd" x-model={ budgetVar } min="0" max="1000" step="0.5" class="input input-sm w-full" placeholder="1.00"/>
-				<div class="text-xs text-base-content/45 mt-1">Stops the run if its cumulative Anthropic cost passes this cap.</div>
 			</div>
 			<div>
 				<div class="text-sm font-medium mb-1.5">Max turns</div>
 				<input type="number" name="max_turns" x-model={ turnsVar } min="0" max="100" step="1" class="input input-sm w-full" placeholder="10"/>
-				<div class="text-xs text-base-content/45 mt-1">Caps how many assistant/tool turns a single run can take.</div>
 			</div>
 		</div>
 	</div>
@@ -421,7 +427,7 @@ templ workflowAdvancedFields(turnsVar, budgetVar string) {
 templ workflowActivateToggle() {
 	<label class="flex items-center gap-2 cursor-pointer tooltip tooltip-bottom" data-tip="Activate as soon as it's set up">
 		<span class="text-xs text-base-content/55 hidden sm:inline">Activate</span>
-		<input type="checkbox" name="enabled" value="true" checked class="toggle toggle-sm toggle-primary"/>
+		<input type="checkbox" name="enabled" value="true" checked class="toggle toggle-sm"/>
 	</label>
 }
 
@@ -433,7 +439,7 @@ templ workflowReconfigureToggle() {
 		<span class="text-xs text-base-content/55 hidden sm:inline" x-text="reconfigure.enabled ? 'On' : 'Off'"></span>
 		<input
 			type="checkbox"
-			class="toggle toggle-sm toggle-primary"
+			class="toggle toggle-sm"
 			x-model="reconfigure.enabled"
 			@change="toggleWorkflow(reconfigure.slug, $event.target)"
 		/>
@@ -466,15 +472,15 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 				for _, opt := range preset.Options {
 					<div>
 						<div class="text-sm font-medium mb-1.5">{ opt.Label }</div>
-						<select name={ opt.Key } class="select select-sm w-full">
+						<div class="join w-full rounded-lg overflow-hidden">
 							for _, ch := range opt.Choices {
 								if ch.Value == opt.Default {
-									<option value={ ch.Value } selected>{ ch.Label }</option>
+									<input type="radio" name={ opt.Key } value={ ch.Value } aria-label={ ch.Label } class="join-item btn btn-sm flex-1 checked:btn-primary" checked/>
 								} else {
-									<option value={ ch.Value }>{ ch.Label }</option>
+									<input type="radio" name={ opt.Key } value={ ch.Value } aria-label={ ch.Label } class="join-item btn btn-sm flex-1 checked:btn-primary"/>
 								}
 							}
-						</select>
+						</div>
 						if opt.Help != "" {
 							<div class="text-xs text-base-content/40 mt-1">{ opt.Help }</div>
 						}
@@ -492,7 +498,7 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 							@click={ "previewPrompt('" + preset.Slug + "', '" + preset.Name + "')" }
 						>
 							@components.LucideIcon("file-text", "w-3.5 h-3.5")
-							Preview prompt
+							Workflow prompt
 						</button>
 					</div>
 					<textarea
@@ -528,4 +534,3 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 		</form>
 	}
 }
-

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -87,7 +87,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				}
 			}
 		}
-		<!-- F2: Preview-prompt modal — one shared daisy dialog filled on demand by previewPrompt(). -->
+		// F2: workflow-prompt preview modal — one shared daisy dialog filled on demand by previewPrompt().
 		@workflowPromptPreviewModal()
 		// F3: one shared reconfigure drawer, hydrated by openReconfigure() from
 		// GET /-/workflows/{slug}/config. Admin-only (the link that opens it is).
@@ -205,8 +205,8 @@ templ workflowPromptPreviewModal() {
 				<span class="loading loading-spinner loading-sm"></span>
 				Loading prompt…
 			</div>
-			<!-- Rendered as markdown via bbRenderMarkdown() in previewPrompt();
-			     x-ref lets the factory target this element after the async fetch. -->
+			// Rendered as markdown via bbRenderMarkdown() in previewPrompt();
+			// x-ref lets the factory target this element after the async fetch.
 			<div
 				x-show="!previewLoading"
 				x-cloak

--- a/internal/templates/components/pages/workflows_gallery_render_test.go
+++ b/internal/templates/components/pages/workflows_gallery_render_test.go
@@ -177,10 +177,11 @@ func TestT15WorkflowsGalleryGridAndTiles(t *testing.T) {
 		t.Error("expected the preset icon (lucide-tag) to render in its card tile")
 	}
 
-	// Preview prompt now lives inside the configure/reconfigure drawer, not
-	// the card ⋯ menu. The button + its handler should be present (admin view).
-	if !strings.Contains(html, "Preview prompt") || !strings.Contains(html, "previewPrompt(") {
-		t.Error("expected the Preview prompt affordance inside the drawer (button + handler)")
+	// The workflow-prompt preview now lives inside the configure/reconfigure
+	// drawer, not the card ⋯ menu. The button + its handler should be present
+	// (admin view).
+	if !strings.Contains(html, "Workflow prompt") || !strings.Contains(html, "previewPrompt(") {
+		t.Error("expected the Workflow prompt affordance inside the drawer (button + handler)")
 	}
 
 	// The cleaned-up row uses a settings gear (not a ⋯ kebab) as the
@@ -316,10 +317,13 @@ func TestT15WorkflowsGalleryNonAdminDisablesSetUp(t *testing.T) {
 	if strings.Contains(html, "submitDrawer") {
 		t.Error("expected no configure drawer (submitDrawer) for non-admin user")
 	}
-	// Preview prompt lives only inside the (admin-only) drawer now, so a
-	// non-admin sees no Preview prompt affordance at all.
-	if strings.Contains(html, "Preview prompt") {
-		t.Error("expected no Preview prompt affordance for non-admin (it lives in the admin-only drawer)")
+	// The workflow-prompt preview opener lives only inside the (admin-only)
+	// drawers, so a non-admin gets no previewPrompt() affordance. (The shared
+	// preview <dialog> itself is always in the DOM — its title fallback
+	// literal "Workflow prompt" is inert without a button to open it — so we
+	// assert on the open handler, not the label.)
+	if strings.Contains(html, "previewPrompt(") {
+		t.Error("expected no previewPrompt() affordance for non-admin (it lives in the admin-only drawer)")
 	}
 }
 

--- a/internal/templates/components/settings_modal_types.go
+++ b/internal/templates/components/settings_modal_types.go
@@ -13,7 +13,7 @@ const (
 	SettingsModalTabGeneral   = "general"
 	SettingsModalTabSystem    = "system"
 	SettingsModalTabProviders = "providers"
-	SettingsModalTabAgents    = "agents"
+	SettingsModalTabWorkflows = "workflows"
 	SettingsModalTabMCP       = "mcp"
 	SettingsModalTabAccess    = "api-keys"
 	SettingsModalTabBackups   = "backups"

--- a/static/js/admin/components/agent_sdk_settings.js
+++ b/static/js/admin/components/agent_sdk_settings.js
@@ -1,7 +1,7 @@
 // Agent SDK settings — Diagnostics card factory.
 //
 // Powers the "Run smoke test" + "Run cleanup now" buttons on
-// /settings/agents. Reads its CSRF token from a sibling data-* attribute on
+// /settings/workflows. Reads its CSRF token from a sibling data-* attribute on
 // the x-data root so the factory itself takes no arguments (per the
 // docs/design-system.md → "Alpine page components" convention).
 document.addEventListener('alpine:init', function () {

--- a/static/js/admin/components/settings_page.js
+++ b/static/js/admin/components/settings_page.js
@@ -270,7 +270,7 @@ document.addEventListener('alpine:init', function () {
 // Valid settings tab ids — used by parseSettingsRedirect to classify a
 // response URL as inside the settings space.
 var BB_SETTINGS_PAGE_TABS = {
-  account: 1, general: 1, system: 1, providers: 1, agents: 1,
+  account: 1, general: 1, system: 1, providers: 1, workflows: 1,
   mcp: 1, 'api-keys': 1, backups: 1, help: 1,
 };
 
@@ -360,7 +360,7 @@ var BB_SETTINGS_SKELETONS = {
   'api-keys': { sections: [3, 3] },
   backups: { sections: [3, 2, 2] },
   providers: { sections: [3, 3, 2] },
-  agents: { sections: [3, 4, 2] },
+  workflows: { sections: [3, 4, 2] },
   mcp: { sections: [2, 2, 2, 3] },
   _default: { sections: [3, 3] },
 };

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -20,6 +20,9 @@ document.addEventListener('alpine:init', function () {
       previewTitle: '',
       previewBody: '',
       previewLoading: false,
+      // previewCopied briefly flips true after a successful Copy so the
+      // button can show a "Copied" confirmation.
+      previewCopied: false,
       // -------------------------------------------------------------------
 
       // --- F3: reconfigure an enabled workflow ---------------------------
@@ -230,7 +233,11 @@ document.addEventListener('alpine:init', function () {
           return;
         }
         self.cronPreviewLoading = true;
-        fetch('/-/workflows/cron-preview?cron=' + encodeURIComponent(cron), {
+        // Pass the viewer's IANA timezone so the preview renders the schedule
+        // in their local time (the scheduler fires cron in the server's tz).
+        var tz = '';
+        try { tz = Intl.DateTimeFormat().resolvedOptions().timeZone || ''; } catch (e) { tz = ''; }
+        fetch('/-/workflows/cron-preview?cron=' + encodeURIComponent(cron) + (tz ? '&tz=' + encodeURIComponent(tz) : ''), {
           credentials: 'same-origin',
           headers: { Accept: 'application/json' },
         })
@@ -322,7 +329,52 @@ document.addEventListener('alpine:init', function () {
           } else {
             el.textContent = self.previewBody || '';
           }
+          // The body element is reused across opens; reset its scroll so a
+          // new prompt always starts at the top rather than wherever the
+          // previous one was left scrolled. The element is x-show-gated on
+          // previewLoading, so a same-tick reset can land while it's still
+          // display:none (a no-op). rAF defers until after x-show flushes and
+          // the element is laid out, so the reset actually sticks.
+          el.scrollTop = 0;
+          requestAnimationFrame(function () { el.scrollTop = 0; });
         });
+      },
+
+      // copyPrompt copies the raw (markdown source) workflow prompt to the
+      // clipboard. Bound to the modal's Copy button and the 'c' shortcut.
+      // Flashes previewCopied for confirmation. Falls back to a hidden
+      // textarea + execCommand on browsers without the async clipboard API.
+      copyPrompt: function () {
+        var self = this;
+        var text = self.previewBody || '';
+        if (!text) return;
+        var done = function () {
+          self.previewCopied = true;
+          setTimeout(function () { self.previewCopied = false; }, 1500);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {
+            self._copyFallback(text, done);
+          });
+        } else {
+          self._copyFallback(text, done);
+        }
+      },
+
+      _copyFallback: function (text, done) {
+        try {
+          var ta = document.createElement('textarea');
+          ta.value = text;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+          done();
+        } catch (e) {
+          console.error('copyPrompt fallback failed', e);
+        }
       },
       // -------------------------------------------------------------------
     };


### PR DESCRIPTION
Follow-ups from hands-on review of the Workflows settings page and the configure/reconfigure drawer. Fourteen small fixes, all validated in a real browser with zero console errors. #1663 (the configure drawer) is already merged; this builds on top of it.

## Settings page
- **Rename `/settings/agents` → `/settings/workflows`** — full tab-id rename across the router, settings rail, `SettingsTab` constant, the JS tab-swapper, and the nav active-key, plus a **301 redirect** from the old path so bookmarks keep working.
- **Auth section** — the two auth options (Subscription token / API key) are now a **full-width 2-up grid**, and the credential field renders **below both cards** instead of wedged between them.
- **Removed the Overview** stat-tile section (and its now-dead builder/types/helpers). Status + Configuration remain.

## Configure / reconfigure drawer
- **Apply mode → segmented control** (daisy `join` of radio-buttons) instead of a `<select>`. The join clips to a rounded rect so both end corners round correctly (fixes the missing left corner) in both the server-rendered and Alpine-`<template>` drawers.
- **Primary tone, not green** — trigger cards, the segmented control, and the schedule pills use the design-system primary tone (the green tint came from the Mintlify copy).
- **Green toggles** — the on/off Activate / run switches render green when enabled (default daisy toggle).
- **Schedule pills** are larger (`btn-sm`) and show **solid primary** when their cron matches the current value.
- **Advanced** is no longer collapsible — the cost-cap + max-turns fields render as **one two-column row**.

## Prompt preview modal
- Renamed the button + modal to **"Workflow prompt"**.
- Added a **Copy button with a `C` kbd hint**; `c` copies while the modal is open (guarded so native ⌘/Ctrl+C still works).
- **Escape closes only the modal**, leaving the drawer open (the shared `Drawer` defers its escape handler while a `<dialog>` is open).
- The body always opens **scrolled to the top**.

## Cron preview timezone
- The live schedule preview localizes to the **viewer's IANA timezone** (sent from the browser). The scheduler fires cron in the server's tz, so times are shifted into the viewer's zone with a `(your time)` label. Representable cases (single hour:minute, weekday-wrap) convert via `shiftCronTimeFields` (unit-tested); complex expressions fall back to a labeled server-time render.

## Screenshots

<table>
<tr><th>Configure drawer</th><th>Auth section</th><th>Prompt preview</th></tr>
<tr>
<td><img src="https://i.img402.dev/0zvj696rfe.jpg" width="280" alt="configure drawer — segmented apply-mode, green toggle, primary pills, 2-col Advanced"></td>
<td><img src="https://i.img402.dev/j7hpsxjzuc.jpg" width="280" alt="auth section — full-width options, field below"></td>
<td><img src="https://i.img402.dev/urmx2d56o9.jpg" width="280" alt="prompt preview — Copy button with C kbd"></td>
</tr>
</table>

## Validation
- `go build ./...`, `go vet`, unit tests, and the cron + workflow-config integration tests all green.
- Lite CLI build green; new files correctly build-tagged.
- Browser-validated: rename (200 new / 301 old), auth layout, segmented control geometry, green toggle (`rgb(52,199,89)`), Escape sequence, copy via click **and** `c`, scroll-to-top, and cron-tz (`Asia/Tokyo` → "12:00 AM (your time)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
