### PR TITLE
fix(ui): render /transactions Grouped/List as a daisy segmented control

### DIFF
--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -445,15 +445,16 @@ templ txResultsShell(p TransactionsProps) {
 					</label>
 				</div>
 			</div>
-			<!-- View Toggle — daisy join + join-item btn (segmented control).
+			<!-- View Toggle — canonical daisy segmented control: join + join-item btn,
+			     active item marked with btn-active (see /design "Join — segmented control").
 			     Sits to the right of the select toggle so view-mode + selection
 			     mode read as a single results-scoped cluster. -->
-			<div class="join border border-base-300 bg-base-200">
-				<button type="button" class="join-item btn btn-xs btn-ghost rounded-md gap-1.5" :class="$store.txView.mode === 'grouped' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/50'" @click="$store.txView.setMode('grouped')" title="Date grouped view">
+			<div class="join">
+				<button type="button" class="btn btn-xs join-item gap-1.5" :class="$store.txView.mode === 'grouped' && 'btn-active'" :aria-pressed="$store.txView.mode === 'grouped'" @click="$store.txView.setMode('grouped')" title="Date grouped view">
 					@components.LucideIcon("calendar-days", "w-3.5 h-3.5")
 					<span class="hidden sm:inline">Grouped</span>
 				</button>
-				<button type="button" class="join-item btn btn-xs btn-ghost rounded-md gap-1.5" :class="$store.txView.mode === 'list' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/50'" @click="$store.txView.setMode('list')" title="Flat list view">
+				<button type="button" class="btn btn-xs join-item gap-1.5" :class="$store.txView.mode === 'list' && 'btn-active'" :aria-pressed="$store.txView.mode === 'list'" @click="$store.txView.setMode('list')" title="Flat list view">
 					@components.LucideIcon("list", "w-3.5 h-3.5")
 					<span class="hidden sm:inline">List</span>
 				</button>


### PR DESCRIPTION
## What

Fix the **Grouped / List** view toggle on `/transactions` so it renders as a proper daisyUI segmented control.

## Why

The toggle already used a daisy `join`, but each `join-item` carried `rounded-md` and hand-rolled active styling (`btn-ghost` + `bg-base-100 … shadow-sm` / `text-base-content/50`). The per-item `rounded-md` overrode the corner-rounding that `join` applies only to the first/last items, so the two buttons rendered as **two disconnected pills** floating in a faint box instead of one connected segmented control.

## Change

Switched to the canonical pattern documented in `.claude/rules/daisyui.md` and the `/design` sandbox ("Join — segmented control"): plain `btn join-item`, active segment marked with `btn-active`. Dropped the container border/bg and the per-item `rounded-md` so `join` controls the radius and the seam. Added `:aria-pressed` for accessibility. Alpine state (`$store.txView`) and `localStorage` persistence are unchanged.

```diff
-<div class="join border border-base-300 bg-base-200">
-  <button … class="join-item btn btn-xs btn-ghost rounded-md gap-1.5" :class="… ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/50'" …>
+<div class="join">
+  <button … class="btn btn-xs join-item gap-1.5" :class="… && 'btn-active'" :aria-pressed="…" …>
```

## Evidence

Before/after on the live page (same data, classes swapped in-DOM for the before shot):

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/mgea5qo49d.png" width="400" alt="toggle — before (two disconnected pills)"></td>
    <td><img src="https://i.img402.dev/kp06ah72ks.png" width="400" alt="toggle — after (unified segmented control)"></td>
  </tr>
</table>

Desktop, in context:

<img src="https://i.img402.dev/8gpndeqzw5.png" width="800" alt="/transactions — segmented toggle in toolbar">

Mobile (labels collapse to icons, segments stay joined):

<img src="https://i.img402.dev/o0p0ytioeq.png" width="280" alt="/transactions — segmented toggle, mobile">

## Validation

- `templ generate` + `go build ./...` + `go vet ./internal/templates/...` ✅
- `go test ./internal/templates/...` (incl. scripts-lint) ✅
- Browser-validated at 1280×800 and 390×844.
