### PR TITLE
fix(ui): OverflowMenu grows to fit its label (no more "Re-run workflow" wrap)

### DIFF
--- a/internal/templates/components/overflow_menu.templ
+++ b/internal/templates/components/overflow_menu.templ
@@ -20,8 +20,13 @@ import (
 //   - Trigger (sm, default): `btn btn-ghost btn-sm btn-square` + icon `w-5 h-5`
 //   - Trigger (xs):          `btn btn-ghost btn-xs btn-square` + icon `w-4 h-4`
 //   - Menu (sm, default):    `dropdown dropdown-end menu bg-base-100 rounded-xl`
-//                            `shadow-lg border border-base-300 w-44 p-1`
-//   - Menu (xs):             same shape, `w-40` instead of `w-44`
+//                            `shadow-lg border border-base-300 min-w-44 p-1`
+//   - Menu (xs):             same shape, `min-w-40` instead of `min-w-44`
+//
+// The menu width is a *minimum*, not a fixed cap: items are
+// `whitespace-nowrap`, so a long label (e.g. "Re-run workflow") widens
+// the menu to fit on one line instead of wrapping. Short menus still
+// render at the comfortable `min-w-40`/`min-w-44` floor.
 //   - Item icon: `w-3.5 h-3.5`
 //   - Destructive items: `text-error` on the inner element
 //   - Disabled items: `disabled` class on the <li>
@@ -94,7 +99,7 @@ templ OverflowMenu(p OverflowMenuProps) {
 templ overflowMenuItem(it OverflowMenuItem) {
 	if it.Disabled {
 		<li class="disabled">
-			<span class="text-base-content/40 cursor-not-allowed" aria-label={ overflowAria(it) }>
+			<span class="whitespace-nowrap text-base-content/40 cursor-not-allowed" aria-label={ overflowAria(it) }>
 				if it.Icon != "" {
 					@LucideIcon(it.Icon, "w-3.5 h-3.5")
 				}
@@ -164,9 +169,9 @@ func overflowMenuListClass(pos, size string) string {
 	if pos == "start" {
 		side = "dropdown-start"
 	}
-	width := "w-44"
+	width := "min-w-44"
 	if size == "xs" {
-		width = "w-40"
+		width = "min-w-40"
 	}
 	return "dropdown " + side + " menu bg-base-100 rounded-xl shadow-lg border border-base-300 " + width + " p-1"
 }
@@ -181,9 +186,9 @@ func overflowMenuListStyle(anchorName, _ string) string {
 
 func overflowItemClass(destructive bool) string {
 	if destructive {
-		return "text-error"
+		return "whitespace-nowrap text-error"
 	}
-	return ""
+	return "whitespace-nowrap"
 }
 
 // overflowItemClickHandler chains the caller's Alpine handler (if any)


### PR DESCRIPTION
## What

Some kebab "more actions" menus were tight on width, so longer labels wrapped to two lines. The most visible case: **"Re-run workflow"** on `/workflows/runs` wrapped to "Re-run / workflow".

## Why

The shared `OverflowMenu` component pinned a **fixed** width — `w-40` (160px) for the dense `xs` variant used in tables, `w-44` default — and its menu items had no `whitespace-nowrap`. Any label longer than ~15 characters wrapped inside the fixed box.

## Fix

Two small changes in `internal/templates/components/overflow_menu.templ`:

- Width is now a **minimum**, not a cap: `w-40`/`w-44` → `min-w-40`/`min-w-44`. The popover menu shrink-wraps to its content, floored at the old comfortable width, so a long label widens the menu instead of wrapping.
- Menu items (button / link / disabled span) get `whitespace-nowrap` so labels render on a single line.

Labels that already fit stay at the identical floor (`min-w-40` == old `w-40` for content under 160px), so **no caller regresses** — this fixes every `OverflowMenu` user at once (rules, tags, categories, accounts, users, agents, workflow runs).

## Validation

Captured on `/workflows/runs` (DaisyUI popover menu, 1280×800). Measured precisely: before = **2 rendered text lines** at a fixed 160px; after = **1 line**, menu 166px, items `white-space: nowrap`.

<table>
  <tr><th>Before — wraps</th><th>After — one line</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/5uqtkqkax4.jpg" width="320" alt="before — Re-run workflow wraps to two lines"></td>
    <td><img src="https://i.img402.dev/eqfkl4h3e3.jpg" width="320" alt="after — Re-run workflow on a single line"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
