### PR TITLE
feat(ui): move the update banner into a dismissible sidebar card

### DIFF
--- a/input.css
+++ b/input.css
@@ -1013,6 +1013,47 @@
     @apply bg-warning/22 text-warning;
   }
 
+  /* ── Update-available callout card ──
+     A small "what's new"-style nudge pinned to the foot of the rail (above
+     the Collapse button) when an admin runs an older release than the latest
+     GitHub tag. A bright base-100 card on the recessed base-200 rail with a
+     dismiss ✕. Part of the bespoke .bb-sidebar-* rail surface (daisy has no
+     sidebar-callout primitive); the collapsed-rail hide lives with the other
+     collapse rules below. */
+  .bb-update-card {
+    @apply relative mt-2 flex flex-col gap-1 rounded-xl border border-base-300
+           bg-base-100 p-3 shadow-sm;
+  }
+  .bb-update-card__dismiss {
+    @apply absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center
+           rounded-md text-base-content/40 cursor-pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+  .bb-update-card__dismiss:hover {
+    @apply bg-base-200 text-base-content/70;
+  }
+  .bb-update-card__dismiss svg { @apply h-3.5 w-3.5; }
+  .bb-update-card__eyebrow {
+    @apply inline-flex items-center gap-1 text-[0.7rem] font-semibold uppercase
+           tracking-wide text-success;
+  }
+  .bb-update-card__eyebrow svg { @apply h-3.5 w-3.5; }
+  .bb-update-card__title {
+    @apply pr-5 text-sm font-semibold leading-tight text-base-content;
+  }
+  .bb-update-card__desc {
+    @apply text-xs leading-snug text-base-content/60;
+  }
+  .bb-update-card__action {
+    @apply mt-1 inline-flex items-center gap-1 text-xs font-semibold text-primary no-underline;
+  }
+  .bb-update-card__action:hover { @apply underline; }
+  .bb-update-card__action svg {
+    @apply h-3.5 w-3.5;
+    transition: transform 0.15s ease;
+  }
+  .bb-update-card__action:hover svg { transform: translateX(2px); }
+
   /* ── Tag chips (pill-shaped) ── */
   /*
    * Canonical tag styling. Always pill-shaped to differentiate from status badges.
@@ -3232,6 +3273,11 @@
   /* Badges have nowhere to sit in the rail. */
   html[data-sidebar="collapsed"] .bb-sidebar .bb-nav-badge,
   html[data-sidebar="collapsed"] .bb-sidebar .badge {
+    display: none;
+  }
+
+  /* The update callout card can't fold into the 4rem icon rail. */
+  html[data-sidebar="collapsed"] .bb-sidebar .bb-update-card {
     display: none;
   }
 }

--- a/internal/admin/stubs_headless.go
+++ b/internal/admin/stubs_headless.go
@@ -43,6 +43,10 @@ func (*TemplateRenderer) SetVersion(string) {}
 // internal/version into the stub.
 func (*TemplateRenderer) SetVersionChecker(any) {}
 
+// SetAppConfigReader is a no-op on headless builds. Accepts any to avoid
+// dragging internal/appconfig into the stub.
+func (*TemplateRenderer) SetAppConfigReader(any) {}
+
 // NewSessionManager mirrors the real signature. Returns a real (empty)
 // scs.SessionManager so chi middleware that handles it as an interface
 // continues to type-check.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"breadbox/internal/appconfig"
 	"breadbox/internal/templates"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
@@ -297,6 +298,7 @@ type TemplateRenderer struct {
 	sm             *scs.SessionManager
 	version        string
 	versionChecker *version.Checker
+	appcfg         appconfig.Reader
 }
 
 // NewTemplateRenderer parses all embedded templates and returns a renderer.
