### PR TITLE
feat(notifications): dedicated settings page + native ntfy formatting

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -407,11 +407,17 @@ The sidecar receives the minted run key as `BREADBOX_API_KEY`. `runMCPStdio` (`i
 
 ## 8. Notification Sink
 
-Workflows can fire an outbound JSON webhook when noteworthy events occur (typically when a run submits a report via `submit_report`).
+Workflows can fire an outbound webhook when noteworthy events occur (typically when a run submits a report via `submit_report`).
 
 ### Configuration
 
-The webhook URL is stored in `app_config[notify.webhook_url]` (plaintext, http(s) only). It is set from Settings -> Agents (the `POST /-/workflows/settings` handler writes `NotifyWebhookURL`). A "Send test" button (`POST /-/workflows/notify-test`) fires a sample payload to verify the wiring.
+The sink lives on its own **Settings → Notifications** page (`/settings/notifications`, admin-only) and is stored across three `app_config` keys (all plaintext):
+
+- `notify.webhook_url` — the http(s) sink. Empty = notifications off.
+- `notify.format` — `auto` (default) | `ntfy` | `json`. Selects the wire shape (see Delivery).
+- `notify.public_base_url` — optional absolute origin (e.g. `https://breadbox.example.com`) used to build absolute deep links so an ntfy tap-through (and relative links in a report body) resolve to the real report.
+
+The `POST /settings/notifications` handler writes all three together; a "Send test" button (`POST /-/notifications/test`) fires a sample payload to verify the wiring. The legacy `POST /-/workflows/notify-test` route remains as a back-compat alias.
 
 ### NotificationPayload
 
@@ -429,9 +435,11 @@ type NotificationPayload struct {
 
 ### Delivery
 
-`SendWorkflowNotification` is a no-op when no URL is configured — callers fire unconditionally without a nil-check. The request uses a 10-second timeout (`notifyHTTPClient`) and sets `Content-Type: application/json` and `User-Agent: breadbox-workflows`. Any HTTP 3xx+ response is treated as an error.
+`SendWorkflowNotification` is a no-op when no URL is configured — callers fire unconditionally without a nil-check. The request uses a 10-second timeout (`notifyHTTPClient`) and `User-Agent: breadbox-workflows`. Any HTTP 3xx+ response is treated as an error. The wire shape depends on `notify.format`:
 
-The sink is generic by design: it works with ntfy, Slack-compatible relay bridges, Discord webhooks (via a formatter), and email bridges without per-provider formatting in Breadbox.
+- **`json`** — POSTs the `NotificationPayload` envelope above as `application/json`. Suits Slack-compatible relay bridges, Discord webhooks (via a formatter), and email bridges.
+- **`ntfy`** — publishes natively to [ntfy](https://docs.ntfy.sh/publish/): the request body is the (markdown) message and metadata rides in headers — `X-Title`, `X-Priority` (info→3 / warning→4 / critical→5), `X-Markdown: yes`, `X-Tags` (an emoji per priority), and `X-Click` (the absolute deep link, when a public base URL is set). Non-ASCII header values are RFC 2047-encoded. This is what makes an ntfy push render as a real titled, tap-through notification instead of a raw JSON blob.
+- **`auto`** (default) — picks `ntfy` when the webhook host looks like ntfy (`ntfy.sh` or any host containing `ntfy`), else `json`.
 
 ---
 

--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -279,11 +279,6 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 			zero := 0.0
 			params.GlobalMaxBudgetUSD = &zero
 		}
-		if r.Form.Has("notify_webhook_url") {
-			v := strings.TrimSpace(r.FormValue("notify_webhook_url"))
-			params.NotifyWebhookURL = &v // empty clears; service validates http(s)
-		}
-
 		if _, err := svc.UpdateAgentSettings(r.Context(), params, a.Config.EncryptionKey, a.Config.DataDir); err != nil {
 			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/workflows")
 			return

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -58,7 +58,6 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			RuntimePath:           settings.RuntimePath,
 			TranscriptDir:         settings.TranscriptDir,
 			GlobalMaxBudgetUSDStr: formatOptionalBudget(settings.GlobalMaxBudgetUSD),
-			NotifyWebhookURL:      settings.NotifyWebhookURL,
 		}
 		if settings.SubscriptionToken != nil {
 			form.SubscriptionTokenDisplay = *settings.SubscriptionToken

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -1,0 +1,90 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"net/http"
+	"strings"
+
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components/pages"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// NotificationsSettingsHandler serves GET /settings/notifications — the
+// dedicated Notifications tab. It owns the outbound notification sink
+// (webhook URL + wire format + public base URL) that workflow runs push
+// reports to. Split out of the Workflows settings tab so notification
+// delivery has room to grow its own surface.
+func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		settings, err := svc.GetNotificationSettings(r.Context())
+		if err != nil {
+			http.Error(w, "Failed to load notification settings: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		flash := GetFlash(r.Context(), sm)
+		var formError, formSuccess string
+		if flash != nil {
+			switch flash.Type {
+			case "error":
+				formError = flash.Message
+			case "success":
+				formSuccess = flash.Message
+			}
+		}
+
+		props := pages.NotificationsSettingsProps{
+			Form: pages.NotificationsSettingsFormFields{
+				WebhookURL:    settings.WebhookURL,
+				Format:        settings.Format,
+				PublicBaseURL: settings.PublicBaseURL,
+			},
+			FieldErrors: map[string]string{},
+			FormError:   formError,
+			FormSuccess: formSuccess,
+			CSRFToken:   GetCSRFToken(r),
+		}
+
+		data := BaseTemplateData(r, sm, "notifications-settings", "Notifications")
+		data["CSRFToken"] = props.CSRFToken
+		data["Flash"] = nil
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabNotifications, pages.NotificationsSettings(props))
+	}
+}
+
+// NotificationsSettingsPostHandler handles POST /settings/notifications —
+// the multi-input sink form. Saves webhook URL, format, and public base
+// URL together, then redirects back to the tab with a flash. The service
+// validates URLs (http(s)) and the format enum.
+func NotificationsSettingsPostHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			FlashRedirect(w, r, sm, "error", "Could not read the submitted form.", "/settings/notifications")
+			return
+		}
+
+		var params service.UpdateNotificationSettingsParams
+		if r.Form.Has("webhook_url") {
+			v := strings.TrimSpace(r.FormValue("webhook_url"))
+			params.WebhookURL = &v // empty clears; service validates http(s)
+		}
+		if r.Form.Has("format") {
+			v := strings.TrimSpace(r.FormValue("format"))
+			params.Format = &v
+		}
+		if r.Form.Has("public_base_url") {
+			v := strings.TrimSpace(r.FormValue("public_base_url"))
+			params.PublicBaseURL = &v // empty clears; service validates http(s)
+		}
+
+		if _, err := svc.UpdateNotificationSettings(r.Context(), params); err != nil {
+			FlashRedirect(w, r, sm, "error", "Failed to save notification settings: "+err.Error(), "/settings/notifications")
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "Notification settings saved.")
+		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -394,6 +394,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings/backups", BackupsPageHandler(a, sm, tr))
 		r.Get("/backups", redirectGET("/settings/backups"))
 
+		// Notifications tab — the outbound notification sink (webhook URL,
+		// wire format, public base URL). Admin-only: the sink config governs
+		// where household report data egresses. The "Send test" button posts
+		// to /-/notifications/test (registered below).
+		r.Get("/settings/notifications", NotificationsSettingsHandler(svc, sm, tr))
+		r.Post("/settings/notifications", NotificationsSettingsPostHandler(svc, sm))
+
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
 		r.Get("/settings/general", SettingsGetHandler(a, sm, tr))
 		r.Get("/settings/sync", redirectGET("/settings/general"))
@@ -603,6 +610,11 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/workflows/test", SmokeTestAgentAdminHandler(a, svc))
 			r.Post("/workflows/notify-test", NotifyTestAdminHandler(svc))
 			r.Post("/workflows/cleanup", AgentCleanupAdminHandler(a, svc))
+
+			// Notifications tab "Send test" button. Canonical home for the
+			// test-delivery endpoint now that the sink lives on its own page;
+			// /-/workflows/notify-test stays as a back-compat alias.
+			r.Post("/notifications/test", NotifyTestAdminHandler(svc))
 		})
 	})
 

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -76,15 +76,37 @@ const (
 	KeyWorkflowsConsentAckAt = "workflows.consent_acknowledged_at"
 
 	// KeyNotifyWebhookURL is an optional outbound webhook URL. When set,
-	// Breadbox POSTs a JSON payload to it for workflow notifications (e.g.
+	// Breadbox POSTs a payload to it for workflow notifications (e.g.
 	// a report a workflow flagged). Empty = notifications disabled. The
 	// self-hoster controls the URL (point it at ntfy / Slack / Discord /
 	// an email bridge). http(s) only.
 	KeyNotifyWebhookURL = "notify.webhook_url"
+
+	// KeyNotifyFormat selects how the outbound notification request is
+	// shaped. "auto" (default) sniffs the webhook URL and publishes
+	// natively to ntfy when it looks like ntfy, falling back to the
+	// generic JSON envelope otherwise; "ntfy" forces ntfy's
+	// header+body publishing; "json" forces the JSON envelope (for
+	// Slack-compatible relays, Discord bridges, custom consumers).
+	KeyNotifyFormat = "notify.format"
+
+	// KeyNotifyPublicBaseURL is the absolute origin (scheme+host, no
+	// trailing slash) Breadbox prepends to report deep links carried in
+	// a notification — so an ntfy "tap to open" (and any relative link
+	// in the body) resolves to the real report instead of a bare path.
+	// Empty = deep links stay relative. http(s) only.
+	KeyNotifyPublicBaseURL = "notify.public_base_url"
 )
 
 // AuthMode values for KeyAgentAuthMode.
 const (
 	AuthModeSubscription = "subscription"
 	AuthModeAPIKey       = "api_key"
+)
+
+// NotifyFormat values for KeyNotifyFormat.
+const (
+	NotifyFormatAuto = "auto"
+	NotifyFormatNtfy = "ntfy"
+	NotifyFormatJSON = "json"
 )

