### PR TITLE
feat(dev): managed dev servers — deterministic ports, auto-cleanup, one-shot UI validation

### DIFF
--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -31,8 +31,14 @@ except Exception: pass" 2>/dev/null || true)"
 }
 CWD="$(bb_json_field cwd)"
 REASON="$(bb_json_field reason)"
-SESSION="$(bb_json_field session_id)"
 [ -n "$CWD" ] || CWD="$PWD"
+# Registry entries are tagged with the ENV session id (bb_session_id). Read the
+# session from the SAME source here so a same-session comparison is identical by
+# construction; only fall back to the stdin JSON id if the env var is absent.
+# (Using a different source than the writer could make the owner check think a
+# sibling owns the server and skip cleanup — a leak. Same source avoids that.)
+SESSION="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+[ -n "$SESSION" ] || SESSION="$(bb_json_field session_id)"
 
 # Locate the lib relative to the active worktree if the project-dir copy is absent.
 LIB="$PROJECT_DIR/scripts/dev-lib.sh"

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SessionEnd hook — stop the managed dev server this session's worktree started,
+# and reap any orphaned servers left by previously-closed sessions.
+#
+# This is the cleanup that was missing: nothing used to stop a `breadbox serve`
+# when a session closed, so stale instances accumulated across 8081-8099. We
+# only stop the CURRENT worktree's managed server (tracked in the dev-server
+# registry) — sibling worktrees' servers are left alone.
+#
+# Skipped on reason=clear (a /clear keeps the session alive; killing the dev
+# server then would be hostile). Reap still runs (cheap, only touches dead
+# entries).
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Hook input arrives as JSON on stdin (cwd, reason, session_id). Parse without a
+# hard python3 dependency (stock macOS often lacks it): try python3, then fall
+# back to a sed string-field extractor.
+INPUT="$(cat 2>/dev/null || true)"
+bb_json_field() { # <key> — reads $INPUT
+  local key="$1" val=""
+  if [ -n "$INPUT" ] && command -v python3 >/dev/null 2>&1; then
+    val="$(printf '%s' "$INPUT" | python3 -c "import sys,json
+try: print(json.load(sys.stdin).get('$key',''))
+except Exception: pass" 2>/dev/null || true)"
+  fi
+  if [ -z "$val" ] && [ -n "$INPUT" ]; then
+    val="$(printf '%s' "$INPUT" | sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1)"
+  fi
+  printf '%s' "$val"
+}
+CWD="$(bb_json_field cwd)"
+REASON="$(bb_json_field reason)"
+SESSION="$(bb_json_field session_id)"
+[ -n "$CWD" ] || CWD="$PWD"
+
+# Locate the lib relative to the active worktree if the project-dir copy is absent.
+LIB="$PROJECT_DIR/scripts/dev-lib.sh"
+if [ ! -f "$LIB" ] && [ -f "$CWD/scripts/dev-lib.sh" ]; then
+  LIB="$CWD/scripts/dev-lib.sh"
+fi
+[ -f "$LIB" ] || exit 0   # nothing we can do without the lib
+
+# shellcheck source=scripts/dev-lib.sh
+. "$LIB"
+
+if [ "$REASON" != "clear" ]; then
+  ROOT="$(bb_worktree_root "$CWD")"
+  PORT_OWNED="$(bb_server_for_worktree "$ROOT" || true)"
+  if [ -n "$PORT_OWNED" ]; then
+    # If the registry entry records a different session than the one ending,
+    # another live session shares this worktree — leave its server running.
+    ENTRY_SESSION="$(bb_meta_get "$(bb_servers_dir)/$PORT_OWNED" session 2>/dev/null || true)"
+    if [ -n "$ENTRY_SESSION" ] && [ -n "$SESSION" ] && [ "$ENTRY_SESSION" != "$SESSION" ]; then
+      :   # owned by another session — don't kill it
+    else
+      bb_stop_worktree "$ROOT" || true
+    fi
+  fi
+fi
+bb_reap || true
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,10 +13,20 @@ cd "$PROJECT_DIR"
 
 # --- Local sessions ---
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  # Reap orphaned dev servers left by previously-closed sessions (dead pids,
+  # removed worktrees). Cheap + safe; runs for both main-repo and worktree
+  # sessions so cleanup happens regardless of where you start. The shared lib
+  # is a committed file, so it's present in every checkout/worktree.
+  if [ -f "$PROJECT_DIR/scripts/dev-lib.sh" ]; then
+    # shellcheck source=scripts/dev-lib.sh
+    . "$PROJECT_DIR/scripts/dev-lib.sh"
+    bb_reap 2>/dev/null || true
+  fi
+
   # Check if we're in a git worktree
   GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null || echo ".git")"
   if [ "$GIT_COMMON" = ".git" ]; then
-    # Main repo — nothing to do
+    # Main repo — nothing else to do
     exit 0
   fi
 
@@ -136,47 +146,25 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
       fi
     fi
 
