### PR TITLE
feat(feed): render every report as its own comment-bubble row

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -107,15 +107,15 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 2. Grouped events from the service. Run after the report fetch so
-		// the service can fold matching reports into bulk_action /
-		// agent_session events. Reports that don't fold into anything come
-		// back via `leftoverReports` for standalone-card rendering. We also
-		// decide here whether the (relatively expensive) tag + category
-		// lookups are needed — they only feed bulk_action subject rendering.
-		// Skipping them on the common no-bulk path saves 5-10ms per request.
+		// 2. Grouped events from the service. The windowed report list is
+		// returned straight back as `standaloneReports` — every report
+		// renders as its own comment-bubble row, never folded into the
+		// session/bulk card it came from. We also decide here whether the
+		// (relatively expensive) tag + category lookups are needed — they
+		// only feed bulk_action subject rendering. Skipping them on the
+		// common no-bulk path saves 5-10ms per request.
 		t0 := time.Now()
-		events, leftoverReports, err := svc.ListFeedEventsWithReports(ctx, service.FeedEventsParams{
+		events, standaloneReports, err := svc.ListFeedEventsWithReports(ctx, service.FeedEventsParams{
 			Window:        window,
 			BulkThreshold: 3,
 			SampleLimit:   5,
@@ -219,16 +219,16 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 5. Append leftover (un-folded) reports as their own feed items.
-		// Reports that the service folded into a bulk_action / agent_session
-		// card are NOT in `leftoverReports` — they render as part of that
-		// card's headline.
+		// 5. Append every report as its own comment-bubble feed item. A
+		// report that came from an agent session / bulk action sorts next to
+		// that card on the timeline (same actor + timeframe) but renders as
+		// its own row — reports are no longer folded into a card headline.
 		//
 		// agentSeedCache memoizes the report-author → avatar-seed resolution
 		// across the loop so repeat agents don't re-query; "" is cached too
 		// (a miss is a decision, not a retry).
 		agentSeedCache := map[string]string{}
-		for _, rep := range leftoverReports {
+		for _, rep := range standaloneReports {
 			if rep.CreatedAt == "" {
 				continue
 			}
@@ -525,13 +525,6 @@ func projectFeedAgentSession(s *service.FeedAgentSessionEvent) *pages.FeedAgentS
 		Commented:          s.KindCounts["comment"],
 		RuleApplied:        s.KindCounts["rule_applied"],
 	}
-	if s.Report != nil {
-		out.ReportID = s.Report.ID
-		out.ReportShortID = s.Report.ShortID
-		out.ReportTitle = s.Report.Title
-		out.ReportPriority = s.Report.Priority
-		out.ReportIsUnread = s.Report.IsUnread
-	}
 	out.SampleTransactions = make([]pages.FeedTransactionRef, 0, len(s.SampleTransactions))
 	for _, tx := range s.SampleTransactions {
 		out.SampleTransactions = append(out.SampleTransactions, projectSampleTx(tx))
@@ -554,13 +547,6 @@ func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(str
 		KindCounts:         kindCounts,
 		StartedAt:          b.StartedAt,
 		EndedAt:            b.EndedAt,
-	}
-	if b.Report != nil {
-		out.ReportID = b.Report.ID
-		out.ReportShortID = b.Report.ShortID
-		out.ReportTitle = b.Report.Title
-		out.ReportPriority = b.Report.Priority
-		out.ReportIsUnread = b.Report.IsUnread
 	}
 	for _, sub := range b.Subjects {
 		display := pages.FeedBulkSubject{

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -155,8 +155,8 @@ type FeedSyncEvent struct {
 	// RetryCount counts the additional same-error sync attempts that
 	// were folded into this card. 0 = single attempt; N = total attempts
 	// is RetryCount + 1. Only populated for failed syncs.
-	RetryCount      int
-	FirstFailureAt  time.Time
+	RetryCount     int
+	FirstFailureAt time.Time
 
 	SampleTransactions []FeedSampleTx
 	AdditionalCount    int
@@ -190,13 +190,6 @@ type FeedAgentSessionEvent struct {
 	KindCounts map[string]int
 
 	SampleTransactions []FeedSampleTx
-
-	// Report, when non-nil, is an agent_report whose session_id matches
-	// this session. Populated by ListFeedEvents so a reporting agent run
-	// surfaces as a single feed row headlined by the report's title — the
-	// alternative (a separate report card adjacent to the session card) is
-	// noisy on the timeline.
-	Report *FeedReportRef
 }
 
 // FeedBulkActionEvent represents ≥ N annotations from the same actor
@@ -239,26 +232,6 @@ type FeedBulkActionEvent struct {
 	EndedAt   time.Time
 
 	SampleTransactions []FeedSampleTx
-
-	// Report, when non-nil, is an agent_report whose actor + window
-	// matches this bucket. Folding the report in lets a reporting agent
-	// run render as a single card headlined by the report title rather
-	// than the generic "X categorised, Y tagged" line.
-	Report *FeedReportRef
-}
-
-// FeedReportRef is the slim projection of an agent report folded into a
-// bulk_action / agent_session card. The handler still owns the canonical
-// report card (rendered when the report wasn't folded into anything) — this
-// shape only carries enough to display the title + priority + tags inline
-// and a link to the full report.
-type FeedReportRef struct {
-	ID       string
-	ShortID  string
-	Title    string
-	Priority string
-	Tags     []string
-	IsUnread bool
 }
 
 // FeedBulkSubject is one (subject, count) pair inside a bulk-action card.
@@ -411,9 +384,10 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 }
 
 // ListFeedEventsWithReports is the report-aware variant the home Feed
-// handler uses. It folds matching reports into bulk_action / agent_session
-// events and returns the leftover (un-folded) reports separately so the
-// handler can render them as standalone report cards.
+// handler uses. The windowed report list is returned straight back as the
+// second result so the handler can render each report as its own
+// standalone comment-bubble row — reports are no longer folded into the
+// bulk_action / agent_session card they came from.
 //
 // Splitting this from `ListFeedEvents` keeps the report-free entry-point
 // available for callers that don't have a windowed report list handy
@@ -467,9 +441,12 @@ func (s *Service) listFeedEventsWithReports(ctx context.Context, params FeedEven
 
 	groupedEvents := groupAnnotationsIntoEvents(annotationRows, sessionMeta, params)
 
-	// Fold matching reports into bulk_action / agent_session events. The
-	// remainder is the standalone-card list returned to the handler.
-	leftoverReports := foldReportsIntoEvents(groupedEvents, reports)
+	// Every report renders as its own comment-bubble row on the timeline
+	// (see feedReportBody in feed.templ) — we no longer fold reports into
+	// the bulk_action / agent_session card they came from. The full report
+	// list passes straight through to the handler as standalone cards; the
+	// paired session/bulk card renders on its own adjacent row.
+	standaloneReports := reports
 
 	out := make([]FeedEvent, 0, len(syncEvents)+len(groupedEvents))
 	out = append(out, syncEvents...)
@@ -480,7 +457,7 @@ func (s *Service) listFeedEventsWithReports(ctx context.Context, params FeedEven
 	})
 
 	out = filterFeedEvents(out, params.Filter, params.ActorID)
-	return out, leftoverReports, nil
+	return out, standaloneReports, nil
 }
 
 // filterFeedEvents narrows a feed-event slice to the subset matching the
@@ -494,12 +471,12 @@ func (s *Service) listFeedEventsWithReports(ctx context.Context, params FeedEven
 //   - "comments"   → only comment events
 //   - "sessions"   → only agent_session events
 //   - "reports"    → reports come from the handler, so ListFeedEvents
-//                    contributes nothing in this mode
+//     contributes nothing in this mode
 //   - "me"         → events authored by the supplied actorID; bulk-action
-//                    rows match on the bucket actor as well. If actorID is
-//                    empty (e.g. the initial admin without a linked user)
-//                    the filter is treated as "no filter" so the page
-//                    keeps rendering instead of going blank.
+//     rows match on the bucket actor as well. If actorID is
+//     empty (e.g. the initial admin without a linked user)
+//     the filter is treated as "no filter" so the page
+//     keeps rendering instead of going blank.
 func filterFeedEvents(events []FeedEvent, filter, actorID string) []FeedEvent {
 	switch filter {
 	case "":
@@ -767,7 +744,6 @@ func enrichFeedActivityRows(in []FeedActivityRow) []FeedActivityRow {
 	}
 	return out
 }
-
 
 // ── Sync events ───────────────────────────────────────────────────────────
 
@@ -1409,118 +1385,6 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 	}
 	ev.SampleTransactions = samples
 	return ev
-}
-
-// foldReportsIntoEvents pairs each report with a matching bulk_action or
-// agent_session event in `events` so the report renders as part of that
-// card's headline instead of as its own row. Matching is:
-//
-//   - SessionID equality with an agent_session event, OR
-//   - actor (id, type+name fallback) equality plus the report's timestamp
-//     falling inside the bulk_action's [StartedAt-15m, EndedAt+15m] window.
-//
-// Mutates the matched events in place (sets `ev.BulkAction.Report` /
-// `ev.AgentSession.Report`) and returns the un-folded reports for the
-// handler to render as standalone report cards.
-func foldReportsIntoEvents(events []FeedEvent, reports []AgentReportResponse) []AgentReportResponse {
-	if len(events) == 0 || len(reports) == 0 {
-		return reports
-	}
-
-	leftover := make([]AgentReportResponse, 0, len(reports))
-	for _, rep := range reports {
-		if folded := tryFoldReport(events, rep); !folded {
-			leftover = append(leftover, rep)
-		}
-	}
-	return leftover
-}
-
-// tryFoldReport attempts to attach `rep` to a matching event in `events`.
-// Returns true if a match was found and the event was mutated.
-func tryFoldReport(events []FeedEvent, rep AgentReportResponse) bool {
-	ref := reportRefFromResponse(rep)
-
-	// 1. Session match wins. If the report's session_id lines up with an
-	//    agent_session event, fold there regardless of timestamps.
-	if rep.SessionID != nil && *rep.SessionID != "" {
-		for i := range events {
-			if events[i].Type != "agent_session" {
-				continue
-			}
-			if events[i].AgentSession == nil {
-				continue
-			}
-			if events[i].AgentSession.SessionID == *rep.SessionID {
-				if events[i].AgentSession.Report == nil {
-					events[i].AgentSession.Report = &ref
-				}
-				return true
-			}
-		}
-	}
-
-	// 2. Actor + window match into a bulk_action event. The report's
-	//    `created_at` must fall inside the bucket window (with a slack
-	//    of feedSoftBucketWindow on either side so a report written
-	//    seconds after the last annotation still anchors).
-	repTime, err := time.Parse(time.RFC3339, rep.CreatedAt)
-	if err != nil {
-		return false
-	}
-	repActorID := ""
-	if rep.CreatedByID != nil {
-		repActorID = *rep.CreatedByID
-	}
-	repActorKey := repActorID
-	if repActorKey == "" {
-		repActorKey = rep.CreatedByType + ":" + rep.CreatedByName
-	}
-
-	for i := range events {
-		if events[i].Type != "bulk_action" {
-			continue
-		}
-		ba := events[i].BulkAction
-		if ba == nil {
-			continue
-		}
-		baKey := ba.ActorID
-		if baKey == "" {
-			baKey = ba.ActorType + ":" + ba.ActorName
-		}
-		if baKey != repActorKey {
-			continue
-		}
-		windowStart := ba.StartedAt.Add(-feedSoftBucketWindow)
-		windowEnd := ba.EndedAt.Add(feedSoftBucketWindow)
-		if repTime.Before(windowStart) || repTime.After(windowEnd) {
-			continue
-		}
-		if ba.Report == nil {
-			ba.Report = &ref
-		}
-		// Take the report's timestamp as the event timestamp so the row
-		// sorts at the report's wall-clock position (typically the run's
-		// last action). Prevents the row drifting earlier than the
-		// report itself.
-		if repTime.After(events[i].Timestamp) {
-			events[i].Timestamp = repTime
-		}
-		return true
-	}
-	return false
-}
-
-func reportRefFromResponse(r AgentReportResponse) FeedReportRef {
-	return FeedReportRef{
-		ID:       r.ID,
-		ShortID:  r.ShortID,
-		Title:    r.Title,
-		Priority: r.Priority,
-		Tags:     r.Tags,
-		IsUnread: r.ReadAt == nil,
-	}
 }
 
 func bulkSubjectKey(a Annotation) string {

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -29,10 +29,10 @@ import (
 // subtest gets a fresh, truncated DB via newService → testutil.Pool, so
 // helpers populate this struct top-down.
 type feedSeed struct {
-	UserID  pgtype.UUID
-	ConnID  pgtype.UUID
-	AcctID  pgtype.UUID
-	TxnIDs  []pgtype.UUID
+	UserID pgtype.UUID
+	ConnID pgtype.UUID
+	AcctID pgtype.UUID
+	TxnIDs []pgtype.UUID
 }
 
 // seedFeedFixture creates one user/connection/account plus `txnCount`
@@ -729,11 +729,12 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		})
 	})
 
-	t.Run("ReportFoldsIntoBulkAction", func(t *testing.T) {
+	t.Run("ReportRendersStandaloneAlongsideBulkAction", func(t *testing.T) {
 		// A reporting agent run: 8 same-actor annotations in a 5-minute
 		// span plus an agent report at the bucket center (same actor).
-		// The report folds into the bulk_action card; only ONE event
-		// surfaces, with the report title in the headline.
+		// Reports are no longer folded into the bulk_action card — the
+		// bulk_action surfaces as its own event and the report is returned
+		// verbatim so the handler renders it as its own comment-bubble row.
 		svc, queries, pool := newService(t)
 		ctx := context.Background()
 		seed := seedFeedFixture(t, queries, "reportfold", 8)
@@ -749,7 +750,7 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 			)
 		}
 
-		// Report from the same agent created in the middle of the bucket.
+		// Report from the same agent created in the middle of the run.
 		actor := service.Actor{Type: "agent", ID: actorID, Name: "ReportingAgent"}
 		report, err := svc.CreateAgentReport(ctx, "Reviewed and cleared 8 transactions",
 			"All 8 looked clean.",
@@ -757,21 +758,18 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CreateAgentReport: %v", err)
 		}
-		// Backdate the report into the middle of the bulk_action's
-		// time window so the actor+window fold check passes.
 		if _, err := pool.Exec(ctx,
 			"UPDATE agent_reports SET created_at = $1 WHERE id::text = $2",
 			anchor.Add(10*time.Second), report.ID,
 		); err != nil {
 			t.Fatalf("backdate report: %v", err)
 		}
-		// Re-fetch the report so the SessionID/CreatedAt round-trip.
 		fetched, err := svc.GetAgentReport(ctx, report.ID)
 		if err != nil {
 			t.Fatalf("GetAgentReport: %v", err)
 		}
 
-		events, leftover, err := svc.ListFeedEventsWithReports(ctx,
+		events, standalone, err := svc.ListFeedEventsWithReports(ctx,
 			service.FeedEventsParams{},
 			[]service.AgentReportResponse{fetched},
 		)
@@ -781,15 +779,13 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		if got := countEventsByType(events, "bulk_action"); got != 1 {
 			t.Fatalf("expected 1 bulk_action event, got %d", got)
 		}
-		if len(leftover) != 0 {
-			t.Errorf("expected 0 leftover reports (folded into bulk), got %d (%+v)", len(leftover), leftover)
+		// The report is passed straight back as a standalone card — never
+		// folded into the bulk_action event.
+		if len(standalone) != 1 {
+			t.Fatalf("expected 1 standalone report, got %d (%+v)", len(standalone), standalone)
 		}
-		ev := findEventByType(events, "bulk_action").BulkAction
-		if ev.Report == nil {
-			t.Fatalf("BulkAction.Report = nil, want non-nil with title %q", "Reviewed and cleared 8 transactions")
-		}
-		if ev.Report.Title != "Reviewed and cleared 8 transactions" {
-			t.Errorf("BulkAction.Report.Title = %q, want %q", ev.Report.Title, "Reviewed and cleared 8 transactions")
+		if standalone[0].Title != "Reviewed and cleared 8 transactions" {
+			t.Errorf("standalone report Title = %q, want %q", standalone[0].Title, "Reviewed and cleared 8 transactions")
 		}
 	})
 

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -525,13 +525,17 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 // feedReportBody renders a report row as a chat-bubble shape that mirrors
 // the per-tx activity-timeline comment row: an inline actor on the meta
 // line, then the report title in a `bb-comment-bubble`. The whole bubble
-// is the click target into /reports/{id}. Priority badges still live on
-// the meta line; the unread "New" pill is intentionally dropped — the
-// report tile's tint already carries that signal.
+// is the click target into /reports/{id}. This is the single rendering
+// path for every agent report on the feed — reports are never folded into
+// the session / bulk-action card they came from. The unread "New" pill and
+// priority badges live on the meta line.
 templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
 	<div class="flex items-center gap-1.5 px-1 flex-wrap text-sm leading-6 min-w-0">
 		@components.TimelineActorInline(feedReportActor(r))
 		<span class="text-base-content/55 shrink-0">filed a report</span>
+		if r.IsUnread {
+			<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
+		}
 		if r.Priority == "critical" {
 			<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
 		} else if r.Priority == "warning" {
@@ -561,146 +565,81 @@ func feedReportActor(r *FeedReport) components.TimelineActor {
 	}
 }
 
+// feedAgentSessionBody renders an MCP agent session as a plain system row
+// ("Agent ran a session · N transactions touched"). Any report the session
+// produced renders as its own adjacent comment-bubble row (feedReportBody),
+// not folded into this card.
 templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
-	if s.ReportTitle != "" {
-		// Report folded into this session — use the report title as the
-		// headline and the session description sinks beneath it. Mirrors
-		// how the bulk_action card folds a report (see feedBulkActionBody).
-		<div class="flex items-baseline gap-1.5 flex-wrap">
-			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
-				{ s.ReportTitle }
-			</a>
-			if s.ReportIsUnread {
-				<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
-			}
-			if s.ReportPriority == "critical" {
-				<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
-			} else if s.ReportPriority == "warning" {
-				<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
-			}
-			@feedRowTimestamp(it.TimestampStr, now)
-		</div>
+	<div class="flex items-baseline gap-1.5 flex-wrap">
+		<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
+		<span class="text-base-content/65 font-normal">ran a session</span>
+		<span class="text-base-content/30">·</span>
+		<span class="text-base-content/75 font-normal tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+	if breakdown := feedSessionBreakdown(s); breakdown != "" {
 		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			@components.LucideIcon("bot", "w-3 h-3")
-			<span class="font-medium text-base-content/75">{ feedSessionActorName(s) }</span>
-			<span class="text-base-content/30">·</span>
-			<span class="tabular-nums">{ fmt.Sprintf("%d transaction%s", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
-			if breakdown := feedSessionBreakdown(s); breakdown != "" {
-				<span class="text-base-content/30">·</span>
-				<span>{ breakdown }</span>
+			@components.LucideIcon("sparkles", "w-3 h-3 text-primary opacity-70")
+			<span>{ breakdown }</span>
+			if dur := feedSessionDuration(s); dur != "" {
+				<span class="text-base-content/30 mx-1">·</span>
+				@components.LucideIcon("clock", "w-3 h-3")
+				<span>{ dur }</span>
 			}
 		</div>
-	} else {
-		<div class="flex items-baseline gap-1.5 flex-wrap">
-			<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
-			<span class="text-base-content/65 font-normal">ran a session</span>
-			<span class="text-base-content/30">·</span>
-			<span class="text-base-content/75 font-normal tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
-			@feedRowTimestamp(it.TimestampStr, now)
-		</div>
-		if breakdown := feedSessionBreakdown(s); breakdown != "" {
-			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-				@components.LucideIcon("sparkles", "w-3 h-3 text-primary opacity-70")
-				<span>{ breakdown }</span>
-				if dur := feedSessionDuration(s); dur != "" {
-					<span class="text-base-content/30 mx-1">·</span>
-					@components.LucideIcon("clock", "w-3 h-3")
-					<span>{ dur }</span>
-				}
-			</div>
-		}
 	}
 	if len(s.SampleTransactions) > 0 {
 		<div class="mt-1.5">
 			@feedTxRefList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
 		</div>
 	}
-	<div class="mt-1 flex items-center gap-3 flex-wrap">
-		if s.ReportTitle != "" && s.ReportID != "" {
-			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors inline-flex items-center gap-1 no-underline">
-				Read the full report
-				@components.LucideIcon("arrow-right", "w-3 h-3")
-			</a>
-		}
-		if s.SessionShortID != "" {
-			<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors inline-flex items-center gap-1 no-underline">
-				Open session log
-				@components.LucideIcon("arrow-right", "w-3 h-3")
-			</a>
-		}
-	</div>
+	if s.SessionShortID != "" {
+		<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors mt-1 inline-flex items-center gap-1 no-underline">
+			Open session log
+			@components.LucideIcon("arrow-right", "w-3 h-3")
+		</a>
+	}
 }
 
+// feedBulkActionBody renders a soft-bucket of same-actor annotations as a
+// plain system row ("Alice categorised N transactions"). Any report the
+// actor filed in the same window renders as its own adjacent comment-bubble
+// row (feedReportBody), not folded into this card.
 templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
-	if b.ReportTitle != "" {
-		// Report folded into this bucket — use the report title as the
-		// headline. Mirrors the agent_session card's report-folded layout.
-		<div class="flex items-baseline gap-1.5 flex-wrap">
-			<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
-				{ b.ReportTitle }
-			</a>
-			if b.ReportIsUnread {
-				<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
-			}
-			if b.ReportPriority == "critical" {
-				<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
-			} else if b.ReportPriority == "warning" {
-				<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
-			}
-			@feedRowTimestamp(it.TimestampStr, now)
-		</div>
-		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			@components.LucideIcon("bot", "w-3 h-3")
-			<span class="font-medium text-base-content/75">{ feedActorDisplay(b.ActorName, b.ActorType) }</span>
-			<span class="text-base-content/30">·</span>
-			<span class="tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
-			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
-				<span class="text-base-content/30">·</span>
-				<span>{ breakdown }</span>
-			}
-		</div>
-	} else {
-		<div class="flex items-baseline gap-1.5 flex-wrap">
-			<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
-			<span class="text-base-content/75 font-normal">{ feedBulkVerb(b.Kind) }</span>
-			<span class="text-base-content/75 font-normal tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
-			if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
-				<span class="text-base-content/65 font-normal">{ subjectLabel }</span>
-			}
-			@feedRowTimestamp(it.TimestampStr, now)
-		</div>
-		if b.Kind == "mixed" {
-			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
-				<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-					@components.LucideIcon("sparkles", "w-3 h-3 text-primary opacity-70")
-					<span>{ breakdown }</span>
-				</div>
-			}
-		} else if len(b.Subjects) > 1 {
+	<div class="flex items-baseline gap-1.5 flex-wrap">
+		<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
+		<span class="text-base-content/75 font-normal">{ feedBulkVerb(b.Kind) }</span>
+		<span class="text-base-content/75 font-normal tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+		if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
+			<span class="text-base-content/65 font-normal">{ subjectLabel }</span>
+		}
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+	if b.Kind == "mixed" {
+		if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
 			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-				for i, sub := range b.Subjects {
-					if i >= 4 {
-						<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
-						break
-					}
-					<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
-						<span class="font-medium text-base-content/85">{ sub.Name }</span>
-						<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
-					</span>
-				}
+				@components.LucideIcon("sparkles", "w-3 h-3 text-primary opacity-70")
+				<span>{ breakdown }</span>
 			</div>
 		}
+	} else if len(b.Subjects) > 1 {
+		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+			for i, sub := range b.Subjects {
+				if i >= 4 {
+					<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
+					break
+				}
+				<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
+					<span class="font-medium text-base-content/85">{ sub.Name }</span>
+					<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
+				</span>
+			}
+		</div>
 	}
 	if len(b.SampleTransactions) > 0 {
 		<div class="mt-1.5">
 			@feedTxRefList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
 		</div>
-	}
-	if b.ReportTitle != "" && b.ReportID != "" {
-		<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors mt-1 inline-flex items-center gap-1 no-underline">
-			Read the full report
-			@components.LucideIcon("arrow-right", "w-3 h-3")
-		</a>
 	}
 }
 

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -262,17 +262,6 @@ type FeedAgentSession struct {
 	RuleApplied     int
 
 	SampleTransactions []FeedTransactionRef
-
-	// Report fields are populated when the service folded an agent_report
-	// whose `session_id` matches this session into the card. The templ
-	// uses ReportTitle as the headline (instead of the generic "ran a
-	// session" line) and renders priority badges + tags inline. Empty
-	// when no report was folded — render the plain session card.
-	ReportID       string
-	ReportShortID  string
-	ReportTitle    string
-	ReportPriority string
-	ReportIsUnread bool
 }
 
 // FeedBulkAction is the rich card that collapses ≥3 same-actor
@@ -306,17 +295,6 @@ type FeedBulkAction struct {
 	EndedAt   time.Time
 
 	SampleTransactions []FeedTransactionRef
-
-	// Report fields are populated when the service folded a matching
-	// agent_report into the card (see service.foldReportsIntoEvents). The
-	// templ uses ReportTitle as the bold headline instead of the generic
-	// "Alice updated N transactions" line and renders priority badges +
-	// tags inline. Empty when no report was folded.
-	ReportID       string
-	ReportShortID  string
-	ReportTitle    string
-	ReportPriority string
-	ReportIsUnread bool
 }
 
 // FeedBulkSubject is one (subject, count) chip inside a bulk-action card.


### PR DESCRIPTION
## What

Consolidates how the feed timeline renders an agent **report** into a single component.

Before, a report could render two different ways depending on whether the
service *folded* it into a paired card:

- **Standalone** (`case "report"`) → a `bb-comment-bubble` (actor · "filed a report" · bubble). ✅ the shape we want.
- **Folded** into an `agent_session` / `bulk_action` card → the report **title became a bold headline** with session metadata beneath and a "Read the full report →" link. ❌ the divergent one.

Now **every report renders as its own comment-bubble row**, and the session /
bulk-action card it came from renders normally on its own adjacent row (they
sort next to each other — same actor + timeframe).

## Why this shape (not "fold the bubble into the card")

`.bb-comment-bubble` carries a **whole-row** CSS treatment — the timeline
`li:has(.bb-comment-bubble)` selector turns the row's first child into a header
bar, the bubble into the card body, and draws a tail at the rail avatar.
Dropping a bubble *inside* a session card (which has a tx list + metadata) would
hijack that card's layout. So a report becomes its **own** row — which is also
the cleanest "one component, one render path".

## Changes

- **service/feed.go** — stop calling `foldReportsIntoEvents`; the windowed
  report list passes straight through as standalone cards. Removed the dead
  fold machinery (`foldReportsIntoEvents`, `tryFoldReport`,
  `reportRefFromResponse`, `FeedReportRef`, and the `Report` field on the
  session/bulk event structs).
- **feed_types.go / admin/feed.go** — removed the now-unused `Report*` fields
  and their projection.
- **feed.templ** — `feedAgentSessionBody` / `feedBulkActionBody` collapse to a
  single report-free path (no more headline-promotion, no "Read the full
  report" link). `feedReportBody` is the lone report component; it now also
  shows the unread **New** badge so unread reports keep a per-row indicator
  (previously only the folded variant showed it).
- **feed_integration_test.go** — `ReportFoldsIntoBulkAction` → `ReportRendersStandaloneAlongsideBulkAction`: asserts the bulk_action event surfaces on its own and the report is returned standalone (not folded).

Net: **−236 lines** across 5 files.

## Validation

`go build`, `go vet`, the feed/report/service/admin integration tests all pass.
Captured on `/feed` against real dev data (a "Backlog Review Agent filed a
report" bubble immediately followed by its own "Bulk Catch-Up updated 36
transactions" card):

<img src="https://i.img402.dev/v2ddklzbzl.jpg" width="800" alt="feed — report renders as its own comment-bubble row above its bulk-action card">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
