### PR TITLE
fix(ui): keep the fixed Settings rail pinned during page-out nav fade

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2163,13 +2163,9 @@
               this.closePalette();
               return;
             }
-            if (window.bbProgress) window.bbProgress.start();
-            var main = document.querySelector('main');
-            if (main) {
-              main.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
-              main.style.opacity = '0.6';
-              main.style.filter = 'blur(1px)';
-              main.style.pointerEvents = 'none';
+            if (window.bbProgress) {
+              window.bbProgress.start();
+              window.bbProgress.fadeMainOut();
             }
             window.location.href = item.href;
           }
@@ -2400,11 +2396,30 @@
         }, 150);
       }
 
-      // Expose globally
-      window.bbProgress = { start: start, finish: finish, setProgress: setProgress };
+      // Soft page-out fade applied to <main> before a full-page navigation.
+      //
+      // Centralized so the click handler, the command palette, and the
+      // chord dispatcher all fade identically. The blur is deliberately
+      // skipped whenever a fixed Settings rail is on the page: a CSS
+      // `filter` on an ancestor turns that ancestor into the containing
+      // block for its position:fixed descendants, which would rip the
+      // viewport-anchored rail out of place and park it mid-screen for the
+      // duration of the fade (regression once Settings grew a full-page
+      // fixed rail). `opacity` creates no containing block, so opacity-only
+      // leaves the rail pinned.
+      function fadeMainOut() {
+        var main = document.querySelector('main');
+        if (!main) return;
+        main.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
+        main.style.opacity = '0.6';
+        main.style.pointerEvents = 'none';
+        if (!main.querySelector('.bb-settings-rail')) {
+          main.style.filter = 'blur(1px)';
+        }
+      }
 
-      // Main content area for fade effect
-      var mainContent = document.querySelector('main');
+      // Expose globally
+      window.bbProgress = { start: start, finish: finish, setProgress: setProgress, fadeMainOut: fadeMainOut };
 
       // Intercept navigation clicks (sidebar links, breadcrumbs, any internal link)
       document.addEventListener('click', function(e) {
@@ -2433,12 +2448,7 @@
         start();
 
         // Subtle content fade during navigation
-        if (mainContent) {
-          mainContent.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
-          mainContent.style.opacity = '0.6';
-          mainContent.style.filter = 'blur(1px)';
-          mainContent.style.pointerEvents = 'none';
-        }
+        fadeMainOut();
 
         // Mobile sidebar: optimistically move the active marker to the
         // clicked tab and show a trailing spinner. The drawer intentionally
@@ -2583,13 +2593,9 @@
           window.dispatchEvent(new CustomEvent('open-settings', { detail: { tab: settingsTab } }));
           return;
         }
-        if (window.bbProgress) window.bbProgress.start();
-        var main = document.querySelector('main');
-        if (main) {
-          main.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
-          main.style.opacity = '0.6';
-          main.style.filter = 'blur(1px)';
-          main.style.pointerEvents = 'none';
+        if (window.bbProgress) {
+          window.bbProgress.start();
+          window.bbProgress.fadeMainOut();
         }
         window.location.href = path;
       }


### PR DESCRIPTION
## What

The full-page Settings rail jumps to the **middle of the screen** for a split second whenever you navigate to another top-level page — visible only during the page-out fade, then gone once the next page paints.

## Why (root cause — a regression from #1644)

#1644 made the Settings rail `position: fixed` (a true sidebar extension). The rail lives *inside* `<main>`.

On every internal navigation, the global page-out fade in `base.html` sets `filter: blur(1px)` on `<main>`. A CSS `filter` on an ancestor turns that ancestor into the **containing block** for its `position: fixed` descendants. So mid-navigation the rail's `top:0; left:16rem` stopped resolving against the viewport and started resolving against `<main>`'s offset box (pushed right `14rem`, below the topbar) — yanking the rail ~480px right and ~56px down for the duration of the fade.

Measured with the rail forced into the fade state: `left 256 → 736`, `top 0 → 56`.

## Fix

Centralize the three duplicated fade-out blocks (sidebar click handler, command palette, chord dispatcher) into one `fadeMainOut()` helper that **skips the blur whenever a fixed `.bb-settings-rail` is present**. `opacity` creates no containing block, so the opacity-only fade still dims the content but leaves the rail pinned. Blur is unchanged on every other page.

One template file (`base.html`), no CSS or Go changes.

## Validation

Verified in Chrome at 1280×800 against a server serving this branch:

- Forcing the pre-fix blur reproduces the jump (rail floats to mid-screen, **left**).
- The shipped `fadeMainOut()` path keeps `getBoundingClientRect()` identical (`left 256`, `top 0`) and `<main>` `filter: none` while still applying `opacity: 0.6` (**right**).
- On a non-Settings page, `fadeMainOut()` still applies `blur(1px)` — global effect intact.

<table>
  <tr><th>Before — rail jumps mid-screen</th><th>After — rail pinned</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/h52qfgpv4o.jpg" width="420" alt="before — settings rail floated to the middle of the screen during nav fade"></td>
    <td><img src="https://i.img402.dev/lcta2pg11m.jpg" width="420" alt="after — settings rail stays pinned at the left edge during nav fade"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
