### PR TITLE
feat(ui): make the topbar the single breadcrumb, drop in-page breadcrumbs

### DIFF
--- a/internal/admin/account_links.go
+++ b/internal/admin/account_links.go
@@ -67,11 +67,11 @@ func renderAccountLinkDetail(tr *TemplateRenderer, w http.ResponseWriter, r *htt
 			MatchedOn:              m.MatchedOn,
 		}
 	}
+	data["Breadcrumbs"] = []components.Breadcrumb{
+		{Label: "Account Links", Href: "/connections?tab=links"},
+		{Label: link.PrimaryAccountName + " → " + link.DependentAccountName},
+	}
 	props := pages.AccountLinkDetailProps{
-		Breadcrumbs: []components.Breadcrumb{
-			{Label: "Account Links", Href: "/connections?tab=links"},
-			{Label: link.PrimaryAccountName + " → " + link.DependentAccountName},
-		},
 		CSRFToken:               GetCSRFToken(r),
 		LinkID:                  link.ID,
 		MatchCount:              link.MatchCount,

--- a/internal/admin/agent_detail_page.go
+++ b/internal/admin/agent_detail_page.go
@@ -55,6 +55,7 @@ func AgentDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Te
 		props := buildAgentDetailProps(def, stats, runs, GetCSRFToken(r))
 
 		data := BaseTemplateData(r, sm, "agents", def.Name)
+		data["Breadcrumbs"] = pages.AgentDetailBreadcrumbs(props)
 		tr.RenderWithTempl(w, r, data, pages.AgentDetail(props))
 	}
 }

--- a/internal/admin/agent_form_page.go
+++ b/internal/admin/agent_form_page.go
@@ -67,6 +67,7 @@ func AgentFormPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Temp
 
 		pageTitle := props.Title
 		data := BaseTemplateData(r, sm, "agents", pageTitle)
+		data["Breadcrumbs"] = pages.AgentFormBreadcrumbs(props)
 		tr.RenderWithTempl(w, r, data, pages.AgentForm(props))
 	}
 }

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -280,6 +280,7 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 		// Run detail is part of the Workflows surface now (reached from the
 		// Workflows → Runs tab), so it highlights the Workflows nav item.
 		data := BaseTemplateData(r, sm, "workflows", title)
+		data["Breadcrumbs"] = pages.AgentRunDetailBreadcrumbs(props)
 		tr.RenderWithTempl(w, r, data, pages.AgentRunDetail(props))
 	}
 }

--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -42,13 +42,13 @@ func CategoryNewPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Te
 			return
 		}
 		data := BaseTemplateData(r, sm, "categories", "Add Category")
+		data["Breadcrumbs"] = []components.Breadcrumb{
+			{Label: "Categories", Href: "/categories"},
+			{Label: "Add Category"},
+		}
 		tr.RenderWithTempl(w, r, data, pages.CategoryForm(pages.CategoryFormProps{
 			IsEdit:     false,
 			Categories: categories,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Categories", Href: "/categories"},
-				{Label: "Add Category"},
-			},
 		}))
 	}
 }
@@ -67,13 +67,13 @@ func CategoryEditPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			return
 		}
 		data := BaseTemplateData(r, sm, "categories", "Edit "+category.DisplayName)
+		data["Breadcrumbs"] = []components.Breadcrumb{
+			{Label: "Categories", Href: "/categories"},
+			{Label: category.DisplayName},
+		}
 		tr.RenderWithTempl(w, r, data, pages.CategoryForm(pages.CategoryFormProps{
 			IsEdit:   true,
 			Category: category,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Categories", Href: "/categories"},
-				{Label: category.DisplayName},
-			},
 		}))
 	}
 }

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -419,11 +419,11 @@ func renderConnectionNew(
 	hasPlaid, hasTeller bool,
 	tellerEnv string,
 ) {
+	data["Breadcrumbs"] = []components.Breadcrumb{
+		{Label: "Connections", Href: "/connections"},
+		{Label: "Connect New Bank"},
+	}
 	props := pages.ConnectionNewProps{
-		Breadcrumbs: []components.Breadcrumb{
-			{Label: "Connections", Href: "/connections"},
-			{Label: "Connect New Bank"},
-		},
 		CSRFToken: GetCSRFToken(r),
 		HasPlaid:  hasPlaid,
 		HasTeller: hasTeller,
@@ -760,9 +760,7 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			HasBalance:           hasBalance,
 			NextSync:             nextSync,
 		})
-		// Mirror the breadcrumbs as components.Breadcrumb so the templ
-		// component can render them via the shared BreadcrumbNav helper.
-		props.Breadcrumbs = []components.Breadcrumb{
+		data["Breadcrumbs"] = []components.Breadcrumb{
 			{Label: "Connections", Href: "/connections"},
 			{Label: conn.InstitutionName.String},
 		}
@@ -977,6 +975,11 @@ func ConnectionReauthHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc 
 			"PageTitle":   "Re-authenticate " + conn.InstitutionName.String,
 			"CurrentPage": "connections",
 			"CSRFToken":   GetCSRFToken(r),
+			"Breadcrumbs": []components.Breadcrumb{
+				{Label: "Connections", Href: "/connections"},
+				{Label: conn.InstitutionName.String, Href: "/connections/" + idStr},
+				{Label: "Re-authenticate"},
+			},
 		}
 		props := pages.ConnectionReauthProps{
 			ConnID:          idStr,
@@ -985,11 +988,6 @@ func ConnectionReauthHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc 
 			UserName:        pgconv.TextOr(conn.UserName, ""),
 			TellerAppID:     a.Config.TellerAppID,
 			TellerEnv:       a.Config.TellerEnv,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Connections", Href: "/connections"},
-				{Label: conn.InstitutionName.String, Href: "/connections/" + idStr},
-				{Label: "Re-authenticate"},
-			},
 		}
 		renderConnectionReauth(w, r, tr, data, props)
 	}

--- a/internal/admin/csv_import.go
+++ b/internal/admin/csv_import.go
@@ -15,7 +15,6 @@ import (
 	"breadbox/internal/pgconv"
 	csvpkg "breadbox/internal/provider/csv"
 	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/alexedwards/scs/v2"
@@ -125,11 +124,6 @@ func CSVImportPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 		}
 		breadcrumbs = append(breadcrumbs, Breadcrumb{Label: "Import CSV"})
 		data["Breadcrumbs"] = breadcrumbs
-
-		props.Breadcrumbs = make([]components.Breadcrumb, len(breadcrumbs))
-		for i, b := range breadcrumbs {
-			props.Breadcrumbs[i] = components.Breadcrumb{Label: b.Label, Href: b.Href}
-		}
 
 		renderCSVImport(w, r, tr, data, props)
 	}

--- a/internal/admin/design.go
+++ b/internal/admin/design.go
@@ -5,7 +5,6 @@ package admin
 import (
 	"net/http"
 
-	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/alexedwards/scs/v2"
@@ -21,9 +20,6 @@ func DesignGalleryHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.Han
 		data["Standalone"] = true
 		tr.RenderWithTempl(w, r, data, pages.DesignGallery(pages.DesignGalleryProps{
 			Sections: pages.DesignSections(),
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Design system"},
-			},
 		}))
 	}
 }
@@ -58,10 +54,6 @@ func DesignComponentHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.H
 		data["Standalone"] = true
 		tr.RenderWithTempl(w, r, data, pages.DesignComponent(pages.DesignComponentProps{
 			Section: section,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Design system", Href: "/design"},
-				{Label: section.Title},
-			},
 		}))
 	}
 }

