### PR TITLE
ci: remove redundant tag-triggered release path from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches: [main, "stack/**", "feat/**", "agents/**", "mobile-safari/**", "workflows/**"]
   merge_group:
+  # Releases are tag-driven and handled entirely by release.yml. This workflow
+  # deliberately does NOT trigger on tags: a tag trigger here re-introduces a
+  # second, conflicting release pipeline that double-pushes the Docker image and
+  # races release.yml to publish the GitHub Release (clobbering the curated
+  # CHANGELOG notes with auto-generated ones). See #1677.
   push:
     branches: [main]
-    tags: ["v*"]
 
 concurrency:
   group: deploy-dev-${{ github.ref }}
@@ -295,109 +299,6 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  release:
-    name: Release Binaries
-    needs: [test, test-headless, test-lite]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.25"
-
-      - name: Install sqlc and generate
-        run: |
-          curl -sL https://github.com/sqlc-dev/sqlc/releases/download/v1.30.0/sqlc_1.30.0_linux_amd64.tar.gz | tar xz -C /usr/local/bin sqlc
-          sqlc generate
-
-      - name: Install templ and generate
-        run: |
-          go install github.com/a-h/templ/cmd/templ@latest
-          templ generate
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Build binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          VERSION=${{ github.ref_name }}
-          go build -ldflags "-s -w -X main.version=${VERSION}" \
-            -o breadbox-${{ matrix.goos }}-${{ matrix.goarch }} \
-            ./cmd/breadbox
-
-      - name: Build sidecar (bun cross-compile)
-        # The Claude Agent SDK is TypeScript-only, so the sidecar ships as a
-        # standalone Bun-compiled binary alongside the Go binary. Bun supports
-        # cross-compilation from any host, so we map goos/goarch to the
-        # matching bun --target and emit one sidecar per release matrix cell.
-        run: |
-          cd agent/sidecar
-          bun install --frozen-lockfile
-          case "${{ matrix.goos }}-${{ matrix.goarch }}" in
-            linux-amd64)  TARGET=bun-linux-x64    ;;
-            linux-arm64)  TARGET=bun-linux-arm64  ;;
-            darwin-amd64) TARGET=bun-darwin-x64   ;;
-            darwin-arm64) TARGET=bun-darwin-arm64 ;;
-            *) echo "unsupported matrix cell: ${{ matrix.goos }}-${{ matrix.goarch }}"; exit 1 ;;
-          esac
-          bun build --compile --minify --target=$TARGET \
-            --outfile ../../breadbox-agent-${{ matrix.goos }}-${{ matrix.goarch }} \
-            index.ts
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: breadbox-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: |
-            breadbox-${{ matrix.goos }}-${{ matrix.goarch }}
-            breadbox-agent-${{ matrix.goos }}-${{ matrix.goarch }}
-
-  publish-release:
-    name: Publish Release
-    needs: [release, build]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: Generate SHA256 checksums
-        # `breadbox-*` matches both the Go binary (`breadbox-<os>-<arch>`)
-        # and the sidecar (`breadbox-agent-<os>-<arch>`) per matrix cell.
-        run: |
-          cd artifacts
-          sha256sum breadbox-* > SHA256SUMS
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            artifacts/breadbox-*
-            artifacts/SHA256SUMS
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Makes `release.yml` the single source of truth for tag-driven releases, removing a second, conflicting release path that was hidden inside `ci.yml`.

## Background

Cutting the first tag (`v0.1.0`) exposed **two overlapping release pipelines** firing on `v*`:

| | `release.yml` (canonical) | `ci.yml` `release`/`publish-release` |
|---|---|---|
| Status on v0.1.0 | ✅ succeeded, published the release | ❌ failed |
| Binaries | Go + CLI | Go + sidecar |
| Docker | pushes `:v0.1.0` + `:latest` | *also* pushes `:0.1.0`/`:v0.1.0` |
| Release notes | curated from CHANGELOG | `generate_release_notes: true` (auto) |

The ci.yml path had **never run before** (no prior tags) and failed immediately:

```
static/embed.go:11:12: pattern all:css: no matching files found
```

Its `release` job runs sqlc + templ generate but **skips the Build CSS step** its own test jobs have, so `go build` hits `//go:embed all:css` with no assets. Worse, had it *succeeded* it would have double-pushed the Docker image and raced release.yml to publish the GitHub Release with auto-generated notes — clobbering the curated CHANGELOG release notes.

## Change

- Drop the `tags: ["v*"]` push trigger from `ci.yml` (with a comment so it isn't re-added). ci.yml no longer runs on tags — no redundant test re-run, no red ❌ on the tag.
- Delete the `release` and `publish-release` jobs.
- `build` (Build & Push) now fires only on **main** push (the dev-deploy path); `deploy` is unchanged.

`release.yml` runs `make generate` (sqlc + templ + **css**), so it has no embed failure.

## Caveat (intentional, pre-existing)

`release.yml` ships **Go binaries only**; the agent sidecar is bundled inside the **Docker image**, not as a loose GitHub Release asset. This matches the actual published v0.1.0 release. If you want loose `breadbox-agent-*` binaries on the Release for binary-install users, that's a separate enhancement to release.yml — happy to do it as a follow-up.

## Verification

- `ci.yml` parses as valid YAML; remaining jobs: `test-shards, test, test-headless, test-lite, build, deploy`.
- `on.push` → `branches: [main]` only; `build.if` → `github.event_name == 'push'` (main-only now); `deploy` needs `build`, main+push gated.
- Tests still run on `pull_request` / `merge_group` / main push, so branch-protection required checks are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
