### PR TITLE
feat(notifications): multiple channels + native Slack/Discord/Google Chat, priority floor, retries

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -418,7 +418,7 @@ Workflows fire outbound notifications when noteworthy events occur (typically wh
 
 ### Channels
 
-The sink is managed on its own **Settings → Notifications** page (`/settings/notifications`, admin-only). Channels are stored as a JSON array under `app_config[notify.channels]` (plaintext); one global key, `notify.public_base_url`, is shared across all channels.
+The sink is managed on its own **Settings → Notifications** page (`/settings/notifications`, admin-only). The add-channel form opens in a right-side **Drawer** (`components.Drawer`). Channels are stored as a JSON array under `app_config[notify.channels]` (plaintext); the deep-link origin shared across all channels is **derived** (see below).
 
 Each channel carries:
 
@@ -446,7 +446,9 @@ The per-channel `format` (or what `auto` sniffs it to, from the URL host) select
 - **`json`** — the generic `NotificationPayload` envelope as `application/json` (relays, bridges, custom consumers).
 - **`auto`** (default) — resolves to the matching provider above when the URL is recognizable, else `json`.
 
-**Reliability.** Delivery is retried up to 3 times with exponential backoff (200ms → 400ms) on transient failures (network error, HTTP 429, 5xx); a non-429 4xx fails fast. The deep link is absolutized with `notify.public_base_url` so ntfy tap-through and relative body links resolve to the real report.
+**Reliability.** Delivery is retried up to 3 times with exponential backoff (200ms → 400ms) on transient failures (network error, HTTP 429, 5xx); a non-429 4xx fails fast. The deep link is absolutized with the resolved deep-link origin so ntfy tap-through and relative body links resolve to the real report.
+
+**Deep-link origin (derived).** Notifications fire from background jobs, so there's no HTTP request to read the public origin from at send time. Instead, every visit to the Notifications page captures the admin's own request origin (`X-Forwarded-Proto` / `X-Forwarded-Host` → `Host`, same derivation as the MCP endpoint / OAuth issuer / setup links) into `notify.detected_base_url`. `Service.ResolveNotifyBaseURL` returns the manual override `notify.public_base_url` when set, otherwise the detected origin — so deep links "just work" without the operator typing a URL. The override is only needed for split-horizon setups (Breadbox reached at a different public URL than the admin browses from, e.g. behind a tunnel).
 
 ### NotificationPayload (the `json` envelope)
 
@@ -520,7 +522,8 @@ All keys are stored in the `app_config` table and read at runtime via `appconfig
 | `agent.run_retention_days` | int | `30` | Days to keep completed `workflow_runs` rows; 0 = disabled |
 | `workflows.consent_acknowledged_at` | RFC3339 | — | Non-empty = household has given first-enable consent |
 | `notify.channels` | JSON array | — | Notification channels (multi-sink): per-channel url/format/min_priority/ntfy_token/enabled/last_status |
-| `notify.public_base_url` | string | — | Absolute origin prepended to notification deep links; empty = relative |
+| `notify.public_base_url` | string | — | **Optional** manual override for the deep-link origin; empty = use the auto-detected origin |
+| `notify.detected_base_url` | string | — | Deep-link origin auto-captured from the admin's request on each Notifications-page load; used when no override is set |
 | `notify.webhook_url` | string | — | Legacy single webhook; synthesized into a "Default" channel when `notify.channels` is empty |
 | `notify.format` | string | `"auto"` | Legacy single-webhook format (back-compat seed for the synthesized channel) |
 | `notify.min_priority` | string | `"info"` | Legacy single-webhook priority floor (back-compat seed) |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -418,7 +418,7 @@ Workflows fire outbound notifications when noteworthy events occur (typically wh
 
 ### Channels
 
-The sink is managed on its own **Settings → Notifications** page (`/settings/notifications`, admin-only). The add-channel form opens in a right-side **Drawer** (`components.Drawer`). Channels are stored as a JSON array under `app_config[notify.channels]` (plaintext); the deep-link origin shared across all channels is **derived** (see below).
+The sink is managed on its own **Settings → Notifications** page (`/settings/notifications`, admin-only). Each channel renders as one quiet row (name · masked URL · format + a single status badge) with a gear button that opens its **edit Drawer** (`components.Drawer`); the **Add channel** button opens the same drawer empty. Channels are stored as a JSON array under `app_config[notify.channels]` (plaintext); the deep-link origin shared across all channels is **derived** (see below).
 
 Each channel carries:
 
@@ -431,7 +431,7 @@ Each channel carries:
 - `enabled` — disabled channels are skipped.
 - `last_status` — `{ok, at, format, detail}`, the most recent delivery attempt (surfaced inline on the page).
 
-`A workflow notification fans out to every enabled channel`, each delivered + retried independently; `SendWorkflowNotification` returns the first delivery error after attempting all of them. CRUD is handled by `AddNotificationChannel` / `SetNotificationChannelEnabled` / `DeleteNotificationChannel`; `SendTestToChannel` backs the per-channel **Test** button, and `POST /-/notifications/test` tests all enabled channels.
+`A workflow notification fans out to every enabled channel`, each delivered + retried independently; `SendWorkflowNotification` returns the first delivery error after attempting all of them. CRUD is handled by `AddNotificationChannel` / `UpdateNotificationChannel` / `SetNotificationChannelEnabled` / `DeleteNotificationChannel`; the edit drawer never echoes secrets, so `UpdateNotificationChannel` treats a blank URL/token as "keep current". `SendTestToChannel` backs the per-channel **Test** button, and `POST /-/notifications/test` tests all enabled channels.
 
 **Back-compat.** When `notify.channels` is empty but the legacy `notify.webhook_url` (+ `notify.format` / `notify.min_priority`) keys are set, a single "Default" channel is synthesized so pre-multi-channel configs keep delivering. The synth channel is never silently persisted by a send (which would freeze the legacy keys) — it's migrated into the array only when the operator first mutates a channel.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -414,19 +414,41 @@ The sidecar receives the minted run key as `BREADBOX_API_KEY`. `runMCPStdio` (`i
 
 ## 8. Notification Sink
 
-Workflows can fire an outbound webhook when noteworthy events occur (typically when a run submits a report via `submit_report`).
+Workflows fire outbound notifications when noteworthy events occur (typically when a run submits a report via `submit_report`). Delivery fans out to a list of **channels** — each its own sink in its own format.
 
-### Configuration
+### Channels
 
-The sink lives on its own **Settings → Notifications** page (`/settings/notifications`, admin-only) and is stored across three `app_config` keys (all plaintext):
+The sink is managed on its own **Settings → Notifications** page (`/settings/notifications`, admin-only). Channels are stored as a JSON array under `app_config[notify.channels]` (plaintext); one global key, `notify.public_base_url`, is shared across all channels.
 
-- `notify.webhook_url` — the http(s) sink. Empty = notifications off.
-- `notify.format` — `auto` (default) | `ntfy` | `json`. Selects the wire shape (see Delivery).
-- `notify.public_base_url` — optional absolute origin (e.g. `https://breadbox.example.com`) used to build absolute deep links so an ntfy tap-through (and relative links in a report body) resolve to the real report.
+Each channel carries:
 
-The `POST /settings/notifications` handler writes all three together; a "Send test" button (`POST /-/notifications/test`) fires a sample payload to verify the wiring. The legacy `POST /-/workflows/notify-test` route remains as a back-compat alias.
+- `id` — 8-char short id.
+- `name` — operator label.
+- `url` — the http(s) sink.
+- `format` — `auto` (default) | `ntfy` | `slack` | `discord` | `googlechat` | `json`.
+- `min_priority` — `info` (default) | `warning` | `critical`; this channel only receives reports at or above the floor.
+- `ntfy_token` — optional Bearer token for a protected ntfy topic (ntfy only).
+- `enabled` — disabled channels are skipped.
+- `last_status` — `{ok, at, format, detail}`, the most recent delivery attempt (surfaced inline on the page).
 
-### NotificationPayload
+`A workflow notification fans out to every enabled channel`, each delivered + retried independently; `SendWorkflowNotification` returns the first delivery error after attempting all of them. CRUD is handled by `AddNotificationChannel` / `SetNotificationChannelEnabled` / `DeleteNotificationChannel`; `SendTestToChannel` backs the per-channel **Test** button, and `POST /-/notifications/test` tests all enabled channels.
+
+**Back-compat.** When `notify.channels` is empty but the legacy `notify.webhook_url` (+ `notify.format` / `notify.min_priority`) keys are set, a single "Default" channel is synthesized so pre-multi-channel configs keep delivering. The synth channel is never silently persisted by a send (which would freeze the legacy keys) — it's migrated into the array only when the operator first mutates a channel.
+
+### Wire formats
+
+The per-channel `format` (or what `auto` sniffs it to, from the URL host) selects the shape. All requests use a 10-second timeout (`notifyHTTPClient`) and `User-Agent: breadbox-workflows`.
+
+- **`ntfy`** ([docs](https://docs.ntfy.sh/publish/)) — body is the markdown message; metadata rides in headers: `X-Title`, `X-Priority` (info→3 / warning→4 / critical→5), `X-Markdown: yes`, `X-Tags` (priority emoji), `X-Click` + `X-Actions` (a "View report" button, when an absolute deep link is available), and `Authorization: Bearer` when a channel token is set. Non-ASCII headers are RFC 2047-encoded.
+- **`slack`** — Slack incoming-webhook JSON `{"text": …}` in mrkdwn (`**bold**`→`*bold*`, `[label](url)`→`<url|label>`), with a priority emoji + "View report →" link. Auto-detected for `hooks.slack.com`.
+- **`discord`** — Discord webhook JSON `{"content": …}` (markdown, 2000-char cap) + a bare deep link. Auto-detected for `discord.com` / `discordapp.com` webhooks.
+- **`googlechat`** — Google Chat incoming-webhook JSON `{"text": …}` (Slack-style markup but unicode emoji, since Google Chat doesn't render `:shortcode:` names). Auto-detected for `chat.googleapis.com`.
+- **`json`** — the generic `NotificationPayload` envelope as `application/json` (relays, bridges, custom consumers).
+- **`auto`** (default) — resolves to the matching provider above when the URL is recognizable, else `json`.
+
+**Reliability.** Delivery is retried up to 3 times with exponential backoff (200ms → 400ms) on transient failures (network error, HTTP 429, 5xx); a non-429 4xx fails fast. The deep link is absolutized with `notify.public_base_url` so ntfy tap-through and relative body links resolve to the real report.
+
+### NotificationPayload (the `json` envelope)
 
 ```go
 type NotificationPayload struct {
@@ -439,14 +461,6 @@ type NotificationPayload struct {
     SentAt   string `json:"sent_at"`            // RFC3339
 }
 ```
-
-### Delivery
-
-`SendWorkflowNotification` is a no-op when no URL is configured — callers fire unconditionally without a nil-check. The request uses a 10-second timeout (`notifyHTTPClient`) and `User-Agent: breadbox-workflows`. Any HTTP 3xx+ response is treated as an error. The wire shape depends on `notify.format`:
-
-- **`json`** — POSTs the `NotificationPayload` envelope above as `application/json`. Suits Slack-compatible relay bridges, Discord webhooks (via a formatter), and email bridges.
-- **`ntfy`** — publishes natively to [ntfy](https://docs.ntfy.sh/publish/): the request body is the (markdown) message and metadata rides in headers — `X-Title`, `X-Priority` (info→3 / warning→4 / critical→5), `X-Markdown: yes`, `X-Tags` (an emoji per priority), and `X-Click` (the absolute deep link, when a public base URL is set). Non-ASCII header values are RFC 2047-encoded. This is what makes an ntfy push render as a real titled, tap-through notification instead of a raw JSON blob.
-- **`auto`** (default) — picks `ntfy` when the webhook host looks like ntfy (`ntfy.sh` or any host containing `ntfy`), else `json`.
 
 ---
 
@@ -505,7 +519,11 @@ All keys are stored in the `app_config` table and read at runtime via `appconfig
 | `agent.transcript_dir` | string | — | Directory for per-run NDJSON transcripts; falls back to `agent.DefaultTranscriptDir()` |
 | `agent.run_retention_days` | int | `30` | Days to keep completed `workflow_runs` rows; 0 = disabled |
 | `workflows.consent_acknowledged_at` | RFC3339 | — | Non-empty = household has given first-enable consent |
-| `notify.webhook_url` | string | — | Outbound webhook URL for workflow notifications; empty = disabled |
+| `notify.channels` | JSON array | — | Notification channels (multi-sink): per-channel url/format/min_priority/ntfy_token/enabled/last_status |
+| `notify.public_base_url` | string | — | Absolute origin prepended to notification deep links; empty = relative |
+| `notify.webhook_url` | string | — | Legacy single webhook; synthesized into a "Default" channel when `notify.channels` is empty |
+| `notify.format` | string | `"auto"` | Legacy single-webhook format (back-compat seed for the synthesized channel) |
+| `notify.min_priority` | string | `"info"` | Legacy single-webhook priority floor (back-compat seed) |
 
 Token values (`agent.subscription_token`, `agent.anthropic_api_key`) are AES-256-GCM encrypted at rest via `appconfig.ReadEncrypted` / `appconfig.WriteEncrypted`, using the server's `ENCRYPTION_KEY`.
 

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -109,6 +109,38 @@ func NotificationsAddChannelHandler(svc *service.Service, sm *scs.SessionManager
 	}
 }
 
+// NotificationsUpdateChannelHandler handles
+// POST /settings/notifications/channels/{id} — the edit-channel drawer. The
+// URL and ntfy token are kept when their fields are submitted blank (the form
+// never echoes secrets back), so only non-empty values replace them.
+func NotificationsUpdateChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			FlashRedirect(w, r, sm, "error", "Could not read the submitted form.", "/settings/notifications")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		params := service.UpdateNotificationChannelParams{
+			Name:        strings.TrimSpace(r.FormValue("name")),
+			Format:      strings.TrimSpace(r.FormValue("format")),
+			MinPriority: strings.TrimSpace(r.FormValue("min_priority")),
+			Enabled:     r.FormValue("enabled") == "true",
+		}
+		if v := strings.TrimSpace(r.FormValue("url")); v != "" {
+			params.URL = &v
+		}
+		if v := strings.TrimSpace(r.FormValue("ntfy_token")); v != "" {
+			params.NtfyToken = &v
+		}
+		if _, err := svc.UpdateNotificationChannel(r.Context(), id, params); err != nil {
+			FlashRedirect(w, r, sm, "error", "Couldn't update channel: "+err.Error(), "/settings/notifications")
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "Channel updated.")
+		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
+	}
+}
+
 // NotificationsToggleChannelHandler handles
 // POST /settings/notifications/channels/{id}/toggle.
 func NotificationsToggleChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
@@ -185,6 +217,7 @@ func notificationChannelViews(channels []service.NotificationChannel) []pages.No
 			URLMasked:   maskNotifyURL(c.URL),
 			MinPriority: c.MinPriority,
 			Enabled:     c.Enabled,
+			EditURL:     "/settings/notifications/channels/" + c.ID,
 			ToggleURL:   "/settings/notifications/channels/" + c.ID + "/toggle",
 			DeleteURL:   "/settings/notifications/channels/" + c.ID + "/delete",
 		}

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -41,6 +41,7 @@ func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, 
 				WebhookURL:    settings.WebhookURL,
 				Format:        settings.Format,
 				PublicBaseURL: settings.PublicBaseURL,
+				MinPriority:   settings.MinPriority,
 			},
 			FieldErrors: map[string]string{},
 			FormError:   formError,
@@ -56,9 +57,9 @@ func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, 
 }
 
 // NotificationsSettingsPostHandler handles POST /settings/notifications —
-// the multi-input sink form. Saves webhook URL, format, and public base
-// URL together, then redirects back to the tab with a flash. The service
-// validates URLs (http(s)) and the format enum.
+// the multi-input sink form. Saves webhook URL, format, minimum priority,
+// and public base URL together, then redirects back to the tab with a flash.
+// The service validates URLs (http(s)) and the format / priority enums.
 func NotificationsSettingsPostHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -74,6 +75,10 @@ func NotificationsSettingsPostHandler(svc *service.Service, sm *scs.SessionManag
 		if r.Form.Has("format") {
 			v := strings.TrimSpace(r.FormValue("format"))
 			params.Format = &v
+		}
+		if r.Form.Has("min_priority") {
+			v := strings.TrimSpace(r.FormValue("min_priority"))
+			params.MinPriority = &v
 		}
 		if r.Form.Has("public_base_url") {
 			v := strings.TrimSpace(r.FormValue("public_base_url"))

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -26,6 +26,10 @@ func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, 
 			http.Error(w, "Failed to load notification channels: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// Capture the origin the admin is reaching Breadbox from so background
+		// notification sends can build absolute deep links without the admin
+		// typing one. Best-effort: a write failure must not block the page.
+		_ = svc.SetDetectedNotifyBaseURL(r.Context(), requestOrigin(r))
 		settings, err := svc.GetNotificationSettings(r.Context())
 		if err != nil {
 			http.Error(w, "Failed to load notification settings: "+err.Error(), http.StatusInternalServerError)
@@ -44,12 +48,13 @@ func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, 
 		}
 
 		props := pages.NotificationsSettingsProps{
-			Channels:      notificationChannelViews(channels),
-			PublicBaseURL: settings.PublicBaseURL,
-			FieldErrors:   map[string]string{},
-			FormError:     formError,
-			FormSuccess:   formSuccess,
-			CSRFToken:     GetCSRFToken(r),
+			Channels:        notificationChannelViews(channels),
+			PublicBaseURL:   settings.PublicBaseURL,
+			DetectedBaseURL: settings.DetectedBaseURL,
+			FieldErrors:     map[string]string{},
+			FormError:       formError,
+			FormSuccess:     formSuccess,
+			CSRFToken:       GetCSRFToken(r),
 		}
 
 		data := BaseTemplateData(r, sm, "notifications-settings", "Notifications")
@@ -144,6 +149,28 @@ func NotificationsTestChannelHandler(svc *service.Service) http.HandlerFunc {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 	}
+}
+
+// requestOrigin derives the public origin (scheme://host, no path) from the
+// incoming request, honoring X-Forwarded-Proto / X-Forwarded-Host when set by
+// a reverse proxy. Mirrors mcpServerURL so deep-link origins match the MCP
+// endpoint, OAuth issuer, and setup links — all derived the same way.
+func requestOrigin(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	host := r.Host
+	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+		host = fwdHost
+	}
+	if host == "" {
+		return ""
+	}
+	return scheme + "://" + host
 }
 
 // notificationChannelViews maps service channels to the display shape.

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -5,12 +5,11 @@ package admin
 import (
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -141,21 +140,6 @@ func NotificationsUpdateChannelHandler(svc *service.Service, sm *scs.SessionMana
 	}
 }
 
-// NotificationsToggleChannelHandler handles
-// POST /settings/notifications/channels/{id}/toggle.
-func NotificationsToggleChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		id := chi.URLParam(r, "id")
-		enabled := r.FormValue("enabled") == "true"
-		if err := svc.SetNotificationChannelEnabled(r.Context(), id, enabled); err != nil {
-			FlashRedirect(w, r, sm, "error", "Couldn't update channel: "+err.Error(), "/settings/notifications")
-			return
-		}
-		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
-	}
-}
-
 // NotificationsDeleteChannelHandler handles
 // POST /settings/notifications/channels/{id}/delete.
 func NotificationsDeleteChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
@@ -218,7 +202,6 @@ func notificationChannelViews(channels []service.NotificationChannel) []pages.No
 			MinPriority: c.MinPriority,
 			Enabled:     c.Enabled,
 			EditURL:     "/settings/notifications/channels/" + c.ID,
-			ToggleURL:   "/settings/notifications/channels/" + c.ID + "/toggle",
 			DeleteURL:   "/settings/notifications/channels/" + c.ID + "/delete",
 		}
 		if c.LastStatus != nil {
@@ -287,7 +270,7 @@ func maskNotifyURL(raw string) string {
 
 // notifyStatusText renders a per-channel delivery status line.
 func notifyStatusText(s *service.NotificationDeliveryStatus) string {
-	when := relTimeRFC3339(s.At)
+	when := timefmt.RelativeRFC3339(s.At)
 	if s.OK {
 		if when != "" {
 			return "Delivered · " + when
@@ -302,23 +285,4 @@ func notifyStatusText(s *service.NotificationDeliveryStatus) string {
 		return "Failed (" + when + "): " + detail
 	}
 	return "Failed: " + detail
-}
-
-// relTimeRFC3339 turns an RFC3339 timestamp into a coarse relative string.
-func relTimeRFC3339(ts string) string {
-	t, err := time.Parse(time.RFC3339, ts)
-	if err != nil {
-		return ""
-	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		return strconv.Itoa(int(d.Minutes())) + "m ago"
-	case d < 24*time.Hour:
-		return strconv.Itoa(int(d.Hours())) + "h ago"
-	default:
-		return t.Local().Format("Jan 2")
-	}
 }

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -4,21 +4,28 @@ package admin
 
 import (
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
 )
 
 // NotificationsSettingsHandler serves GET /settings/notifications — the
-// dedicated Notifications tab. It owns the outbound notification sink
-// (webhook URL + wire format + public base URL) that workflow runs push
-// reports to. Split out of the Workflows settings tab so notification
-// delivery has room to grow its own surface.
+// Notifications tab. It manages the list of outbound notification channels
+// (the multi-sink model) plus the global public base URL for deep links.
 func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		channels, err := svc.GetNotificationChannels(r.Context())
+		if err != nil {
+			http.Error(w, "Failed to load notification channels: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 		settings, err := svc.GetNotificationSettings(r.Context())
 		if err != nil {
 			http.Error(w, "Failed to load notification settings: "+err.Error(), http.StatusInternalServerError)
@@ -37,16 +44,12 @@ func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, 
 		}
 
 		props := pages.NotificationsSettingsProps{
-			Form: pages.NotificationsSettingsFormFields{
-				WebhookURL:    settings.WebhookURL,
-				Format:        settings.Format,
-				PublicBaseURL: settings.PublicBaseURL,
-				MinPriority:   settings.MinPriority,
-			},
-			FieldErrors: map[string]string{},
-			FormError:   formError,
-			FormSuccess: formSuccess,
-			CSRFToken:   GetCSRFToken(r),
+			Channels:      notificationChannelViews(channels),
+			PublicBaseURL: settings.PublicBaseURL,
+			FieldErrors:   map[string]string{},
+			FormError:     formError,
+			FormSuccess:   formSuccess,
+			CSRFToken:     GetCSRFToken(r),
 		}
 
 		data := BaseTemplateData(r, sm, "notifications-settings", "Notifications")
@@ -56,40 +59,189 @@ func NotificationsSettingsHandler(svc *service.Service, sm *scs.SessionManager, 
 	}
 }
 
-// NotificationsSettingsPostHandler handles POST /settings/notifications —
-// the multi-input sink form. Saves webhook URL, format, minimum priority,
-// and public base URL together, then redirects back to the tab with a flash.
-// The service validates URLs (http(s)) and the format / priority enums.
+// NotificationsSettingsPostHandler handles POST /settings/notifications — the
+// global (cross-channel) settings, currently just the public base URL.
 func NotificationsSettingsPostHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			FlashRedirect(w, r, sm, "error", "Could not read the submitted form.", "/settings/notifications")
 			return
 		}
-
 		var params service.UpdateNotificationSettingsParams
-		if r.Form.Has("webhook_url") {
-			v := strings.TrimSpace(r.FormValue("webhook_url"))
-			params.WebhookURL = &v // empty clears; service validates http(s)
-		}
-		if r.Form.Has("format") {
-			v := strings.TrimSpace(r.FormValue("format"))
-			params.Format = &v
-		}
-		if r.Form.Has("min_priority") {
-			v := strings.TrimSpace(r.FormValue("min_priority"))
-			params.MinPriority = &v
-		}
 		if r.Form.Has("public_base_url") {
 			v := strings.TrimSpace(r.FormValue("public_base_url"))
-			params.PublicBaseURL = &v // empty clears; service validates http(s)
+			params.PublicBaseURL = &v
 		}
-
 		if _, err := svc.UpdateNotificationSettings(r.Context(), params); err != nil {
-			FlashRedirect(w, r, sm, "error", "Failed to save notification settings: "+err.Error(), "/settings/notifications")
+			FlashRedirect(w, r, sm, "error", "Failed to save: "+err.Error(), "/settings/notifications")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Notification settings saved.")
 		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
+	}
+}
+
+// NotificationsAddChannelHandler handles POST /settings/notifications/channels.
+func NotificationsAddChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			FlashRedirect(w, r, sm, "error", "Could not read the submitted form.", "/settings/notifications")
+			return
+		}
+		_, err := svc.AddNotificationChannel(r.Context(), service.AddNotificationChannelParams{
+			Name:        strings.TrimSpace(r.FormValue("name")),
+			URL:         strings.TrimSpace(r.FormValue("url")),
+			Format:      strings.TrimSpace(r.FormValue("format")),
+			MinPriority: strings.TrimSpace(r.FormValue("min_priority")),
+			NtfyToken:   strings.TrimSpace(r.FormValue("ntfy_token")),
+		})
+		if err != nil {
+			FlashRedirect(w, r, sm, "error", "Couldn't add channel: "+err.Error(), "/settings/notifications")
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "Channel added.")
+		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
+	}
+}
+
+// NotificationsToggleChannelHandler handles
+// POST /settings/notifications/channels/{id}/toggle.
+func NotificationsToggleChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		id := chi.URLParam(r, "id")
+		enabled := r.FormValue("enabled") == "true"
+		if err := svc.SetNotificationChannelEnabled(r.Context(), id, enabled); err != nil {
+			FlashRedirect(w, r, sm, "error", "Couldn't update channel: "+err.Error(), "/settings/notifications")
+			return
+		}
+		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
+	}
+}
+
+// NotificationsDeleteChannelHandler handles
+// POST /settings/notifications/channels/{id}/delete.
+func NotificationsDeleteChannelHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.DeleteNotificationChannel(r.Context(), id); err != nil {
+			FlashRedirect(w, r, sm, "error", "Couldn't remove channel: "+err.Error(), "/settings/notifications")
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "Channel removed.")
+		http.Redirect(w, r, "/settings/notifications", http.StatusSeeOther)
+	}
+}
+
+// NotificationsTestChannelHandler handles POST /-/notifications/channels/{id}/test —
+// a JSON endpoint that fires a sample notification to one channel.
+func NotificationsTestChannelHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.SendTestToChannel(r.Context(), id); err != nil {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"ok": false, "error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+}
+
+// notificationChannelViews maps service channels to the display shape.
+func notificationChannelViews(channels []service.NotificationChannel) []pages.NotificationChannelView {
+	out := make([]pages.NotificationChannelView, 0, len(channels))
+	for _, c := range channels {
+		v := pages.NotificationChannelView{
+			ID:          c.ID,
+			Name:        c.Name,
+			Format:      c.Format,
+			FormatLabel: notifyFormatLabel(c.Format),
+			URLMasked:   maskNotifyURL(c.URL),
+			MinPriority: c.MinPriority,
+			Enabled:     c.Enabled,
+			ToggleURL:   "/settings/notifications/channels/" + c.ID + "/toggle",
+			DeleteURL:   "/settings/notifications/channels/" + c.ID + "/delete",
+		}
+		if c.LastStatus != nil {
+			v.HasStatus = true
+			v.StatusOK = c.LastStatus.OK
+			v.StatusText = notifyStatusText(c.LastStatus)
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// notifyFormatLabel renders a human label for a stored format value.
+func notifyFormatLabel(format string) string {
+	switch format {
+	case "ntfy":
+		return "ntfy"
+	case "slack":
+		return "Slack"
+	case "discord":
+		return "Discord"
+	case "json":
+		return "Generic JSON"
+	default:
+		return "Auto-detect"
+	}
+}
+
+// maskNotifyURL renders a webhook URL with its secret path obscured —
+// "https://host/…abcd" — so the channel list doesn't print full secret URLs.
+func maskNotifyURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		if len(raw) > 12 {
+			return raw[:8] + "…" + raw[len(raw)-4:]
+		}
+		return raw
+	}
+	base := u.Scheme + "://" + u.Host
+	if u.Path == "" || u.Path == "/" {
+		return base
+	}
+	tail := raw
+	if len(tail) > 4 {
+		tail = tail[len(tail)-4:]
+	}
+	return base + "/…" + tail
+}
+
+// notifyStatusText renders a per-channel delivery status line.
+func notifyStatusText(s *service.NotificationDeliveryStatus) string {
+	when := relTimeRFC3339(s.At)
+	if s.OK {
+		if when != "" {
+			return "Delivered · " + when
+		}
+		return "Delivered"
+	}
+	detail := s.Detail
+	if detail == "" {
+		detail = "failed"
+	}
+	if when != "" {
+		return "Failed (" + when + "): " + detail
+	}
+	return "Failed: " + detail
+}
+
+// relTimeRFC3339 turns an RFC3339 timestamp into a coarse relative string.
+func relTimeRFC3339(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return strconv.Itoa(int(d.Minutes())) + "m ago"
+	case d < 24*time.Hour:
+		return strconv.Itoa(int(d.Hours())) + "h ago"
+	default:
+		return t.Local().Format("Jan 2")
 	}
 }

--- a/internal/admin/notifications_settings.go
+++ b/internal/admin/notifications_settings.go
@@ -154,7 +154,7 @@ func notificationChannelViews(channels []service.NotificationChannel) []pages.No
 			ID:          c.ID,
 			Name:        c.Name,
 			Format:      c.Format,
-			FormatLabel: notifyFormatLabel(c.Format),
+			FormatLabel: channelFormatLabel(c.Format, c.URL),
 			URLMasked:   maskNotifyURL(c.URL),
 			MinPriority: c.MinPriority,
 			Enabled:     c.Enabled,
@@ -180,11 +180,28 @@ func notifyFormatLabel(format string) string {
 		return "Slack"
 	case "discord":
 		return "Discord"
+	case "googlechat":
+		return "Google Chat"
 	case "json":
 		return "Generic JSON"
 	default:
 		return "Auto-detect"
 	}
+}
+
+// channelFormatLabel labels a channel's format for the list. For an
+// "auto" channel it shows what the URL actually resolves to (e.g.
+// "Auto · ntfy") so the operator sees the effective provider; for a
+// generic URL it stays "Auto-detect".
+func channelFormatLabel(format, rawURL string) string {
+	if format != "auto" && format != "" {
+		return notifyFormatLabel(format)
+	}
+	resolved := service.ResolveNotifyFormat("auto", rawURL)
+	if resolved == "json" {
+		return "Auto-detect"
+	}
+	return "Auto · " + notifyFormatLabel(resolved)
 }
 
 // maskNotifyURL renders a webhook URL with its secret path obscured —

--- a/internal/admin/notifications_settings_unit_test.go
+++ b/internal/admin/notifications_settings_unit_test.go
@@ -58,9 +58,3 @@ func TestChannelFormatLabel(t *testing.T) {
 		t.Errorf("auto generic = %q, want 'Auto-detect'", got)
 	}
 }
-
-func TestRelTimeRFC3339_BadInput(t *testing.T) {
-	if got := relTimeRFC3339("not-a-time"); got != "" {
-		t.Errorf("relTimeRFC3339(bad) = %q, want empty", got)
-	}
-}

--- a/internal/admin/notifications_settings_unit_test.go
+++ b/internal/admin/notifications_settings_unit_test.go
@@ -25,18 +25,37 @@ func TestMaskNotifyURL(t *testing.T) {
 
 func TestNotifyFormatLabel(t *testing.T) {
 	cases := map[string]string{
-		"ntfy":    "ntfy",
-		"slack":   "Slack",
-		"discord": "Discord",
-		"json":    "Generic JSON",
-		"auto":    "Auto-detect",
-		"":        "Auto-detect",
-		"weird":   "Auto-detect",
+		"ntfy":       "ntfy",
+		"slack":      "Slack",
+		"discord":    "Discord",
+		"googlechat": "Google Chat",
+		"json":       "Generic JSON",
+		"auto":       "Auto-detect",
+		"":           "Auto-detect",
+		"weird":      "Auto-detect",
 	}
 	for in, want := range cases {
 		if got := notifyFormatLabel(in); got != want {
 			t.Errorf("notifyFormatLabel(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestChannelFormatLabel(t *testing.T) {
+	// Explicit format → plain label.
+	if got := channelFormatLabel("slack", "https://hooks.slack.com/x"); got != "Slack" {
+		t.Errorf("explicit slack = %q", got)
+	}
+	// Auto over a recognizable URL → "Auto · <provider>".
+	if got := channelFormatLabel("auto", "https://ntfy.sh/t"); got != "Auto · ntfy" {
+		t.Errorf("auto ntfy = %q, want 'Auto · ntfy'", got)
+	}
+	if got := channelFormatLabel("auto", "https://chat.googleapis.com/v1/spaces/A/messages"); got != "Auto · Google Chat" {
+		t.Errorf("auto googlechat = %q", got)
+	}
+	// Auto over a generic URL → plain "Auto-detect".
+	if got := channelFormatLabel("auto", "https://example.com/hook"); got != "Auto-detect" {
+		t.Errorf("auto generic = %q, want 'Auto-detect'", got)
 	}
 }
 

--- a/internal/admin/notifications_settings_unit_test.go
+++ b/internal/admin/notifications_settings_unit_test.go
@@ -1,0 +1,47 @@
+//go:build !headless && !lite
+
+package admin
+
+import "testing"
+
+func TestMaskNotifyURL(t *testing.T) {
+	cases := map[string]string{
+		"https://hooks.slack.com/services/T0/B0/secret": "https://hooks.slack.com/…cret",
+		"https://ntfy.sh/my-topic":                      "https://ntfy.sh/…opic",
+		"https://ntfy.sh":                               "https://ntfy.sh",
+		"https://ntfy.sh/":                              "https://ntfy.sh",
+	}
+	for in, want := range cases {
+		if got := maskNotifyURL(in); got != want {
+			t.Errorf("maskNotifyURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// A secret webhook path must never appear in full.
+	full := "https://discord.com/api/webhooks/123456/SUPER-SECRET-TOKEN"
+	if got := maskNotifyURL(full); got == full {
+		t.Error("maskNotifyURL leaked the full secret URL")
+	}
+}
+
+func TestNotifyFormatLabel(t *testing.T) {
+	cases := map[string]string{
+		"ntfy":    "ntfy",
+		"slack":   "Slack",
+		"discord": "Discord",
+		"json":    "Generic JSON",
+		"auto":    "Auto-detect",
+		"":        "Auto-detect",
+		"weird":   "Auto-detect",
+	}
+	for in, want := range cases {
+		if got := notifyFormatLabel(in); got != want {
+			t.Errorf("notifyFormatLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRelTimeRFC3339_BadInput(t *testing.T) {
+	if got := relTimeRFC3339("not-a-time"); got != "" {
+		t.Errorf("relTimeRFC3339(bad) = %q, want empty", got)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -403,7 +403,6 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Multi-channel management (form POSTs → redirect back to the tab).
 		r.Post("/settings/notifications/channels", NotificationsAddChannelHandler(svc, sm))
 		r.Post("/settings/notifications/channels/{id}", NotificationsUpdateChannelHandler(svc, sm))
-		r.Post("/settings/notifications/channels/{id}/toggle", NotificationsToggleChannelHandler(svc, sm))
 		r.Post("/settings/notifications/channels/{id}/delete", NotificationsDeleteChannelHandler(svc, sm))
 
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -402,6 +402,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/settings/notifications", NotificationsSettingsPostHandler(svc, sm))
 		// Multi-channel management (form POSTs → redirect back to the tab).
 		r.Post("/settings/notifications/channels", NotificationsAddChannelHandler(svc, sm))
+		r.Post("/settings/notifications/channels/{id}", NotificationsUpdateChannelHandler(svc, sm))
 		r.Post("/settings/notifications/channels/{id}/toggle", NotificationsToggleChannelHandler(svc, sm))
 		r.Post("/settings/notifications/channels/{id}/delete", NotificationsDeleteChannelHandler(svc, sm))
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -400,6 +400,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// to /-/notifications/test (registered below).
 		r.Get("/settings/notifications", NotificationsSettingsHandler(svc, sm, tr))
 		r.Post("/settings/notifications", NotificationsSettingsPostHandler(svc, sm))
+		// Multi-channel management (form POSTs → redirect back to the tab).
+		r.Post("/settings/notifications/channels", NotificationsAddChannelHandler(svc, sm))
+		r.Post("/settings/notifications/channels/{id}/toggle", NotificationsToggleChannelHandler(svc, sm))
+		r.Post("/settings/notifications/channels/{id}/delete", NotificationsDeleteChannelHandler(svc, sm))
 
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
 		r.Get("/settings/general", SettingsGetHandler(a, sm, tr))
@@ -619,6 +623,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			// test-delivery endpoint now that the sink lives on its own page;
 			// /-/workflows/notify-test stays as a back-compat alias.
 			r.Post("/notifications/test", NotifyTestAdminHandler(svc))
+			// Per-channel test delivery (JSON; driven by the channel row's
+			// "Test" button).
+			r.Post("/notifications/channels/{id}/test", NotificationsTestChannelHandler(svc))
 		})
 	})
 

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -89,12 +89,24 @@ const (
 	// "ntfy" / "slack" / "discord" / "json" force a specific shape.
 	KeyNotifyFormat = "notify.format"
 
-	// KeyNotifyPublicBaseURL is the absolute origin (scheme+host, no
-	// trailing slash) Breadbox prepends to report deep links carried in
-	// a notification — so an ntfy "tap to open" (and any relative link
-	// in the body) resolves to the real report instead of a bare path.
-	// Empty = deep links stay relative. http(s) only.
+	// KeyNotifyPublicBaseURL is an OPTIONAL manual override for the
+	// absolute origin (scheme+host, no trailing slash) Breadbox prepends
+	// to report deep links carried in a notification — so an ntfy "tap to
+	// open" (and any relative link in the body) resolves to the real
+	// report instead of a bare path. Empty (the default) means "use the
+	// auto-detected origin" (KeyNotifyDetectedBaseURL). Set this only when
+	// Breadbox is reached at a different public URL than the admin browses
+	// from. http(s) only.
 	KeyNotifyPublicBaseURL = "notify.public_base_url"
+
+	// KeyNotifyDetectedBaseURL is the origin auto-captured from the admin's
+	// own request (X-Forwarded-Proto/Host → Host) whenever the Notifications
+	// settings page is loaded. Notifications fire from background jobs with
+	// no HTTP request in scope, so we persist the last-seen browsing origin
+	// here and read it at send time. The manual override
+	// (KeyNotifyPublicBaseURL) wins when set; otherwise this is used. Empty
+	// until the settings page has been visited at least once.
+	KeyNotifyDetectedBaseURL = "notify.detected_base_url"
 
 	// KeyNotifyMinPriority gates outbound notifications by report priority:
 	// only reports at or above this floor are delivered. One of

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -101,6 +101,15 @@ const (
 	// info | warning | critical; default "info" (everything). Lets a
 	// household silence routine info-level reports and keep only alerts.
 	KeyNotifyMinPriority = "notify.min_priority"
+
+	// KeyNotifyChannels holds the JSON array of configured notification
+	// channels (the multi-sink model). Each entry carries its own URL,
+	// format, priority floor, optional ntfy token, enabled flag, and last
+	// delivery status. When empty, a single legacy channel is synthesized
+	// from KeyNotifyWebhookURL / KeyNotifyFormat / KeyNotifyMinPriority so
+	// pre-multi-channel configs keep working. A workflow notification fans
+	// out to every enabled channel.
+	KeyNotifyChannels = "notify.channels"
 )
 
 // AuthMode values for KeyAgentAuthMode.

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -120,11 +120,12 @@ const (
 
 // NotifyFormat values for KeyNotifyFormat.
 const (
-	NotifyFormatAuto    = "auto"
-	NotifyFormatNtfy    = "ntfy"
-	NotifyFormatSlack   = "slack"
-	NotifyFormatDiscord = "discord"
-	NotifyFormatJSON    = "json"
+	NotifyFormatAuto       = "auto"
+	NotifyFormatNtfy       = "ntfy"
+	NotifyFormatSlack      = "slack"
+	NotifyFormatDiscord    = "discord"
+	NotifyFormatGoogleChat = "googlechat"
+	NotifyFormatJSON       = "json"
 )
 
 // NotifyMinPriority values for KeyNotifyMinPriority (delivery floor).

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -84,10 +84,9 @@ const (
 
 	// KeyNotifyFormat selects how the outbound notification request is
 	// shaped. "auto" (default) sniffs the webhook URL and publishes
-	// natively to ntfy when it looks like ntfy, falling back to the
-	// generic JSON envelope otherwise; "ntfy" forces ntfy's
-	// header+body publishing; "json" forces the JSON envelope (for
-	// Slack-compatible relays, Discord bridges, custom consumers).
+	// natively to the matching provider (ntfy / Slack / Discord), falling
+	// back to the generic JSON envelope otherwise. The explicit values
+	// "ntfy" / "slack" / "discord" / "json" force a specific shape.
 	KeyNotifyFormat = "notify.format"
 
 	// KeyNotifyPublicBaseURL is the absolute origin (scheme+host, no
@@ -96,6 +95,12 @@ const (
 	// in the body) resolves to the real report instead of a bare path.
 	// Empty = deep links stay relative. http(s) only.
 	KeyNotifyPublicBaseURL = "notify.public_base_url"
+
+	// KeyNotifyMinPriority gates outbound notifications by report priority:
+	// only reports at or above this floor are delivered. One of
+	// info | warning | critical; default "info" (everything). Lets a
+	// household silence routine info-level reports and keep only alerts.
+	KeyNotifyMinPriority = "notify.min_priority"
 )
 
 // AuthMode values for KeyAgentAuthMode.
@@ -106,7 +111,16 @@ const (
 
 // NotifyFormat values for KeyNotifyFormat.
 const (
-	NotifyFormatAuto = "auto"
-	NotifyFormatNtfy = "ntfy"
-	NotifyFormatJSON = "json"
+	NotifyFormatAuto    = "auto"
+	NotifyFormatNtfy    = "ntfy"
+	NotifyFormatSlack   = "slack"
+	NotifyFormatDiscord = "discord"
+	NotifyFormatJSON    = "json"
+)
+
+// NotifyMinPriority values for KeyNotifyMinPriority (delivery floor).
+const (
+	NotifyMinPriorityInfo     = "info"
+	NotifyMinPriorityWarning  = "warning"
+	NotifyMinPriorityCritical = "critical"
 )

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -123,7 +123,7 @@ func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPa
 	}
 	// Absolutize the deep link once so every channel (ntfy tap-through, JSON
 	// consumers) resolves to the real report rather than a bare path.
-	baseURL := normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""))
+	baseURL := s.ResolveNotifyBaseURL(ctx)
 	if baseURL != "" && strings.HasPrefix(p.URL, "/") {
 		p.URL = baseURL + p.URL
 	}

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -172,6 +172,8 @@ func (s *Service) sendToChannel(ctx context.Context, c *NotificationChannel, p N
 			return buildSlackRequest(ctx, c.URL, p)
 		case appconfig.NotifyFormatDiscord:
 			return buildDiscordRequest(ctx, c.URL, p)
+		case appconfig.NotifyFormatGoogleChat:
+			return buildGoogleChatRequest(ctx, c.URL, p)
 		default:
 			return buildJSONNotifyRequest(ctx, c.URL, p)
 		}
@@ -185,13 +187,21 @@ func (s *Service) sendToChannel(ctx context.Context, c *NotificationChannel, p N
 	return err
 }
 
+// ResolveNotifyFormat is the exported view of format resolution — used by the
+// admin UI to show what a channel's "auto" format actually resolved to.
+func ResolveNotifyFormat(configured, rawURL string) string {
+	return resolveNotifyFormat(configured, rawURL)
+}
+
 // resolveNotifyFormat maps the configured format to a concrete wire shape.
 // "auto" (the default, and any unknown value) sniffs the URL for a known
-// provider (ntfy / Slack / Discord), falling back to the generic JSON shape.
+// provider (ntfy / Slack / Discord / Google Chat), falling back to the
+// generic JSON shape.
 func resolveNotifyFormat(configured, rawURL string) string {
 	switch configured {
 	case appconfig.NotifyFormatNtfy, appconfig.NotifyFormatSlack,
-		appconfig.NotifyFormatDiscord, appconfig.NotifyFormatJSON:
+		appconfig.NotifyFormatDiscord, appconfig.NotifyFormatGoogleChat,
+		appconfig.NotifyFormatJSON:
 		return configured
 	default:
 		switch {
@@ -201,10 +211,17 @@ func resolveNotifyFormat(configured, rawURL string) string {
 			return appconfig.NotifyFormatSlack
 		case looksLikeDiscord(rawURL):
 			return appconfig.NotifyFormatDiscord
+		case looksLikeGoogleChat(rawURL):
+			return appconfig.NotifyFormatGoogleChat
 		default:
 			return appconfig.NotifyFormatJSON
 		}
 	}
+}
+
+// looksLikeGoogleChat reports whether a URL is a Google Chat incoming webhook.
+func looksLikeGoogleChat(raw string) bool {
+	return urlHost(raw) == "chat.googleapis.com"
 }
 
 // looksLikeNtfy reports whether a webhook URL points at an ntfy server.
@@ -466,6 +483,41 @@ func buildSlackRequest(ctx context.Context, rawURL string, p NotificationPayload
 		b.WriteString("|View report →>")
 	}
 	return jsonNotifyRequest(ctx, rawURL, map[string]any{"text": b.String()})
+}
+
+// buildGoogleChatRequest POSTs a Google Chat incoming-webhook payload
+// ({"text": …}). Google Chat uses the same single-asterisk bold + <url|label>
+// link syntax as Slack mrkdwn, but renders unicode emoji rather than
+// :shortcode: names — so the priority cue is a unicode glyph.
+func buildGoogleChatRequest(ctx context.Context, rawURL string, p NotificationPayload) (*http.Request, error) {
+	var b strings.Builder
+	b.WriteString(notifyEmojiUnicode(p.Priority))
+	b.WriteString(" *")
+	b.WriteString(slackEscape(collapseToLine(p.Title)))
+	b.WriteString("*")
+	if body := strings.TrimSpace(p.Body); body != "" {
+		b.WriteString("\n")
+		b.WriteString(toSlackMrkdwn(body))
+	}
+	if isAbsoluteURL(p.URL) {
+		b.WriteString("\n<")
+		b.WriteString(p.URL)
+		b.WriteString("|View report →>")
+	}
+	return jsonNotifyRequest(ctx, rawURL, map[string]any{"text": b.String()})
+}
+
+// notifyEmojiUnicode returns a unicode emoji for a priority — used where
+// :shortcode: names aren't rendered (Google Chat).
+func notifyEmojiUnicode(priority string) string {
+	switch priority {
+	case "critical":
+		return "\U0001F6A8" // 🚨
+	case "warning":
+		return "⚠️" // ⚠️
+	default:
+		return "ℹ️" // ℹ️
+	}
 }
 
 // buildDiscordRequest POSTs a Discord webhook payload ({"content": …}).

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -78,73 +78,111 @@ func truncateNotifyBody(body string) string {
 	return strings.TrimRight(string(r[:notifyBodyMaxLen]), " \t\n") + "…"
 }
 
-// WorkflowNotificationConfigured reports whether an outbound webhook URL is set.
+// WorkflowNotificationConfigured reports whether at least one enabled
+// notification channel is configured.
 func (s *Service) WorkflowNotificationConfigured(ctx context.Context) bool {
-	return strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, "")) != ""
+	for _, c := range s.loadNotificationChannels(ctx) {
+		if c.Enabled {
+			return true
+		}
+	}
+	return false
 }
 
-// SendWorkflowNotification delivers the payload to the configured
-// notification webhook. It is a no-op (returns nil) when no URL is
-// configured, so callers can fire unconditionally. The URL must be http(s).
+// SendWorkflowNotification fans the payload out to every enabled notification
+// channel. It is a no-op (returns nil) when no channel is configured, so
+// callers can fire unconditionally.
 //
-// The wire shape depends on the configured format (notify.format):
+// Each channel is rendered in its own format and gated by its own priority
+// floor. The wire shape per channel:
 //   - ntfy    → a plain-text (markdown) body plus ntfy's publishing headers
-//     (Title / Priority / Click / Markdown / Tags), so the push renders as
-//     a real titled notification instead of a raw JSON blob.
+//     (Title / Priority / Click / Markdown / Tags / Actions), so the push
+//     renders as a real titled notification instead of a raw JSON blob.
 //   - slack   → a Slack incoming-webhook JSON ({"text": …}) with mrkdwn.
 //   - discord → a Discord webhook JSON ({"content": …}) with markdown.
-//   - json    → the generic NotificationPayload envelope (relays, bridges,
-//     custom consumers).
+//   - json    → the generic NotificationPayload envelope (relays, bridges).
 //   - auto    → the matching provider when the URL is recognizable, else json.
 //
-// Reports below the configured priority floor (notify.min_priority) are
-// dropped silently. Delivery is retried with backoff on transient failures.
+// Reports below a channel's priority floor are skipped for that channel.
+// Per-channel delivery is retried with backoff on transient failures, and the
+// outcome is recorded on the channel. Returns the first delivery error (if
+// any) after attempting every channel.
 func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPayload) error {
-	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""))
-	if raw == "" {
+	// A persisted channels array is the source of truth; an empty one means we
+	// synthesize an ephemeral legacy channel. We must NOT persist statuses back
+	// in the synth case — doing so would promote the legacy config into the
+	// channels array and make further legacy-webhook edits silently ignored.
+	persisted := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyChannels, "")) != ""
+	chans := s.loadNotificationChannels(ctx)
+	if len(chans) == 0 {
 		return nil // notifications disabled — no-op
-	}
-	if err := validateNotifyURL(raw); err != nil {
-		return err
-	}
-
-	// Priority floor: drop reports below the configured minimum. Test
-	// notifications (Event == "test") always go through — the operator is
-	// explicitly checking the wiring.
-	floor := appconfig.String(ctx, s.Queries, appconfig.KeyNotifyMinPriority, appconfig.NotifyMinPriorityInfo)
-	if p.Event != "test" && priorityRank(p.Priority) < priorityRank(floor) {
-		return nil
 	}
 
 	if p.SentAt == "" {
-		p.SentAt = time.Now().UTC().Format(time.RFC3339)
+		p.SentAt = nowRFC3339()
 	}
-
-	// Absolutize the deep link so both JSON consumers and ntfy tap-through
-	// resolve to the real report rather than a bare path. No-op when the
-	// operator hasn't set a public base URL.
+	// Absolutize the deep link once so every channel (ntfy tap-through, JSON
+	// consumers) resolves to the real report rather than a bare path.
 	baseURL := normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""))
 	if baseURL != "" && strings.HasPrefix(p.URL, "/") {
 		p.URL = baseURL + p.URL
 	}
 
-	format := resolveNotifyFormat(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto), raw)
+	var firstErr error
+	attempted := false
+	for i := range chans {
+		c := &chans[i]
+		if !c.Enabled {
+			continue
+		}
+		// Per-channel priority floor; test sends always go through.
+		if p.Event != "test" && priorityRank(p.Priority) < priorityRank(c.MinPriority) {
+			continue
+		}
+		attempted = true
+		if err := s.sendToChannel(ctx, c, p, baseURL); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if attempted && persisted {
+		// Persist the recorded per-channel statuses (best-effort — a status
+		// write failure must not mask a successful delivery). Skipped for the
+		// synthesized legacy channel so legacy config stays editable.
+		_ = s.persistNotificationChannels(ctx, chans)
+	}
+	return firstErr
+}
 
-	// build constructs a fresh request per attempt — the body is a reader
-	// that can't be rewound, so we can't reuse one *http.Request across retries.
+// sendToChannel delivers p to a single channel, recording the outcome on
+// c.LastStatus. The channel's URL is validated defensively (legacy/imported
+// data) and its format + token drive the wire shape.
+func (s *Service) sendToChannel(ctx context.Context, c *NotificationChannel, p NotificationPayload, baseURL string) error {
+	if err := validateNotifyURL(c.URL); err != nil {
+		c.LastStatus = &NotificationDeliveryStatus{OK: false, At: nowRFC3339(), Detail: "invalid URL"}
+		return err
+	}
+	format := resolveNotifyFormat(c.Format, c.URL)
+	// build constructs a fresh request per attempt — the body is a reader that
+	// can't be rewound, so we can't reuse one *http.Request across retries.
 	build := func() (*http.Request, error) {
 		switch format {
 		case appconfig.NotifyFormatNtfy:
-			return buildNtfyRequest(ctx, raw, p, baseURL)
+			return buildNtfyRequest(ctx, c.URL, p, baseURL, c.NtfyToken)
 		case appconfig.NotifyFormatSlack:
-			return buildSlackRequest(ctx, raw, p)
+			return buildSlackRequest(ctx, c.URL, p)
 		case appconfig.NotifyFormatDiscord:
-			return buildDiscordRequest(ctx, raw, p)
+			return buildDiscordRequest(ctx, c.URL, p)
 		default:
-			return buildJSONNotifyRequest(ctx, raw, p)
+			return buildJSONNotifyRequest(ctx, c.URL, p)
 		}
 	}
-	return sendNotifyWithRetry(ctx, build)
+	err := sendNotifyWithRetry(ctx, build)
+	status := NotificationDeliveryStatus{OK: err == nil, At: nowRFC3339(), Format: format, Detail: "delivered"}
+	if err != nil {
+		status.Detail = err.Error()
+	}
+	c.LastStatus = &status
+	return err
 }
 
 // resolveNotifyFormat maps the configured format to a concrete wire shape.
@@ -284,8 +322,9 @@ func buildJSONNotifyRequest(ctx context.Context, rawURL string, p NotificationPa
 
 // buildNtfyRequest POSTs to an ntfy topic using ntfy's native publishing
 // protocol: the request body is the message text and metadata rides in
-// headers. See https://docs.ntfy.sh/publish/.
-func buildNtfyRequest(ctx context.Context, rawURL string, p NotificationPayload, baseURL string) (*http.Request, error) {
+// headers. See https://docs.ntfy.sh/publish/. token, when non-empty, is sent
+// as a Bearer credential for protected topics on self-hosted servers.
+func buildNtfyRequest(ctx context.Context, rawURL string, p NotificationPayload, baseURL, token string) (*http.Request, error) {
 	message := p.Body
 	if baseURL != "" {
 		message = absolutizeMarkdownLinks(message, baseURL)
@@ -300,6 +339,9 @@ func buildNtfyRequest(ctx context.Context, rawURL string, p NotificationPayload,
 	}
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
 	req.Header.Set("User-Agent", "breadbox-workflows")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	if title := encodeNtfyHeader(p.Title); title != "" {
 		req.Header.Set("X-Title", title)
 	}
@@ -309,8 +351,10 @@ func buildNtfyRequest(ctx context.Context, rawURL string, p NotificationPayload,
 		req.Header.Set("X-Tags", tags)
 	}
 	// ntfy needs an absolute URL for tap-through; a relative path is dropped.
-	if strings.HasPrefix(p.URL, "http://") || strings.HasPrefix(p.URL, "https://") {
+	if isAbsoluteURL(p.URL) {
 		req.Header.Set("X-Click", p.URL)
+		// A tappable action button in addition to the whole-notification tap.
+		req.Header.Set("X-Actions", "view, View report, "+p.URL)
 	}
 	return req, nil
 }
@@ -501,14 +545,9 @@ func isAbsoluteURL(u string) bool {
 // webhook wiring from Settings. Returns ErrInvalidParameter when no URL is set.
 func (s *Service) SendTestNotification(ctx context.Context) error {
 	if !s.WorkflowNotificationConfigured(ctx) {
-		return fmt.Errorf("%w: no notification webhook URL configured", ErrInvalidParameter)
+		return fmt.Errorf("%w: no notification channel configured", ErrInvalidParameter)
 	}
-	return s.SendWorkflowNotification(ctx, NotificationPayload{
-		Event:    "test",
-		Title:    "Breadbox workflow notification test",
-		Body:     "If you can see this, your workflow notification webhook is wired up correctly.",
-		Priority: "info",
-	})
+	return s.SendWorkflowNotification(ctx, testNotificationPayload())
 }
 
 // validateNotifyURL rejects anything that isn't a well-formed http(s) URL.

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -87,12 +88,17 @@ func (s *Service) WorkflowNotificationConfigured(ctx context.Context) bool {
 // configured, so callers can fire unconditionally. The URL must be http(s).
 //
 // The wire shape depends on the configured format (notify.format):
-//   - ntfy   → a plain-text (markdown) body plus ntfy's publishing headers
+//   - ntfy    → a plain-text (markdown) body plus ntfy's publishing headers
 //     (Title / Priority / Click / Markdown / Tags), so the push renders as
 //     a real titled notification instead of a raw JSON blob.
-//   - json   → the generic NotificationPayload envelope (Slack relays,
-//     Discord bridges, custom consumers).
-//   - auto   → ntfy when the URL looks like ntfy, else json.
+//   - slack   → a Slack incoming-webhook JSON ({"text": …}) with mrkdwn.
+//   - discord → a Discord webhook JSON ({"content": …}) with markdown.
+//   - json    → the generic NotificationPayload envelope (relays, bridges,
+//     custom consumers).
+//   - auto    → the matching provider when the URL is recognizable, else json.
+//
+// Reports below the configured priority floor (notify.min_priority) are
+// dropped silently. Delivery is retried with backoff on transient failures.
 func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPayload) error {
 	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""))
 	if raw == "" {
@@ -101,6 +107,15 @@ func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPa
 	if err := validateNotifyURL(raw); err != nil {
 		return err
 	}
+
+	// Priority floor: drop reports below the configured minimum. Test
+	// notifications (Event == "test") always go through — the operator is
+	// explicitly checking the wiring.
+	floor := appconfig.String(ctx, s.Queries, appconfig.KeyNotifyMinPriority, appconfig.NotifyMinPriorityInfo)
+	if p.Event != "test" && priorityRank(p.Priority) < priorityRank(floor) {
+		return nil
+	}
+
 	if p.SentAt == "" {
 		p.SentAt = time.Now().UTC().Format(time.RFC3339)
 	}
@@ -115,41 +130,42 @@ func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPa
 
 	format := resolveNotifyFormat(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto), raw)
 
-	var req *http.Request
-	var err error
-	if format == appconfig.NotifyFormatNtfy {
-		req, err = buildNtfyRequest(ctx, raw, p, baseURL)
-	} else {
-		req, err = buildJSONNotifyRequest(ctx, raw, p)
+	// build constructs a fresh request per attempt — the body is a reader
+	// that can't be rewound, so we can't reuse one *http.Request across retries.
+	build := func() (*http.Request, error) {
+		switch format {
+		case appconfig.NotifyFormatNtfy:
+			return buildNtfyRequest(ctx, raw, p, baseURL)
+		case appconfig.NotifyFormatSlack:
+			return buildSlackRequest(ctx, raw, p)
+		case appconfig.NotifyFormatDiscord:
+			return buildDiscordRequest(ctx, raw, p)
+		default:
+			return buildJSONNotifyRequest(ctx, raw, p)
+		}
 	}
-	if err != nil {
-		return err
-	}
-
-	resp, err := notifyHTTPClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("notification webhook: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		return fmt.Errorf("notification webhook returned HTTP %d", resp.StatusCode)
-	}
-	return nil
+	return sendNotifyWithRetry(ctx, build)
 }
 
 // resolveNotifyFormat maps the configured format to a concrete wire shape.
-// "auto" (the default, and any unknown value) sniffs the URL for ntfy.
+// "auto" (the default, and any unknown value) sniffs the URL for a known
+// provider (ntfy / Slack / Discord), falling back to the generic JSON shape.
 func resolveNotifyFormat(configured, rawURL string) string {
 	switch configured {
-	case appconfig.NotifyFormatNtfy:
-		return appconfig.NotifyFormatNtfy
-	case appconfig.NotifyFormatJSON:
-		return appconfig.NotifyFormatJSON
+	case appconfig.NotifyFormatNtfy, appconfig.NotifyFormatSlack,
+		appconfig.NotifyFormatDiscord, appconfig.NotifyFormatJSON:
+		return configured
 	default:
-		if looksLikeNtfy(rawURL) {
+		switch {
+		case looksLikeNtfy(rawURL):
 			return appconfig.NotifyFormatNtfy
+		case looksLikeSlack(rawURL):
+			return appconfig.NotifyFormatSlack
+		case looksLikeDiscord(rawURL):
+			return appconfig.NotifyFormatDiscord
+		default:
+			return appconfig.NotifyFormatJSON
 		}
-		return appconfig.NotifyFormatJSON
 	}
 }
 
@@ -157,12 +173,97 @@ func resolveNotifyFormat(configured, rawURL string) string {
 // Matches the public host and any self-hosted host carrying "ntfy" in its
 // name (push.ntfy.example.com, ntfy.lan, …).
 func looksLikeNtfy(raw string) bool {
+	host := urlHost(raw)
+	return host == "ntfy.sh" || strings.Contains(host, "ntfy")
+}
+
+// looksLikeSlack reports whether a URL is a Slack incoming webhook.
+func looksLikeSlack(raw string) bool {
+	return urlHost(raw) == "hooks.slack.com"
+}
+
+// looksLikeDiscord reports whether a URL is a Discord webhook.
+func looksLikeDiscord(raw string) bool {
+	host := urlHost(raw)
+	return (host == "discord.com" || host == "discordapp.com" || strings.HasSuffix(host, ".discord.com")) &&
+		strings.Contains(raw, "/webhooks/")
+}
+
+// urlHost returns the lower-cased host of a URL, or "" if unparsable.
+func urlHost(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return false
+		return ""
 	}
-	host := strings.ToLower(u.Hostname())
-	return host == "ntfy.sh" || strings.Contains(host, "ntfy")
+	return strings.ToLower(u.Hostname())
+}
+
+// priorityRank orders the canonical priorities for floor comparison.
+// Unknown values rank as "info" (the lowest) so they're never silently
+// filtered by a stricter floor.
+func priorityRank(priority string) int {
+	switch priority {
+	case "critical":
+		return 2
+	case "warning":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// notifyMaxAttempts bounds delivery retries (1 initial + retries).
+const notifyMaxAttempts = 3
+
+// sendNotifyWithRetry delivers a freshly-built request, retrying transient
+// failures (network errors, HTTP 429, and 5xx) with exponential backoff.
+// A 4xx other than 429 fails fast — retrying a malformed payload or a bad
+// topic won't help. Each attempt rebuilds the request because its body is a
+// one-shot reader.
+func sendNotifyWithRetry(ctx context.Context, build func() (*http.Request, error)) error {
+	var lastErr error
+	for attempt := 1; attempt <= notifyMaxAttempts; attempt++ {
+		req, err := build()
+		if err != nil {
+			return err // build errors are deterministic — don't retry
+		}
+		resp, err := notifyHTTPClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("notification webhook: %w", err)
+		} else {
+			func() {
+				defer resp.Body.Close()
+				if resp.StatusCode < 300 {
+					lastErr = nil
+				} else {
+					lastErr = fmt.Errorf("notification webhook returned HTTP %d", resp.StatusCode)
+				}
+			}()
+			if lastErr == nil {
+				return nil
+			}
+			if !notifyRetriableStatus(resp.StatusCode) {
+				return lastErr // permanent (4xx ≠ 429) — stop now
+			}
+		}
+		if attempt < notifyMaxAttempts {
+			// Exponential backoff: 200ms, 400ms, … bounded and ctx-aware.
+			backoff := time.Duration(200*(1<<(attempt-1))) * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+	}
+	return lastErr
+}
+
+// notifyRetriableStatus reports whether an HTTP status warrants a retry:
+// 429 (rate limited) and any 5xx (server-side transient). 4xx otherwise is
+// permanent.
+func notifyRetriableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
 }
 
 // buildJSONNotifyRequest POSTs the generic JSON envelope. This is the
@@ -280,6 +381,120 @@ func absolutizeMarkdownLinks(body, baseURL string) string {
 // callers can concatenate "/path" without doubling the separator.
 func normalizeBaseURL(raw string) string {
 	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}
+
+// notifyMarkdownLink matches a markdown inline link: [label](url).
+var notifyMarkdownLink = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+
+// notifyBoldRun matches a **bold** run.
+var notifyBoldRun = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+
+// notifyEmojiShortcode returns an emoji shortcode (rendered by Slack and
+// Discord alike) for a priority — the same visual cue ntfy gets from tags.
+func notifyEmojiShortcode(priority string) string {
+	switch priority {
+	case "critical":
+		return ":rotating_light:"
+	case "warning":
+		return ":warning:"
+	default:
+		return ":information_source:"
+	}
+}
+
+// buildSlackRequest POSTs a Slack incoming-webhook payload ({"text": …}).
+// The body is converted from Markdown to Slack mrkdwn: **bold** → *bold*
+// and [label](url) → <url|label>. A leading priority emoji + bold title set
+// the headline; an absolute deep link is appended as a tappable link.
+func buildSlackRequest(ctx context.Context, rawURL string, p NotificationPayload) (*http.Request, error) {
+	var b strings.Builder
+	b.WriteString(notifyEmojiShortcode(p.Priority))
+	b.WriteString(" *")
+	b.WriteString(slackEscape(collapseToLine(p.Title)))
+	b.WriteString("*")
+	if body := strings.TrimSpace(p.Body); body != "" {
+		b.WriteString("\n")
+		b.WriteString(toSlackMrkdwn(body))
+	}
+	if isAbsoluteURL(p.URL) {
+		b.WriteString("\n<")
+		b.WriteString(p.URL)
+		b.WriteString("|View report →>")
+	}
+	return jsonNotifyRequest(ctx, rawURL, map[string]any{"text": b.String()})
+}
+
+// buildDiscordRequest POSTs a Discord webhook payload ({"content": …}).
+// Discord renders standard Markdown (bold, lists) in message content, so the
+// body passes through; an absolute deep link is appended on its own line
+// (Discord auto-links bare URLs). Content is capped at Discord's 2000-char
+// limit.
+func buildDiscordRequest(ctx context.Context, rawURL string, p NotificationPayload) (*http.Request, error) {
+	var b strings.Builder
+	b.WriteString(notifyEmojiShortcode(p.Priority))
+	b.WriteString(" **")
+	b.WriteString(collapseToLine(p.Title))
+	b.WriteString("**")
+	if body := strings.TrimSpace(p.Body); body != "" {
+		b.WriteString("\n")
+		b.WriteString(body)
+	}
+	if isAbsoluteURL(p.URL) {
+		b.WriteString("\n")
+		b.WriteString(p.URL)
+	}
+	content := b.String()
+	if r := []rune(content); len(r) > 1990 {
+		content = strings.TrimRight(string(r[:1990]), " \t\n") + "…"
+	}
+	return jsonNotifyRequest(ctx, rawURL, map[string]any{"content": content})
+}
+
+// jsonNotifyRequest marshals v and builds a JSON POST with the shared headers.
+func jsonNotifyRequest(ctx context.Context, rawURL string, v any) (*http.Request, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal notification: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build notification request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "breadbox-workflows")
+	return req, nil
+}
+
+// toSlackMrkdwn converts the subset of Markdown our report bodies use into
+// Slack mrkdwn: [label](url) → <url|label>, then **bold** → *bold*.
+// Links are rewritten first so the bold pass can't touch a URL.
+func toSlackMrkdwn(s string) string {
+	s = notifyMarkdownLink.ReplaceAllString(s, "<$2|$1>")
+	s = notifyBoldRun.ReplaceAllString(s, "*$1*")
+	return s
+}
+
+// slackEscape escapes the three characters Slack reserves in mrkdwn text so a
+// stray <, >, or & in a title can't break link syntax. Applied to plain-text
+// fragments only — never to a fragment that already contains <url|label>.
+func slackEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}
+
+// collapseToLine flattens newlines to spaces — used for titles that must
+// render on a single line.
+func collapseToLine(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
+}
+
+// isAbsoluteURL reports whether u is an http(s) absolute URL.
+func isAbsoluteURL(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
 }
 
 // SendTestNotification fires a sample payload so an operator can verify their

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -442,6 +443,26 @@ func absolutizeMarkdownLinks(body, baseURL string) string {
 // callers can concatenate "/path" without doubling the separator.
 func normalizeBaseURL(raw string) string {
 	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}
+
+// isLoopbackOrigin reports whether an origin's host is loopback
+// (localhost / 127.0.0.0/8 / ::1). Such an origin only resolves on the server
+// itself, so it's never a valid deep-link target for an external notification
+// client — auto-detection must not persist it (a private LAN IP, by contrast,
+// IS reachable by other devices on the network and is kept).
+func isLoopbackOrigin(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // notifyMarkdownLink matches a markdown inline link: [label](url).

--- a/internal/service/notify_base_url_integration_test.go
+++ b/internal/service/notify_base_url_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestResolveNotifyBaseURL covers the derived deep-link origin: an
+// auto-detected origin is used when no manual override is set, the override
+// wins when present, and clearing the override falls back to detected.
+func TestResolveNotifyBaseURL(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if got := svc.ResolveNotifyBaseURL(ctx); got != "" {
+		t.Fatalf("fresh state base URL = %q, want empty", got)
+	}
+
+	// Detected origin (with a trailing slash) is captured and normalized.
+	if err := svc.SetDetectedNotifyBaseURL(ctx, "https://bb.detected.example/"); err != nil {
+		t.Fatalf("set detected: %v", err)
+	}
+	if got := svc.ResolveNotifyBaseURL(ctx); got != "https://bb.detected.example" {
+		t.Fatalf("after detect, base URL = %q, want https://bb.detected.example", got)
+	}
+
+	// An invalid origin is ignored (best-effort), leaving the prior value.
+	if err := svc.SetDetectedNotifyBaseURL(ctx, "not a url"); err != nil {
+		t.Fatalf("set detected (invalid): %v", err)
+	}
+	if got := svc.ResolveNotifyBaseURL(ctx); got != "https://bb.detected.example" {
+		t.Fatalf("invalid detect should be a no-op, base URL = %q", got)
+	}
+
+	// Manual override wins over detected.
+	override := "https://override.example.com"
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{PublicBaseURL: &override}); err != nil {
+		t.Fatalf("set override: %v", err)
+	}
+	if got := svc.ResolveNotifyBaseURL(ctx); got != override {
+		t.Fatalf("override should win, base URL = %q, want %q", got, override)
+	}
+
+	// Clearing the override falls back to the detected origin.
+	empty := ""
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{PublicBaseURL: &empty}); err != nil {
+		t.Fatalf("clear override: %v", err)
+	}
+	if got := svc.ResolveNotifyBaseURL(ctx); got != "https://bb.detected.example" {
+		t.Fatalf("after clear, base URL = %q, want detected fallback", got)
+	}
+}
+
+// TestDetectedBaseURLAbsolutizesDeepLink proves the derived origin is applied
+// end-to-end: a relative report URL is absolutized against the detected origin
+// when a notification fires (no manual override configured).
+func TestDetectedBaseURLAbsolutizesDeepLink(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	var gotClick atomic.Value
+	gotClick.Store("")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotClick.Store(r.Header.Get("X-Click"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := svc.SetDetectedNotifyBaseURL(ctx, "https://bb.detected.example"); err != nil {
+		t.Fatalf("set detected: %v", err)
+	}
+	if _, err := svc.AddNotificationChannel(ctx, service.AddNotificationChannelParams{Name: "push", URL: srv.URL, Format: "ntfy"}); err != nil {
+		t.Fatalf("add channel: %v", err)
+	}
+
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{
+		Event:    "report",
+		Title:    "deep link",
+		Body:     "body",
+		Priority: "info",
+		URL:      "/reports/abc123",
+	}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	if got := gotClick.Load().(string); got != "https://bb.detected.example/reports/abc123" {
+		t.Fatalf("X-Click = %q, want absolutized against detected origin", got)
+	}
+}

--- a/internal/service/notify_base_url_integration_test.go
+++ b/internal/service/notify_base_url_integration_test.go
@@ -39,6 +39,17 @@ func TestResolveNotifyBaseURL(t *testing.T) {
 		t.Fatalf("invalid detect should be a no-op, base URL = %q", got)
 	}
 
+	// A loopback origin (dev/tunnel visit) must NOT clobber the real detected
+	// origin — it can never be a valid deep-link target for an external client.
+	for _, loop := range []string{"http://localhost:8080", "http://127.0.0.1:9000", "http://[::1]:8080"} {
+		if err := svc.SetDetectedNotifyBaseURL(ctx, loop); err != nil {
+			t.Fatalf("set detected (loopback %s): %v", loop, err)
+		}
+		if got := svc.ResolveNotifyBaseURL(ctx); got != "https://bb.detected.example" {
+			t.Fatalf("loopback %s should be a no-op, base URL = %q", loop, got)
+		}
+	}
+
 	// Manual override wins over detected.
 	override := "https://override.example.com"
 	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{PublicBaseURL: &override}); err != nil {

--- a/internal/service/notify_channels.go
+++ b/internal/service/notify_channels.go
@@ -1,0 +1,237 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"breadbox/internal/appconfig"
+	"breadbox/internal/shortid"
+)
+
+// NotificationChannel is one outbound sink in the multi-channel model. A
+// workflow notification fans out to every enabled channel, each rendered in
+// its own format and gated by its own priority floor. Channels are stored as
+// a JSON array under app_config[notify.channels].
+type NotificationChannel struct {
+	ID          string `json:"id"`           // 8-char short id
+	Name        string `json:"name"`         // operator label ("Family ntfy", "#alerts")
+	URL         string `json:"url"`          // http(s) sink
+	Format      string `json:"format"`       // auto | ntfy | slack | discord | json
+	MinPriority string `json:"min_priority"` // info | warning | critical
+	NtfyToken   string `json:"ntfy_token,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	// LastStatus records the most recent delivery attempt to this channel.
+	LastStatus *NotificationDeliveryStatus `json:"last_status,omitempty"`
+}
+
+// NotificationDeliveryStatus is the per-channel delivery observability record.
+type NotificationDeliveryStatus struct {
+	OK     bool   `json:"ok"`
+	At     string `json:"at"`     // RFC3339
+	Format string `json:"format"` // resolved wire format used
+	Detail string `json:"detail"` // "delivered" or the error string
+}
+
+// AddNotificationChannelParams is the input for creating a channel.
+type AddNotificationChannelParams struct {
+	Name        string
+	URL         string
+	Format      string
+	MinPriority string
+	NtfyToken   string
+}
+
+// loadNotificationChannels returns the configured channels. When none are
+// stored, it synthesizes a single "Default" channel from the legacy single-
+// webhook keys so configs created before the multi-channel model keep
+// delivering. The synthesized channel is not persisted until first edited.
+func (s *Service) loadNotificationChannels(ctx context.Context) []NotificationChannel {
+	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyChannels, ""))
+	if raw != "" {
+		var chans []NotificationChannel
+		if err := json.Unmarshal([]byte(raw), &chans); err == nil {
+			return chans
+		}
+		// Corrupt JSON: fall through to legacy/empty rather than erroring a send.
+	}
+	legacyURL := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""))
+	if legacyURL == "" {
+		return nil
+	}
+	return []NotificationChannel{{
+		ID:          "legacy",
+		Name:        "Default",
+		URL:         legacyURL,
+		Format:      notifyFormatOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto)),
+		MinPriority: notifyMinPriorityOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyMinPriority, appconfig.NotifyMinPriorityInfo)),
+		Enabled:     true,
+	}}
+}
+
+// persistNotificationChannels writes the channel array back to app_config.
+func (s *Service) persistNotificationChannels(ctx context.Context, chans []NotificationChannel) error {
+	if chans == nil {
+		chans = []NotificationChannel{}
+	}
+	b, err := json.Marshal(chans)
+	if err != nil {
+		return fmt.Errorf("marshal notification channels: %w", err)
+	}
+	if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyChannels, string(b))); err != nil {
+		return fmt.Errorf("set notify_channels: %w", err)
+	}
+	return nil
+}
+
+// GetNotificationChannels returns the configured channels for display. The
+// returned slice always reflects the persisted (or synthesized-legacy) state.
+func (s *Service) GetNotificationChannels(ctx context.Context) ([]NotificationChannel, error) {
+	return s.loadNotificationChannels(ctx), nil
+}
+
+// AddNotificationChannel validates and appends a new enabled channel,
+// migrating any synthesized legacy channel into the persisted array so the
+// existing sink is preserved alongside the new one.
+func (s *Service) AddNotificationChannel(ctx context.Context, p AddNotificationChannelParams) (*NotificationChannel, error) {
+	url := strings.TrimSpace(p.URL)
+	if err := validateNotifyURL(url); err != nil {
+		return nil, err
+	}
+	format := strings.TrimSpace(p.Format)
+	if format == "" {
+		format = appconfig.NotifyFormatAuto
+	}
+	if !validNotifyFormat(format) {
+		return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, or json", ErrInvalidParameter)
+	}
+	minPriority := strings.TrimSpace(p.MinPriority)
+	if minPriority == "" {
+		minPriority = appconfig.NotifyMinPriorityInfo
+	}
+	if !validNotifyMinPriority(minPriority) {
+		return nil, fmt.Errorf("%w: minimum priority must be info, warning, or critical", ErrInvalidParameter)
+	}
+	id, err := shortid.Generate()
+	if err != nil {
+		return nil, fmt.Errorf("generate channel id: %w", err)
+	}
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		name = defaultChannelName(url)
+	}
+	ch := NotificationChannel{
+		ID:          id,
+		Name:        name,
+		URL:         url,
+		Format:      format,
+		MinPriority: minPriority,
+		NtfyToken:   strings.TrimSpace(p.NtfyToken),
+		Enabled:     true,
+	}
+	chans := s.persistedOrMigratedChannels(ctx)
+	chans = append(chans, ch)
+	if err := s.persistNotificationChannels(ctx, chans); err != nil {
+		return nil, err
+	}
+	return &ch, nil
+}
+
+// SetNotificationChannelEnabled flips a channel's enabled flag.
+func (s *Service) SetNotificationChannelEnabled(ctx context.Context, id string, enabled bool) error {
+	chans := s.persistedOrMigratedChannels(ctx)
+	found := false
+	for i := range chans {
+		if chans[i].ID == id {
+			chans[i].Enabled = enabled
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("%w: notification channel not found", ErrNotFound)
+	}
+	return s.persistNotificationChannels(ctx, chans)
+}
+
+// DeleteNotificationChannel removes a channel by id.
+func (s *Service) DeleteNotificationChannel(ctx context.Context, id string) error {
+	chans := s.persistedOrMigratedChannels(ctx)
+	out := chans[:0]
+	found := false
+	for _, c := range chans {
+		if c.ID == id {
+			found = true
+			continue
+		}
+		out = append(out, c)
+	}
+	if !found {
+		return fmt.Errorf("%w: notification channel not found", ErrNotFound)
+	}
+	return s.persistNotificationChannels(ctx, out)
+}
+
+// SendTestToChannel delivers a sample notification to a single channel and
+// records its status — backs the per-channel "Send test" button.
+func (s *Service) SendTestToChannel(ctx context.Context, id string) error {
+	chans := s.persistedOrMigratedChannels(ctx)
+	idx := -1
+	for i := range chans {
+		if chans[i].ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("%w: notification channel not found", ErrNotFound)
+	}
+	baseURL := normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""))
+	p := testNotificationPayload()
+	err := s.sendToChannel(ctx, &chans[idx], p, baseURL)
+	// Best-effort persist of the recorded status.
+	_ = s.persistNotificationChannels(ctx, chans)
+	return err
+}
+
+// persistedOrMigratedChannels returns the persisted channel array, first
+// migrating a synthesized legacy channel into storage if that's all there is.
+// This guarantees a mutation (add/toggle/delete) operates on a real array.
+func (s *Service) persistedOrMigratedChannels(ctx context.Context) []NotificationChannel {
+	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyChannels, ""))
+	if raw != "" {
+		var chans []NotificationChannel
+		if err := json.Unmarshal([]byte(raw), &chans); err == nil {
+			return chans
+		}
+	}
+	return s.loadNotificationChannels(ctx) // legacy-synth (or nil)
+}
+
+// defaultChannelName derives a friendly label from a URL host when the
+// operator didn't name the channel.
+func defaultChannelName(rawURL string) string {
+	if h := urlHost(rawURL); h != "" {
+		return h
+	}
+	return "Channel"
+}
+
+// testNotificationPayload is the shared sample payload for test sends.
+func testNotificationPayload() NotificationPayload {
+	return NotificationPayload{
+		Event:    "test",
+		Title:    "Breadbox notification test",
+		Body:     "If you can see this, this channel is wired up correctly.",
+		Priority: "info",
+	}
+}
+
+// nowRFC3339 is the timestamp helper for delivery records.
+func nowRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}

