### PR TITLE
feat(workflows): per-workflow editable name + avatar (animated shuffle); default agent style → Glyphs

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -37,7 +37,7 @@ const maxAvatarUploadSize = 5 << 20 // 5 MB
 //
 //	?type=user|agent — picks which configured DiceBear style to use.
 //	                   Default "user". Agent identicons use a separate
-//	                   style (default "icons") so agent activity reads
+//	                   style (default "glyphs") so agent activity reads
 //	                   as obviously non-human. When the id resolves to
 //	                   an api_keys row with actor_type='agent', the
 //	                   handler upgrades the style to "agent" regardless

--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -3,6 +3,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -36,7 +37,7 @@ const maxAvatarUploadSize = 5 << 20 // 5 MB
 //
 //	?type=user|agent — picks which configured DiceBear style to use.
 //	                   Default "user". Agent identicons use a separate
-//	                   style (default "bottts-neutral") so agent activity reads
+//	                   style (default "icons") so agent activity reads
 //	                   as obviously non-human. When the id resolves to
 //	                   an api_keys row with actor_type='agent', the
 //	                   handler upgrades the style to "agent" regardless
@@ -52,7 +53,15 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 
 		uid, err := resolveUUID(idStr)
 		if err != nil {
-			serveGeneratedAvatarForActor(w, r, idStr, actor, size)
+			// Non-UUID id. Agent avatar URLs are built from the workflow's
+			// stable slug (/avatars/<slug>?type=agent), so resolve any
+			// per-workflow custom seed before generating — keeping the slug-
+			// keyed render and the api_keys-keyed render (below) consistent.
+			seed := idStr
+			if actor == avatar.ActorAgent {
+				seed = agentAvatarSeed(r.Context(), a.Queries, idStr)
+			}
+			serveGeneratedAvatarForActor(w, r, seed, actor, size)
 			return
 		}
 
@@ -88,7 +97,9 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 			if key.ActorType == "agent" {
 				actor = avatar.ActorAgent
 				if slug, ok := service.ParseAgentKeySlug(key.Name); ok {
-					seed = slug
+					// Recovered the agent's stable slug; prefer its per-workflow
+					// custom avatar seed when one is set, else seed on the slug.
+					seed = agentAvatarSeed(r.Context(), a.Queries, slug)
 				}
 			}
 			serveGeneratedAvatarForActor(w, r, seed, actor, size)
@@ -98,6 +109,19 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 		// Unknown id — generate a stable pattern from the raw string.
 		serveGeneratedAvatarForActor(w, r, idStr, actor, size)
 	}
+}
+
+// agentAvatarSeed resolves a workflow's DiceBear avatar seed from its stable
+// slug: the per-workflow custom seed when one is set, otherwise the slug
+// itself (the historical default). Workflows seed every render off the slug —
+// either passed literally in the URL or recovered from the run key — so this
+// single lookup keeps both render paths consistent. Soft-fails to the slug on
+// any DB error so a hiccup never breaks avatar rendering.
+func agentAvatarSeed(ctx context.Context, q *db.Queries, slug string) string {
+	if as, err := q.GetWorkflowAvatarSeedBySlug(ctx, slug); err == nil && as.Valid && as.String != "" {
+		return as.String
+	}
+	return slug
 }
 
 // parseActorType reads the `?type=` query param and normalises it

--- a/internal/admin/workflows_reconfigure_handler.go
+++ b/internal/admin/workflows_reconfigure_handler.go
@@ -5,7 +5,9 @@ package admin
 import (
 	"errors"
 	"net/http"
+	"strings"
 
+	"breadbox/internal/avatar"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -53,6 +55,22 @@ func ReconfigureWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
 			MaxTurns:               cfg.MaxTurns,
 			MaxBudgetUSD:           cfg.MaxBudgetUSD,
 		}
+		// Identity edits from the drawer header. Both are optional — an absent
+		// field leaves the current value untouched. The service ignores a blank
+		// name (it's required); the avatar seed is validated to a URL/cache-safe
+		// charset here, and an empty value clears it back to slug-seeded.
+		if _, ok := r.Form["name"]; ok {
+			n := r.FormValue("name")
+			params.Name = &n
+		}
+		if _, ok := r.Form["avatar_seed"]; ok {
+			seed := strings.TrimSpace(r.FormValue("avatar_seed"))
+			if seed != "" && !avatar.IsValidSeed(seed) {
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid avatar seed")
+				return
+			}
+			params.AvatarSeed = &seed
+		}
 		// Any non-control form field is a preset-specialized option (e.g.
 		// apply_mode); the service validates each against the preset's
 		// declared options and falls back to the default for unknown keys.