-    # PORT — find next available port starting from 8081
-    # Uses lock files under main repo's .claude/ to prevent races between
-    # concurrent worktree sessions that haven't started their server yet.
-    if [ -z "${PORT:-}" ]; then
-      MAIN_REPO="$(dirname "$GIT_COMMON")"
-      PORT_LOCKS="$MAIN_REPO/.claude/port-locks"
-      mkdir -p "$PORT_LOCKS"
-
-      # Clean up stale lock files (port not in use AND lock older than 5 min)
-      for lockfile in "$PORT_LOCKS"/*; do
-        [ -f "$lockfile" ] || continue
-        LOCK_PORT="$(basename "$lockfile")"
-        if ! lsof -i :"$LOCK_PORT" >/dev/null 2>&1; then
-          LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$lockfile" 2>/dev/null || echo 0) ))
-          if [ "$LOCK_AGE" -gt 300 ]; then
-            rm -f "$lockfile"
-          fi
-        fi
-      done
-
-      PORT=8081
-      while [ "$PORT" -le 8099 ]; do
-        if ! lsof -i :"$PORT" >/dev/null 2>&1 && ! [ -f "$PORT_LOCKS/$PORT" ]; then
-          # Claim it atomically
-          if (set -o noclobber; echo "$$" > "$PORT_LOCKS/$PORT") 2>/dev/null; then
-            break
-          fi
-        fi
-        PORT=$((PORT + 1))
-      done
-
-      if [ "$PORT" -le 8099 ]; then
-        # Export both: PORT is consumed by the Makefile (which maps it to
-        # SERVER_PORT when invoking `go run`), and SERVER_PORT is what the
-        # binary itself reads — so direct `go run ./cmd/breadbox serve`
-        # also picks up the right port.
-        echo "PORT=$PORT" >> "$CLAUDE_ENV_FILE"
-        echo "SERVER_PORT=$PORT" >> "$CLAUDE_ENV_FILE"
-        echo "    Assigned port $PORT (PORT + SERVER_PORT exported)"
+    # PORT — reserve a deterministic port via the shared dev-server registry
+    # (scripts/dev-lib.sh, sourced above). One registry — keyed by worktree,
+    # reaped automatically — replaces the old ad-hoc .claude/port-locks files.
+    # `make dev`, `make dev-bg`, and the validation scripts all resolve the
+    # same port, so nothing has to fish for a free one.
+    if [ -z "${PORT:-}" ] && command -v bb_claim_port >/dev/null 2>&1; then
+      # Key the reservation by the git worktree root (canonicalized) so it
+      # matches what dev-server / dev-port / session-end resolve — keying by a
+      # raw CLAUDE_PROJECT_DIR that differs (trailing slash, /private symlink)
+      # would orphan the reservation.
+      ASSIGNED_PORT="$(bb_claim_port "$(bb_worktree_root "$PROJECT_DIR")" RESERVED || true)"
+      if [ -n "$ASSIGNED_PORT" ]; then
+        # Export both: PORT is consumed by the Makefile, SERVER_PORT by the
+        # binary — so `make dev` and a direct `breadbox serve` both land here.
+        echo "PORT=$ASSIGNED_PORT" >> "$CLAUDE_ENV_FILE"
+        echo "SERVER_PORT=$ASSIGNED_PORT" >> "$CLAUDE_ENV_FILE"
+        echo "    Reserved port $ASSIGNED_PORT (PORT + SERVER_PORT exported)"
       else
-        echo "WARN: no available port in 8081-8099"
+        echo "WARN: no available port in 8081-8099 (try: make dev-reap)"
       fi
     fi
 

--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -166,9 +166,26 @@ Output is `<svg aria-hidden="true" class="lucide lucide-{name} ...">` with the `
 
 ## Validation / PR evidence
 
-UI changes must be validated in a real browser before the task is reported done, and the PR must include a screenshot. Use the `validate-ui` skill — it picks the right backend for your session. **Never** fall back to `screencapture` / AppleScript.
+UI changes must be validated in a real browser before the task is reported done, and the PR must include a screenshot. **Never** fall back to `screencapture` / AppleScript.
 
-**Backend selection** — pick once, up front:
+**Fast path (preferred for agents): `make dev-shot`.** One command rebuilds,
+(re)starts this worktree's tracked background server, and screenshots routes —
+no port fishing, no Chrome-MCP profile lock, auto-cleaned on session end:
+
+```sh
+make dev-shot ARGS="/transactions --mobile --wait '.join'"   # → prints JPEG paths
+```
+
+Routes are positional (`path[:slug]`); flags: `--desktop|--mobile|--tablet|--wide`
+(repeatable), `--wait <css>`, `--full`, `--no-rebuild`. Under the hood it uses
+puppeteer + system Chrome with a fresh profile (`scripts/ui-validate` →
+`scripts/ui-shot.mjs`), so it never collides with a Chrome DevTools MCP session.
+Upload the JPEGs via the `github-image-hosting` skill (img402.dev). See
+`scripts/README.md` for the full lifecycle. Use the `validate-ui` skill / the
+backends below when you need an interactive multi-step browser flow instead of a
+straight capture.
+
+**Backend selection** (interactive flows) — pick once, up front:
 
 - **Local sessions**: prefer the **Chrome DevTools MCP** (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*`). Real Chrome you can see, scriptable across multiple turns.
 - **Cloud sessions** (`CLAUDE_CODE_REMOTE=true` is set): the Chrome DevTools MCP is typically not loaded. Fall back to **headless Chromium via Playwright** — pre-installed on the cloud image at `/opt/node22/lib/node_modules/playwright` with bundled Chromium at `/opt/pw-browsers/chromium-1194/chrome-linux/chrome`. The skill ships a copy-pasteable Node script under "Step 5b — headless Chromium fallback".

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/skills/validate-ui/SKILL.md
+++ b/.claude/skills/validate-ui/SKILL.md
@@ -12,6 +12,17 @@ description: >
 
 # Validate UI
 
+> **Fastest path — try this first:** `make dev-shot ARGS="/transactions --mobile"`.
+> It rebuilds, (re)starts this worktree's tracked background server (resolving a
+> port for you — no fishing), and screenshots the route(s) via puppeteer + system
+> Chrome with a fresh profile, printing the JPEG paths. It never collides with a
+> locked Chrome DevTools MCP profile and is auto-cleaned when the session ends.
+> Flags: `--desktop|--mobile|--tablet|--wide` (repeatable), `--wait <css>`,
+> `--full`, `--no-rebuild`. Then upload via the `github-image-hosting` skill and
+> embed per the rules below. The two backends below are for **interactive
+> multi-step** flows (filling forms, JS evaluation across turns) — for a straight
+> capture, `make dev-shot` is fewer moving parts. See `scripts/README.md`.
+
 Validate a Breadbox admin UI change in the running app, then attach a screenshot to the PR as evidence. Two backends, picked in this order:
 
 1. **Chrome DevTools MCP** (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*`) — preferred when available. Drives a real Chrome you can also see; supports interactive flows (forms, snapshots, JS evaluation).

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,10 @@ static/css/styles.css
 # Environment files
 .local.env
 
-# Dev server port marker (written by make dev)
+# Dev server port marker (written by make dev / scripts/dev-port)
 .breadbox-port
+# Managed background dev server: per-worktree binary + logs (scripts/dev-server)
+.breadbox-dev/
 .docker.env
 
 # air (hot-reload) build output — used by `make dev-watch`
@@ -59,9 +61,8 @@ transcripts/
 # OS
 .DS_Store
 
-# Claude Code worktrees, port locks, and task locks
+# Claude Code worktrees and task locks
 .claude/worktrees/
-.claude/port-locks/
 .claude/scheduled_tasks.lock
 
 # MCP config (contains API key)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,16 +76,18 @@ Prereqs: Go 1.24+, PostgreSQL.
 make db         # start Postgres via Docker (skip if local Postgres)
 make dev        # starts server with embedded assets (prod-like; restart on any UI edit)
 make dev-watch  # hot-reload: air rebuilds Go on *.go changes; HTML/CSS served from disk — no restart for UI edits
+make dev-bg     # start/reuse a BACKGROUND server for this worktree; prints the URL (no port fishing, auto-cleaned)
+make dev-shot ARGS="/transactions --mobile"   # rebuild + restart + screenshot route(s) → JPEG paths
 ```
 
-Prefer `make dev-watch` for UI work. See `.claude/rules/ui.md` for the hot-reload loop and when to fall back to `make dev`.
+Prefer `make dev-watch` for interactive UI work. For **agent/automated validation** prefer `make dev-bg` (a tracked background server) + `make dev-shot` (one-shot screenshots) — these resolve the port for you and are reaped automatically. See `.claude/rules/ui.md` for the loop and `scripts/README.md` for the full lifecycle.
 
 - Dev DB: `postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable`
 - Test DB: `postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable`
 - Required env when any provider configured: `DATABASE_URL` (set explicitly — pgx's Unix-socket fallback often breaks in worktrees), `ENCRYPTION_KEY` (the session-start hook resolves this with precedence `.local.env` → running `breadbox serve` env → `~/.local/share/breadbox/dev-encryption-key` cache, and seeds the cache whenever the running-process path succeeds; if all three miss, recover manually via `ps eww -p $(pgrep -f 'breadbox serve' | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`).
-- Worktrees (`claude -w`): `.worktreeinclude` copies build artifacts; `.claude/hooks/session-start.sh` assigns a port from 8081–8099 and injects env via `CLAUDE_ENV_FILE`, exporting both `PORT` (read by the Makefile) and `SERVER_PORT` (read by the binary) so `make dev` *and* direct `go run ./cmd/breadbox serve` both land on the assigned port. Main repo uses 8080.
+- Worktrees (`claude -w`): `.worktreeinclude` copies build artifacts; `.claude/hooks/session-start.sh` reserves a port from 8081–8099 (via the shared `scripts/dev-lib.sh` registry under `~/.local/share/breadbox/dev-servers/`, keyed by worktree) and injects env via `CLAUDE_ENV_FILE`, exporting both `PORT` (read by the Makefile) and `SERVER_PORT` (read by the binary) so `make dev` *and* direct `go run ./cmd/breadbox serve` both land on the assigned port. Main repo uses 8080. If the hook didn't run for a worktree (e.g. created mid-session via the worktree tool), `make dev-bg` / `make dev` resolve a port lazily anyway — nothing has to fish.
 - Cloud sessions (Claude Code on the web): the same hook brings up Postgres, creates `breadbox` + `breadbox_test`, mints + caches `ENCRYPTION_KEY` at `~/.local/share/breadbox/dev-encryption-key`, builds `bin/breadbox`, applies migrations, seeds an admin (`admin@example.com` / `password`), and exports `DATABASE_URL` / `ENCRYPTION_KEY` / `SERVER_PORT=8081` / `BB_USER` / `BB_PASS` via `CLAUDE_ENV_FILE`. `bin/breadbox serve` works in one command; the validate-ui skill picks up `BB_USER`/`BB_PASS` automatically.
-- Stop all dev servers: `make dev-stop`.
+- Stop **this worktree's** managed server: `make dev-stop` (safe — leaves sibling worktrees running). Kill orphans (dead pid / removed worktree): `make dev-reap`. List all: `make dev-ps`. Nuke everything on 8080–8099: `make dev-stop-all`. Sessions also auto-stop their own server on exit (`.claude/hooks/session-end.sh`) and reap orphans on start, so stale instances no longer pile up.
 
 ## Browser automation
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ dev: generate css
 		echo "  Or add it to .local.env (auto-loaded by Make)"; \
 		exit 1; \
 	fi
-	@port=$$(PORT='$(PORT)' ./scripts/dev-port) || exit 1; \
+	@port=$$(BB_PORT_EXPLICIT='$(if $(filter command line,$(origin PORT)),1,)' PORT='$(PORT)' ./scripts/dev-port) || exit 1; \
 	if lsof -ti:$$port >/dev/null 2>&1; then \
 		echo "Error: port $$port is already in use."; \
 		echo "  - Run on another port:  make dev PORT=8085"; \
@@ -90,7 +90,7 @@ dev-watch: generate air-install
 		echo "  Or add it to .local.env (auto-loaded by Make)"; \
 		exit 1; \
 	fi
-	@port=$$(PORT='$(PORT)' ./scripts/dev-port) || exit 1; \
+	@port=$$(BB_PORT_EXPLICIT='$(if $(filter command line,$(origin PORT)),1,)' PORT='$(PORT)' ./scripts/dev-port) || exit 1; \
 	if lsof -ti:$$port >/dev/null 2>&1; then \
 		echo "Error: port $$port is already in use."; \
 		echo "  - Run on another port:  make dev-watch PORT=8085"; \
@@ -143,16 +143,11 @@ dev-reap:
 	@echo "Reaped orphaned dev servers."
 
 # dev-stop-all: blunt instrument — kill every process listening on 8080-8099,
-# including OTHER active worktrees. Also clears the managed-server registry.
+# including OTHER active worktrees. SIGTERM then SIGKILL survivors, then clears
+# the registry of entries whose process is actually gone (a survivor stays
+# tracked so dev-ps/dev-reap can still find it).
 dev-stop-all:
-	@pids=$$(lsof -ti:8080-8099 2>/dev/null | sort -u || true); \
-	if [ -z "$$pids" ]; then \
-		echo "No dev instances running."; \
-	else \
-		echo "$$pids" | xargs kill 2>/dev/null; \
-		echo "Stopped dev instances on ports 8080-8099: $$pids"; \
-	fi
-	@rm -f "$${BB_STATE_DIR:-$$HOME/.local/share/breadbox}"/dev-servers/* 2>/dev/null || true
+	@./scripts/dev-server stop-all
 
 build: generate
 	go build -o breadbox ./cmd/breadbox

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export
 
 TAILWIND_BIN := ./tailwindcss-extra
 
-.PHONY: dev dev-watch dev-stop build build-headless build-lite test test-integration lint lint-headless lint-lite generate migrate-up migrate-down migrate-create sqlc sqlc-install sqlc-tag seed db db-stop docker-up docker-down css css-watch css-install air-install templ templ-install templ-check openapi-validate agent-sidecar agent-sidecar-install agent-sidecar-install-user agent-sidecar-typecheck
+.PHONY: dev dev-watch dev-stop dev-stop-all dev-bg dev-ps dev-reap dev-shot build build-headless build-lite test test-integration lint lint-headless lint-lite generate migrate-up migrate-down migrate-create sqlc sqlc-install sqlc-tag seed db db-stop docker-up docker-down css css-watch css-install air-install templ templ-install templ-check openapi-validate agent-sidecar agent-sidecar-install agent-sidecar-install-user agent-sidecar-typecheck
 
 PORT ?= 8080
 
@@ -68,14 +68,16 @@ dev: generate css
 		echo "  Or add it to .local.env (auto-loaded by Make)"; \
 		exit 1; \
 	fi
-	@if lsof -ti:$(PORT) >/dev/null 2>&1; then \
-		echo "Error: port $(PORT) is already in use."; \
-		echo "  - Run on another port:  make dev PORT=8081"; \
-		echo "  - Or kill the existing process:  kill $$(lsof -ti:$(PORT))"; \
+	@port=$$(PORT='$(PORT)' ./scripts/dev-port) || exit 1; \
+	if lsof -ti:$$port >/dev/null 2>&1; then \
+		echo "Error: port $$port is already in use."; \
+		echo "  - Run on another port:  make dev PORT=8085"; \
+		echo "  - Or kill the existing process:  kill $$(lsof -ti:$$port)"; \
 		exit 1; \
-	fi
-	@echo $(PORT) > .breadbox-port
-	SERVER_PORT=$(PORT) go run ./cmd/breadbox serve; rm -f .breadbox-port
+	fi; \
+	echo $$port > .breadbox-port; \
+	echo "==> dev server: http://localhost:$$port"; \
+	SERVER_PORT=$$port go run ./cmd/breadbox serve; rm -f .breadbox-port
 
 # dev-watch: hot-reload everything — Go rebuilds via air, CSS rebuilds via
 # tailwind --watch, and BREADBOX_DEV_RELOAD=1 makes the running binary read
@@ -88,16 +90,18 @@ dev-watch: generate air-install
 		echo "  Or add it to .local.env (auto-loaded by Make)"; \
 		exit 1; \
 	fi
-	@if lsof -ti:$(PORT) >/dev/null 2>&1; then \
-		echo "Error: port $(PORT) is already in use."; \
-		echo "  - Run on another port:  make dev-watch PORT=8081"; \
-		echo "  - Or kill the existing process:  kill $$(lsof -ti:$(PORT))"; \
+	@port=$$(PORT='$(PORT)' ./scripts/dev-port) || exit 1; \
+	if lsof -ti:$$port >/dev/null 2>&1; then \
+		echo "Error: port $$port is already in use."; \
+		echo "  - Run on another port:  make dev-watch PORT=8085"; \
+		echo "  - Or kill the existing process:  kill $$(lsof -ti:$$port)"; \
 		exit 1; \
-	fi
-	@echo $(PORT) > .breadbox-port
-	@trap 'rm -f .breadbox-port; kill 0' EXIT INT TERM; \
+	fi; \
+	echo $$port > .breadbox-port; \
+	echo "==> dev-watch server: http://localhost:$$port"; \
+	trap 'rm -f .breadbox-port; kill 0' EXIT INT TERM; \
 		$(TAILWIND_BIN) -i input.css -o static/css/styles.css --watch & \
-		BREADBOX_DEV_RELOAD=1 SERVER_PORT=$(PORT) air -c .air.toml; \
+		BREADBOX_DEV_RELOAD=1 SERVER_PORT=$$port air -c .air.toml; \
 		wait
 
 air-install:
@@ -106,7 +110,41 @@ air-install:
 		go install github.com/air-verse/air@latest; \
 	fi
 
+# dev-bg: start (or reuse) a managed background dev server for THIS worktree.
+# Idempotent — reuses a healthy server if one is already up. Prints the URL.
+# This is the validation/pre-warm entrypoint: no port fishing, tracked for
+# cleanup, and reaped automatically when the session ends or the worktree is
+# removed. For interactive hot-reload instead, use `make dev-watch`.
+dev-bg:
+	@./scripts/dev-server ensure
+
+# dev-shot: rebuild, (re)start the managed server, and screenshot routes.
+# Pass routes + flags via ARGS, e.g.:
+#   make dev-shot ARGS="/transactions --mobile --wait '.join button'"
+# Prints the saved JPEG paths (upload via the github-image-hosting skill).
+dev-shot:
+	@./scripts/ui-validate $(ARGS)
+
+# dev-stop: stop ONLY this worktree's managed server (safe to run while other
+# worktrees keep theirs). Use dev-stop-all for the blunt range kill.
 dev-stop:
+	@./scripts/dev-server stop
+	@echo "Stopped this worktree's managed dev server (if any)."
+	@echo "To stop every breadbox on 8080-8099, run: make dev-stop-all"
+
+# dev-ps: list every managed dev server (port, pid, branch, worktree, alive).
+dev-ps:
+	@./scripts/dev-server ps
+
+# dev-reap: kill orphaned servers — dead pids and servers whose worktree was
+# removed. Leaves healthy, actively-owned servers alone.
+dev-reap:
+	@./scripts/dev-server reap
+	@echo "Reaped orphaned dev servers."
+
+# dev-stop-all: blunt instrument — kill every process listening on 8080-8099,
+# including OTHER active worktrees. Also clears the managed-server registry.
+dev-stop-all:
 	@pids=$$(lsof -ti:8080-8099 2>/dev/null | sort -u || true); \
 	if [ -z "$$pids" ]; then \
 		echo "No dev instances running."; \
@@ -114,6 +152,7 @@ dev-stop:
 		echo "$$pids" | xargs kill 2>/dev/null; \
 		echo "Stopped dev instances on ports 8080-8099: $$pids"; \
 	fi
+	@rm -f "$${BB_STATE_DIR:-$$HOME/.local/share/breadbox}"/dev-servers/* 2>/dev/null || true
 
 build: generate
 	go build -o breadbox ./cmd/breadbox

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,80 @@
+# Dev-server lifecycle scripts
+
+Tooling that makes running + validating Breadbox locally smooth across many
+worktrees and parallel agent sessions. The goals:
+
+1. **No port fishing.** Every worktree gets a deterministic port; all tools
+   resolve the same one.
+2. **No orphaned servers.** Servers are tracked and reaped when a session ends
+   or a worktree is removed.
+3. **One-command UI validation.** Rebuild + (re)start + screenshot in a single
+   step, with no dependence on the Chrome DevTools MCP (whose shared profile is
+   often locked by a concurrent session).
+
+Everything is plain bash 3.2 + coreutils + `lsof` + `curl` + `node`. No jq.
+
+## The pieces
+
+| File | What it does |
+|------|--------------|
+| `dev-lib.sh` | Sourced library: port resolution, the server registry, reaping. Single source of truth — the Makefile, both session hooks, and the validation scripts all call it. |
+| `dev-port` | Prints a bindable port for the current worktree (env → `.breadbox-port` → first free in 8081–8099). Used by `make dev` / `make dev-watch` so they never hard-fail on a busy port. Leaves the main checkout on 8080. |
+| `dev-server` | Manage a **background** server for this worktree: `ensure [--rebuild]`, `restart`, `stop`, `status`, `ps`, `reap`. |
+| `ui-shot.mjs` | puppeteer + system Chrome (fresh profile) authenticated screenshots. Env-driven. |
+| `ui-validate` | Rebuild → (re)start the managed server → screenshot routes. The validation entrypoint. |
+
+## The registry
+
+Running/reserved servers are tracked as one file per port under
+`~/.local/share/breadbox/dev-servers/<port>` (override with `BB_STATE_DIR`):
+
+```
+port=8087
+pid=12345           # a number = running; RESERVED = held, no server yet
+worktree=/Users/.../worktrees/foo
+branch=feat/x
+started=1730000000
+```
+
+Keyed by port, tagged with worktree. Reaping (on every SessionStart, on
+SessionEnd, and via `make dev-reap`) drops entries whose **pid is dead** and
+kills+drops servers whose **worktree was removed** — healthy, actively-owned
+servers are left alone.
+
+## Common commands (via make)
+
+All of these match the `make dev*` sandbox exclusion, so agents run them
+without disabling the sandbox.
+
+```sh
+make dev-bg                 # start/reuse a background server; prints the URL
+make dev-shot ARGS="/transactions --mobile"   # rebuild + restart + screenshot
+make dev-ps                 # list every managed server
+make dev-stop               # stop THIS worktree's server (safe for siblings)
+make dev-reap               # kill orphans (dead pid / removed worktree)
+make dev-stop-all           # blunt: kill everything on 8080-8099 + clear registry
+```
+
+`make dev` / `make dev-watch` are unchanged in spirit — they now resolve a free
+port automatically instead of erroring when their default is taken.
+
+## Lifecycle
+
+- **SessionStart** (`.claude/hooks/session-start.sh`) reaps orphans and reserves
+  this worktree's port into `CLAUDE_ENV_FILE` (`PORT` + `SERVER_PORT`).
+- **SessionEnd** (`.claude/hooks/session-end.sh`) stops this worktree's managed
+  server (skipped on `/clear`) and reaps the rest.
+- Worktree removed without a clean session end? The next SessionStart (or
+  `make dev-reap`) reaps the leftover server.
+
+## Notes
+
+- The managed background server runs a single `breadbox serve` with
+  `BREADBOX_DEV_RELOAD=1` (templates + static from disk). It is intentionally
+  **not** `air` — one process means a trivial, reliable lifecycle. Code edits
+  are picked up by `dev-server restart` (which rebuilds). For interactive
+  hot-reload, use `make dev-watch`.
+- `build` is resilient to the stale-`internal/db` gotcha: if `go build` fails it
+  forces `make sqlc && make templ` and retries once.
+- Per-worktree artifacts live in `.breadbox-dev/` (gitignored): the built
+  binary + `server.log`.

--- a/scripts/dev-lib.sh
+++ b/scripts/dev-lib.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# dev-lib.sh — shared helpers for managed Breadbox dev servers + deterministic
+# port assignment. Sourced by scripts/dev-server, scripts/dev-port,
+# scripts/ui-validate, and the session-start / session-end hooks.
+#
+# Goals:
+#   1. One place that decides which port a worktree's dev server uses, so no
+#      tool has to "fish" for a free port.
+#   2. A registry of running servers (keyed by port, tagged with worktree +
+#      pid) so they can be found, reused, and reaped — no more orphaned
+#      `breadbox serve` processes piling up after sessions close.
+#
+# Pure bash 3.2 + coreutils + lsof + curl. No jq, no associative arrays
+# (macOS ships bash 3.2). Local-dev only — cloud sessions pin SERVER_PORT=8081
+# and don't use the background manager.
+
+# --- tunables -------------------------------------------------------------
+BB_PORT_MIN="${BB_PORT_MIN:-8081}"
+BB_PORT_MAX="${BB_PORT_MAX:-8099}"
+
+# --- paths ----------------------------------------------------------------
+bb_state_dir()   { printf '%s\n' "${BB_STATE_DIR:-$HOME/.local/share/breadbox}"; }
+bb_servers_dir() { printf '%s\n' "$(bb_state_dir)/dev-servers"; }
+bb_log()         { printf '%s\n' "$*" >&2; }
+
+# Worktree root for a dir (defaults to cwd). Falls back to the dir itself.
+bb_worktree_root() {
+  local d="${1:-$PWD}"
+  ( cd "$d" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null ) \
+    || printf '%s\n' "$d"
+}
+
+bb_current_branch() {
+  local d="${1:-$PWD}"
+  ( cd "$d" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null ) || true
+}
+
+# True only inside a linked worktree (git worktree add), not the main checkout.
+# In a linked worktree --git-dir (.../.git/worktrees/<name>) differs from
+# --git-common-dir (.../.git); in the main repo they match.
+bb_is_linked_worktree() {
+  local d="${1:-$PWD}" gd cd
+  gd="$( cd "$d" 2>/dev/null && git rev-parse --git-dir 2>/dev/null )" || return 1
+  cd="$( cd "$d" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null )" || return 1
+  [ -n "$gd" ] && [ "$gd" != "$cd" ]
+}
+
+# --- primitives -----------------------------------------------------------
+# -nP: skip DNS + service-name lookups; -sTCP:LISTEN: only count a listener.
+bb_port_in_use() { lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1; }
+bb_pid_alive()   { [ -n "$1" ] && kill -0 "$1" >/dev/null 2>&1; }
+bb_now()         { date +%s; }
+bb_mtime()       { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0; }
+bb_health()      { curl -fsS -o /dev/null --max-time 2 "http://localhost:$1/health/live" 2>/dev/null; }
+
+# meta files are simple key=value lines. pid is a number, or RESERVED (a port
+# held by session-start before any server is booted).
+bb_meta_get() { # <file> <key>
+  [ -f "$1" ] || return 1
+  sed -n "s/^$2=//p" "$1" | head -1
+}
+
+# --- env ------------------------------------------------------------------
+# Populate DATABASE_URL + ENCRYPTION_KEY for a server boot. Mirrors the
+# session-start hook's resolution: .local.env (canonical) -> on-disk key cache.
+bb_load_env() { # <root>
+  local root="$1" cache cand _opts
+  if [ -f "$root/.local.env" ]; then
+    # Source tolerantly: a .local.env that references an unset var must not
+    # abort a caller running `set -euo pipefail`. Save + restore errexit/nounset.
+    _opts="$-"
+    set -a; set +eu
+    . "$root/.local.env" || true
+    set +a
+    case "$_opts" in *e*) set -e;; esac
+    case "$_opts" in *u*) set -u;; esac
+  fi
+  export DATABASE_URL="${DATABASE_URL:-postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable}"
+  if [ -z "${ENCRYPTION_KEY:-}" ]; then
+    cache="$(bb_state_dir)/dev-encryption-key"
+    if [ -f "$cache" ]; then
+      cand="$(head -1 "$cache" 2>/dev/null | tr -d '\r\n')"
+      if [[ "$cand" =~ ^[0-9a-fA-F]{64}$ ]]; then export ENCRYPTION_KEY="$cand"; fi
+    fi
+  fi
+}
+
+# --- registry -------------------------------------------------------------
+# Print the port whose registry entry is owned by <root>, if any.
+bb_server_for_worktree() { # <root>
+  local root="$1" dir f wt
+  dir="$(bb_servers_dir)"
+  [ -d "$dir" ] || return 1
+  for f in "$dir"/*; do
+    [ -f "$f" ] || continue
+    wt="$(bb_meta_get "$f" worktree)"
+    if [ "$wt" = "$root" ]; then
+      basename "$f"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Claim a port for <root>, writing a placeholder registry entry. Preference:
+# explicit SERVER_PORT/PORT env -> existing .breadbox-port -> existing
+# reservation owned by this root -> first free port in range. <state> is the
+# pid field to stamp (RESERVED for a reservation, PENDING for an imminent boot).
+# Echoes the claimed port, or returns non-zero if the range is exhausted.
+bb_claim_port() { # <root> <state>
+  local root="$1" state="${2:-PENDING}" dir port pref owner opid
+  dir="$(bb_servers_dir)"; mkdir -p "$dir"
+
+  pref=""
+  [ -n "${SERVER_PORT:-}" ] && pref="$SERVER_PORT"
+  if [ -z "$pref" ] && [ -n "${PORT:-}" ] && [ "$PORT" != "8080" ]; then pref="$PORT"; fi
+  if [ -z "$pref" ] && [ -f "$root/.breadbox-port" ]; then
+    pref="$(head -1 "$root/.breadbox-port" 2>/dev/null | tr -dc '0-9')"
+  fi
+
+  for port in $pref $(seq "$BB_PORT_MIN" "$BB_PORT_MAX"); do
+    [ -n "$port" ] || continue
+    if [ -f "$dir/$port" ]; then
+      owner="$(bb_meta_get "$dir/$port" worktree)"
+      if [ "$owner" = "$root" ]; then
+        printf '%s\n' "$port"; return 0   # already ours — reuse the claim
+      fi
+      opid="$(bb_meta_get "$dir/$port" pid)"
+      if [ "$opid" = "RESERVED" ] || [ "$opid" = "PENDING" ] || bb_pid_alive "$opid"; then
+        continue                          # held by another live worktree
+      fi
+      rm -f "$dir/$port"                   # stale entry — reclaim
+    fi
+    bb_port_in_use "$port" && continue
+    if ( set -o noclobber
+         printf 'port=%s\npid=%s\nworktree=%s\nbranch=%s\nstarted=%s\n' \
+           "$port" "$state" "$root" "$(bb_current_branch "$root")" "$(bb_now)" \
+           > "$dir/$port" ) 2>/dev/null; then
+      printf '%s\n' "$port"; return 0
+    fi
+  done
+  return 1
+}
+
+bb_meta_write() { # <port> <pid> <root> <log>
+  local port="$1" pid="$2" root="$3" log="$4"
+  printf 'port=%s\npid=%s\nworktree=%s\nbranch=%s\nstarted=%s\nlog=%s\nsession=%s\n' \
+    "$port" "$pid" "$root" "$(bb_current_branch "$root")" "$(bb_now)" "$log" \
+    "${CLAUDE_SESSION_ID:-}" > "$(bb_servers_dir)/$port"
+}
+
+# Stop the server registered on <port> and clear its entry.
+bb_stop_port() { # <port>
+  local port="$1" f pid root i
+  f="$(bb_servers_dir)/$port"
+  pid=""; root=""
+  if [ -f "$f" ]; then
+    pid="$(bb_meta_get "$f" pid)"
+    root="$(bb_meta_get "$f" worktree)"
+  fi
+  case "$pid" in
+    ''|RESERVED|PENDING) : ;;
+    *)
+      # launch() execs into the server, so the recorded pid IS the listener —
+      # killing it frees the port. `|| true` keeps a lost race (pid already
+      # gone) from aborting cleanup under the caller's set -e.
+      if bb_pid_alive "$pid"; then
+        kill "$pid" 2>/dev/null || true
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+          bb_pid_alive "$pid" || break
+          sleep 0.3
+        done
+        bb_pid_alive "$pid" && { kill -9 "$pid" 2>/dev/null || true; }
+      fi
+      ;;
+  esac
+  rm -f "$f"
+  if [ -n "$root" ] && [ -f "$root/.breadbox-port" ]; then
+    [ "$(head -1 "$root/.breadbox-port" 2>/dev/null | tr -dc '0-9')" = "$port" ] \
+      && rm -f "$root/.breadbox-port"
+  fi
+}
+
+# Stop the managed server for a worktree root (if any).
+bb_stop_worktree() { # <root>
+  local root="$1" port
+  port="$(bb_server_for_worktree "$root" || true)"
+  [ -n "$port" ] || return 0
+  bb_log "==> stopping dev server on :$port ($root)"
+  bb_stop_port "$port"
+}
+
+# Reap orphans: forget dead servers, kill servers whose worktree was removed,
+# and drop stale RESERVED/PENDING claims for worktrees that no longer exist.
+bb_reap() {
+  local dir f pid wt killed
+  dir="$(bb_servers_dir)"
+  [ -d "$dir" ] || return 0
+  killed=0
+  for f in "$dir"/*; do
+    [ -f "$f" ] || continue
+    pid="$(bb_meta_get "$f" pid)"
+    wt="$(bb_meta_get "$f" worktree)"
+    case "$pid" in
+      RESERVED)
+        # A session reservation survives while its worktree exists.
+        if [ -n "$wt" ] && [ ! -d "$wt" ]; then rm -f "$f"; fi
+        ;;
+      PENDING)
+        # A boot-in-progress claim should be short-lived. Drop it if the
+        # worktree is gone, or if it's older than 10 min (a crashed/killed
+        # boot that never reached bb_meta_write) — otherwise it would hold the
+        # port forever with no time-based recovery.
+        if { [ -n "$wt" ] && [ ! -d "$wt" ]; } \
+           || [ "$(( $(bb_now) - $(bb_mtime "$f") ))" -gt 600 ]; then
+          rm -f "$f"
+        fi
+        ;;
+      ''|*[!0-9]*)
+        rm -f "$f"            # malformed
+        ;;
+      *)
+        if ! bb_pid_alive "$pid"; then
+          rm -f "$f"          # process gone — forget it
+        elif [ -n "$wt" ] && [ ! -d "$wt" ]; then
+          kill "$pid" 2>/dev/null && killed=$((killed + 1))
+          rm -f "$f"          # worktree removed but server lingered — reap it
+        fi
+        ;;
+    esac
+  done
+  [ "$killed" -gt 0 ] && bb_log "==> reaped $killed orphaned dev server(s)"
+  return 0
+}

--- a/scripts/dev-lib.sh
+++ b/scripts/dev-lib.sh
@@ -53,6 +53,12 @@ bb_now()         { date +%s; }
 bb_mtime()       { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0; }
 bb_health()      { curl -fsS -o /dev/null --max-time 2 "http://localhost:$1/health/live" 2>/dev/null; }
 
+# Claude Code exposes the session id to hooks (stdin JSON) and to the session
+# environment as CLAUDE_CODE_SESSION_ID. Older builds used CLAUDE_SESSION_ID, so
+# accept both. Used to tag registry entries with their creating session so
+# session-end won't kill a server another live session in the same worktree owns.
+bb_session_id()  { printf '%s' "${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"; }
+
 # meta files are simple key=value lines. pid is a number, or RESERVED (a port
 # held by session-start before any server is booted).
 bb_meta_get() { # <file> <key>
@@ -71,9 +77,9 @@ bb_load_env() { # <root>
     _opts="$-"
     set -a; set +eu
     . "$root/.local.env" || true
-    set +a
     case "$_opts" in *e*) set -e;; esac
     case "$_opts" in *u*) set -u;; esac
+    case "$_opts" in *a*) ;; *) set +a;; esac   # only disable allexport if caller had it off
   fi
   export DATABASE_URL="${DATABASE_URL:-postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable}"
   if [ -z "${ENCRYPTION_KEY:-}" ]; then
@@ -133,8 +139,8 @@ bb_claim_port() { # <root> <state>
     fi
     bb_port_in_use "$port" && continue
     if ( set -o noclobber
-         printf 'port=%s\npid=%s\nworktree=%s\nbranch=%s\nstarted=%s\n' \
-           "$port" "$state" "$root" "$(bb_current_branch "$root")" "$(bb_now)" \
+         printf 'port=%s\npid=%s\nworktree=%s\nbranch=%s\nstarted=%s\nsession=%s\n' \
+           "$port" "$state" "$root" "$(bb_current_branch "$root")" "$(bb_now)" "$(bb_session_id)" \
            > "$dir/$port" ) 2>/dev/null; then
       printf '%s\n' "$port"; return 0
     fi
@@ -146,7 +152,7 @@ bb_meta_write() { # <port> <pid> <root> <log>
   local port="$1" pid="$2" root="$3" log="$4"
   printf 'port=%s\npid=%s\nworktree=%s\nbranch=%s\nstarted=%s\nlog=%s\nsession=%s\n' \
     "$port" "$pid" "$root" "$(bb_current_branch "$root")" "$(bb_now)" "$log" \
-    "${CLAUDE_SESSION_ID:-}" > "$(bb_servers_dir)/$port"
+    "$(bb_session_id)" > "$(bb_servers_dir)/$port"
 }
 
 # Stop the server registered on <port> and clear its entry.
@@ -230,5 +236,39 @@ bb_reap() {
     esac
   done
   [ "$killed" -gt 0 ] && bb_log "==> reaped $killed orphaned dev server(s)"
+  return 0
+}
+
+# Blunt instrument: stop EVERY process listening on the dev range (including
+# other worktrees') and clear the registry. SIGTERM first, wait, then SIGKILL
+# survivors — a process that ignores TERM (e.g. an `air` supervisor) would
+# otherwise live on untracked. Only registry entries whose process is actually
+# gone are removed, so a true survivor stays findable via dev-ps/dev-reap.
+bb_stop_all() { # [lo] [hi]
+  local lo="${1:-8080}" hi="${2:-8099}" pids pid i dir f epid
+  pids="$(lsof -ti:"$lo"-"$hi" 2>/dev/null | sort -u || true)"
+  if [ -n "$pids" ]; then
+    for pid in $pids; do kill "$pid" 2>/dev/null || true; done
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+      pids="$(lsof -ti:"$lo"-"$hi" 2>/dev/null | sort -u || true)"
+      [ -n "$pids" ] || break
+      sleep 0.3
+    done
+    pids="$(lsof -ti:"$lo"-"$hi" 2>/dev/null | sort -u || true)"
+    for pid in $pids; do kill -9 "$pid" 2>/dev/null || true; done
+    bb_log "==> stopped dev instances on $lo-$hi"
+  else
+    bb_log "No dev instances running on $lo-$hi."
+  fi
+  dir="$(bb_servers_dir)"
+  [ -d "$dir" ] || return 0
+  for f in "$dir"/*; do
+    [ -f "$f" ] || continue
+    epid="$(bb_meta_get "$f" pid)"
+    case "$epid" in
+      ''|RESERVED|PENDING) rm -f "$f" ;;          # no live process behind these
+      *) bb_pid_alive "$epid" || rm -f "$f" ;;    # keep tracking a survivor
+    esac
+  done
   return 0
 }

--- a/scripts/dev-port
+++ b/scripts/dev-port
@@ -2,7 +2,9 @@
 # dev-port — print a port the current worktree can bind a dev server to.
 #
 # Resolution order:
-#   1. SERVER_PORT / PORT (if explicitly set, and not the main-repo default 8080)
+#   0. an EXPLICIT `make dev PORT=N` (BB_PORT_EXPLICIT=1) — wins over everything,
+#      including a SERVER_PORT a worktree session exported into the environment
+#   1. SERVER_PORT / PORT (if set in the env, and not the main-repo default 8080)
 #   2. this worktree's last port (.breadbox-port), if currently free
 #   3. the first free, unclaimed port in BB_PORT_MIN..BB_PORT_MAX
 #
@@ -35,6 +37,13 @@ usable() { # <port> -> bindable now and not held by another worktree
   return 0
 }
 
+# An explicit `make dev PORT=N` (set on the command line; the Makefile forwards
+# BB_PORT_EXPLICIT=1) is the user's deliberate override and wins over the ambient
+# SERVER_PORT a worktree session exports. Honored verbatim, even if it's 8080.
+if [ "${BB_PORT_EXPLICIT:-}" = "1" ] && [ -n "${PORT:-}" ]; then
+  printf '%s\n' "$PORT"; exit 0
+fi
+
 candidate=""
 if [ -n "${SERVER_PORT:-}" ]; then candidate="$SERVER_PORT"
 elif [ -n "${PORT:-}" ] && [ "$PORT" != "8080" ]; then candidate="$PORT"
@@ -42,7 +51,7 @@ elif [ -f "$ROOT/.breadbox-port" ]; then
   candidate="$(head -1 "$ROOT/.breadbox-port" 2>/dev/null | tr -dc '0-9')"
 fi
 
-# An explicitly-set env port is honored as-is (the user/Makefile asked for it).
+# An ambient env port (SERVER_PORT, or a non-default PORT) is honored as-is.
 if [ -n "${SERVER_PORT:-}" ] || { [ -n "${PORT:-}" ] && [ "$PORT" != "8080" ]; }; then
   printf '%s\n' "$candidate"; exit 0
 fi

--- a/scripts/dev-port
+++ b/scripts/dev-port
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# dev-port — print a port the current worktree can bind a dev server to.
+#
+# Resolution order:
+#   1. SERVER_PORT / PORT (if explicitly set, and not the main-repo default 8080)
+#   2. this worktree's last port (.breadbox-port), if currently free
+#   3. the first free, unclaimed port in BB_PORT_MIN..BB_PORT_MAX
+#
+# Used by `make dev` / `make dev-watch` so they land on a free port instead of
+# hard-failing when their default is taken. Unlike `dev-server ensure`, this
+# does NOT boot anything and does NOT write the server registry — it resolves a
+# port, records it in .breadbox-port for stability, and prints it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/dev-lib.sh
+. "$SCRIPT_DIR/dev-lib.sh"
+
+ROOT="$(bb_worktree_root)"
+DIR="$(bb_servers_dir)"; mkdir -p "$DIR"
+
+claimed_by_other() { # <port> -> 0 if a *different* live worktree holds it
+  local port="$1" owner opid
+  [ -f "$DIR/$port" ] || return 1
+  owner="$(bb_meta_get "$DIR/$port" worktree)"
+  [ "$owner" = "$ROOT" ] && return 1
+  opid="$(bb_meta_get "$DIR/$port" pid)"
+  { [ "$opid" = RESERVED ] || [ "$opid" = PENDING ] || bb_pid_alive "$opid"; }
+}
+
+usable() { # <port> -> bindable now and not held by another worktree
+  local port="$1"
+  bb_port_in_use "$port" && return 1
+  claimed_by_other "$port" && return 1
+  return 0
+}
+
+candidate=""
+if [ -n "${SERVER_PORT:-}" ]; then candidate="$SERVER_PORT"
+elif [ -n "${PORT:-}" ] && [ "$PORT" != "8080" ]; then candidate="$PORT"
+elif [ -f "$ROOT/.breadbox-port" ]; then
+  candidate="$(head -1 "$ROOT/.breadbox-port" 2>/dev/null | tr -dc '0-9')"
+fi
+
+# An explicitly-set env port is honored as-is (the user/Makefile asked for it).
+if [ -n "${SERVER_PORT:-}" ] || { [ -n "${PORT:-}" ] && [ "$PORT" != "8080" ]; }; then
+  printf '%s\n' "$candidate"; exit 0
+fi
+
+# The main checkout keeps its conventional 8080 — only linked worktrees get an
+# auto-assigned 8081-8099 port. (A worktree that already recorded a port in
+# .breadbox-port still reuses it, handled below.)
+if ! bb_is_linked_worktree "$ROOT" && [ -z "$candidate" ]; then
+  printf '%s\n' "${PORT:-8080}"; exit 0
+fi
+
+port=""
+if [ -n "$candidate" ] && usable "$candidate"; then
+  port="$candidate"
+else
+  for p in $(seq "$BB_PORT_MIN" "$BB_PORT_MAX"); do
+    if usable "$p"; then port="$p"; break; fi
+  done
+fi
+
+if [ -z "$port" ]; then
+  bb_log "ERROR: no free port in $BB_PORT_MIN-$BB_PORT_MAX (try: make dev-reap)"
+  exit 1
+fi
+
+# Record the choice in .breadbox-port for per-worktree stability, but do NOT
+# write a registry entry: `make dev` runs the server in the foreground and never
+# clears such an entry on exit, which would leak a stale RESERVED claim. The
+# registry is owned exclusively by managed background servers (scripts/dev-server),
+# whose actual port-bind already protects the port from concurrent pickers.
+printf '%s\n' "$port" > "$ROOT/.breadbox-port" 2>/dev/null || true
+printf '%s\n' "$port"

--- a/scripts/dev-server
+++ b/scripts/dev-server
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# dev-server — manage a background Breadbox dev server for the current worktree.
+#
+#   scripts/dev-server ensure   [--rebuild]   boot if needed (reuse if up); print URL
+#   scripts/dev-server restart                rebuild + relaunch (used by ui-validate)
+#   scripts/dev-server stop                   stop this worktree's server
+#   scripts/dev-server status                 print this worktree's server, if any
+#   scripts/dev-server ps                     list all managed servers
+#   scripts/dev-server reap                   kill orphans (dead pid / worktree gone)
+#
+# The managed server runs a single `breadbox serve` with BREADBOX_DEV_RELOAD=1
+# (templates + static served from disk). It is intentionally NOT `air`: one
+# process means a trivial, reliable lifecycle. Code changes are picked up by
+# `restart` (which rebuilds). For interactive hot-reload, use `make dev-watch`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/dev-lib.sh
+. "$SCRIPT_DIR/dev-lib.sh"
+
+ROOT="$(bb_worktree_root)"
+BIN_DIR="$ROOT/.breadbox-dev"
+BIN="$BIN_DIR/breadbox"
+LOG="$BIN_DIR/server.log"
+
+build_binary() { # regenerate templ + css so the server reflects edits, then build
+  mkdir -p "$BIN_DIR"
+  bb_log "==> generating templ + css..."
+  ( cd "$ROOT" && make generate >/dev/null 2>&1 ) || true
+  bb_log "==> building server binary..."
+  if ( cd "$ROOT" && go build -o "$BIN" ./cmd/breadbox ) 2>"$BIN_DIR/build.err"; then
+    return 0
+  fi
+  # Stale gitignored generated code is the usual culprit on a fresh checkout or
+  # branch switch: `make generate` only reruns sqlc when models.go is *missing*,
+  # so an existing-but-stale internal/db breaks the build (e.g. a column added
+  # on main). Force a full sqlc + templ regen and retry once.
+  bb_log "==> build failed — forcing sqlc + templ regen and retrying..."
+  ( cd "$ROOT" && make sqlc >/dev/null 2>&1 ) || true
+  ( cd "$ROOT" && make templ >/dev/null 2>&1 ) || true
+  if ( cd "$ROOT" && go build -o "$BIN" ./cmd/breadbox ) 2>"$BIN_DIR/build.err"; then
+    return 0
+  fi
+  bb_log "ERROR: go build still failing. Last errors:"
+  tail -n 20 "$BIN_DIR/build.err" >&2 || true
+  return 1
+}
+
+launch() { # <port> — boot the server, record it, wait for health
+  local port="$1" pid i
+  bb_load_env "$ROOT"
+  mkdir -p "$BIN_DIR"
+  bb_log "==> launching breadbox serve on :$port ..."
+  # `exec` so the backgrounded subshell BECOMES the server: $! is then the real
+  # breadbox pid, not a wrapping subshell whose death would orphan the server.
+  ( cd "$ROOT" && exec nohup env \
+      DATABASE_URL="$DATABASE_URL" \
+      ENCRYPTION_KEY="${ENCRYPTION_KEY:-}" \
+      SERVER_PORT="$port" \
+      BREADBOX_DEV_RELOAD=1 \
+      "$BIN" serve >"$LOG" 2>&1 ) &
+  pid=$!
+  # disown takes a jobspec, not a PID; bare `disown` drops the just-backgrounded
+  # job so the script's exit can't SIGHUP it (nohup is belt-and-suspenders).
+  disown 2>/dev/null || true
+  bb_meta_write "$port" "$pid" "$ROOT" "$LOG"
+  printf '%s\n' "$port" > "$ROOT/.breadbox-port"
+
+  for i in $(seq 1 40); do
+    if bb_health "$port"; then
+      bb_log "==> up: http://localhost:$port (pid $pid)"
+      printf '%s\n' "$port"
+      return 0
+    fi
+    if ! bb_pid_alive "$pid"; then
+      bb_log "ERROR: server exited during startup. Last log lines:"
+      tail -n 15 "$LOG" >&2 || true
+      bb_stop_port "$port"
+      return 1
+    fi
+    sleep 0.5
+  done
+  bb_log "ERROR: server did not become healthy on :$port within 20s. Log tail:"
+  tail -n 15 "$LOG" >&2 || true
+  bb_stop_port "$port"
+  return 1
+}
+
+cmd_ensure() {
+  local rebuild=0
+  [ "${1:-}" = "--rebuild" ] && rebuild=1
+
+  local existing pid
+  existing="$(bb_server_for_worktree "$ROOT" || true)"
+  if [ -n "$existing" ]; then
+    pid="$(bb_meta_get "$(bb_servers_dir)/$existing" pid)"
+    if [ "$pid" != RESERVED ] && [ "$pid" != PENDING ] && bb_pid_alive "$pid" && bb_health "$existing"; then
+      if [ "$rebuild" -eq 1 ]; then
+        bb_log "==> rebuilding + restarting healthy server on :$existing"
+        bb_stop_port "$existing"
+      else
+        bb_log "==> reusing healthy server on :$existing"
+        printf '%s\n' "http://localhost:$existing"
+        return 0
+      fi
+    else
+      bb_stop_port "$existing"   # stale / unhealthy — clear it
+    fi
+  fi
+
+  local port
+  port="$(bb_claim_port "$ROOT" PENDING)" || {
+    bb_log "ERROR: no free port in $BB_PORT_MIN-$BB_PORT_MAX. Try: scripts/dev-server reap"
+    return 1
+  }
+  if ! build_binary; then
+    bb_stop_port "$port"   # release the claim we just made
+    return 1
+  fi
+  if ! port="$(launch "$port")"; then
+    return 1               # launch() already released the claim on failure
+  fi
+  printf '%s\n' "http://localhost:$port"
+}
+
+case "${1:-ensure}" in
+  ensure)  shift || true; cmd_ensure "${1:-}";;
+  restart) cmd_ensure --rebuild;;
+  stop)    bb_stop_worktree "$ROOT";;
+  status)
+    port="$(bb_server_for_worktree "$ROOT" || true)"
+    if [ -n "$port" ]; then
+      pid="$(bb_meta_get "$(bb_servers_dir)/$port" pid)"
+      alive="no"; bb_pid_alive "$pid" && alive="yes"
+      printf 'port=%s pid=%s alive=%s url=http://localhost:%s\n' "$port" "$pid" "$alive" "$port"
+    else
+      echo "no managed server for $ROOT"
+    fi
+    ;;
+  ps)
+    dir="$(bb_servers_dir)"
+    printf '%-6s %-8s %-6s %-28s %s\n' PORT PID ALIVE BRANCH WORKTREE
+    if [ -d "$dir" ]; then
+      for f in "$dir"/*; do
+        [ -f "$f" ] || continue
+        p="$(bb_meta_get "$f" port)"; pid="$(bb_meta_get "$f" pid)"
+        br="$(bb_meta_get "$f" branch)"; wt="$(bb_meta_get "$f" worktree)"
+        alive="no"; { [ "$pid" = RESERVED ] || [ "$pid" = PENDING ]; } && alive="$pid"
+        bb_pid_alive "$pid" && alive="yes"
+        printf '%-6s %-8s %-6s %-28s %s\n' "$p" "$pid" "$alive" "${br:-?}" "${wt:-?}"
+      done
+    fi
+    ;;
+  reap)  bb_reap;;
+  *) bb_log "usage: dev-server {ensure [--rebuild]|restart|stop|status|ps|reap}"; exit 2;;
+esac

--- a/scripts/dev-server
+++ b/scripts/dev-server
@@ -4,6 +4,7 @@
 #   scripts/dev-server ensure   [--rebuild]   boot if needed (reuse if up); print URL
 #   scripts/dev-server restart                rebuild + relaunch (used by ui-validate)
 #   scripts/dev-server stop                   stop this worktree's server
+#   scripts/dev-server stop-all               stop EVERY breadbox on 8080-8099 (blunt)
 #   scripts/dev-server status                 print this worktree's server, if any
 #   scripts/dev-server ps                     list all managed servers
 #   scripts/dev-server reap                   kill orphans (dead pid / worktree gone)
@@ -127,6 +128,7 @@ case "${1:-ensure}" in
   ensure)  shift || true; cmd_ensure "${1:-}";;
   restart) cmd_ensure --rebuild;;
   stop)    bb_stop_worktree "$ROOT";;
+  stop-all) bb_stop_all 8080 8099;;
   status)
     port="$(bb_server_for_worktree "$ROOT" || true)"
     if [ -n "$port" ]; then
@@ -152,5 +154,5 @@ case "${1:-ensure}" in
     fi
     ;;
   reap)  bb_reap;;
-  *) bb_log "usage: dev-server {ensure [--rebuild]|restart|stop|status|ps|reap}"; exit 2;;
+  *) bb_log "usage: dev-server {ensure [--rebuild]|restart|stop|stop-all|status|ps|reap}"; exit 2;;
 esac

--- a/scripts/ui-shot.mjs
+++ b/scripts/ui-shot.mjs
@@ -1,0 +1,120 @@
+// ui-shot.mjs — authenticated, deterministic screenshots of the Breadbox admin
+// UI using puppeteer + system Chrome with a fresh profile. Deliberately avoids
+// the Chrome DevTools MCP, whose shared profile is frequently locked by a
+// concurrent session — this path never collides.
+//
+// Driven entirely by env vars so it stays shell-friendly:
+//   BASE      base URL                       (default http://localhost:8081)
+//   ROUTES    comma list of `path[:slug]`    (default "/transactions:transactions")
+//   OUTDIR    directory for the JPEGs        (default $TMPDIR or /tmp)
+//   VIEWPORT  desktop|mobile|tablet|WxH      (default desktop = 1280x800)
+//   WAIT      optional CSS selector to await before capture
+//   FULL      "true" for full-page capture   (default viewport-only)
+//   BB_USER / BB_PASS  admin login           (default admin@example.com/password)
+//
+// Prints one absolute file path per captured route, to stdout.
+
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+function loadPuppeteer() {
+  const candidates = [
+    '/opt/homebrew/lib/node_modules/mint/node_modules/puppeteer', // local: nested under mint
+    'puppeteer',                                                   // global, if installed
+    '/opt/node22/lib/node_modules/puppeteer',                     // cloud image
+  ];
+  for (const c of candidates) {
+    try { return require(c); } catch { /* try next */ }
+  }
+  throw new Error('puppeteer not found in any known location: ' + candidates.join(', '));
+}
+
+function chromePath() {
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+  ].filter(Boolean);
+  for (const c of candidates) if (existsSync(c)) return c;
+  return undefined; // let puppeteer use its bundled chromium if present
+}
+
+const VIEWPORTS = {
+  desktop: { width: 1280, height: 800 },
+  wide:    { width: 1440, height: 900 },
+  tablet:  { width: 768,  height: 1024 },
+  mobile:  { width: 390,  height: 844 },
+};
+
+function parseViewport(v) {
+  if (!v) return VIEWPORTS.desktop;
+  if (VIEWPORTS[v]) return VIEWPORTS[v];
+  const m = /^(\d+)x(\d+)$/.exec(v);
+  if (m) return { width: +m[1], height: +m[2] };
+  return VIEWPORTS.desktop;
+}
+
+const BASE = process.env.BASE || 'http://localhost:8081';
+const OUTDIR = process.env.OUTDIR || process.env.TMPDIR || '/tmp';
+const VP = parseViewport(process.env.VIEWPORT);
+const WAIT = process.env.WAIT || '';
+const FULL = process.env.FULL === 'true';
+const USER = process.env.BB_USER || 'admin@example.com';
+const PASS = process.env.BB_PASS || 'password';
+const VTAG = process.env.VIEWPORT && VIEWPORTS[process.env.VIEWPORT] ? process.env.VIEWPORT
+           : (process.env.VIEWPORT ? 'custom' : 'desktop');
+
+const routes = (process.env.ROUTES || '/transactions:transactions')
+  .split(',').map(s => s.trim()).filter(Boolean)
+  .map(r => { const [path, slug] = r.split(':'); return { path, slug: slug || path.replace(/\W+/g, '-').replace(/^-|-$/g, '') || 'page' }; });
+
+const puppeteer = loadPuppeteer();
+
+const browser = await puppeteer.launch({
+  executablePath: chromePath(),
+  headless: 'new',
+  userDataDir: process.env.UDD,
+  args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-breakpad'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ ...VP, deviceScaleFactor: 2 });
+
+  // Use domcontentloaded (not networkidle2): admin pages run setInterval polling
+  // that can keep the network busy indefinitely, so networkidle2 may never fire
+  // and would throw, aborting the whole run. Navigation errors are non-fatal —
+  // we still attempt the capture.
+  const goto = (u) => page.goto(u, { waitUntil: 'domcontentloaded', timeout: 25000 }).catch(() => {});
+
+  // Prime + login once.
+  await goto(BASE + routes[0].path);
+  if (page.url().includes('/login')) {
+    const ok = await page.evaluate((u, p) => {
+      const f = document.querySelector('form');
+      if (!f) return false;
+      const user = f.querySelector('input[name="username"], input[type="text"], input[type="email"]');
+      const pass = f.querySelector('input[name="password"], input[type="password"]');
+      if (!user || !pass) return false;
+      user.value = u; pass.value = p;
+      f.submit();
+      return true;
+    }, USER, PASS);
+    if (!ok) { console.error('login form not found at /login — check selectors/credentials'); }
+    await page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 25000 }).catch(() => {});
+  }
+
+  for (const { path, slug } of routes) {
+    await goto(BASE + path);
+    if (WAIT) await page.waitForSelector(WAIT, { timeout: 12000 }).catch(() => {});
+    await new Promise(r => setTimeout(r, 800)); // let lucide + alpine settle
+    const out = `${OUTDIR.replace(/\/$/, '')}/ui-${slug}-${VTAG}.jpg`;
+    await page.screenshot({ path: out, type: 'jpeg', quality: 85, fullPage: FULL });
+    console.log(out);
+  }
+} finally {
+  await browser.close();
+}

