### PR TITLE
feat(ui): redesign Getting Started as a guided setup journey

### DIFF
--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -3,6 +3,7 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 
 	"breadbox/internal/app"
@@ -80,6 +81,28 @@ func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 			completedSteps++
 		}
 
+		// Resolve the active step (first incomplete) and a rough time-to-finish
+		// estimate for the hero. Step order + per-step minutes are paired so the
+		// estimate sums only the steps still outstanding.
+		stepsDone := []bool{hasMember, hasProvider, hasConnection, hasSync, hasAPIKey}
+		stepMinutes := []int{1, 2, 2, 1, 3}
+		activeStep := 0
+		minutesLeft := 0
+		for i, done := range stepsDone {
+			if done {
+				continue
+			}
+			if activeStep == 0 {
+				activeStep = i + 1 // 1-based
+			}
+			minutesLeft += stepMinutes[i]
+		}
+		allComplete := completedSteps == len(stepsDone)
+		timeRemaining := ""
+		if !allComplete && minutesLeft > 0 {
+			timeRemaining = fmt.Sprintf("~%d min left", minutesLeft)
+		}
+
 		// Check if onboarding is dismissed (for the nav badge display).
 		dismissed := appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false)
 
@@ -91,7 +114,10 @@ func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 			HasSync:             hasSync,
 			HasAPIKey:           hasAPIKey,
 			CompletedSteps:      completedSteps,
-			TotalSteps:          5,
+			TotalSteps:          len(stepsDone),
+			AllComplete:         allComplete,
+			ActiveStep:          activeStep,
+			TimeRemaining:       timeRemaining,
 			ConnectionCount:     connCount,
 			AccountCount:        accountCount,
 			TransactionCount:    txCount,

--- a/internal/templates/components/onboarding_alt_path.templ
+++ b/internal/templates/components/onboarding_alt_path.templ
@@ -1,0 +1,88 @@
+package components
+
+// OnboardingAltPath is the calm "alternative path + resources" aside shown on
+// the /getting-started page WHILE setup is still in progress (i.e. not yet
+// AllComplete). It de-risks the "I don't have a supported bank / I'm stuck"
+// drop-off by:
+//
+//   1. surfacing the CSV-import alternative for people without Plaid/Teller, and
+//   2. listing a few documentation resources.
+//
+// It is deliberately QUIET — a helpful aside, not a primary CTA — so it sits
+// below the active step without competing with it. Use a soft surface and ghost
+// affordances; the external resource links carry an arrow-up-right so they
+// clearly read as leaving the app.
+//
+// Copy adapts to whether a provider is already connected:
+//
+//   - HasProvider=false → lean into "no bank? import CSV".
+//   - HasProvider=true  → soften to "prefer to import manually?".
+//
+// Usage:
+//
+//	@components.OnboardingAltPath(components.OnboardingAltPathProps{
+//	  HasProvider: false,
+//	})
+type OnboardingAltPathProps struct {
+	HasProvider bool // tweak copy: if false, lean into "no bank? import CSV"; if true, soften
+}
+
+templ OnboardingAltPath(p OnboardingAltPathProps) {
+	<div class="bb-card p-5 sm:p-6">
+		@onbAltCSV(p)
+		<div class="border-t border-base-200 mt-5 pt-5">
+			@onbAltResources()
+		</div>
+	</div>
+}
+
+// onbAltCSV is the CSV-import alternative: an icon tile, an adaptive heading +
+// body, and a quiet ghost button to /import-csv.
+templ onbAltCSV(p OnboardingAltPathProps) {
+	<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-4">
+		<div class="w-10 h-10 rounded-lg bg-base-200/70 flex items-center justify-center shrink-0">
+			@LucideIcon("file-spreadsheet", "w-5 h-5 text-base-content/50")
+		</div>
+		<div class="min-w-0 flex-1">
+			<h3 class="text-sm font-semibold">
+				if p.HasProvider {
+					Prefer to import manually?
+				} else {
+					Don't use Plaid or Teller?
+				}
+			</h3>
+			<p class="text-sm text-base-content/60 mt-0.5">
+				Import transactions directly from a CSV file — no bank connection required.
+			</p>
+		</div>
+		<a href="/connections/import-csv" class="btn btn-ghost btn-sm gap-2 shrink-0">
+			@LucideIcon("upload", "w-4 h-4")
+			Import CSV
+		</a>
+	</div>
+}
+
+// onbAltResources is the quiet, menu-like list of three external doc links.
+// Each row reads as external via the trailing arrow-up-right glyph.
+templ onbAltResources() {
+	<div class="text-xs uppercase tracking-wider text-base-content/40 mb-1">Resources</div>
+	@onbAltResourceLink("link-2", "How connections work", "https://docs.breadbox.sh")
+	@onbAltResourceLink("file-spreadsheet", "Import a CSV", "https://docs.breadbox.sh")
+	@onbAltResourceLink("bot", "Set up AI agents", "https://docs.breadbox.sh/guides/multi-agent-reviewer")
+}
+
+// onbAltResourceLink renders one external resource row: a small leading lucide
+// icon, the label, and a trailing arrow-up-right that signals "opens
+// externally". Styled like a quiet menu item.
+templ onbAltResourceLink(icon, label, href string) {
+	<a
+		href={ templ.SafeURL(href) }
+		target="_blank"
+		rel="noopener noreferrer"
+		class="flex items-center gap-2 py-1.5 text-sm hover:text-base-content text-base-content/70 transition-colors"
+	>
+		@LucideIcon(icon, "w-4 h-4 opacity-60 shrink-0")
+		<span class="flex-1 min-w-0 truncate">{ label }</span>
+		@LucideIcon("arrow-up-right", "w-3.5 h-3.5 opacity-40 shrink-0")
+	</a>
+}

--- a/internal/templates/components/onboarding_footer.templ
+++ b/internal/templates/components/onboarding_footer.templ
@@ -1,0 +1,45 @@
+package components
+
+// OnboardingFooter is the redesigned dismiss/resume footer for the
+// /getting-started page. It replaces today's tiny ghost-button-with-inline-
+// caption with a calm, hairline-separated footer row that reads as a
+// deliberate, respectful affordance — never a dark pattern, never a hidden
+// link.
+//
+// Two states:
+//
+//   - !Dismissed: a clean row with muted helper text on the left ("Done for
+//     now? You can reopen this guide anytime from Settings.") and a real POST
+//     form on the right submitting to /getting-started/dismiss with the CSRF
+//     token. The dismiss control is an actual <button type="submit"> inside
+//     the form (btn-ghost btn-sm), not a link — so dismissing is a genuine,
+//     accessible form action.
+//   - Dismissed: a quiet, form-less note row with an info icon reassuring the
+//     user the guide stays reachable.
+
+type OnboardingFooterProps struct {
+	Dismissed bool
+	CSRFToken string
+}
+
+templ OnboardingFooter(p OnboardingFooterProps) {
+	if !p.Dismissed {
+		<div class="mt-8 pt-6 border-t border-base-200 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+			<p class="text-sm text-base-content/50">
+				Done for now? You can reopen this guide anytime from Settings.
+			</p>
+			<form method="POST" action="/getting-started/dismiss" class="shrink-0">
+				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+				<button type="submit" class="btn btn-ghost btn-sm gap-2 text-base-content/60">
+					@LucideIcon("x", "w-4 h-4")
+					Dismiss guide
+				</button>
+			</form>
+		</div>
+	} else {
+		<div class="mt-8 pt-6 border-t border-base-200 flex items-center gap-2 text-sm text-base-content/40">
+			@LucideIcon("info", "w-4 h-4 shrink-0")
+			<span>This guide stays available at /getting-started and from Settings.</span>
+		</div>
+	}
+}

--- a/internal/templates/components/onboarding_hero.templ
+++ b/internal/templates/components/onboarding_hero.templ
@@ -1,0 +1,112 @@
+package components
+
+import "fmt"
+
+// OnboardingHero is the prominent banner at the top of /getting-started:
+// a ProgressRing on the left and a text column (headline + subhead +
+// optional time-remaining row) on the right. It's the page's emotional
+// anchor — confident copy, strong hierarchy, and the ring as the focal
+// point. Stacks vertically and centers on mobile, side-by-side from `sm`.
+//
+// Presentation only: the handler supplies CompletedSteps / TotalSteps /
+// AllComplete (and optionally TimeRemaining); copy is derived when the
+// caller leaves Headline / Subhead empty.
+//
+// When AllComplete, the shell picks up a soft `bg-success/5` tint and the
+// ring is forced to its success tone — celebratory but restrained.
+//
+// Props:
+//   - CompletedSteps, TotalSteps: progress fraction (drives the ring + %).
+//   - AllComplete:   true once every step is done; flips tone + copy.
+//   - Headline:      big title. Derived from progress when "".
+//   - Subhead:       supporting line. Derived from progress when "".
+//   - TimeRemaining: e.g. "~4 min left"; the row is hidden when "".
+
+type OnboardingHeroProps struct {
+	CompletedSteps, TotalSteps int
+	AllComplete                bool
+	Headline                   string
+	Subhead                    string
+	TimeRemaining              string
+}
+
+// onbHeroPercent returns the integer completion percentage, guarding /0.
+func onbHeroPercent(p OnboardingHeroProps) int {
+	if p.TotalSteps <= 0 {
+		return 0
+	}
+	pct := p.CompletedSteps * 100 / p.TotalSteps
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	return pct
+}
+
+// onbHeroHeadline resolves the headline, deriving from progress when the
+// caller passes "".
+func onbHeroHeadline(p OnboardingHeroProps) string {
+	if p.Headline != "" {
+		return p.Headline
+	}
+	switch {
+	case p.AllComplete:
+		return "You're all set 🎉"
+	case p.CompletedSteps <= 0:
+		return "Welcome to Breadbox"
+	default:
+		return fmt.Sprintf("You're %d%% set up", onbHeroPercent(p))
+	}
+}
+
+// onbHeroSubhead resolves the subhead, deriving from progress when "".
+func onbHeroSubhead(p OnboardingHeroProps) string {
+	if p.Subhead != "" {
+		return p.Subhead
+	}
+	switch {
+	case p.AllComplete:
+		return "Breadbox is fully configured and syncing your finances."
+	case p.CompletedSteps <= 0:
+		return "Let's get your finances set up — it only takes a few minutes."
+	default:
+		return "Nice progress — keep going to finish connecting your data."
+	}
+}
+
+// onbHeroShell returns the bb-card classes, adding a soft success tint when
+// everything's done.
+func onbHeroShell(p OnboardingHeroProps) string {
+	base := "bb-card p-6 sm:p-8 flex flex-col items-center text-center gap-5 sm:flex-row sm:text-left sm:gap-7"
+	if p.AllComplete {
+		base += " bg-success/5"
+	}
+	return base
+}
+
+templ OnboardingHero(p OnboardingHeroProps) {
+	<div class={ onbHeroShell(p) }>
+		@ProgressRing(ProgressRingProps{
+			Value:    p.CompletedSteps,
+			Max:      p.TotalSteps,
+			Sublabel: "steps",
+			Complete: p.AllComplete,
+		})
+		<div class="min-w-0 flex-1">
+			<h1 class="text-2xl sm:text-3xl font-semibold tracking-tight text-balance">
+				{ onbHeroHeadline(p) }
+			</h1>
+			<p class="mt-1.5 text-base-content/60">
+				{ onbHeroSubhead(p) }
+			</p>
+			if p.TimeRemaining != "" {
+				<div class="mt-3 inline-flex items-center gap-1.5 text-sm text-base-content/45">
+					@LucideIcon("clock", "w-3.5 h-3.5")
+					<span class="tabular-nums">{ p.TimeRemaining }</span>
+				</div>
+			}
+		</div>
+	</div>
+}

