### PR TITLE
feat(ui): lead the Help → Getting started row with a compass icon

### DIFF
--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -342,22 +342,28 @@ templ settingsResourcesSection(p SettingsProps) {
 }
 
 // Getting Started doesn't fit SettingsRowLink because the trailing
-// affordance is either a button or a form (re-open vs. open).
+// affordance is either a button or a form (re-open vs. open), so the
+// row is composed by hand. The leading compass icon mirrors the
+// sibling Documentation row's leading book-open icon — this Resources
+// section is an action list where the leading icon is the affordance.
 templ settingsGettingStartedRow(p SettingsProps) {
-	@components.SettingsRow(components.SettingsRowProps{
-		Label:   "Getting started",
-		Caption: "Step-by-step setup walkthrough",
-	}) {
-		@components.LucideIcon("compass", "w-4 h-4 text-base-content/40 mr-3 hidden")
-		if p.OnboardingDismissed {
-			<form method="POST" action="/getting-started/reopen">
-				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
-				<button type="submit" class="btn btn-ghost btn-sm">Re-open</button>
-			</form>
-		} else {
-			<a href="/getting-started" class="btn btn-ghost btn-sm">Open</a>
-		}
-	}
+	<div class="bb-settings-row">
+		@components.LucideIcon("compass", "w-4 h-4 text-base-content opacity-50 shrink-0")
+		<div class="bb-settings-row__main">
+			<div class="bb-settings-row__label">Getting started</div>
+			<p class="bb-settings-row__caption">Step-by-step setup walkthrough</p>
+		</div>
+		<div class="bb-settings-row__control">
+			if p.OnboardingDismissed {
+				<form method="POST" action="/getting-started/reopen">
+					<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+					<button type="submit" class="btn btn-ghost btn-sm">Re-open</button>
+				</form>
+			} else {
+				<a href="/getting-started" class="btn btn-ghost btn-sm">Open</a>
+			}
+		</div>
+	</div>
 }
 
 templ settingsDeveloperSection() {


### PR DESCRIPTION
Leads the Help → Getting started row with a compass icon so the Resources section reads as a consistent action list.

## Changes
- `settingsGettingStartedRow` (`internal/templates/components/pages/settings.templ`): move the compass icon from the trailing control slot (where it was `hidden`, next to the Open button) to the **leading** position, left of the label.
- Compose the row by hand (it can't use `SettingsRowLink` — its trailing affordance is a button/form, not a plain link) so it mirrors the sibling **Documentation** row's leading `book-open` icon.
- Match the sibling icon's classes exactly (`w-4 h-4 text-base-content opacity-50 shrink-0`).

## After
<img src="https://i.img402.dev/9ah1cf2epu.jpg" width="800" alt="Settings → Help — Getting started row now leads with a compass icon">

## Test plan
- [x] `go build ./internal/templates/...` — clean
- [x] `go vet ./internal/templates/components/pages/` — clean
- [x] `templ generate` regenerates without diff noise
- [x] Authenticated DOM check: row renders `compass` (leading) → label/caption → Open button
- [x] Browser screenshot (Settings → Help, 1280×900) confirms alignment with the Documentation row's icon