--- a/internal/admin/page_section_test.go
+++ b/internal/admin/page_section_test.go
@@ -6,7 +6,57 @@ import (
 	"os"
 	"regexp"
 	"testing"
+
+	"breadbox/internal/templates/components"
 )
+
+// TestPageIDFromHref locks the href → nav-page-id extraction the topbar
+// uses to resolve a trail's section group.
+func TestPageIDFromHref(t *testing.T) {
+	cases := map[string]string{
+		"/connections?tab=links": "connections",
+		"/workflows/runs":        "workflows",
+		"/transactions":          "transactions",
+		"/agents/definitions":    "agents",
+		"/household/123/edit":    "household",
+		"":                       "",
+	}
+	for href, want := range cases {
+		if got := pageIDFromHref(href); got != want {
+			t.Errorf("pageIDFromHref(%q) = %q, want %q", href, got, want)
+		}
+	}
+}
+
+// TestTopbarSectionLabel verifies the topbar section is derived from the
+// trail's root crumb (so it never contradicts the path), and falls back to
+// the current page's section on trail-less list pages.
+func TestTopbarSectionLabel(t *testing.T) {
+	crumb := func(label, href string) components.Breadcrumb {
+		return components.Breadcrumb{Label: label, Href: href}
+	}
+	cases := []struct {
+		name        string
+		currentPage string
+		items       []components.Breadcrumb
+		want        string
+	}{
+		{"list page falls back to current section", "transactions", nil, "Overview"},
+		{"detail derives section from trail root", "transactions",
+			[]components.Breadcrumb{crumb("Connections", "/connections"), crumb("Chase", "/connections/x"), crumb("Account", "")},
+			"System"},
+		{"agent run trail roots at workflows", "workflows",
+			[]components.Breadcrumb{crumb("Runs", "/workflows/runs"), crumb("Agent", ""), crumb("ab12", "")},
+			"Manage"},
+		{"sectionless current crumb falls back to current page", "design",
+			[]components.Breadcrumb{crumb("Design system", "")}, ""},
+	}
+	for _, c := range cases {
+		if got := topbarSectionLabel(c.currentPage, c.items); got != c.want {
+			t.Errorf("%s: topbarSectionLabel(%q, …) = %q, want %q", c.name, c.currentPage, got, c.want)
+		}
+	}
+}
 
 // TestPageSectionCoversNav guards the one coupling pageSectionLabel can't
 // express in code: the topbar breadcrumb's section is derived here, but the

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -122,13 +122,12 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 		// titles can be full sentences; interpolating them into the breadcrumb
 		// overflows on mobile/tablet and visually competes with the header
 		// card below, which already shows the full title.
-		breadcrumbs := []components.Breadcrumb{
+		data["Breadcrumbs"] = []components.Breadcrumb{
 			{Label: "Reports", Href: "/reports"},
 			{Label: "Report"},
 		}
 		tr.RenderWithTempl(w, r, data, pages.ReportDetail(pages.ReportDetailProps{
-			Report:      detail,
-			Breadcrumbs: breadcrumbs,
+			Report: detail,
 		}))
 	}
 }

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -172,13 +172,13 @@ func RuleFormPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 			IsEdit:         false,
 			FlatCategories: flattenCategories(categories),
 			Tags:           tags,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Rules", Href: "/rules"},
-				{Label: "New Rule"},
-			},
 		}
 
 		data := BaseTemplateData(r, sm, "rules", "New Rule")
+		data["Breadcrumbs"] = []components.Breadcrumb{
+			{Label: "Rules", Href: "/rules"},
+			{Label: "New Rule"},
+		}
 
 		// Edit mode: load existing rule
 		if id := chi.URLParam(r, "id"); id != "" {
@@ -193,7 +193,7 @@ func RuleFormPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 			}
 			props.Rule = rule
 			props.IsEdit = true
-			props.Breadcrumbs = []components.Breadcrumb{
+			data["Breadcrumbs"] = []components.Breadcrumb{
 				{Label: "Rules", Href: "/rules"},
 				{Label: rule.Name},
 			}
@@ -332,6 +332,10 @@ func renderRuleDetail(
 	actionCategoryName string,
 	categories []service.CategoryResponse,
 ) {
+	data["Breadcrumbs"] = []components.Breadcrumb{
+		{Label: "Rules", Href: "/rules"},
+		{Label: rule.Name},
+	}
 	props := pages.RuleDetailProps{
 		Rule:                rule,
 		Preview:             preview,
@@ -347,10 +351,6 @@ func renderRuleDetail(
 		ConditionSummary:    service.ConditionSummary(rule.Conditions),
 		TriggerLabel:        service.TriggerLabel(rule.Trigger),
 		ConditionRows:       buildRuleDetailConditionRows(rule.Conditions),
-		Breadcrumbs: []components.Breadcrumb{
-			{Label: "Rules", Href: "/rules"},
-			{Label: rule.Name},
-		},
 	}
 
 	// Parse last_hit_at for relative time display.

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -266,6 +266,10 @@ func SubscriptionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 			"CurrentPage": "recurring",
 			"CSRFToken":   GetCSRFToken(r),
 			"Flash":       GetFlash(ctx, sm),
+			"Breadcrumbs": []components.Breadcrumb{
+				{Label: "Recurring", Href: "/recurring"},
+				{Label: s.Name},
+			},
 		}
 		tr.RenderWithTempl(w, r, data, pages.SubscriptionDetail(props))
 	}
@@ -563,8 +567,18 @@ func NewRecurringSeriesPageHandler(a *app.App, svc *service.Service, sm *scs.Ses
 			"PageTitle":   "New recurring series",
 			"CurrentPage": "recurring",
 			"CSRFToken":   GetCSRFToken(r),
+			"Breadcrumbs": recurringFormBreadcrumbs(),
 		}
 		tr.RenderWithTempl(w, r, data, pages.RecurringSeriesForm(props))
+	}
+}
+
+// recurringFormBreadcrumbs is the topbar trail for the new-series form,
+// shared by the GET handler and its validation-error re-render.
+func recurringFormBreadcrumbs() []components.Breadcrumb {
+	return []components.Breadcrumb{
+		{Label: "Recurring", Href: "/recurring"},
+		{Label: "New series"},
 	}
 }
 
@@ -596,6 +610,7 @@ func CreateRecurringSeriesHandler(a *app.App, svc *service.Service, sm *scs.Sess
 				"PageTitle":   "New recurring series",
 				"CurrentPage": "recurring",
 				"CSRFToken":   GetCSRFToken(r),
+				"Breadcrumbs": recurringFormBreadcrumbs(),
 			}, pages.RecurringSeriesForm(pages.RecurringSeriesFormProps{
 				CSRFToken: GetCSRFToken(r), Error: msg,
 				Name: name, Type: typ, Cadence: cadence, Currency: currency,

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -48,12 +48,12 @@ func SyncLogDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			"Flash":       GetFlash(ctx, sm),
 		}
 
-		breadcrumbs := []components.Breadcrumb{
+		data["Breadcrumbs"] = []components.Breadcrumb{
 			{Label: "Logs", Href: "/logs?tab=syncs"},
 			{Label: syncLog.InstitutionName},
 		}
 
-		props := buildSyncLogDetailProps(syncLog, accounts, breadcrumbs)
+		props := buildSyncLogDetailProps(syncLog, accounts)
 		renderSyncLogDetail(w, r, tr, data, props)
 	}
 }
