### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/service/agent_settings_notify_url_unit_test.go
+++ b/internal/service/agent_settings_notify_url_unit_test.go
@@ -237,7 +237,7 @@ func TestT17ValidateNotifyURL_TrimmedInputs(t *testing.T) {
 			wantErr: false,
 		},
 		// Whitespace-only input collapses to empty after trim.
-		// UpdateAgentSettings skips validateNotifyURL when trimmed == "",
+		// UpdateNotificationSettings skips validateNotifyURL when trimmed == "",
 		// but the empty string itself must fail if accidentally passed through.
 		{
 			name:    "empty string (whitespace collapsed) fails",

--- a/internal/templates/components/onboarding_hero.templ
+++ b/internal/templates/components/onboarding_hero.templ
@@ -36,9 +36,6 @@ func onbHeroPercent(p OnboardingHeroProps) int {
 		return 0
 	}
 	pct := p.CompletedSteps * 100 / p.TotalSteps
-	if pct < 0 {
-		pct = 0
-	}
 	if pct > 100 {
 		pct = 100
 	}

--- a/internal/templates/components/setup_step.templ
+++ b/internal/templates/components/setup_step.templ
@@ -246,9 +246,7 @@ func setupStepTileClass(s SetupStepState) string {
 	switch s {
 	case SetupStepComplete:
 		return "rounded-full bg-success/10 text-success"
-	case SetupStepActive:
-		return "rounded-xl bg-primary/10 text-primary"
-	case SetupStepInProgress:
+	case SetupStepActive, SetupStepInProgress:
 		return "rounded-xl bg-primary/10 text-primary"
 	default:
 		return "rounded-xl bg-base-200 text-base-content/30"


### PR DESCRIPTION
## Summary

Daily simplify-drift review of the 15 PRs merged in the last 24 hours (since the previous drift PR #1679). Four parallel review agents — reuse, simplification, efficiency, altitude — surfaced ~30 findings; this PR applies only the safest, behavior-preserving cleanups. The rest (efficiency wins requiring caching, altitude wins requiring shared error-mapping helpers, etc.) need their own scoped follow-ups.

## PRs reviewed

- #1694 — feat(workflows): polish one-off run UX — toasts, deep-links, live spinner
- #1693 — fix(ui): render /transactions Grouped/List as a daisy segmented control
- #1692 — feat(ui): inline per-step stats + vertically centered action in SetupStep
- #1691 — feat(ui): redesign Getting Started as a guided setup journey
- #1690 — feat(ui): split CSV into its own section + Test button to drawer footer
- #1689 — feat(workflows): curate gallery — drop 3 presets, add 2 on-demand one-offs
- #1688 — feat(ui): lead the Help → Getting started row with a compass icon
- #1687 — feat(notifications): dedicated settings page + native ntfy formatting
- #1686 — feat(ui): move provider settings into per-provider drawers
- #1685 — feat(ui): make the topbar the single breadcrumb, drop in-page breadcrumbs
- #1684 — feat(workflows): per-workflow editable name + avatar; default agent style → Glyphs
- #1683 — fix(ui): OverflowMenu grows to fit its label
- #1682 — fix(workflows): base cron schedule shortcuts on the user's local timezone
- #1681 — feat(commands): add /submit-and-merge slash command
- #1680 — ci: remove redundant tag-triggered release path from ci.yml

## Changes

- `setup_step.templ:245-256` — `setupStepTileClass` had identical return values for `SetupStepActive` and `SetupStepInProgress`. Collapsed into one combined case so future tile-class tweaks can't accidentally diverge between the two states.
- `onboarding_hero.templ:39-41` — `onbHeroPercent` had a `pct < 0` clamp that can never fire (the `TotalSteps > 0` precondition and the handler-side step counters guarantee non-negative operands). Dropped the branch; kept the `> 100` clamp.
- `agent_settings_notify_url_unit_test.go:240` — Stale `UpdateAgentSettings` comment reference. The function was renamed to `UpdateNotificationSettings` in #1687.

## Skipped (worth a follow-up, out of scope here)

- 3× `GetAppConfig` round-trips per outbound notification (`notify.go`).
- Per-render DB query in `avatars.go` for the workflow seed lookup (no in-process cache).
- Cron-shift logic duplicated between Go `service.shiftCronTimeFields` and JS `cronShiftTimeFields` (intentional per the diff, but worth flagging in a follow-up).
- Identical orchestrator-error mapping in `RunAgentNowAdminHandler` + `RunWorkflowPresetAdminHandler` — should consolidate into a `writeOrchestratorRunError` helper.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (one pre-existing environmental failure in `internal/agent` process-group test, unrelated to this diff — confirmed failing on `main`)

https://claude.ai/code/session_01KPPUaU62kBgqDJT3TKBUFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPUaU62kBgqDJT3TKBUFG)_