--- a/scripts/ui-validate
+++ b/scripts/ui-validate
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ui-validate — one command to validate a Breadbox admin UI change:
+# rebuild, (re)start this worktree's managed dev server, and screenshot one or
+# more routes. Prints the saved JPEG paths, ready to upload (img402.dev) and
+# embed in a PR.
+#
+#   scripts/ui-validate /transactions
+#   scripts/ui-validate /transactions /reviews --mobile
+#   scripts/ui-validate /transactions:tx --wait '.join button' --desktop --mobile
+#
+# Routes are positional (`path[:slug]`). Flags:
+#   --desktop / --mobile / --tablet / --wide   viewport(s); repeatable; default --desktop
+#   --wait <css>     wait for a selector before capture
+#   --full           full-page capture
+#   --no-rebuild     reuse the running server as-is (skip rebuild+restart)
+#   --base <url>     override base URL (default: this worktree's managed server)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/dev-lib.sh
+. "$SCRIPT_DIR/dev-lib.sh"
+
+ROOT="$(bb_worktree_root)"
+ROUTES=""
+VIEWPORTS=""
+WAIT=""
+FULL="false"
+REBUILD=1
+BASE_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --desktop) VIEWPORTS="$VIEWPORTS desktop";;
+    --mobile)  VIEWPORTS="$VIEWPORTS mobile";;
+    --tablet)  VIEWPORTS="$VIEWPORTS tablet";;
+    --wide)    VIEWPORTS="$VIEWPORTS wide";;
+    --wait)    shift; WAIT="${1:-}";;
+    --full)    FULL="true";;
+    --no-rebuild) REBUILD=0;;
+    --base)    shift; BASE_OVERRIDE="${1:-}";;
+    -*) bb_log "unknown flag: $1"; exit 2;;
+    *)  ROUTES="$ROUTES $1";;
+  esac
+  shift || true
+done
+
+ROUTES="$(printf '%s' "$ROUTES" | sed 's/^ *//')"
+[ -n "$ROUTES" ] || ROUTES="/transactions"
+[ -n "$VIEWPORTS" ] || VIEWPORTS="desktop"
+
+# Resolve the server (rebuild + restart unless overridden / --no-rebuild).
+if [ -n "$BASE_OVERRIDE" ]; then
+  BASE="$BASE_OVERRIDE"
+else
+  if [ "$REBUILD" -eq 1 ]; then
+    URL="$("$SCRIPT_DIR/dev-server" restart)"
+  else
+    URL="$("$SCRIPT_DIR/dev-server" ensure)"
+  fi
+  BASE="$(printf '%s' "$URL" | grep -oE 'http://localhost:[0-9]+' | tail -1)"
+fi
+[ -n "$BASE" ] || { bb_log "ERROR: could not resolve a server URL"; exit 1; }
+bb_log "==> validating against $BASE"
+
+# Comma-join routes for ui-shot.
+ROUTES_CSV="$(printf '%s' "$ROUTES" | tr -s ' ' ',' | sed 's/^,//;s/,$//')"
+
+# Per-run output dir so concurrent ui-validate runs (sibling worktrees) don't
+# overwrite each other's fixed-name JPEGs. Honors an explicit OUTDIR if set.
+OUTDIR="${OUTDIR:-$(mktemp -d "${TMPDIR:-/tmp}/bb-shots-XXXXXX")}"
+UDD="$(mktemp -d "${TMPDIR:-/tmp}/bb-chrome-XXXXXX")"
+bb_load_env "$ROOT"   # picks up BB_USER/BB_PASS if present in .local.env
+
+for vp in $VIEWPORTS; do
+  BASE="$BASE" ROUTES="$ROUTES_CSV" OUTDIR="$OUTDIR" VIEWPORT="$vp" \
+    WAIT="$WAIT" FULL="$FULL" UDD="$UDD" \
+    BB_USER="${BB_USER:-admin@example.com}" BB_PASS="${BB_PASS:-password}" \
+    node "$SCRIPT_DIR/ui-shot.mjs"
+done
+
+rm -rf "$UDD" 2>/dev/null || true