@@ -68,10 +68,8 @@ func renderSyncLogDetail(w http.ResponseWriter, r *http.Request, tr *TemplateRen
 // buildSyncLogDetailProps projects service-layer types into the flat
 // view-model the templ renders. Pre-renders relative time and rule
 // condition summaries so the templ stays free of funcMap helpers.
-func buildSyncLogDetailProps(log *service.SyncLogRow, accounts []service.SyncLogAccountRow, breadcrumbs []components.Breadcrumb) pages.SyncLogDetailProps {
-	out := pages.SyncLogDetailProps{
-		Breadcrumbs: breadcrumbs,
-	}
+func buildSyncLogDetailProps(log *service.SyncLogRow, accounts []service.SyncLogAccountRow) pages.SyncLogDetailProps {
+	out := pages.SyncLogDetailProps{}
 	if log != nil {
 		out.Log = pages.SyncLogDetailLog{
 			ID:                log.ID,

--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -54,12 +54,12 @@ func TagsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateR
 func TagNewPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := BaseTemplateData(r, sm, "tags", "Add Tag")
+		data["Breadcrumbs"] = []components.Breadcrumb{
+			{Label: "Tags", Href: "/tags"},
+			{Label: "Add Tag"},
+		}
 		tr.RenderWithTempl(w, r, data, pages.TagForm(pages.TagFormProps{
 			IsEdit: false,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Tags", Href: "/tags"},
-				{Label: "Add Tag"},
-			},
 		}))
 	}
 }
@@ -79,13 +79,13 @@ func TagEditPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templa
 		}
 
 		data := BaseTemplateData(r, sm, "tags", "Edit "+tag.DisplayName)
+		data["Breadcrumbs"] = []components.Breadcrumb{
+			{Label: "Tags", Href: "/tags"},
+			{Label: tag.DisplayName},
+		}
 		tr.RenderWithTempl(w, r, data, pages.TagForm(pages.TagFormProps{
 			IsEdit: true,
 			Tag:    tag,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Tags", Href: "/tags"},
-				{Label: tag.DisplayName},
-			},
 		}))
 	}
 }

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -46,19 +46,15 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.Flash(f.Type, f.Message), nil
 	},
-	"Breadcrumb": func(data any) (templ.Component, error) {
-		crumbs, ok := data.([]Breadcrumb)
-		if !ok {
-			return nil, fmt.Errorf("want []admin.Breadcrumb, got %T", data)
-		}
-		if len(crumbs) == 0 {
-			return templ.NopComponent, nil
-		}
-		items := make([]components.Breadcrumb, len(crumbs))
-		for i, b := range crumbs {
-			items[i] = components.Breadcrumb{Label: b.Label, Href: b.Href}
-		}
-		return components.BreadcrumbNav(items), nil
+	// TopbarBreadcrumb renders the app's single location trail in the
+	// desktop topbar; TopbarBreadcrumbMobile is the scrollable mobile-strip
+	// variant. Both read the full layout data map (CurrentPage, PageTitle,
+	// Breadcrumbs) — see topbarBreadcrumbComponent.
+	"TopbarBreadcrumb": func(data any) (templ.Component, error) {
+		return topbarBreadcrumbComponent(data, false)
+	},
+	"TopbarBreadcrumbMobile": func(data any) (templ.Component, error) {
+		return topbarBreadcrumbComponent(data, true)
 	},
 	"CategoryPickerScript": func(_ any) (templ.Component, error) {
 		return components.CategoryPickerScript(), nil
@@ -143,6 +139,74 @@ func pageSectionLabel(currentPage string) string {
 	default:
 		return ""
 	}
+}
+
+// pageIDFromHref extracts the nav page id from a breadcrumb href so the
+// topbar can resolve the section group of the trail's root —
+// "/connections?tab=links" → "connections", "/workflows/runs" →
+// "workflows". Returns "" for the current-page crumb (empty href).
+func pageIDFromHref(href string) string {
+	if href == "" {
+		return ""
+	}
+	h := strings.TrimPrefix(href, "/")
+	if i := strings.IndexAny(h, "/?#"); i >= 0 {
+		h = h[:i]
+	}
+	return h
+}
+
+// topbarSectionLabel resolves the muted group label shown before the
+// trail. When a trail is present it derives the section from the trail's
+// root crumb so the section and the path can never contradict (e.g. an
+// account detail rooted at "Connections" reads "System / Connections / …"
+// regardless of which nav item is active). Falls back to the current
+// page's own section for trail-less list/top-level pages.
+func topbarSectionLabel(currentPage string, items []components.Breadcrumb) string {
+	if len(items) > 0 {
+		if s := pageSectionLabel(pageIDFromHref(items[0].Href)); s != "" {
+			return s
+		}
+	}
+	return pageSectionLabel(currentPage)
+}
+
+// breadcrumbItemsFromData normalises whatever a handler stashed under
+// data["Breadcrumbs"] into the component slice. Accepts the component
+// slice directly and the admin Breadcrumb slice (handlers that build the
+// admin shape for other uses). Anything else → nil (no trail).
+func breadcrumbItemsFromData(v any) []components.Breadcrumb {
+	switch s := v.(type) {
+	case []components.Breadcrumb:
+		return s
+	case []Breadcrumb:
+		out := make([]components.Breadcrumb, len(s))
+		for i, b := range s {
+			out[i] = components.Breadcrumb{Label: b.Label, Href: b.Href}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// topbarBreadcrumbComponent builds the topbar trail from the layout data
+// map. scrollable picks the mobile-strip variant. Shared by the
+// TopbarBreadcrumb / TopbarBreadcrumbMobile registry adapters.
+func topbarBreadcrumbComponent(data any, scrollable bool) (templ.Component, error) {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("TopbarBreadcrumb: want map[string]any, got %T", data)
+	}
+	currentPage, _ := m["CurrentPage"].(string)
+	pageTitle, _ := m["PageTitle"].(string)
+	items := breadcrumbItemsFromData(m["Breadcrumbs"])
+	return components.TopbarBreadcrumb(components.TopbarBreadcrumbProps{
+		Section:    topbarSectionLabel(currentPage, items),
+		Items:      items,
+		PageTitle:  pageTitle,
+		Scrollable: scrollable,
+	}), nil
 }
 
 // toStringSlice coerces the value passed via renderComponent into a
@@ -320,9 +384,6 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				// (e.g. `{{renderComponent "KbdCombo" (strs "cmd" "k")}}`).
 				"strs":            func(vals ...string) []string { return vals },
 				"renderComponent": renderTemplComponent,
-				// pageSection maps the current nav page id to its sidebar
-				// section, for the desktop topbar breadcrumb in base.html.
-				"pageSection": pageSectionLabel,
 				// userAvatarProps constructs a UserAvatarProps from the
 				// BaseTemplateData fields html/template partials carry,
 				// for use through renderComponent. Kept inline so the
@@ -360,7 +421,6 @@ var templatePartials = []string{
 	"partials/flash.html",
 	"partials/nav.html",
 	"partials/category_picker.html",
-	"partials/breadcrumb.html",
 }
 
 func (tr *TemplateRenderer) parseTemplates() error {

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -577,16 +577,12 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			"Flash":       GetFlash(ctx, sm),
 		}
 
-		// Translate admin breadcrumbs to the components shape the templ
-		// component consumes. Same pattern as renderTransactionDetail.
-		componentBreadcrumbs := make([]components.Breadcrumb, 0, len(breadcrumbs))
-		for _, c := range breadcrumbs {
-			componentBreadcrumbs = append(componentBreadcrumbs, components.Breadcrumb{Label: c.Label, Href: c.Href})
-		}
+		// Breadcrumbs are chrome — feed the trail to the layout (topbar +
+		// mobile strip) instead of the page body.
+		data["Breadcrumbs"] = breadcrumbs
 
 		props := pages.AccountDetailProps{
 			CSRFToken:             GetCSRFToken(r),
-			Breadcrumbs:           componentBreadcrumbs,
 			AccountID:             idStr,
 			Account:               detail,
 			IsLiability:           isLiability,
@@ -782,10 +778,9 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 		// shapes pages.TransactionDetail expects. The component owns its
 		// view-model so the handler is the only place that bridges between
 		// the admin and pages packages.
-		componentBreadcrumbs := make([]components.Breadcrumb, 0, len(breadcrumbs))
-		for _, c := range breadcrumbs {
-			componentBreadcrumbs = append(componentBreadcrumbs, components.Breadcrumb{Label: c.Label, Href: c.Href})
-		}
+		// Breadcrumbs are chrome — feed the trail to the layout (topbar +
+		// mobile strip) instead of the page body.
+		data["Breadcrumbs"] = breadcrumbs
 		componentActivityDays := make([]pages.ActivityDayGroup, 0, len(activityDays))
 		for _, day := range activityDays {
 			componentActivityDays = append(componentActivityDays, pages.ActivityDayGroup{
@@ -796,7 +791,6 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 
 		props := pages.TransactionDetailProps{
 			CSRFToken:        GetCSRFToken(r),
-			Breadcrumbs:      componentBreadcrumbs,
 			Transaction:      txn,
 			TransactionID:    idStr,
 			AccountID:        accountID,

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -172,6 +172,13 @@ func renderUserForm(sm *scs.SessionManager, tr *TemplateRenderer, w http.Respons
 		pageTitle = "Edit " + props.User.Name
 	}
 	data := BaseTemplateData(r, sm, "household", pageTitle)
+	crumbs := []components.Breadcrumb{{Label: "Household", Href: "/household"}}
+	if props.IsEdit && props.User != nil {
+		crumbs = append(crumbs, components.Breadcrumb{Label: props.User.Name})
+	} else {
+		crumbs = append(crumbs, components.Breadcrumb{Label: "Add Member"})
+	}
+	data["Breadcrumbs"] = crumbs
 	tr.RenderWithTempl(w, r, data, pages.UserForm(props))
 }
 
@@ -269,10 +276,6 @@ func NewUserHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) ht
 	return func(w http.ResponseWriter, r *http.Request) {
 		renderUserForm(sm, tr, w, r, pages.UserFormProps{
 			IsEdit: false,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Household", Href: "/household"},
-				{Label: "Add Member"},
-			},
 		})
 	}
 }
@@ -298,10 +301,6 @@ func EditUserHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) h
 			IsEdit: true,
 			User:   &user,
 			UserID: idStr,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Household", Href: "/household"},
-				{Label: user.Name},
-			},
 		})
 	}
 }