--- a/internal/templates/components/onboarding_next_steps.templ
+++ b/internal/templates/components/onboarding_next_steps.templ
@@ -1,0 +1,97 @@
+package components
+
+// OnboardingNextSteps renders the celebratory "what's next" grid shown on
+// the /getting-started page once every onboarding step is complete. The
+// checklist gives way to a reward: a responsive 2-up grid of confident,
+// interactive destination cards that point the freshly-onboarded user at
+// the highest-value next actions (review transactions, write a rule, wire
+// up a workflow, invite the household).
+//
+// Each card is a real <a> link wrapped in the canonical
+// `bb-card bb-card--interactive` shell (the same hover-lift affordance the
+// StatTile link variant uses), so it's keyboard-focusable and behaves like
+// a navigation target rather than a button. A tinted rounded icon tile,
+// title, supporting body, and a trailing CTA affordance row anchor each
+// card; the per-card Tone drives the icon-tile color and the CTA accent.
+//
+// Tones are semantic daisy tokens only (primary / success / info / accent)
+// so the grid adapts cleanly across light and dark themes. Unknown tones
+// fall back to primary.
+
+type OnboardingNextStep struct {
+	Icon     string // Lucide name
+	Title    string
+	Body     string
+	Href     templ.SafeURL
+	CTALabel string
+	Tone     string // "primary" | "success" | "info" | "accent"
+}
+
+type OnboardingNextStepsProps struct {
+	Steps []OnboardingNextStep
+}
+
+// onbNextToneBg returns the tinted icon-tile background + icon color for a
+// next-step card. Mirrors the StatTile tone helper shape — bg-{tone}/10
+// behind a text-{tone} glyph.
+func onbNextToneBg(tone string) string {
+	switch tone {
+	case "success":
+		return "bg-success/10 text-success"
+	case "info":
+		return "bg-info/10 text-info"
+	case "accent":
+		return "bg-accent/10 text-accent"
+	default: // primary
+		return "bg-primary/10 text-primary"
+	}
+}
+
+// onbNextToneText returns the accent color used on the trailing CTA row
+// (label + arrow) so the affordance picks up the card's tone.
+func onbNextToneText(tone string) string {
+	switch tone {
+	case "success":
+		return "text-success"
+	case "info":
+		return "text-info"
+	case "accent":
+		return "text-accent"
+	default: // primary
+		return "text-primary"
+	}
+}
+
+templ OnboardingNextSteps(p OnboardingNextStepsProps) {
+	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+		for _, s := range p.Steps {
+			@onbNextStepCard(s)
+		}
+	</div>
+}
+
+// onbNextStepCard renders a single interactive destination card.
+templ onbNextStepCard(s OnboardingNextStep) {
+	<a
+		href={ s.Href }
+		class="bb-card bb-card--interactive p-5 no-underline block group"
+	>
+		<div class="flex flex-col gap-3 h-full">
+			<div class={ "w-10 h-10 rounded-xl flex items-center justify-center shrink-0", onbNextToneBg(s.Tone) }>
+				@LucideIcon(s.Icon, "w-5 h-5")
+			</div>
+			<div class="flex flex-col gap-1 flex-1">
+				<h3 class="font-semibold text-base-content">{ s.Title }</h3>
+				if s.Body != "" {
+					<p class="text-sm text-base-content/60 leading-relaxed">{ s.Body }</p>
+				}
+			</div>
+			if s.CTALabel != "" {
+				<div class={ "flex items-center gap-1.5 text-sm font-medium mt-1", onbNextToneText(s.Tone) }>
+					<span>{ s.CTALabel }</span>
+					@LucideIcon("arrow-right", "w-4 h-4 transition-transform group-hover:translate-x-0.5")
+				</div>
+			}
+		</div>
+	</a>
+}

--- a/internal/templates/components/onboarding_stats.templ
+++ b/internal/templates/components/onboarding_stats.templ
@@ -1,0 +1,76 @@
+package components
+
+// OnboardingStats is the always-on 4-up metrics strip for the
+// /getting-started page: Connections / Accounts / Transactions /
+// Successful syncs. Unlike the legacy getting-started page (which hid
+// stats until at least one transaction existed), this strip renders at
+// all times — including the fresh, all-zero install — with a graceful
+// muted zero state so the metrics read as "nothing here yet" rather than
+// "broken".
+//
+// It composes the canonical StatTile + StatTileRow (no bespoke tiles):
+// each tile links to where the user would go to grow that metric. A zero
+// value renders StatToneNeutral (muted icon tile) plus a subtle "None
+// yet" description; a positive value switches to a lightly-tinted tone.
+
+type OnboardingStatsProps struct {
+	Connections  int64
+	Accounts     int64
+	Transactions int64
+	Syncs        int64
+}
+
+// onbStatsTone returns the muted neutral tone when v is zero, otherwise
+// the supplied non-zero tone. Keeps the zero-state styling in one place.
+func onbStatsTone(v int64, nonZero StatTileTone) StatTileTone {
+	if v <= 0 {
+		return StatToneNeutral
+	}
+	return nonZero
+}
+
+// onbStatsDesc returns a subtle "None yet" hint for empty tiles and an
+// empty string otherwise (StatTile omits the line when blank).
+func onbStatsDesc(v int64) string {
+	if v <= 0 {
+		return "None yet"
+	}
+	return ""
+}
+
+templ OnboardingStats(p OnboardingStatsProps) {
+	@StatTileRow() {
+		@StatTile(StatTileProps{
+			Icon:        "link-2",
+			Label:       "Connections",
+			Value:       CommaInt(p.Connections),
+			Description: onbStatsDesc(p.Connections),
+			Tone:        onbStatsTone(p.Connections, StatTonePrimary),
+			Href:        "/connections",
+		})
+		@StatTile(StatTileProps{
+			Icon:        "wallet",
+			Label:       "Accounts",
+			Value:       CommaInt(p.Accounts),
+			Description: onbStatsDesc(p.Accounts),
+			Tone:        onbStatsTone(p.Accounts, StatToneInfo),
+			Href:        "/connections",
+		})
+		@StatTile(StatTileProps{
+			Icon:        "receipt",
+			Label:       "Transactions",
+			Value:       CommaInt(p.Transactions),
+			Description: onbStatsDesc(p.Transactions),
+			Tone:        onbStatsTone(p.Transactions, StatToneSuccess),
+			Href:        "/transactions",
+		})
+		@StatTile(StatTileProps{
+			Icon:        "refresh-cw",
+			Label:       "Syncs",
+			Value:       CommaInt(p.Syncs),
+			Description: onbStatsDesc(p.Syncs),
+			Tone:        onbStatsTone(p.Syncs, StatToneSuccess),
+			Href:        "/logs",
+		})
+	}
+}

--- a/internal/templates/components/pages/design_onboarding_alt_path.templ
+++ b/internal/templates/components/pages/design_onboarding_alt_path.templ
@@ -1,0 +1,40 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// SectionOnboardingAltPath demonstrates components.OnboardingAltPath — the
+// calm "alternative path + resources" aside shown on /getting-started while
+// setup is still in progress. It shows both copy variants:
+//
+//   - HasProvider=false → "Don't use Plaid or Teller?" (lean into CSV)
+//   - HasProvider=true  → "Prefer to import manually?" (softened)
+//
+// In both variants the Resources list is identical (three external doc links).
+templ SectionOnboardingAltPath() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>A quiet aside on <code>/getting-started</code>, rendered ONLY while setup is in progress (<code>!AllComplete</code>) — it de-risks the "no supported bank / I'm stuck" drop-off.</li>
+				<li>It surfaces the CSV-import alternative and a few doc links; it must NOT compete with the active step, so it's a soft surface with ghost affordances.</li>
+				<li>Copy adapts to whether a provider is connected — pass <code>HasProvider</code> from the page's onboarding state.</li>
+			</ul>
+		</div>
+		@designExample("No provider yet (HasProvider: false)", "Leans into \"no bank? import CSV\" — the most common reason someone stalls on the connect step.") {
+			@doaltVariant(false)
+		}
+		@designExample("Provider connected (HasProvider: true)", "Softened to \"prefer to import manually?\" — CSV is now an addendum, not a rescue.") {
+			@doaltVariant(true)
+		}
+	</div>
+}
+
+// doaltVariant constrains the card to a readable width so the sandbox preview
+// matches how it sits in the onboarding column.
+templ doaltVariant(hasProvider bool) {
+	<div class="max-w-xl">
+		@components.OnboardingAltPath(components.OnboardingAltPathProps{
+			HasProvider: hasProvider,
+		})
+	</div>
+}

