### PR TITLE
fix(workflows): base cron schedule shortcuts on the user's local timezone

### DIFF
--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -17,6 +17,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 	<div
 		x-data="workflowsGallery"
 		data-csrf={ p.CSRFToken }
+		data-server-utc-offset-min={ serverUTCOffsetMin() }
 		x-init="$store.shortcuts.setScope('workflows')"
 		x-destroy="$store.shortcuts.setScope('global')"
 	>
@@ -350,10 +351,10 @@ templ workflowTriggerFields(triggerVar, cronVar string) {
 		<div x-show={ triggerVar + " === 'false'" } x-cloak class="mt-3 space-y-2">
 			<div class="text-xs font-medium text-base-content/70">Schedule</div>
 			<div class="flex flex-wrap gap-1.5">
-				@workflowCronPill(cronVar, "0 8 * * *", "Daily")
-				@workflowCronPill(cronVar, "0 7 * * 1", "Every Monday")
-				@workflowCronPill(cronVar, "0 7 * * 5", "Every Friday")
-				@workflowCronPill(cronVar, "0 8 1 * *", "Monthly")
+				@workflowCronPill(cronVar, "0 9 * * *", "Daily")
+				@workflowCronPill(cronVar, "0 9 * * 1", "Every Monday")
+				@workflowCronPill(cronVar, "0 9 * * 5", "Every Friday")
+				@workflowCronPill(cronVar, "0 9 1 * *", "Monthly")
 			</div>
 			<input
 				type="text"
@@ -373,14 +374,19 @@ templ workflowTriggerFields(triggerVar, cronVar string) {
 	</div>
 }
 
-// workflowCronPill is one schedule shortcut. Sets cronVar to a known cron and
-// refreshes the preview; highlights when it matches the current value.
+// workflowCronPill is one schedule shortcut. `value` is the cron in the
+// VIEWER's local timezone (e.g. "0 9 * * *" = 9 AM their time); on click it's
+// converted to the SERVER-local cron the scheduler stores via
+// localCronToServer(), then the preview refreshes. The pill highlights when
+// the current (server-local) cron equals this shortcut's local intent, so it
+// stays lit across timezones whether clicked, typed, or hydrated from a saved
+// workflow.
 templ workflowCronPill(cronVar, value, label string) {
 	<button
 		type="button"
 		class="btn btn-sm"
-		x-bind:class={ cronVar + " === '" + value + "' ? 'btn-primary' : 'btn-soft'" }
-		@click={ cronVar + " = '" + value + "'; describeCron(" + cronVar + ")" }
+		x-bind:class={ "cronPillActive('" + value + "', " + cronVar + ") ? 'btn-primary' : 'btn-soft'" }
+		@click={ cronVar + " = localCronToServer('" + value + "'); describeCron(" + cronVar + ")" }
 	>
 		{ label }
 	</button>

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -32,6 +32,19 @@ func workflowConfigDrawerData(p WorkflowPresetCardProps) string {
 	)
 }
 
+// serverUTCOffsetMin returns the server's current UTC offset in minutes (east
+// of UTC, matching time.Zone's sign), as a decimal string for a data-* attr.
+// The workflows gallery embeds it on its root element so the cron shortcut
+// pills can translate a friendly hour in the VIEWER's timezone (e.g. 9 AM
+// "your time") into the SERVER-local cron the scheduler actually fires — the
+// inverse of the shift service.DescribeCronInTZ applies for the live preview,
+// so a pill round-trips. Read at the current instant, so it tracks the active
+// DST offset for the near-term schedule being edited.
+func serverUTCOffsetMin() string {
+	_, off := time.Now().Zone()
+	return fmt.Sprintf("%d", off/60)
+}
+
 // workflowBoolJS renders a Go bool as a JS boolean literal, for inline
 // Alpine @click expressions (e.g. the reconfigure gear passing run-state).
 func workflowBoolJS(b bool) string {

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -3,9 +3,75 @@
 // root element's data-csrf attribute. Registers via Alpine.data per the admin
 // page convention (see docs/design-system.md → "Alpine page components").
 document.addEventListener('alpine:init', function () {
+  // ---- cron timezone shift ------------------------------------------------
+  //
+  // The scheduler fires cron in the SERVER's local timezone, but the schedule
+  // shortcut pills express a friendly hour in the VIEWER's timezone ("Daily" =
+  // 9 AM your time). The helpers below convert a viewer-local cron into the
+  // server-local cron we store + submit — the exact inverse of the shift the
+  // cron-preview endpoint (service.DescribeCronInTZ) applies to render a stored
+  // cron back in the viewer's time, so the two round-trip. Ported from
+  // service.shiftCronTimeFields so the client and server agree.
+
+  function cronSingleInt(s) {
+    return /^\d+$/.test(s) ? parseInt(s, 10) : null;
+  }
+
+  // Shift a day-of-week field (single value or comma list, 0/7 = Sunday) by
+  // dayDelta days, wrapping within the week. Returns null for ranges, steps, or
+  // named days so the caller falls back to the unshifted expression.
+  function cronShiftDow(field, dayDelta) {
+    var parts = field.split(',');
+    var out = [];
+    for (var i = 0; i < parts.length; i++) {
+      var p = parts[i].trim();
+      if (!/^\d+$/.test(p)) return null;
+      var n = parseInt(p, 10);
+      if (n < 0 || n > 7) return null;
+      if (n === 7) n = 0; // normalize Sunday
+      out.push(String(((n + dayDelta) % 7 + 7) % 7));
+    }
+    return out.join(',');
+  }
+
+  // Shift a standard 5-field cron's time-of-day by deltaMin minutes, carrying a
+  // midnight wrap into the day-of-week set. Returns null for the
+  // non-representable cases (non-integer minute/hour, or a day-of-month
+  // constrained schedule whose wrap would land on a different calendar day) so
+  // the caller keeps the original. Mirrors service.shiftCronTimeFields.
+  function cronShiftTimeFields(expr, deltaMin) {
+    var f = String(expr).trim().split(/\s+/);
+    if (f.length !== 5) return null;
+    var minute = cronSingleInt(f[0]);
+    var hour = cronSingleInt(f[1]);
+    if (minute === null || hour === null) return null;
+    var total = hour * 60 + minute + deltaMin;
+    var dayDelta = 0;
+    while (total < 0) { total += 1440; dayDelta--; }
+    while (total >= 1440) { total -= 1440; dayDelta++; }
+    f[0] = String(total % 60);
+    f[1] = String(Math.floor(total / 60));
+    if (dayDelta !== 0) {
+      if (f[2] !== '*' || f[3] !== '*') return null; // monthly/dom + wrap → too risky
+      if (f[4] !== '*') { // "*" is daily — a wrap leaves it daily
+        var shifted = cronShiftDow(f[4], dayDelta);
+        if (shifted === null) return null;
+        f[4] = shifted;
+      }
+    }
+    return f.join(' ');
+  }
+  // -------------------------------------------------------------------------
+
   Alpine.data('workflowsGallery', function () {
     return {
       csrfToken: '',
+      // Server's UTC offset in minutes (east of UTC), seeded from the root
+      // element's data-server-utc-offset-min. Drives localCronToServer() so the
+      // schedule shortcut pills resolve to the viewer's local hour. 0 (no
+      // shift) is the right fallback for the common self-hosted case where the
+      // server and the viewer share a timezone.
+      serverUtcOffsetMin: 0,
       // Drawer open/close is owned by the global $store.drawers store
       // (see layout/base.html). The configure drawers are keyed
       // 'wf-config-<presetSlug>'; the shared reconfigure drawer is
@@ -58,6 +124,33 @@ document.addEventListener('alpine:init', function () {
 
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
+        var off = parseInt(this.$el.dataset.serverUtcOffsetMin || '0', 10);
+        this.serverUtcOffsetMin = isNaN(off) ? 0 : off;
+      },
+
+      // localCronToServer converts a viewer-local cron (what a shortcut pill
+      // means — e.g. "0 9 * * *" is 9 AM in the viewer's timezone) into the
+      // server-local cron the scheduler stores + fires. Falls back to the input
+      // unchanged when there's no timezone delta (server tz == viewer tz, the
+      // common self-hosted case) or the shift isn't representable.
+      localCronToServer: function (localExpr) {
+        var viewerOff;
+        try {
+          viewerOff = -new Date().getTimezoneOffset(); // minutes east of UTC
+        } catch (e) {
+          return localExpr;
+        }
+        var deltaMin = this.serverUtcOffsetMin - viewerOff; // viewer-local → server-local
+        if (!deltaMin) return localExpr;
+        return cronShiftTimeFields(localExpr, deltaMin) || localExpr;
+      },
+
+      // cronPillActive highlights a shortcut pill when the current
+      // (server-local) cron equals that pill's viewer-local intent converted to
+      // server time — so a pill stays lit whether it was clicked, typed, or
+      // hydrated from a saved workflow, and across timezones.
+      cronPillActive: function (localExpr, currentCron) {
+        return this.localCronToServer(localExpr).trim() === String(currentCron || '').trim();
       },
 
       restorePageState: function () {


### PR DESCRIPTION
Cron schedule **shortcut pills** in the Workflows configure drawer were writing a hardcoded *server-local* cron, so a user whose timezone differs from the server got the wrong local hour — on a UTC-hosted Breadbox a viewer in PT clicking **Daily** was scheduled for **1 AM** their time.

## What changed
The shortcut pills now express a friendly hour (**9 AM**) in the **viewer's** timezone and convert to the server-local cron the scheduler fires on click — the exact inverse of the shift `service.DescribeCronInTZ` already applies for the live preview, so they round-trip.

- `serverUTCOffsetMin()` embeds the server's current UTC offset on the gallery root element.
- `localCronToServer()` / `cronPillActive()` (JS) port `service.shiftCronTimeFields` / `shiftCronDow` so client and server agree — minute offsets + midnight day-of-week wrap; unsafe day-of-month wraps fall back to the raw expression.
- Pills bumped to 9 AM local (were Daily 8am / Mon,Fri 7am / Monthly 8am).

Same-timezone self-hosters (offset delta 0) get the unchanged cron — behavior is identical to before for them. Shared by both the setup and reconfigure drawers via `workflowCronPill`.

## Validation
Ran the server with `TZ=UTC` (simulating a UTC prod deploy), browser in `America/Los_Angeles`:

| Pill | Stored cron (UTC) | Preview |
|---|---|---|
| Daily | `0 16 * * *` | At 09:00 AM (your time) |
| Every Monday | `0 16 * * 1` | At 09:00 AM, only on Monday (your time) |
| Monthly | `0 16 1 * *` | At 09:00 AM, on day 1 of the month (your time) |

<img src="https://i.img402.dev/c35ot1738d.jpg" width="800" alt="Workflows configure drawer — Daily pill stores 0 16 * * * but previews At 09:00 AM (your time) on a UTC server">

`go build`, `go vet`, the workflows render tests, and the scripts-lint test all pass.

## Out of scope
- The **seeded preset default** cron (e.g. Backlog Closer's `0 7 * * 1`) is a preset definition, not a shortcut, and still renders in server-local terms until a pill is clicked.
- The legacy `/agents/new` form (`agent_form.js`) has the same hardcoded-server-local presets — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