--- a/internal/service/notify_channels.go
+++ b/internal/service/notify_channels.go
@@ -190,7 +190,7 @@ func (s *Service) SendTestToChannel(ctx context.Context, id string) error {
 	if idx == -1 {
 		return fmt.Errorf("%w: notification channel not found", ErrNotFound)
 	}
-	baseURL := normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""))
+	baseURL := s.ResolveNotifyBaseURL(ctx)
 	p := testNotificationPayload()
 	err := s.sendToChannel(ctx, &chans[idx], p, baseURL)
 	// Best-effort persist of the recorded status.

--- a/internal/service/notify_channels.go
+++ b/internal/service/notify_channels.go
@@ -107,7 +107,7 @@ func (s *Service) AddNotificationChannel(ctx context.Context, p AddNotificationC
 		format = appconfig.NotifyFormatAuto
 	}
 	if !validNotifyFormat(format) {
-		return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, or json", ErrInvalidParameter)
+		return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, googlechat, or json", ErrInvalidParameter)
 	}
 	minPriority := strings.TrimSpace(p.MinPriority)
 	if minPriority == "" {

--- a/internal/service/notify_channels.go
+++ b/internal/service/notify_channels.go
@@ -141,6 +141,79 @@ func (s *Service) AddNotificationChannel(ctx context.Context, p AddNotificationC
 	return &ch, nil
 }
 
+// UpdateNotificationChannelParams holds the editable fields of a channel. URL
+// and NtfyToken are pointers so the edit form can leave a secret blank to keep
+// the current value (nil = keep, non-nil = replace) — neither is rendered back
+// into the page, so a blank submit must not wipe them.
+type UpdateNotificationChannelParams struct {
+	Name        string
+	URL         *string
+	Format      string
+	MinPriority string
+	NtfyToken   *string
+	Enabled     bool
+}
+
+// UpdateNotificationChannel edits an existing channel in place. A nil URL or
+// NtfyToken keeps the stored value; the format/priority are normalized and
+// validated like Add. Returns ErrNotFound if no channel matches id.
+func (s *Service) UpdateNotificationChannel(ctx context.Context, id string, p UpdateNotificationChannelParams) (*NotificationChannel, error) {
+	chans := s.persistedOrMigratedChannels(ctx)
+	idx := -1
+	for i := range chans {
+		if chans[i].ID == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil, fmt.Errorf("%w: notification channel not found", ErrNotFound)
+	}
+
+	url := chans[idx].URL
+	if p.URL != nil {
+		if u := strings.TrimSpace(*p.URL); u != "" {
+			if err := validateNotifyURL(u); err != nil {
+				return nil, err
+			}
+			url = u
+		}
+	}
+	format := strings.TrimSpace(p.Format)
+	if format == "" {
+		format = appconfig.NotifyFormatAuto
+	}
+	if !validNotifyFormat(format) {
+		return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, googlechat, or json", ErrInvalidParameter)
+	}
+	minPriority := strings.TrimSpace(p.MinPriority)
+	if minPriority == "" {
+		minPriority = appconfig.NotifyMinPriorityInfo
+	}
+	if !validNotifyMinPriority(minPriority) {
+		return nil, fmt.Errorf("%w: minimum priority must be info, warning, or critical", ErrInvalidParameter)
+	}
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		name = defaultChannelName(url)
+	}
+	token := chans[idx].NtfyToken
+	if p.NtfyToken != nil {
+		token = strings.TrimSpace(*p.NtfyToken)
+	}
+
+	chans[idx].Name = name
+	chans[idx].URL = url
+	chans[idx].Format = format
+	chans[idx].MinPriority = minPriority
+	chans[idx].NtfyToken = token
+	chans[idx].Enabled = p.Enabled
+	if err := s.persistNotificationChannels(ctx, chans); err != nil {
+		return nil, err
+	}
+	return &chans[idx], nil
+}
+
 // SetNotificationChannelEnabled flips a channel's enabled flag.
 func (s *Service) SetNotificationChannelEnabled(ctx context.Context, id string, enabled bool) error {
 	chans := s.persistedOrMigratedChannels(ctx)

--- a/internal/service/notify_channels_integration_test.go
+++ b/internal/service/notify_channels_integration_test.go
@@ -1,0 +1,159 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestNotifyMultiChannelFanout configures two channels in different formats
+// and verifies a single report reaches both, each in its own wire shape, with
+// per-channel delivery status recorded.
+func TestNotifyMultiChannelFanout(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	var ntfyHits, jsonHits atomic.Int32
+	var sawNtfyTitle, sawJSONBody atomic.Bool
+
+	ntfySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ntfyHits.Add(1)
+		if r.Header.Get("X-Title") != "" {
+			sawNtfyTitle.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ntfySrv.Close()
+	jsonSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonHits.Add(1)
+		b, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(b), `"event"`) {
+			sawJSONBody.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer jsonSrv.Close()
+
+	ch1, err := svc.AddNotificationChannel(ctx, service.AddNotificationChannelParams{Name: "push", URL: ntfySrv.URL, Format: "ntfy"})
+	if err != nil {
+		t.Fatalf("add ntfy channel: %v", err)
+	}
+	if _, err := svc.AddNotificationChannel(ctx, service.AddNotificationChannelParams{Name: "bridge", URL: jsonSrv.URL, Format: "json"}); err != nil {
+		t.Fatalf("add json channel: %v", err)
+	}
+
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "fanout", Body: "x", Priority: "info"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if ntfyHits.Load() != 1 || jsonHits.Load() != 1 {
+		t.Fatalf("fan-out hits: ntfy=%d json=%d, want 1/1", ntfyHits.Load(), jsonHits.Load())
+	}
+	if !sawNtfyTitle.Load() {
+		t.Error("ntfy channel did not receive X-Title header")
+	}
+	if !sawJSONBody.Load() {
+		t.Error("json channel did not receive JSON envelope")
+	}
+
+	// Per-channel status recorded + persisted.
+	chans, _ := svc.GetNotificationChannels(ctx)
+	if len(chans) != 2 {
+		t.Fatalf("channels = %d, want 2", len(chans))
+	}
+	for _, c := range chans {
+		if c.LastStatus == nil || !c.LastStatus.OK {
+			t.Errorf("channel %q missing OK status: %+v", c.Name, c.LastStatus)
+		}
+	}
+
+	// Disable the json channel → only ntfy is hit next time.
+	if err := svc.SetNotificationChannelEnabled(ctx, ch1.ID, true); err != nil { // no-op enable, sanity
+		t.Fatalf("enable: %v", err)
+	}
+	var jsonID string
+	for _, c := range chans {
+		if c.Name == "bridge" {
+			jsonID = c.ID
+		}
+	}
+	if err := svc.SetNotificationChannelEnabled(ctx, jsonID, false); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "again", Body: "x", Priority: "info"}); err != nil {
+		t.Fatalf("send 2: %v", err)
+	}
+	if ntfyHits.Load() != 2 || jsonHits.Load() != 1 {
+		t.Fatalf("after disable: ntfy=%d json=%d, want 2/1", ntfyHits.Load(), jsonHits.Load())
+	}
+
+	// Delete the disabled channel.
+	if err := svc.DeleteNotificationChannel(ctx, jsonID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	chans, _ = svc.GetNotificationChannels(ctx)
+	if len(chans) != 1 {
+		t.Fatalf("after delete channels = %d, want 1", len(chans))
+	}
+}
+
+// TestNotifyChannelBackCompat verifies a legacy single-webhook config is
+// surfaced as one synthesized channel.
+func TestNotifyChannelBackCompat(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	url := "https://ntfy.sh/legacy-topic"
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{WebhookURL: &url}); err != nil {
+		t.Fatalf("set legacy webhook: %v", err)
+	}
+	chans, _ := svc.GetNotificationChannels(ctx)
+	if len(chans) != 1 {
+		t.Fatalf("channels = %d, want 1 synthesized", len(chans))
+	}
+	if chans[0].URL != url || !chans[0].Enabled {
+		t.Errorf("synth channel = %+v", chans[0])
+	}
+	if !svc.WorkflowNotificationConfigured(ctx) {
+		t.Error("expected configured via legacy synth channel")
+	}
+}
+
+// TestNotifyPerChannelFloor verifies each channel's own priority floor gates
+// fan-out independently.
+func TestNotifyPerChannelFloor(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if _, err := svc.AddNotificationChannel(ctx, service.AddNotificationChannelParams{Name: "crit", URL: srv.URL, Format: "json", MinPriority: "critical"}); err != nil {
+		t.Fatalf("add channel: %v", err)
+	}
+	// Warning report is below the critical floor → skipped.
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "warn", Body: "x", Priority: "warning"}); err != nil {
+		t.Fatalf("send warning: %v", err)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("warning delivered despite critical floor (hits=%d)", hits.Load())
+	}
+	// Critical report clears the floor.
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "crit", Body: "x", Priority: "critical"}); err != nil {
+		t.Fatalf("send critical: %v", err)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("critical not delivered (hits=%d)", hits.Load())
+	}
+}

