### PR TITLE
chore(release): consolidate CHANGELOG into the 0.1.0 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,38 @@ All notable changes to Breadbox will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.0] - 2026-06-01
 
-### Fixed
+> **Pre-1.0.** Breadbox follows SemVer — while we're on `0.x`, minor releases may
+> include breaking changes. Pin your version and review the changelog before
+> upgrading. The **Changed / Deprecated / Fixed / Breaking Changes** notes below
+> are relative to recent unreleased `main` builds; for a fresh install,
+> everything here is simply part of 0.1.0.
 
-- **MCP tool `list_annotations`** now wraps its response in a `{ "annotations": [...] }` envelope. The previous bare-array shape failed client-side schema validation on clients that strictly enforce the MCP spec — `structuredContent` is required to be a JSON record, not an array. The new envelope matches every other list tool (`list_accounts`, `list_categories`, `list_tags`, …) and the REST `/transactions/{id}/annotations` endpoint.
+### Added
+
+- Bank sync via Plaid, Teller, and CSV import
+- REST API for transaction queries, categories, rules, and account management
+- MCP server (Streamable HTTP + stdio) for AI agent integration
+- Admin dashboard with DaisyUI 5 + Alpine.js
+- Transaction rules engine with recursive AND/OR/NOT conditions
+- Review queue for transaction triage (auto-enqueue during sync)
+- Account linking for cross-connection transaction deduplication
+- Multi-user household support (admin + family members)
+- Category system with 2-level hierarchy and slug-based identification
+- Field selection on queries for response size control
+- Transaction and merchant summary aggregations
+- Agent reports for AI agents to submit findings
+- API key authentication with scoped access (full/read-only)
+- MCP permissions (read-only/read-write mode, per-tool enable/disable)
+- AES-256-GCM encryption for provider credentials at rest
+- Docker deployment with Caddy auto-HTTPS
+- CLI tool (`breadbox serve`, `breadbox create-admin`, `breadbox mcp-stdio`)
+- **Claude Agent SDK integration**: schedule recurring AI workflows from the v2 SPA at `/v2/agents`. Self-hosters configure an Anthropic credential (subscription OAuth token or API key, AES-256-GCM encrypted at rest), pick from 5 seeded starter agents (Initial Setup, Bulk Review, Quick Review, Routine Review, Spending Report), or author their own with a full prompt builder. Runs fire via the bundled `breadbox-agent` sidecar (built with `make agent-sidecar`), call breadbox MCP to enrich/categorize/review data, and surface in a run history page with a transcript viewer showing turns, tool calls, cost, and token usage. Safety: per-agent + global cost/turn caps; server-wide concurrency mutex; mint-and-revoke scoped API keys per run; daily cleanup of old runs. Every legacy v1 admin agent URL (`/agent-prompts`, `/agent-wizard/*`, `/agents`) now 302s to `/v2/agents`. See [Agents on docs.breadbox.sh](https://docs.breadbox.sh/guides/multi-agent-reviewer).
+- **`breadbox agent run <slug>` CLI** for triggering a named agent from cron/shell — same code path as the v2 SPA "Run now" button. Mints a scoped API key, spawns the sidecar, persists the `agent_runs` row, revokes the key. `--json` emits the full result for scripting.
+- **`breadbox agent test` CLI** for diagnosing the agent subsystem end-to-end: verifies auth is configured, sidecar binary is discoverable, and a tiny "say OK" prompt round-trips through the SDK. Exit code 3 = no auth, 5 = no binary.
+- **`breadbox doctor` now reports an `agent subsystem` line**: PASS when both an Anthropic credential and the `breadbox-agent` binary are present, WARN with remediation when one is missing, SKIP when the subsystem hasn't been set up. Free + side-effect-free — for the live API round-trip use `breadbox agent test`.
+- **MCP tool `list_annotations`** now accepts an optional `kinds` filter using generic, agent-friendly names: `comment`, `rule`, `tag`, `category`. Each response row carries the generic `kind` plus an `action` field (`added` / `removed` for `tag`, `set` for `category`, `applied` for `rule`) so agents can branch on the specific event without parsing the kind string. Empty preserves the existing full-timeline behavior. Pass `kinds=['comment']` for the comment-only view (replaces `list_transaction_comments`); pass `kinds=['tag']` for both add+remove tag events; pass `kinds=['comment','tag','category']` to skip rule-application churn. The DB-level kinds (`tag_added`, `tag_removed`, `rule_applied`, `category_set`) are no longer accepted at the MCP boundary — use the generic names. The admin UI and other internal code paths still see the raw DB kinds (no behavior change). (#776)
 
 ### Changed
 
@@ -43,12 +70,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
   Skipping the migration leaves prior transcripts and backups stranded on the old volumes — Breadbox still works, but old data is invisible until copied over. Fresh installs are unaffected.
 
-### Added
+### Deprecated
 
-- **`breadbox agent test` CLI** for diagnosing the agent subsystem end-to-end: verifies auth is configured, sidecar binary is discoverable, and a tiny "say OK" prompt round-trips through the SDK. Exit code 3 = no auth, 5 = no binary.
-- **`breadbox agent run <slug>` CLI** for triggering a named agent from cron/shell — same code path as the v2 SPA "Run now" button. Mints a scoped API key, spawns the sidecar, persists the `agent_runs` row, revokes the key. `--json` emits the full result for scripting.
-- **`breadbox doctor` now reports an `agent subsystem` line**: PASS when both an Anthropic credential and the `breadbox-agent` binary are present, WARN with remediation when one is missing, SKIP when the subsystem hasn't been set up. Free + side-effect-free — for the live API round-trip use `breadbox agent test`.
-- **Claude Agent SDK integration**: schedule recurring AI workflows from the v2 SPA at `/v2/agents`. Self-hosters configure an Anthropic credential (subscription OAuth token or API key, AES-256-GCM encrypted at rest), pick from 5 seeded starter agents (Initial Setup, Bulk Review, Quick Review, Routine Review, Spending Report), or author their own with a full prompt builder. Runs fire via the bundled `breadbox-agent` sidecar (built with `make agent-sidecar`), call breadbox MCP to enrich/categorize/review data, and surface in a run history page with a transcript viewer showing turns, tool calls, cost, and token usage. Safety: per-agent + global cost/turn caps; server-wide concurrency mutex; mint-and-revoke scoped API keys per run; daily cleanup of old runs. Every legacy v1 admin agent URL (`/agent-prompts`, `/agent-wizard/*`, `/agents`) now 302s to `/v2/agents`. See [Agents on docs.breadbox.sh](https://docs.breadbox.sh/guides/multi-agent-reviewer).
+- **MCP tool `list_transaction_comments`** is deprecated in favor of `list_annotations` with `kinds=['comment']`. The new `kinds` filter on `list_annotations` returns the same comment data using the canonical annotation shape. The legacy tool still works for now but will be removed in a future release. (#776)
+
+### Fixed
+
+- **MCP tool `list_annotations`** now wraps its response in a `{ "annotations": [...] }` envelope. The previous bare-array shape failed client-side schema validation on clients that strictly enforce the MCP spec — `structuredContent` is required to be a JSON record, not an array. The new envelope matches every other list tool (`list_accounts`, `list_categories`, `list_tags`, …) and the REST `/transactions/{id}/annotations` endpoint.
 
 ### Breaking Changes (Pre-1.0)
 
@@ -60,32 +88,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   - Sort parameter: `sort_by=name` → `sort_by=provider_name` (`date`, `amount` unchanged)
   - New `provider_raw JSONB` column stores the unmodified provider payload for each transaction
 - **Rule DSL field renames.** Rules condition trees now use `provider_name`, `provider_merchant_name`, `provider_category_primary`, `provider_category_detailed` instead of the unqualified versions.
-
-### Deprecated
-
-- **MCP tool `list_transaction_comments`** is deprecated in favor of `list_annotations` with `kinds=['comment']`. The new `kinds` filter on `list_annotations` returns the same comment data using the canonical annotation shape. The legacy tool still works for now but will be removed in a future release. (#776)
-
-### Added
-
-- **MCP tool `list_annotations`** now accepts an optional `kinds` filter using generic, agent-friendly names: `comment`, `rule`, `tag`, `category`. Each response row carries the generic `kind` plus an `action` field (`added` / `removed` for `tag`, `set` for `category`, `applied` for `rule`) so agents can branch on the specific event without parsing the kind string. Empty preserves the existing full-timeline behavior. Pass `kinds=['comment']` for the comment-only view (replaces `list_transaction_comments`); pass `kinds=['tag']` for both add+remove tag events; pass `kinds=['comment','tag','category']` to skip rule-application churn. The DB-level kinds (`tag_added`, `tag_removed`, `rule_applied`, `category_set`) are no longer accepted at the MCP boundary — use the generic names. The admin UI and other internal code paths still see the raw DB kinds (no behavior change). (#776)
-
-## [0.1.0] - 2026-04-XX
-
-### Added
-- Bank sync via Plaid, Teller, and CSV import
-- REST API for transaction queries, categories, rules, and account management
-- MCP server (Streamable HTTP + stdio) for AI agent integration
-- Admin dashboard with DaisyUI 5 + Alpine.js
-- Transaction rules engine with recursive AND/OR/NOT conditions
-- Review queue for transaction triage (auto-enqueue during sync)
-- Account linking for cross-connection transaction deduplication
-- Multi-user household support (admin + family members)
-- Category system with 2-level hierarchy and slug-based identification
-- Field selection on queries for response size control
-- Transaction and merchant summary aggregations
-- Agent reports for AI agents to submit findings
-- API key authentication with scoped access (full/read-only)
-- MCP permissions (read-only/read-write mode, per-tool enable/disable)
-- AES-256-GCM encryption for provider credentials at rest
-- Docker deployment with Caddy auto-HTTPS
-- CLI tool (`breadbox serve`, `breadbox create-admin`, `breadbox mcp-stdio`)


### PR DESCRIPTION
Prepares the **first tagged release, `v0.1.0`**, by consolidating the changelog so the release workflow emits complete notes.

## What changed

- Folds the `[Unreleased]` entries **and** the base `[0.1.0]` placeholder into a single dated `## [0.1.0] - 2026-06-01` section.
- Adds a **Pre-1.0 callout**: while on `0.x`, minor releases may include breaking changes; the Changed/Deprecated/Fixed/Breaking entries are relative to recent unreleased `main` builds, so fresh installs can read them simply as "what's in 0.1.0."

CHANGELOG-only — no code, no generated files.

## Why this shape

`release.yml` builds release notes from the **first `## ` section** of `CHANGELOG.md` and fails if that section is empty. Leaving an empty `[Unreleased]` on top would break that extractor, so `## [0.1.0]` is the first section. An `[Unreleased]` header will be re-added when the next change lands.

Verified locally with the workflow's exact `awk`: 83 lines extracted, callout first, non-empty.

## Release plan (after merge)

1. Tag `v0.1.0` on the merge commit and push → triggers `release.yml`.
2. Workflow cross-compiles binaries, pushes `ghcr.io/canalesb93/breadbox:0.1.0` + `:latest`, and creates a GitHub Release **marked Latest** (not pre-release) so `install.sh`'s `/releases/latest` detection pins installs to `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