--- a/internal/service/agent_settings.go
+++ b/internal/service/agent_settings.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -34,7 +33,6 @@ type AgentSettingsResponse struct {
 	GlobalMaxBudgetUSD *float64 `json:"global_max_budget_usd,omitempty"`
 	RuntimePath        string   `json:"runtime_path"`
 	TranscriptDir      string   `json:"transcript_dir"`
-	NotifyWebhookURL   string   `json:"notify_webhook_url"`
 }
 
 // UpdateAgentSettingsParams holds writable settings. Nil = don't touch;
@@ -47,7 +45,6 @@ type UpdateAgentSettingsParams struct {
 	GlobalMaxBudgetUSD *float64
 	RuntimePath        *string
 	TranscriptDir      *string
-	NotifyWebhookURL   *string
 }
 
 // GetAgentSettings reads agent.* keys from app_config, decrypts tokens,
@@ -71,7 +68,6 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte, dataDir s
 	// form showing the active path on a fresh install rather than blank.
 	transcriptDir := appconfig.String(ctx, s.Queries, appconfig.KeyAgentTranscriptDir, agent.DefaultTranscriptDir(dataDir))
 	globalBudget := readOptionalFloat(ctx, s.Queries, appconfig.KeyAgentGlobalMaxBudgetUSD)
-	notifyURL := appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, "")
 
 	return &AgentSettingsResponse{
 		AuthMode:           authMode,
@@ -81,7 +77,6 @@ func (s *Service) GetAgentSettings(ctx context.Context, encKey []byte, dataDir s
 		GlobalMaxBudgetUSD: globalBudget,
 		RuntimePath:        runtimePath,
 		TranscriptDir:      transcriptDir,
-		NotifyWebhookURL:   notifyURL,
 	}, nil
 }
 
@@ -130,19 +125,6 @@ func (s *Service) UpdateAgentSettings(ctx context.Context, p UpdateAgentSettings
 	if p.TranscriptDir != nil {
 		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyAgentTranscriptDir, *p.TranscriptDir)); err != nil {
 			return nil, fmt.Errorf("set transcript_dir: %w", err)
-		}
-	}
-	if p.NotifyWebhookURL != nil {
-		// Empty clears the webhook (notifications off); a non-empty value
-		// must be a valid http(s) URL.
-		trimmed := strings.TrimSpace(*p.NotifyWebhookURL)
-		if trimmed != "" {
-			if err := validateNotifyURL(trimmed); err != nil {
-				return nil, err
-			}
-		}
-		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyWebhookURL, trimmed)); err != nil {
-			return nil, fmt.Errorf("set notify_webhook_url: %w", err)
 		}
 	}
 	return s.GetAgentSettings(ctx, encKey, dataDir)

--- a/internal/service/agent_settings_notify_url_unit_test.go
+++ b/internal/service/agent_settings_notify_url_unit_test.go
@@ -2,9 +2,10 @@
 
 package service
 
-// T17-settings-notify-url: unit tests for the pure (no-DB) logic in
-// agent_settings.go that handles NotifyWebhookURL -- validation, masking,
-// trimming -- and the related helpers maskToken / lastN / readOptionalFloat.
+// T17-settings-notify-url: unit tests for the pure (no-DB) logic shared by
+// the settings layer -- the notify-URL validator (validateNotifyURL, also
+// used by UpdateNotificationSettings) plus the agent-settings helpers
+// maskToken / lastN / readOptionalFloat.
 //
 // No DB is required: every function under test is either pure or accepts
 // an appconfig.Reader that we satisfy with a lightweight stub.
@@ -218,7 +219,7 @@ func TestT17ValidateNotifyURL_Invalid(t *testing.T) {
 
 // The settings path trims whitespace before validating. Verify that the
 // already-trimmed URL is what gets validated (mirrors the
-// trimmed := strings.TrimSpace(*p.NotifyWebhookURL) path in UpdateAgentSettings).
+// trimmed := strings.TrimSpace(*p.WebhookURL) path in UpdateNotificationSettings).
 func TestT17ValidateNotifyURL_TrimmedInputs(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
 
 	"breadbox/internal/appconfig"
 )
@@ -80,9 +82,17 @@ func (s *Service) WorkflowNotificationConfigured(ctx context.Context) bool {
 	return strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, "")) != ""
 }
 
-// SendWorkflowNotification POSTs the payload as JSON to the configured
+// SendWorkflowNotification delivers the payload to the configured
 // notification webhook. It is a no-op (returns nil) when no URL is
 // configured, so callers can fire unconditionally. The URL must be http(s).
