### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -194,19 +194,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings/oauth-clients/new", redirectGET("/settings/api-keys"))
 		r.Get("/settings/oauth-clients/{id}/created", redirectGET("/settings/api-keys"))
 
-		// Agents — Claude Agent SDK admin pages.
-		//
-		// IA: /agents is the **runs landing** (the most interesting
-		// surface; what happened, when, with what outcome). The Agents
-		// list (the definitions table) moves to /agents/definitions and
-		// both share a 2-tab nav rendered immediately below the
-		// PageHeader. /agents?agent=<slug> filters the runs feed to one
-		// agent, which subsumes the old /agents/{slug}/runs route.
-		// Legacy /agents/runs and /agents/{slug}/runs 301-redirect.
-		// Legacy /agents page surface is retired — Workflows is the single
-		// automation home. The entry points 301-redirect to their Workflows
-		// equivalents (the hand-authored form pages below stay reachable by
-		// direct URL until the custom-workflow builder lands).
+		// Legacy /agents → Workflows redirects + hand-authored agent form
+		// pages (kept reachable by direct URL until the custom-workflow
+		// builder lands).
 		r.Get("/agents", redirectGET("/workflows/runs"))
 		r.Get("/agents/definitions", redirectGET("/workflows"))
 		r.Get("/workflows", WorkflowsGalleryPageHandler(svc, sm, tr))

--- a/internal/admin/workflows_runs_page.go
+++ b/internal/admin/workflows_runs_page.go
@@ -93,7 +93,7 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			Offset:         offset,
 			HasMore:        result.HasMore,
 			CSRFToken:      GetCSRFToken(r),
