### PR TITLE
fix(ui): side-drawer scrim dims the sidebar, not just the content

### DIFF
--- a/internal/templates/components/drawer.templ
+++ b/internal/templates/components/drawer.templ
@@ -58,7 +58,11 @@ type DrawerProps struct {
 
 templ Drawer(p DrawerProps) {
 	<div x-data class="contents">
-		<!-- scrim -->
+		<!-- scrim — z-[45] sits above the sidebar's .drawer-side
+		     (z-40 !important in input.css) so the scrim dims the rail
+		     too, while staying below the panel (z-50). At plain z-40 it
+		     tied the sidebar and, being earlier in the DOM, lost — the
+		     rail stayed undimmed. -->
 		<div
 			x-show={ "$store.drawers.is('" + p.ID + "')" }
 			x-cloak
@@ -68,7 +72,7 @@ templ Drawer(p DrawerProps) {
 			x-transition:leave="transition-opacity ease-in duration-150"
 			x-transition:leave-start="opacity-100"
 			x-transition:leave-end="opacity-0"
-			class="fixed inset-0 bg-black/40 z-40"
+			class="fixed inset-0 bg-black/40 z-[45]"
 			@click="$store.drawers.close()"
 			aria-hidden="true"
 		></div>


### PR DESCRIPTION
Bumps the side-drawer scrim above the sidebar so opening a drawer dims the whole page — sidebar included — instead of leaving the nav rail brightly lit.

## Changes
- `internal/templates/components/drawer.templ`: scrim `z-40` → `z-[45]`. The sidebar's `.drawer-side` is pinned `z-index: 40 !important` (to clear the sticky mobile navbar); at a plain `z-40` the scrim tied it and — rendering earlier in the DOM with no ancestor creating a stacking context — lost, so the rail stayed undimmed. `z-[45]` sits above the rail and below the panel (`z-50`).
- Added a comment on the scrim explaining the stacking so it isn't "tidied" back down.

## Validation (Chrome DevTools MCP, real browser)
- Computed `z-index`: scrim **45**, sidebar `.drawer-side` **40**.
- `document.elementFromPoint` at three points down the sidebar all return the scrim (`coveredByScrim: true`).
- Ancestor walk (`main → .drawer-content → .drawer → body`) confirms none create a stacking context, so `z-[45]` competes head-to-head with the sidebar in the root context.

<table>
  <tr><th>Before (scrim z-40 — sidebar stays lit)</th><th>After (scrim z-[45] — sidebar dims)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/tsgi1ou1mf.png" width="400" alt="before — sidebar not dimmed"></td>
    <td><img src="https://i.img402.dev/p9a05te995.png" width="400" alt="after — sidebar dimmed"></td>
  </tr>
</table>

## Test plan
- [ ] Open any drawer on `/workflows` (gear / "Set up") — the sidebar dims with the content.
- [ ] Drawer panel renders fully bright above the scrim.
- [ ] Clicking the dimmed sidebar closes the drawer (scrim backdrop-close).
- [ ] Escape still closes; body scroll-lock intact.