+//
+// The wire shape depends on the configured format (notify.format):
+//   - ntfy   → a plain-text (markdown) body plus ntfy's publishing headers
+//     (Title / Priority / Click / Markdown / Tags), so the push renders as
+//     a real titled notification instead of a raw JSON blob.
+//   - json   → the generic NotificationPayload envelope (Slack relays,
+//     Discord bridges, custom consumers).
+//   - auto   → ntfy when the URL looks like ntfy, else json.
 func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPayload) error {
 	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""))
 	if raw == "" {
@@ -94,16 +104,28 @@ func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPa
 	if p.SentAt == "" {
 		p.SentAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	body, err := json.Marshal(p)
-	if err != nil {
-		return fmt.Errorf("marshal notification: %w", err)
+
+	// Absolutize the deep link so both JSON consumers and ntfy tap-through
+	// resolve to the real report rather than a bare path. No-op when the
+	// operator hasn't set a public base URL.
+	baseURL := normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""))
+	if baseURL != "" && strings.HasPrefix(p.URL, "/") {
+		p.URL = baseURL + p.URL
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, raw, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("build notification request: %w", err)
+
+	format := resolveNotifyFormat(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto), raw)
+
+	var req *http.Request
+	var err error
+	if format == appconfig.NotifyFormatNtfy {
+		req, err = buildNtfyRequest(ctx, raw, p, baseURL)
+	} else {
+		req, err = buildJSONNotifyRequest(ctx, raw, p)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "breadbox-workflows")
+	if err != nil {
+		return err
+	}
+
 	resp, err := notifyHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("notification webhook: %w", err)
@@ -113,6 +135,151 @@ func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPa
 		return fmt.Errorf("notification webhook returned HTTP %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// resolveNotifyFormat maps the configured format to a concrete wire shape.
+// "auto" (the default, and any unknown value) sniffs the URL for ntfy.
+func resolveNotifyFormat(configured, rawURL string) string {
+	switch configured {
+	case appconfig.NotifyFormatNtfy:
+		return appconfig.NotifyFormatNtfy
+	case appconfig.NotifyFormatJSON:
+		return appconfig.NotifyFormatJSON
+	default:
+		if looksLikeNtfy(rawURL) {
+			return appconfig.NotifyFormatNtfy
+		}
+		return appconfig.NotifyFormatJSON
+	}
+}
+
+// looksLikeNtfy reports whether a webhook URL points at an ntfy server.
+// Matches the public host and any self-hosted host carrying "ntfy" in its
+// name (push.ntfy.example.com, ntfy.lan, …).
+func looksLikeNtfy(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "ntfy.sh" || strings.Contains(host, "ntfy")
+}
+
+// buildJSONNotifyRequest POSTs the generic JSON envelope. This is the
+// original, provider-neutral shape consumed by Slack relays and bridges.
+func buildJSONNotifyRequest(ctx context.Context, rawURL string, p NotificationPayload) (*http.Request, error) {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal notification: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build notification request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "breadbox-workflows")
+	return req, nil
+}
+
+// buildNtfyRequest POSTs to an ntfy topic using ntfy's native publishing
+// protocol: the request body is the message text and metadata rides in
+// headers. See https://docs.ntfy.sh/publish/.
+func buildNtfyRequest(ctx context.Context, rawURL string, p NotificationPayload, baseURL string) (*http.Request, error) {
+	message := p.Body
+	if baseURL != "" {
+		message = absolutizeMarkdownLinks(message, baseURL)
+	}
+	if strings.TrimSpace(message) == "" {
+		message = p.Title // a body-less payload still needs a non-empty message
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, strings.NewReader(message))
+	if err != nil {
+		return nil, fmt.Errorf("build notification request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	req.Header.Set("User-Agent", "breadbox-workflows")
+	if title := encodeNtfyHeader(p.Title); title != "" {
+		req.Header.Set("X-Title", title)
+	}
+	req.Header.Set("X-Priority", ntfyPriority(p.Priority))
+	req.Header.Set("X-Markdown", "yes")
+	if tags := ntfyTags(p.Priority); tags != "" {
+		req.Header.Set("X-Tags", tags)
+	}
+	// ntfy needs an absolute URL for tap-through; a relative path is dropped.
+	if strings.HasPrefix(p.URL, "http://") || strings.HasPrefix(p.URL, "https://") {
+		req.Header.Set("X-Click", p.URL)
+	}
+	return req, nil
+}
+
+// ntfyPriority maps the canonical info/warning/critical scale to ntfy's
+// numeric 1–5 priority (3 = default, 4 = high, 5 = max).
+func ntfyPriority(priority string) string {
+	switch priority {
+	case "critical":
+		return "5"
+	case "warning":
+		return "4"
+	default:
+		return "3"
+	}
+}
+
+// ntfyTags maps a priority to an ntfy tag that renders as a leading emoji
+// (ℹ️ / ⚠️ / 🚨) on the notification.
+func ntfyTags(priority string) string {
+	switch priority {
+	case "critical":
+		return "rotating_light"
+	case "warning":
+		return "warning"
+	default:
+		return "information_source"
+	}
+}
+
+// encodeNtfyHeader makes a string safe to carry in an HTTP header value:
+// header values are single-line and ASCII, so collapse newlines and
+// RFC 2047-encode any non-ASCII content (ntfy decodes it back).
+func encodeNtfyHeader(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if isASCII(s) {
+		return s
+	}
+	return mime.QEncoding.Encode("utf-8", s)
+}
+
+// isASCII reports whether every rune in s is a 7-bit ASCII character.
+func isASCII(s string) bool {
+	for _, r := range s {
+		if r > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
+}
+
+// absolutizeMarkdownLinks rewrites root-relative markdown links (`](/foo)`)
+// to absolute ones so an ntfy client (which has no notion of the Breadbox
+// origin) can follow them. Only root-relative targets are touched.
+func absolutizeMarkdownLinks(body, baseURL string) string {
+	if baseURL == "" {
+		return body
+	}
+	return strings.ReplaceAll(body, "](/", "]("+baseURL+"/")
+}
+
+// normalizeBaseURL trims surrounding whitespace and any trailing slash so
+// callers can concatenate "/path" without doubling the separator.
+func normalizeBaseURL(raw string) string {
+	return strings.TrimRight(strings.TrimSpace(raw), "/")
 }
 
 // SendTestNotification fires a sample payload so an operator can verify their

--- a/internal/service/notify_integration_test.go
+++ b/internal/service/notify_integration_test.go
@@ -31,7 +31,7 @@ func TestSendWorkflowNotification(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{NotifyWebhookURL: &srv.URL}, devEncKey, ""); err != nil {
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{WebhookURL: &srv.URL}); err != nil {
 		t.Fatalf("set webhook: %v", err)
 	}
 	if !svc.WorkflowNotificationConfigured(ctx) {

--- a/internal/service/notify_ntfy_integration_test.go
+++ b/internal/service/notify_ntfy_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestNotifyNtfyDispatch verifies the end-to-end ntfy publishing path:
+// when the format is "ntfy" and a public base URL is set, the outbound
+// request carries ntfy's metadata headers, an absolute X-Click, and a
+// markdown body whose relative links have been absolutized.
+func TestNotifyNtfyDispatch(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	type captured struct {
+		method      string
+		contentType string
+		title       string
+		priority    string
+		markdown    string
+		tags        string
+		click       string
+		body        []byte
+	}
+	var got captured
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.contentType = r.Header.Get("Content-Type")
+		got.title = r.Header.Get("X-Title")
+		got.priority = r.Header.Get("X-Priority")
+		got.markdown = r.Header.Get("X-Markdown")
+		got.tags = r.Header.Get("X-Tags")
+		got.click = r.Header.Get("X-Click")
+		got.body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ntfy := "ntfy"
+	base := "https://bb.example.com"
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{
+		WebhookURL:    &srv.URL,
+		Format:        &ntfy,
+		PublicBaseURL: &base,
+	}); err != nil {
+		t.Fatalf("set notification settings: %v", err)
+	}
+
+	err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{
+		Event:    "report",
+		Title:    "Large charge detected",
+		Body:     "A **$420** charge. See [tx](/transactions/abc).",
+		Priority: "critical",
+		URL:      "/reports/xyz",
+	})
+	if err != nil {
+		t.Fatalf("SendWorkflowNotification: %v", err)
+	}
+
+	if got.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", got.method)
+	}
+	if got.title != "Large charge detected" {
+		t.Errorf("X-Title = %q", got.title)
+	}
+	if got.priority != "5" {
+		t.Errorf("X-Priority = %q, want 5 (critical)", got.priority)
+	}
+	if got.markdown != "yes" {
+		t.Errorf("X-Markdown = %q, want yes", got.markdown)
+	}
+	if got.tags != "rotating_light" {
+		t.Errorf("X-Tags = %q, want rotating_light", got.tags)
+	}
+	if got.click != "https://bb.example.com/reports/xyz" {
+		t.Errorf("X-Click = %q, want absolute report URL", got.click)
+	}
+	wantBody := "A **$420** charge. See [tx](https://bb.example.com/transactions/abc)."
+	if string(got.body) != wantBody {
+		t.Errorf("body =\n  %q\nwant\n  %q", string(got.body), wantBody)
+	}
+}

--- a/internal/service/notify_ntfy_unit_test.go
+++ b/internal/service/notify_ntfy_unit_test.go
@@ -1,0 +1,228 @@
+//go:build !lite
+
+package service
+
+// Unit tests for the ntfy publishing path in notify.go — format resolution,
+// header encoding, priority/tag mapping, link absolutization, and the
+// assembled ntfy request. All pure (no DB).
+
+import (
+	"io"
+	"testing"
+
+	"breadbox/internal/appconfig"
+)
+
+func TestResolveNotifyFormat(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		url        string
+		want       string
+	}{
+		{"explicit ntfy wins", appconfig.NotifyFormatNtfy, "https://example.com/hook", appconfig.NotifyFormatNtfy},
+		{"explicit json wins", appconfig.NotifyFormatJSON, "https://ntfy.sh/topic", appconfig.NotifyFormatJSON},
+		{"auto detects ntfy.sh", appconfig.NotifyFormatAuto, "https://ntfy.sh/breadbox", appconfig.NotifyFormatNtfy},
+		{"auto detects self-hosted ntfy", appconfig.NotifyFormatAuto, "https://push.ntfy.example.com/t", appconfig.NotifyFormatNtfy},
+		{"auto falls back to json", appconfig.NotifyFormatAuto, "https://hooks.slack.com/services/x", appconfig.NotifyFormatJSON},
+		{"empty configured behaves as auto", "", "https://ntfy.sh/t", appconfig.NotifyFormatNtfy},
+		{"unknown configured behaves as auto", "garbage", "https://example.com/h", appconfig.NotifyFormatJSON},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveNotifyFormat(tc.configured, tc.url); got != tc.want {
+				t.Errorf("resolveNotifyFormat(%q, %q) = %q, want %q", tc.configured, tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeNtfy(t *testing.T) {
+	yes := []string{
+		"https://ntfy.sh/breadbox",
+		"http://ntfy.sh/t",
+		"https://ntfy.example.com/topic",
+		"https://push.ntfy.lan:8080/alerts",
+	}
+	no := []string{
+		"https://hooks.slack.com/services/x",
+		"https://example.com/webhook",
+		"https://discord.com/api/webhooks/1/abc",
+		"not a url",
+	}
+	for _, u := range yes {
+		if !looksLikeNtfy(u) {
+			t.Errorf("looksLikeNtfy(%q) = false, want true", u)
+		}
+	}
+	for _, u := range no {
+		if looksLikeNtfy(u) {
+			t.Errorf("looksLikeNtfy(%q) = true, want false", u)
+		}
+	}
+}
+
+func TestNtfyPriority(t *testing.T) {
+	cases := map[string]string{
+		"info":     "3",
+		"warning":  "4",
+		"critical": "5",
+		"":         "3", // unknown → default
+		"weird":    "3",
+	}
+	for in, want := range cases {
+		if got := ntfyPriority(in); got != want {
+			t.Errorf("ntfyPriority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNtfyTags(t *testing.T) {
+	cases := map[string]string{
+		"info":     "information_source",
+		"warning":  "warning",
+		"critical": "rotating_light",
+		"":         "information_source",
+	}
+	for in, want := range cases {
+		if got := ntfyTags(in); got != want {
+			t.Errorf("ntfyTags(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEncodeNtfyHeader(t *testing.T) {
+	// ASCII passes through unchanged (newlines collapsed to spaces).
+	if got := encodeNtfyHeader("Large charge detected"); got != "Large charge detected" {
+		t.Errorf("ascii encode = %q, want unchanged", got)
+	}
+	if got := encodeNtfyHeader("line1\nline2"); got != "line1 line2" {
+		t.Errorf("newline collapse = %q, want %q", got, "line1 line2")
+	}
+	// Non-ASCII is RFC 2047 encoded (starts with the encoded-word marker).
+	got := encodeNtfyHeader("Café charge ⚠️")
+	if len(got) < 8 || got[:2] != "=?" {
+		t.Errorf("non-ascii encode = %q, want RFC2047 encoded-word", got)
+	}
+	if encodeNtfyHeader("   ") != "" {
+		t.Error("whitespace-only should encode to empty")
+	}
+}
+
+func TestAbsolutizeMarkdownLinks(t *testing.T) {
+	body := "See [tx](/transactions/abc) and [report](/reports/x)."
+	want := "See [tx](https://bb.example.com/transactions/abc) and [report](https://bb.example.com/reports/x)."
+	if got := absolutizeMarkdownLinks(body, "https://bb.example.com"); got != want {
+		t.Errorf("absolutizeMarkdownLinks =\n  %q\nwant\n  %q", got, want)
+	}
+	// Absolute links and external links are left untouched.
+	ext := "Visit [site](https://other.com/x)"
+	if got := absolutizeMarkdownLinks(ext, "https://bb.example.com"); got != ext {
+		t.Errorf("external link rewritten: %q", got)
+	}
+	// Empty base URL is a no-op.
+	if got := absolutizeMarkdownLinks(body, ""); got != body {
+		t.Errorf("empty base URL should no-op, got %q", got)
+	}
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"https://bb.example.com/":   "https://bb.example.com",
+		"  https://bb.example.com ": "https://bb.example.com",
+		"https://bb.example.com///": "https://bb.example.com",
+		"":                          "",
+	}
+	for in, want := range cases {
+		if got := normalizeBaseURL(in); got != want {
+			t.Errorf("normalizeBaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildNtfyRequest(t *testing.T) {
+	p := NotificationPayload{
+		Event:    "report",
+		Title:    "Large charge detected",
+		Body:     "A **$420** charge hit checking. See [tx](/transactions/abc).",
+		Priority: "warning",
+		URL:      "https://bb.example.com/reports/xyz",
+	}
+	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/breadbox", p, "https://bb.example.com")
+	if err != nil {
+		t.Fatalf("buildNtfyRequest: %v", err)
+	}
+	if req.Method != "POST" {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if got := req.Header.Get("X-Title"); got != "Large charge detected" {
+		t.Errorf("X-Title = %q", got)
+	}
+	if got := req.Header.Get("X-Priority"); got != "4" {
+		t.Errorf("X-Priority = %q, want 4", got)
+	}
+	if got := req.Header.Get("X-Markdown"); got != "yes" {
+		t.Errorf("X-Markdown = %q, want yes", got)
+	}
+	if got := req.Header.Get("X-Tags"); got != "warning" {
+		t.Errorf("X-Tags = %q, want warning", got)
+	}
+	if got := req.Header.Get("X-Click"); got != "https://bb.example.com/reports/xyz" {
+		t.Errorf("X-Click = %q", got)
+	}
+	body, _ := io.ReadAll(req.Body)
+	want := "A **$420** charge hit checking. See [tx](https://bb.example.com/transactions/abc)."
+	if string(body) != want {
+		t.Errorf("body =\n  %q\nwant\n  %q", string(body), want)
+	}
+}
+
+func TestBuildNtfyRequest_RelativeClickDropped(t *testing.T) {
+	// Without a public base URL the deep link stays relative; ntfy needs an
+	// absolute URL for X-Click, so it must be omitted rather than sent broken.
+	p := NotificationPayload{Title: "Test", Body: "hi", Priority: "info", URL: "/reports/xyz"}
+	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/t", p, "")
+	if err != nil {
+		t.Fatalf("buildNtfyRequest: %v", err)
+	}
+	if got := req.Header.Get("X-Click"); got != "" {
+		t.Errorf("X-Click = %q, want empty for relative URL", got)
+	}
+}
+
+func TestBuildNtfyRequest_EmptyBodyFallsBackToTitle(t *testing.T) {
+	p := NotificationPayload{Title: "Sync watchdog", Body: "", Priority: "info"}
+	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/t", p, "")
+	if err != nil {
+		t.Fatalf("buildNtfyRequest: %v", err)
+	}
+	body, _ := io.ReadAll(req.Body)
+	if string(body) != "Sync watchdog" {
+		t.Errorf("body = %q, want title fallback", string(body))
+	}
+}
+
+func TestValidNotifyFormat(t *testing.T) {
+	for _, v := range []string{"auto", "ntfy", "json"} {
+		if !validNotifyFormat(v) {
+			t.Errorf("validNotifyFormat(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "JSON", "slack", "Ntfy"} {
+		if validNotifyFormat(v) {
+			t.Errorf("validNotifyFormat(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestNotifyFormatOrDefault(t *testing.T) {
+	if got := notifyFormatOrDefault("ntfy"); got != "ntfy" {
+		t.Errorf("valid passthrough = %q", got)
+	}
+	if got := notifyFormatOrDefault(""); got != appconfig.NotifyFormatAuto {
+		t.Errorf("empty → %q, want auto", got)
+	}
+	if got := notifyFormatOrDefault("bogus"); got != appconfig.NotifyFormatAuto {
+		t.Errorf("bogus → %q, want auto", got)
+	}
+}

--- a/internal/service/notify_on_report_integration_test.go
+++ b/internal/service/notify_on_report_integration_test.go
@@ -77,7 +77,7 @@ func TestF5NotifyOnReport_WorkflowReportFires(t *testing.T) {
 	ctx := context.Background()
 
 	rec := f5newNotifyRecorder(t)
-	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{NotifyWebhookURL: &rec.srv.URL}, devEncKey, ""); err != nil {
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{WebhookURL: &rec.srv.URL}); err != nil {
 		t.Fatalf("set webhook: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestF5NotifyOnReport_OperatorReportNoFire(t *testing.T) {
 	ctx := context.Background()
 
 	rec := f5newNotifyRecorder(t)
-	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{NotifyWebhookURL: &rec.srv.URL}, devEncKey, ""); err != nil {
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{WebhookURL: &rec.srv.URL}); err != nil {
 		t.Fatalf("set webhook: %v", err)
 	}
 

--- a/internal/service/notify_send_recorder_integration_test.go
+++ b/internal/service/notify_send_recorder_integration_test.go
@@ -66,10 +66,10 @@ func TestT16NotifyPostsJSONWhenConfigured(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Configure the webhook URL via UpdateAgentSettings (the canonical write path).
-	if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
-		NotifyWebhookURL: &srv.URL,
-	}, devEncKey, ""); err != nil {
+	// Configure the webhook URL via UpdateNotificationSettings (the canonical write path).
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{
+		WebhookURL: &srv.URL,
+	}); err != nil {
 		t.Fatalf("T16: set webhook URL: %v", err)
 	}
 
@@ -148,9 +148,9 @@ func TestT16NotifyErrorOnNon2xx(t *testing.T) {
 			defer srv.Close()
 
 			// (Re-)configure the webhook URL for each sub-test.
-			if _, err := svc.UpdateAgentSettings(ctx, service.UpdateAgentSettingsParams{
-				NotifyWebhookURL: &srv.URL,
-			}, devEncKey, ""); err != nil {
+			if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{
+				WebhookURL: &srv.URL,
+			}); err != nil {
 				t.Fatalf("T16: set webhook URL: %v", err)
 			}
 

--- a/internal/service/notify_settings.go
+++ b/internal/service/notify_settings.go
@@ -1,0 +1,98 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"breadbox/internal/appconfig"
+)
+
+// NotificationSettingsResponse is the read shape for the Settings →
+// Notifications page. Unlike credential settings, nothing here is secret —
+// the webhook URL, format, and public base URL all surface in plaintext.
+type NotificationSettingsResponse struct {
+	WebhookURL    string `json:"webhook_url"`
+	Format        string `json:"format"` // auto | ntfy | json
+	PublicBaseURL string `json:"public_base_url"`
+}
+
+// UpdateNotificationSettingsParams holds the writable notification settings.
+// Nil = leave untouched; an empty string clears the value (webhook/base URL)
+// or resets to the default (format → auto).
+type UpdateNotificationSettingsParams struct {
+	WebhookURL    *string
+	Format        *string
+	PublicBaseURL *string
+}
+
+// GetNotificationSettings reads the notify.* keys from app_config.
+func (s *Service) GetNotificationSettings(ctx context.Context) (*NotificationSettingsResponse, error) {
+	return &NotificationSettingsResponse{
+		WebhookURL:    appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""),
+		Format:        notifyFormatOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto)),
+		PublicBaseURL: appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""),
+	}, nil
+}
+
+// UpdateNotificationSettings validates and writes the non-nil fields, then
+// returns the new state. URLs must be http(s); the format must be one of the
+// canonical values.
+func (s *Service) UpdateNotificationSettings(ctx context.Context, p UpdateNotificationSettingsParams) (*NotificationSettingsResponse, error) {
+	if p.WebhookURL != nil {
+		trimmed := strings.TrimSpace(*p.WebhookURL)
+		if trimmed != "" {
+			if err := validateNotifyURL(trimmed); err != nil {
+				return nil, err
+			}
+		}
+		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyWebhookURL, trimmed)); err != nil {
+			return nil, fmt.Errorf("set notify_webhook_url: %w", err)
+		}
+	}
+	if p.Format != nil {
+		format := strings.TrimSpace(*p.Format)
+		if format == "" {
+			format = appconfig.NotifyFormatAuto
+		}
+		if !validNotifyFormat(format) {
+			return nil, fmt.Errorf("%w: notification format must be auto, ntfy, or json", ErrInvalidParameter)
+		}
+		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyFormat, format)); err != nil {
+			return nil, fmt.Errorf("set notify_format: %w", err)
+		}
+	}
+	if p.PublicBaseURL != nil {
+		trimmed := normalizeBaseURL(*p.PublicBaseURL)
+		if trimmed != "" {
+			if err := validateNotifyURL(trimmed); err != nil {
+				return nil, fmt.Errorf("%w: public base URL must be a valid http(s) URL", ErrInvalidParameter)
+			}
+		}
+		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyPublicBaseURL, trimmed)); err != nil {
+			return nil, fmt.Errorf("set notify_public_base_url: %w", err)
+		}
+	}
+	return s.GetNotificationSettings(ctx)
+}
+
+// validNotifyFormat reports whether v is one of the canonical format values.
+func validNotifyFormat(v string) bool {
+	switch v {
+	case appconfig.NotifyFormatAuto, appconfig.NotifyFormatNtfy, appconfig.NotifyFormatJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+// notifyFormatOrDefault normalizes a stored format, coercing empty or
+// unrecognized values back to "auto" so the UI always shows a valid choice.
+func notifyFormatOrDefault(v string) string {
+	if validNotifyFormat(v) {
+		return v
+	}
+	return appconfig.NotifyFormatAuto
+}

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -243,21 +243,6 @@ templ agentSDKConfigSection(p AgentSDKSettingsProps) {
 			}) {
 				<span class="text-sm tabular-nums text-base-content/80">{ p.HouseholdSpend30dStr }</span>
 			}
-			@components.SettingsRow(components.SettingsRowProps{
-				Label:   "Notification webhook",
-				Caption: "POST workflow notifications to this http(s) URL (ntfy / Slack / Discord / email bridge). Empty = off.",
-				For:     "notify_webhook_url",
-				Stack:   true,
-			}) {
-				<input
-					id="notify_webhook_url"
-					type="url"
-					name="notify_webhook_url"
-					value={ p.Form.NotifyWebhookURL }
-					placeholder="https://ntfy.sh/my-breadbox-topic"
-					class="bb-form-input font-mono w-full"
-				/>
-			}
 			if p.FieldErrors["max_concurrent"] != "" || p.FieldErrors["global_max_budget_usd"] != "" {
 				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 					if p.FieldErrors["max_concurrent"] != "" {
@@ -357,41 +342,6 @@ templ agentSDKDiagnosticsSection(csrfToken string) {
 					</span>
 				</button>
 			}
-			@components.SettingsRow(components.SettingsRowProps{
-				Label:   "Test notification",
-				Caption: "Sends a sample payload to the configured webhook",
-			}) {
-				<button
-					type="button"
-					class="btn btn-ghost btn-sm"
-					@click="runNotifyTest()"
-					:disabled="notifyState === 'loading'"
-				>
-					<span x-show="notifyState !== 'loading'" class="flex items-center gap-1.5">
-						@components.LucideIcon("bell", "w-4 h-4")
-						Send test
-					</span>
-					<span x-show="notifyState === 'loading'" x-cloak class="flex items-center gap-1.5">
-						<span class="loading loading-spinner loading-xs"></span> Sending…
-					</span>
-				</button>
-			}
-			<template x-if="notifyState === 'ok'">
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-					<div role="alert" class="alert alert-success alert-soft rounded-xl">
-						@components.LucideIcon("circle-check", "w-4 h-4")
-						<span>Test notification sent — check your webhook destination.</span>
-					</div>
-				}
-			</template>
-			<template x-if="notifyState === 'error' && notifyError">
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-					<div role="alert" class="alert alert-error alert-soft rounded-xl">
-						@components.LucideIcon("circle-x", "w-4 h-4")
-						<span x-text="'Test notification failed: ' + notifyError"></span>
-					</div>
-				}
-			</template>
 			<template x-if="smokeState === 'ok' && smokeResult">
 				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 					<div class="rounded-lg bg-base-200/60 p-4 space-y-2">

--- a/internal/templates/components/pages/agent_sdk_settings_types.go
+++ b/internal/templates/components/pages/agent_sdk_settings_types.go
@@ -36,7 +36,6 @@ type AgentSDKSettingsFormFields struct {
 	GlobalMaxBudgetUSDStr    string // string so empty means "no cap"
 	RuntimePath              string
 	TranscriptDir            string
-	NotifyWebhookURL         string // outbound notification webhook (empty = off)
 }
 
 // AgentSDKStatusProps mirrors service.AgentSubsystemStatus for the

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -1,0 +1,154 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// NotificationsSettings renders the Settings → Notifications tab — the
+// outbound notification sink that workflow runs push reports to. One
+// section configures the webhook (URL + wire format + public base URL,
+// saved together); a second fires a test delivery. See
+// .claude/rules/settings.md for the section/row vocabulary.
+templ NotificationsSettings(p NotificationsSettingsProps) {
+	<script src="/static/js/admin/components/notifications_settings.js"></script>
+	<div>
+		@settingsTabHeader(settingsTabHeaderProps{
+			Title:    "Notifications",
+			Subtitle: "Push workflow reports and alerts to ntfy, Slack, or any webhook",
+		})
+		if p.FormError != "" {
+			<div role="alert" class="alert alert-error alert-soft mb-4 rounded-xl">
+				@components.LucideIcon("circle-x", "w-4 h-4")
+				<span>{ p.FormError }</span>
+			</div>
+		}
+		if p.FormSuccess != "" {
+			<div role="alert" class="alert alert-success alert-soft mb-4 rounded-xl">
+				@components.LucideIcon("circle-check", "w-4 h-4")
+				<span>{ p.FormSuccess }</span>
+			</div>
+		}
+		<div class="space-y-6">
+			@notificationsWebhookSection(p)
+			@notificationsTestSection(p.CSRFToken)
+		</div>
+	</div>
+}
+
+// notificationsWebhookSection is the single multi-input form that owns the
+// sink: URL, format, and public base URL save together via one Save button.
+templ notificationsWebhookSection(p NotificationsSettingsProps) {
+	@components.SettingsSection(components.SettingsSectionProps{
+		Icon:    "bell",
+		Title:   "Notification sink",
+		Caption: "Where Breadbox POSTs each workflow report",
+		Form: &components.SettingsSectionFormProps{
+			Action:    "/settings/notifications",
+			CSRFToken: p.CSRFToken,
+		},
+		Footer: notificationsSettingsFooter(),
+	}) {
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Webhook URL",
+			Caption: "http(s) only. Empty turns notifications off.",
+			For:     "webhook_url",
+			Stack:   true,
+		}) {
+			<input
+				id="webhook_url"
+				type="url"
+				name="webhook_url"
+				value={ p.Form.WebhookURL }
+				placeholder="https://ntfy.sh/my-breadbox-topic"
+				class="bb-form-input font-mono w-full"
+			/>
+			if p.FieldErrors["webhook_url"] != "" {
+				<p class="text-xs text-error mt-1">{ p.FieldErrors["webhook_url"] }</p>
+			}
+		}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Format",
+			Caption: "ntfy sends a native title, priority, and tap-through; JSON suits Slack relays and bridges. Auto-detect picks ntfy for ntfy URLs.",
+			For:     "format",
+		}) {
+			<select id="format" name="format" class="select select-sm bg-base-200 min-w-44">
+				<option value="auto" selected?={ p.Form.Format == "auto" }>Auto-detect</option>
+				<option value="ntfy" selected?={ p.Form.Format == "ntfy" }>ntfy</option>
+				<option value="json" selected?={ p.Form.Format == "json" }>Generic JSON</option>
+			</select>
+		}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Public URL",
+			Caption: "Absolute origin for tap-through deep links (e.g. https://breadbox.example.com). Optional.",
+			For:     "public_base_url",
+			Stack:   true,
+		}) {
+			<input
+				id="public_base_url"
+				type="url"
+				name="public_base_url"
+				value={ p.Form.PublicBaseURL }
+				placeholder="https://breadbox.example.com"
+				class="bb-form-input font-mono w-full"
+			/>
+			if p.FieldErrors["public_base_url"] != "" {
+				<p class="text-xs text-error mt-1">{ p.FieldErrors["public_base_url"] }</p>
+			}
+		}
+	}
+}
+
+templ notificationsSettingsFooter() {
+	<div class="bb-action-row">
+		<button type="submit" class="btn btn-primary btn-sm gap-2">
+			@components.LucideIcon("save", "w-4 h-4")
+			Save changes
+		</button>
+	</div>
+}
+
+// notificationsTestSection fires a sample delivery to the configured sink so
+// the operator can confirm the wiring without waiting for a real run.
+templ notificationsTestSection(csrfToken string) {
+	<div x-data="notificationsSettings" data-csrf={ csrfToken }>
+		@components.SettingsSection(components.SettingsSectionProps{
+			Icon:    "send",
+			Title:   "Test delivery",
+			Caption: "Fires a sample notification to the URL above",
+		}) {
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Send a test",
+				Caption: "Confirms the webhook is reachable and renders as expected",
+			}) {
+				<button
+					type="button"
+					class="btn btn-secondary btn-sm gap-2"
+					@click="runTest()"
+					:disabled="state === 'loading'"
+				>
+					<span x-show="state !== 'loading'" class="flex items-center gap-1.5">
+						@components.LucideIcon("bell-ring", "w-4 h-4")
+						Send test
+					</span>
+					<span x-show="state === 'loading'" x-cloak class="flex items-center gap-1.5">
+						<span class="loading loading-spinner loading-xs"></span> Sending…
+					</span>
+				</button>
+			}
+			<template x-if="state === 'ok'">
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<div role="alert" class="alert alert-success alert-soft rounded-xl">
+						@components.LucideIcon("circle-check", "w-4 h-4")
+						<span>Test notification sent — check your destination.</span>
+					</div>
+				}
+			</template>
+			<template x-if="state === 'error' && error">
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<div role="alert" class="alert alert-error alert-soft rounded-xl">
+						@components.LucideIcon("circle-x", "w-4 h-4")
+						<span x-text="'Test failed: ' + error"></span>
+					</div>
+				}
+			</template>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/notifications_settings_types.go
+++ b/internal/templates/components/pages/notifications_settings_types.go
@@ -1,0 +1,23 @@
+//go:build !headless && !lite
+
+package pages
+
+// NotificationsSettingsProps drives the Settings → Notifications tab. The
+// page owns the outbound notification sink (webhook URL + wire format +
+// public base URL) that workflow runs use to push reports. Nothing here is
+// secret — every value renders in plaintext.
+type NotificationsSettingsProps struct {
+	Form        NotificationsSettingsFormFields
+	FieldErrors map[string]string
+	FormError   string
+	FormSuccess string
+	CSRFToken   string
+}
+
+// NotificationsSettingsFormFields mirrors the writable settings exposed by
+// service.UpdateNotificationSettings.
+type NotificationsSettingsFormFields struct {
+	WebhookURL    string // http(s) sink; empty = notifications off
+	Format        string // "auto" | "ntfy" | "json"
+	PublicBaseURL string // absolute origin for deep links; empty = relative
+}

--- a/internal/templates/components/pages/settings_page.templ
+++ b/internal/templates/components/pages/settings_page.templ
@@ -58,6 +58,7 @@ templ settingsPageRail(p SettingsPageProps) {
 				<div class="bb-settings-rail__group-label">Integrations</div>
 				@settingsRailItem(p, "providers", "plug", "Providers")
 				@settingsRailItem(p, "workflows", "sparkles", "Workflows")
+				@settingsRailItem(p, "notifications", "bell", "Notifications")
 				@settingsRailItem(p, "mcp", "brand:model-context-protocol", "MCP")
 			}
 			if p.IsEditor {

--- a/internal/templates/components/pages/settings_tabs.go
+++ b/internal/templates/components/pages/settings_tabs.go
@@ -15,13 +15,14 @@ import "breadbox/internal/templates/components"
 //   - SettingsTabHousehold — promoted to its own top-level /household
 //     page, hung off the sidebar's System section.
 const (
-	SettingsTabAccount   = components.SettingsModalTabAccount
-	SettingsTabGeneral   = components.SettingsModalTabGeneral
-	SettingsTabSystem    = components.SettingsModalTabSystem
-	SettingsTabProviders = components.SettingsModalTabProviders
-	SettingsTabWorkflows = components.SettingsModalTabWorkflows
-	SettingsTabMCP       = components.SettingsModalTabMCP
-	SettingsTabAccess    = components.SettingsModalTabAccess
-	SettingsTabBackups   = components.SettingsModalTabBackups
-	SettingsTabHelp      = components.SettingsModalTabHelp
+	SettingsTabAccount       = components.SettingsModalTabAccount
+	SettingsTabGeneral       = components.SettingsModalTabGeneral
+	SettingsTabSystem        = components.SettingsModalTabSystem
+	SettingsTabProviders     = components.SettingsModalTabProviders
+	SettingsTabWorkflows     = components.SettingsModalTabWorkflows
+	SettingsTabNotifications = components.SettingsModalTabNotifications
+	SettingsTabMCP           = components.SettingsModalTabMCP
+	SettingsTabAccess        = components.SettingsModalTabAccess
+	SettingsTabBackups       = components.SettingsModalTabBackups
+	SettingsTabHelp          = components.SettingsModalTabHelp
 )

--- a/internal/templates/components/settings_modal_types.go
+++ b/internal/templates/components/settings_modal_types.go
@@ -9,13 +9,14 @@ package components
 // top-level page). Security folds into System; the legacy Sync tab became
 // General (schedule, retention, avatars).
 const (
-	SettingsModalTabAccount   = "account"
-	SettingsModalTabGeneral   = "general"
-	SettingsModalTabSystem    = "system"
-	SettingsModalTabProviders = "providers"
-	SettingsModalTabWorkflows = "workflows"
-	SettingsModalTabMCP       = "mcp"
-	SettingsModalTabAccess    = "api-keys"
-	SettingsModalTabBackups   = "backups"
-	SettingsModalTabHelp      = "help"
+	SettingsModalTabAccount       = "account"
+	SettingsModalTabGeneral       = "general"
+	SettingsModalTabSystem        = "system"
+	SettingsModalTabProviders     = "providers"
+	SettingsModalTabWorkflows     = "workflows"
+	SettingsModalTabNotifications = "notifications"
+	SettingsModalTabMCP           = "mcp"
+	SettingsModalTabAccess        = "api-keys"
+	SettingsModalTabBackups       = "backups"
+	SettingsModalTabHelp          = "help"
 )

--- a/static/js/admin/components/agent_sdk_settings.js
+++ b/static/js/admin/components/agent_sdk_settings.js
@@ -14,8 +14,6 @@ document.addEventListener('alpine:init', function () {
       cleanupState: 'idle',
       cleanupResult: null,
       cleanupError: null,
-      notifyState: 'idle',
-      notifyError: null,
 
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
@@ -84,29 +82,6 @@ document.addEventListener('alpine:init', function () {
           });
       },
 
-      runNotifyTest: function () {
-        var self = this;
-        this.notifyState = 'loading';
-        this.notifyError = null;
-        this._post('/-/workflows/notify-test')
-          .then(function (res) {
-            return res.json().then(function (body) {
-              return { ok: res.ok, status: res.status, body: body };
-            });
-          })
-          .then(function (r) {
-            if (!r.ok || (r.body && r.body.ok === false)) {
-              self.notifyError = (r.body && r.body.error) || ('HTTP ' + r.status);
-              self.notifyState = 'error';
-              return;
-            }
-            self.notifyState = 'ok';
-          })
-          .catch(function (e) {
-            self.notifyError = (e && e.message) || 'Request failed';
-            self.notifyState = 'error';
-          });
-      },
     };
   });
 });

