### PR TITLE
feat(workflows): polish run-detail header — single live status, drop redundant chrome

### DIFF
--- a/internal/admin/agent_run_live.go
+++ b/internal/admin/agent_run_live.go
@@ -31,9 +31,9 @@ import (
 // transcript is capped at 500 events, so a few KB of HTML on a 3 s
 // cadence is cheaper than maintaining a JS-side renderer.
 type AgentRunLivePayload struct {
-	Status          string `json:"status"`
-	StatusBadgeHTML string `json:"statusBadgeHTML"`
-	TranscriptHTML  string `json:"transcriptHTML"`
+	Status            string `json:"status"`
+	SummaryStatusHTML string `json:"summaryStatusHTML"`
+	TranscriptHTML    string `json:"transcriptHTML"`
 	StatsHTML       string `json:"statsHTML"`
 	EventCount      int    `json:"eventCount"`
 	DurationMs      int64  `json:"durationMs,omitempty"`
@@ -124,12 +124,12 @@ func AgentRunLiveHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 		}
 		payload.TranscriptHTML = buf.String()
 
-		// Status badge for terminal states only, inlined here so we
-		// stay on plain daisy `badge` markup. in_progress sends an
-		// empty fragment — the "live" indicator on the header meta
-		// line carries that state, and loading shouldn't sit inside
-		// a badge.
-		payload.StatusBadgeHTML = agentRunLiveStatusBadgeHTML(run.Status)
+		// Status markup for the summary STATUS card — the single run-status
+		// indicator. in_progress renders a "running" spinner so it persists for
+		// the whole run; terminal states render a soft daisy badge. Mirrors the
+		// agentRunSummaryStatus templ so the patched HTML matches the initial
+		// server render exactly.
+		payload.SummaryStatusHTML = agentRunLiveSummaryStatusHTML(run.Status)
 
 		if row.DurationMs > 0 {
 			payload.DurationMs = row.DurationMs
@@ -164,22 +164,25 @@ func writeAdminError(w http.ResponseWriter, status int, code, message string) {
 	writeAdminJSON(w, status, b)
 }
 
-// agentRunLiveStatusBadgeHTML returns the inline daisy badge markup
-// the live-update endpoint patches into the header. Terminal states
-// get a soft daisy badge; in_progress returns "" because the "live"
-// indicator below the header already carries that state.
-func agentRunLiveStatusBadgeHTML(status string) string {
+// agentRunLiveSummaryStatusHTML returns the STATUS-card markup the live-update
+// endpoint patches into the summary stats. It must stay byte-for-byte in step
+// with the agentRunSummaryStatus templ so a live swap is visually seamless:
+// terminal states get a soft daisy badge, in_progress a "running" spinner so
+// the indicator persists for the whole run.
+func agentRunLiveSummaryStatusHTML(status string) string {
 	switch status {
 	case "success":
-		return `<span class="badge badge-soft badge-success badge-xs">success</span>`
+		return `<span class="badge badge-soft badge-success badge-sm">success</span>`
 	case "error":
-		return `<span class="badge badge-soft badge-error badge-xs">error</span>`
-	case "skipped":
-		return `<span class="badge badge-ghost badge-xs">skipped</span>`
+		return `<span class="badge badge-soft badge-error badge-sm">error</span>`
 	case "timeout":
-		return `<span class="badge badge-soft badge-error badge-xs">timeout</span>`
+		return `<span class="badge badge-soft badge-error badge-sm">timeout</span>`
+	case "skipped":
+		return `<span class="badge badge-ghost badge-sm">skipped</span>`
+	case "in_progress":
+		return `<span class="inline-flex items-center gap-1.5 text-primary text-sm"><span class="loading loading-spinner loading-xs"></span>running</span>`
 	default:
-		return ""
+		return `<span class="text-base-content/40 text-sm">` + status + `</span>`
 	}
 }
 

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -59,7 +59,6 @@ templ AgentRunDetail(p AgentRunDetailProps) {
 			<template x-ref="promptText">{ effectiveRunPrompt(p) }</template>
 		}
 		@agentRunDetailHeader(p)
-		@agentRunSummaryStats(p)
 		if p.Run.Status == "error" && p.Run.ErrorMessage != "" {
 			@agentRunErrorAlert(p.Run)
 		}
@@ -95,9 +94,6 @@ templ AgentRunDetail(p AgentRunDetailProps) {
 templ agentRunDetailHeader(p AgentRunDetailProps) {
 	<div class="bb-run-header">
 		<div class="bb-run-header__lead">
-			<a href={ templ.SafeURL(agentRunHeaderBackHref(p)) } class="btn btn-ghost btn-sm btn-square" title="Back to runs">
-				@components.LucideIcon("arrow-left", "w-4 h-4")
-			</a>
 			@components.UserAvatar(components.UserAvatarProps{
 				ID:         p.Run.AgentSlug,
 				Name:       p.Run.AgentName,
@@ -123,21 +119,10 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 						<i data-lucide="clipboard" class="w-3 h-3" x-show="!copiedRunId"></i>
 						<i data-lucide="check" class="w-3 h-3" x-show="copiedRunId" x-cloak></i>
 					</button>
-					<!-- Status badge for terminal states only. in_progress
-					     stays empty here — the "live" indicator in the meta
-					     line below already announces the running state, and
-					     loading states shouldn't sit inside a badge. -->
-					<span x-ref="status">
-						switch p.Run.Status {
-							case "success":
-								<span class="badge badge-soft badge-success badge-xs">success</span>
-							case "error":
-								<span class="badge badge-soft badge-error badge-xs">error</span>
-							case "skipped":
-								<span class="badge badge-ghost badge-xs">skipped</span>
-							case "timeout":
-								<span class="badge badge-soft badge-error badge-xs">timeout</span>
-						}
+					<!-- The single run-status indicator. x-ref so the live poll
+					     swaps running → terminal in place, persisting for the run. -->
+					<span x-ref="summaryStatus">
+						@agentRunSummaryStatus(p.Run.Status)
 					</span>
 				</div>
 				<div class="text-xs text-base-content/50 mt-0.5 flex items-center gap-1.5 flex-wrap">
@@ -155,25 +140,10 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 							{ AgentModelShortLabel(p.Run.Model) }
 						</span>
 					}
-					<span x-show="status==='in_progress'" x-cloak class="inline-flex items-center gap-1 text-primary">
-						<span class="loading loading-spinner loading-xs"></span>
-						<span class="text-[0.65rem] uppercase tracking-wider">live</span>
-					</span>
 				</div>
 			</div>
 		</div>
 		<div class="bb-run-header__actions">
-			if TranscriptHasResultEvent(p.Transcript) {
-				<button
-					type="button"
-					class="btn btn-sm btn-ghost gap-2"
-					title="Jump to the run's final result bubble"
-					@click="jumpToResult()"
-				>
-					@components.LucideIcon("flag-triangle-right", "w-4 h-4")
-					Jump to result
-				</button>
-			}
 			if effectiveRunPrompt(p) != "" {
 				<button
 					type="button"
@@ -205,52 +175,6 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 					</span>
 				</button>
 			}
-		</div>
-	</div>
-}
-
-// agentRunSummaryStats is the compact at-a-glance strip directly under
-// the sticky header — status, duration, trigger, model, and cost in a
-// daisy `stats` block. It restates the facts an operator scans for first
-// without making them hunt through the Usage card in the side panel.
-// The Model tile is omitted for runs predating the per-run model
-// snapshot (empty model). daisy `stats` is the canonical home for these
-// tiles per .claude/rules/daisyui.md (the rule explicitly nominates
-// `stats stats-horizontal` for dashboard-tile clusters); cost reuses the
-// same canonical Amount renderer as the rest of the page.
-templ agentRunSummaryStats(p AgentRunDetailProps) {
-	<div class="stats stats-horizontal bb-card w-full overflow-x-auto mb-4">
-		<div class="stat px-4 py-3">
-			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Status</div>
-			<div class="stat-value text-base font-semibold">
-				@agentRunSummaryStatus(p.Run.Status)
-			</div>
-		</div>
-		<div class="stat px-4 py-3">
-			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Duration</div>
-			<div class="stat-value text-base font-semibold tabular-nums">{ formatAgentRunDuration(p.Run.DurationMs) }</div>
-		</div>
-		<div class="stat px-4 py-3">
-			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Trigger</div>
-			<div class="stat-value text-base font-semibold capitalize">
-				if p.Run.Trigger != "" {
-					{ p.Run.Trigger }
-				} else {
-					<span class="text-base-content/40">—</span>
-				}
-			</div>
-		</div>
-		if AgentModelShortLabel(p.Run.Model) != "" {
-			<div class="stat px-4 py-3">
-				<div class="stat-title text-[0.65rem] uppercase tracking-wider">Model</div>
-				<div class="stat-value text-base font-semibold" title={ p.Run.Model }>{ AgentModelShortLabel(p.Run.Model) }</div>
-			</div>
-		}
-		<div class="stat px-4 py-3">
-			<div class="stat-title text-[0.65rem] uppercase tracking-wider">Cost</div>
-			<div class="stat-value text-base font-semibold">
-				@agentRunCost(p.Run.CostUSD, "font-semibold tabular-nums")
-			</div>
 		</div>
 	</div>
 }
@@ -295,16 +219,6 @@ func effectiveRunPrompt(p AgentRunDetailProps) string {
 	default:
 		return body
 	}
-}
-
-// agentRunHeaderBackHref returns the "back" target for the sticky header.
-// Prefers the per-agent filter so consecutive runs of the same agent
-// stay in scope; falls back to the global feed.
-func agentRunHeaderBackHref(p AgentRunDetailProps) string {
-	if p.Run.AgentSlug != "" {
-		return "/agents?agent=" + p.Run.AgentSlug
-	}
-	return "/agents"
 }
 
 // agentRunErrorAlert renders the run's error_message in a soft warning/

--- a/static/js/admin/components/agent_run_detail.js
+++ b/static/js/admin/components/agent_run_detail.js
@@ -204,7 +204,9 @@ document.addEventListener('alpine:init', function () {
         }
         if (typeof body.status === 'string' && body.status !== this.status) {
           this.status = body.status;
-          if (this.$refs.status) this.$refs.status.innerHTML = body.statusBadgeHTML || '';
+          // The summary STATUS card is the single status indicator; swap its
+          // markup in place so "running" lasts the run, then flips to terminal.
+          if (this.$refs.summaryStatus) this.$refs.summaryStatus.innerHTML = body.summaryStatusHTML || '';
           if (window.lucide && typeof window.lucide.createIcons === 'function') {
             window.lucide.createIcons();
           }
@@ -246,23 +248,6 @@ document.addEventListener('alpine:init', function () {
           if (shouldOpen) d.setAttribute('open', '');
           else d.removeAttribute('open');
         });
-      },
-
-      // jumpToResult scrolls the page so the run's "Final result"
-      // bubble lands at the top of the viewport (with a little
-      // breathing room for the sticky header). For long transcripts
-      // this is the single most-requested affordance — "skip to the
-      // bottom line." We pick the LAST .bb-run-summary because some
-      // transcripts have two result events and we already drop the
-      // zero-valued one, but defence-in-depth is cheap.
-      jumpToResult: function () {
-        var nodes = this.$el.querySelectorAll('.bb-run-summary');
-        if (!nodes.length) return;
-        var target = nodes[nodes.length - 1];
-        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
-        // Brief highlight pulse so the eye catches where we landed.
-        target.classList.add('bb-run-summary--flash');
-        setTimeout(function () { target.classList.remove('bb-run-summary--flash'); }, 1200);
       },
 
       // restorePageState clears the global SPA progress bar + content


### PR DESCRIPTION
Polishes the run-detail page header (`/workflows/runs/{id}`) — removes redundant chrome and makes the status indicator honest. Follows the gallery run-UX polish in #1694.

## Changes
- **Removed the back button.** The breadcrumb (`Manage / Runs / … / {id}`) already covers navigation.
- **Removed the summary stats strip** (Duration / Trigger / Model / Cost). Duration, trigger, and model already sit in the header meta line; cost lives in the side-panel **Usage** card. The strip only restated facts shown elsewhere.
- **Single, live status indicator.** Status is now the one run-status element, moved into the header next to the run id. It's wired to the live poll (`x-ref="summaryStatus"` + a `summaryStatusHTML` fragment from `/-/workflows/runs/{id}/live`, byte-matching the templ), so it shows **"running" with a spinner for the whole run** and flips to `success`/`error` when it actually finishes. This fixes the prior bug where the stats card never refreshed and diverged from the header badge.
- **Removed "Jump to result."** It targeted a `.bb-run-summary` element that isn't present, so it did nothing.

## Notes
- Net `-128 / +30` lines. Dropped the now-unused `agentRunSummaryStats` component and `agentRunHeaderBackHref` helper.
- `go build` / `go vet` / pages + admin tests pass; JS syntax-checks; the `/live` endpoint returns the correct `summaryStatusHTML`. Verified the cleaned header renders against a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
