### PR TITLE
feat(workflows): reframe Rule Foundation rule handling as backfill choice

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -118,7 +118,7 @@ Options are per-preset single-selects rendered in the configure drawer; the chos
 | Key | Used by | Choices | Default |
 |---|---|---|---|
 | `apply_mode` | `routine-reviewer`, `backlog-closer`, `bulk-catchup` | `auto` (apply categories), `flag_only` (review only, no writes) | `auto` |
-| `rule_mode` | `rule-foundation` | `create_apply` (create & apply rules), `draft_only` (propose only, no writes) | `create_apply` |
+| `rule_mode` | `rule-foundation` | `create_apply` (create rules & backfill history), `create_only` (create rules, skip retroactive backfill) | `create_apply` |
 | `lookback_window` | `large-charge-sentinel` | `7` / `30` / `90` days | `7` |
 | `report_verbosity` | `large-charge-sentinel` | `concise` (headline findings), `detailed` (full evidence) | `concise` |
 

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -91,20 +91,21 @@ var applyModeOption = WorkflowPresetOption{
 }
 
 // ruleApplyModeOption is the "what to do with the rules it finds" choice for
-// the Rule Foundation one-off. The default creates and carefully applies the
-// vetted rules; draft-only suppresses every rule write so a human reviews the
-// proposed rules first.
+// the Rule Foundation one-off. Both choices create the vetted rules (so future
+// syncs auto-categorize); they differ only on the retroactive backfill. The
+// default also applies each rule to the matching history; create-only suppresses
+// the apply_rules sweep and leaves already-synced transactions untouched.
 var ruleApplyModeOption = WorkflowPresetOption{
 	Key:     "rule_mode",
 	Label:   "Rule handling",
-	Help:    "What to do with the rules it identifies.",
+	Help:    "Both create the rules — choose whether to also backfill existing transactions.",
 	Default: "create_apply",
 	Choices: []WorkflowPresetChoice{
-		{Value: "create_apply", Label: "Create & apply", Directive: ""},
+		{Value: "create_apply", Label: "Create rules & backfill history", Directive: ""},
 		{
-			Value:     "draft_only",
-			Label:     "Draft only — don't create",
-			Directive: "RULE MODE — DRAFT ONLY: Do NOT create or apply any transaction rules. Do NOT call create_transaction_rule, batch_create_rules, or apply_rules. Instead, produce a report listing each rule you would create — its conditions, target category, and the number of transactions in your sample it would match — so a human can review and create them.",
+			Value:     "create_only",
+			Label:     "Create rules only — skip backfill",
+			Directive: "RULE HANDLING — CREATE ONLY: Create the vetted rules as usual (dry-run each first), but do NOT call apply_rules — skip the backfill. Rules take effect on the next sync; leave existing transactions untouched. In your report, give each rule's dry-run match count and note that nothing was backfilled.",
 		},
 	},
 }


### PR DESCRIPTION
## What

Reframes the **Rule Foundation** workflow's `rule_mode` option from a "draft vs. apply" choice into a clearer **backfill** choice, and tightens the copy.

| | Before | After |
|---|---|---|
| Choice 1 (default) | `create_apply` — "Create & apply" | `create_apply` — **"Create rules & backfill history"** |
| Choice 2 | `draft_only` — "Draft only — don't create" | `create_only` — **"Create rules only — skip backfill"** |
| Help | "What to do with the rules it identifies." | "Both create the rules — choose whether to also backfill existing transactions." |

## Why

The old second option (`draft_only`) created **no** rules — it only proposed them. The clearer mental model for a self-hoster: *both modes create the rules so future syncs auto-categorize; the only question is whether to also sweep your existing history.* `create_only` does exactly that — creates the rules but skips the retroactive `apply_rules` backfill.

The standalone "draft / propose-only" mode is intentionally dropped for now.

## How it works

`rule_mode` is a prompt-level directive (same mechanism as `apply_mode`): the chosen choice's `Directive` is appended to the composed agent prompt under a `## Rule handling` heading at enable/reconfigure time. The default carries an empty directive (the base `strategy-rule-foundation` prompt already does create-and-apply); `create_only` appends an instruction to skip `apply_rules`. Tool scope is unchanged (`read_write`).

## Test

- `go build ./internal/service/...` + `go vet ./internal/service/...` — clean
- `go test ./internal/service/...` — pass (option/directive resolution covered by existing unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