--- a/internal/service/notify_ntfy_unit_test.go
+++ b/internal/service/notify_ntfy_unit_test.go
@@ -148,12 +148,18 @@ func TestBuildNtfyRequest(t *testing.T) {
 		Priority: "warning",
 		URL:      "https://bb.example.com/reports/xyz",
 	}
-	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/breadbox", p, "https://bb.example.com")
+	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/breadbox", p, "https://bb.example.com", "tk_secret")
 	if err != nil {
 		t.Fatalf("buildNtfyRequest: %v", err)
 	}
 	if req.Method != "POST" {
 		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tk_secret" {
+		t.Errorf("Authorization = %q, want Bearer tk_secret", got)
+	}
+	if got := req.Header.Get("X-Actions"); got != "view, View report, https://bb.example.com/reports/xyz" {
+		t.Errorf("X-Actions = %q", got)
 	}
 	if got := req.Header.Get("X-Title"); got != "Large charge detected" {
 		t.Errorf("X-Title = %q", got)
@@ -181,18 +187,24 @@ func TestBuildNtfyRequest_RelativeClickDropped(t *testing.T) {
 	// Without a public base URL the deep link stays relative; ntfy needs an
 	// absolute URL for X-Click, so it must be omitted rather than sent broken.
 	p := NotificationPayload{Title: "Test", Body: "hi", Priority: "info", URL: "/reports/xyz"}
-	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/t", p, "")
+	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/t", p, "", "")
 	if err != nil {
 		t.Fatalf("buildNtfyRequest: %v", err)
 	}
 	if got := req.Header.Get("X-Click"); got != "" {
 		t.Errorf("X-Click = %q, want empty for relative URL", got)
 	}
+	if got := req.Header.Get("X-Actions"); got != "" {
+		t.Errorf("X-Actions = %q, want empty for relative URL", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty when no token", got)
+	}
 }
 
 func TestBuildNtfyRequest_EmptyBodyFallsBackToTitle(t *testing.T) {
 	p := NotificationPayload{Title: "Sync watchdog", Body: "", Priority: "info"}
-	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/t", p, "")
+	req, err := buildNtfyRequest(t.Context(), "https://ntfy.sh/t", p, "", "")
 	if err != nil {
 		t.Fatalf("buildNtfyRequest: %v", err)
 	}

--- a/internal/service/notify_ntfy_unit_test.go
+++ b/internal/service/notify_ntfy_unit_test.go
@@ -24,7 +24,7 @@ func TestResolveNotifyFormat(t *testing.T) {
 		{"explicit json wins", appconfig.NotifyFormatJSON, "https://ntfy.sh/topic", appconfig.NotifyFormatJSON},
 		{"auto detects ntfy.sh", appconfig.NotifyFormatAuto, "https://ntfy.sh/breadbox", appconfig.NotifyFormatNtfy},
 		{"auto detects self-hosted ntfy", appconfig.NotifyFormatAuto, "https://push.ntfy.example.com/t", appconfig.NotifyFormatNtfy},
-		{"auto falls back to json", appconfig.NotifyFormatAuto, "https://hooks.slack.com/services/x", appconfig.NotifyFormatJSON},
+		{"auto falls back to json", appconfig.NotifyFormatAuto, "https://example.com/generic-hook", appconfig.NotifyFormatJSON},
 		{"empty configured behaves as auto", "", "https://ntfy.sh/t", appconfig.NotifyFormatNtfy},
 		{"unknown configured behaves as auto", "garbage", "https://example.com/h", appconfig.NotifyFormatJSON},
 	}
@@ -203,12 +203,12 @@ func TestBuildNtfyRequest_EmptyBodyFallsBackToTitle(t *testing.T) {
 }
 
 func TestValidNotifyFormat(t *testing.T) {
-	for _, v := range []string{"auto", "ntfy", "json"} {
+	for _, v := range []string{"auto", "ntfy", "slack", "discord", "json"} {
 		if !validNotifyFormat(v) {
 			t.Errorf("validNotifyFormat(%q) = false, want true", v)
 		}
 	}
-	for _, v := range []string{"", "JSON", "slack", "Ntfy"} {
+	for _, v := range []string{"", "JSON", "Slack", "Ntfy", "webhook"} {
 		if validNotifyFormat(v) {
 			t.Errorf("validNotifyFormat(%q) = true, want false", v)
 		}

--- a/internal/service/notify_providers_unit_test.go
+++ b/internal/service/notify_providers_unit_test.go
@@ -43,6 +43,7 @@ func TestResolveNotifyFormat_Providers(t *testing.T) {
 	}{
 		{appconfig.NotifyFormatAuto, "https://hooks.slack.com/services/x", appconfig.NotifyFormatSlack},
 		{appconfig.NotifyFormatAuto, "https://discord.com/api/webhooks/1/a", appconfig.NotifyFormatDiscord},
+		{appconfig.NotifyFormatAuto, "https://chat.googleapis.com/v1/spaces/AAA/messages?key=k&token=t", appconfig.NotifyFormatGoogleChat},
 		{appconfig.NotifyFormatAuto, "https://ntfy.sh/t", appconfig.NotifyFormatNtfy},
 		{appconfig.NotifyFormatAuto, "https://example.com/h", appconfig.NotifyFormatJSON},
 		{appconfig.NotifyFormatSlack, "https://ntfy.sh/t", appconfig.NotifyFormatSlack},     // explicit overrides sniff
@@ -110,6 +111,43 @@ func TestBuildSlackRequest(t *testing.T) {
 		if !strings.Contains(text, w) {
 			t.Errorf("slack text missing %q\ngot: %q", w, text)
 		}
+	}
+}
+
+func TestBuildGoogleChatRequest(t *testing.T) {
+	p := NotificationPayload{
+		Title:    "Sync watchdog",
+		Body:     "Last sync **failed**. See [logs](https://bb/logs).",
+		Priority: "critical",
+		URL:      "https://bb/reports/xyz",
+	}
+	req, err := buildGoogleChatRequest(t.Context(), "https://chat.googleapis.com/v1/spaces/A/messages?key=k", p)
+	if err != nil {
+		t.Fatalf("buildGoogleChatRequest: %v", err)
+	}
+	if ct := req.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	text := decodeJSONField(t, req, "text")
+	// Single-asterisk bold title, mrkdwn link conversion, unicode emoji (not a
+	// :shortcode:), and the view-report link.
+	wants := []string{"\U0001F6A8", "*Sync watchdog*", "*failed*", "<https://bb/logs|logs>", "<https://bb/reports/xyz|View report →>"}
+	for _, w := range wants {
+		if !strings.Contains(text, w) {
+			t.Errorf("googlechat text missing %q\ngot: %q", w, text)
+		}
+	}
+	if strings.Contains(text, ":rotating_light:") {
+		t.Errorf("googlechat should use unicode emoji, not a shortcode: %q", text)
+	}
+}
+
+func TestLooksLikeGoogleChat(t *testing.T) {
+	if !looksLikeGoogleChat("https://chat.googleapis.com/v1/spaces/A/messages?key=k&token=t") {
+		t.Error("google chat webhook not detected")
+	}
+	if looksLikeGoogleChat("https://hooks.slack.com/services/x") {
+		t.Error("slack detected as google chat")
 	}
 }
 

--- a/internal/service/notify_providers_unit_test.go
+++ b/internal/service/notify_providers_unit_test.go
@@ -1,0 +1,180 @@
+//go:build !lite
+
+package service
+
+// Unit tests (no DB) for the Slack/Discord publishing paths, provider
+// auto-detection, the priority floor, and the retry classifier.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"breadbox/internal/appconfig"
+)
+
+func TestLooksLikeSlackAndDiscord(t *testing.T) {
+	if !looksLikeSlack("https://hooks.slack.com/services/T0/B0/xyz") {
+		t.Error("slack webhook not detected")
+	}
+	if looksLikeSlack("https://example.com/hook") {
+		t.Error("non-slack detected as slack")
+	}
+	discord := []string{
+		"https://discord.com/api/webhooks/123/abc",
+		"https://discordapp.com/api/webhooks/123/abc",
+		"https://ptb.discord.com/api/webhooks/123/abc",
+	}
+	for _, u := range discord {
+		if !looksLikeDiscord(u) {
+			t.Errorf("discord webhook not detected: %s", u)
+		}
+	}
+	if looksLikeDiscord("https://discord.com/channels/123") {
+		t.Error("non-webhook discord URL detected as webhook")
+	}
+}
+
+func TestResolveNotifyFormat_Providers(t *testing.T) {
+	cases := []struct {
+		configured, url, want string
+	}{
+		{appconfig.NotifyFormatAuto, "https://hooks.slack.com/services/x", appconfig.NotifyFormatSlack},
+		{appconfig.NotifyFormatAuto, "https://discord.com/api/webhooks/1/a", appconfig.NotifyFormatDiscord},
+		{appconfig.NotifyFormatAuto, "https://ntfy.sh/t", appconfig.NotifyFormatNtfy},
+		{appconfig.NotifyFormatAuto, "https://example.com/h", appconfig.NotifyFormatJSON},
+		{appconfig.NotifyFormatSlack, "https://ntfy.sh/t", appconfig.NotifyFormatSlack},     // explicit overrides sniff
+		{appconfig.NotifyFormatDiscord, "https://example.com/h", appconfig.NotifyFormatDiscord},
+	}
+	for _, tc := range cases {
+		if got := resolveNotifyFormat(tc.configured, tc.url); got != tc.want {
+			t.Errorf("resolveNotifyFormat(%q,%q)=%q want %q", tc.configured, tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestPriorityRank(t *testing.T) {
+	if !(priorityRank("info") < priorityRank("warning") && priorityRank("warning") < priorityRank("critical")) {
+		t.Error("priority ranks not ordered info<warning<critical")
+	}
+	if priorityRank("bogus") != priorityRank("info") {
+		t.Error("unknown priority should rank as info")
+	}
+}
+
+func TestToSlackMrkdwn(t *testing.T) {
+	in := "A **bold** word and a [link](https://x.com/a)."
+	got := toSlackMrkdwn(in)
+	if !strings.Contains(got, "*bold*") {
+		t.Errorf("bold not converted: %q", got)
+	}
+	if !strings.Contains(got, "<https://x.com/a|link>") {
+		t.Errorf("link not converted: %q", got)
+	}
+	if strings.Contains(got, "**") || strings.Contains(got, "](") {
+		t.Errorf("markdown left over: %q", got)
+	}
+}
+
+// decodeJSONField reads the request body and returns one string field.
+func decodeJSONField(t *testing.T, r *http.Request, field string) string {
+	t.Helper()
+	b, _ := io.ReadAll(r.Body)
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("body not JSON: %v (%s)", err, string(b))
+	}
+	s, _ := m[field].(string)
+	return s
+}
+
+func TestBuildSlackRequest(t *testing.T) {
+	p := NotificationPayload{
+		Title:    "Large charge",
+		Body:     "A **$420** charge. See [tx](https://bb/tx/abc).",
+		Priority: "critical",
+		URL:      "https://bb/reports/xyz",
+	}
+	req, err := buildSlackRequest(t.Context(), "https://hooks.slack.com/services/x", p)
+	if err != nil {
+		t.Fatalf("buildSlackRequest: %v", err)
+	}
+	if ct := req.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	text := decodeJSONField(t, req, "text")
+	wants := []string{":rotating_light:", "*Large charge*", "*$420*", "<https://bb/tx/abc|tx>", "<https://bb/reports/xyz|View report →>"}
+	for _, w := range wants {
+		if !strings.Contains(text, w) {
+			t.Errorf("slack text missing %q\ngot: %q", w, text)
+		}
+	}
+}
+
+func TestBuildDiscordRequest(t *testing.T) {
+	p := NotificationPayload{
+		Title:    "Spending spike",
+		Body:     "Dining up **3×** this week.",
+		Priority: "warning",
+		URL:      "https://bb/reports/xyz",
+	}
+	req, err := buildDiscordRequest(t.Context(), "https://discord.com/api/webhooks/1/a", p)
+	if err != nil {
+		t.Fatalf("buildDiscordRequest: %v", err)
+	}
+	content := decodeJSONField(t, req, "content")
+	wants := []string{":warning:", "**Spending spike**", "**3×**", "https://bb/reports/xyz"}
+	for _, w := range wants {
+		if !strings.Contains(content, w) {
+			t.Errorf("discord content missing %q\ngot: %q", w, content)
+		}
+	}
+}
+
+func TestBuildDiscordRequest_TruncatesAt2000(t *testing.T) {
+	p := NotificationPayload{Title: "T", Body: strings.Repeat("x", 5000), Priority: "info"}
+	req, err := buildDiscordRequest(t.Context(), "https://discord.com/api/webhooks/1/a", p)
+	if err != nil {
+		t.Fatalf("buildDiscordRequest: %v", err)
+	}
+	content := decodeJSONField(t, req, "content")
+	if n := len([]rune(content)); n > 2000 {
+		t.Errorf("discord content = %d runes, want ≤ 2000", n)
+	}
+	if !strings.HasSuffix(content, "…") {
+		t.Error("truncated content should end with ellipsis")
+	}
+}
+
+func TestNotifyRetriableStatus(t *testing.T) {
+	retriable := []int{429, 500, 502, 503}
+	permanent := []int{400, 401, 403, 404, 422}
+	for _, c := range retriable {
+		if !notifyRetriableStatus(c) {
+			t.Errorf("status %d should be retriable", c)
+		}
+	}
+	for _, c := range permanent {
+		if notifyRetriableStatus(c) {
+			t.Errorf("status %d should be permanent", c)
+		}
+	}
+}
+
+func TestValidNotifyMinPriority(t *testing.T) {
+	for _, v := range []string{"info", "warning", "critical"} {
+		if !validNotifyMinPriority(v) {
+			t.Errorf("%q should be valid", v)
+		}
+	}
+	for _, v := range []string{"", "low", "urgent"} {
+		if validNotifyMinPriority(v) {
+			t.Errorf("%q should be invalid", v)
+		}
+	}
+	if notifyMinPriorityOrDefault("bogus") != appconfig.NotifyMinPriorityInfo {
+		t.Error("bogus floor should default to info")
+	}
+}

--- a/internal/service/notify_retry_floor_integration_test.go
+++ b/internal/service/notify_retry_floor_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestNotifyRetriesTransientThenSucceeds verifies the send is retried on a
+// 5xx and succeeds once the sink recovers.
+func TestNotifyRetriesTransientThenSucceeds(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable) // 503 → retriable
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{WebhookURL: &srv.URL}); err != nil {
+		t.Fatalf("set webhook: %v", err)
+	}
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "test", Title: "retry", Body: "x", Priority: "info"}); err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if n := attempts.Load(); n != 3 {
+		t.Errorf("attempts = %d, want 3 (two 503s then OK)", n)
+	}
+}
+
+// TestNotifyFailsFastOn4xx verifies a permanent 4xx is not retried.
+func TestNotifyFailsFastOn4xx(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest) // 400 → permanent
+	}))
+	defer srv.Close()
+
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{WebhookURL: &srv.URL}); err != nil {
+		t.Fatalf("set webhook: %v", err)
+	}
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "test", Title: "nope", Body: "x", Priority: "info"}); err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if n := attempts.Load(); n != 1 {
+		t.Errorf("attempts = %d, want 1 (4xx must not retry)", n)
+	}
+}
+
+// TestNotifyMinPriorityFloor verifies reports below the floor are dropped,
+// reports at/above it are delivered, and a test notification always goes.
+func TestNotifyMinPriorityFloor(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	floor := "warning"
+	if _, err := svc.UpdateNotificationSettings(ctx, service.UpdateNotificationSettingsParams{
+		WebhookURL:  &srv.URL,
+		MinPriority: &floor,
+	}); err != nil {
+		t.Fatalf("set settings: %v", err)
+	}
+
+	// Below floor → dropped, no HTTP call.
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "info report", Body: "x", Priority: "info"}); err != nil {
+		t.Fatalf("info send returned error: %v", err)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("info report was delivered despite warning floor (hits=%d)", hits.Load())
+	}
+
+	// At floor → delivered.
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "report", Title: "warn report", Body: "x", Priority: "warning"}); err != nil {
+		t.Fatalf("warning send returned error: %v", err)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("warning report not delivered (hits=%d)", hits.Load())
+	}
+
+	// Test notifications bypass the floor.
+	if err := svc.SendWorkflowNotification(ctx, service.NotificationPayload{Event: "test", Title: "test", Body: "x", Priority: "info"}); err != nil {
+		t.Fatalf("test send returned error: %v", err)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("test notification did not bypass floor (hits=%d)", hits.Load())
+	}
+}