@@ -546,7 +545,6 @@ func CreateLoginPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 				LoginRole:        loginAccount.Role,
 				LoginPasswordSet: len(loginAccount.HashedPassword) > 0,
 				SetupURL:         setupURL,
-				Breadcrumbs:      breadcrumbsToComponent(breadcrumbs),
 			})
 			return
 		}
@@ -571,7 +569,6 @@ func CreateLoginPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			UserID:      idStr,
 			UserName:    user.Name,
 			UserEmail:   userEmail,
-			Breadcrumbs: breadcrumbsToComponent(breadcrumbs),
 		})
 	}
 }
@@ -580,16 +577,5 @@ func CreateLoginPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 // sub-view of the top-level Household page.
 func renderCreateLogin(w http.ResponseWriter, r *http.Request, tr *TemplateRenderer, data map[string]any, props pages.CreateLoginProps) {
 	tr.RenderWithTempl(w, r, data, pages.CreateLogin(props))
-}
-
-// breadcrumbsToComponent converts the admin Breadcrumb slice (used by the
-// legacy html/template breadcrumb partial) into the components.Breadcrumb
-// slice consumed by templ-based pages.
-func breadcrumbsToComponent(crumbs []Breadcrumb) []components.Breadcrumb {
-	out := make([]components.Breadcrumb, len(crumbs))
-	for i, b := range crumbs {
-		out[i] = components.Breadcrumb{Label: b.Label, Href: b.Href}
-	}
-	return out
 }
 

--- a/internal/templates/components/breadcrumb.templ
+++ b/internal/templates/components/breadcrumb.templ
@@ -8,32 +8,60 @@ type Breadcrumb struct {
 	Href  string
 }
 
-// BreadcrumbNav renders a navigation breadcrumb trail. The last entry is
-// the current page (no link, bolder text).
+// TopbarBreadcrumbProps carries the resolved topbar location trail.
+type TopbarBreadcrumbProps struct {
+	// Section is the nav-section group shown before the trail
+	// (e.g. "Manage"). Muted, non-link. Empty for sectionless pages.
+	Section string
+	// Items is the navigable trail. Intermediate entries link; the last
+	// entry (Href == "") is the bold current page. Empty on list / top
+	// level pages, where PageTitle stands in as the current crumb.
+	Items []Breadcrumb
+	// PageTitle is the current-page label used when Items is empty.
+	PageTitle string
+	// Scrollable renders the trail for the mobile strip: crumbs keep their
+	// natural width and the container scrolls horizontally instead of
+	// truncating the current crumb (the desktop topbar truncates instead).
+	Scrollable bool
+}
+
+// TopbarBreadcrumb renders the app's single location trail in the topbar
+// slash style: `Section / parent / … / current`. It is the only
+// breadcrumb surface — the layout renders it in the desktop topbar and
+// the mobile strip (base.html); pages no longer carry their own.
 //