-			SubsystemReady: buildAgentsListStatus(subStatus).Ready,
+			SubsystemReady: subStatus != nil && subStatus.Ready,
 			Counts: pages.WorkflowRunStatusCounts{
 				All:        all,
 				Success:    counts["success"],

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -120,21 +120,15 @@ func (s *MCPServer) handleUpdateSeries(ctx context.Context, _ *mcpsdk.CallToolRe
 	if input.ID == "" {
 		return errorResult(fmt.Errorf("id is required")), nil, nil
 	}
-	opt := func(v string) *string {
-		if v == "" {
-			return nil
-		}
-		return &v
-	}
 	edit := service.EditSeriesInput{
-		Name:            opt(input.Name),
+		Name:            optStr(input.Name),
 		ExpectedAmount:  input.ExpectedAmount,
 		AmountTolerance: input.AmountTolerance,
-		Currency:        opt(input.Currency),
-		Cadence:         opt(input.Cadence),
+		Currency:        optStr(input.Currency),
+		Cadence:         optStr(input.Cadence),
 		ExpectedDay:     input.ExpectedDay,
-		CategoryID:      opt(input.CategoryID),
-		UserID:          opt(input.UserID),
+		CategoryID:      optStr(input.CategoryID),
+		UserID:          optStr(input.UserID),
 	}
 	if edit.Name == nil && edit.ExpectedAmount == nil && edit.AmountTolerance == nil &&
 		edit.Currency == nil && edit.Cadence == nil && edit.ExpectedDay == nil &&
@@ -297,23 +291,17 @@ func (s *MCPServer) handleAssignSeries(ctx context.Context, _ *mcpsdk.CallToolRe
 		return errorResult(err), nil, nil
 	}
 	actor := service.ActorFromContext(ctx)
-	opt := func(v string) *string {
-		if v == "" {
-			return nil
-		}
-		return &v
-	}
 	series, err := s.svc.AssignSeries(context.Background(), service.AssignSeriesInput{
-		SeriesID:        opt(input.SeriesID),
+		SeriesID:        optStr(input.SeriesID),
 		MerchantKey:     input.MerchantKey,
 		CreateIfMissing: input.CreateIfMissing,
 		Name:            input.Name,
 		Cadence:         input.Cadence,
 		Type:            input.Type,
 		ExpectedAmount:  input.ExpectedAmount,
-		Currency:        opt(input.Currency),
-		CategoryID:      opt(input.CategoryID),
-		UserID:          opt(input.UserID),
+		Currency:        optStr(input.Currency),
+		CategoryID:      optStr(input.CategoryID),
+		UserID:          optStr(input.UserID),
 		TransactionIDs:  input.TransactionIDs,
 		Confirm:         input.Confirm,
 	}, actor)

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -163,20 +163,9 @@ func (o *Orchestrator) RunNowWith(ctx context.Context, def *AgentDefinitionRespo
 }
 
 // FireSyncCompleteAgents dispatches a webhook-triggered run for every
-// agent definition with trigger_on_sync_complete=true. Called by the sync
-// engine's OnSyncComplete hook after a successful sync. Each agent fires
-// through RunOrSkip with trigger="webhook" so a busy semaphore leaves a
-// skipped row in the history rather than dropping the event silently.
-//
-// Runs each agent in its own goroutine so the sync engine returns
-// immediately. Concurrency is bounded by the orchestrator's existing
-// semaphore (iter-29 default: 3) — excess fires roll into skipped rows.
-//
-// Post-sync debounce: a definition that already ran (non-skipped) within
-// PostSyncDebounceWindow is skipped silently here, so N rapid syncs
-// coalesce to one run instead of fanning out (the design-doc §4
-// cost-amplification trap). The debounce is intentionally row-less — a
-// coalesced trigger isn't a "missed" run worth a skipped row.
+// agent with trigger_on_sync_complete=true. A definition that already ran
+// (non-skipped) within PostSyncDebounceWindow is silently skipped here —
+// row-less, since a coalesced trigger isn't a "missed" run.
 func (o *Orchestrator) FireSyncCompleteAgents(ctx context.Context) {
 	// Use a fresh context for the lookup — the incoming ctx is the sync
 	// engine's, and a cancelled webhook request or timed-out sync would
@@ -414,8 +403,7 @@ func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionRespo
 		// Mirrors the runLocked path; same reasoning as the deferred revoke.
 		persistCtx, persistCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer persistCancel()
-		completedRow, completeErr := o.svc.CompleteAgentRunDB(persistCtx, runRow.ID, result, def.MaxTurns)
-		if completeErr != nil {
+		if _, completeErr := o.svc.CompleteAgentRunDB(persistCtx, runRow.ID, result, def.MaxTurns); completeErr != nil {
 			o.logger.Error("orchestrator: persist completed run failed",
 				"agent", def.Slug, "run", runResp.ShortID, "error", completeErr)
 			return
@@ -426,7 +414,6 @@ func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionRespo
 					"agent", def.Slug, "run", runResp.ShortID, "cap", cap, "error", err)
 			}
 		}
-		_ = completedRow
 		if runErr != nil {
 			o.logger.Warn("orchestrator: run finished with error",
 				"agent", def.Slug, "run", runResp.ShortID,

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -75,7 +75,7 @@ type AgentDefinitionResponse struct {
 	QuietHoursStart *string  `json:"quiet_hours_start,omitempty"`
 	QuietHoursEnd   *string  `json:"quiet_hours_end,omitempty"`
 	// TriggerOnSyncComplete fires this agent after every successful sync
-	// (in addition to any cron schedule). Disabled by default.
+	// (independent of cron).
 	TriggerOnSyncComplete bool `json:"trigger_on_sync_complete"`
 	// SourceTemplate is the workflow-preset slug this definition was
 	// instantiated from, or nil if it was hand-authored.
@@ -156,11 +156,8 @@ type AgentRunResponse struct {
 	CacheReadTokens     *int     `json:"cache_read_tokens,omitempty"`
 	CacheCreationTokens *int     `json:"cache_creation_tokens,omitempty"`
 	TurnCount           *int     `json:"turn_count,omitempty"`
-	// MaxTurnsUsed is the per-run snapshot of the agent's max_turns cap
-	// at the time the run started. Named for historical reasons; "max
-	// turns at run-start" would be clearer. Pair with turn_count to
-	// render "actual / cap". Until iter-33 this column erroneously
-	// mirrored turn_count, making every run look like it hit the cap.
+	// MaxTurnsUsed is the max_turns cap snapshotted at run start; pair
+	// with turn_count for "actual / cap" rendering.
 	MaxTurnsUsed   *int    `json:"max_turns_used,omitempty"`
 	NumToolCalls   *int    `json:"num_tool_calls,omitempty"`
 	ErrorMessage   *string `json:"error_message,omitempty"`

--- a/internal/service/workflow_actions.go
+++ b/internal/service/workflow_actions.go
@@ -4,18 +4,8 @@ package service
 
 import "context"
 
-// GetEnabledWorkflowLastRuns returns the most-recent run for every workflow
-// instantiated from a preset, keyed by the workflow's slug. It reuses the
-// existing per-definition last-run query that ListAgentDefinitions already
-// inlines (GetLatestAgentRun via lastRunSummary) — there's no extra query
-// here, just a projection of the catalog into a slug → last-run map the
-// gallery can render per enabled card.
-//
-// Definitions with no run history (instantiated but never run) are omitted
-// from the map; callers treat a missing key as "never run". Only
-// preset-sourced definitions (SourceTemplate != nil) are included — the
-// gallery only renders cards for presets, so hand-authored agents are
-// irrelevant here.
+// GetEnabledWorkflowLastRuns returns each preset-sourced workflow's
+// most-recent run, keyed by slug. Workflows with no runs are omitted.
 func (s *Service) GetEnabledWorkflowLastRuns(ctx context.Context) (map[string]*AgentRunSummary, error) {
 	defs, err := s.ListAgentDefinitions(ctx)
 	if err != nil {

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -413,20 +413,9 @@ func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, par
 		}
 	}
 
-	prompt, err := composePresetPrompt(preset.PromptBlocks)
+	prompt, err := composeWorkflowPrompt(preset, params.Options, params.AdditionalInstructions)
 	if err != nil {
 		return nil, err
-	}
-	// Apply the preset's specialized options: each chosen choice's directive
-	// is appended to the base prompt (auto/default choices have no directive).
-	prompt += resolveOptionDirectives(preset, params.Options)
-	// Append the household's per-workflow tuning to the base prompt.
-	instr := strings.TrimSpace(params.AdditionalInstructions)
-	if len(instr) > maxAdditionalInstructions {
-		return nil, fmt.Errorf("%w: additional instructions exceed %d chars", ErrInvalidParameter, maxAdditionalInstructions)
-	}
-	if instr != "" {
-		prompt = prompt + "\n\n## Additional instructions\n\n" + instr
 	}
 
 	create := CreateAgentDefinitionParams{

--- a/internal/service/workflows_list.go
+++ b/internal/service/workflows_list.go
@@ -99,13 +99,18 @@ func (s *Service) ListWorkflowsForMCP(ctx context.Context) (*WorkflowsMCPResult,
 	}
 	presets := make([]WorkflowPresetMCPView, 0, len(views))
 	for _, v := range views {
+		var cron *string
+		if v.ScheduleCron != "" {
+			c := v.ScheduleCron
+			cron = &c
+		}
 		presets = append(presets, WorkflowPresetMCPView{
 			Slug:         v.Slug,
 			Name:         v.Name,
 			Category:     v.Category,
 			Description:  v.Description,
 			ToolScope:    v.ToolScope,
-			Trigger:      workflowTriggerLabel(v.TriggerOnSyncComplete, ptrIfNotEmptyStr(v.ScheduleCron)),
+			Trigger:      workflowTriggerLabel(v.TriggerOnSyncComplete, cron),
 			ScheduleCron: v.ScheduleCron,
 			Enabled:      v.Enabled,
 		})
@@ -126,14 +131,4 @@ func workflowTriggerLabel(onSync bool, cron *string) string {
 	default:
 		return "manual"
 	}
-}
-
-// ptrIfNotEmptyStr returns a pointer to s when non-empty, else nil. Local to
-// this file so the preset's plain-string ScheduleCron can reuse the shared
-// trigger-label helper.
-func ptrIfNotEmptyStr(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
 }


### PR DESCRIPTION
## Summary

Daily simplify-drift review of 35 PRs merged in the last 24 hours. Net **-64 LOC** across 8 files. All cleanups behavior-neutral; `go build`, `go vet`, and `go test` all clean.

## PRs reviewed

#1639, #1644, #1646, #1647, #1648, #1649, #1650, #1651, #1652, #1653, #1654, #1655, #1656, #1657, #1658, #1659, #1660, #1661, #1662, #1663, #1664, #1665, #1666, #1667, #1668, #1669, #1670, #1671, #1672, #1673, #1674, #1675, #1676, #1677, #1678

## Changes

**Reuse — call existing helpers instead of re-implementing:**

- `internal/service/workflow_presets.go:416-430` — `EnableWorkflowFromPreset` inlined the prompt composition (`composePresetPrompt` + `resolveOptionDirectives` + `maxAdditionalInstructions` check + heading append) that `composeWorkflowPrompt` was created to share. Call the helper instead — the doc comment on it already promised lockstep.
- `internal/mcp/tools_series.go:123-128, 300-305` — `handleUpdateSeries` and `handleAssignSeries` each defined a local `opt := func(v string) *string {...}` closure when `mcp/helpers.go:15`'s `optStr` is identical. Use the shared helper.

**Dead code:**

- `internal/service/agent_orchestrator.go:417,429` — drop the unused `completedRow` capture and the trailing `_ = completedRow` discard.
- `internal/service/workflows_list.go:131-139` — inline single-use `ptrIfNotEmptyStr` at its one call site; delete the helper.

**Wrong altitude / wasted call:**

- `internal/admin/workflows_runs_page.go:96` — replace `buildAgentsListStatus(subStatus).Ready` with a direct `subStatus != nil && subStatus.Ready` — the helper was being called just to discard its other four fields.

**What-comments trimmed to one-liners (per CLAUDE.md "default to writing no comments; only WHY"):**

- `internal/admin/router.go:197-209` — 13-line obsolete IA-history narrative on the legacy `/agents` redirects → one line stating the live contract.
- `internal/service/agents.go:159-164` — `MaxTurnsUsed` doc was rehashing an iter-33 bug; reduced to the contract.
- `internal/service/agents.go:78` — `TriggerOnSyncComplete` "disabled by default" stated Go's bool zero-value; dropped.
- `internal/service/agent_orchestrator.go:165-180` — `FireSyncCompleteAgents` 16-line doc restated implementation detail visible inline; trimmed to one paragraph stating contract + debounce.
- `internal/service/workflow_actions.go:7-18` — `GetEnabledWorkflowLastRuns` 12-line doc on a 13-line function → one sentence.

## Findings deferred (out of scope for daily simplify-drift)

The review surfaced several deeper opportunities that would change SQL queries, service signatures, or introduce new abstractions — left for a focused PR rather than rolling them into a daily cleanup:

- N+1 in `series.go::emitSeriesMembershipAnnotations` (needs a new batch-insert sqlc query)
- Duplicate `ListAgentDefinitions` call per `/workflows` render (needs to thread `defs` through two service funcs)
- Per-definition debounce probe in `FireSyncCompleteAgents` (needs a new "any-recent-runs" sqlc query)
- `AddSeriesTag`/`RemoveSeriesTag` API + MCP refetch the series after mutation (service signature change)
- `groupWorkflowPresets` defaulting model/max-turns at the admin layer (belongs in `ListWorkflowPresets`'s view model)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (the `internal/agent` `TestSidecarRun_ProcessGroupReapsGrandchild` flake reproduces on pristine `main` and is unrelated)

https://claude.ai/code/session_01P5sxpzsUXUgimxr66MMWMU

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5sxpzsUXUgimxr66MMWMU)_