### PR DESCRIPTION
Makes running + validating Breadbox locally smooth across many worktrees and parallel agent sessions — no port fishing, no orphaned servers, one-command UI validation.

## Why

This came out of a retro on a tiny UI PR that took ~10 min: the change was 30s, the rest was wrestling the dev loop — fishing for a free port (8080–8099 saturated by parallel jobs), recovering the encryption key, fighting a locked Chrome-MCP profile, and a server that outlived the session. Root causes:

- **Port fishing.** Port logic was duplicated (the session-start hook *and* `make dev`), and it broke entirely when a worktree was created mid-session (the hook had already run against the main repo and exited early) — so the agent had no assigned port and scanned by hand.
- **Stale instances.** There was **no SessionEnd hook**. Nothing stopped a `breadbox serve` when a session closed, so they accumulated across 8081–8099. `make dev-stop` nuked the whole range (killing *active* siblings), so it wasn't safe to run casually.
- **Slow validation.** No reusable server, no checked-in screenshot script, and the Chrome DevTools MCP profile is frequently locked by a concurrent session.

## What

**One source of truth.** All port/server logic lives in `scripts/dev-lib.sh`; the Makefile, both session hooks, and the validation scripts call it. Servers are tracked in a registry under `~/.local/share/breadbox/dev-servers/`, keyed by worktree.