@@ -489,11 +491,10 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 		}
 		// Auto-inject version update status for nav footer.
 		if _, exists := m["NavUpdateAvailable"]; !exists && tr.versionChecker != nil {
-			updateAvailable, latest, err := tr.versionChecker.CheckForUpdate(r.Context())
-			if err == nil && updateAvailable != nil && *updateAvailable && latest != nil {
+			if show, ver, url := updateCallout(r.Context(), tr.versionChecker, tr.appcfg); show {
 				m["NavUpdateAvailable"] = true
-				m["NavLatestVersion"] = latest.Version
-				m["NavLatestURL"] = latest.URL
+				m["NavLatestVersion"] = ver
+				m["NavLatestURL"] = url
 			}
 		}
 		// Auto-inject sidebar notification badges from middleware context.
@@ -639,6 +640,13 @@ func (tr *TemplateRenderer) SetVersionChecker(vc *version.Checker) {
 	tr.versionChecker = vc
 }
 
+// SetAppConfigReader wires the app_config reader used to honor a dismissed
+// update banner (the "update_dismissed_version" key). Optional — when nil,
+// dismissal is not consulted and the callout shows whenever an update exists.
+func (tr *TemplateRenderer) SetAppConfigReader(r appconfig.Reader) {
+	tr.appcfg = r
+}
+
 // ruleFieldLabel maps a rule-condition field name to its human-readable
 // label. Falls back to title-casing the raw identifier so unknown fields
 // still read reasonably.
@@ -755,4 +763,3 @@ func ruleValueFormat(v any) string {
 		return fmt.Sprint(v)
 	}
 }
-

--- a/internal/admin/update.go
+++ b/internal/admin/update.go
@@ -11,13 +11,42 @@ import (
 	"net/http"
 
 	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
+	"breadbox/internal/version"
 )
 
-// DismissUpdateHandler handles POST /admin/api/update/dismiss.
+// updateCallout reports whether the "update available" sidebar callout should
+// render, combining the cached GitHub version check with the admin's last
+// dismissal. The callout is suppressed once the newest release has been
+// dismissed (stored in app_config under "update_dismissed_version" by
+// DismissUpdateHandler) and resurfaces automatically when a release newer than
+// the dismissed one ships. cfg may be nil, in which case dismissal is ignored.
+//
+// Intentionally consulted only for the passive sidebar nudge — the Settings →
+// System version badge always reflects true version state regardless of
+// dismissal, so dismissing the nudge never makes the app claim it's "up to
+// date" when it isn't.
+func updateCallout(ctx context.Context, vc *version.Checker, cfg appconfig.Reader) (show bool, latestVersion, latestURL string) {
+	if vc == nil {
+		return false, "", ""
+	}
+	available, latest, err := vc.CheckForUpdate(ctx)
+	if err != nil || available == nil || !*available || latest == nil {
+		return false, "", ""
+	}
+	if cfg != nil {
+		if dismissed := appconfig.String(ctx, cfg, "update_dismissed_version", ""); dismissed == latest.Version {
+			return false, "", ""
+		}
+	}
+	return true, latest.Version, latest.URL
+}
+
+// DismissUpdateHandler handles POST /-/update/dismiss.
 // It stores the dismissed version in app_config so the banner is hidden until
-// a newer release is published.
+// a newer release is published (read back by updateCallout).
 func DismissUpdateHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
@@ -37,7 +66,7 @@ func DismissUpdateHandler(a *app.App) http.HandlerFunc {
 	}
 }
 
-// TriggerUpdateHandler handles POST /admin/api/update.
+// TriggerUpdateHandler handles POST /-/update.
 // It pulls the latest Docker image via the Docker Engine API (Unix socket).
 // After pulling, the admin must run `docker compose up -d` to apply the update.
 func TriggerUpdateHandler(a *app.App) http.HandlerFunc {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -304,6 +304,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		} else {
 			tr.SetVersion(a.Config.Version)
 			tr.SetVersionChecker(a.VersionChecker)
+			tr.SetAppConfigReader(a.Queries)
 			adminRouter := admin.NewAdminRouter(a, sm, tr, svc, mcpServer)
 			r.Mount("/", adminRouter)
 		}

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -87,18 +87,40 @@ templ Nav(p NavProps) {
 		}
 		@navLink("/settings/account", "settings", "Settings", navSettingsActive(p.CurrentPage))
 	</nav>