--- a/internal/templates/components/pages/design_onboarding_hero.templ
+++ b/internal/templates/components/pages/design_onboarding_hero.templ
@@ -1,0 +1,44 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// SectionOnboardingHero renders the /getting-started onboarding hero and its
+// ProgressRing atom across the states the live page cycles through: empty,
+// partway, and fully complete. The ring is shown standalone first (0/5,
+// 3/5, 5/5) so its proportions and tone shift read on their own, then the
+// full hero is shown in the three copy-derivation cases.
+//
+// All copy here is derived (Headline/Subhead left empty) to exercise the
+// progress-based defaults; the handler passes TimeRemaining from its own
+// estimate.
+templ SectionOnboardingHero() {
+	<div class="flex flex-col gap-6">
+		@designExample("Progress ring — tone + fill", "The atom on its own. 0/5 and 3/5 use text-primary; 5/5 flips to text-success. The arc animates on load via a stroke-dashoffset transition; the centered count is tabular-nums.") {
+			<div class="flex flex-wrap items-center gap-8">
+				@components.ProgressRing(components.ProgressRingProps{Value: 0, Max: 5, Sublabel: "steps"})
+				@components.ProgressRing(components.ProgressRingProps{Value: 3, Max: 5, Sublabel: "steps"})
+				@components.ProgressRing(components.ProgressRingProps{Value: 5, Max: 5, Sublabel: "steps"})
+			</div>
+		}
+		@designExample("Onboarding hero — fresh", "0 of 5 complete, no time estimate. Derived welcome copy; primary-tone ring.") {
+			@components.OnboardingHero(components.OnboardingHeroProps{
+				CompletedSteps: 0,
+				TotalSteps:     5,
+			})
+		}
+		@designExample("Onboarding hero — in progress", "3 of 5 complete with a time-remaining row. Headline derives the percentage; the clock row only renders when TimeRemaining is set.") {
+			@components.OnboardingHero(components.OnboardingHeroProps{
+				CompletedSteps: 3,
+				TotalSteps:     5,
+				TimeRemaining:  "~4 min left",
+			})
+		}
+		@designExample("Onboarding hero — all set", "AllComplete tints the shell bg-success/5 and forces the ring to its success tone. Celebratory but soft.") {
+			@components.OnboardingHero(components.OnboardingHeroProps{
+				CompletedSteps: 5,
+				TotalSteps:     5,
+				AllComplete:    true,
+			})
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_onboarding_next_steps.templ
+++ b/internal/templates/components/pages/design_onboarding_next_steps.templ
@@ -1,0 +1,72 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// SectionOnboardingNextSteps is the /design sandbox section for the
+// getting-started completion experience: the "what's next" reward grid
+// (components.OnboardingNextSteps) plus both states of the redesigned
+// dismiss/resume footer (components.OnboardingFooter).
+//
+// The grid sample uses the real routes + copy the live page should pass
+// once onboarding is complete; the footer demo uses a placeholder CSRF
+// token since the sandbox has no live form target.
+templ SectionOnboardingNextSteps() {
+	<div class="flex flex-col gap-6">
+		@designExample("What's next grid (OnboardingNextSteps)", "Shown once every onboarding step is complete — the checklist gives way to a 2-up grid of interactive destination cards. Tone drives the icon tile + CTA accent; hover lifts the card and nudges the arrow.") {
+			@components.OnboardingNextSteps(components.OnboardingNextStepsProps{
+				Steps: donextSampleSteps(),
+			})
+		}
+		@designExample("Footer — active (OnboardingFooter, !Dismissed)", "A calm hairline-separated row: muted helper text on the left, a real POST dismiss form on the right. The dismiss control is an actual submit button, not a hidden link.") {
+			@components.OnboardingFooter(components.OnboardingFooterProps{
+				Dismissed: false,
+				CSRFToken: "demo-csrf-token",
+			})
+		}
+		@designExample("Footer — dismissed (OnboardingFooter, Dismissed)", "After dismissal: a quiet, form-less note reassuring the user the guide stays reachable.") {
+			@components.OnboardingFooter(components.OnboardingFooterProps{
+				Dismissed: true,
+				CSRFToken: "demo-csrf-token",
+			})
+		}
+	</div>
+}
+
+// donextSampleSteps returns the four realistic next-step cards the live
+// getting-started page should pass once onboarding completes.
+func donextSampleSteps() []components.OnboardingNextStep {
+	return []components.OnboardingNextStep{
+		{
+			Icon:     "receipt",
+			Title:    "Review transactions",
+			Body:     "See everything Breadbox synced and categorize what matters.",
+			Href:     templ.SafeURL("/transactions"),
+			CTALabel: "View transactions",
+			Tone:     "primary",
+		},
+		{
+			Icon:     "list-filter",
+			Title:    "Create a rule",
+			Body:     "Auto-categorize and tag transactions as they sync.",
+			Href:     templ.SafeURL("/rules/new"),
+			CTALabel: "New rule",
+			Tone:     "info",
+		},
+		{
+			Icon:     "bot",
+			Title:    "Set up a workflow",
+			Body:     "Let an AI agent review and enrich your finances on a schedule.",
+			Href:     templ.SafeURL("/workflows"),
+			CTALabel: "Browse workflows",
+			Tone:     "accent",
+		},
+		{
+			Icon:     "users",
+			Title:    "Invite household",
+			Body:     "Add the people whose accounts you track.",
+			Href:     templ.SafeURL("/household/new"),
+			CTALabel: "Add member",
+			Tone:     "success",
+		},
+	}
+}

--- a/internal/templates/components/pages/design_onboarding_stats.templ
+++ b/internal/templates/components/pages/design_onboarding_stats.templ
@@ -1,0 +1,36 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// SectionOnboardingStats showcases the always-on getting-started metrics
+// strip (components.OnboardingStats) in its two load-bearing states: the
+// fresh, all-zero install (every tile muted with a subtle "None yet"
+// hint) and a populated household (tinted tones, comma-formatted values).
+// The strip renders at all times on /getting-started — there is no
+// "hide until first transaction" gate — so the zero state must read as
+// intentional, not broken.
+templ SectionOnboardingStats() {
+	<div class="flex flex-col gap-6">
+		@designExample("Fresh install (all zero)", "Always shown — never hidden behind a first-transaction gate. Every tile is muted neutral with a subtle \"None yet\" line so the empty state reads intentional.") {
+			@components.OnboardingStats(dostatsEmpty())
+		}
+		@designExample("Populated household", "Once data flows in, each tile picks up a light tone (connections primary, accounts info, transactions + syncs success) and comma-formats its value.") {
+			@components.OnboardingStats(dostatsPopulated())
+		}
+	</div>
+}
+
+// dostatsEmpty is the fresh-install fixture: nothing connected yet.
+func dostatsEmpty() components.OnboardingStatsProps {
+	return components.OnboardingStatsProps{}
+}
+
+// dostatsPopulated is a representative active-household fixture.
+func dostatsPopulated() components.OnboardingStatsProps {
+	return components.OnboardingStatsProps{
+		Connections:  3,
+		Accounts:     8,
+		Transactions: 1240,
+		Syncs:        57,
+	}
+}

--- a/internal/templates/components/pages/design_setup_step.templ
+++ b/internal/templates/components/pages/design_setup_step.templ
@@ -1,0 +1,154 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// SectionSetupStep renders the /design gallery section for the SetupStep
+// onboarding row — one example of each state plus an Optional variant and a
+// variant carrying a DocHref. The states are stacked the way they appear on
+// the live /getting-started page (resolved steps on top, the active "you are
+// here" row in the middle, locked steps below) so the visual hierarchy reads
+// true: active dominates, complete recedes, pending reads as "not yet".
+templ SectionSetupStep() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>One step row per onboarding step on <code>/getting-started</code>. The caller computes <code>State</code> — the first incomplete step is <code>active</code>, every later incomplete step is <code>pending</code>, completed steps are <code>complete</code>, and a running first sync is <code>in_progress</code>.</li>
+				<li>The <code>active</code> row is the focal "you are here" surface — a primary ring + faint wash, the topical icon, the full description, a meta row, and a solid primary CTA. Exactly one row should be <code>active</code> at a time.</li>
+				<li>Never put the running state inside a daisy badge — the <code>in_progress</code> tile uses a spinner, badges are reserved for terminal / categorical state.</li>
+			</ul>
+		</div>
+		@designExample("State hierarchy (the full cascade)", "How the five onboarding steps read top-to-bottom: two complete steps recede, the active step dominates, and the remaining steps wait muted. Note the disabled CTA on the locked step.") {
+			<div class="grid gap-3">
+				@components.SetupStep(components.SetupStepProps{
+					Number:   1,
+					Icon:     "users",
+					Title:    "Add a family member",
+					Summary:  "Jordan added — connections link to household members.",
+					State:    components.SetupStepComplete,
+					CTAHref:  templ.SafeURL("/household"),
+					CTALabel: "View members",
+				})
+				@components.SetupStep(components.SetupStepProps{
+					Number:   2,
+					Icon:     "landmark",
+					Title:    "Configure a bank provider",
+					Summary:  "Plaid configured.",
+					State:    components.SetupStepComplete,
+					CTAHref:  templ.SafeURL("/settings/providers"),
+					CTALabel: "View providers",
+				})
+				@components.SetupStep(components.SetupStepProps{
+					Number:       3,
+					Icon:         "link-2",
+					Title:        "Connect your first bank",
+					Description:  "Link a bank account to start syncing transactions.",
+					State:        components.SetupStepActive,
+					TimeEstimate: "~2 min",
+					CTAHref:      templ.SafeURL("/connections/new"),
+					CTAIcon:      "plus",
+					CTALabel:     "Connect Bank",
+				})
+				@components.SetupStep(components.SetupStepProps{
+					Number:       4,
+					Icon:         "refresh-cw",
+					Title:        "Complete first sync",
+					Description:  "Connect a bank first, then transactions will sync automatically.",
+					State:        components.SetupStepPending,
+					TimeEstimate: "~1 min",
+					CTAIcon:      "scroll-text",
+					CTALabel:     "View logs",
+					CTADisabled:  true,
+				})
+				@components.SetupStep(components.SetupStepProps{
+					Number:      5,
+					Icon:        "bot",
+					Title:       "Set up AI agents",
+					Description: "Create an API key so AI agents can query your data via the MCP server.",
+					State:       components.SetupStepPending,
+					Optional:    true,
+					CTAHref:     templ.SafeURL("/workflows"),
+					CTAIcon:     "arrow-right",
+					CTALabel:    "Set up workflows",
+				})
+			</div>
+		}
+		@designExample("Active — the elevated focal step", "Primary ring + faint wash, topical icon tile, full description, meta row, and a solid primary CTA. The visually dominant row.") {
+			@components.SetupStep(components.SetupStepProps{
+				Number:       3,
+				Icon:         "link-2",
+				Title:        "Connect your first bank",
+				Description:  "Link a bank account to start syncing transactions.",
+				State:        components.SetupStepActive,
+				TimeEstimate: "~2 min",
+				CTAHref:      templ.SafeURL("/connections/new"),
+				CTAIcon:      "plus",
+				CTALabel:     "Connect Bank",
+			})
+		}
+		@designExample("Active — Optional + Learn more", "The meta row carries an Optional badge and a doc deep-link alongside the time estimate. DocLabel defaults to \"Learn more\" when left empty.") {
+			@components.SetupStep(components.SetupStepProps{
+				Number:       5,
+				Icon:         "bot",
+				Title:        "Set up AI agents",
+				Description:  "Create an API key so AI agents can query your financial data via the MCP server.",
+				State:        components.SetupStepActive,
+				TimeEstimate: "~3 min",
+				Optional:     true,
+				DocHref:      templ.SafeURL("https://docs.breadbox.sh/guides/multi-agent-reviewer"),
+				CTAHref:      templ.SafeURL("/workflows"),
+				CTAIcon:      "sparkles",
+				CTALabel:     "Set up workflows",
+			})
+		}
+		@designExample("In progress — work happening", "The tile swaps the icon for a spinner (never a badge). A quiet \"In progress…\" hint and a ghost CTA to follow along.") {
+			@components.SetupStep(components.SetupStepProps{
+				Number:      4,
+				Icon:        "refresh-cw",
+				Title:       "Complete first sync",
+				Description: "Your first sync is running — accounts and transactions are landing now.",
+				State:       components.SetupStepInProgress,
+				CTAHref:     templ.SafeURL("/logs"),
+				CTAIcon:     "scroll-text",
+				CTALabel:    "View logs",
+			})
+		}
+		@designExample("Complete — done and quiet", "Success-green check tile, a one-line Summary, and a ghost \"view\" affordance. The whole row recedes.") {
+			@components.SetupStep(components.SetupStepProps{
+				Number:   3,
+				Icon:     "link-2",
+				Title:    "Connect your first bank",
+				Summary:  "Chase connected — 2 accounts, syncing automatically.",
+				State:    components.SetupStepComplete,
+				CTAHref:  templ.SafeURL("/connections"),
+				CTALabel: "View connections",
+			})
+		}
+		@designExample("Pending — prerequisites unmet", "Muted: the tile shows the step number, the copy dims, and the CTA renders as a disabled span when CTADisabled (left) or a quiet ghost link otherwise (right).") {
+			<div class="grid gap-3">
+				@components.SetupStep(components.SetupStepProps{
+					Number:       4,
+					Icon:         "refresh-cw",
+					Title:        "Complete first sync",
+					Description:  "Connect a bank first, then transactions will sync automatically.",
+					State:        components.SetupStepPending,
+					TimeEstimate: "~1 min",
+					CTAIcon:      "scroll-text",
+					CTALabel:     "View logs",
+					CTADisabled:  true,
+				})
+				@components.SetupStep(components.SetupStepProps{
+					Number:      5,
+					Icon:        "bot",
+					Title:       "Set up AI agents",
+					Description: "Create an API key so AI agents can query your data via the MCP server.",
+					State:       components.SetupStepPending,
+					Optional:    true,
+					CTAHref:     templ.SafeURL("/workflows"),
+					CTAIcon:     "arrow-right",
+					CTALabel:    "Set up workflows",
+				})
+			</div>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -64,6 +64,7 @@ func DesignSectionGroups() []DesignSectionGroup {
 		{Slug: "data", Label: "Data display"},
 		{Slug: "feedback", Label: "Feedback"},
 		{Slug: "patterns", Label: "Patterns"},
+		{Slug: "onboarding", Label: "Onboarding"},
 	}
 }
 
@@ -421,6 +422,43 @@ func DesignSections() []DesignSection {
 			Description: "SettingsSection / SettingsRow / SettingsAutoSaveForm — the shared shape every /settings/* tab uses. See .claude/rules/settings.md for the design language (anatomy, width, auto-save vs single-Save-per-section, danger variant).",
 			Group:       "patterns",
 			Render:      func() templ.Component { return SectionSettings() },
+		},
+
+		// ── Onboarding ──────────────────────────────────────────────
+		{
+			Slug:        "onboarding-hero",
+			Title:       "Onboarding hero",
+			Description: "The /getting-started banner: a circular ProgressRing + a headline that warms up by progress toward an all-set celebration, with a time-remaining estimate. Use components.OnboardingHero + components.ProgressRing.",
+			Group:       "onboarding",
+			Render:      func() templ.Component { return SectionOnboardingHero() },
+		},
+		{
+			Slug:        "setup-step",
+			Title:       "Setup step",
+			Description: "The stateful onboarding step row: active (elevated, \"you are here\"), in_progress (spinner), complete (collapsed confirmation), and pending (muted). Topical icon, time estimate, optional badge, doc link, single reflowing CTA. Use components.SetupStep.",
+			Group:       "onboarding",
+			Render:      func() templ.Component { return SectionSetupStep() },
+		},
+		{
+			Slug:        "onboarding-stats",
+			Title:       "Onboarding stats",
+			Description: "Always-on Connections/Accounts/Transactions/Syncs strip for /getting-started, with a graceful muted zero state. Composes StatTile + StatTileRow. Use components.OnboardingStats.",
+			Group:       "onboarding",
+			Render:      func() templ.Component { return SectionOnboardingStats() },
+		},
+		{
+			Slug:        "onboarding-next-steps",
+			Title:       "Onboarding next steps + footer",
+			Description: "The celebratory \"what's next\" destination grid shown once onboarding completes, plus the redesigned dismiss/resume footer (both states). Use components.OnboardingNextSteps + components.OnboardingFooter.",
+			Group:       "onboarding",
+			Render:      func() templ.Component { return SectionOnboardingNextSteps() },
+		},
+		{
+			Slug:        "onboarding-alt-path",
+			Title:       "Onboarding alt path",
+			Description: "Calm CSV-import alternative + documentation resources aside, shown while setup is in progress. Copy adapts to whether a provider is configured. Use components.OnboardingAltPath.",
+			Group:       "onboarding",
+			Render:      func() templ.Component { return SectionOnboardingAltPath() },
 		},
 	}
 }

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -6,344 +6,230 @@ import (
 	"breadbox/internal/templates/components"
 )
 