--- a/internal/service/notify_settings.go
+++ b/internal/service/notify_settings.go
@@ -69,6 +69,13 @@ func (s *Service) SetDetectedNotifyBaseURL(ctx context.Context, origin string) e
 	if normalized == "" || validateNotifyURL(normalized) != nil {
 		return nil
 	}
+	// A loopback origin (localhost/127.0.0.1) is only reachable from the server
+	// itself — persisting it would bake dead deep links into every background
+	// notification. So a dev/tunnel visit to the settings page doesn't clobber
+	// a real public (or LAN) origin captured from a normal visit.
+	if isLoopbackOrigin(normalized) {
+		return nil
+	}
 	if normalized == normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyDetectedBaseURL, "")) {
 		return nil
 	}

--- a/internal/service/notify_settings.go
+++ b/internal/service/notify_settings.go
@@ -14,10 +14,15 @@ import (
 // Notifications page. Unlike credential settings, nothing here is secret —
 // the webhook URL, format, and public base URL all surface in plaintext.
 type NotificationSettingsResponse struct {
-	WebhookURL    string `json:"webhook_url"`
-	Format        string `json:"format"`       // auto | ntfy | slack | discord | json
+	WebhookURL string `json:"webhook_url"`
+	Format     string `json:"format"` // auto | ntfy | slack | discord | json
+	// PublicBaseURL is the manual override (empty = auto-detect).
 	PublicBaseURL string `json:"public_base_url"`
-	MinPriority   string `json:"min_priority"` // info | warning | critical
+	// DetectedBaseURL is the origin auto-captured from the admin's last
+	// visit to the settings page (read-only; surfaced so the UI can show
+	// the effective deep-link origin).
+	DetectedBaseURL string `json:"detected_base_url"`
+	MinPriority     string `json:"min_priority"` // info | warning | critical
 }
 
 // UpdateNotificationSettingsParams holds the writable notification settings.
@@ -33,11 +38,44 @@ type UpdateNotificationSettingsParams struct {
 // GetNotificationSettings reads the notify.* keys from app_config.
 func (s *Service) GetNotificationSettings(ctx context.Context) (*NotificationSettingsResponse, error) {
 	return &NotificationSettingsResponse{
-		WebhookURL:    appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""),
-		Format:        notifyFormatOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto)),
-		PublicBaseURL: appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""),
-		MinPriority:   notifyMinPriorityOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyMinPriority, appconfig.NotifyMinPriorityInfo)),
+		WebhookURL:      appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""),
+		Format:          notifyFormatOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto)),
+		PublicBaseURL:   appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""),
+		DetectedBaseURL: appconfig.String(ctx, s.Queries, appconfig.KeyNotifyDetectedBaseURL, ""),
+		MinPriority:     notifyMinPriorityOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyMinPriority, appconfig.NotifyMinPriorityInfo)),
 	}, nil
