### PR TITLE
fix(ui): drop the 2px row nudge on comment/report cards (top-edge seam)

### DIFF
--- a/input.css
+++ b/input.css
@@ -3386,6 +3386,16 @@
    * tile vertically. */
   padding-top: 0.125rem;
 }
+/* …EXCEPT comment/report CARDS. A card's body is a bordered, rounded
+ * box whose header band must sit flush against the top border. The 2px
+ * nudge above shoves the header DOWN off that border, exposing a strip
+ * of the darker card body under the rounded top edge — the seam. The
+ * card re-centers its own first line via the header band's own padding,
+ * so it neither needs nor wants the row nudge. The extra :has() class
+ * outweighs the rule above, so this wins. */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1.text-sm.leading-6 {
+  padding-top: 0;
+}
 
 /* Rail mask. The 28px tile bg + ring are painted with base-100
  * (card-surface) classes by the shared row markup, and the rail seam is


### PR DESCRIPTION
The prominent activity timeline's `.flex-1` row body carries `padding-top: 0.125rem` (2px) so one-line system-event sentences baseline-align against the 28px rail tile. Comment and report **cards** have the same `flex-1 text-sm leading-6` classes, so they inherited the nudge — which shoved the bordered header band down off the card's top border and exposed a 2px strip of the darker card body under the rounded top edge. That strip is the seam, and it ran the whole top edge in both light and dark mode.

Cards re-center their own first line via the header band's own padding, so they don't need the row nudge. This zeroes it for cards only — `:has(.bb-comment-bubble)` out-specificities the base rule.

CSS-only, 10 lines, no markup/structure change. Validated on the real running app — `/transactions/{id}` comment cards and `/feed` report cards, both modes (computed `padding-top: 0px`, header now flush to the border).

<img src="https://i.img402.dev/glv2x7imi9.jpg" width="860" alt="comment card seam before/after, dark and light">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
