### PR TITLE
feat(ui): inline per-step stats + vertically centered action in SetupStep

### DIFF
--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -118,10 +118,12 @@ func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 			AllComplete:         allComplete,
 			ActiveStep:          activeStep,
 			TimeRemaining:       timeRemaining,
+			MemberCount:         userCount,
 			ConnectionCount:     connCount,
 			AccountCount:        accountCount,
 			TransactionCount:    txCount,
 			SuccessfulSyncs:     successfulSyncs,
+			ApiKeyCount:         activeAPIKeys,
 			OnboardingDismissed: dismissed,
 			CSRFToken:           GetCSRFToken(r),
 		}

--- a/internal/templates/components/pages/design_setup_step.templ
+++ b/internal/templates/components/pages/design_setup_step.templ
@@ -16,18 +16,21 @@ templ SectionSetupStep() {
 				<li>One step row per onboarding step on <code>/getting-started</code>. The caller computes <code>State</code> — the first incomplete step is <code>active</code>, every later incomplete step is <code>pending</code>, completed steps are <code>complete</code>, and a running first sync is <code>in_progress</code>.</li>
 				<li>The <code>active</code> row is the focal "you are here" surface — a primary ring + faint wash, the topical icon, the full description, a meta row, and a solid primary CTA. Exactly one row should be <code>active</code> at a time.</li>
 				<li>Never put the running state inside a daisy badge — the <code>in_progress</code> tile uses a spinner, badges are reserved for terminal / categorical state.</li>
+				<li>An optional inline <code>Stat</code> + <code>StatLabel</code> surfaces the count a step produced (members, connections, transactions). It sits left of the CTA and is vertically centered with it.</li>
 			</ul>
 		</div>
 		@designExample("State hierarchy (the full cascade)", "How the five onboarding steps read top-to-bottom: two complete steps recede, the active step dominates, and the remaining steps wait muted. Note the disabled CTA on the locked step.") {
 			<div class="grid gap-3">
 				@components.SetupStep(components.SetupStepProps{
-					Number:   1,
-					Icon:     "users",
-					Title:    "Add a family member",
-					Summary:  "Jordan added — connections link to household members.",
-					State:    components.SetupStepComplete,
-					CTAHref:  templ.SafeURL("/household"),
-					CTALabel: "View members",
+					Number:    1,
+					Icon:      "users",
+					Title:     "Add a family member",
+					Summary:   "Jordan added — connections link to household members.",
+					State:     components.SetupStepComplete,
+					Stat:      "1",
+					StatLabel: "member",
+					CTAHref:   templ.SafeURL("/household"),
+					CTALabel:  "View members",
 				})
 				@components.SetupStep(components.SetupStepProps{
 					Number:   2,
@@ -113,15 +116,17 @@ templ SectionSetupStep() {
 				CTALabel:    "View logs",
 			})
 		}
-		@designExample("Complete — done and quiet", "Success-green check tile, a one-line Summary, and a ghost \"view\" affordance. The whole row recedes.") {
+		@designExample("Complete — done and quiet", "Success-green check tile, a one-line Summary, an optional inline Stat (value + label, vertically centered with the CTA), and a ghost \"view\" affordance. The whole row recedes.") {
 			@components.SetupStep(components.SetupStepProps{
-				Number:   3,
-				Icon:     "link-2",
-				Title:    "Connect your first bank",
-				Summary:  "Chase connected — 2 accounts, syncing automatically.",
-				State:    components.SetupStepComplete,
-				CTAHref:  templ.SafeURL("/connections"),
-				CTALabel: "View connections",
+				Number:    3,
+				Icon:      "link-2",
+				Title:     "Connect your first bank",
+				Summary:   "Chase connected, syncing automatically.",
+				State:     components.SetupStepComplete,
+				Stat:      "2",
+				StatLabel: "accounts",
+				CTAHref:   templ.SafeURL("/connections"),
+				CTALabel:  "View connections",
 			})
 		}
 		@designExample("Pending — prerequisites unmet", "Muted: the tile shows the step number, the copy dims, and the CTA renders as a disabled span when CTADisabled (left) or a quiet ghost link otherwise (right).") {

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -89,6 +89,8 @@ templ gsStep1(p GettingStartedProps) {
 		Summary:      "Household member added.",
 		State:        gsStepState(p.HasMember, 1, p.ActiveStep),
 		TimeEstimate: "~1 min",
+		Stat:         gsStat(p.MemberCount),
+		StatLabel:    gsPlural(p.MemberCount, "member", "members"),
 		CTAHref:      gsStepCTAHref(p.HasMember, "/household", "/household/new"),
 		CTAIcon:      gsStepCTAIcon(p.HasMember, "plus"),
 		CTALabel:     gsStepCTALabel(p.HasMember, "View members", "Add member"),
@@ -124,6 +126,8 @@ templ gsStep3(p GettingStartedProps) {
 		Summary:      "Bank connected and syncing.",
 		State:        gsStepState(p.HasConnection, 3, p.ActiveStep),
 		TimeEstimate: "~2 min",
+		Stat:         gsStat(p.ConnectionCount),
+		StatLabel:    gsPlural(p.ConnectionCount, "connection", "connections"),
 		DocHref:      "https://docs.breadbox.sh",
 		DocLabel:     "Connecting a bank",
 		CTAHref:      gsStepCTAHref(p.HasConnection, "/connections", "/connections/new"),
@@ -141,9 +145,11 @@ templ gsStep4(p GettingStartedProps) {
 		Icon:         "refresh-cw",
 		Title:        "Complete the first sync",
 		Description:  "Your first sync runs automatically. Check the logs if it doesn't start.",
-		Summary:      fmt.Sprintf("%s transactions across %s accounts.", components.CommaInt(p.TransactionCount), components.CommaInt(p.AccountCount)),
+		Summary:      fmt.Sprintf("Synced across %s.", gsPluralCount(p.AccountCount, "account", "accounts")),
 		State:        gsSyncState(p),
 		TimeEstimate: "~1 min",
+		Stat:         gsStat(p.TransactionCount),
+		StatLabel:    gsPlural(p.TransactionCount, "transaction", "transactions"),
 		CTAHref:      gsStepCTAHref(p.HasSync, "/transactions", "/logs"),
 		CTAIcon:      "",
 		CTALabel:     gsStepCTALabel(p.HasSync, "View transactions", "View logs"),
@@ -163,6 +169,8 @@ templ gsStep5(p GettingStartedProps) {
 		State:        gsStepState(p.HasAPIKey, 5, p.ActiveStep),
 		TimeEstimate: "~3 min",
 		Optional:     true,
+		Stat:         gsStat(p.ApiKeyCount),
+		StatLabel:    gsPlural(p.ApiKeyCount, "API key", "API keys"),
 		DocHref:      "https://docs.breadbox.sh/guides/multi-agent-reviewer",
 		DocLabel:     "Multi-agent reviewer",
 		CTAHref:      "/workflows",
@@ -232,4 +240,29 @@ func gsStepCTAIcon(complete bool, todoIcon string) string {
 		return ""
 	}
 	return todoIcon
+}
+
+// gsStat formats a step's inline metric value, returning "" for zero/empty so
+// SetupStep hides the stat block entirely (a step only shows a count once it
+// has produced one — which in practice means it's complete).
+func gsStat(n int64) string {
+	if n <= 0 {
+		return ""
+	}
+	return components.CommaInt(n)
+}
+
+// gsPlural returns the singular or plural label for a count — the small label
+// under a step's inline stat (e.g. "member" vs "members").
+func gsPlural(n int64, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}
+
+// gsPluralCount renders "N <unit>" with correct pluralization for inline prose
+// (e.g. the sync step summary "Synced across 8 accounts.").
+func gsPluralCount(n int64, singular, plural string) string {
+	return components.CommaInt(n) + " " + gsPlural(n, singular, plural)
 }

--- a/internal/templates/components/pages/getting_started_types.go
+++ b/internal/templates/components/pages/getting_started_types.go
@@ -41,11 +41,13 @@ type GettingStartedProps struct {
 	// "~5 min left". Empty hides the hero's time row (also empty when done).
 	TimeRemaining string
 
-	// Counters for the always-on stats strip.
+	// Counters for the always-on stats strip + per-step inline stats.
+	MemberCount      int64
 	ConnectionCount  int64
 	AccountCount     int64
 	TransactionCount int64
 	SuccessfulSyncs  int64
+	ApiKeyCount      int64
 
 	// Whether the onboarding guide has been dismissed (controls the footer's
 	// dismiss form vs. the always-available note).

--- a/internal/templates/components/setup_step.templ
+++ b/internal/templates/components/setup_step.templ
@@ -66,6 +66,13 @@ type SetupStepProps struct {
 	CTAIcon      string
 	CTALabel     string
 	CTADisabled  bool // render as a disabled btn span (no link)
+
+	// Stat is an optional inline metric shown in the trailing area, left of
+	// the CTA and vertically centered with it — e.g. "3" + StatLabel
+	// "connections". Hidden when "". Use for the count a step produced (the
+	// members it created, the connections/transactions it synced).
+	Stat      string
+	StatLabel string // small uppercase label under Stat (e.g. "connections")
 }
 
 templ SetupStep(p SetupStepProps) {
@@ -119,10 +126,16 @@ templ SetupStep(p SetupStepProps) {
 						@setupStepMetaRow(p)
 				}
 			</div>
-			<!-- Trailing CTA — reflows below on narrow viewports via flex-wrap -->
-			if p.CTALabel != "" {
-				<div class="shrink-0 ml-auto">
-					@setupStepCTA(p)
+			<!-- Trailing area: optional inline stat + CTA, vertically centered
+			     against the content column. Reflows below on narrow viewports. -->
+			if p.CTALabel != "" || p.Stat != "" {
+				<div class="shrink-0 ml-auto self-center flex items-center gap-4 sm:gap-5">
+					if p.Stat != "" {
+						@setupStepStat(p)
+					}
+					if p.CTALabel != "" {
+						@setupStepCTA(p)
+					}
 				</div>
 			}
 		</div>
@@ -196,6 +209,18 @@ templ setupStepCTA(p SetupStepProps) {
 				{ p.CTALabel }
 			</a>
 	}
+}
+
+// setupStepStat renders the optional inline metric in the trailing area: a
+// tabular-nums value with a small uppercase label beneath. Kept quiet (it sits
+// next to the CTA) and right-aligned so the value and label share an edge.
+templ setupStepStat(p SetupStepProps) {
+	<div class="text-right leading-tight">
+		<div class="text-base sm:text-lg font-semibold tabular-nums text-base-content/80">{ p.Stat }</div>
+		if p.StatLabel != "" {
+			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/40">{ p.StatLabel }</div>
+		}
+	</div>
 }
 
 // setupStepCardClass elevates the active step and dims the resolved ones. The


### PR DESCRIPTION
Small follow-up to #1691 (the Getting Started redesign), addressing review feedback: show a basic inline stat in each setup step, and vertically center the step's action.

## Changes
- **Inline per-step stat.** `SetupStep` gains optional `Stat` + `StatLabel` — a quiet tabular-nums value over a small uppercase label, rendered in the trailing area to the left of the CTA. The page wires it per step from live counts: **members**, **connections**, **transactions**, and **API keys**. It only appears once a step has produced a count (in practice, on completed steps), so it reads as a confirming metric rather than noise.
- **Vertically centered action.** The trailing area (stat + CTA) is now `self-center`, so the action sits in the vertical middle of the row instead of top-aligned — cleaner against the taller active row (title + description + meta).
- **De-duplicated copy.** The sync step's summary dropped the transaction count it used to repeat (the inline stat carries it) and now reads "Synced across N accounts."
- The `/design` `setup-step` section demonstrates the inline stat on the complete rows, and the "When to use" note documents it.

## Screenshot — `/design/c/setup-step`
The inline stat ("1 MEMBER", "2 ACCOUNTS") sits left of each action, vertically centered with it:

<img src="https://i.img402.dev/0f2tsi5hhk.jpg" width="800" alt="SetupStep — inline stats + vertically centered action">

## Test plan
- `go build ./...`, `go vet ./...`, `go test ./internal/templates/... ./internal/admin/...` green (routes-drift + design smoke included).
- Validated in a real browser (Chrome via Puppeteer) against the dev DB — the `/design` setup-step matrix shows the stat on the complete rows and the centered action across all states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