@@ -60,6 +78,8 @@ func ReconfigureWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
 		// fields (enabled/consent) that don't apply to a reconfigure.
 		control := map[string]bool{
 			"additional_instructions": true,
+			"name":                    true,
+			"avatar_seed":             true,
 			"_csrf":                   true,
 		}
 		for k := range cfgControl {

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -63,8 +63,8 @@ const (
 	// KeyAvatarAgentStyle is the DiceBear style slug used for agent
 	// identicons. Agents render distinct avatars from users so an
 	// AI-authored activity row reads unambiguously against a human
-	// one. Default: "bottts-neutral" (robot identicons on a flat
-	// transparent background).
+	// one. Default: "icons" (DiceBear glyph identicons, surfaced as
+	// "Glyphs" in the picker).
 	KeyAvatarAgentStyle = "avatar.dicebear_style_agent"
 
 	// KeyWorkflowsConsentAckAt records when the household first

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -63,8 +63,7 @@ const (
 	// KeyAvatarAgentStyle is the DiceBear style slug used for agent
 	// identicons. Agents render distinct avatars from users so an
 	// AI-authored activity row reads unambiguously against a human
-	// one. Default: "icons" (DiceBear glyph identicons, surfaced as
-	// "Glyphs" in the picker).
+	// one. Default: "glyphs" (DiceBear's v10 glyph identicons).
 	KeyAvatarAgentStyle = "avatar.dicebear_style_agent"
 
 	// KeyWorkflowsConsentAckAt records when the household first

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -3,7 +3,7 @@
 //
 // The package tracks two DiceBear styles — one for human users
 // (avatar.dicebear_style_user, default "shapes") and one for AI
-// agents (avatar.dicebear_style_agent, default "icons") — so a
+// agents (avatar.dicebear_style_agent, default "glyphs") — so a
 // human-authored activity row reads unambiguously against an
 // agent-authored one. Both values live in app_config and are pushed
 // into the package via SetUserStyle / SetAgentStyle at server
@@ -41,17 +41,17 @@ const (
 	// symmetrical with DefaultAgentStyle.
 	DefaultUserStyle = "shapes"
 
-	// DefaultAgentStyle is the fallback for agent identicons. "icons"
-	// is DiceBear's glyph style — a pictographic icon on a colored
-	// rounded tile (surfaced in the settings picker as "Glyphs"). Agents
-	// read as obviously non-human, and each workflow gets a distinct,
-	// recognisable mark that pairs with the lucide icon language used on
-	// the Workflows gallery cards.
-	DefaultAgentStyle = "icons"
+	// DefaultAgentStyle is the fallback for agent identicons. "glyphs"
+	// is DiceBear's glyph style (added in v10) — a clean monochrome glyph
+	// on a soft tinted tile. Agents read as obviously non-human, and each
+	// workflow gets a distinct, recognisable mark that pairs with the
+	// lucide icon language used on the Workflows gallery cards.
+	DefaultAgentStyle = "glyphs"
 
-	// DefaultAPIBaseURL is the DiceBear v9 HTTP API root. Tests
-	// override this via SetAPIBaseURL.
-	DefaultAPIBaseURL = "https://api.dicebear.com/9.x"
+	// DefaultAPIBaseURL is the DiceBear v10 HTTP API root (v10 is the
+	// first major to ship the "glyphs" style). Tests override this via
+	// SetAPIBaseURL.
+	DefaultAPIBaseURL = "https://api.dicebear.com/10.x"
 
 	httpTimeout      = 5 * time.Second
 	maxResponseBytes = 1 << 20 // 1 MiB — DiceBear SVGs are < 50 KiB
@@ -294,14 +294,14 @@ func fallbackSVG(seed string, size int) []byte {
 }
 
 // StyleOption is one entry in AvailableStyles. ID matches DiceBear's
-// URL slug (https://api.dicebear.com/9.x/<id>/svg); Label is the
+// URL slug (https://api.dicebear.com/10.x/<id>/svg); Label is the
 // human-readable name shown in the settings dropdown.
 type StyleOption struct {
 	ID    string
 	Label string
 }
 
-// AvailableStyles is the catalog of DiceBear v9 styles surfaced in
+// AvailableStyles is the catalog of DiceBear v10 styles surfaced in
 // the settings UI. Ordered roughly from abstract (top) to character-
 // based (bottom) so the selector reads naturally.
 var AvailableStyles = []StyleOption{
@@ -309,9 +309,10 @@ var AvailableStyles = []StyleOption{
 	{ID: "rings", Label: "Rings"},
 	{ID: "identicon", Label: "Identicon (GitHub-style)"},
 	{ID: "glass", Label: "Glass"},
+	{ID: "glyphs", Label: "Glyphs"},
 	{ID: "initials", Label: "Initials"},
 	{ID: "thumbs", Label: "Thumbs"},
-	{ID: "icons", Label: "Glyphs"},
+	{ID: "icons", Label: "Icons"},
 	{ID: "bottts", Label: "Bottts (robots)"},
 	{ID: "bottts-neutral", Label: "Bottts neutral"},
 	{ID: "fun-emoji", Label: "Fun emoji"},

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -3,7 +3,7 @@
 //
 // The package tracks two DiceBear styles — one for human users
 // (avatar.dicebear_style_user, default "shapes") and one for AI
-// agents (avatar.dicebear_style_agent, default "bottts-neutral") — so a
+// agents (avatar.dicebear_style_agent, default "icons") — so a
 // human-authored activity row reads unambiguously against an
 // agent-authored one. Both values live in app_config and are pushed
 // into the package via SetUserStyle / SetAgentStyle at server
@@ -41,12 +41,13 @@ const (
 	// symmetrical with DefaultAgentStyle.
 	DefaultUserStyle = "shapes"
 
-	// DefaultAgentStyle is the fallback for agent identicons.
-	// "bottts-neutral" is DiceBear's robot style on a flat, transparent
-	// background (no per-avatar colored tile) — agents read as obviously
-	// non-human while sitting cleanly on our own surfaces/rings instead
-	// of carrying their own background swatch.
-	DefaultAgentStyle = "bottts-neutral"
+	// DefaultAgentStyle is the fallback for agent identicons. "icons"
+	// is DiceBear's glyph style — a pictographic icon on a colored
+	// rounded tile (surfaced in the settings picker as "Glyphs"). Agents
+	// read as obviously non-human, and each workflow gets a distinct,
+	// recognisable mark that pairs with the lucide icon language used on
+	// the Workflows gallery cards.
+	DefaultAgentStyle = "icons"
 
 	// DefaultAPIBaseURL is the DiceBear v9 HTTP API root. Tests
 	// override this via SetAPIBaseURL.
@@ -310,7 +311,7 @@ var AvailableStyles = []StyleOption{
 	{ID: "glass", Label: "Glass"},
 	{ID: "initials", Label: "Initials"},
 	{ID: "thumbs", Label: "Thumbs"},
-	{ID: "icons", Label: "Icons"},
+	{ID: "icons", Label: "Glyphs"},
 	{ID: "bottts", Label: "Bottts (robots)"},
 	{ID: "bottts-neutral", Label: "Bottts neutral"},
 	{ID: "fun-emoji", Label: "Fun emoji"},

--- a/internal/db/migrations/20260602060936_workflow_avatar_seed.sql
+++ b/internal/db/migrations/20260602060936_workflow_avatar_seed.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Per-workflow DiceBear avatar seed. NULL falls back to the workflow's slug
+-- (the historical seed), so existing rows keep their current avatar until an
+-- operator changes it from the Workflows reconfigure drawer. Additive — safe
+-- on the shared dev DB.
+ALTER TABLE workflows ADD COLUMN avatar_seed TEXT;
+
+-- +goose Down
+ALTER TABLE workflows DROP COLUMN avatar_seed;

--- a/internal/db/queries/agent_definitions.sql
+++ b/internal/db/queries/agent_definitions.sql
@@ -16,6 +16,12 @@ SELECT * FROM workflows WHERE short_id = $1;
 -- name: GetAgentDefinitionBySlug :one
 SELECT * FROM workflows WHERE slug = $1;
 
+-- name: GetWorkflowAvatarSeedBySlug :one
+-- Resolves a workflow's custom DiceBear avatar seed from its stable slug.
+-- NULL/absent means the avatar falls back to seeding on the slug itself.
+-- Used by the avatar handler to render agent identicons.
+SELECT avatar_seed FROM workflows WHERE slug = $1;
+
 -- name: ListAgentDefinitions :many
 SELECT * FROM workflows
 ORDER BY created_at DESC;
@@ -41,6 +47,7 @@ SET name                     = $2,
     quiet_hours_start        = $13,
     quiet_hours_end          = $14,
     trigger_on_sync_complete = $15,
+    avatar_seed              = $16,
     updated_at               = NOW()
 WHERE id = $1
 RETURNING *;

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -80,7 +80,11 @@ type AgentDefinitionResponse struct {
 	// SourceTemplate is the workflow-preset slug this definition was
 	// instantiated from, or nil if it was hand-authored.
 	SourceTemplate *string          `json:"source_template,omitempty"`
-	LastRun        *AgentRunSummary `json:"last_run,omitempty"`
+	// AvatarSeed is the per-workflow DiceBear seed for this definition's
+	// identicon. nil/empty means the avatar seeds on the slug instead (the
+	// historical default). Editable from the Workflows reconfigure drawer.
+	AvatarSeed *string          `json:"avatar_seed,omitempty"`
+	LastRun    *AgentRunSummary `json:"last_run,omitempty"`
 	// CostStats30d is populated only by ListAgentDefinitions (the surface
 	// where users want to compare spend at a glance). Single-row
 	// GetAgentDefinition leaves it nil so the edit-page hot path doesn't
@@ -238,6 +242,10 @@ type UpdateAgentDefinitionParams struct {
 	QuietHoursStart       *string
 	QuietHoursEnd         *string
 	TriggerOnSyncComplete *bool
+	// AvatarSeed sets the per-workflow DiceBear avatar seed. nil leaves it
+	// untouched; a non-empty value replaces it; an empty string clears it
+	// back to slug-seeded.
+	AvatarSeed *string
 }
 
 // RecentErroredAgentRun is one entry in the admin run-failed banner
@@ -525,6 +533,9 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 	if p.TriggerOnSyncComplete != nil {
 		merged.TriggerOnSyncComplete = *p.TriggerOnSyncComplete
 	}
+	if p.AvatarSeed != nil {
+		merged.AvatarSeed = emptyToNil(strings.TrimSpace(*p.AvatarSeed))
+	}
 
 	if err := validateAgentDefinitionFields(merged.Name, merged.Slug, merged.Prompt, merged.ToolScope, merged.Model, merged.MaxTurns, merged.MaxBudgetUSD, merged.ScheduleCron); err != nil {
 		return nil, err
@@ -558,6 +569,7 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 		QuietHoursStart:       pgconv.TextPtrIfNotEmpty(merged.QuietHoursStart),
 		QuietHoursEnd:         pgconv.TextPtrIfNotEmpty(merged.QuietHoursEnd),
 		TriggerOnSyncComplete: merged.TriggerOnSyncComplete,
+		AvatarSeed:            pgconv.TextPtrIfNotEmpty(merged.AvatarSeed),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update agent definition: %w", err)
@@ -1433,6 +1445,7 @@ func agentDefinitionFromRow(row db.Workflow, lastRun *AgentRunSummary) AgentDefi
 		QuietHoursEnd:         pgconv.TextPtr(row.QuietHoursEnd),
 		TriggerOnSyncComplete: row.TriggerOnSyncComplete,
 		SourceTemplate:        pgconv.TextPtr(row.SourceTemplate),
+		AvatarSeed:            pgconv.TextPtr(row.AvatarSeed),
 		LastRun:               lastRun,
 		CreatedAt:             pgconv.TimestampStr(row.CreatedAt),
 		UpdatedAt:             pgconv.TimestampStr(row.UpdatedAt),

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -351,6 +351,12 @@ func (s *Service) ListWorkflowPresets(ctx context.Context) ([]WorkflowPresetView
 			en := d.Enabled
 			view.WorkflowSlug = &slug
 			view.WorkflowEnabled = &en
+			// An instantiated workflow can be renamed from the reconfigure
+			// drawer; surface the live name on the card instead of the preset's
+			// static label so the gallery matches the activity feed.
+			if strings.TrimSpace(d.Name) != "" {
+				view.Name = d.Name
+			}
 		}
 		out = append(out, view)
 	}

--- a/internal/service/workflow_reconfigure.go
+++ b/internal/service/workflow_reconfigure.go
@@ -41,6 +41,10 @@ type WorkflowConfig struct {
 	Slug string `json:"slug"`
 	// Name is the workflow's display name.
 	Name string `json:"name"`
+	// AvatarSeed is the workflow's custom DiceBear avatar seed (empty when
+	// it falls back to seeding on the slug). Drives the drawer's avatar
+	// preview.
+	AvatarSeed string `json:"avatar_seed"`
 	// TriggerOnSync is true when the workflow fires after each sync (vs a
 	// custom cron). The drawer's trigger radio is seeded from this; it's
 	// now user-switchable per workflow, not fixed by the preset.
@@ -90,6 +94,13 @@ type UpdateWorkflowConfigParams struct {
 	// (keyed by WorkflowPresetOption.Key). Unknown/missing keys fall back to
 	// the option's Default, matching enable-time semantics.
 	Options map[string]string
+	// Name, when non-nil and non-blank, renames the workflow. A blank value
+	// is ignored (the name is required), leaving the current name in place.
+	Name *string
+	// AvatarSeed, when non-nil, replaces the workflow's DiceBear avatar seed
+	// (empty string clears it back to slug-seeded). The slug itself is never
+	// touched — it's the stable identity baked into run keys and routes.
+	AvatarSeed *string
 }
 
 // presetForEnabledWorkflow resolves an enabled workflow by slug and returns
@@ -170,6 +181,9 @@ func (s *Service) GetWorkflowConfig(ctx context.Context, slug string) (*Workflow
 		MaxTurns:               def.MaxTurns,
 		AdditionalInstructions: instructions,
 	}
+	if def.AvatarSeed != nil {
+		cfg.AvatarSeed = *def.AvatarSeed
+	}
 	if def.ScheduleCron != nil {
 		cfg.ScheduleCron = *def.ScheduleCron
 	}
@@ -229,6 +243,19 @@ func (s *Service) UpdateWorkflowConfig(ctx context.Context, slug string, params 
 	}
 
 	update := UpdateAgentDefinitionParams{Prompt: &prompt}
+
+	// Identity: name (rename) + avatar seed. The slug stays put — it's the
+	// stable identity baked into run keys and routes. A blank name is ignored
+	// (name is required); the avatar seed passes through verbatim (empty =
+	// clear back to slug-seeded).
+	if params.Name != nil {
+		if n := strings.TrimSpace(*params.Name); n != "" {
+			update.Name = &n
+		}
+	}
+	if params.AvatarSeed != nil {
+		update.AvatarSeed = params.AvatarSeed
+	}
 
 	// Trigger + schedule. The trigger is now user-switchable per workflow
 	// (not fixed by the preset). The two modes are mutually exclusive — see

--- a/internal/templates/components/editable_avatar.templ
+++ b/internal/templates/components/editable_avatar.templ
@@ -1,0 +1,61 @@
+package components
+
+// EditableAvatarProps configures EditableAvatar — a circular avatar with a
+// small shuffle/regenerate button overlaid on its lower-right corner. It's the
+// "change this identity's picture" affordance used by the Workflows
+// reconfigure-drawer header. The image source and the shuffle action are
+// Alpine expressions so the caller owns the seed state (the component is
+// state-agnostic and reusable across any x-data scope).
+type EditableAvatarProps struct {
+	// SrcExpr is the Alpine expression bound to the <img> via x-bind:src,
+	// e.g. "reconfigureAvatarSrc()". Required — the avatar is always live.
+	SrcExpr string
+	// OnShuffle is the Alpine @click expression for the shuffle button,
+	// e.g. "shuffleAvatar()". Required.
+	OnShuffle string
+	// Alt is the image alt text. Pass a meaningful label (e.g. "Workflow
+	// avatar"); empty renders alt="".
+	Alt string
+	// SizeClass overrides the avatar's width/height utilities. Empty defaults
+	// to "w-11 h-11" (44px) — the drawer-header size.
+	SizeClass string
+}
+
+// EditableAvatar renders a live avatar with a shuffle/regenerate overlay
+// button. The button reveals a primary tint and spins its glyph on hover
+// (and shows a pointer cursor) so it reads as an actionable "give me another"
+// control rather than decoration. Drop it inside any Alpine scope that owns a
+// seed value; wire SrcExpr/OnShuffle to that scope.
+//
+//	@components.EditableAvatar(components.EditableAvatarProps{
+//		SrcExpr:   "reconfigureAvatarSrc()",
+//		OnShuffle: "shuffleAvatar()",
+//		Alt:       "Workflow avatar",
+//	})
+templ EditableAvatar(p EditableAvatarProps) {
+	<div class={ "relative shrink-0 " + editableAvatarSizeClass(p.SizeClass) }>
+		<img
+			x-bind:src={ p.SrcExpr }
+			alt={ p.Alt }
+			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300"
+		/>
+		<button
+			type="button"
+			@click={ p.OnShuffle }
+			title="Shuffle avatar"
+			aria-label="Shuffle avatar"
+			class="group absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/60 cursor-pointer transition-colors hover:bg-primary hover:text-primary-content hover:border-primary focus-visible:bg-primary focus-visible:text-primary-content focus-visible:outline-none"
+		>
+			@LucideIcon("shuffle", "w-3 h-3 transition-transform duration-300 group-hover:rotate-180")
+		</button>
+	</div>
+}
+
+// editableAvatarSizeClass returns the avatar's w/h utilities, defaulting to the
+// 44px drawer-header size when the caller doesn't override it.
+func editableAvatarSizeClass(s string) string {
+	if s == "" {
+		return "w-11 h-11"
+	}
+	return s
+}

--- a/internal/templates/components/editable_avatar.templ
+++ b/internal/templates/components/editable_avatar.templ
@@ -23,11 +23,13 @@ type EditableAvatarProps struct {
 }
 
 // EditableAvatar renders a live avatar whose entire surface is the
-// shuffle/regenerate control. The whole circle is one button (pointer cursor,
-// primary focus ring); on hover the ring + corner badge tint primary and the
-// badge glyph spins, so it reads as an actionable "give me another" target
-// rather than decoration. Drop it inside any Alpine scope that owns a seed
-// value; wire SrcExpr/OnShuffle to that scope.
+// shuffle/regenerate control, with a deliberate animated state change: on tap
+// the current avatar dims, scales down and blurs while a spinner overlays it
+// and the corner badge tints primary; when the freshly-seeded image finishes
+// loading it springs back in (overshoot ease) and the spinner fades. The whole
+// circle is one button (pointer cursor, primary focus ring, press feedback).
+// Local Alpine state (imgLoading) drives the loading animation, cleared by the
+// <img>'s load/error events — so it works inside any caller x-data scope.
 //
 //	@components.EditableAvatar(components.EditableAvatarProps{
 //		SrcExpr:   "reconfigureAvatarSrc()",
@@ -37,21 +39,47 @@ type EditableAvatarProps struct {
 templ EditableAvatar(p EditableAvatarProps) {
 	<button
 		type="button"
-		@click={ p.OnShuffle }
+		x-data="{ imgLoading: false }"
+		@click={ "imgLoading = true; " + p.OnShuffle }
+		x-bind:aria-busy="imgLoading"
 		title="Shuffle avatar"
 		aria-label="Shuffle avatar"
-		class={ "group relative shrink-0 rounded-full cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 " + editableAvatarSizeClass(p.SizeClass) }
+		class={ "group relative shrink-0 rounded-full cursor-pointer transition-transform duration-150 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 " + editableAvatarSizeClass(p.SizeClass) }
 	>
 		<img
 			x-bind:src={ p.SrcExpr }
+			@load="imgLoading = false"
+			@error="imgLoading = false"
 			alt={ p.Alt }
-			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300 transition group-hover:ring-primary/60"
+			x-bind:class="imgLoading ? 'scale-90 opacity-40 blur-[2px]' : 'scale-100 opacity-100 blur-none'"
+			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300 transition duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:ring-primary/60"
 		/>
+		<!-- Loading overlay: a spinner sits over the dimmed avatar while the
+		     new DiceBear SVG fetches. Fades in/out with the loading state. -->
+		<span
+			x-show="imgLoading"
+			x-cloak
+			x-transition:enter="transition-opacity ease-out duration-200"
+			x-transition:enter-start="opacity-0"
+			x-transition:enter-end="opacity-100"
+			x-transition:leave="transition-opacity ease-in duration-150"
+			x-transition:leave-start="opacity-100"
+			x-transition:leave-end="opacity-0"
+			class="absolute inset-0 flex items-center justify-center"
+			aria-hidden="true"
+		>
+			<span class="loading loading-spinner loading-sm text-primary"></span>
+		</span>
+		<!-- Corner badge: the shuffle cue. Tints primary on hover/loading; the
+		     glyph spins continuously while loading and rotates 180° on hover. -->
 		<span
 			aria-hidden="true"
+			x-bind:class="imgLoading ? 'bg-primary text-primary-content border-primary' : ''"
 			class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/60 transition-colors group-hover:bg-primary group-hover:text-primary-content group-hover:border-primary"
 		>
-			@LucideIcon("shuffle", "w-3 h-3 transition-transform duration-300 group-hover:rotate-180")
+			<span x-bind:class="imgLoading ? 'animate-spin' : 'transition-transform duration-300 group-hover:rotate-180'" class="inline-flex">
+				@LucideIcon("shuffle", "w-3 h-3")
+			</span>
 		</span>
 	</button>
 }

--- a/internal/templates/components/editable_avatar.templ
+++ b/internal/templates/components/editable_avatar.templ
@@ -23,18 +23,20 @@ type EditableAvatarProps struct {
 }
 
 // EditableAvatar renders a live avatar whose entire surface is the
-// shuffle/regenerate control, with a deliberate (but gentle) animated state
-// change: on tap the current avatar dims, scales down and blurs under a
-// spinner while the freshly-seeded image fetches, then springs back in
-// (overshoot ease) as the spinner fades; the corner badge's glyph softly tints
-// primary on hover and spins while loading. The whole circle is one button
-// (pointer cursor, primary focus ring, press feedback).
+// shuffle/regenerate control:
 //
-// Transitions are deliberately scoped to transform/filter/opacity (avatar) and
-// color (badge glyph) so that flipping the light/dark theme — which swaps every
-// color variable at once — does NOT animate the ring/border/background and
-// flash a stroke; those snap instantly. Local Alpine state (imgLoading) drives
-// the loading animation, cleared by the <img>'s load/error events.
+//   - Hover: the whole avatar lifts slightly (scale) and the corner badge's
+//     glyph tints primary — a clear but gentle "this is interactive" cue.
+//   - Press: a small scale-down for tactile feedback.
+//   - Tap (shuffle): the current avatar dims, scales down and blurs under a
+//     spinner while the freshly-seeded image fetches, then springs back in
+//     (overshoot ease) as the spinner fades.
+//
+// Hover/press/loading motion is all transform/filter/opacity (plus the badge
+// glyph's color), so flipping the light/dark theme — which swaps every color
+// variable at once — never animates the ring/border/background into a flashing
+// stroke; those snap. Local Alpine state (imgLoading) drives the loading
+// animation, cleared by the <img>'s load/error events.
 //
 //	@components.EditableAvatar(components.EditableAvatarProps{
 //		SrcExpr:   "reconfigureAvatarSrc()",
@@ -49,7 +51,7 @@ templ EditableAvatar(p EditableAvatarProps) {
 		x-bind:aria-busy="imgLoading"
 		title="Shuffle avatar"
 		aria-label="Shuffle avatar"
-		class={ "group relative shrink-0 rounded-full cursor-pointer transition-transform duration-150 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 " + editableAvatarSizeClass(p.SizeClass) }
+		class={ "group relative shrink-0 rounded-full cursor-pointer transition-transform duration-200 ease-out hover:scale-105 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 " + editableAvatarSizeClass(p.SizeClass) }
 	>
 		<img
 			x-bind:src={ p.SrcExpr }
@@ -76,16 +78,15 @@ templ EditableAvatar(p EditableAvatarProps) {
 			<span class="loading loading-spinner loading-sm text-primary"></span>
 		</span>
 		<!-- Corner badge: the shuffle cue. The glyph softly tints primary on
-		     hover (color only — so the theme flip never animates the border) and
-		     spins while loading. -->
+		     hover and while loading (color only — so the theme flip never
+		     animates the border). It doesn't rotate; the overlay spinner is the
+		     loading indicator. -->
 		<span
 			aria-hidden="true"
 			x-bind:class="imgLoading ? 'text-primary' : ''"
 			class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/55 transition-[color] duration-200 group-hover:text-primary"
 		>
-			<span x-bind:class="imgLoading ? 'animate-spin' : ''" class="inline-flex">
-				@LucideIcon("shuffle", "w-3 h-3")
-			</span>
+			@LucideIcon("shuffle", "w-3 h-3")
 		</span>
 	</button>
 }

--- a/internal/templates/components/editable_avatar.templ
+++ b/internal/templates/components/editable_avatar.templ
@@ -1,8 +1,9 @@
 package components
 
-// EditableAvatarProps configures EditableAvatar — a circular avatar with a
-// small shuffle/regenerate button overlaid on its lower-right corner. It's the
-// "change this identity's picture" affordance used by the Workflows
+// EditableAvatarProps configures EditableAvatar — a circular avatar that is
+// itself a shuffle/regenerate control: tapping anywhere on the avatar mints a
+// new seed, with a small badge in the lower-right corner as the visual cue.
+// It's the "change this identity's picture" affordance used by the Workflows
 // reconfigure-drawer header. The image source and the shuffle action are
 // Alpine expressions so the caller owns the seed state (the component is
 // state-agnostic and reusable across any x-data scope).
@@ -10,22 +11,23 @@ type EditableAvatarProps struct {
 	// SrcExpr is the Alpine expression bound to the <img> via x-bind:src,
 	// e.g. "reconfigureAvatarSrc()". Required — the avatar is always live.
 	SrcExpr string
-	// OnShuffle is the Alpine @click expression for the shuffle button,
-	// e.g. "shuffleAvatar()". Required.
+	// OnShuffle is the Alpine @click expression run when the avatar is
+	// tapped, e.g. "shuffleAvatar()". Required.
 	OnShuffle string
-	// Alt is the image alt text. Pass a meaningful label (e.g. "Workflow
-	// avatar"); empty renders alt="".
+	// Alt is the image alt text. The button carries its own aria-label
+	// ("Shuffle avatar"), so this is supplementary.
 	Alt string
 	// SizeClass overrides the avatar's width/height utilities. Empty defaults
 	// to "w-11 h-11" (44px) — the drawer-header size.
 	SizeClass string
 }
 
-// EditableAvatar renders a live avatar with a shuffle/regenerate overlay
-// button. The button reveals a primary tint and spins its glyph on hover
-// (and shows a pointer cursor) so it reads as an actionable "give me another"
-// control rather than decoration. Drop it inside any Alpine scope that owns a
-// seed value; wire SrcExpr/OnShuffle to that scope.
+// EditableAvatar renders a live avatar whose entire surface is the
+// shuffle/regenerate control. The whole circle is one button (pointer cursor,
+// primary focus ring); on hover the ring + corner badge tint primary and the
+// badge glyph spins, so it reads as an actionable "give me another" target
+// rather than decoration. Drop it inside any Alpine scope that owns a seed
+// value; wire SrcExpr/OnShuffle to that scope.
 //
 //	@components.EditableAvatar(components.EditableAvatarProps{
 //		SrcExpr:   "reconfigureAvatarSrc()",
@@ -33,22 +35,25 @@ type EditableAvatarProps struct {
 //		Alt:       "Workflow avatar",
 //	})
 templ EditableAvatar(p EditableAvatarProps) {
-	<div class={ "relative shrink-0 " + editableAvatarSizeClass(p.SizeClass) }>
+	<button
+		type="button"
+		@click={ p.OnShuffle }
+		title="Shuffle avatar"
+		aria-label="Shuffle avatar"
+		class={ "group relative shrink-0 rounded-full cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 " + editableAvatarSizeClass(p.SizeClass) }
+	>
 		<img
 			x-bind:src={ p.SrcExpr }
 			alt={ p.Alt }
-			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300"
+			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300 transition group-hover:ring-primary/60"
 		/>
-		<button
-			type="button"
-			@click={ p.OnShuffle }
-			title="Shuffle avatar"
-			aria-label="Shuffle avatar"
-			class="group absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/60 cursor-pointer transition-colors hover:bg-primary hover:text-primary-content hover:border-primary focus-visible:bg-primary focus-visible:text-primary-content focus-visible:outline-none"
+		<span
+			aria-hidden="true"
+			class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/60 transition-colors group-hover:bg-primary group-hover:text-primary-content group-hover:border-primary"
 		>
 			@LucideIcon("shuffle", "w-3 h-3 transition-transform duration-300 group-hover:rotate-180")
-		</button>
-	</div>
+		</span>
+	</button>
 }
 
 // editableAvatarSizeClass returns the avatar's w/h utilities, defaulting to the

--- a/internal/templates/components/editable_avatar.templ
+++ b/internal/templates/components/editable_avatar.templ
@@ -23,13 +23,18 @@ type EditableAvatarProps struct {
 }
 
 // EditableAvatar renders a live avatar whose entire surface is the
-// shuffle/regenerate control, with a deliberate animated state change: on tap
-// the current avatar dims, scales down and blurs while a spinner overlays it
-// and the corner badge tints primary; when the freshly-seeded image finishes
-// loading it springs back in (overshoot ease) and the spinner fades. The whole
-// circle is one button (pointer cursor, primary focus ring, press feedback).
-// Local Alpine state (imgLoading) drives the loading animation, cleared by the
-// <img>'s load/error events — so it works inside any caller x-data scope.
+// shuffle/regenerate control, with a deliberate (but gentle) animated state
+// change: on tap the current avatar dims, scales down and blurs under a
+// spinner while the freshly-seeded image fetches, then springs back in
+// (overshoot ease) as the spinner fades; the corner badge's glyph softly tints
+// primary on hover and spins while loading. The whole circle is one button
+// (pointer cursor, primary focus ring, press feedback).
+//
+// Transitions are deliberately scoped to transform/filter/opacity (avatar) and
+// color (badge glyph) so that flipping the light/dark theme — which swaps every
+// color variable at once — does NOT animate the ring/border/background and
+// flash a stroke; those snap instantly. Local Alpine state (imgLoading) drives
+// the loading animation, cleared by the <img>'s load/error events.
 //
 //	@components.EditableAvatar(components.EditableAvatarProps{
 //		SrcExpr:   "reconfigureAvatarSrc()",
@@ -52,7 +57,7 @@ templ EditableAvatar(p EditableAvatarProps) {
 			@error="imgLoading = false"
 			alt={ p.Alt }
 			x-bind:class="imgLoading ? 'scale-90 opacity-40 blur-[2px]' : 'scale-100 opacity-100 blur-none'"
-			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300 transition duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] group-hover:ring-primary/60"
+			class="w-full h-full rounded-full bg-base-200 ring-1 ring-base-300 transition-[transform,filter,opacity] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
 		/>
 		<!-- Loading overlay: a spinner sits over the dimmed avatar while the
 		     new DiceBear SVG fetches. Fades in/out with the loading state. -->
@@ -70,14 +75,15 @@ templ EditableAvatar(p EditableAvatarProps) {
 		>
 			<span class="loading loading-spinner loading-sm text-primary"></span>
 		</span>
-		<!-- Corner badge: the shuffle cue. Tints primary on hover/loading; the
-		     glyph spins continuously while loading and rotates 180° on hover. -->
+		<!-- Corner badge: the shuffle cue. The glyph softly tints primary on
+		     hover (color only — so the theme flip never animates the border) and
+		     spins while loading. -->
 		<span
 			aria-hidden="true"
-			x-bind:class="imgLoading ? 'bg-primary text-primary-content border-primary' : ''"
-			class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/60 transition-colors group-hover:bg-primary group-hover:text-primary-content group-hover:border-primary"
+			x-bind:class="imgLoading ? 'text-primary' : ''"
+			class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/55 transition-[color] duration-200 group-hover:text-primary"
 		>
-			<span x-bind:class="imgLoading ? 'animate-spin' : 'transition-transform duration-300 group-hover:rotate-180'" class="inline-flex">
+			<span x-bind:class="imgLoading ? 'animate-spin' : ''" class="inline-flex">
 				@LucideIcon("shuffle", "w-3 h-3")
 			</span>
 		</span>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -3041,7 +3041,7 @@ templ SectionUserAvatar() {
 // OnShuffle are Alpine expressions, so the component is state-agnostic.
 templ SectionEditableAvatar() {
 	<div class="flex flex-col gap-6">
-		@designExample("Shuffle to reseed — hover the button", "An avatar with a shuffle/regenerate button pinned to its lower-right. The button shows a pointer cursor, tints primary, and spins its glyph on hover so it reads as an actionable \"give me another\" control. Click it: the seed changes and the avatar reseeds live (the chip shows the current seed).") {
+		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): it shows a pointer cursor, and on hover the ring + corner badge tint primary and the badge glyph spins so it reads as an actionable \"give me another\" target. Tap anywhere on it and the seed changes — the avatar reseeds live (the chip shows the current seed).") {
 			<div x-data="{ s: 'editable-demo' }" class="flex items-center gap-4">
 				@components.EditableAvatar(components.EditableAvatarProps{
 					SrcExpr:   "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=88'",
@@ -3051,7 +3051,7 @@ templ SectionEditableAvatar() {
 				<code class="text-xs text-base-content/50 px-2 py-1 rounded bg-base-200" x-text="s"></code>
 			</div>
 		}
-		@designExample("Sizes", "SizeClass overrides the tile dimensions; the 20px shuffle button keeps its hit target across sizes. Default is w-11 h-11 (44px) — the reconfigure-drawer header size. All three share one seed here, so a shuffle reseeds them together.") {
+		@designExample("Sizes", "SizeClass overrides the tile dimensions; the whole avatar stays the tap target at every size, with a 20px corner badge as the cue. Default is w-11 h-11 (44px) — the reconfigure-drawer header size. All three share one seed here, so a shuffle reseeds them together.") {
 			<div x-data="{ s: 'editable-sizes' }" class="flex items-end gap-6">
 				<div class="flex flex-col items-center gap-2">
 					<span class="text-xs text-base-content/40">40px</span>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -2836,7 +2836,7 @@ templ SectionUserAvatar() {
 				@components.UserAvatar(components.UserAvatarProps{ID: "drew-uuid", Name: "Drew Dawson", Size: components.UserAvatarLg, Version: "1735776000"})
 			</div>
 		}
-		@designExample("Agents — dual style + bot fallback", "IsAgent has two render paths. With an ID set, the URL routes through ?type=agent and the server picks the configured agent DiceBear style (default \"bottts-neutral\") — distinct from the user style so agent activity reads as obviously non-human. With no ID, the bot-tile fallback fires.") {
+		@designExample("Agents — dual style + bot fallback", "IsAgent has two render paths. With an ID set, the URL routes through ?type=agent and the server picks the configured agent DiceBear style (default \"glyphs\") — distinct from the user style so agent activity reads as obviously non-human. With no ID, the bot-tile fallback fires.") {
 			<div class="flex flex-col gap-4">
 				<div class="flex flex-wrap items-center gap-4">
 					<span class="text-xs text-base-content/40 w-32">Agent identicon (ID + IsAgent)</span>
@@ -3026,8 +3026,44 @@ templ SectionUserAvatar() {
 				<div class="flex items-center gap-2">
 					<span class="text-xs text-base-content/40 w-24">Agent seeds</span>
 					for _, seed := range []string{"categorizer", "auditor", "reviewer", "scout"} {
-						<img class="w-10 h-10 rounded-full bg-base-200" alt={ "Preview " + seed } src={ "/avatars/preview/" + seed + "?style=bottts-neutral" }/>
+						<img class="w-10 h-10 rounded-full bg-base-200" alt={ "Preview " + seed } src={ "/avatars/preview/" + seed + "?style=glyphs" }/>
 					}
+				</div>
+			</div>
+		}
+	</div>
+}
+
+// SectionEditableAvatar showcases components.EditableAvatar — the avatar +
+// shuffle/regenerate affordance from the Workflows reconfigure-drawer header.
+// Each example wraps the component in a tiny Alpine scope so the shuffle button
+// is live: clicking it mints a new seed and the avatar reseeds. SrcExpr /
+// OnShuffle are Alpine expressions, so the component is state-agnostic.
+templ SectionEditableAvatar() {
+	<div class="flex flex-col gap-6">
+		@designExample("Shuffle to reseed — hover the button", "An avatar with a shuffle/regenerate button pinned to its lower-right. The button shows a pointer cursor, tints primary, and spins its glyph on hover so it reads as an actionable \"give me another\" control. Click it: the seed changes and the avatar reseeds live (the chip shows the current seed).") {
+			<div x-data="{ s: 'editable-demo' }" class="flex items-center gap-4">
+				@components.EditableAvatar(components.EditableAvatarProps{
+					SrcExpr:   "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=88'",
+					OnShuffle: "s = 'sb-' + Math.floor(Math.random() * 1e9).toString(36)",
+					Alt:       "Demo workflow avatar",
+				})
+				<code class="text-xs text-base-content/50 px-2 py-1 rounded bg-base-200" x-text="s"></code>
+			</div>
+		}
+		@designExample("Sizes", "SizeClass overrides the tile dimensions; the 20px shuffle button keeps its hit target across sizes. Default is w-11 h-11 (44px) — the reconfigure-drawer header size. All three share one seed here, so a shuffle reseeds them together.") {
+			<div x-data="{ s: 'editable-sizes' }" class="flex items-end gap-6">
+				<div class="flex flex-col items-center gap-2">
+					<span class="text-xs text-base-content/40">40px</span>
+					@components.EditableAvatar(components.EditableAvatarProps{SrcExpr: "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=80'", OnShuffle: "s = 'sz-' + Math.floor(Math.random() * 1e9).toString(36)", Alt: "Demo avatar", SizeClass: "w-10 h-10"})
+				</div>
+				<div class="flex flex-col items-center gap-2">
+					<span class="text-xs text-base-content/40">44px · default</span>
+					@components.EditableAvatar(components.EditableAvatarProps{SrcExpr: "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=88'", OnShuffle: "s = 'sz-' + Math.floor(Math.random() * 1e9).toString(36)", Alt: "Demo avatar"})
+				</div>
+				<div class="flex flex-col items-center gap-2">
+					<span class="text-xs text-base-content/40">56px</span>
+					@components.EditableAvatar(components.EditableAvatarProps{SrcExpr: "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=112'", OnShuffle: "s = 'sz-' + Math.floor(Math.random() * 1e9).toString(36)", Alt: "Demo avatar", SizeClass: "w-14 h-14"})
 				</div>
 			</div>
 		}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -3041,7 +3041,7 @@ templ SectionUserAvatar() {
 // OnShuffle are Alpine expressions, so the component is state-agnostic.
 templ SectionEditableAvatar() {
 	<div class="flex flex-col gap-6">
-		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): pointer cursor, and on hover the ring + corner badge tint primary. Tap anywhere and the state change is animated — the current avatar dims, scales down and blurs under a spinner while the new DiceBear SVG fetches, then the fresh avatar springs back in (overshoot ease) as the spinner fades. The chip shows the current seed.") {
+		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): pointer cursor, and on hover the corner badge's glyph softly tints primary. Tap anywhere and the state change is animated — the current avatar dims, scales down and blurs under a spinner while the new DiceBear SVG fetches, then the fresh avatar springs back in (overshoot ease) as the spinner fades. Transitions are scoped to transform/filter/opacity so flipping the theme never flashes a stroke. The chip shows the current seed.") {
 			<div x-data="{ s: 'editable-demo' }" class="flex items-center gap-4">
 				@components.EditableAvatar(components.EditableAvatarProps{
 					SrcExpr:   "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=88'",

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -3041,7 +3041,7 @@ templ SectionUserAvatar() {
 // OnShuffle are Alpine expressions, so the component is state-agnostic.
 templ SectionEditableAvatar() {
 	<div class="flex flex-col gap-6">
-		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): it shows a pointer cursor, and on hover the ring + corner badge tint primary and the badge glyph spins so it reads as an actionable \"give me another\" target. Tap anywhere on it and the seed changes — the avatar reseeds live (the chip shows the current seed).") {
+		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): pointer cursor, and on hover the ring + corner badge tint primary. Tap anywhere and the state change is animated — the current avatar dims, scales down and blurs under a spinner while the new DiceBear SVG fetches, then the fresh avatar springs back in (overshoot ease) as the spinner fades. The chip shows the current seed.") {
 			<div x-data="{ s: 'editable-demo' }" class="flex items-center gap-4">
 				@components.EditableAvatar(components.EditableAvatarProps{
 					SrcExpr:   "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=88'",

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -3041,7 +3041,7 @@ templ SectionUserAvatar() {
 // OnShuffle are Alpine expressions, so the component is state-agnostic.
 templ SectionEditableAvatar() {
 	<div class="flex flex-col gap-6">
-		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): pointer cursor, and on hover the corner badge's glyph softly tints primary. Tap anywhere and the state change is animated — the current avatar dims, scales down and blurs under a spinner while the new DiceBear SVG fetches, then the fresh avatar springs back in (overshoot ease) as the spinner fades. Transitions are scoped to transform/filter/opacity so flipping the theme never flashes a stroke. The chip shows the current seed.") {
+		@designExample("Shuffle to reseed — tap the avatar", "The entire avatar is the shuffle control (one button): pointer cursor, and on hover it lifts slightly while the corner badge's glyph tints primary. Tap anywhere and the state change is animated — the current avatar dims, scales down and blurs under a spinner while the new DiceBear SVG fetches, then the fresh avatar springs back in (overshoot ease) as the spinner fades. Hover/press/loading motion is transform/filter/opacity only, so flipping the theme never flashes a stroke. The chip shows the current seed.") {
 			<div x-data="{ s: 'editable-demo' }" class="flex items-center gap-4">
 				@components.EditableAvatar(components.EditableAvatarProps{
 					SrcExpr:   "'/avatars/' + encodeURIComponent(s) + '?type=agent&size=88'",

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -300,6 +300,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionUserAvatar() },
 		},
 		{
+			Slug:        "editable-avatar",
+			Title:       "Editable avatar",
+			Description: "components.EditableAvatar — a live avatar with a shuffle/regenerate button overlaid on its corner. The \"change this identity's picture\" affordance used by the Workflows reconfigure-drawer header. SrcExpr/OnShuffle are Alpine expressions so it drops into any seed-owning scope; the button tints primary + spins its glyph on hover.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionEditableAvatar() },
+		},
+		{
 			Slug:        "transaction-rows",
 			Title:       "Transaction rows",
 			Description: "TxRow / TxRowCompact / TxRowFeed and their building blocks (bb-tx-avatar, bb-tx-owner-badge, bb-tx-amount). The same avatar + amount shapes carry across every surface that lists transactions.",

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -302,7 +302,7 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "editable-avatar",
 			Title:       "Editable avatar",
-			Description: "components.EditableAvatar — a live avatar with a shuffle/regenerate button overlaid on its corner. The \"change this identity's picture\" affordance used by the Workflows reconfigure-drawer header. SrcExpr/OnShuffle are Alpine expressions so it drops into any seed-owning scope; the button tints primary + spins its glyph on hover.",
+			Description: "components.EditableAvatar — a live avatar whose entire surface is a shuffle/regenerate control (corner badge as the cue). The \"change this identity's picture\" affordance used by the Workflows reconfigure-drawer header. SrcExpr/OnShuffle are Alpine expressions so it drops into any seed-owning scope; the ring + badge tint primary and the glyph spins on hover.",
 			Group:       "data",
 			Render:      func() templ.Component { return SectionEditableAvatar() },
 		},

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -183,33 +183,27 @@ templ workflowReconfigureDrawer() {
 // slug is never touched — it's the stable identity behind run keys + routes.
 // Bound to the gallery factory's reconfigure.* state.
 templ workflowReconfigureIdentityHeader() {
-	<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300 shrink-0">
-		<div class="flex items-center gap-3 min-w-0">
+	<div class="flex items-center justify-between gap-4 p-5 pb-4 border-b border-base-300 shrink-0">
+		<div class="flex items-center gap-3.5 min-w-0 flex-1">
 			<!-- reconfigureAvatarSrc() reseeds live as the hidden avatar_seed
-			     changes; shuffleAvatar() mints a new seed. -->
+			     changes; tapping the avatar (shuffleAvatar()) mints a new seed. -->
 			@components.EditableAvatar(components.EditableAvatarProps{
 				SrcExpr:   "reconfigureAvatarSrc()",
 				OnShuffle: "shuffleAvatar()",
 				Alt:       "Workflow avatar",
-				SizeClass: "w-11 h-11",
+				SizeClass: "w-12 h-12",
 			})
 			<div class="min-w-0 flex-1">
-				<div class="flex items-center gap-1">
-					<input
-						type="text"
-						name="name"
-						x-model="reconfigure.name"
-						maxlength="80"
-						placeholder="Workflow name"
-						aria-label="Workflow name"
-						class="input input-ghost input-sm !text-lg font-semibold flex-1 min-w-0 px-1.5 -ml-1.5"
-					/>
-					<span class="tooltip tooltip-bottom shrink-0" data-tip="Name + avatar shown across activity and run history.">
-						<span class="flex items-center justify-center w-5 h-5 text-base-content/40 hover:text-base-content/70 transition-colors cursor-help" aria-label="Where this name and avatar appear">
-							@components.LucideIcon("info", "w-4 h-4")
-						</span>
-					</span>
-				</div>
+				<input
+					type="text"
+					name="name"
+					x-model="reconfigure.name"
+					maxlength="80"
+					placeholder="Workflow name"
+					aria-label="Workflow name"
+					class="input input-ghost !text-lg font-semibold leading-tight w-full h-auto py-0.5 px-1.5 -ml-1.5"
+				/>
+				<div class="text-xs text-base-content/55 mt-0.5 px-1.5">Shown across activity &amp; run history. Tap the avatar to reshuffle.</div>
 			</div>
 		</div>
 		<div class="flex items-center gap-2 shrink-0">

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -110,12 +110,7 @@ templ workflowReconfigureDrawer() {
 		Title: "Reconfigure workflow",
 	}) {
 		<form class="flex flex-col h-full" @submit.prevent="submitReconfigure($event.target)">
-			@components.DrawerHeader(components.DrawerHeaderProps{
-				Icon:      "sliders-horizontal",
-				TitleExpr: "reconfigure.name || 'Reconfigure workflow'",
-				Subtitle:  "Adjust how this workflow runs. Its base behavior stays the same.",
-				Right:     workflowReconfigureToggle(),
-			})
+			@workflowReconfigureIdentityHeader()
 			<div x-show="reconfigure.loading" class="flex items-center gap-2 text-sm text-base-content/60 p-5">
 				<span class="loading loading-spinner loading-sm"></span>
 				Loading configuration…
@@ -178,6 +173,53 @@ templ workflowReconfigureDrawer() {
 			}
 		</form>
 	}
+}
+
+// workflowReconfigureIdentityHeader is the reconfigure drawer's header,
+// upgraded from the generic DrawerHeader into an inline identity editor: the
+// workflow's DiceBear avatar with a shuffle control to reseed it, the name as
+// a subtle inline-editable field, and the live run-state toggle. The name
+// (name=) and the avatar seed (hidden avatar_seed=) post with the form; the
+// slug is never touched — it's the stable identity behind run keys + routes.
+// Bound to the gallery factory's reconfigure.* state.
+templ workflowReconfigureIdentityHeader() {
+	<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300 shrink-0">
+		<div class="flex items-center gap-3 min-w-0">
+			<!-- Avatar + shuffle. reconfigureAvatarSrc() reseeds live as the
+			     hidden avatar_seed changes; shuffleAvatar() mints a new seed. -->
+			<div class="relative shrink-0">
+				<img :src="reconfigureAvatarSrc()" alt="Workflow avatar" class="w-11 h-11 rounded-full bg-base-200 ring-1 ring-base-300"/>
+				<button
+					type="button"
+					@click="shuffleAvatar()"
+					title="Shuffle avatar"
+					aria-label="Shuffle avatar"
+					class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/55 hover:text-base-content hover:bg-base-200 transition-colors"
+				>
+					@components.LucideIcon("shuffle", "w-3 h-3")
+				</button>
+			</div>
+			<div class="min-w-0 flex-1">
+				<input
+					type="text"
+					name="name"
+					x-model="reconfigure.name"
+					maxlength="80"
+					placeholder="Workflow name"
+					aria-label="Workflow name"
+					class="input input-sm input-ghost font-semibold w-full px-1.5 -ml-1.5"
+				/>
+				<div class="text-xs text-base-content/55 mt-0.5 px-1.5">Name + avatar shown across activity and run history.</div>
+			</div>
+		</div>
+		<div class="flex items-center gap-2 shrink-0">
+			@workflowReconfigureToggle()
+			<button type="button" class="btn btn-ghost btn-sm btn-square" @click="$store.drawers.close()" aria-label="Close">
+				@components.LucideIcon("x", "w-4 h-4")
+			</button>
+		</div>
+		<input type="hidden" name="avatar_seed" x-model="reconfigure.avatarSeed"/>
+	</div>
 }
 
 // workflowPromptPreviewModal is the shared read-only dialog that shows a

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -185,31 +185,31 @@ templ workflowReconfigureDrawer() {
 templ workflowReconfigureIdentityHeader() {
 	<div class="flex items-start justify-between gap-3 p-5 border-b border-base-300 shrink-0">
 		<div class="flex items-center gap-3 min-w-0">
-			<!-- Avatar + shuffle. reconfigureAvatarSrc() reseeds live as the
-			     hidden avatar_seed changes; shuffleAvatar() mints a new seed. -->
-			<div class="relative shrink-0">
-				<img :src="reconfigureAvatarSrc()" alt="Workflow avatar" class="w-11 h-11 rounded-full bg-base-200 ring-1 ring-base-300"/>
-				<button
-					type="button"
-					@click="shuffleAvatar()"
-					title="Shuffle avatar"
-					aria-label="Shuffle avatar"
-					class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full bg-base-100 border border-base-300 shadow-sm flex items-center justify-center text-base-content/55 hover:text-base-content hover:bg-base-200 transition-colors"
-				>
-					@components.LucideIcon("shuffle", "w-3 h-3")
-				</button>
-			</div>
+			<!-- reconfigureAvatarSrc() reseeds live as the hidden avatar_seed
+			     changes; shuffleAvatar() mints a new seed. -->
+			@components.EditableAvatar(components.EditableAvatarProps{
+				SrcExpr:   "reconfigureAvatarSrc()",
+				OnShuffle: "shuffleAvatar()",
+				Alt:       "Workflow avatar",
+				SizeClass: "w-11 h-11",
+			})
 			<div class="min-w-0 flex-1">
-				<input
-					type="text"
-					name="name"
-					x-model="reconfigure.name"
-					maxlength="80"
-					placeholder="Workflow name"
-					aria-label="Workflow name"
-					class="input input-sm input-ghost font-semibold w-full px-1.5 -ml-1.5"
-				/>
-				<div class="text-xs text-base-content/55 mt-0.5 px-1.5">Name + avatar shown across activity and run history.</div>
+				<div class="flex items-center gap-1">
+					<input
+						type="text"
+						name="name"
+						x-model="reconfigure.name"
+						maxlength="80"
+						placeholder="Workflow name"
+						aria-label="Workflow name"
+						class="input input-ghost input-sm !text-lg font-semibold flex-1 min-w-0 px-1.5 -ml-1.5"
+					/>
+					<span class="tooltip tooltip-bottom shrink-0" data-tip="Name + avatar shown across activity and run history.">
+						<span class="flex items-center justify-center w-5 h-5 text-base-content/40 hover:text-base-content/70 transition-colors cursor-help" aria-label="Where this name and avatar appear">
+							@components.LucideIcon("info", "w-4 h-4")
+						</span>
+					</span>
+				</div>
 			</div>
 		</div>
 		<div class="flex items-center gap-2 shrink-0">

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -183,7 +183,7 @@ templ workflowReconfigureDrawer() {
 // slug is never touched — it's the stable identity behind run keys + routes.
 // Bound to the gallery factory's reconfigure.* state.
 templ workflowReconfigureIdentityHeader() {
-	<div class="flex items-center justify-between gap-4 p-5 pb-4 border-b border-base-300 shrink-0">
+	<div class="flex items-center justify-between gap-4 p-5 border-b border-base-300 shrink-0">
 		<div class="flex items-center gap-3.5 min-w-0 flex-1">
 			<!-- reconfigureAvatarSrc() reseeds live as the hidden avatar_seed
 			     changes; tapping the avatar (shuffleAvatar()) mints a new seed. -->
@@ -193,18 +193,17 @@ templ workflowReconfigureIdentityHeader() {
 				Alt:       "Workflow avatar",
 				SizeClass: "w-12 h-12",
 			})
-			<div class="min-w-0 flex-1">
-				<input
-					type="text"
-					name="name"
-					x-model="reconfigure.name"
-					maxlength="80"
-					placeholder="Workflow name"
-					aria-label="Workflow name"
-					class="input input-ghost !text-lg font-semibold leading-tight w-full h-auto py-0.5 px-1.5 -ml-1.5"
-				/>
-				<div class="text-xs text-base-content/55 mt-0.5 px-1.5">Shown across activity &amp; run history. Tap the avatar to reshuffle.</div>
-			</div>
+			<!-- Editable title. A subtle bg appears on hover so it reads as a
+			     field; daisy input-ghost handles the focus state. -->
+			<input
+				type="text"
+				name="name"
+				x-model="reconfigure.name"
+				maxlength="80"
+				placeholder="Workflow name"
+				aria-label="Workflow name"
+				class="input input-ghost !text-lg font-semibold leading-tight flex-1 min-w-0 h-auto py-1.5 px-1.5 -ml-1.5 rounded-lg transition-colors hover:bg-base-200/70"
+			/>
 		</div>
 		<div class="flex items-center gap-2 shrink-0">
 			@workflowReconfigureToggle()

--- a/internal/templates/components/user_avatar.templ
+++ b/internal/templates/components/user_avatar.templ
@@ -11,8 +11,9 @@ package components
 //   - <img> when ID (or SrcOverride) is set. For users the URL is built
 //     via AvatarURL(id, version); for agents (IsAgent) it routes through
 //     AgentAvatarURL → ?type=agent so the server picks the configured
-//     agent DiceBear style (default "bottts-neutral"). Seed an agent with its
-//     stable slug and each one renders as a distinct robot.
+//     agent DiceBear style (default "icons", a glyph mark). Seed an agent
+//     with its stable slug (or a per-workflow avatar_seed) and each one
+//     renders as a distinct mark.
 //   - Bot tile when IsAgent is true but no ID/SrcOverride is set —
 //     `bg-primary/10` with a lucide "bot" glyph sized to the variant
 //     (the generic "some agent" fallback).

--- a/internal/templates/components/user_avatar.templ
+++ b/internal/templates/components/user_avatar.templ
@@ -11,7 +11,7 @@ package components
 //   - <img> when ID (or SrcOverride) is set. For users the URL is built
 //     via AvatarURL(id, version); for agents (IsAgent) it routes through
 //     AgentAvatarURL → ?type=agent so the server picks the configured
-//     agent DiceBear style (default "icons", a glyph mark). Seed an agent
+//     agent DiceBear style (default "glyphs", a glyph mark). Seed an agent
 //     with its stable slug (or a per-workflow avatar_seed) and each one
 //     renders as a distinct mark.
 //   - Bot tile when IsAgent is true but no ID/SrcOverride is set —

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -35,6 +35,9 @@ document.addEventListener('alpine:init', function () {
         loading: false,
         slug: '',
         name: '',
+        // avatarSeed drives the header DiceBear preview + posts as the hidden
+        // avatar_seed field. Empty = seed on the slug (the historical default).
+        avatarSeed: '',
         enabled: false, // run-state, driven by the header toggle (toggleWorkflow)
         // triggerOnSync is a STRING ('true' | 'false') so the trigger radios
         // can bind via x-model and submit as the trigger_on_sync form field.
@@ -191,6 +194,7 @@ document.addEventListener('alpine:init', function () {
         self.reconfigure.model = '';
         self.reconfigure.maxTurns = '';
         self.reconfigure.maxBudget = '';
+        self.reconfigure.avatarSeed = '';
         self.cronPreview = '';
         Alpine.store('drawers').open('wf-reconfigure');
         fetch('/-/workflows/' + encodeURIComponent(slug) + '/config', {
@@ -209,6 +213,7 @@ document.addEventListener('alpine:init', function () {
             self.reconfigure.maxTurns = data.max_turns ? String(data.max_turns) : '';
             self.reconfigure.maxBudget = data.max_budget_usd ? String(data.max_budget_usd) : '';
             self.reconfigure.additionalInstructions = data.additional_instructions || '';
+            self.reconfigure.avatarSeed = data.avatar_seed || '';
             self.reconfigure.options = Array.isArray(data.options) ? data.options : [];
             if (self.reconfigure.triggerOnSync === 'false') self.describeCron(self.reconfigure.scheduleCron);
           })
@@ -220,6 +225,31 @@ document.addEventListener('alpine:init', function () {
           .finally(function () {
             self.reconfigure.loading = false;
           });
+      },
+
+      // reconfigureAvatarSrc builds the header avatar URL for the workflow's
+      // current seed, falling back to the slug when no custom seed is set. The
+      // ?type=agent param picks the agent DiceBear style server-side; the server
+      // also maps a slug to its stored avatar_seed, so the live preview (raw
+      // seed) and the saved render (slug-keyed) resolve to the same image.
+      reconfigureAvatarSrc: function () {
+        var seed = this.reconfigure.avatarSeed || this.reconfigure.slug || 'workflow';
+        return '/avatars/' + encodeURIComponent(seed) + '?type=agent&size=88';
+      },
+
+      // shuffleAvatar mints a fresh random seed so the operator can cycle to a
+      // different DiceBear mark. The preview updates reactively; the seed posts
+      // with the form (hidden avatar_seed) on Save.
+      shuffleAvatar: function () {
+        var bytes = new Uint8Array(8);
+        if (window.crypto && window.crypto.getRandomValues) {
+          window.crypto.getRandomValues(bytes);
+        } else {
+          for (var i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+        }
+        var hex = '';
+        for (var j = 0; j < bytes.length; j++) hex += ('0' + bytes[j].toString(16)).slice(-2);
+        this.reconfigure.avatarSeed = hex;
       },
 
       // describeCron fetches a human-readable rendering of a cron expression


### PR DESCRIPTION
## What

Workflow/agent **DiceBear avatars stay**, but they're now **editable per workflow**, and the **default agent style is DiceBear's `glyphs`** (v10) — a clean glyph-on-tinted-tile mark that reads as obviously non-human and pairs with the lucide icons on the gallery cards.

The Workflows **reconfigure drawer** header is an inline identity editor:

- the workflow's avatar via the new **`components.EditableAvatar`** — the **entire avatar is the shuffle control** (tap anywhere to reseed). The state change is **animated**: the current avatar dims, scales down and blurs under a spinner while the new SVG fetches, then the fresh one **springs in** (overshoot ease) as the spinner fades and the corner badge tints primary.
- the **name** as a larger, title-style field, **vertically centered**, with a subtle fill on hover so it reads as editable (no subtitle).
- the run-state toggle + close.

Name + avatar seed post on **Save**; the **slug is never touched** (stable identity behind run keys + routes). A nullable `avatar_seed` column drives the avatar (NULL → falls back to the slug, so existing avatars are unchanged).

<table>
  <tr><th>Resting</th><th>Shuffling (loading)</th><th>Title hover</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/0v6dpbxlii.jpg" width="270" alt="resting header"></td>
    <td><img src="https://i.img402.dev/uqehmzlxil.jpg" width="270" alt="shuffle loading state — spinner + blur"></td>
    <td><img src="https://i.img402.dev/q3euivcpbt.jpg" width="270" alt="title hover fill"></td>
  </tr>
</table>

### Default style → real `glyphs` (DiceBear v10)

DiceBear added a dedicated **`glyphs`** style in **v10**, so this bumps the API base `9.x → 10.x`, sets the agent default to `glyphs`, and lists **Glyphs** and **Icons** as separate options in the picker (every existing style still renders on 10.x — spot-checked across families).

<img src="https://i.img402.dev/tv105iwcdt.jpg" width="820" alt="Settings → General → Avatars: Glyphs and Icons as distinct styles, agent default Glyphs">

### Sandbox: `EditableAvatar` (`/design/c/editable-avatar`)

The avatar + animated-shuffle affordance is a reusable, state-agnostic component (SrcExpr/OnShuffle are Alpine expressions) showcased in the design system with a live demo + size matrix.

<img src="https://i.img402.dev/0ociz6026l.jpg" width="820" alt="Design sandbox — Editable avatar section">

## How

- **avatar** (`internal/avatar`): API base `9.x → 10.x`; `DefaultAgentStyle = "glyphs"`; catalog gains `Glyphs` and keeps `Icons` as distinct entries.
- **db**: additive migration adds `workflows.avatar_seed` (NULL → slug fallback); `GetWorkflowAvatarSeedBySlug`; `avatar_seed` on `UpdateAgentDefinition`.
- **service**: `AvatarSeed` on the definition response + update params; `UpdateWorkflowConfig` gains `Name`/`AvatarSeed` (blank name ignored; slug untouched); `WorkflowConfig` returns `avatar_seed`; the gallery card shows the instantiated workflow's live name.
- **admin**: `AvatarHandler` resolves a workflow's custom seed by slug in both render paths (slug-keyed URL + run-key-recovered), so feed / run-history avatars reflect the per-workflow seed; reconfigure handler parses + validates `name`/`avatar_seed`.
- **ui**: new `components.EditableAvatar` — whole-avatar shuffle button with an animated loading→spring-in state (local `imgLoading` Alpine state), hover/cursor/focus/press states; cleaner reconfigure-drawer header (centered title, hover-fill field, no subtitle); gallery JS gets `avatarSeed` state, hydration, `shuffleAvatar()`, `reconfigureAvatarSrc()`.
- **design**: new `editable-avatar` sandbox section (data group).

Generated `*.sql.go` / `*_templ.go` are gitignored and regenerated in CI from the committed query + migration + templ sources.

## Verification

- `go build ./...`, `go vet ./...` clean; design-gallery smoke test + scripts-lint + avatar + service + admin tests green. (One pre-existing flaky `internal/agent` timing test passes in isolation; package untouched.)
- End-to-end in a real browser on the dev DB: tapping the avatar animates the reshuffle (spinner + spring-in); save persists `workflows.avatar_seed`, and `GET /avatars/<slug>?type=agent` returns the same SVG as the custom seed (chokepoint confirmed). Agent avatars render real DiceBear v10 glyphs; the picker lists Glyphs + Icons separately; the title shows a hover fill.

## Test plan

- [ ] `/settings/general` → Avatars: Agents default is **Glyphs**; **Glyphs** and **Icons** are separate options.
- [ ] `/workflows` → gear on an enabled workflow → centered title, hover the title (subtle fill), **tap the avatar** anywhere → animated reshuffle.
- [ ] Save → reload; feed/run avatars + card name reflect the change.
- [ ] `/design/c/editable-avatar` renders; tapping the avatar animates the reseed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