+	// Update-available callout. A small card pinned to the foot of the rail
+	// (above the Collapse button) when an admin runs an older release than the
+	// latest GitHub tag. The ✕ POSTs the version to /-/update/dismiss (CSRF
+	// auto-injected by base.html's fetch wrapper) so it stays gone until a
+	// newer release ships. Hidden in the collapsed icon-rail (no room) — see
+	// the .bb-update-card rule in input.css. Dismissal is read back server-side
+	// in templates.go::updateCallout so it survives navigation.
 	if p.NavUpdateAvailable && p.IsAdmin {
-		<a
-			href={ templ.SafeURL(p.NavLatestURL) }
-			target="_blank"
-			rel="noopener noreferrer"
-			class="bb-sidebar-link text-warning"
-			title={ "Release notes for " + p.NavLatestVersion }
-		>
-			@LucideIcon("arrow-up-circle", "")
-			<span class="bb-sidebar-link__label">Update available</span>
-			<span class="badge badge-soft badge-warning badge-xs">{ p.NavLatestVersion }</span>
-		</a>
+		<div class="bb-update-card" x-data="{ shown: true }" x-show="shown" data-version={ p.NavLatestVersion }>
+			<button
+				type="button"
+				class="bb-update-card__dismiss"
+				aria-label="Dismiss update notice"
+				@click="shown = false; fetch('/-/update/dismiss', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ version: $root.dataset.version }) }).catch(() => {})"
+			>
+				@LucideIcon("x", "")
+			</button>
+			<span class="bb-update-card__eyebrow">
+				@LucideIcon("arrow-up-circle", "")
+				Update
+			</span>
+			<p class="bb-update-card__title">Version { p.NavLatestVersion }</p>
+			<p class="bb-update-card__desc">A new release of Breadbox is available.</p>
+			<a
+				href={ templ.SafeURL(p.NavLatestURL) }
+				target="_blank"
+				rel="noopener noreferrer"
+				class="bb-update-card__action"
+				title={ "Release notes for " + p.NavLatestVersion }
+			>
+				Release notes
+				@LucideIcon("arrow-right", "")
+			</a>
+		</div>
 	}
 	// Collapse toggle — pinned to the rail's foot (Mintlify-style). Desktop
 	// only; on mobile the drawer is a transient overlay with no collapsed


### PR DESCRIPTION
## What

Moves the admin **"Update available"** banner out of the flat nav-link slot and into a small "what's new"-style **card** pinned to the foot of the sidebar, just above **Collapse** — eyebrow + version + one-line description + **Release notes →** link + a **✕ dismiss**. Hidden in the collapsed icon-rail (consistent with how nav badges hide there).

## Why

The old banner was a warning-colored link with no way to dismiss it. The `DismissUpdateHandler` already existed and wrote `update_dismissed_version` to `app_config`, **but nothing ever read that key back** — so the banner could never actually be dismissed.

## Changes

- **`nav.templ`** — the card markup (`.bb-update-card`), Alpine `x-data` for the optimistic hide, `✕` POSTs to dismiss.
- **`update.go`** — new `updateCallout()` helper combines the cached GitHub version check with `update_dismissed_version`; suppresses the card once the **latest** release has been dismissed, and resurfaces it when a newer release ships.
- **`templates.go` / `router.go` / `stubs_headless.go`** — the renderer gains an `appconfig.Reader` so the nav injection can consult the dismissal (no-op on `-tags=headless`).
- **`input.css`** — `.bb-update-card*` styles + collapsed-rail hide rule.
- The **Settings → System** version badge **deliberately ignores** dismissal, so dismissing the nudge never makes the app claim it's "up to date" when it isn't.

### Bug caught while validating

The dismiss handler's doc-comment said the route was `/admin/api/update/dismiss` — the real path is **`/-/update/dismiss`** (the former 404s). Fixed in the client `fetch` and the handler doc-comments.

## Screenshots

<img src="https://i.img402.dev/mk1oz39ue4.jpg" width="320" alt="update card — close-up">

<table>
  <tr><th>Light</th><th>Dark</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/9nyj39aomn.jpg" width="400" alt="sidebar update card — light"></td>
    <td><img src="https://i.img402.dev/s4cyddvc62.jpg" width="400" alt="sidebar update card — dark"></td>
  </tr>
</table>

> `Version 1.5.0` is placeholder text forced for the screenshot (dev builds report version `dev`, which suppresses the real check). In production it shows the actual latest GitHub release.

## Testing

- `go build ./...`, `go build -tags=headless ./...`, `go vet`, unit tests (`version` / `templates` / `appconfig`) — all green.
- Verified in a real browser: card renders in light + dark, sits above Collapse, hidden when the rail is collapsed.
- Dismiss click hides the card and `POST /-/update/dismiss` returns `{"ok":true}` and persists the row (cleaned up after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