--- a/static/js/admin/components/notifications_settings.js
+++ b/static/js/admin/components/notifications_settings.js
@@ -1,0 +1,50 @@
+// Settings → Notifications — test-delivery button factory.
+//
+// Powers the "Send test" button on /settings/notifications. Reads its CSRF
+// token from a sibling data-* attribute on the x-data root so the factory
+// itself takes no arguments (per docs/design-system.md → "Alpine page
+// components").
+document.addEventListener('alpine:init', function () {
+  Alpine.data('notificationsSettings', function () {
+    return {
+      csrfToken: '',
+      state: 'idle',
+      error: null,
+
+      init: function () {
+        this.csrfToken = this.$el.dataset.csrf || '';
+      },
+
+      runTest: function () {
+        var self = this;
+        this.state = 'loading';
+        this.error = null;
+        fetch('/-/notifications/test', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRF-Token': this.csrfToken,
+            Accept: 'application/json',
+          },
+        })
+          .then(function (res) {
+            return res.json().then(function (body) {
+              return { ok: res.ok, status: res.status, body: body };
+            });
+          })
+          .then(function (r) {
+            if (!r.ok || (r.body && r.body.ok === false)) {
+              self.error = (r.body && r.body.error) || ('HTTP ' + r.status);
+              self.state = 'error';
+              return;
+            }
+            self.state = 'ok';
+          })
+          .catch(function (e) {
+            self.error = (e && e.message) || 'Request failed';
+            self.state = 'error';
+          });
+      },
+    };
+  });
+});