**No more fishing.** Port resolution is lazy + on-demand, so it works even when the session-start hook never ran. `make dev` / `make dev-watch` now auto-resolve a free port instead of hard-failing. The main checkout keeps 8080; only linked worktrees get 8081–8099.

**Auto-cleanup.** A new `SessionEnd` hook stops *this worktree's* server when the session closes (skipped on `/clear`). A reaper runs on every `SessionStart` and via `make dev-reap`, killing servers whose pid is dead or whose worktree was removed. `make dev-stop` is now worktree-safe; the old range-nuke is `make dev-stop-all`.

**One-command validation.** `make dev-shot ARGS="/transactions --mobile"` rebuilds, (re)starts a tracked background server, and screenshots via puppeteer + system Chrome with a fresh profile — never colliding with a locked Chrome-MCP session.

### Command surface (all match the `make dev*` sandbox exclusion)

```sh
make dev-bg                                   # start/reuse a background server; prints URL
make dev-shot ARGS="/transactions --mobile"   # rebuild + restart + screenshot → JPEG paths
make dev-ps                                    # list every managed server
make dev-stop                                  # stop THIS worktree's server (safe for siblings)
make dev-reap                                  # kill orphans (dead pid / removed worktree)
make dev-stop-all                              # blunt: kill everything on 8080-8099
```