+}
+
+// ResolveNotifyBaseURL returns the effective origin prepended to report
+// deep links at send time: the manual override (KeyNotifyPublicBaseURL)
+// when set, otherwise the origin auto-detected from the admin's last visit
+// to the settings page (KeyNotifyDetectedBaseURL). Empty when neither is
+// known — deep links then stay relative. The result is normalized (no
+// trailing slash).
+func (s *Service) ResolveNotifyBaseURL(ctx context.Context) string {
+	if override := normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, "")); override != "" {
+		return override
+	}
+	return normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyDetectedBaseURL, ""))
+}
+
+// SetDetectedNotifyBaseURL records the origin Breadbox is currently being
+// browsed from so background notification sends can build absolute deep
+// links. It is a best-effort write-through: invalid origins are ignored, and
+// the write is skipped when the stored value already matches (so a normal
+// page load doesn't churn app_config on every request).
+func (s *Service) SetDetectedNotifyBaseURL(ctx context.Context, origin string) error {
+	normalized := normalizeBaseURL(origin)
+	if normalized == "" || validateNotifyURL(normalized) != nil {
+		return nil
+	}
+	if normalized == normalizeBaseURL(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyDetectedBaseURL, "")) {
+		return nil
+	}
+	if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyDetectedBaseURL, normalized)); err != nil {
+		return fmt.Errorf("set notify_detected_base_url: %w", err)
+	}
+	return nil
 }
 
 // UpdateNotificationSettings validates and writes the non-nil fields, then

--- a/internal/service/notify_settings.go
+++ b/internal/service/notify_settings.go
@@ -61,7 +61,7 @@ func (s *Service) UpdateNotificationSettings(ctx context.Context, p UpdateNotifi
 			format = appconfig.NotifyFormatAuto
 		}
 		if !validNotifyFormat(format) {
-			return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, or json", ErrInvalidParameter)
+			return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, googlechat, or json", ErrInvalidParameter)
 		}
 		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyFormat, format)); err != nil {
 			return nil, fmt.Errorf("set notify_format: %w", err)
@@ -98,7 +98,7 @@ func validNotifyFormat(v string) bool {
 	switch v {
 	case appconfig.NotifyFormatAuto, appconfig.NotifyFormatNtfy,
 		appconfig.NotifyFormatSlack, appconfig.NotifyFormatDiscord,
-		appconfig.NotifyFormatJSON:
+		appconfig.NotifyFormatGoogleChat, appconfig.NotifyFormatJSON:
 		return true
 	default:
 		return false

--- a/internal/service/notify_settings.go
+++ b/internal/service/notify_settings.go
@@ -15,17 +15,19 @@ import (
 // the webhook URL, format, and public base URL all surface in plaintext.
 type NotificationSettingsResponse struct {
 	WebhookURL    string `json:"webhook_url"`
-	Format        string `json:"format"` // auto | ntfy | json
+	Format        string `json:"format"`       // auto | ntfy | slack | discord | json
 	PublicBaseURL string `json:"public_base_url"`
+	MinPriority   string `json:"min_priority"` // info | warning | critical
 }
 
 // UpdateNotificationSettingsParams holds the writable notification settings.
 // Nil = leave untouched; an empty string clears the value (webhook/base URL)
-// or resets to the default (format → auto).
+// or resets to the default (format → auto, min_priority → info).
 type UpdateNotificationSettingsParams struct {
 	WebhookURL    *string
 	Format        *string
 	PublicBaseURL *string
+	MinPriority   *string
 }
 
 // GetNotificationSettings reads the notify.* keys from app_config.
@@ -34,6 +36,7 @@ func (s *Service) GetNotificationSettings(ctx context.Context) (*NotificationSet
 		WebhookURL:    appconfig.String(ctx, s.Queries, appconfig.KeyNotifyWebhookURL, ""),
 		Format:        notifyFormatOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyFormat, appconfig.NotifyFormatAuto)),
 		PublicBaseURL: appconfig.String(ctx, s.Queries, appconfig.KeyNotifyPublicBaseURL, ""),
+		MinPriority:   notifyMinPriorityOrDefault(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyMinPriority, appconfig.NotifyMinPriorityInfo)),
 	}, nil
 }
 