--- a/static/js/admin/components/settings_page.js
+++ b/static/js/admin/components/settings_page.js
@@ -271,7 +271,7 @@ document.addEventListener('alpine:init', function () {
 // response URL as inside the settings space.
 var BB_SETTINGS_PAGE_TABS = {
   account: 1, general: 1, system: 1, providers: 1, workflows: 1,
-  mcp: 1, 'api-keys': 1, backups: 1, help: 1,
+  notifications: 1, mcp: 1, 'api-keys': 1, backups: 1, help: 1,
 };
 
 // Sibling URL prefixes that render under an existing rail tab.
@@ -361,6 +361,7 @@ var BB_SETTINGS_SKELETONS = {
   backups: { sections: [3, 2, 2] },
   providers: { sections: [3, 3, 2] },
   workflows: { sections: [3, 4, 2] },
+  notifications: { sections: [3, 1] },
   mcp: { sections: [2, 2, 2, 3] },
   _default: { sections: [3, 3] },
 };


### PR DESCRIPTION
Notifications now have their own settings page, and the outbound webhook speaks ntfy's native publishing protocol — so an ntfy push renders as a real titled, tappable notification instead of the raw JSON blob it used to dump.

## The problem

The notification sink POSTed a JSON envelope to whatever URL you gave it. Pointed at ntfy, that meant the push body was the literal JSON:

```
{"event":"report","title":"Cleared the needs-review queue — 4 transactions confirmed…","body":"## Summary\n\nReviewed 4 transactions…","priority":"info","workflow":"Routine Reviewer","url":"/reports/uhwQoYH5","sent_at":"2026-06-01T07:11:14Z"}
```

ntfy treats the body of a POST to a topic as the message text, so none of that titled/markdown/priority structure surfaced.

## What changed

**Native ntfy formatting.** When the sink resolves to ntfy, Breadbox now publishes the [ntfy way](https://docs.ntfy.sh/publish/) — a markdown message body plus metadata headers:

- `X-Title` — the headline (RFC 2047-encoded when non-ASCII)
- `X-Priority` — `info→3`, `warning→4`, `critical→5`
- `X-Markdown: yes` — so the body renders formatted
- `X-Tags` — a per-priority emoji (`information_source` / `warning` / `rotating_light`)
- `X-Click` — the absolute deep link to the report (tap to open)

Two new config keys, both on the new page:
- `notify.format` — `auto` (default) · `ntfy` · `json`. **Auto** sniffs the URL and picks ntfy for ntfy hosts, else JSON — so existing JSON consumers (Slack relays, Discord bridges, email bridges) are untouched.
- `notify.public_base_url` — optional absolute origin (e.g. `https://breadbox.exe.xyz`) used to make the tap-through link and relative markdown links in the body absolute.

**Dedicated Notifications page.** The sink moved out of Settings → Workflows into its own admin tab at `/settings/notifications` (rail item under Integrations), backed by new `Get`/`UpdateNotificationSettings` service methods. Webhook URL + format + public base URL save together; a "Send test" button fires a sample to confirm wiring. Room to grow per-event controls later.

## Screenshot

<img src="https://i.img402.dev/sr6rmhothc.jpg" width="800" alt="Settings → Notifications">

## Testing

- `go build ./...`, `go vet ./...`, full `go test ./...` (unit) — green.
- New unit tests: format resolution, ntfy detection, header RFC2047 encoding, priority/tag mapping, markdown-link absolutization, and the assembled ntfy request.
- New integration test asserts the end-to-end ntfy dispatch (headers + absolutized body); existing notify JSON + agent-settings integration tests still pass against `breadbox_test`.
- Verified both pages render 200 in a logged-in browser; Settings → Workflows is intact with the notify field removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