### Design choices

- **On-demand, not auto-boot.** Booting a server at every session start would *add* servers (most sessions never touch UI) and worsen the stale problem. `make dev-bg` is instant-and-reusable instead.
- **Plain `breadbox serve` (not `air`) for the managed server** — one process = a trivial, reliable lifecycle. `dev-server restart` rebuilds. `make dev-watch` still exists for interactive hot-reload.
- Resilient to the stale-`internal/db` gotcha: if `go build` fails, it forces `make sqlc && make templ` and retries once.

## Review

Self-reviewed at `/code-review high` (7 finder angles); fixed the confirmed issues **before** this commit:

- `dev-port` no longer writes registry entries — the `make dev` foreground path never cleared them, leaking stale `RESERVED` claims. The registry is now owned solely by managed background servers (whose port-bind already protects the port).
- `bb_load_env` tolerates `set -u`/`set -e` while sourcing `.local.env` (an unset-var reference no longer aborts the caller).
- `bb_stop_port` guards `kill` against `set -e` and drops a redundant lsof-listener block — the `exec`-based launch makes the recorded pid the real listener, so the block only added a sibling-kill TOCTOU race.
- `session-end` parses the hook JSON without a hard `python3` dependency (sed fallback), so `/clear` is honored on stock macOS, and skips killing a server another session owns.
- Reservations are keyed by the canonical git worktree root; stale `PENDING` boots are reaped by age.
- `disown` fixed (jobspec, not pid); faster `lsof -nP -sTCP:LISTEN`; dead `.gitignore`/`server.pid` removed.

## Test plan

- [x] `bash -n` + `node --check` on every script/hook
- [x] Unit test of the lib (claim/idempotency/lookup/reap/meta-write/stop)
- [x] E2E: boot → recorded pid **==** port listener → idempotent reuse → screenshot → stop frees the port + empties the registry
- [x] SessionEnd hook: `reason=clear` leaves the server up; `reason=other` stops it
- [ ] Reviewer: confirm the SessionEnd hook addition doesn't surprise in-flight sessions (only new sessions load it; existing ~20 won't run it until restarted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