@@ -58,10 +61,22 @@ func (s *Service) UpdateNotificationSettings(ctx context.Context, p UpdateNotifi
 			format = appconfig.NotifyFormatAuto
 		}
 		if !validNotifyFormat(format) {
-			return nil, fmt.Errorf("%w: notification format must be auto, ntfy, or json", ErrInvalidParameter)
+			return nil, fmt.Errorf("%w: notification format must be auto, ntfy, slack, discord, or json", ErrInvalidParameter)
 		}
 		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyFormat, format)); err != nil {
 			return nil, fmt.Errorf("set notify_format: %w", err)
+		}
+	}
+	if p.MinPriority != nil {
+		mp := strings.TrimSpace(*p.MinPriority)
+		if mp == "" {
+			mp = appconfig.NotifyMinPriorityInfo
+		}
+		if !validNotifyMinPriority(mp) {
+			return nil, fmt.Errorf("%w: minimum priority must be info, warning, or critical", ErrInvalidParameter)
+		}
+		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyNotifyMinPriority, mp)); err != nil {
+			return nil, fmt.Errorf("set notify_min_priority: %w", err)
 		}
 	}
 	if p.PublicBaseURL != nil {
@@ -81,7 +96,9 @@ func (s *Service) UpdateNotificationSettings(ctx context.Context, p UpdateNotifi
 // validNotifyFormat reports whether v is one of the canonical format values.
 func validNotifyFormat(v string) bool {
 	switch v {
-	case appconfig.NotifyFormatAuto, appconfig.NotifyFormatNtfy, appconfig.NotifyFormatJSON:
+	case appconfig.NotifyFormatAuto, appconfig.NotifyFormatNtfy,
+		appconfig.NotifyFormatSlack, appconfig.NotifyFormatDiscord,
+		appconfig.NotifyFormatJSON:
 		return true
 	default:
 		return false
@@ -95,4 +112,22 @@ func notifyFormatOrDefault(v string) string {
 		return v
 	}
 	return appconfig.NotifyFormatAuto
+}
+
+// validNotifyMinPriority reports whether v is a canonical priority floor.
+func validNotifyMinPriority(v string) bool {
+	switch v {
+	case appconfig.NotifyMinPriorityInfo, appconfig.NotifyMinPriorityWarning, appconfig.NotifyMinPriorityCritical:
+		return true
+	default:
+		return false
+	}
+}
+
+// notifyMinPriorityOrDefault coerces an unrecognized floor back to "info".
+func notifyMinPriorityOrDefault(v string) string {
+	if validNotifyMinPriority(v) {
+		return v
+	}
+	return appconfig.NotifyMinPriorityInfo
 }

--- a/internal/service/notify_update_channel_integration_test.go
+++ b/internal/service/notify_update_channel_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// TestUpdateNotificationChannel covers the edit-drawer semantics: non-secret
+// fields update, a blank URL/token keeps the stored secret, and a provided
+// URL/token replaces it.
+func TestUpdateNotificationChannel(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	created, err := svc.AddNotificationChannel(ctx, service.AddNotificationChannelParams{
+		Name:        "Family",
+		URL:         "https://ntfy.sh/secret-topic",
+		Format:      "ntfy",
+		MinPriority: "info",
+		NtfyToken:   "tk_original",
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// Blank URL + token (nil) → keep secrets; other fields change.
+	if _, err := svc.UpdateNotificationChannel(ctx, created.ID, service.UpdateNotificationChannelParams{
+		Name:        "Family alerts",
+		Format:      "ntfy",
+		MinPriority: "critical",
+		Enabled:     false,
+		// URL and NtfyToken left nil → keep current.
+	}); err != nil {
+		t.Fatalf("update (keep secrets): %v", err)
+	}
+	got := getChannel(t, svc, created.ID)
+	if got.Name != "Family alerts" || got.MinPriority != "critical" || got.Enabled {
+		t.Fatalf("non-secret fields not updated: %+v", got)
+	}
+	if got.URL != "https://ntfy.sh/secret-topic" {
+		t.Fatalf("blank URL should keep current, got %q", got.URL)
+	}
+	if got.NtfyToken != "tk_original" {
+		t.Fatalf("blank token should keep current, got %q", got.NtfyToken)
+	}
+
+	// Provided URL + token → replace.
+	newURL := "https://ntfy.sh/new-topic"
+	newToken := "tk_rotated"
+	if _, err := svc.UpdateNotificationChannel(ctx, created.ID, service.UpdateNotificationChannelParams{
+		Name:        "Family alerts",
+		URL:         &newURL,
+		Format:      "ntfy",
+		MinPriority: "critical",
+		NtfyToken:   &newToken,
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("update (replace secrets): %v", err)
+	}
+	got = getChannel(t, svc, created.ID)
+	if got.URL != newURL || got.NtfyToken != newToken || !got.Enabled {
+		t.Fatalf("secrets/enabled not replaced: %+v", got)
+	}
+
+	// Unknown id → ErrNotFound.
+	if _, err := svc.UpdateNotificationChannel(ctx, "nope1234", service.UpdateNotificationChannelParams{Format: "auto", MinPriority: "info"}); !errors.Is(err, service.ErrNotFound) {
+		t.Fatalf("unknown id err = %v, want ErrNotFound", err)
+	}
+}
+
+func getChannel(t *testing.T, svc *service.Service, id string) service.NotificationChannel {
+	t.Helper()
+	chans, err := svc.GetNotificationChannels(context.Background())
+	if err != nil {
+		t.Fatalf("get channels: %v", err)
+	}
+	for _, c := range chans {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("channel %s not found", id)
+	return service.NotificationChannel{}
+}

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -2,17 +2,16 @@ package pages
 
 import "breadbox/internal/templates/components"
 
-// NotificationsSettings renders the Settings → Notifications tab — the
-// outbound notification sink that workflow runs push reports to. One
-// section configures the webhook (URL + wire format + public base URL,
-// saved together); a second fires a test delivery. See
-// .claude/rules/settings.md for the section/row vocabulary.
+// NotificationsSettings renders the Settings → Notifications tab — a list of
+// outbound notification channels (ntfy / Slack / Discord / JSON), an add form,
+// and the global public base URL used for deep links. A workflow notification
+// fans out to every enabled channel. See .claude/rules/settings.md.
 templ NotificationsSettings(p NotificationsSettingsProps) {
 	<script src="/static/js/admin/components/notifications_settings.js"></script>
-	<div>
+	<div x-data="notificationsSettings" data-csrf={ p.CSRFToken }>
 		@settingsTabHeader(settingsTabHeaderProps{
 			Title:    "Notifications",
-			Subtitle: "Push workflow reports and alerts to ntfy, Slack, or any webhook",
+			Subtitle: "Fan workflow reports and alerts out to ntfy, Slack, Discord, or any webhook",
 		})
 		if p.FormError != "" {
 			<div role="alert" class="alert alert-error alert-soft mb-4 rounded-xl">
@@ -27,67 +26,149 @@ templ NotificationsSettings(p NotificationsSettingsProps) {
 			</div>
 		}
 		<div class="space-y-6">
-			@notificationsWebhookSection(p)
-			@notificationsTestSection(p.CSRFToken)
+			@notificationsChannelsSection(p)
+			@notificationsAddChannelSection(p)
+			@notificationsGlobalSection(p)
 		</div>
 	</div>
 }
 
-// notificationsWebhookSection is the single multi-input form that owns the
-// sink: URL, format, and public base URL save together via one Save button.
-templ notificationsWebhookSection(p NotificationsSettingsProps) {
+// notificationsChannelsSection lists the configured channels with per-channel
+// enable/disable, test, and remove actions.
+templ notificationsChannelsSection(p NotificationsSettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "bell",
-		Title:   "Notification sink",
-		Caption: "Where Breadbox POSTs each workflow report",
+		Title:   "Channels",
+		Caption: "Every enabled channel receives each workflow notification",
+	}) {
+		if len(p.Channels) == 0 {
+			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+				<p class="text-sm text-base-content/60">No channels yet — add one below to start receiving workflow notifications.</p>
+			}
+		}
+		for _, c := range p.Channels {
+			@notificationChannelRow(c, p.CSRFToken)
+		}
+	}
+}
+
+// notificationChannelRow renders one channel: identity + status on the left,
+// the toggle / test / remove actions on the right.
+templ notificationChannelRow(c NotificationChannelView, csrf string) {
+	@components.SettingsRow(components.SettingsRowProps{
+		Label:   c.Name,
+		Caption: c.URLMasked,
+	}) {
+		<div class="flex flex-col items-end gap-1.5">
+			<div class="flex items-center gap-2">
+				<span class="badge badge-ghost badge-sm">{ c.FormatLabel }</span>
+				if c.Enabled {
+					<span class="badge badge-soft badge-success badge-sm">Enabled</span>
+				} else {
+					<span class="badge badge-soft badge-neutral badge-sm">Disabled</span>
+				}
+			</div>
+			<div class="flex items-center gap-1">
+				<form method="POST" action={ templ.SafeURL(c.ToggleURL) }>
+					<input type="hidden" name="_csrf" value={ csrf }/>
+					if c.Enabled {
+						<input type="hidden" name="enabled" value="false"/>
+						<button type="submit" class="btn btn-ghost btn-xs gap-1">@components.LucideIcon("bell-off", "w-3.5 h-3.5") Disable</button>
+					} else {
+						<input type="hidden" name="enabled" value="true"/>
+						<button type="submit" class="btn btn-ghost btn-xs gap-1">@components.LucideIcon("bell", "w-3.5 h-3.5") Enable</button>
+					}
+				</form>
+				<button type="button" class="btn btn-ghost btn-xs gap-1" @click={ "testChannel('" + c.ID + "')" }>
+					@components.LucideIcon("send", "w-3.5 h-3.5")
+					Test
+				</button>
+				<form method="POST" action={ templ.SafeURL(c.DeleteURL) }>
+					<input type="hidden" name="_csrf" value={ csrf }/>
+					<button type="submit" class="btn btn-ghost btn-xs gap-1 text-error/80 hover:text-error">@components.LucideIcon("trash-2", "w-3.5 h-3.5") Remove</button>
+				</form>
+			</div>
+			if c.HasStatus {
+				if c.StatusOK {
+					<p class="text-xs text-success/80 inline-flex items-center gap-1">@components.LucideIcon("circle-check", "w-3 h-3") { c.StatusText }</p>
+				} else {
+					<p class="text-xs text-error/80 inline-flex items-center gap-1">@components.LucideIcon("circle-x", "w-3 h-3") { c.StatusText }</p>
+				}
+			}
+			<template x-if={ "testState['" + c.ID + "'] === 'ok'" }>
+				<p class="text-xs text-success/80">Test sent — check this channel.</p>
+			</template>
+			<template x-if={ "testState['" + c.ID + "'] && testState['" + c.ID + "'].startsWith('err:')" }>
+				<p class="text-xs text-error/80" x-text={ "testState['" + c.ID + "'].slice(4)" }></p>
+			</template>
+		</div>
+	}
+}
+
+// notificationsAddChannelSection is the create form (one channel per submit).
+templ notificationsAddChannelSection(p NotificationsSettingsProps) {
+	@components.SettingsSection(components.SettingsSectionProps{
+		Icon:    "plus",
+		Title:   "Add a channel",
+		Caption: "Paste a webhook URL — the provider is auto-detected from it",
+		Form: &components.SettingsSectionFormProps{
+			Action:    "/settings/notifications/channels",
+			CSRFToken: p.CSRFToken,
+		},
+		Footer: notificationsAddChannelFooter(),
+	}) {
+		@components.SettingsRow(components.SettingsRowProps{Label: "Name", Caption: "Optional label (defaults to the host)", For: "name", Stack: true}) {
+			<input id="name" type="text" name="name" maxlength="60" placeholder="Family ntfy" class="bb-form-input w-full"/>
+		}
+		@components.SettingsRow(components.SettingsRowProps{Label: "Webhook URL", Caption: "http(s) only", For: "url", Stack: true}) {
+			<input id="url" type="url" name="url" placeholder="https://ntfy.sh/my-breadbox-topic" class="bb-form-input font-mono w-full"/>
+			if p.FieldErrors["url"] != "" {
+				<p class="text-xs text-error mt-1">{ p.FieldErrors["url"] }</p>
+			}
+		}
+		@components.SettingsRow(components.SettingsRowProps{Label: "Format", Caption: "Native ntfy/Slack/Discord render a real titled message; JSON is the generic envelope. Auto-detect picks from the URL.", For: "format"}) {
+			<select id="format" name="format" class="select select-sm bg-base-200 min-w-44">
+				<option value="auto">Auto-detect</option>
+				<option value="ntfy">ntfy</option>
+				<option value="slack">Slack</option>
+				<option value="discord">Discord</option>
+				<option value="json">Generic JSON</option>
+			</select>
+		}
+		@components.SettingsRow(components.SettingsRowProps{Label: "Minimum priority", Caption: "Only deliver reports at or above this level to this channel.", For: "min_priority"}) {
+			<select id="min_priority" name="min_priority" class="select select-sm bg-base-200 min-w-44">
+				<option value="info">Info — everything</option>
+				<option value="warning">Warning &amp; above</option>
+				<option value="critical">Critical only</option>
+			</select>
+		}
+		@components.SettingsRow(components.SettingsRowProps{Label: "ntfy token", Caption: "Optional Bearer token for a protected ntfy topic (ntfy channels only).", For: "ntfy_token", Stack: true}) {
+			<input id="ntfy_token" type="text" name="ntfy_token" placeholder="tk_…" class="bb-form-input font-mono w-full"/>
+		}
+	}
+}
+
+templ notificationsAddChannelFooter() {
+	<div class="bb-action-row">
+		<button type="submit" class="btn btn-primary btn-sm gap-2">
+			@components.LucideIcon("plus", "w-4 h-4")
+			Add channel
+		</button>
+	</div>
+}
+
+// notificationsGlobalSection holds settings shared across all channels.
+templ notificationsGlobalSection(p NotificationsSettingsProps) {
+	@components.SettingsSection(components.SettingsSectionProps{
+		Icon:    "link",
+		Title:   "Deep links",
+		Caption: "Shared by every channel",
 		Form: &components.SettingsSectionFormProps{
 			Action:    "/settings/notifications",
 			CSRFToken: p.CSRFToken,
 		},
-		Footer: notificationsSettingsFooter(),
+		Footer: notificationsGlobalFooter(),
 	}) {
-		@components.SettingsRow(components.SettingsRowProps{
-			Label:   "Webhook URL",
-			Caption: "http(s) only. Empty turns notifications off.",
-			For:     "webhook_url",
-			Stack:   true,
-		}) {
-			<input
-				id="webhook_url"
-				type="url"
-				name="webhook_url"
-				value={ p.Form.WebhookURL }
-				placeholder="https://ntfy.sh/my-breadbox-topic"
-				class="bb-form-input font-mono w-full"
-			/>
-			if p.FieldErrors["webhook_url"] != "" {
-				<p class="text-xs text-error mt-1">{ p.FieldErrors["webhook_url"] }</p>
-			}
-		}
-		@components.SettingsRow(components.SettingsRowProps{
-			Label:   "Format",
-			Caption: "Native ntfy, Slack, and Discord render a real titled message; JSON is the generic envelope for relays and bridges. Auto-detect picks the provider from the URL.",
-			For:     "format",
-		}) {
-			<select id="format" name="format" class="select select-sm bg-base-200 min-w-44">
-				<option value="auto" selected?={ p.Form.Format == "auto" }>Auto-detect</option>
-				<option value="ntfy" selected?={ p.Form.Format == "ntfy" }>ntfy</option>
-				<option value="slack" selected?={ p.Form.Format == "slack" }>Slack</option>
-				<option value="discord" selected?={ p.Form.Format == "discord" }>Discord</option>
-				<option value="json" selected?={ p.Form.Format == "json" }>Generic JSON</option>
-			</select>
-		}
-		@components.SettingsRow(components.SettingsRowProps{
-			Label:   "Minimum priority",
-			Caption: "Only deliver reports at or above this level. Raise it to silence routine info-level reports and keep only alerts.",
-			For:     "min_priority",
-		}) {
-			<select id="min_priority" name="min_priority" class="select select-sm bg-base-200 min-w-44">
-				<option value="info" selected?={ p.Form.MinPriority == "info" }>Info — everything</option>
-				<option value="warning" selected?={ p.Form.MinPriority == "warning" }>Warning &amp; above</option>
-				<option value="critical" selected?={ p.Form.MinPriority == "critical" }>Critical only</option>
-			</select>
-		}
 		@components.SettingsRow(components.SettingsRowProps{
 			Label:   "Public URL",
 			Caption: "Absolute origin for tap-through deep links (e.g. https://breadbox.example.com). Optional.",
@@ -98,7 +179,7 @@ templ notificationsWebhookSection(p NotificationsSettingsProps) {
 				id="public_base_url"
 				type="url"
 				name="public_base_url"
-				value={ p.Form.PublicBaseURL }
+				value={ p.PublicBaseURL }
 				placeholder="https://breadbox.example.com"
 				class="bb-form-input font-mono w-full"
 			/>
@@ -109,59 +190,11 @@ templ notificationsWebhookSection(p NotificationsSettingsProps) {
 	}
 }
 
-templ notificationsSettingsFooter() {
+templ notificationsGlobalFooter() {
 	<div class="bb-action-row">
 		<button type="submit" class="btn btn-primary btn-sm gap-2">
 			@components.LucideIcon("save", "w-4 h-4")
 			Save changes
 		</button>
-	</div>
-}
-
-// notificationsTestSection fires a sample delivery to the configured sink so
-// the operator can confirm the wiring without waiting for a real run.
-templ notificationsTestSection(csrfToken string) {
-	<div x-data="notificationsSettings" data-csrf={ csrfToken }>
-		@components.SettingsSection(components.SettingsSectionProps{
-			Icon:    "send",
-			Title:   "Test delivery",
-			Caption: "Fires a sample notification to the URL above",
-		}) {
-			@components.SettingsRow(components.SettingsRowProps{
-				Label:   "Send a test",
-				Caption: "Confirms the webhook is reachable and renders as expected",
-			}) {
-				<button
-					type="button"
-					class="btn btn-secondary btn-sm gap-2"
-					@click="runTest()"
-					:disabled="state === 'loading'"
-				>
-					<span x-show="state !== 'loading'" class="flex items-center gap-1.5">
-						@components.LucideIcon("bell-ring", "w-4 h-4")
-						Send test
-					</span>
-					<span x-show="state === 'loading'" x-cloak class="flex items-center gap-1.5">
-						<span class="loading loading-spinner loading-xs"></span> Sending…
-					</span>
-				</button>
-			}
-			<template x-if="state === 'ok'">
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-					<div role="alert" class="alert alert-success alert-soft rounded-xl">
-						@components.LucideIcon("circle-check", "w-4 h-4")
-						<span>Test notification sent — check your destination.</span>
-					</div>
-				}
-			</template>
-			<template x-if="state === 'error' && error">
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-					<div role="alert" class="alert alert-error alert-soft rounded-xl">
-						@components.LucideIcon("circle-x", "w-4 h-4")
-						<span x-text="'Test failed: ' + error"></span>
-					</div>
-				}
-			</template>
-		}
 	</div>
 }

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -27,9 +27,9 @@ templ NotificationsSettings(p NotificationsSettingsProps) {
 		}
 		<div class="space-y-6">
 			@notificationsChannelsSection(p)
-			@notificationsAddChannelSection(p)
 			@notificationsGlobalSection(p)
 		</div>
+		@notificationsAddChannelDrawer(p)
 	</div>
 }
 
@@ -44,7 +44,13 @@ templ notificationsChannelsSection(p NotificationsSettingsProps) {
 	}) {
 		if len(p.Channels) == 0 {
 			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-				<p class="text-sm text-base-content/60">No channels yet — add one below to start receiving workflow notifications.</p>
+				<div class="flex flex-col items-start gap-3 py-2">
+					<p class="text-sm text-base-content/60">No channels yet. Add one to start fanning workflow reports out to ntfy, Slack, Discord, Google Chat, or any webhook.</p>
+					<button type="button" class="btn btn-primary btn-sm gap-1.5" @click="$store.drawers.open('add-channel')">
+						@components.LucideIcon("plus", "w-4 h-4")
+						Add your first channel
+					</button>
+				</div>
 			}
 		}
 		<template x-if="allState === 'ok'">
@@ -69,20 +75,27 @@ templ notificationsChannelsSection(p NotificationsSettingsProps) {
 	}
 }
 
-// notificationsChannelsHeaderRight renders the "Test all" header action,
-// shown only when at least one channel exists.
+// notificationsChannelsHeaderRight renders the section header actions:
+// "Test all" (only when at least one channel exists) and the primary
+// "Add channel" button that opens the create drawer.
 templ notificationsChannelsHeaderRight(p NotificationsSettingsProps) {
-	if len(p.Channels) > 0 {
-		<button type="button" class="btn btn-ghost btn-sm gap-1.5" @click="testAll()" :disabled="allState === 'loading'">
-			<span x-show="allState !== 'loading'" class="flex items-center gap-1.5">
-				@components.LucideIcon("send", "w-4 h-4")
-				Test all
-			</span>
-			<span x-show="allState === 'loading'" x-cloak class="flex items-center gap-1.5">
-				<span class="loading loading-spinner loading-xs"></span> Sending…
-			</span>
+	<div class="flex items-center gap-2">
+		if len(p.Channels) > 0 {
+			<button type="button" class="btn btn-ghost btn-sm gap-1.5" @click="testAll()" :disabled="allState === 'loading'">
+				<span x-show="allState !== 'loading'" class="flex items-center gap-1.5">
+					@components.LucideIcon("send", "w-4 h-4")
+					Test all
+				</span>
+				<span x-show="allState === 'loading'" x-cloak class="flex items-center gap-1.5">
+					<span class="loading loading-spinner loading-xs"></span> Sending…
+				</span>
+			</button>
+		}
+		<button type="button" class="btn btn-primary btn-sm gap-1.5" @click="$store.drawers.open('add-channel')">
+			@components.LucideIcon("plus", "w-4 h-4")
+			Add channel
 		</button>
-	}
+	</div>
 }
 
 // notificationChannelRow renders one channel: identity + status on the left,
@@ -138,65 +151,86 @@ templ notificationChannelRow(c NotificationChannelView, csrf string) {
 	}
 }
 
-// notificationsAddChannelSection is the create form (one channel per submit).
-templ notificationsAddChannelSection(p NotificationsSettingsProps) {
-	@components.SettingsSection(components.SettingsSectionProps{
-		Icon:    "plus",
-		Title:   "Add a channel",
-		Caption: "Paste a webhook URL — the provider is auto-detected from it",
-		Form: &components.SettingsSectionFormProps{
-			Action:    "/settings/notifications/channels",
-			CSRFToken: p.CSRFToken,
-		},
-		Footer: notificationsAddChannelFooter(),
-	}) {
-		@components.SettingsRow(components.SettingsRowProps{Label: "Name", Caption: "Optional label (defaults to the host)", For: "name", Stack: true}) {
-			<input id="name" type="text" name="name" maxlength="60" placeholder="Family ntfy" class="bb-form-input w-full"/>
-		}
-		@components.SettingsRow(components.SettingsRowProps{Label: "Webhook URL", Caption: "http(s) only", For: "url", Stack: true}) {
-			<input id="url" type="url" name="url" placeholder="https://ntfy.sh/my-breadbox-topic" class="bb-form-input font-mono w-full"/>
-			if p.FieldErrors["url"] != "" {
-				<p class="text-xs text-error mt-1">{ p.FieldErrors["url"] }</p>
+// notificationsAddChannelDrawer is the create form, rendered as a right-side
+// slide-over (components.Drawer) opened from the "Add channel" buttons. It's a
+// plain POST form — on submit the page redirects back with a flash, which
+// closes the drawer.
+templ notificationsAddChannelDrawer(p NotificationsSettingsProps) {
+	@components.Drawer(components.DrawerProps{ID: "add-channel", Title: "Add a channel", Size: "md"}) {
+		<form method="POST" action="/settings/notifications/channels" class="flex flex-col h-full">
+			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     "bell-plus",
+				Title:    "Add a channel",
+				Subtitle: "Paste a webhook URL — the provider is auto-detected",
+			})
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				<div>
+					<label for="ch-url" class="block text-sm font-medium mb-1.5">
+						Webhook URL
+						<span class="text-base-content/50 font-normal">· http(s) only</span>
+					</label>
+					<input id="ch-url" type="url" name="url" required placeholder="https://ntfy.sh/my-breadbox-topic" class="bb-form-input font-mono w-full"/>
+					<p class="text-xs text-base-content/60 mt-1.5">ntfy, Slack, Discord, and Google Chat webhooks are recognized automatically.</p>
+				</div>
+				<div>
+					<label for="ch-name" class="block text-sm font-medium mb-1.5">
+						Name
+						<span class="text-base-content/50 font-normal">· optional</span>
+					</label>
+					<input id="ch-name" type="text" name="name" maxlength="60" placeholder="Family ntfy" class="bb-form-input w-full"/>
+					<p class="text-xs text-base-content/60 mt-1.5">Defaults to the host if left blank.</p>
+				</div>
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+					<div>
+						<label for="ch-format" class="block text-sm font-medium mb-1.5">Format</label>
+						<select id="ch-format" name="format" class="select select-sm bg-base-200 w-full">
+							<option value="auto">Auto-detect</option>
+							<option value="ntfy">ntfy</option>
+							<option value="slack">Slack</option>
+							<option value="discord">Discord</option>
+							<option value="googlechat">Google Chat</option>
+							<option value="json">Generic JSON</option>
+						</select>
+					</div>
+					<div>
+						<label for="ch-min-priority" class="block text-sm font-medium mb-1.5">Minimum priority</label>
+						<select id="ch-min-priority" name="min_priority" class="select select-sm bg-base-200 w-full">
+							<option value="info">Info — everything</option>
+							<option value="warning">Warning &amp; above</option>
+							<option value="critical">Critical only</option>
+						</select>
+					</div>
+				</div>
+				<p class="text-xs text-base-content/60 -mt-2">Auto-detect picks the native shape from the URL; JSON is the generic envelope. Priority floors this channel to reports at or above the chosen level.</p>
+				<div>
+					<label for="ch-ntfy-token" class="block text-sm font-medium mb-1.5">
+						ntfy token
+						<span class="text-base-content/50 font-normal">· optional</span>
+					</label>
+					<input id="ch-ntfy-token" type="text" name="ntfy_token" placeholder="tk_…" class="bb-form-input font-mono w-full"/>
+					<p class="text-xs text-base-content/60 mt-1.5">Bearer token for a protected ntfy topic. Ignored by other providers.</p>
+				</div>
+			</div>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm gap-2">
+					@components.LucideIcon("plus", "w-4 h-4")
+					Add channel
+				</button>
 			}
-		}
-		@components.SettingsRow(components.SettingsRowProps{Label: "Format", Caption: "Native ntfy/Slack/Discord render a real titled message; JSON is the generic envelope. Auto-detect picks from the URL.", For: "format"}) {
-			<select id="format" name="format" class="select select-sm bg-base-200 min-w-44">
-				<option value="auto">Auto-detect</option>
-				<option value="ntfy">ntfy</option>
-				<option value="slack">Slack</option>
-				<option value="discord">Discord</option>
-				<option value="googlechat">Google Chat</option>
-				<option value="json">Generic JSON</option>
-			</select>
-		}
-		@components.SettingsRow(components.SettingsRowProps{Label: "Minimum priority", Caption: "Only deliver reports at or above this level to this channel.", For: "min_priority"}) {
-			<select id="min_priority" name="min_priority" class="select select-sm bg-base-200 min-w-44">
-				<option value="info">Info — everything</option>
-				<option value="warning">Warning &amp; above</option>
-				<option value="critical">Critical only</option>
-			</select>
-		}
-		@components.SettingsRow(components.SettingsRowProps{Label: "ntfy token", Caption: "Optional Bearer token for a protected ntfy topic (ntfy channels only).", For: "ntfy_token", Stack: true}) {
-			<input id="ntfy_token" type="text" name="ntfy_token" placeholder="tk_…" class="bb-form-input font-mono w-full"/>
-		}
+		</form>
 	}
 }
 
-templ notificationsAddChannelFooter() {
-	<div class="bb-action-row">
-		<button type="submit" class="btn btn-primary btn-sm gap-2">
-			@components.LucideIcon("plus", "w-4 h-4")
-			Add channel
-		</button>
-	</div>
-}
-
-// notificationsGlobalSection holds settings shared across all channels.
+// notificationsGlobalSection holds the deep-link origin shared across every
+// channel. The origin is derived (auto-detected from the address you reach
+// Breadbox at); the input is an optional override for split-horizon setups.
 templ notificationsGlobalSection(p NotificationsSettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "link",
 		Title:   "Deep links",
-		Caption: "Shared by every channel",
+		Caption: "Where “tap to open” links resolve",
 		Form: &components.SettingsSectionFormProps{
 			Action:    "/settings/notifications",
 			CSRFToken: p.CSRFToken,
@@ -204,22 +238,37 @@ templ notificationsGlobalSection(p NotificationsSettingsProps) {
 		Footer: notificationsGlobalFooter(),
 	}) {
 		@components.SettingsRow(components.SettingsRowProps{
-			Label:   "Public URL",
-			Caption: "Absolute origin for tap-through deep links (e.g. https://breadbox.example.com). Optional.",
-			For:     "public_base_url",
+			Label:   "Origin",
+			Caption: "Notifications prepend this to report links so “tap to open” reaches the real report.",
 			Stack:   true,
 		}) {
-			<input
-				id="public_base_url"
-				type="url"
-				name="public_base_url"
-				value={ p.PublicBaseURL }
-				placeholder="https://breadbox.example.com"
-				class="bb-form-input font-mono w-full"
-			/>
-			if p.FieldErrors["public_base_url"] != "" {
-				<p class="text-xs text-error mt-1">{ p.FieldErrors["public_base_url"] }</p>
-			}
+			<div class="w-full">
+				<div class="flex items-center flex-wrap gap-2 mb-3 rounded-lg bg-base-200/60 px-3 py-2">
+					if p.UsingDetectedBaseURL() {
+						<span class="badge badge-soft badge-success badge-sm">Auto-detected</span>
+					} else {
+						<span class="badge badge-soft badge-info badge-sm">Custom override</span>
+					}
+					if p.EffectiveBaseURL() != "" {
+						<code class="text-xs font-mono text-base-content/80 break-all">{ p.EffectiveBaseURL() }</code>
+					} else {
+						<span class="text-xs text-base-content/60">Unknown yet — links stay relative until the page is loaded over its public URL.</span>
+					}
+				</div>
+				<label for="public_base_url" class="block text-xs font-medium text-base-content/70 mb-1.5">Override</label>
+				<input
+					id="public_base_url"
+					type="url"
+					name="public_base_url"
+					value={ p.PublicBaseURL }
+					placeholder={ p.OverridePlaceholder() }
+					class="bb-form-input font-mono w-full"
+				/>
+				<p class="text-xs text-base-content/60 mt-1.5">Leave blank to keep auto-detecting. Set this only if Breadbox is reached at a different public URL than the one you administer from (e.g. behind a tunnel).</p>
+				if p.FieldErrors["public_base_url"] != "" {
+					<p class="text-xs text-error mt-1">{ p.FieldErrors["public_base_url"] }</p>
+				}
+			</div>
 		}
 	}
 }

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -66,13 +66,26 @@ templ notificationsWebhookSection(p NotificationsSettingsProps) {
 		}
 		@components.SettingsRow(components.SettingsRowProps{
 			Label:   "Format",
-			Caption: "ntfy sends a native title, priority, and tap-through; JSON suits Slack relays and bridges. Auto-detect picks ntfy for ntfy URLs.",
+			Caption: "Native ntfy, Slack, and Discord render a real titled message; JSON is the generic envelope for relays and bridges. Auto-detect picks the provider from the URL.",
 			For:     "format",
 		}) {
 			<select id="format" name="format" class="select select-sm bg-base-200 min-w-44">
 				<option value="auto" selected?={ p.Form.Format == "auto" }>Auto-detect</option>
 				<option value="ntfy" selected?={ p.Form.Format == "ntfy" }>ntfy</option>
+				<option value="slack" selected?={ p.Form.Format == "slack" }>Slack</option>
+				<option value="discord" selected?={ p.Form.Format == "discord" }>Discord</option>
 				<option value="json" selected?={ p.Form.Format == "json" }>Generic JSON</option>
+			</select>
+		}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Minimum priority",
+			Caption: "Only deliver reports at or above this level. Raise it to silence routine info-level reports and keep only alerts.",
+			For:     "min_priority",
+		}) {
+			<select id="min_priority" name="min_priority" class="select select-sm bg-base-200 min-w-44">
+				<option value="info" selected?={ p.Form.MinPriority == "info" }>Info — everything</option>
+				<option value="warning" selected?={ p.Form.MinPriority == "warning" }>Warning &amp; above</option>
+				<option value="critical" selected?={ p.Form.MinPriority == "critical" }>Critical only</option>
 			</select>
 		}
 		@components.SettingsRow(components.SettingsRowProps{

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -40,15 +40,48 @@ templ notificationsChannelsSection(p NotificationsSettingsProps) {
 		Icon:    "bell",
 		Title:   "Channels",
 		Caption: "Every enabled channel receives each workflow notification",
+		Right:   notificationsChannelsHeaderRight(p),
 	}) {
 		if len(p.Channels) == 0 {
 			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 				<p class="text-sm text-base-content/60">No channels yet — add one below to start receiving workflow notifications.</p>
 			}
 		}
+		<template x-if="allState === 'ok'">
+			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+				<div role="alert" class="alert alert-success alert-soft rounded-xl">
+					@components.LucideIcon("circle-check", "w-4 h-4")
+					<span>Test sent to all enabled channels.</span>
+				</div>
+			}
+		</template>
+		<template x-if="allState && allState.startsWith('err:')">
+			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+				<div role="alert" class="alert alert-error alert-soft rounded-xl">
+					@components.LucideIcon("circle-x", "w-4 h-4")
+					<span x-text="allState.slice(4)"></span>
+				</div>
+			}
+		</template>
 		for _, c := range p.Channels {
 			@notificationChannelRow(c, p.CSRFToken)
 		}
+	}
+}
+
+// notificationsChannelsHeaderRight renders the "Test all" header action,
+// shown only when at least one channel exists.
+templ notificationsChannelsHeaderRight(p NotificationsSettingsProps) {
+	if len(p.Channels) > 0 {
+		<button type="button" class="btn btn-ghost btn-sm gap-1.5" @click="testAll()" :disabled="allState === 'loading'">
+			<span x-show="allState !== 'loading'" class="flex items-center gap-1.5">
+				@components.LucideIcon("send", "w-4 h-4")
+				Test all
+			</span>
+			<span x-show="allState === 'loading'" x-cloak class="flex items-center gap-1.5">
+				<span class="loading loading-spinner loading-xs"></span> Sending…
+			</span>
+		</button>
 	}
 }
 
