### PR TITLE
feat(workflows): polish one-off run UX — toasts, deep-links, live spinner

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -265,6 +265,30 @@ func RunWorkflowPresetAdminHandler(a *app.App, svc *service.Service) http.Handle
 	}
 }
 
+// WorkflowRunStatusAdminHandler handles GET /-/workflows/runs/{shortId}/status —
+// a lightweight JSON status poll for the gallery's one-off Run button, which
+// keeps its spinner up for the whole run (not just the async dispatch). Returns
+// just short_id + status so the poll stays cheap (no transcript parsing, unlike
+// the run-detail /live fragment).
+func WorkflowRunStatusAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		shortID := chi.URLParam(r, "shortId")
+		run, err := svc.GetAgentRun(r.Context(), shortID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Run not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load run")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"short_id": run.ShortID,
+			"status":   run.Status,
+		})
+	}
+}
+
 // UpdateAgentRunNoteAdminHandler handles POST /-/agents/runs/{shortID}/note —
 // form-data, redirects back to the run detail page.
 func UpdateAgentRunNoteAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -495,6 +495,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/workflows/{slug}/disable", DisableAgentAdminHandler(svc))
 			r.Post("/workflows/{slug}/run", RunAgentNowAdminHandler(a, svc))
 			r.Post("/workflows/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))
+			// Lightweight JSON status poll (short_id + status) for the gallery's
+			// one-off Run button spinner. Static "runs" segment never shadows
+			// the {slug}/* routes above.
+			r.Get("/workflows/runs/{shortId}/status", WorkflowRunStatusAdminHandler(svc))
 
 			// Preview the composed internal base prompt for a preset (read-only JSON).
 			r.Get("/workflows/{slug}/prompt", WorkflowPromptPreviewAdminHandler(svc))

--- a/internal/templates/components/pages/design_workflow_cards.templ
+++ b/internal/templates/components/pages/design_workflow_cards.templ
@@ -13,7 +13,7 @@ package pages
 // stays self-contained (clicking a control is an inert no-op — no console
 // error, and no drawer since the drawers live at the gallery root).
 templ SectionWorkflowPresetCard() {
-	<div class="flex flex-col gap-6" x-data="{ open: '', runWorkflow() {}, toggleWorkflow() {}, openReconfigure() {}, previewPrompt() {} }">
+	<div class="flex flex-col gap-6" x-data="{ open: '', runWorkflow() {}, toggleWorkflow() {}, openReconfigure() {}, previewPrompt() {}, runOneOff() {}, copyPromptDirect() {}, runningOneOff: {} }">
 		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
 			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
 			<ul class="space-y-1 list-disc pl-4">

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -335,14 +335,22 @@ templ workflowOneOffControls(preset WorkflowPresetCardProps, isAdmin bool) {
 		@components.LucideIcon("copy", "w-4 h-4")
 	</button>
 	if isAdmin {
+		// Run is the always-present action on a one-off — a subtle icon button
+		// (matching copy/settings), shown even before any setup. While a run is
+		// in progress it swaps the play glyph for a spinner and disables itself
+		// (runningOneOff[slug], held true for the whole run, not just dispatch).
 		<button
 			type="button"
 			class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
 			data-tip="Run now"
 			@click={ "runOneOff('" + preset.Slug + "')" }
+			x-bind:disabled={ "runningOneOff['" + preset.Slug + "']" }
 			aria-label={ "Run " + preset.Name + " now" }
 		>
-			@components.LucideIcon("play", "w-4 h-4")
+			<span x-show={ "!runningOneOff['" + preset.Slug + "']" }>
+				@components.LucideIcon("play", "w-4 h-4")
+			</span>
+			<span class="loading loading-spinner loading-xs" x-show={ "runningOneOff['" + preset.Slug + "']" } x-cloak></span>
 		</button>
 		if preset.Enabled {
 			<button

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -659,15 +659,21 @@
            const id = (typeof crypto !== 'undefined' && crypto.randomUUID)
              ? crypto.randomUUID()
              : ('t-' + (++this.nextId) + '-' + Math.random().toString(36).slice(2));
-           const toast = { message: detail.message, type: detail.type || 'success', id: id };
+           // Optional action link (href + linkLabel) and a per-toast duration so
+           // a toast carrying something to click stays long enough to act on.
+           const duration = detail.duration || 3000;
+           const toast = {
+             message: detail.message, type: detail.type || 'success', id: id,
+             href: detail.href || '', linkLabel: detail.linkLabel || 'View', duration: duration,
+           };
            this.toasts.push(toast);
-           setTimeout(() => { this.toasts = this.toasts.filter(t2 => t2.id !== id); }, 3500);
+           setTimeout(() => { this.toasts = this.toasts.filter(t2 => t2.id !== id); }, duration + 500);
          },
          dismiss(id) { this.toasts = this.toasts.filter(t2 => t2.id !== id); },
        }"
        @bb-toast.window="add($event.detail)">
     <template x-for="t in toasts" :key="t.id">
-      <div x-data="{ show: false }" x-init="$nextTick(() => { show = true; lucide.createIcons({nodes:[$el]}); setTimeout(() => show = false, 3000) })"
+      <div x-data="{ show: false }" x-init="$nextTick(() => { show = true; lucide.createIcons({nodes:[$el]}); setTimeout(() => show = false, t.duration) })"
            x-show="show"
            :role="t.type === 'error' ? 'alert' : 'status'"
            x-transition:enter="transition ease-out duration-200"
@@ -682,6 +688,11 @@
         <template x-if="t.type === 'warning'">{{ lucide "alert-triangle" "w-4 h-4 text-warning shrink-0" }}</template>
         <template x-if="t.type === 'info'">{{ lucide "info" "w-4 h-4 text-info shrink-0" }}</template>
         <span class="text-sm font-medium" x-text="t.message"></span>
+        <template x-if="t.href">
+          <a :href="t.href"
+             x-text="t.linkLabel"
+             class="text-sm font-semibold link link-primary no-underline hover:underline shrink-0"></a>
+        </template>
         <button type="button"
                 class="ml-1 -mr-1 p-1 rounded-lg text-base-content/40 hover:text-base-content hover:bg-base-200 transition-colors shrink-0"
                 aria-label="Dismiss notification"

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -125,6 +125,13 @@ document.addEventListener('alpine:init', function () {
       cronPreviewLoading: false,
       // -------------------------------------------------------------------
 
+      // runningOneOff[slug] is true while a one-off's Run-now request is in
+      // flight, so each card's inline Run button can show a spinner + disable
+      // itself (preventing a double-dispatch). Keyed by preset slug since two
+      // one-off cards can be on screen at once.
+      runningOneOff: {},
+      // -------------------------------------------------------------------
+
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
         var off = parseInt(this.$el.dataset.serverUtcOffsetMin || '0', 10);
@@ -231,36 +238,81 @@ document.addEventListener('alpine:init', function () {
       },
 
       // --- F1: run an enabled workflow now -------------------------------
-      // toast dispatches the global bb-toast event (handled in base.html).
-      toast: function (message, type) {
+      // toast dispatches the global bb-toast event (handled in base.html). opts
+      // may carry { href, linkLabel, duration } so a run toast can deep-link to
+      // the run it just started and linger long enough to click.
+      toast: function (message, type, opts) {
+        opts = opts || {};
         window.dispatchEvent(
-          new CustomEvent('bb-toast', { detail: { message: message, type: type || 'info' } })
+          new CustomEvent('bb-toast', {
+            detail: {
+              message: message,
+              type: type || 'info',
+              href: opts.href || '',
+              linkLabel: opts.linkLabel || 'View',
+              duration: opts.duration || 0,
+            },
+          })
         );
       },
 
-      // Run an enabled workflow on demand. The run is async server-side
-      // (202 Accepted returns the in_progress row immediately), so we show an
-      // optimistic "started" toast the instant the request is accepted rather
-      // than waiting on the run. Concurrency/budget/auth refusals come back as
-      // error envelopes — surface their message instead of the optimistic toast.
+      // runStartedToast turns a 202 run row into a success toast that deep-links
+      // to the run detail page (/workflows/runs/{short_id}). Falls back to a
+      // plain toast when the row has no short_id.
+      runStartedToast: function (run) {
+        var sid = run && run.short_id;
+        if (sid) {
+          this.toast('Run started.', 'success', {
+            href: '/workflows/runs/' + encodeURIComponent(sid),
+            linkLabel: 'View run',
+            duration: 6000,
+          });
+        } else {
+          this.toast('Run started.', 'success', { duration: 4000 });
+        }
+      },
+
+      // runErrorToast maps a run error envelope to a toast, attaching a helpful
+      // action link where one exists (settings for auth/budget, the runs list
+      // when another run holds the lock). Returns false for CONSENT_REQUIRED so
+      // the caller can route to the setup drawer instead of toasting.
+      runErrorToast: function (body) {
+        var code = body && body.error && body.error.code;
+        var msg = (body && body.error && body.error.message) || 'Could not start the run.';
+        if (code === 'CONSENT_REQUIRED') return false;
+        if (code === 'CONCURRENCY_LOCKED') {
+          this.toast('A run is already in progress.', 'warning', {
+            href: '/workflows/runs', linkLabel: 'View runs', duration: 6000,
+          });
+          return true;
+        }
+        if (code === 'AUTH_NOT_CONFIGURED' || code === 'BINARY_NOT_FOUND' || code === 'AGENTS_DISABLED') {
+          this.toast(msg, 'error', { href: '/settings/workflows', linkLabel: 'Configure', duration: 7000 });
+          return true;
+        }
+        if (code === 'BUDGET_CEILING_REACHED') {
+          this.toast(msg, 'error', { href: '/settings/workflows', linkLabel: 'Adjust', duration: 7000 });
+          return true;
+        }
+        this.toast(msg, 'error', { duration: 5000 });
+        return true;
+      },
+
+      // Run an enabled workflow on demand (the reconfigure drawer's Run now).
+      // The run is async server-side (202 returns the in_progress row), so the
+      // success toast deep-links to that run rather than waiting on completion.
       runWorkflow: function (workflowSlug) {
         var self = this;
-        self.toast('Starting run…', 'info');
         self._post('/-/workflows/' + encodeURIComponent(workflowSlug) + '/run')
           .then(function (res) {
-            if (res.ok) {
-              self.toast('Workflow run started.', 'success');
-              return;
-            }
-            return res
-              .json()
-              .catch(function () {
-                return null;
-              })
-              .then(function (body) {
-                var msg = (body && body.error && body.error.message) || 'Could not start the run.';
-                self.toast(msg, 'error');
+            if (res.ok || res.status === 202) {
+              return res.json().catch(function () { return null; }).then(function (run) {
+                self.runStartedToast(run);
               });
+            }
+            return res.json().catch(function () { return null; }).then(function (body) {
+              self.runErrorToast(body);
+            });
           })
           .catch(function (e) {
             console.error('runWorkflow failed', e);
@@ -271,42 +323,101 @@ document.addEventListener('alpine:init', function () {
       // -------------------------------------------------------------------
 
       // --- One-off (on-demand) workflows ---------------------------------
-      // Run an on-demand workflow from its card's run button. The endpoint
-      // instantiates the manual-only workflow on first use, then dispatches
-      // the run, so this one call covers both first-run and re-run. On a
-      // CONSENT_REQUIRED refusal (first-ever workflow), route the user through
-      // the setup drawer, which carries the consent checkbox. A successful
-      // first run flips the card into its instantiated state, so reload after a
-      // beat to surface that (and any last-run status).
+      // Run an on-demand workflow from its card's Run button. The endpoint
+      // instantiates the manual-only workflow on first use, then dispatches the
+      // run, so this one call covers first-run and re-run alike. CONSENT_REQUIRED
+      // (first-ever workflow) routes to the setup drawer instead of erroring. No
+      // full-page reload — the deep-link is the post-run affordance.
+      //
+      // The run is async server-side (the 202 returns the in_progress row in an
+      // instant, then a goroutine does the actual work). So we hold the spinner
+      // up (runningOneOff[slug]) through the whole run by polling the run's
+      // status until it reaches a terminal state — not just for the dispatch.
       runOneOff: function (slug) {
         var self = this;
-        self.toast('Starting run…', 'info');
+        if (self.runningOneOff[slug]) return; // guard against a double-click
+        self.runningOneOff[slug] = true;
         self._post('/-/workflow-presets/' + encodeURIComponent(slug) + '/run')
           .then(function (res) {
-            if (res.ok) {
-              self.toast('Workflow run started.', 'success');
-              setTimeout(function () { window.location.reload(); }, 1200);
-              return;
-            }
-            return res
-              .json()
-              .catch(function () { return null; })
-              .then(function (body) {
-                var code = body && body.error && body.error.code;
-                if (code === 'CONSENT_REQUIRED') {
-                  self.toast('Review and confirm setup first.', 'info');
-                  Alpine.store('drawers').open('wf-config-' + slug);
-                  return;
+            if (res.ok || res.status === 202) {
+              return res.json().catch(function () { return null; }).then(function (run) {
+                self.runStartedToast(run);
+                if (run && run.short_id) {
+                  // Keep the spinner up and follow the run to completion.
+                  self._pollOneOffRun(slug, run.short_id);
+                } else {
+                  self.runningOneOff[slug] = false; // can't track it — release the button
                 }
-                var msg = (body && body.error && body.error.message) || 'Could not start the run.';
-                self.toast(msg, 'error');
               });
+            }
+            return res.json().catch(function () { return null; }).then(function (body) {
+              self.runningOneOff[slug] = false;
+              if (!self.runErrorToast(body)) {
+                // CONSENT_REQUIRED — send them through the setup drawer, which
+                // carries the consent checkbox, rather than a dead-end toast.
+                self.toast('Confirm setup to run this workflow.', 'info');
+                Alpine.store('drawers').open('wf-config-' + slug);
+              }
+            });
           })
           .catch(function (e) {
             console.error('runOneOff failed', e);
+            self.runningOneOff[slug] = false;
             self.toast('Network error — could not start the run.', 'error');
             self.restorePageState();
           });
+      },
+
+      // _pollOneOffRun polls a run's status (short_id + status) every few
+      // seconds, holding runningOneOff[slug] true until the run reaches a
+      // terminal state, then clears the spinner and toasts the outcome. Caps the
+      // poll so a stuck run can't spin forever, and releases the button on a
+      // poll error rather than leaving it disabled.
+      _pollOneOffRun: function (slug, shortId) {
+        var self = this;
+        var attempts = 0;
+        var maxAttempts = 200; // ~200 × 3s ≈ 10 min ceiling
+        var tick = function () {
+          fetch('/-/workflows/runs/' + encodeURIComponent(shortId) + '/status', {
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+          })
+            .then(function (res) {
+              if (!res.ok) throw new Error('HTTP ' + res.status);
+              return res.json();
+            })
+            .then(function (data) {
+              var status = data && data.status;
+              if (status && status !== 'in_progress') {
+                self.runningOneOff[slug] = false;
+                self._oneOffDoneToast(status, shortId);
+                return;
+              }
+              attempts++;
+              if (attempts >= maxAttempts) {
+                self.runningOneOff[slug] = false; // give up tracking; run may still finish
+                return;
+              }
+              setTimeout(tick, 3000);
+            })
+            .catch(function () {
+              // Can't confirm status — stop spinning so the button isn't stuck.
+              self.runningOneOff[slug] = false;
+            });
+        };
+        setTimeout(tick, 3000);
+      },
+
+      // _oneOffDoneToast announces a finished one-off run, deep-linking to it.
+      _oneOffDoneToast: function (status, shortId) {
+        var href = '/workflows/runs/' + encodeURIComponent(shortId);
+        if (status === 'success') {
+          this.toast('Run finished.', 'success', { href: href, linkLabel: 'View run', duration: 6000 });
+        } else if (status === 'error') {
+          this.toast('Run failed.', 'error', { href: href, linkLabel: 'View run', duration: 8000 });
+        } else {
+          this.toast('Run ' + status + '.', 'warning', { href: href, linkLabel: 'View run', duration: 6000 });
+        }
       },
 
       // copyPromptDirect copies a workflow's composed base prompt straight to


### PR DESCRIPTION
Polishes the on-demand (one-off) workflow Run UX added in #1689 — better feedback and an honest in-progress indicator.

## Changes
- **Subtle Run button.** Stays an icon-only `btn-ghost` (matching copy/settings), always present even before setup. The play glyph swaps to a spinner and the button disables itself while a run is in progress.
- **Spinner tracks the real run, not just the dispatch.** The run is async (the `202` returns instantly while the work continues server-side), so the spinner used to just flash. Now after the 202, `runOneOff` polls a new lightweight status endpoint — `GET /-/workflows/runs/{shortId}/status` (just `short_id` + `status`, no transcript parsing) — every 3s until the run reaches a terminal state, then clears the spinner and toasts the outcome. Capped ~10 min; releases the button on a poll error so it can't get stuck.
- **Richer toasts with deep-links.** The global toast (`base.html`) gained an optional action link + per-toast duration. Run toasts now deep-link to the run (`/workflows/runs/{short_id}`): **"Run started · View run"** on dispatch and **"Run finished / failed · View run"** on completion. Error toasts link to settings (auth/budget) or the runs list (concurrency). Same treatment applied to the reconfigure drawer's "Run now".
- Dropped the post-run full-page reload — the deep-link is the affordance. Per-card loading is keyed by slug so two one-off cards don't interfere and a double-click can't double-dispatch.

## Notes
- The new admin route is out of OpenAPI-drift scope (that test only scans `/api/v1`).
- `go build` / `go vet` / pages + admin tests pass; JS syntax-checks; the status endpoint returns the proper `NOT_FOUND` envelope for a bogus id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