-// GettingStarted renders the onboarding setup walkthrough page. Hosts inside
-// the base layout via TemplateRenderer.RenderWithTempl. Step states cascade
-// in the order: complete (success), in-progress (primary, the next pending
-// step), and pending (muted base-200) — the per-step circle/icon switch is
-// the visible signal.
+// GettingStarted renders the redesigned onboarding walkthrough — the "setup
+// journey". It composes the shared onboarding components:
+//
+//   - OnboardingHero — a progress ring + a headline that warms up toward a
+//     completion celebration, plus a time-remaining estimate.
+//   - OnboardingStats — an always-on Connections/Accounts/Transactions/Syncs
+//     strip with a graceful zero state.
+//   - SetupStep ×5 — the guided checklist. The next actionable step is
+//     elevated ("you are here"); completed steps collapse to quiet
+//     confirmations; pending steps wait, muted.
+//   - OnboardingAltPath — a calm CSV-alternative + resources aside, shown
+//     only while setup is in progress.
+//   - OnboardingNextSteps — the celebratory "what's next" grid, shown once
+//     every step is complete.
+//   - OnboardingFooter — the redesigned dismiss/resume affordance.
+//
+// State per step is computed in the handler (ActiveStep = first incomplete
+// step) and resolved here via gsStepState; the sync step is special-cased to
+// "in_progress" while a connection exists but no sync has landed.
 templ GettingStarted(p GettingStartedProps) {
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title flex items-center gap-2">
-				@components.LucideIcon("compass", "w-6 h-6 text-primary")
-				Getting Started
-			</h1>
-			<p class="text-sm text-base-content/50 mt-1">Set up Breadbox step by step. Complete each step to start tracking your finances.</p>
-		</div>
-	</div>
-	<!-- Progress summary -->
-	<div class="bb-card p-4 sm:p-5 mb-6">
-		<div class="flex flex-col sm:flex-row sm:items-center gap-4">
-			<div class="flex-1">
-				<div class="flex items-center gap-2 mb-2">
-					<span class="text-sm font-semibold">Setup Progress</span>
-					<span class={ "badge badge-sm", gsProgressBadgeClass(p) }>{ fmt.Sprintf("%d / %d", p.CompletedSteps, p.TotalSteps) }</span>
-				</div>
-				<progress class={ "progress w-full", gsProgressBarClass(p) } value={ fmt.Sprintf("%d", p.CompletedSteps) } max={ fmt.Sprintf("%d", p.TotalSteps) }></progress>
-			</div>
-			if p.TransactionCount > 0 {
-				<div class="flex flex-wrap gap-4 text-sm tabular-nums">
-					<div class="flex items-center gap-1.5">
-						@components.LucideIcon("link", "w-3.5 h-3.5 text-base-content opacity-40")
-						<span class="text-base-content/50">Connections</span>
-						<span class="font-semibold">{ components.CommaInt(p.ConnectionCount) }</span>
-					</div>
-					<div class="flex items-center gap-1.5">
-						@components.LucideIcon("wallet", "w-3.5 h-3.5 text-base-content opacity-40")
-						<span class="text-base-content/50">Accounts</span>
-						<span class="font-semibold">{ components.CommaInt(p.AccountCount) }</span>
-					</div>
-					<div class="flex items-center gap-1.5">
-						@components.LucideIcon("receipt", "w-3.5 h-3.5 text-base-content opacity-40")
-						<span class="text-base-content/50">Transactions</span>
-						<span class="font-semibold">{ components.CommaInt(p.TransactionCount) }</span>
-					</div>
-					<div class="flex items-center gap-1.5">
-						@components.LucideIcon("refresh-cw", "w-3.5 h-3.5 text-base-content opacity-40")
-						<span class="text-base-content/50">Syncs</span>
-						<span class="font-semibold">{ components.CommaInt(p.SuccessfulSyncs) }</span>
-					</div>
-				</div>
-			}
-		</div>
-	</div>
-	<!-- Steps -->
-	<div class="grid gap-4">
-		<!-- Step 1: Create a family member -->
-		@gsStep1(p)
-		<!-- Step 2: Configure a provider -->
-		@gsStep2(p)
-		<!-- Step 3: Connect a bank -->
-		@gsStep3(p)
-		<!-- Step 4: First sync -->
-		@gsStep4(p)
-		<!-- Step 5: Configure agents -->
-		@gsStep5(p)
-	</div>
-	<!-- Dismiss section -->
-	<div class="mt-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
-		if !p.OnboardingDismissed {
-			<form method="POST" action="/getting-started/dismiss">
-				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
-				<button type="submit" class="btn btn-ghost btn-sm text-base-content/50">
-					@components.LucideIcon("x", "w-3.5 h-3.5")
-					Dismiss guide
-					<span class="text-xs text-base-content/30 ml-1 hidden sm:inline">-- you can always find it at /getting-started or in Settings</span>
-				</button>
-			</form>
+	<div class="flex flex-col gap-6">
+		@components.OnboardingHero(components.OnboardingHeroProps{
+			CompletedSteps: p.CompletedSteps,
+			TotalSteps:     p.TotalSteps,
+			AllComplete:    p.AllComplete,
+			TimeRemaining:  p.TimeRemaining,
+		})
+		@components.OnboardingStats(components.OnboardingStatsProps{
+			Connections:  p.ConnectionCount,
+			Accounts:     p.AccountCount,
+			Transactions: p.TransactionCount,
+			Syncs:        p.SuccessfulSyncs,
+		})
+		if p.AllComplete {
+			@gsWhatsNext()
 		} else {
-			<div class="text-xs text-base-content/30 flex items-center gap-1.5">
-				@components.LucideIcon("info", "w-3 h-3")
-				This guide is always available at /getting-started or from Settings.
+			<div class="flex flex-col gap-3">
+				@gsStep1(p)
+				@gsStep2(p)
+				@gsStep3(p)
+				@gsStep4(p)
+				@gsStep5(p)
 			</div>
+			@components.OnboardingAltPath(components.OnboardingAltPathProps{HasProvider: p.HasProvider})
 		}
+		@components.OnboardingFooter(components.OnboardingFooterProps{
+			Dismissed: p.OnboardingDismissed,
+			CSRFToken: p.CSRFToken,
+		})
 	</div>
 }
 
-// gsStep1 — Add a family member. Always reachable (the entry point of the
-// flow), so the circle is primary on the pending state.
+// gsWhatsNext renders the celebratory completion grid: a small section header
+// followed by the OnboardingNextSteps destination cards.
+templ gsWhatsNext() {
+	<div>
+		@components.SectionHeader(components.SectionHeaderProps{
+			Icon:  "sparkles",
+			Title: "What's next",
+		})
+		@components.OnboardingNextSteps(components.OnboardingNextStepsProps{
+			Steps: []components.OnboardingNextStep{
+				{Icon: "receipt", Title: "Review transactions", Body: "See everything Breadbox synced and categorize what matters.", Href: "/transactions", CTALabel: "View transactions", Tone: "primary"},
+				{Icon: "list-filter", Title: "Create a rule", Body: "Auto-categorize and tag transactions as they sync.", Href: "/rules/new", CTALabel: "New rule", Tone: "info"},
+				{Icon: "bot", Title: "Set up a workflow", Body: "Let an AI agent review and enrich your finances on a schedule.", Href: "/workflows", CTALabel: "Browse workflows", Tone: "accent"},
+				{Icon: "users", Title: "Invite household", Body: "Add the people whose accounts you track.", Href: "/household/new", CTALabel: "Add member", Tone: "success"},
+			},
+		})
+	</div>
+}
+
+// ── Steps ────────────────────────────────────────────────────────────────
+
+// gsStep1 — Add a household member.
 templ gsStep1(p GettingStartedProps) {
-	<div class="bb-card p-0 overflow-hidden">
-		<div class="flex items-start gap-4 p-4 sm:p-5">
-			<div class={ "flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center", gsCircleClass(p.HasMember, true) }>
-				if p.HasMember {
-					@components.LucideIcon("check", "w-4 h-4")
-				} else {
-					<span class="text-sm font-bold">1</span>
-				}
-			</div>
-			<div class="flex-1 min-w-0 flex flex-col gap-2">
-				<div>
-					<h3 class={ "font-semibold", templ.KV("text-success", p.HasMember) }>Add a family member</h3>
-					<p class="text-sm text-base-content/50 mt-0.5">
-						if p.HasMember {
-							Family member added. Bank connections are linked to household members.
-						} else {
-							Create a household member to link bank connections to. Each member represents a person in your household.
-						}
-					</p>
-				</div>
-				<div class="flex items-center gap-2 sm:hidden">
-					if p.HasMember {
-						<a href="/household" class="btn btn-ghost btn-sm">View Members</a>
-					} else {
-						<a href="/household/new" class="btn btn-primary btn-sm">Add Member</a>
-					}
-				</div>
-			</div>
-			<div class="hidden sm:flex flex-shrink-0">
-				if p.HasMember {
-					<a href="/household" class="btn btn-ghost btn-sm">View Members</a>
-				} else {
-					<a href="/household/new" class="btn btn-primary btn-sm">Add Member</a>
-				}
-			</div>
-		</div>
-	</div>
+	@components.SetupStep(components.SetupStepProps{
+		Number:       1,
+		Icon:         "users",
+		Title:        "Add a household member",
+		Description:  "Create a household member so bank connections have someone to belong to.",
+		Summary:      "Household member added.",
+		State:        gsStepState(p.HasMember, 1, p.ActiveStep),
+		TimeEstimate: "~1 min",
+		CTAHref:      gsStepCTAHref(p.HasMember, "/household", "/household/new"),
+		CTAIcon:      gsStepCTAIcon(p.HasMember, "plus"),
+		CTALabel:     gsStepCTALabel(p.HasMember, "View members", "Add member"),
+	})
 }
 
-// gsStep2 — Configure a bank provider. Becomes in-progress only after the
-// member step is complete; otherwise it renders muted to telegraph the
-// dependency chain.
+// gsStep2 — Configure a bank provider.
 templ gsStep2(p GettingStartedProps) {
-	<div class="bb-card p-0 overflow-hidden">
-		<div class="flex items-start gap-4 p-4 sm:p-5">
-			<div class={ "flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center", gsCircleClass(p.HasProvider, p.HasMember) }>
-				if p.HasProvider {
-					@components.LucideIcon("check", "w-4 h-4")
-				} else {
-					<span class="text-sm font-bold">2</span>
-				}
-			</div>
-			<div class="flex-1 min-w-0 flex flex-col gap-2">
-				<div>
-					<h3 class={ "font-semibold", templ.KV("text-success", p.HasProvider) }>Configure a bank provider</h3>
-					<p class="text-sm text-base-content/50 mt-0.5">
-						if p.HasProvider {
-							Provider configured. You can connect bank accounts through Plaid or Teller.
-						} else {
-							Set up Plaid or Teller to connect bank accounts. You can also import transactions via CSV.
-						}
-					</p>
-				</div>
-				<div class="flex items-center gap-2 sm:hidden">
-					if p.HasProvider {
-						<a href="/settings/providers" class="btn btn-ghost btn-sm">View Providers</a>
-					} else {
-						<a href="/settings/providers" class="btn btn-primary btn-sm">Configure</a>
-					}
-				</div>
-			</div>
-			<div class="hidden sm:flex flex-shrink-0">
-				if p.HasProvider {
-					<a href="/settings/providers" class="btn btn-ghost btn-sm">View Providers</a>
-				} else {
-					<a href="/settings/providers" class="btn btn-primary btn-sm">Configure</a>
-				}
-			</div>
-		</div>
-	</div>
+	@components.SetupStep(components.SetupStepProps{
+		Number:       2,
+		Icon:         "landmark",
+		Title:        "Configure a bank provider",
+		Description:  "Set up Plaid or Teller to link bank accounts — or import a CSV instead.",
+		Summary:      "Provider configured — ready to connect banks.",
+		State:        gsStepState(p.HasProvider, 2, p.ActiveStep),
+		TimeEstimate: "~2 min",
+		DocHref:      "https://docs.breadbox.sh",
+		DocLabel:     "How providers work",
+		CTAHref:      "/settings/providers",
+		CTAIcon:      gsStepCTAIcon(p.HasProvider, "settings"),
+		CTALabel:     gsStepCTALabel(p.HasProvider, "View providers", "Configure"),
+		CTADisabled:  gsStepPendingDisabled(p.HasProvider, 2, p.ActiveStep),
+	})
 }
 
-// gsStep3 — Connect a bank. Becomes in-progress once both the member and
-// provider exist; the disabled CTA on the no-provider branch matches the
-// pre-templ markup exactly (no link, span styled as a btn-disabled).
+// gsStep3 — Connect the first bank.
 templ gsStep3(p GettingStartedProps) {
-	<div class="bb-card p-0 overflow-hidden">
-		<div class="flex items-start gap-4 p-4 sm:p-5">
-			<div class={ "flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center", gsCircleClass(p.HasConnection, p.HasMember && p.HasProvider) }>
-				if p.HasConnection {
-					@components.LucideIcon("check", "w-4 h-4")
-				} else {
-					<span class="text-sm font-bold">3</span>
-				}
-			</div>
-			<div class="flex-1 min-w-0 flex flex-col gap-2">
-				<div>
-					<h3 class={ "font-semibold", templ.KV("text-success", p.HasConnection) }>Connect your first bank</h3>
-					<p class="text-sm text-base-content/50 mt-0.5">
-						if p.HasConnection {
-							Bank connected. Accounts and transactions will sync automatically.
-						} else if p.HasProvider {
-							Link a bank account to start syncing transactions.
-						} else {
-							Configure a provider first, then connect a bank account.
-						}
-					</p>
-				</div>
-				<div class="flex items-center gap-2 sm:hidden">
-					if p.HasConnection {
-						<a href="/connections" class="btn btn-ghost btn-sm">View Connections</a>
-					} else if p.HasProvider {
-						<a href="/connections/new" class="btn btn-primary btn-sm">Connect Bank</a>
-					} else {
-						<span class="btn btn-sm btn-disabled">Connect Bank</span>
-					}
-				</div>
-			</div>
-			<div class="hidden sm:flex flex-shrink-0">
-				if p.HasConnection {
-					<a href="/connections" class="btn btn-ghost btn-sm">View Connections</a>
-				} else if p.HasProvider {
-					<a href="/connections/new" class="btn btn-primary btn-sm">Connect Bank</a>
-				} else {
-					<span class="btn btn-sm btn-disabled">Connect Bank</span>
-				}
-			</div>
-		</div>
-	</div>
+	@components.SetupStep(components.SetupStepProps{
+		Number:       3,
+		Icon:         "link-2",
+		Title:        "Connect your first bank",
+		Description:  "Link a bank account to start syncing accounts and transactions.",
+		Summary:      "Bank connected and syncing.",
+		State:        gsStepState(p.HasConnection, 3, p.ActiveStep),
+		TimeEstimate: "~2 min",
+		DocHref:      "https://docs.breadbox.sh",
+		DocLabel:     "Connecting a bank",
+		CTAHref:      gsStepCTAHref(p.HasConnection, "/connections", "/connections/new"),
+		CTAIcon:      gsStepCTAIcon(p.HasConnection, "plus"),
+		CTALabel:     gsStepCTALabel(p.HasConnection, "View connections", "Connect bank"),
+		CTADisabled:  gsStepPendingDisabled(p.HasConnection, 3, p.ActiveStep),
+	})
 }
 
-// gsStep4 — First sync. The complete state surfaces transaction + account
-// counters so the user gets a concrete confirmation of the data that landed.
+// gsStep4 — First sync. Renders "in_progress" while a connection exists but no
+// sync has landed yet (the first sync runs automatically), surfacing the logs.
 templ gsStep4(p GettingStartedProps) {
-	<div class="bb-card p-0 overflow-hidden">
-		<div class="flex items-start gap-4 p-4 sm:p-5">
-			<div class={ "flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center", gsCircleClass(p.HasSync, p.HasConnection) }>
-				if p.HasSync {
-					@components.LucideIcon("check", "w-4 h-4")
-				} else {
-					<span class="text-sm font-bold">4</span>
-				}
-			</div>
-			<div class="flex-1 min-w-0 flex flex-col gap-2">
-				<div>
-					<h3 class={ "font-semibold", templ.KV("text-success", p.HasSync) }>Complete first sync</h3>
-					<p class="text-sm text-base-content/50 mt-0.5">
-						if p.HasSync {
-							{ fmt.Sprintf("Sync complete. %s transactions synced across %s accounts.", components.CommaInt(p.TransactionCount), components.CommaInt(p.AccountCount)) }
-						} else if p.HasConnection {
-							Your first sync should start automatically. Check the sync logs if it hasn't started.
-						} else {
-							Connect a bank first, then transactions will sync automatically.
-						}
-					</p>
-				</div>
-				<div class="flex items-center gap-2 sm:hidden">
-					if p.HasSync {
-						<a href="/transactions" class="btn btn-ghost btn-sm">View Transactions</a>
-					} else if p.HasConnection {
-						<a href="/logs" class="btn btn-ghost btn-sm">View Logs</a>
-					} else {
-						<span class="btn btn-sm btn-disabled">View Logs</span>
-					}
-				</div>
-			</div>
-			<div class="hidden sm:flex flex-shrink-0">
-				if p.HasSync {
-					<a href="/transactions" class="btn btn-ghost btn-sm">View Transactions</a>
-				} else if p.HasConnection {
-					<a href="/logs" class="btn btn-ghost btn-sm">View Logs</a>
-				} else {
-					<span class="btn btn-sm btn-disabled">View Logs</span>
-				}
-			</div>
-		</div>
-	</div>
+	@components.SetupStep(components.SetupStepProps{
+		Number:       4,
+		Icon:         "refresh-cw",
+		Title:        "Complete the first sync",
+		Description:  "Your first sync runs automatically. Check the logs if it doesn't start.",
+		Summary:      fmt.Sprintf("%s transactions across %s accounts.", components.CommaInt(p.TransactionCount), components.CommaInt(p.AccountCount)),
+		State:        gsSyncState(p),
+		TimeEstimate: "~1 min",
+		CTAHref:      gsStepCTAHref(p.HasSync, "/transactions", "/logs"),
+		CTAIcon:      "",
+		CTALabel:     gsStepCTALabel(p.HasSync, "View transactions", "View logs"),
+		CTADisabled:  gsStepPendingDisabled(p.HasSync, 4, p.ActiveStep),
+	})
 }
 
-// gsStep5 — Set up AI agents. Becomes in-progress once a sync has landed —
-// keying off HasSync (not HasConnection) ensures the user sees real data
-// before being prompted to wire up agents.
+// gsStep5 — Set up AI agents (optional). The badge tells users they can stop
+// before it; completing it is the final flourish.
 templ gsStep5(p GettingStartedProps) {
-	<div class="bb-card p-0 overflow-hidden">
-		<div class="flex items-start gap-4 p-4 sm:p-5">
-			<div class={ "flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center", gsCircleClass(p.HasAPIKey, p.HasSync) }>
-				if p.HasAPIKey {
-					@components.LucideIcon("check", "w-4 h-4")
-				} else {
-					<span class="text-sm font-bold">5</span>
-				}
-			</div>
-			<div class="flex-1 min-w-0 flex flex-col gap-2">
-				<div>
-					<h3 class={ "font-semibold", templ.KV("text-success", p.HasAPIKey) }>Set up AI agents</h3>
-					<p class="text-sm text-base-content/50 mt-0.5">
-						if p.HasAPIKey {
-							API key created. AI agents can access Breadbox via the MCP server or REST API.
-						} else {
-							Create an API key so AI agents can query your financial data via the MCP server.
-						}
-					</p>
-				</div>
-				<div class="flex items-center gap-2 sm:hidden">
-					if p.HasAPIKey {
-						<a href="/workflows" class="btn btn-ghost btn-sm">View workflows</a>
-					} else {
-						<a href="/workflows" class="btn btn-primary btn-sm">Set up workflows</a>
-					}
-				</div>
-			</div>
-			<div class="hidden sm:flex flex-shrink-0">
-				if p.HasAPIKey {
-					<a href="/workflows" class="btn btn-ghost btn-sm">View workflows</a>
-				} else {
-					<a href="/workflows" class="btn btn-primary btn-sm">Set up workflows</a>
-				}
-			</div>
-		</div>
-	</div>
+	@components.SetupStep(components.SetupStepProps{
+		Number:       5,
+		Icon:         "bot",
+		Title:        "Set up AI agents",
+		Description:  "Create an API key so AI agents can query your finances via the MCP server.",
+		Summary:      "API key created — agents can reach your data.",
+		State:        gsStepState(p.HasAPIKey, 5, p.ActiveStep),
+		TimeEstimate: "~3 min",
+		Optional:     true,
+		DocHref:      "https://docs.breadbox.sh/guides/multi-agent-reviewer",
+		DocLabel:     "Multi-agent reviewer",
+		CTAHref:      "/workflows",
+		CTAIcon:      gsStepCTAIcon(p.HasAPIKey, "sparkles"),
+		CTALabel:     gsStepCTALabel(p.HasAPIKey, "View workflows", "Set up workflows"),
+		CTADisabled:  gsStepPendingDisabled(p.HasAPIKey, 5, p.ActiveStep),
+	})
 }
 
-// gsCircleClass returns the per-step badge classes for the round step
-// indicator. complete → success, in-progress → primary, pending → muted.
-// `inProgress` should be true when all prerequisites for this step are
-// met (the next actionable step in the flow).
-func gsCircleClass(complete, inProgress bool) string {
+// ── State + CTA helpers ────────────────────────────────────────────────────
+
+// gsStepState resolves a step to complete / active / pending. The first
+// incomplete step (== ActiveStep) is the elevated "you are here" row; all
+// later incomplete steps are pending.
+func gsStepState(complete bool, stepNum, activeStep int) components.SetupStepState {
 	switch {
 	case complete:
-		return "bg-success/10 text-success"
-	case inProgress:
-		return "bg-primary/10 text-primary"
+		return components.SetupStepComplete
+	case stepNum == activeStep:
+		return components.SetupStepActive
 	default:
-		return "bg-base-200 text-base-content/30"
+		return components.SetupStepPending
 	}
 }
 
-// gsProgressBadgeClass returns the badge variant for the "X / Y" pill: green
-// when every step is complete, ghost otherwise.
-func gsProgressBadgeClass(p GettingStartedProps) string {
-	if p.CompletedSteps == p.TotalSteps {
-		return "badge-success"
+// gsSyncState special-cases the sync step: once it's the active step a
+// connection already exists (steps 1–3 are done), so the first sync is
+// running — render it in_progress (spinner + "check the logs") rather than a
+// plain active CTA.
+func gsSyncState(p GettingStartedProps) components.SetupStepState {
+	if p.HasSync {
+		return components.SetupStepComplete
 	}
-	return "badge-ghost"
+	if p.ActiveStep == 4 {
+		return components.SetupStepInProgress
+	}
+	return components.SetupStepPending
 }
 
-// gsProgressBarClass returns the daisyUI progress variant — green at 100%,
-// primary while in flight.
-func gsProgressBarClass(p GettingStartedProps) string {
-	if p.CompletedSteps == p.TotalSteps {
-		return "progress-success"
+// gsStepPendingDisabled returns true for a step that is pending (incomplete and
+// not yet the active step) — its action target isn't reachable yet, so the CTA
+// renders as a disabled span.
+func gsStepPendingDisabled(complete bool, stepNum, activeStep int) bool {
+	return !complete && stepNum != activeStep
+}
+
+// gsStepCTAHref picks the "view" target when complete, else the "do it" target.
+func gsStepCTAHref(complete bool, doneHref, todoHref string) templ.SafeURL {
+	if complete {
+		return templ.SafeURL(doneHref)
 	}
-	return "progress-primary"
+	return templ.SafeURL(todoHref)
+}
+
+// gsStepCTALabel picks the "view" label when complete, else the "do it" label.
+func gsStepCTALabel(complete bool, doneLabel, todoLabel string) string {
+	if complete {
+		return doneLabel
+	}
+	return todoLabel
+}
+
+// gsStepCTAIcon drops the icon on the ghost "view" CTA (complete state) and
+// keeps the action icon on the primary CTA otherwise.
+func gsStepCTAIcon(complete bool, todoIcon string) string {
+	if complete {
+		return ""
+	}
+	return todoIcon
 }

--- a/internal/templates/components/pages/getting_started_types.go
+++ b/internal/templates/components/pages/getting_started_types.go
@@ -2,9 +2,20 @@
 
 package pages
 
-// GettingStartedProps mirrors the data map the old getting_started.html
-// read. The handler computes step completion against the live database
-// and assembles flat primitives so the templ side stays pure-presentation.
+// GettingStartedProps drives the redesigned onboarding walkthrough. The
+// handler computes step completion against the live database and assembles
+// flat primitives so the templ side stays pure-presentation.
+//
+// The page composes the shared onboarding components (OnboardingHero +
+// progress ring, OnboardingStats, SetupStep ×5, OnboardingAltPath,
+// OnboardingNextSteps, OnboardingFooter). State per step is derived from the
+// completion flags + ActiveStep:
+//
+//   - a step whose flag is set renders "complete"
+//   - the first incomplete step (ActiveStep) renders "active" — except the
+//     sync step, which renders "in_progress" while a connection exists but no
+//     sync has landed yet
+//   - every later incomplete step renders "pending"
 type GettingStartedProps struct {
 	// Step completion flags.
 	HasMember     bool
@@ -17,14 +28,27 @@ type GettingStartedProps struct {
 	CompletedSteps int
 	TotalSteps     int
 
-	// Counters for the summary strip — only shown when TransactionCount > 0.
+	// AllComplete is true once every step is done — flips the page from the
+	// checklist to the celebratory "what's next" grid and the success-tinted
+	// hero.
+	AllComplete bool
+
+	// ActiveStep is the 1-based index of the first incomplete step (0 when
+	// AllComplete). Drives which step renders elevated/active.
+	ActiveStep int
+
+	// TimeRemaining is a rough estimate of time left to finish setup, e.g.
+	// "~5 min left". Empty hides the hero's time row (also empty when done).
+	TimeRemaining string
+
+	// Counters for the always-on stats strip.
 	ConnectionCount  int64
 	AccountCount     int64
 	TransactionCount int64
 	SuccessfulSyncs  int64
 
-	// Whether the onboarding banner has been dismissed (controls the
-	// dismiss form vs. the always-available info note).
+	// Whether the onboarding guide has been dismissed (controls the footer's
+	// dismiss form vs. the always-available note).
 	OnboardingDismissed bool
 
 	// CSRF token for the dismiss form.

--- a/internal/templates/components/progress_ring.templ
+++ b/internal/templates/components/progress_ring.templ
@@ -1,0 +1,193 @@
+package components
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// ProgressRing is a presentation-only circular progress atom: a faint
+// background track ring with a foreground arc that sweeps from 12 o'clock
+// clockwise to represent Value/Max. The arc animates on load via a CSS
+// transition on `stroke-dashoffset`, and a big tabular-nums count sits
+// centered over the SVG.
+//
+// It's the memorable moment of the onboarding hero — the proportions
+// (size, stroke, centered count) are deliberate. Pure inline SVG, no JS,
+// no keyframes; the only motion is the stroke-dashoffset transition.
+//
+// Color: foreground arc is `text-primary` (via stroke-current on a wrapping
+// class), flipping to `text-success` when Complete is true or Value >= Max.
+// The track is `text-base-200`. All colors are semantic daisy tokens so
+// dark mode and theming come for free.
+//
+// Props:
+//   - Value, Max: the fraction. Max <= 0 is treated as 1 to avoid /0.
+//   - Size:       px diameter. Defaults to 112 when 0.
+//   - Stroke:     px stroke width. Defaults to 9 when 0.
+//   - Centerline: big center text. Defaults to "Value/Max" when "".
+//   - Sublabel:   small muted text under the centerline (e.g. "steps").
+//   - Complete:   forces the success tone regardless of Value/Max.
+
+type ProgressRingProps struct {
+	Value, Max int
+	Size       int
+	Stroke     int
+	Centerline string
+	Sublabel   string
+	Complete   bool
+}
+
+// prGeom carries the resolved pixel geometry for one ring render.
+type prGeom struct {
+	size       int
+	stroke     int
+	radius     float64
+	center     float64
+	circumf    float64
+	dashOffset float64
+	frac       float64
+}
+
+// prResolve fills in defaults and computes the SVG geometry.
+func prResolve(p ProgressRingProps) prGeom {
+	size := p.Size
+	if size <= 0 {
+		size = 112
+	}
+	stroke := p.Stroke
+	if stroke <= 0 {
+		stroke = 9
+	}
+	max := p.Max
+	if max <= 0 {
+		max = 1
+	}
+	frac := float64(p.Value) / float64(max)
+	if frac < 0 {
+		frac = 0
+	}
+	if frac > 1 {
+		frac = 1
+	}
+	center := float64(size) / 2
+	// inset the radius by half the stroke so the arc stays inside the box
+	radius := center - float64(stroke)/2
+	circumf := 2 * math.Pi * radius
+	// dashoffset shrinks as the arc grows; full offset = empty ring
+	dashOffset := circumf * (1 - frac)
+	return prGeom{
+		size:       size,
+		stroke:     stroke,
+		radius:     radius,
+		center:     center,
+		circumf:    circumf,
+		dashOffset: dashOffset,
+		frac:       frac,
+	}
+}
+
+// prTone returns the Tailwind text-color class that drives the foreground
+// arc's stroke (via stroke-current). Success when complete or full.
+func prTone(p ProgressRingProps) string {
+	if p.Complete || (p.Max > 0 && p.Value >= p.Max) {
+		return "text-success"
+	}
+	return "text-primary"
+}
+
+// prCenterline picks the big center label, defaulting to "Value/Max".
+func prCenterline(p ProgressRingProps) string {
+	if p.Centerline != "" {
+		return p.Centerline
+	}
+	return fmt.Sprintf("%d/%d", p.Value, p.Max)
+}
+
+// prAriaLabel describes the ring for assistive tech, e.g.
+// "3 of 5 steps complete".
+func prAriaLabel(p ProgressRingProps) string {
+	if p.Complete {
+		return "All steps complete"
+	}
+	return fmt.Sprintf("%d of %d steps complete", p.Value, p.Max)
+}
+
+func prF(v float64) string {
+	return strconv.FormatFloat(v, 'f', 2, 64)
+}
+
+func prI(v int) string {
+	return strconv.Itoa(v)
+}
+
+// prCenterFontSize / prSubFontSize scale the center typography to the ring
+// diameter so the count stays proportionate at any Size (inline px so we
+// don't depend on a fixed Tailwind step that only fits the 112 default).
+func prCenterFontSize(size int) string {
+	px := float64(size) * 0.26
+	if px < 14 {
+		px = 14
+	}
+	return fmt.Sprintf("font-size:%spx", prF(px))
+}
+
+func prSubFontSize(size int) string {
+	px := float64(size) * 0.105
+	if px < 10 {
+		px = 10
+	}
+	return fmt.Sprintf("font-size:%spx;letter-spacing:.02em", prF(px))
+}
+
+templ ProgressRing(p ProgressRingProps) {
+	{{ g := prResolve(p) }}
+	<div
+		class="relative inline-grid place-items-center shrink-0"
+		style={ fmt.Sprintf("width:%dpx;height:%dpx", g.size, g.size) }
+	>
+		<svg
+			class={ prTone(p) }
+			width={ prI(g.size) }
+			height={ prI(g.size) }
+			viewBox={ fmt.Sprintf("0 0 %d %d", g.size, g.size) }
+			role="img"
+			aria-label={ prAriaLabel(p) }
+		>
+			<circle
+				cx={ prF(g.center) }
+				cy={ prF(g.center) }
+				r={ prF(g.radius) }
+				fill="none"
+				stroke="currentColor"
+				stroke-width={ prI(g.stroke) }
+				class="text-base-200"
+			></circle>
+			<circle
+				cx={ prF(g.center) }
+				cy={ prF(g.center) }
+				r={ prF(g.radius) }
+				fill="none"
+				stroke="currentColor"
+				stroke-width={ prI(g.stroke) }
+				stroke-linecap="round"
+				stroke-dasharray={ prF(g.circumf) }
+				stroke-dashoffset={ prF(g.dashOffset) }
+				transform={ fmt.Sprintf("rotate(-90 %s %s)", prF(g.center), prF(g.center)) }
+				style="transition: stroke-dashoffset .6s ease"
+			></circle>
+		</svg>
+		<div class="absolute inset-0 grid place-items-center text-center leading-none">
+			<div>
+				<div class="tabular-nums font-semibold text-base-content" style={ prCenterFontSize(g.size) }>
+					{ prCenterline(p) }
+				</div>
+				if p.Sublabel != "" {
+					<div class="text-base-content/45 mt-0.5" style={ prSubFontSize(g.size) }>
+						{ p.Sublabel }
+					</div>
+				}
+			</div>
+		</div>
+	</div>
+}

--- a/internal/templates/components/setup_step.templ
+++ b/internal/templates/components/setup_step.templ
@@ -1,0 +1,240 @@
+package components
+
+import "fmt"
+
+// SetupStep is the rich, stateful row used for each step of the
+// /getting-started onboarding walkthrough. It is presentation-only — the
+// caller computes the State (and which step is "active") and supplies copy +
+// action routes; the component owns the per-state visual hierarchy.
+//
+// The whole point of the redesign is strong state hierarchy:
+//
+//   - Active     — the focal "you are here" step. ELEVATED: a primary ring +
+//     faint primary wash, the topical icon in a primary tile, the full
+//     description, a meta row (time estimate, optional badge, doc link), and a
+//     solid btn-primary CTA. This row dominates the stack.
+//   - InProgress — work is happening (e.g. the first sync is running). The tile
+//     swaps the icon for a spinner; never a daisy badge (badges are terminal /
+//     categorical only). Description + a quiet "In progress…" hint; a ghost
+//     "view" CTA.
+//   - Complete   — done and quiet. The tile goes success-green with a check; the
+//     row collapses to a one-line Summary; a ghost "view" CTA. It recedes.
+//   - Pending    — prerequisites unmet. Muted: the tile shows the step Number on
+//     base-200, the title + description are dimmed, and the CTA is a disabled
+//     span (when CTADisabled) or a quiet ghost link.
+//
+// One CTA that reflows: the row is `flex items-start gap-4 flex-wrap`, so the
+// trailing action wraps below the content column on narrow viewports rather
+// than being duplicated behind responsive visibility classes.
+//
+// Usage:
+//
+//	@components.SetupStep(components.SetupStepProps{
+//	  Number:       3,
+//	  Icon:         "link-2",
+//	  Title:        "Connect your first bank",
+//	  Description:  "Link a bank account to start syncing transactions.",
+//	  State:        components.SetupStepActive,
+//	  TimeEstimate: "~2 min",
+//	  DocHref:      templ.SafeURL("https://docs.breadbox.sh/connections"),
+//	  CTAHref:      templ.SafeURL("/connections/new"),
+//	  CTAIcon:      "plus",
+//	  CTALabel:     "Connect Bank",
+//	})
+
+type SetupStepState string
+
+const (
+	SetupStepComplete   SetupStepState = "complete"
+	SetupStepActive     SetupStepState = "active"      // the next actionable step — ELEVATED ("you are here")
+	SetupStepInProgress SetupStepState = "in_progress" // work happening (e.g. first sync running)
+	SetupStepPending    SetupStepState = "pending"     // prerequisites unmet — muted/locked
+)
+
+type SetupStepProps struct {
+	Number       int
+	Icon         string        // topical lucide name (e.g. "users","landmark","link-2","refresh-cw","bot")
+	Title        string
+	Description  string        // shown in active/in_progress/pending states
+	Summary      string        // shown when Complete (compact confirmation line)
+	State        SetupStepState
+	TimeEstimate string        // "~1 min" — shown in active/pending meta row; hide when ""
+	Optional     bool          // render an "Optional" badge
+	DocHref      templ.SafeURL // optional "Learn more" deep link; hide when ""
+	DocLabel     string        // defaults to "Learn more" when DocHref set and this is ""
+	CTAHref      templ.SafeURL // primary/secondary action target
+	CTAIcon      string
+	CTALabel     string
+	CTADisabled  bool // render as a disabled btn span (no link)
+}
+
+templ SetupStep(p SetupStepProps) {
+	<div class={ "bb-card p-4 sm:p-5 transition-colors", setupStepCardClass(p.State) }>
+		<div class="flex items-start gap-4 flex-wrap">
+			<!-- Status tile -->
+			<div class={ "shrink-0 w-10 h-10 flex items-center justify-center", setupStepTileClass(p.State) }>
+				switch p.State {
+					case SetupStepComplete:
+						@LucideIcon("check", "w-5 h-5")
+					case SetupStepInProgress:
+						<span class="loading loading-spinner loading-sm text-primary"></span>
+					case SetupStepActive:
+						if p.Icon != "" {
+							@LucideIcon(p.Icon, "w-5 h-5")
+						} else {
+							<span class="text-sm font-semibold tabular-nums">{ fmt.Sprintf("%d", p.Number) }</span>
+						}
+					default:
+						<span class="text-sm font-semibold tabular-nums">{ fmt.Sprintf("%d", p.Number) }</span>
+				}
+			</div>
+			<!-- Content column -->
+			<div class="flex-1 min-w-0 flex flex-col gap-1.5">
+				switch p.State {
+					case SetupStepComplete:
+						<h3 class="text-sm font-medium text-success leading-tight">{ p.Title }</h3>
+						if p.Summary != "" {
+							<p class="text-sm text-base-content/50">{ p.Summary }</p>
+						}
+					case SetupStepActive:
+						<h3 class="font-semibold leading-tight">{ p.Title }</h3>
+						if p.Description != "" {
+							<p class="text-sm text-base-content/60">{ p.Description }</p>
+						}
+						@setupStepMetaRow(p)
+					case SetupStepInProgress:
+						<h3 class="font-medium leading-tight">{ p.Title }</h3>
+						if p.Description != "" {
+							<p class="text-sm text-base-content/60">{ p.Description }</p>
+						}
+						<div class="flex items-center gap-1.5 text-xs text-primary">
+							<span class="loading loading-dots loading-xs"></span>
+							<span>In progress…</span>
+						</div>
+					default:
+						<h3 class="font-medium leading-tight text-base-content/60">{ p.Title }</h3>
+						if p.Description != "" {
+							<p class="text-sm text-base-content/40">{ p.Description }</p>
+						}
+						@setupStepMetaRow(p)
+				}
+			</div>
+			<!-- Trailing CTA — reflows below on narrow viewports via flex-wrap -->
+			if p.CTALabel != "" {
+				<div class="shrink-0 ml-auto">
+					@setupStepCTA(p)
+				</div>
+			}
+		</div>
+	</div>
+}
+
+// setupStepMetaRow renders the secondary affordance line beneath the
+// description: time estimate, an Optional badge, and a "Learn more" doc link.
+// Shared by the active + pending states; it renders nothing when every slot is
+// empty so it never leaves an orphaned gap.
+templ setupStepMetaRow(p SetupStepProps) {
+	if p.TimeEstimate != "" || p.Optional || p.DocHref != "" {
+		<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-0.5 text-xs text-base-content/45">
+			if p.TimeEstimate != "" {
+				<span class="inline-flex items-center gap-1">
+					@LucideIcon("clock", "w-3 h-3")
+					<span>{ p.TimeEstimate }</span>
+				</span>
+			}
+			if p.Optional {
+				<span class="badge badge-soft badge-xs">Optional</span>
+			}
+			if p.DocHref != "" {
+				<a
+					href={ p.DocHref }
+					target="_blank"
+					rel="noopener noreferrer"
+					class="inline-flex items-center gap-1 link link-hover text-base-content/55 hover:text-primary"
+				>
+					<span>{ setupStepDocLabel(p.DocLabel) }</span>
+					@LucideIcon("arrow-up-right", "w-3 h-3")
+				</a>
+			}
+		</div>
+	}
+}
+
+// setupStepCTA renders the single trailing action. Its prominence tracks the
+// state: solid primary while active, ghost while complete / in-progress, and a
+// disabled span (or quiet ghost link) while pending.
+templ setupStepCTA(p SetupStepProps) {
+	switch p.State {
+		case SetupStepActive:
+			<a href={ p.CTAHref } class="btn btn-primary btn-sm gap-2">
+				if p.CTAIcon != "" {
+					@LucideIcon(p.CTAIcon, "w-4 h-4")
+				}
+				{ p.CTALabel }
+			</a>
+		case SetupStepPending:
+			if p.CTADisabled {
+				<span class="btn btn-sm btn-disabled gap-2" aria-disabled="true">
+					if p.CTAIcon != "" {
+						@LucideIcon(p.CTAIcon, "w-4 h-4")
+					}
+					{ p.CTALabel }
+				</span>
+			} else {
+				<a href={ p.CTAHref } class="btn btn-ghost btn-sm gap-2 text-base-content/60">
+					if p.CTAIcon != "" {
+						@LucideIcon(p.CTAIcon, "w-4 h-4")
+					}
+					{ p.CTALabel }
+				</a>
+			}
+		default:
+			<a href={ p.CTAHref } class="btn btn-ghost btn-sm gap-2">
+				if p.CTAIcon != "" {
+					@LucideIcon(p.CTAIcon, "w-4 h-4")
+				}
+				{ p.CTALabel }
+			</a>
+	}
+}
+
+// setupStepCardClass elevates the active step and dims the resolved ones. The
+// active card gets a primary ring + faint wash so it reads as the focal "you
+// are here" row; complete + pending recede.
+func setupStepCardClass(s SetupStepState) string {
+	switch s {
+	case SetupStepActive:
+		return "ring-2 ring-primary/30 bg-primary/[0.03]"
+	case SetupStepComplete:
+		return "opacity-90"
+	case SetupStepPending:
+		return "opacity-75"
+	default:
+		return ""
+	}
+}
+
+// setupStepTileClass returns the leading status-tile classes. Complete →
+// success-green circle; active/in-progress → primary tile; pending → muted
+// base-200 square holding the step number.
+func setupStepTileClass(s SetupStepState) string {
+	switch s {
+	case SetupStepComplete:
+		return "rounded-full bg-success/10 text-success"
+	case SetupStepActive:
+		return "rounded-xl bg-primary/10 text-primary"
+	case SetupStepInProgress:
+		return "rounded-xl bg-primary/10 text-primary"
+	default:
+		return "rounded-xl bg-base-200 text-base-content/30"
+	}
+}
+
+// setupStepDocLabel falls back to "Learn more" when the caller leaves DocLabel
+// empty but supplied a DocHref.
+func setupStepDocLabel(label string) string {
+	if label == "" {
+		return "Learn more"
+	}
+	return label
+}


### PR DESCRIPTION
Redesigns `/getting-started` from a flat 5-card checklist into a cohesive **guided setup journey** — a progress-ring hero, an always-on stats strip, stateful step rows, a completion celebration, and a CSV/resources aside. Built from **7 new sandboxed components** (all registered under a new "Onboarding" group in `/design`).

## The 12 UI/UX & feature improvements
1. **Progress-ring hero** — circular SVG ring replaces the thin linear bar, animating its fill on load.
2. **Dynamic headline** — copy warms up by progress: *Welcome → "You're N% set up" → "You're all set 🎉"*.
3. **Time estimates** — total "~N min left" in the hero + per-step "~1 min" hints.
4. **Elevated "next step"** — the next actionable step is visually dominant (primary ring + wash) so "you are here" is unmistakable.
5. **Collapse completed / mute pending** — done steps fold into one-line confirmations; future steps wait, muted, with disabled CTAs.
6. **Topical per-step icons** — `users` / `landmark` / `link-2` / `refresh-cw` / `bot` instead of bare numbers.
7. **Optional-step badge** — the AI-agents step is marked Optional, and a CSV alternative is surfaced.
8. **Per-step "Learn more"** doc deep-links (providers, connecting a bank, multi-agent reviewer).
9. **Always-on stats strip** — Connections/Accounts/Transactions/Syncs at all times, with a graceful muted zero state (previously hidden until the first transaction).
10. **Completion "What's next" grid** — review transactions, create a rule, set up a workflow, invite household.
11. **Live sync state** — while a connection exists but no sync has landed, the sync step shows an in-progress spinner + a link to logs.
12. **Redesigned dismiss/resume footer** + a calm **CSV alternative-path & resources** aside.

## New components (daisy-first, semantic-token only, dark-mode clean)
`ProgressRing`, `OnboardingHero`, `SetupStep`, `OnboardingStats`, `OnboardingNextSteps`, `OnboardingFooter`, `OnboardingAltPath` — each with a `/design` sandbox section under the new **Onboarding** group (`/design/c/onboarding-hero`, `/setup-step`, etc.). The handler now computes the active step, all-complete state, and a rough time-to-finish estimate.

## Screenshots

### Live page — complete state (desktop & mobile)
<img src="https://i.img402.dev/dlwtnpj8zf.jpg" width="800" alt="Getting Started — complete state, desktop">

<img src="https://i.img402.dev/mydxwmfimv.jpg" width="360" alt="Getting Started — mobile">

### Hero + progress ring (every progress state)
<img src="https://i.img402.dev/5jjxhcgh6l.jpg" width="800" alt="OnboardingHero + ProgressRing — 0/5, 3/5, 5/5 and hero variants">

### Setup steps (every state: active, in-progress, complete, pending, optional)
<img src="https://i.img402.dev/8f7o3ebfq8.jpg" width="800" alt="SetupStep — full cascade and isolated states">

### Stats strip (zero state + populated)
<img src="https://i.img402.dev/bx84kzbyxs.jpg" width="800" alt="OnboardingStats — fresh install and populated">

### Completion grid + footer
<img src="https://i.img402.dev/hiqqf2tipx.jpg" width="800" alt="OnboardingNextSteps grid + dismiss/resume footer">

### CSV alternative + resources
<img src="https://i.img402.dev/zl2k513e9f.jpg" width="800" alt="OnboardingAltPath — CSV alternative and resource links">

## Test plan
- `go build ./...`, `go vet ./...`, `go test ./...` all green (the routes-drift guard caught a wrong CSV href — fixed to `/connections/import-csv`).
- Validated in a real browser (Chrome via Puppeteer) against the dev DB: live page in the complete state + all component states via the `/design` sandbox, desktop **and** mobile.
- No new `bb-*` CSS classes or `input.css` edits; new pieces use Tailwind utilities + existing primitives (`bb-card`, `StatTile`, `SectionHeader`) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