@@ -132,6 +165,7 @@ templ notificationsAddChannelSection(p NotificationsSettingsProps) {
 				<option value="ntfy">ntfy</option>
 				<option value="slack">Slack</option>
 				<option value="discord">Discord</option>
+				<option value="googlechat">Google Chat</option>
 				<option value="json">Generic JSON</option>
 			</select>
 		}

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -98,56 +98,118 @@ templ notificationsChannelsHeaderRight(p NotificationsSettingsProps) {
 	</div>
 }
 
-// notificationChannelRow renders one channel: identity + status on the left,
-// the toggle / test / remove actions on the right.
+// notificationChannelRow renders one channel as a single clean line: name +
+// (masked URL · format) on the left, one status badge + a gear button that
+// opens its edit drawer on the right. Test / edit / remove all live in the
+// drawer — the same row-opens-a-drawer pattern the Workflows gallery uses.
 templ notificationChannelRow(c NotificationChannelView, csrf string) {
 	@components.SettingsRow(components.SettingsRowProps{
 		Label:   c.Name,
-		Caption: c.URLMasked,
+		Caption: c.URLMasked + " · " + c.FormatLabel,
 	}) {
-		<div class="flex flex-col items-end gap-1.5">
-			<div class="flex items-center gap-2">
-				<span class="badge badge-ghost badge-sm">{ c.FormatLabel }</span>
-				if c.Enabled {
-					<span class="badge badge-soft badge-success badge-sm">Enabled</span>
-				} else {
-					<span class="badge badge-soft badge-neutral badge-sm">Disabled</span>
-				}
-			</div>
-			<div class="flex items-center gap-1">
-				<form method="POST" action={ templ.SafeURL(c.ToggleURL) }>
-					<input type="hidden" name="_csrf" value={ csrf }/>
-					if c.Enabled {
-						<input type="hidden" name="enabled" value="false"/>
-						<button type="submit" class="btn btn-ghost btn-xs gap-1">@components.LucideIcon("bell-off", "w-3.5 h-3.5") Disable</button>
-					} else {
-						<input type="hidden" name="enabled" value="true"/>
-						<button type="submit" class="btn btn-ghost btn-xs gap-1">@components.LucideIcon("bell", "w-3.5 h-3.5") Enable</button>
-					}
-				</form>
-				<button type="button" class="btn btn-ghost btn-xs gap-1" @click={ "testChannel('" + c.ID + "')" }>
-					@components.LucideIcon("send", "w-3.5 h-3.5")
-					Test
-				</button>
-				<form method="POST" action={ templ.SafeURL(c.DeleteURL) }>
-					<input type="hidden" name="_csrf" value={ csrf }/>
-					<button type="submit" class="btn btn-ghost btn-xs gap-1 text-error/80 hover:text-error">@components.LucideIcon("trash-2", "w-3.5 h-3.5") Remove</button>
-				</form>
-			</div>
-			if c.HasStatus {
-				if c.StatusOK {
-					<p class="text-xs text-success/80 inline-flex items-center gap-1">@components.LucideIcon("circle-check", "w-3 h-3") { c.StatusText }</p>
-				} else {
-					<p class="text-xs text-error/80 inline-flex items-center gap-1">@components.LucideIcon("circle-x", "w-3 h-3") { c.StatusText }</p>
-				}
-			}
-			<template x-if={ "testState['" + c.ID + "'] === 'ok'" }>
-				<p class="text-xs text-success/80">Test sent — check this channel.</p>
-			</template>
-			<template x-if={ "testState['" + c.ID + "'] && testState['" + c.ID + "'].startsWith('err:')" }>
-				<p class="text-xs text-error/80" x-text={ "testState['" + c.ID + "'].slice(4)" }></p>
-			</template>
+		<div class="flex items-center gap-2">
+			@notificationChannelStatusBadge(c)
+			<button
+				type="button"
+				class="btn btn-ghost btn-sm btn-square"
+				@click={ "$store.drawers.open('edit-channel-" + c.ID + "')" }
+				aria-label={ "Edit " + c.Name }
+			>
+				@components.LucideIcon("settings-2", "w-4 h-4")
+			</button>
 		</div>
+	}
+	@notificationsEditChannelDrawer(c, csrf)
+}
+
+// notificationChannelStatusBadge collapses enabled state + last-delivery health
+// into one badge so the row stays quiet: Disabled (neutral), Delivery failed
+// (error) when the last send failed, otherwise Enabled (success).
+templ notificationChannelStatusBadge(c NotificationChannelView) {
+	if !c.Enabled {
+		<span class="badge badge-soft badge-neutral badge-sm">Disabled</span>
+	} else if c.HasStatus && !c.StatusOK {
+		<span class="badge badge-soft badge-error badge-sm">Delivery failed</span>
+	} else {
+		<span class="badge badge-soft badge-success badge-sm">Enabled</span>
+	}
+}
+
+// notificationChannelFields is the shared add/edit form body. The add drawer
+// passes IsEdit=false; each edit drawer passes the channel's non-secret values
+// + IsEdit=true. Secrets (URL, ntfy token) are never prefilled — every edit
+// drawer lives in the page DOM, so echoing them would reprint every channel's
+// secrets; on edit a blank URL/token means "keep current".
+templ notificationChannelFields(f ChannelFormValues) {
+	<div>
+		<label for={ f.FieldID("url") } class="block text-sm font-medium mb-1.5">
+			Webhook URL
+			if f.IsEdit && f.HasURL {
+				<span class="text-base-content/50 font-normal">· leave blank to keep current</span>
+			} else {
+				<span class="text-base-content/50 font-normal">· http(s) only</span>
+			}
+		</label>
+		<input
+			id={ f.FieldID("url") }
+			type="url"
+			name="url"
+			required?={ !f.IsEdit }
+			placeholder={ f.URLPlaceholder() }
+			class="bb-form-input font-mono w-full"
+		/>
+		<p class="text-xs text-base-content/60 mt-1.5">ntfy, Slack, Discord, and Google Chat webhooks are recognized automatically.</p>
+	</div>
+	<div>
+		<label for={ f.FieldID("name") } class="block text-sm font-medium mb-1.5">
+			Name
+			<span class="text-base-content/50 font-normal">· optional</span>
+		</label>
+		<input id={ f.FieldID("name") } type="text" name="name" maxlength="60" value={ f.Name } placeholder="Family ntfy" class="bb-form-input w-full"/>
+		<p class="text-xs text-base-content/60 mt-1.5">Defaults to the host if left blank.</p>
+	</div>
+	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+		<div>
+			<label for={ f.FieldID("format") } class="block text-sm font-medium mb-1.5">Format</label>
+			<select id={ f.FieldID("format") } name="format" class="select select-sm bg-base-200 w-full">
+				<option value="auto" selected?={ f.Format == "" || f.Format == "auto" }>Auto-detect</option>
+				<option value="ntfy" selected?={ f.Format == "ntfy" }>ntfy</option>
+				<option value="slack" selected?={ f.Format == "slack" }>Slack</option>
+				<option value="discord" selected?={ f.Format == "discord" }>Discord</option>
+				<option value="googlechat" selected?={ f.Format == "googlechat" }>Google Chat</option>
+				<option value="json" selected?={ f.Format == "json" }>Generic JSON</option>
+			</select>
+		</div>
+		<div>
+			<label for={ f.FieldID("min-priority") } class="block text-sm font-medium mb-1.5">Minimum priority</label>
+			<select id={ f.FieldID("min-priority") } name="min_priority" class="select select-sm bg-base-200 w-full">
+				<option value="info" selected?={ f.MinPriority == "" || f.MinPriority == "info" }>Info — everything</option>
+				<option value="warning" selected?={ f.MinPriority == "warning" }>Warning &amp; above</option>
+				<option value="critical" selected?={ f.MinPriority == "critical" }>Critical only</option>
+			</select>
+		</div>
+	</div>
+	<p class="text-xs text-base-content/60 -mt-2">Auto-detect picks the native shape from the URL; JSON is the generic envelope. Priority floors this channel to reports at or above the chosen level.</p>
+	<div>
+		<label for={ f.FieldID("ntfy-token") } class="block text-sm font-medium mb-1.5">
+			ntfy token
+			if f.IsEdit {
+				<span class="text-base-content/50 font-normal">· leave blank to keep current</span>
+			} else {
+				<span class="text-base-content/50 font-normal">· optional</span>
+			}
+		</label>
+		<input id={ f.FieldID("ntfy-token") } type="text" name="ntfy_token" placeholder="tk_…" class="bb-form-input font-mono w-full"/>
+		<p class="text-xs text-base-content/60 mt-1.5">Bearer token for a protected ntfy topic. Ignored by other providers.</p>
+	</div>
+	if f.IsEdit {
+		<label for={ f.FieldID("enabled") } class="flex items-center justify-between gap-3 cursor-pointer pt-1">
+			<span class="min-w-0">
+				<span class="block text-sm font-medium">Enabled</span>
+				<span class="block text-xs text-base-content/60">Disabled channels are skipped during fan-out.</span>
+			</span>
+			<input id={ f.FieldID("enabled") } type="checkbox" name="enabled" value="true" class="toggle toggle-sm" checked?={ f.Enabled }/>
+		</label>
 	}
 }
 
