### PR TITLE
feat(workflows): name a workflow at setup, not only after first save

### DIFF
--- a/internal/admin/workflows_actions.go
+++ b/internal/admin/workflows_actions.go
@@ -44,11 +44,19 @@ func EnableWorkflowPresetAdminHandler(svc *service.Service) http.HandlerFunc {
 			MaxTurns:               cfg.MaxTurns,
 			MaxBudgetUSD:           cfg.MaxBudgetUSD,
 		}
+		// Optional custom name from the setup drawer. Present-but-blank falls
+		// back to the preset name in the service.
+		if _, ok := r.Form["name"]; ok {
+			n := r.FormValue("name")
+			params.Name = &n
+		}
 		// Any non-control form field is a preset-specialized option (e.g.
 		// apply_mode); the service validates each against the preset's
-		// declared options and ignores unknown keys.
+		// declared options and ignores unknown keys. "name" is a control key
+		// (consumed above), not an option.
 		control := map[string]bool{
 			"enabled": true, "additional_instructions": true, "consent": true, "_csrf": true,
+			"name": true,
 		}
 		for k := range cfgControl {
 			control[k] = true

--- a/internal/service/enable_workflow_from_preset_extra_integration_test.go
+++ b/internal/service/enable_workflow_from_preset_extra_integration_test.go
@@ -425,3 +425,44 @@ func TestT14_SourceTemplateStampedOnInstantiation(t *testing.T) {
 		t.Errorf("T14: hand-authored definition must have nil SourceTemplate, got %q", *plain.SourceTemplate)
 	}
 }
+
+// TestEnableWorkflowFromPreset_CustomName verifies a name supplied at setup
+// (the new setup-drawer Name field) is applied to the instantiated workflow
+// instead of the preset's static name, while the slug stays the preset slug.
+func TestEnableWorkflowFromPreset_CustomName(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	custom := "Monthly Rule Tune-Up"
+	def, err := svc.EnableWorkflowFromPreset(ctx, "rule-foundation", service.EnableWorkflowFromPresetParams{
+		Name: &custom,
+	})
+	if err != nil {
+		t.Fatalf("enable with custom name: %v", err)
+	}
+	if def.Name != custom {
+		t.Errorf("Name = %q, want %q", def.Name, custom)
+	}
+	if def.Slug != "rule-foundation" {
+		t.Errorf("Slug = %q, want rule-foundation (slug must not change with a custom name)", def.Slug)
+	}
+}
+
+// TestEnableWorkflowFromPreset_BlankNameFallsBackToPreset verifies that a
+// present-but-blank name (e.g. the user cleared the field) falls back to the
+// preset's name rather than instantiating an empty-named workflow.
+func TestEnableWorkflowFromPreset_BlankNameFallsBackToPreset(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	blank := "   "
+	def, err := svc.EnableWorkflowFromPreset(ctx, "rule-foundation", service.EnableWorkflowFromPresetParams{
+		Name: &blank,
+	})
+	if err != nil {
+		t.Fatalf("enable with blank name: %v", err)
+	}
+	if def.Name != "Rule Foundation" {
+		t.Errorf("Name = %q, want preset fallback %q", def.Name, "Rule Foundation")
+	}
+}

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -392,6 +392,11 @@ type EnableWorkflowFromPresetParams struct {
 	// Enabled controls whether the instantiated workflow runs immediately.
 	// Defaults to false (instantiated but paused) so a household can review it.
 	Enabled bool
+	// Name, when non-nil and non-blank, names the workflow at setup. A blank
+	// value falls back to the preset's name. Mirrors the rename available in
+	// the reconfigure drawer (UpdateWorkflowConfigParams.Name) so a household
+	// can name the workflow up front instead of only after the first save.
+	Name *string
 	// TriggerOnSync, when non-nil, overrides the preset's default trigger:
 	// true = after each sync; false = custom schedule (uses ScheduleCron).
 	// nil = use the preset's default. The trigger is user-selectable at
@@ -457,6 +462,12 @@ func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, par
 		Enabled:               params.Enabled,
 		TriggerOnSyncComplete: preset.TriggerOnSyncComplete,
 		SourceTemplate:        &preset.Slug,
+	}
+	// Custom name from the setup drawer. Blank falls back to the preset name.
+	if params.Name != nil {
+		if n := strings.TrimSpace(*params.Name); n != "" {
+			create.Name = n
+		}
 	}
 	// Model override (Advanced / model select). Blank falls back to the preset.
 	if params.Model != nil {

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -623,6 +623,19 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 				Right:    workflowSetupActivate(preset.OneOff),
 			})
 			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				<div>
+					<div class="text-sm font-medium mb-1.5">Name</div>
+					<input
+						type="text"
+						name="name"
+						value={ preset.Name }
+						maxlength="80"
+						placeholder={ preset.Name }
+						aria-label="Workflow name"
+						class="input input-bordered input-sm w-full"
+					/>
+					<div class="text-xs text-base-content/40 mt-1">What this workflow is called in your gallery and activity feed.</div>
+				</div>
 				if !preset.OneOff {
 					@workflowTriggerFields("triggerOnSync", "cron")
 				}


### PR DESCRIPTION
## What

Lets you **name a workflow during initial setup** instead of only after the first save.

Previously the workflow setup drawer had no name field — a new workflow always took the preset's static name (e.g. "Rule Foundation"), and the editable name only appeared in the *reconfigure* drawer, which you can't open until the workflow exists. So the name felt locked until you'd saved once.

Now the setup drawer leads with an editable **Name** field, prefilled with the preset name. Edit it (or leave it) and it's applied on the first save.

<img src="https://i.img402.dev/0oe4ppr47p.jpg" width="820" alt="Workflow setup drawer with new editable Name field">

## How it works (3 layers)

- **templ** (`workflows_gallery.templ`) — adds the Name field as the first field in the setup drawer, prefilled with the preset name. Posts via the existing `FormData` submit, so no JS-state change was needed.
- **service** (`workflow_presets.go`) — `EnableWorkflowFromPresetParams` gains `Name *string`; `EnableWorkflowFromPreset` applies it, falling back to the preset name when nil/blank. Mirrors the rename already in `UpdateWorkflowConfigParams`.
- **handler** (`workflows_actions.go`) — reads `name` from the enable form and treats it as a control field (not a preset option). Present-but-blank falls back in the service.

The slug is untouched (it's the stable identity behind run keys + routes) — only the display name is customized.

## Test

- New integration tests in `enable_workflow_from_preset_extra_integration_test.go`: custom name is applied; blank name falls back to the preset name; slug stays put. Both pass.
- `go build ./...`, `go vet ./...` (incl. `-tags integration`), `go test ./...` (incl. `scripts_lint_test`) — clean.
- Validated in a real browser (screenshot above): setup drawer for Rule Foundation showing the editable Name field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