-// Built on daisy 5 `breadcrumbs` — daisy renders the chevron as a CSS-only
-// rotated border (no SVG), so we don't fight sub-pixel SVG row-height
-// mismatches and can drop the `overflow-y: clip` workaround the previous
-// hand-rolled `.bb-breadcrumb` carried.
-//
-// Three-tier colour ramp is preserved via Tailwind utilities:
-//   - chevron:        text-base-content/25  (set on the <li>, inherited by ::before)
-//   - link:           text-base-content/40 → hover text-base-content/70
-//   - current crumb:  text-base-content/70 font-medium
-templ BreadcrumbNav(items []Breadcrumb) {
-	if len(items) > 0 {
-		<nav aria-label="Breadcrumb" class="breadcrumbs text-sm mb-6 py-0">
-			<ul>
-				for _, crumb := range items {
-					<li class="text-base-content/25">
-						if crumb.Href != "" {
-							<a class="text-base-content/40 no-underline hover:no-underline hover:text-base-content/70 transition-colors duration-150" href={ templ.SafeURL(crumb.Href) }>{ crumb.Label }</a>
-						} else {
-							<span class="text-base-content/70 font-medium cursor-default">{ crumb.Label }</span>
-						}
-					</li>
+// Tiers (matching the legacy topbar ramp):
+//   - section:    text-base-content/40  (non-link group label)
+//   - separator:  text-base-content/25
+//   - link crumb: text-base-content/40 → hover text-base-content/70
+//   - current:    text-base-content     font-medium
+templ TopbarBreadcrumb(p TopbarBreadcrumbProps) {
+	<div class={ "bb-topbar-breadcrumb", templ.KV("overflow-x-auto", p.Scrollable) }>
+		{{ first := true }}
+		if p.Section != "" {
+			<span class="shrink-0 text-base-content/40">{ p.Section }</span>
+			{{ first = false }}
+		}
+		if len(p.Items) > 0 {
+			for i, crumb := range p.Items {
+				if !first {
+					<span class="shrink-0 text-base-content/25">/</span>
 				}
-			</ul>
-		</nav>
-	}
+				if crumb.Href != "" {
+					<a
+						href={ templ.SafeURL(crumb.Href) }
+						class="shrink-0 whitespace-nowrap text-base-content/40 no-underline hover:no-underline hover:text-base-content/70 transition-colors duration-150"
+					>{ crumb.Label }</a>
+				} else {
+					<span class={ "whitespace-nowrap font-medium text-base-content", templ.KV("min-w-0 truncate", !p.Scrollable && i == len(p.Items)-1) }>{ crumb.Label }</span>
+				}
+				{{ first = false }}
+			}
+		} else {
+			if !first {
+				<span class="shrink-0 text-base-content/25">/</span>
+			}
+			<span class={ "whitespace-nowrap font-medium text-base-content", templ.KV("min-w-0 truncate", !p.Scrollable) }>{ p.PageTitle }</span>
+		}
+	</div>
 }

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -36,7 +36,6 @@ templ AccountDetail(p AccountDetailProps) {
 	<script src="/static/js/admin/components/account_detail.js"></script>
 	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	@acctHeader(p)
 	@acctSummaryCards(p)
 	@acctSettings(p)

--- a/internal/templates/components/pages/account_detail_types.go
+++ b/internal/templates/components/pages/account_detail_types.go
@@ -4,7 +4,6 @@ package pages
 
 import (
 	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
 )
 
 // AccountDetailProps is the full view model for the /admin/accounts/{id}
@@ -13,7 +12,6 @@ import (
 // TemplateRenderer.RenderWithTempl.
 type AccountDetailProps struct {
 	CSRFToken   string
-	Breadcrumbs []components.Breadcrumb
 
 	// Account context.
 	AccountID string

--- a/internal/templates/components/pages/account_link_detail.templ
+++ b/internal/templates/components/pages/account_link_detail.templ
@@ -14,7 +14,6 @@ import (
 // card list, same empty-state, same per-match Confirm/Reject affordances
 // for auto-confidence rows.
 templ AccountLinkDetail(p AccountLinkDetailProps) {
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Transaction Matches</h1>

--- a/internal/templates/components/pages/account_link_detail_types.go
+++ b/internal/templates/components/pages/account_link_detail_types.go
@@ -2,7 +2,6 @@
 
 package pages
 
-import "breadbox/internal/templates/components"
 
 // AccountLinkDetailProps is the flat view-model the account-link detail
 // page renders. Mirrors the data map the old account_link_detail.html
@@ -11,7 +10,6 @@ import "breadbox/internal/templates/components"
 // projecting *string merchant fields into Go strings for the templ
 // layer.
 type AccountLinkDetailProps struct {
-	Breadcrumbs []components.Breadcrumb
 	CSRFToken   string
 
 	LinkID                  string

--- a/internal/templates/components/pages/agent_detail.templ
+++ b/internal/templates/components/pages/agent_detail.templ
@@ -25,7 +25,6 @@ import (
 //  7. agentDetailRecentRuns — last 10 runs via AgentRunRow.
 templ AgentDetail(p AgentDetailProps) {
 	<div x-data x-init="$store.shortcuts.setScope('agent-detail')" x-destroy="$store.shortcuts.setScope('global')"></div>
-	@components.BreadcrumbNav(agentDetailBreadcrumbs(p))
 	@components.PageHeader(components.PageHeaderProps{
 		Title:    p.Name,
 		Subtitle: agentDetailSubtitle(p),
@@ -252,8 +251,9 @@ templ agentDetailRecentRuns(p AgentDetailProps) {
 	@templ.Raw(agentDetailRunScriptHTML)
 }
 
-// agentDetailBreadcrumbs builds Agents › <agent name>.
-func agentDetailBreadcrumbs(p AgentDetailProps) []components.Breadcrumb {
+// AgentDetailBreadcrumbs builds Agents › <agent name>. Consumed by the
+// handler to populate the layout's topbar trail (data["Breadcrumbs"]).
+func AgentDetailBreadcrumbs(p AgentDetailProps) []components.Breadcrumb {
 	return []components.Breadcrumb{
 		{Label: "Agents", Href: "/agents/definitions"},
 		{Label: p.Name},

--- a/internal/templates/components/pages/agent_form.templ
+++ b/internal/templates/components/pages/agent_form.templ
@@ -32,7 +32,6 @@ templ AgentForm(p AgentFormProps) {
 	<script src="/static/js/admin/slug.js"></script>
 	<script src="/static/js/admin/components/agent_form.js"></script>
 	@templ.JSONScript("agent-form-data", agentFormInitialJSON(p.Form))
-	@components.BreadcrumbNav(agentFormBreadcrumbs(p))
 	@components.PageHeader(components.PageHeaderProps{
 		Title:    p.Title,
 		Subtitle: "Configure when this agent runs, which tools it can use, and what prompt drives it.",
@@ -548,9 +547,9 @@ func agentFormSubmitAction(p AgentFormProps) string {
 	return "/-/agents"
 }
 
-// agentFormBreadcrumbs builds the breadcrumb trail. Last entry is the
-// current page label (rendered without a link by BreadcrumbNav).
-func agentFormBreadcrumbs(p AgentFormProps) []components.Breadcrumb {
+// AgentFormBreadcrumbs builds the breadcrumb trail. Consumed by the
+// handler to populate the layout's topbar trail (data["Breadcrumbs"]).
+func AgentFormBreadcrumbs(p AgentFormProps) []components.Breadcrumb {
 	last := "New"
 	if p.Mode == "edit" {
 		last = "Edit"

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -58,7 +58,6 @@ templ AgentRunDetail(p AgentRunDetailProps) {
 		if effectiveRunPrompt(p) != "" {
 			<template x-ref="promptText">{ effectiveRunPrompt(p) }</template>
 		}
-		@components.BreadcrumbNav(agentRunDetailBreadcrumbs(p))
 		@agentRunDetailHeader(p)
 		@agentRunSummaryStats(p)
 		if p.Run.Status == "error" && p.Run.ErrorMessage != "" {
@@ -330,10 +329,11 @@ templ agentRunErrorAlert(run AgentRunRowProps) {
 	}
 }
 
-// agentRunDetailBreadcrumbs builds the breadcrumb trail. Agents › Agent
-// name › <short ID>. The agent crumb links to /agents?agent=<slug> (the
-// filtered feed) so consecutive runs stay in scope.
-func agentRunDetailBreadcrumbs(p AgentRunDetailProps) []components.Breadcrumb {
+// AgentRunDetailBreadcrumbs builds the breadcrumb trail: Runs › Agent
+// name › <short ID>. The agent crumb links to /workflows/runs?workflow=<slug>
+// (the filtered feed) so consecutive runs stay in scope. Consumed by the
+// handler to populate the layout's topbar trail (data["Breadcrumbs"]).
+func AgentRunDetailBreadcrumbs(p AgentRunDetailProps) []components.Breadcrumb {
 	out := []components.Breadcrumb{{Label: "Runs", Href: "/workflows/runs"}}
 	if p.Run.AgentSlug != "" {
 		out = append(out, components.Breadcrumb{

--- a/internal/templates/components/pages/category_form.templ
+++ b/internal/templates/components/pages/category_form.templ
@@ -22,7 +22,6 @@ templ CategoryForm(p CategoryFormProps) {
 		<script src="/static/js/admin/slug.js"></script>
 	}
 	@components.CategoryPickerScript()
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	@components.CategoryPickerStyles()
 	<div class="bb-page-header">
 		<div>

--- a/internal/templates/components/pages/category_form_types.go
+++ b/internal/templates/components/pages/category_form_types.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
 )
 
 // CategoryFormProps mirrors the data map the old category_form.html
@@ -18,7 +17,6 @@ type CategoryFormProps struct {
 	IsEdit      bool
 	Category    *service.CategoryResponse
 	Categories  []service.CategoryResponse
-	Breadcrumbs []components.Breadcrumb
 }
 
 // categoryColorOr returns the current color value or a sensible default

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -24,7 +24,6 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 	     from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/connection_detail.js"></script>
 	<div class="max-w-full overflow-x-hidden" x-data="connectionDetail" data-conn-id={ p.ConnID }>
-		@components.BreadcrumbNav(p.Breadcrumbs)
 		if p.Status == "error" || p.Status == "pending_reauth" {
 			<div role="alert" class="alert alert-error rounded-xl mb-6">
 				@components.LucideIcon("alert-triangle", "w-5 h-5 shrink-0")

--- a/internal/templates/components/pages/connection_detail_types.go
+++ b/internal/templates/components/pages/connection_detail_types.go
@@ -2,15 +2,12 @@
 
 package pages
 
-import "breadbox/internal/templates/components"
-
 // ConnectionDetailProps mirrors the data map the old connection_detail.html
 // read off the layout. Kept flat so admin/connections.go can copy fields
 // one-to-one.
 type ConnectionDetailProps struct {
 	ConnID      string
 	CSRFToken   string
-	Breadcrumbs []components.Breadcrumb
 
 	// Connection fields (flattened from db.GetBankConnectionRow)
 	Provider                          string

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -17,7 +17,6 @@ templ ConnectionNew(p ConnectionNewProps) {
 	     Alpine.data() registration runs before Alpine — itself deferred
 	     from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/connection_new.js"></script>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Connect New Bank</h1>

--- a/internal/templates/components/pages/connection_new_types.go
+++ b/internal/templates/components/pages/connection_new_types.go
@@ -2,7 +2,6 @@
 
 package pages
 
-import "breadbox/internal/templates/components"
 
 // ConnectionNewProps mirrors the data map the old connection_new.html read
 // off the layout's data map. The handler pre-resolves the user list into a
@@ -15,7 +14,6 @@ import "breadbox/internal/templates/components"
 // inline <script> so TellerConnect.setup picks up sandbox/development/
 // production from the running config.
 type ConnectionNewProps struct {
-	Breadcrumbs []components.Breadcrumb
 	Users       []ConnectionNewUser
 	CSRFToken   string
 	HasPlaid    bool

--- a/internal/templates/components/pages/connection_reauth.templ
+++ b/internal/templates/components/pages/connection_reauth.templ
@@ -41,7 +41,6 @@ templ ConnectionReauth(p ConnectionReauthProps) {
 		<script src="https://cdn.teller.io/connect/connect.js"></script>
 	}
 	<script src="/static/js/admin/components/connection_reauth.js"></script>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Re-authenticate</h1>

--- a/internal/templates/components/pages/create_login.templ
+++ b/internal/templates/components/pages/create_login.templ
@@ -15,7 +15,6 @@ import "breadbox/internal/templates/components"
 // newLoginBootstrap) so the templ template stays free of inline JS string
 // concatenation. The wrapping HTML mirrors create_login.html byte-for-byte.
 templ CreateLogin(p CreateLoginProps) {
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	if p.IsManage {
 		@createLoginManage(p)
 	} else {

--- a/internal/templates/components/pages/create_login_types.go
+++ b/internal/templates/components/pages/create_login_types.go
@@ -5,7 +5,6 @@ package pages
 import (
 	"fmt"
 
-	"breadbox/internal/templates/components"
 )
 
 // CreateLoginProps mirrors the data map create_login.html consumed. The
@@ -31,7 +30,6 @@ type CreateLoginProps struct {
 	SetupURL          string // empty when no token / password already set
 
 	// Breadcrumb trail.
-	Breadcrumbs []components.Breadcrumb
 }
 
 // manageLoginRoleAlpine returns the inline x-data expression for the role

--- a/internal/templates/components/pages/csv_import.templ
+++ b/internal/templates/components/pages/csv_import.templ
@@ -23,7 +23,6 @@ templ CSVImport(p CSVImportProps) {
 	     synchronously (no defer) so the Alpine.data() registration runs
 	     before Alpine — itself deferred from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/csv_import.js"></script>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Import CSV</h1>

--- a/internal/templates/components/pages/csv_import_types.go
+++ b/internal/templates/components/pages/csv_import_types.go
@@ -2,7 +2,6 @@
 
 package pages
 
-import "breadbox/internal/templates/components"
 
 // CSVImportProps mirrors the data map the old csv_import.html read off the
 // layout's data map. The handler pre-resolves the user list into a flat
@@ -12,7 +11,6 @@ import "breadbox/internal/templates/components"
 // member + account-name fields are hidden and replaced by an info row that
 // shows the existing connection's name + owner.
 type CSVImportProps struct {
-	Breadcrumbs            []components.Breadcrumb
 	Users                  []CSVImportUser
 	CSRFToken              string
 	ConnectionID           string

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1353,6 +1353,58 @@ templ SectionOverflowMenu() {
 	</div>
 }
 
+// ─── Topbar breadcrumb ─────────────────────────────────────────────────
+
+templ SectionTopbarBreadcrumb() {
+	<div class="flex flex-col gap-6">
+		@designExample("Section + navigable trail", "The common detail-page shape. The section group (muted) is non-link; ancestor crumbs link; the last crumb is the bold current page.") {
+			@components.TopbarBreadcrumb(components.TopbarBreadcrumbProps{
+				Section: "Manage",
+				Items: []components.Breadcrumb{
+					{Label: "Rules", Href: "/rules"},
+					{Label: "My Rule"},
+				},
+			})
+		}
+		@designExample("Deep / cross-section trail", "The section is derived from the trail's root crumb, so it stays coherent even when the page's nav-active item differs (an account detail roots at Connections).") {
+			@components.TopbarBreadcrumb(components.TopbarBreadcrumbProps{
+				Section: "System",
+				Items: []components.Breadcrumb{
+					{Label: "Connections", Href: "/connections"},
+					{Label: "Chase", Href: "/connections/x"},
+					{Label: "Account"},
+				},
+			})
+		}
+		@designExample("List / top-level page", "No trail — PageTitle stands in as the current crumb. Every list page reads Section / Page.") {
+			@components.TopbarBreadcrumb(components.TopbarBreadcrumbProps{
+				Section:   "Overview",
+				PageTitle: "Transactions",
+			})
+		}
+		@designExample("Sectionless", "Pages with no nav section render the current crumb alone.") {
+			@components.TopbarBreadcrumb(components.TopbarBreadcrumbProps{
+				Items: []components.Breadcrumb{
+					{Label: "Design system"},
+				},
+			})
+		}
+		@designExample("Mobile strip (scrollable)", "The lg:hidden variant below the mobile navbar: crumbs keep their natural width and the row scrolls horizontally instead of truncating. Constrained here to show the scroll.") {
+			<div class="max-w-[16rem] rounded-lg border border-base-300 px-3 py-2">
+				@components.TopbarBreadcrumb(components.TopbarBreadcrumbProps{
+					Section: "System",
+					Items: []components.Breadcrumb{
+						{Label: "Connections", Href: "/connections"},
+						{Label: "Chase Sapphire Reserve", Href: "/connections/x"},
+						{Label: "Primary Checking Account"},
+					},
+					Scrollable: true,
+				})
+			</div>
+		}
+	</div>
+}
+
 // ─── Sidebar user menu ─────────────────────────────────────────────────
 
 templ SectionSidebarUserMenu() {

--- a/internal/templates/components/pages/design_smoke_test.go
+++ b/internal/templates/components/pages/design_smoke_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-
-	"breadbox/internal/templates/components"
 )
 
 // TestDesignGalleryRenders is a smoke test: every DesignSections() entry
@@ -58,8 +56,7 @@ func TestDesignGalleryRenders(t *testing.T) {
 	// Gallery render: must include the anchor for every section's slug.
 	var buf bytes.Buffer
 	props := DesignGalleryProps{
-		Sections:    sections,
-		Breadcrumbs: []components.Breadcrumb{{Label: "Design system"}},
+		Sections: sections,
 	}
 	if err := DesignGallery(props).Render(context.Background(), &buf); err != nil {
 		t.Fatalf("gallery render error: %v", err)
@@ -100,10 +97,6 @@ func TestDesignComponentRenders(t *testing.T) {
 		var buf bytes.Buffer
 		props := DesignComponentProps{
 			Section: sec,
-			Breadcrumbs: []components.Breadcrumb{
-				{Label: "Design system", Href: "/design"},
-				{Label: sec.Title},
-			},
 		}
 		if err := DesignComponent(props).Render(context.Background(), &buf); err != nil {
 			t.Errorf("section %q standalone render error: %v", sec.Slug, err)

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -16,7 +16,6 @@ import (
 // DesignGalleryProps is the prop bag for the /design page — the full
 // component gallery rendered on one scrollable page with section anchors.
 type DesignGalleryProps struct {
-	Breadcrumbs []components.Breadcrumb
 	Sections    []DesignSection
 }
 
@@ -24,7 +23,6 @@ type DesignGalleryProps struct {
 // component rendered in isolation so agents (and humans) can focus
 // screenshots on one piece at a time.
 type DesignComponentProps struct {
-	Breadcrumbs []components.Breadcrumb
 	Section     DesignSection
 }
 

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -196,6 +196,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionOverflowMenu() },
 		},
 		{
+			Slug:        "topbar-breadcrumb",
+			Title:       "Topbar breadcrumb",
+			Description: "The app's single location trail, rendered in the topbar (and a scrollable mobile strip). Section group + navigable parent crumbs + bold current page. Use components.TopbarBreadcrumb; the layout owns it — pages don't render their own breadcrumb.",
+			Group:       "navigation",
+			Render:      func() templ.Component { return SectionTopbarBreadcrumb() },
+		},
+		{
 			Slug:        "sidebar-user-menu",
 			Title:       "Sidebar user menu",
 			Description: "Consolidated identity + actions popover at the bottom of the sidebar. Trigger shows avatar + display name + role; popover holds Documentation, GitHub, an editor-only /design shortcut, and a destructive Sign out below an <hr> separator. (Settings lives in the sidebar System section, not here.) Use components.SidebarUserMenu.",

--- a/internal/templates/components/pages/recurring_form.templ
+++ b/internal/templates/components/pages/recurring_form.templ
@@ -8,10 +8,6 @@ import "breadbox/internal/templates/components"
 // page. Plain POST form (no Alpine) → CreateRecurringSeriesHandler mints an
 // active, confirmed, user-authored series and redirects to its detail page.
 templ RecurringSeriesForm(p RecurringSeriesFormProps) {
-	@components.BreadcrumbNav([]components.Breadcrumb{
-		{Label: "Recurring", Href: "/recurring"},
-		{Label: "New series"},
-	})
 	@components.PageHeader(components.PageHeaderProps{
 		Title:                "New recurring series",
 		Subtitle:             "Add a recurring charge Breadbox hasn't detected yet. It starts active and confirmed.",

--- a/internal/templates/components/pages/report_detail.templ
+++ b/internal/templates/components/pages/report_detail.templ
@@ -25,7 +25,6 @@ templ ReportDetail(p ReportDetailProps) {
 	<script src="/static/js/admin/markdown.js"></script>
 	<script src="/static/js/admin/components/report_detail.js"></script>
 	<div class="max-w-4xl mx-auto">
-		@components.BreadcrumbNav(p.Breadcrumbs)
 		<div
 			x-data="reportDetail"
 			data-report-id={ p.Report.ID }

--- a/internal/templates/components/pages/report_detail_types.go
+++ b/internal/templates/components/pages/report_detail_types.go
@@ -3,7 +3,6 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components"
 )
 
 // ReportDetailProps mirrors the data the old report_detail.html read off
@@ -14,7 +13,6 @@ import (
 // keep the templ free of pgtype/funcMap helpers.
 type ReportDetailProps struct {
 	Report      ReportDetailReport
-	Breadcrumbs []components.Breadcrumb
 }
 
 // ReportDetailReport flattens the agent-report fields the detail page

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -33,7 +33,6 @@ templ RuleDetail(p RuleDetailProps) {
 	<script src="/static/js/admin/components/tx_row_helpers.js"></script>
 	<script src="/static/js/admin/components/rule_detail.js"></script>
 	@components.CategoryPickerScript()
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	@templ.JSONScript("rule-detail-data", p.Categories)
 	<div
 		x-data="ruleDetail"

--- a/internal/templates/components/pages/rule_detail_types.go
+++ b/internal/templates/components/pages/rule_detail_types.go
@@ -29,7 +29,6 @@ type RuleDetailProps struct {
 	LastActiveTime time.Time
 	HasLastActive  bool
 	ConditionSummary string
-	Breadcrumbs      []components.Breadcrumb
 	// ConditionRows is the pre-formatted list of ConditionRowProps the handler
 	// computes for non-match-all rules. Empty when the rule matches everything
 	// or when no conditions are stored. Order mirrors the source tree (And, Or,

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -20,7 +20,6 @@ templ RuleForm(p RuleFormProps) {
 	     synchronously (no defer) so the Alpine.data() registration runs
 	     before Alpine — itself deferred from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/rule_form.js"></script>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	if p.Rule != nil {
 		@templ.JSONScript("rule-form-data", p.Rule)
 	}

--- a/internal/templates/components/pages/rule_form_types.go
+++ b/internal/templates/components/pages/rule_form_types.go
@@ -4,7 +4,6 @@ package pages
 
 import (
 	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
 )
 
 // RuleFormProps mirrors the data map the old rule_form.html read off the
@@ -14,7 +13,6 @@ type RuleFormProps struct {
 	Rule           *service.TransactionRuleResponse
 	FlatCategories []service.CategoryResponse
 	Tags           []service.TagResponse
-	Breadcrumbs    []components.Breadcrumb
 }
 
 // ruleFormIsEditAttr returns the literal string "true" or "false" for the

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -24,10 +24,6 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()
 	<div x-data="seriesDetail" data-series-id={ p.Series.ShortID }>
-		@components.BreadcrumbNav([]components.Breadcrumb{
-			{Label: "Recurring", Href: "/recurring"},
-			{Label: p.Series.Name},
-		})
 		@components.EntityHeader(components.EntityHeaderProps{
 			Title:    p.Series.Name,
 			Icon:     seriesTypeIcon(p.Series.Type),

--- a/internal/templates/components/pages/sync_log_detail.templ
+++ b/internal/templates/components/pages/sync_log_detail.templ
@@ -11,7 +11,6 @@ import (
 // handler builds typed props in admin/synclogs.go and the bridge drops
 // the rendered HTML into base.html's TemplContent slot.
 templ SyncLogDetail(p SyncLogDetailProps) {
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	@components.EntityHeader(components.EntityHeaderProps{
 		Title:         p.Log.InstitutionName,
 		IconComponent: syncDetailHeaderIcon(p.Log.Status),

--- a/internal/templates/components/pages/sync_log_detail_types.go
+++ b/internal/templates/components/pages/sync_log_detail_types.go
@@ -3,7 +3,6 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components"
 )
 
 // SyncLogDetailProps mirrors the data the old sync_log_detail.html
@@ -16,7 +15,6 @@ import (
 type SyncLogDetailProps struct {
 	Log         SyncLogDetailLog
 	Accounts    []SyncLogDetailAccount
-	Breadcrumbs []components.Breadcrumb
 }
 
 // SyncLogDetailLog flattens service.SyncLogRow into the subset the

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -8,7 +8,6 @@ import "breadbox/internal/templates/components"
 // Alpine submit flow) is preserved.
 templ TagForm(p TagFormProps) {
 	<script src="/static/js/admin/slug.js"></script>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">

--- a/internal/templates/components/pages/tag_form_types.go
+++ b/internal/templates/components/pages/tag_form_types.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
 )
 
 // TagFormProps mirrors the data map the old tag_form.html read: the
@@ -15,7 +14,6 @@ import (
 type TagFormProps struct {
 	IsEdit      bool
 	Tag         *service.TagResponse
-	Breadcrumbs []components.Breadcrumb
 }
 
 // tagIDOr returns the tag ID or empty string when no tag is set.

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -54,7 +54,6 @@ templ TransactionDetail(p TransactionDetailProps) {
 		'global' on Alpine teardown so other pages don't inherit the scope.
 	-->
 	<div x-data x-init="$store.shortcuts.setScope('transaction-detail')" x-destroy="$store.shortcuts.setScope('global')"></div>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	@txdHero(p)
 	if p.AccountName != "" {
 		@txdAccountBanner(p)

--- a/internal/templates/components/pages/transaction_detail_types.go
+++ b/internal/templates/components/pages/transaction_detail_types.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
 )
 
 // metadataKV is one rendered key/value row from a transaction's metadata blob.
@@ -68,7 +67,6 @@ type ActivityDayGroup struct {
 type TransactionDetailProps struct {
 	CSRFToken string
 
-	Breadcrumbs []components.Breadcrumb
 
 	Transaction   *service.TransactionResponse
 	TransactionID string

--- a/internal/templates/components/pages/user_form.templ
+++ b/internal/templates/components/pages/user_form.templ
@@ -12,7 +12,6 @@ templ UserForm(p UserFormProps) {
 	// listener before Alpine fires the event. See #828 for the debugging
 	// trail behind this rule.
 	<script src="/static/js/admin/components/user_form.js"></script>
-	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">

--- a/internal/templates/components/pages/user_form_types.go
+++ b/internal/templates/components/pages/user_form_types.go
@@ -4,7 +4,6 @@ package pages
 
 import (
 	"breadbox/internal/db"
-	"breadbox/internal/templates/components"
 )
 
 // UserFormProps mirrors the data map the old user_form.html read: the
@@ -14,7 +13,6 @@ type UserFormProps struct {
 	IsEdit      bool
 	User        *db.User
 	UserID      string
-	Breadcrumbs []components.Breadcrumb
 }
 
 // userFormName returns the user's name or empty string.

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -484,14 +484,9 @@
            mobile navbar below takes over). Left: breadcrumb of the current
            section/page. Right: ⌘K search, theme toggle, profile menu. -->
       <header class="bb-topbar">
-        <div class="bb-topbar-breadcrumb">
-          {{$section := pageSection .CurrentPage}}
-          {{if $section}}
-          <span class="text-base-content/40">{{$section}}</span>
-          <span class="text-base-content/25">/</span>
-          {{end}}
-          <span class="font-medium text-base-content truncate">{{.PageTitle}}</span>
-        </div>
+        {{/* Single location trail — Section / parent / … / current. The
+             layout owns this; pages no longer render their own breadcrumb. */}}
+        {{renderComponent "TopbarBreadcrumb" .}}
         <div class="flex items-center gap-1.5 shrink-0">
           <button type="button"
                   class="bb-topbar-search"
@@ -548,6 +543,14 @@
           {{end}}
         </div>
       </div>
+      {{/* Mobile location trail — the desktop topbar is hidden < lg, so the
+           breadcrumb rides below the mobile navbar (scrollable) on detail
+           pages. Only rendered when the page supplies a trail. */}}
+      {{if .Breadcrumbs}}
+      <div class="lg:hidden px-4 pt-3">
+        {{renderComponent "TopbarBreadcrumbMobile" .}}
+      </div>
+      {{end}}
       <!-- Page content -->
       <main class="p-4 sm:p-6 min-h-screen">
         {{template "flash" .}}

--- a/internal/templates/partials/breadcrumb.html
+++ b/internal/templates/partials/breadcrumb.html
@@ -1,8 +1,0 @@
-{{/*
-  Thin html/template facade around the templ component in
-  internal/templates/components/breadcrumb.templ. Pages still call
-  {{template "breadcrumb" .}} and pass the full layout data; we
-  forward the .Breadcrumbs slice to the component. Empty slice renders
-  nothing. See issue #462 for migration context.
-*/}}
-{{define "breadcrumb"}}{{renderComponent "Breadcrumb" .Breadcrumbs}}{{end}}


### PR DESCRIPTION
The navbar title (`Section / Page`) and the per-page in-page breadcrumb both read as breadcrumbs and stacked redundantly on every detail page. This unifies on **one** breadcrumb surface — the topbar becomes the real, navigable trail and pages no longer render their own.

## What changed

- **The topbar is the breadcrumb.** It keeps the existing slash style but now renders the full navigable trail — `Section / parent / … / current`. The section group is derived from the trail's **root crumb** (not the nav-active page), so it never contradicts the path: an account detail rooted at Connections reads `System / Connections / …` even though its active nav item is Transactions.
- **New `components.TopbarBreadcrumb`** (with a `Scrollable` mobile variant). `components.BreadcrumbNav` and `partials/breadcrumb.html` are retired.
- **Mobile preserved.** The desktop topbar is `hidden < lg`, so the trail also renders as a slim, scrollable `lg:hidden` strip below the mobile navbar. The two never appear at once.
- **Breadcrumbs are chrome now.** Handlers stash the trail in `data["Breadcrumbs"]`; the per-page `Props.Breadcrumbs` fields are removed. Agent trail builders are exported (`AgentDetailBreadcrumbs`, etc.) and called from their handlers.
- Unit tests for `pageIDFromHref` + `topbarSectionLabel` (the section-coverage test still guards the nav mapping).

## Validation

`go build/vet/test ./...` green (one pre-existing timing flake in `internal/agent`, unrelated — passes in isolation). Verified in a real browser against the dev DB:

**Transaction detail — desktop** — `Overview / Transactions / Platinum Card / Kohl's`, body starts straight at the entity header (no in-page breadcrumb):

<img src="https://i.img402.dev/osmi7a1ag7.jpg" width="800" alt="transaction detail — desktop topbar breadcrumb">

**Rule detail — desktop** — `Manage / Rules / …` (section derived from the trail root):

<img src="https://i.img402.dev/1hmsvmwd63.jpg" width="800" alt="rule detail — desktop topbar breadcrumb">

**Transaction detail — mobile** — the trail rides below the mobile navbar (scrollable), so back-nav survives where the desktop topbar is hidden:

<img src="https://i.img402.dev/vbg590v3pb.jpg" width="320" alt="transaction detail — mobile breadcrumb strip">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