@@ -165,52 +227,7 @@ templ notificationsAddChannelDrawer(p NotificationsSettingsProps) {
 				Subtitle: "Paste a webhook URL — the provider is auto-detected",
 			})
 			<div class="flex-1 overflow-y-auto p-5 space-y-5">
-				<div>
-					<label for="ch-url" class="block text-sm font-medium mb-1.5">
-						Webhook URL
-						<span class="text-base-content/50 font-normal">· http(s) only</span>
-					</label>
-					<input id="ch-url" type="url" name="url" required placeholder="https://ntfy.sh/my-breadbox-topic" class="bb-form-input font-mono w-full"/>
-					<p class="text-xs text-base-content/60 mt-1.5">ntfy, Slack, Discord, and Google Chat webhooks are recognized automatically.</p>
-				</div>
-				<div>
-					<label for="ch-name" class="block text-sm font-medium mb-1.5">
-						Name
-						<span class="text-base-content/50 font-normal">· optional</span>
-					</label>
-					<input id="ch-name" type="text" name="name" maxlength="60" placeholder="Family ntfy" class="bb-form-input w-full"/>
-					<p class="text-xs text-base-content/60 mt-1.5">Defaults to the host if left blank.</p>
-				</div>
-				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-					<div>
-						<label for="ch-format" class="block text-sm font-medium mb-1.5">Format</label>
-						<select id="ch-format" name="format" class="select select-sm bg-base-200 w-full">
-							<option value="auto">Auto-detect</option>
-							<option value="ntfy">ntfy</option>
-							<option value="slack">Slack</option>
-							<option value="discord">Discord</option>
-							<option value="googlechat">Google Chat</option>
-							<option value="json">Generic JSON</option>
-						</select>
-					</div>
-					<div>
-						<label for="ch-min-priority" class="block text-sm font-medium mb-1.5">Minimum priority</label>
-						<select id="ch-min-priority" name="min_priority" class="select select-sm bg-base-200 w-full">
-							<option value="info">Info — everything</option>
-							<option value="warning">Warning &amp; above</option>
-							<option value="critical">Critical only</option>
-						</select>
-					</div>
-				</div>
-				<p class="text-xs text-base-content/60 -mt-2">Auto-detect picks the native shape from the URL; JSON is the generic envelope. Priority floors this channel to reports at or above the chosen level.</p>
-				<div>
-					<label for="ch-ntfy-token" class="block text-sm font-medium mb-1.5">
-						ntfy token
-						<span class="text-base-content/50 font-normal">· optional</span>
-					</label>
-					<input id="ch-ntfy-token" type="text" name="ntfy_token" placeholder="tk_…" class="bb-form-input font-mono w-full"/>
-					<p class="text-xs text-base-content/60 mt-1.5">Bearer token for a protected ntfy topic. Ignored by other providers.</p>
-				</div>
+				@notificationChannelFields(ChannelFormValues{IDSuffix: "new"})
 			</div>
 			@components.DrawerFooter() {
 				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
@@ -221,6 +238,81 @@ templ notificationsAddChannelDrawer(p NotificationsSettingsProps) {
 			}
 		</form>
 	}
+}
+
+// notificationsEditChannelDrawer is the per-channel edit slide-over opened from
+// the row's gear button. The main edit form (fields + enabled toggle) lives in
+// the scrollable body; the footer carries Remove (its own delete form, pushed
+// left), an inline Test, and Save (wired to the body form via the `form`
+// attribute so the two POST forms never nest).
+templ notificationsEditChannelDrawer(c NotificationChannelView, csrf string) {
+	@components.Drawer(components.DrawerProps{ID: "edit-channel-" + c.ID, Title: "Edit channel", Size: "md"}) {
+		<div class="flex flex-col h-full">
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     "settings-2",
+				Title:    c.Name,
+				Subtitle: c.FormatLabel,
+			})
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				<form id={ "edit-ch-form-" + c.ID } method="POST" action={ templ.SafeURL(c.EditURL) } class="space-y-5">
+					<input type="hidden" name="_csrf" value={ csrf }/>
+					@notificationChannelFields(ChannelFormValues{
+						IDSuffix:    c.ID,
+						IsEdit:      true,
+						Name:        c.Name,
+						Format:      c.Format,
+						MinPriority: c.MinPriority,
+						Enabled:     c.Enabled,
+						URLMasked:   c.URLMasked,
+						HasURL:      c.URLMasked != "",
+					})
+				</form>
+				@notificationChannelDrawerStatus(c)
+			</div>
+			@components.DrawerFooter() {
+				<form method="POST" action={ templ.SafeURL(c.DeleteURL) } class="mr-auto">
+					<input type="hidden" name="_csrf" value={ csrf }/>
+					<button type="submit" class="btn btn-ghost btn-sm gap-1.5 text-error/80 hover:text-error">
+						@components.LucideIcon("trash-2", "w-4 h-4")
+						Remove
+					</button>
+				</form>
+				<button type="button" class="btn btn-ghost btn-sm gap-1.5" @click={ "testChannel('" + c.ID + "')" } :disabled={ "testState['" + c.ID + "'] === 'loading'" }>
+					@components.LucideIcon("send", "w-4 h-4")
+					Test
+				</button>
+				<button type="submit" form={ "edit-ch-form-" + c.ID } class="btn btn-primary btn-sm gap-2">
+					@components.LucideIcon("save", "w-4 h-4")
+					Save
+				</button>
+			}
+		</div>
+	}
+}
+
+// notificationChannelDrawerStatus shows the last-delivery line plus live Test
+// feedback inside the edit drawer.
+templ notificationChannelDrawerStatus(c NotificationChannelView) {
+	<div class="space-y-1.5 border-t border-base-200 pt-4">
+		if c.HasStatus {
+			if c.StatusOK {
+				<p class="text-xs text-success/80 inline-flex items-center gap-1.5">@components.LucideIcon("circle-check", "w-3.5 h-3.5") Last delivery: { c.StatusText }</p>
+			} else {
+				<p class="text-xs text-error/80 inline-flex items-center gap-1.5">@components.LucideIcon("circle-x", "w-3.5 h-3.5") Last delivery: { c.StatusText }</p>
+			}
+		} else {
+			<p class="text-xs text-base-content/50">No delivery yet — use Test to send a sample.</p>
+		}
+		<template x-if={ "testState['" + c.ID + "'] === 'loading'" }>
+			<p class="text-xs text-base-content/60 inline-flex items-center gap-1.5"><span class="loading loading-spinner loading-xs"></span> Sending test…</p>
+		</template>
+		<template x-if={ "testState['" + c.ID + "'] === 'ok'" }>
+			<p class="text-xs text-success/80">Test sent — check this channel.</p>
+		</template>
+		<template x-if={ "testState['" + c.ID + "'] && testState['" + c.ID + "'].startsWith('err:')" }>
+			<p class="text-xs text-error/80" x-text={ "testState['" + c.ID + "'].slice(4)" }></p>
+		</template>
+	</div>
 }
 
 // notificationsGlobalSection holds the deep-link origin shared across every
@@ -273,11 +365,13 @@ templ notificationsGlobalSection(p NotificationsSettingsProps) {
 	}
 }
 
+// notificationsGlobalFooter is the section's Save button. SettingsSection
+// renders the Footer slot inside bb-settings-card__footer, which already
+// supplies the bordered, right-aligned action row — so this passes the button
+// alone (wrapping it in bb-action-row would double the divider).
 templ notificationsGlobalFooter() {
-	<div class="bb-action-row">
-		<button type="submit" class="btn btn-primary btn-sm gap-2">
-			@components.LucideIcon("save", "w-4 h-4")
-			Save changes
-		</button>
-	</div>
+	<button type="submit" class="btn btn-primary btn-sm gap-2">
+		@components.LucideIcon("save", "w-4 h-4")
+		Save changes
+	</button>
 }

--- a/internal/templates/components/pages/notifications_settings_types.go
+++ b/internal/templates/components/pages/notifications_settings_types.go
@@ -2,17 +2,49 @@
 
 package pages
 
+import "strings"
+
 // NotificationsSettingsProps drives the Settings → Notifications tab. The
 // page manages a list of outbound notification channels (the multi-sink
-// model) plus the global public base URL used for deep links. Nothing here is
-// secret beyond the channel URLs/tokens, which are masked for display.
+// model) plus the global deep-link origin. Nothing here is secret beyond the
+// channel URLs/tokens, which are masked for display.
 type NotificationsSettingsProps struct {
-	Channels      []NotificationChannelView
+	Channels []NotificationChannelView
+	// PublicBaseURL is the manual deep-link origin override (empty = use
+	// the auto-detected origin).
 	PublicBaseURL string
-	FieldErrors   map[string]string
-	FormError     string
-	FormSuccess   string
-	CSRFToken     string
+	// DetectedBaseURL is the origin Breadbox auto-captured from the admin's
+	// current request — the effective deep-link origin when no override is
+	// set.
+	DetectedBaseURL string
+	FieldErrors     map[string]string
+	FormError       string
+	FormSuccess     string
+	CSRFToken       string
+}
+
+// UsingDetectedBaseURL reports whether deep links fall back to the
+// auto-detected origin (no manual override set).
+func (p NotificationsSettingsProps) UsingDetectedBaseURL() bool {
+	return strings.TrimSpace(p.PublicBaseURL) == ""
+}
+
+// EffectiveBaseURL is the origin notifications actually prepend to report
+// deep links: the override when set, otherwise the auto-detected origin.
+func (p NotificationsSettingsProps) EffectiveBaseURL() string {
+	if v := strings.TrimSpace(p.PublicBaseURL); v != "" {
+		return v
+	}
+	return strings.TrimSpace(p.DetectedBaseURL)
+}
+
+// OverridePlaceholder is the example shown in the override input — the
+// detected origin when known, else a generic example.
+func (p NotificationsSettingsProps) OverridePlaceholder() string {
+	if v := strings.TrimSpace(p.DetectedBaseURL); v != "" {
+		return v
+	}
+	return "https://breadbox.example.com"
 }
 
 // NotificationChannelView is one channel rendered in the list. Display fields

--- a/internal/templates/components/pages/notifications_settings_types.go
+++ b/internal/templates/components/pages/notifications_settings_types.go
@@ -96,7 +96,6 @@ type NotificationChannelView struct {
 	// templ.SafeURL as variables (not string literals — keeps the
 	// route-drift guard from treating these POST endpoints as GET hrefs).
 	EditURL   string
-	ToggleURL string
 	DeleteURL string
 	// Status line: HasStatus=false → never delivered. Otherwise StatusOK
 	// drives the tone and StatusText is the message ("Delivered · 14:02" /

--- a/internal/templates/components/pages/notifications_settings_types.go
+++ b/internal/templates/components/pages/notifications_settings_types.go
@@ -47,6 +47,40 @@ func (p NotificationsSettingsProps) OverridePlaceholder() string {
 	return "https://breadbox.example.com"
 }
 
+// ChannelFormValues drives the shared add/edit channel form rendered inside a
+// Drawer. The add drawer passes a zero value (IDSuffix "new"); an edit drawer
+// passes the channel's current non-secret values plus IsEdit=true. Secrets
+// (URL, ntfy token) are never prefilled — every edit drawer lives in the page
+// DOM, so echoing them would reprint every channel's secrets; the edit form
+// treats a blank URL/token as "keep current" instead.
+type ChannelFormValues struct {
+	IDSuffix     string // unique per drawer: "new" for add, the channel id for edit
+	Action       string // form POST endpoint
+	IsEdit       bool
+	Name         string // prefilled on edit (not secret)
+	Format       string // selected option
+	MinPriority  string // selected option
+	Enabled      bool   // edit toggle state
+	URLMasked    string // placeholder on edit (full URL never rendered)
+	HasURL       bool   // edit: a URL already exists → field is optional ("keep current")
+	DeleteAction string // edit: formaction for the Remove button
+}
+
+// FieldID namespaces an input id/for so add + N edit drawers don't collide.
+func (f ChannelFormValues) FieldID(field string) string {
+	return "ch-" + field + "-" + f.IDSuffix
+}
+
+// URLPlaceholder is the webhook-URL field's placeholder: on edit it shows the
+// masked current URL (so the operator knows which sink they're editing without
+// the full secret being printed); on add it's a worked example.
+func (f ChannelFormValues) URLPlaceholder() string {
+	if f.IsEdit && strings.TrimSpace(f.URLMasked) != "" {
+		return f.URLMasked
+	}
+	return "https://ntfy.sh/my-breadbox-topic"
+}
+
 // NotificationChannelView is one channel rendered in the list. Display fields
 // (masked URL, format label, status line) are precomputed by the handler so
 // the template stays declarative.
@@ -61,6 +95,7 @@ type NotificationChannelView struct {
 	// Action endpoints, precomputed so the template passes them to
 	// templ.SafeURL as variables (not string literals — keeps the
 	// route-drift guard from treating these POST endpoints as GET hrefs).
+	EditURL   string
 	ToggleURL string
 	DeleteURL string
 	// Status line: HasStatus=false → never delivered. Otherwise StatusOK

--- a/internal/templates/components/pages/notifications_settings_types.go
+++ b/internal/templates/components/pages/notifications_settings_types.go
@@ -18,6 +18,7 @@ type NotificationsSettingsProps struct {
 // service.UpdateNotificationSettings.
 type NotificationsSettingsFormFields struct {
 	WebhookURL    string // http(s) sink; empty = notifications off
-	Format        string // "auto" | "ntfy" | "json"
+	Format        string // "auto" | "ntfy" | "slack" | "discord" | "json"
 	PublicBaseURL string // absolute origin for deep links; empty = relative
+	MinPriority   string // "info" | "warning" | "critical" delivery floor
 }

--- a/internal/templates/components/pages/notifications_settings_types.go
+++ b/internal/templates/components/pages/notifications_settings_types.go
@@ -3,22 +3,38 @@
 package pages
 
 // NotificationsSettingsProps drives the Settings → Notifications tab. The
-// page owns the outbound notification sink (webhook URL + wire format +
-// public base URL) that workflow runs use to push reports. Nothing here is
-// secret — every value renders in plaintext.
+// page manages a list of outbound notification channels (the multi-sink
+// model) plus the global public base URL used for deep links. Nothing here is
+// secret beyond the channel URLs/tokens, which are masked for display.
 type NotificationsSettingsProps struct {
-	Form        NotificationsSettingsFormFields
-	FieldErrors map[string]string
-	FormError   string
-	FormSuccess string
-	CSRFToken   string
+	Channels      []NotificationChannelView
+	PublicBaseURL string
+	FieldErrors   map[string]string
+	FormError     string
+	FormSuccess   string
+	CSRFToken     string
 }
 
-// NotificationsSettingsFormFields mirrors the writable settings exposed by
-// service.UpdateNotificationSettings.
-type NotificationsSettingsFormFields struct {
-	WebhookURL    string // http(s) sink; empty = notifications off
-	Format        string // "auto" | "ntfy" | "slack" | "discord" | "json"
-	PublicBaseURL string // absolute origin for deep links; empty = relative
-	MinPriority   string // "info" | "warning" | "critical" delivery floor
+// NotificationChannelView is one channel rendered in the list. Display fields
+// (masked URL, format label, status line) are precomputed by the handler so
+// the template stays declarative.
+type NotificationChannelView struct {
+	ID          string
+	Name        string
+	Format      string // raw value ("auto" | "ntfy" | …)
+	FormatLabel string // human label ("Auto-detect", "ntfy", …)
+	URLMasked   string
+	MinPriority string
+	Enabled     bool
+	// Action endpoints, precomputed so the template passes them to
+	// templ.SafeURL as variables (not string literals — keeps the
+	// route-drift guard from treating these POST endpoints as GET hrefs).
+	ToggleURL string
+	DeleteURL string
+	// Status line: HasStatus=false → never delivered. Otherwise StatusOK
+	// drives the tone and StatusText is the message ("Delivered · 14:02" /
+	// "Failed: HTTP 500").
+	HasStatus  bool
+	StatusOK   bool
+	StatusText string
 }

--- a/static/js/admin/components/notifications_settings.js
+++ b/static/js/admin/components/notifications_settings.js
@@ -9,9 +9,35 @@ document.addEventListener('alpine:init', function () {
     return {
       csrfToken: '',
       testState: {},
+      allState: 'idle',
 
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
+      },
+
+      testAll: function () {
+        var self = this;
+        this.allState = 'loading';
+        fetch('/-/notifications/test', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'X-CSRF-Token': this.csrfToken, Accept: 'application/json' },
+        })
+          .then(function (res) {
+            return res.json().then(function (body) {
+              return { ok: res.ok, status: res.status, body: body };
+            });
+          })
+          .then(function (r) {
+            if (!r.ok || (r.body && r.body.ok === false)) {
+              self.allState = 'err:' + ((r.body && r.body.error) || ('HTTP ' + r.status));
+              return;
+            }
+            self.allState = 'ok';
+          })
+          .catch(function (e) {
+            self.allState = 'err:' + ((e && e.message) || 'Request failed');
+          });
       },
 
       _set: function (id, val) {

--- a/static/js/admin/components/notifications_settings.js
+++ b/static/js/admin/components/notifications_settings.js
@@ -1,31 +1,33 @@
-// Settings → Notifications — test-delivery button factory.
+// Settings → Notifications — per-channel test-delivery factory.
 //
-// Powers the "Send test" button on /settings/notifications. Reads its CSRF
-// token from a sibling data-* attribute on the x-data root so the factory
-// itself takes no arguments (per docs/design-system.md → "Alpine page
-// components").
+// Powers the "Test" button on each channel row. testState maps a channel id
+// to 'loading' | 'ok' | 'err:<message>'; the template reads it to show inline
+// feedback. CSRF token comes from a sibling data-* attribute (per
+// docs/design-system.md → "Alpine page components").
 document.addEventListener('alpine:init', function () {
   Alpine.data('notificationsSettings', function () {
     return {
       csrfToken: '',
-      state: 'idle',
-      error: null,
+      testState: {},
 
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
       },
 
-      runTest: function () {
+      _set: function (id, val) {
+        // Reassign so Alpine picks up the new key reactively.
+        var next = Object.assign({}, this.testState);
+        next[id] = val;
+        this.testState = next;
+      },
+
+      testChannel: function (id) {
         var self = this;
-        this.state = 'loading';
-        this.error = null;
-        fetch('/-/notifications/test', {
+        this._set(id, 'loading');
+        fetch('/-/notifications/channels/' + encodeURIComponent(id) + '/test', {
           method: 'POST',
           credentials: 'same-origin',
-          headers: {
-            'X-CSRF-Token': this.csrfToken,
-            Accept: 'application/json',
-          },
+          headers: { 'X-CSRF-Token': this.csrfToken, Accept: 'application/json' },
         })
           .then(function (res) {
             return res.json().then(function (body) {
@@ -34,15 +36,13 @@ document.addEventListener('alpine:init', function () {
           })
           .then(function (r) {
             if (!r.ok || (r.body && r.body.ok === false)) {
-              self.error = (r.body && r.body.error) || ('HTTP ' + r.status);
-              self.state = 'error';
+              self._set(id, 'err:' + ((r.body && r.body.error) || ('HTTP ' + r.status)));
               return;
             }
-            self.state = 'ok';
+            self._set(id, 'ok');
           })
           .catch(function (e) {
-            self.error = (e && e.message) || 'Request failed';
-            self.state = 'error';
+            self._set(id, 'err:' + ((e && e.message) || 'Request failed'));
           });
       },
     };


### PR DESCRIPTION
Builds on the merged notifications work (#1687) to make the notification system fan out to **multiple channels** — each its own sink, format, and priority floor — plus native Slack/Discord/Google Chat formatting, a priority floor, delivery retries, and per-channel delivery status. Autonomous sprint on `notifications/sprint`; three reviewable commits.

## What's new

**Multiple channels (the headline).** Notifications now go to a *list* of channels instead of one webhook. Each channel has its own URL, format, minimum-priority floor, optional ntfy token, and enable toggle; a workflow report fans out to every enabled channel, each delivered and retried independently. Managed on **Settings → Notifications**: add, enable/disable, per-channel **Test**, **Test all**, and remove. Stored as JSON in `app_config` (no schema migration). Your existing single webhook is auto-adopted as a "Default" channel, so nothing breaks.

**Native provider formatting** — one webhook field, provider auto-detected from the URL:
- **ntfy** — title/priority/markdown/tap-through + a "View report" action button + optional Bearer token for protected topics.
- **Slack** — `{"text"}` mrkdwn (`**b**`→`*b*`, `[x](y)`→`<y|x>`).
- **Discord** — `{"content"}` markdown, 2000-char cap.
- **Google Chat** — `{"text"}` with unicode emoji (Google Chat doesn't render `:shortcodes:`).
- **Generic JSON** — the original envelope, for relays/bridges.

The badge shows what Auto-detect resolved to (e.g. "Auto · ntfy").

**Reliability & control:**
- **Priority floor** per channel — drop routine info reports, keep alerts.
- **Retry with backoff** — 3 attempts on transient failures (network/429/5xx), fail-fast on 4xx.
- **Per-channel delivery status** — each channel shows its last attempt (✓/✗ + time).

## Screenshot

<img src="https://i.img402.dev/em3yxkd6sy.jpg" width="900" alt="Settings → Notifications — multiple channels across ntfy/Slack/Discord/Google Chat">

## Testing

- `go build`/`go vet`/full `go test ./...` (unit) — green.
- Unit: provider detection, each provider's request builder + markdown conversion, priority rank, retry classifier, ntfy token/action headers, URL masking, resolved auto-labels.
- Integration (`breadbox_test`): multi-channel fan-out, enable/disable, delete, per-channel priority floor, retry-then-succeed, fail-fast-on-4xx, the global floor, ntfy dispatch, and legacy single-webhook back-compat.
- Validated in a logged-in browser (screenshot above) with a live test delivery to ntfy.

## Notes

This is a sizeable, cohesive feature sprint on one branch (3 commits: formats → multi-channel → Google Chat/labels/docs). Happy to split into a stack if you'd prefer to review in pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
