### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -63,33 +63,18 @@ func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 			a.Logger.Error("getting started: count transactions", "error", err)
 		}
 
-		// Count completed steps.
-		completedSteps := 0
-		if hasMember {
-			completedSteps++
-		}
-		if hasProvider {
-			completedSteps++
-		}
-		if hasConnection {
-			completedSteps++
-		}
-		if hasSync {
-			completedSteps++
-		}
-		if hasAPIKey {
-			completedSteps++
-		}
-
-		// Resolve the active step (first incomplete) and a rough time-to-finish
-		// estimate for the hero. Step order + per-step minutes are paired so the
-		// estimate sums only the steps still outstanding.
+		// Resolve the active step (first incomplete), completion count, and a
+		// rough time-to-finish estimate for the hero. Step order + per-step
+		// minutes are paired so the estimate sums only the steps still
+		// outstanding.
 		stepsDone := []bool{hasMember, hasProvider, hasConnection, hasSync, hasAPIKey}
 		stepMinutes := []int{1, 2, 2, 1, 3}
+		completedSteps := 0
 		activeStep := 0
 		minutesLeft := 0
 		for i, done := range stepsDone {
 			if done {
+				completedSteps++
 				continue
 			}
 			if activeStep == 0 {

--- a/internal/service/notify.go
+++ b/internal/service/notify.go
@@ -109,15 +109,16 @@ func (s *Service) WorkflowNotificationConfigured(ctx context.Context) bool {
 // outcome is recorded on the channel. Returns the first delivery error (if
 // any) after attempting every channel.
 func (s *Service) SendWorkflowNotification(ctx context.Context, p NotificationPayload) error {
-	// A persisted channels array is the source of truth; an empty one means we
-	// synthesize an ephemeral legacy channel. We must NOT persist statuses back
-	// in the synth case — doing so would promote the legacy config into the
-	// channels array and make further legacy-webhook edits silently ignored.
-	persisted := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyChannels, "")) != ""
 	chans := s.loadNotificationChannels(ctx)
 	if len(chans) == 0 {
 		return nil // notifications disabled — no-op
 	}
+	// A persisted channels array is the source of truth; an empty one means we
+	// synthesize an ephemeral legacy channel (identified by ID "legacy"). We
+	// must NOT persist statuses back in the synth case — doing so would promote
+	// the legacy config into the channels array and make further legacy-webhook
+	// edits silently ignored.
+	persisted := chans[0].ID != "legacy"
 
 	if p.SentAt == "" {
 		p.SentAt = nowRFC3339()
@@ -489,21 +490,7 @@ func notifyEmojiShortcode(priority string) string {
 // and [label](url) → <url|label>. A leading priority emoji + bold title set
 // the headline; an absolute deep link is appended as a tappable link.
 func buildSlackRequest(ctx context.Context, rawURL string, p NotificationPayload) (*http.Request, error) {
-	var b strings.Builder
-	b.WriteString(notifyEmojiShortcode(p.Priority))
-	b.WriteString(" *")
-	b.WriteString(slackEscape(collapseToLine(p.Title)))
-	b.WriteString("*")
-	if body := strings.TrimSpace(p.Body); body != "" {
-		b.WriteString("\n")
-		b.WriteString(toSlackMrkdwn(body))
-	}
-	if isAbsoluteURL(p.URL) {
-		b.WriteString("\n<")
-		b.WriteString(p.URL)
-		b.WriteString("|View report →>")
-	}
-	return jsonNotifyRequest(ctx, rawURL, map[string]any{"text": b.String()})
+	return buildSlackMrkdwnRequest(ctx, rawURL, p, notifyEmojiShortcode(p.Priority))
 }
 
 // buildGoogleChatRequest POSTs a Google Chat incoming-webhook payload
@@ -511,8 +498,15 @@ func buildSlackRequest(ctx context.Context, rawURL string, p NotificationPayload
 // link syntax as Slack mrkdwn, but renders unicode emoji rather than
 // :shortcode: names — so the priority cue is a unicode glyph.
 func buildGoogleChatRequest(ctx context.Context, rawURL string, p NotificationPayload) (*http.Request, error) {
+	return buildSlackMrkdwnRequest(ctx, rawURL, p, notifyEmojiUnicode(p.Priority))
+}
+
+// buildSlackMrkdwnRequest builds the shared "{text: ...}" payload used by
+// Slack and Google Chat: a priority emoji + bold title, optional body in
+// Slack-flavored mrkdwn, and a "View report →" link.
+func buildSlackMrkdwnRequest(ctx context.Context, rawURL string, p NotificationPayload, emoji string) (*http.Request, error) {
 	var b strings.Builder
-	b.WriteString(notifyEmojiUnicode(p.Priority))
+	b.WriteString(emoji)
 	b.WriteString(" *")
 	b.WriteString(slackEscape(collapseToLine(p.Title)))
 	b.WriteString("*")

--- a/internal/service/notify_channels.go
+++ b/internal/service/notify_channels.go
@@ -133,7 +133,7 @@ func (s *Service) AddNotificationChannel(ctx context.Context, p AddNotificationC
 		NtfyToken:   strings.TrimSpace(p.NtfyToken),
 		Enabled:     true,
 	}
-	chans := s.persistedOrMigratedChannels(ctx)
+	chans := s.loadNotificationChannels(ctx)
 	chans = append(chans, ch)
 	if err := s.persistNotificationChannels(ctx, chans); err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ type UpdateNotificationChannelParams struct {
 // NtfyToken keeps the stored value; the format/priority are normalized and
 // validated like Add. Returns ErrNotFound if no channel matches id.
 func (s *Service) UpdateNotificationChannel(ctx context.Context, id string, p UpdateNotificationChannelParams) (*NotificationChannel, error) {
-	chans := s.persistedOrMigratedChannels(ctx)
+	chans := s.loadNotificationChannels(ctx)
 	idx := -1
 	for i := range chans {
 		if chans[i].ID == id {
@@ -216,7 +216,7 @@ func (s *Service) UpdateNotificationChannel(ctx context.Context, id string, p Up
 
 // SetNotificationChannelEnabled flips a channel's enabled flag.
 func (s *Service) SetNotificationChannelEnabled(ctx context.Context, id string, enabled bool) error {
-	chans := s.persistedOrMigratedChannels(ctx)
+	chans := s.loadNotificationChannels(ctx)
 	found := false
 	for i := range chans {
 		if chans[i].ID == id {
@@ -233,7 +233,7 @@ func (s *Service) SetNotificationChannelEnabled(ctx context.Context, id string, 
 
 // DeleteNotificationChannel removes a channel by id.
 func (s *Service) DeleteNotificationChannel(ctx context.Context, id string) error {
-	chans := s.persistedOrMigratedChannels(ctx)
+	chans := s.loadNotificationChannels(ctx)
 	out := chans[:0]
 	found := false
 	for _, c := range chans {
@@ -252,7 +252,7 @@ func (s *Service) DeleteNotificationChannel(ctx context.Context, id string) erro
 // SendTestToChannel delivers a sample notification to a single channel and
 // records its status — backs the per-channel "Send test" button.
 func (s *Service) SendTestToChannel(ctx context.Context, id string) error {
-	chans := s.persistedOrMigratedChannels(ctx)
+	chans := s.loadNotificationChannels(ctx)
 	idx := -1
 	for i := range chans {
 		if chans[i].ID == id {
@@ -269,20 +269,6 @@ func (s *Service) SendTestToChannel(ctx context.Context, id string) error {
 	// Best-effort persist of the recorded status.
 	_ = s.persistNotificationChannels(ctx, chans)
 	return err
-}
-
-// persistedOrMigratedChannels returns the persisted channel array, first
-// migrating a synthesized legacy channel into storage if that's all there is.
-// This guarantees a mutation (add/toggle/delete) operates on a real array.
-func (s *Service) persistedOrMigratedChannels(ctx context.Context) []NotificationChannel {
-	raw := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyNotifyChannels, ""))
-	if raw != "" {
-		var chans []NotificationChannel
-		if err := json.Unmarshal([]byte(raw), &chans); err == nil {
-			return chans
-		}
-	}
-	return s.loadNotificationChannels(ctx) // legacy-synth (or nil)
 }
 
 // defaultChannelName derives a friendly label from a URL host when the

--- a/static/js/admin/components/notifications_settings.js
+++ b/static/js/admin/components/notifications_settings.js
@@ -15,10 +15,9 @@ document.addEventListener('alpine:init', function () {
         this.csrfToken = this.$el.dataset.csrf || '';
       },
 
-      testAll: function () {
-        var self = this;
-        this.allState = 'loading';
-        fetch('/-/notifications/test', {
+      _runTest: function (url, set) {
+        set('loading');
+        fetch(url, {
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'X-CSRF-Token': this.csrfToken, Accept: 'application/json' },
@@ -30,14 +29,21 @@ document.addEventListener('alpine:init', function () {
           })
           .then(function (r) {
             if (!r.ok || (r.body && r.body.ok === false)) {
-              self.allState = 'err:' + ((r.body && r.body.error) || ('HTTP ' + r.status));
+              set('err:' + ((r.body && r.body.error) || ('HTTP ' + r.status)));
               return;
             }
-            self.allState = 'ok';
+            set('ok');
           })
           .catch(function (e) {
-            self.allState = 'err:' + ((e && e.message) || 'Request failed');
+            set('err:' + ((e && e.message) || 'Request failed'));
           });
+      },
+
+      testAll: function () {
+        var self = this;
+        this._runTest('/-/notifications/test', function (v) {
+          self.allState = v;
+        });
       },
 
       _set: function (id, val) {
@@ -49,27 +55,9 @@ document.addEventListener('alpine:init', function () {
 
       testChannel: function (id) {
         var self = this;
-        this._set(id, 'loading');
-        fetch('/-/notifications/channels/' + encodeURIComponent(id) + '/test', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'X-CSRF-Token': this.csrfToken, Accept: 'application/json' },
-        })
-          .then(function (res) {
-            return res.json().then(function (body) {
-              return { ok: res.ok, status: res.status, body: body };
-            });
-          })
-          .then(function (r) {
-            if (!r.ok || (r.body && r.body.ok === false)) {
-              self._set(id, 'err:' + ((r.body && r.body.error) || ('HTTP ' + r.status)));
-              return;
-            }
-            self._set(id, 'ok');
-          })
-          .catch(function (e) {
-            self._set(id, 'err:' + ((e && e.message) || 'Request failed'));
-          });
+        this._runTest('/-/notifications/channels/' + encodeURIComponent(id) + '/test', function (v) {
+          self._set(id, v);
+        });
       },
     };
   });


### PR DESCRIPTION
## Summary

Daily simplify-drift review of PRs merged in the last 24 hours.

## PRs reviewed

- #1679 — chore: simplify drift from recent PRs
- #1680 — ci: remove redundant tag-triggered release path from ci.yml
- #1681 — feat(commands): add /submit-and-merge slash command
- #1682 — fix(workflows): base cron schedule shortcuts on the user's local timezone
- #1683 — fix(ui): OverflowMenu grows to fit its label
- #1684 — feat(workflows): per-workflow editable name + avatar
- #1685 — feat(ui): make the topbar the single breadcrumb
- #1686 — feat(ui): move provider settings into per-provider drawers
- #1687 — feat(notifications): dedicated settings page + native ntfy formatting
- #1688 — feat(ui): lead the Help → Getting started row with a compass icon
- #1689 — feat(workflows): curate gallery — drop 3 presets, add 2 on-demand one-offs
- #1690 — feat(ui): split CSV into its own section + Test button to drawer footer
- #1691 — feat(ui): redesign Getting Started as a guided setup journey
- #1692 — feat(ui): inline per-step stats + vertically centered action in SetupStep
- #1693 — fix(ui): render /transactions Grouped/List as a daisy segmented control
- #1694 — feat(workflows): polish one-off run UX
- #1695 — feat(workflows): polish run-detail header
- #1696 — chore: simplify drift from PRs #1680-#1694
- #1697 — feat(workflows): redesign configure-drawer Advanced section
- #1698 — fix(ui): drop the 2px row nudge on comment/report cards
- #1699 — feat(notifications): multiple channels + native Slack/Discord/Google Chat
- #1700 — feat(dev): managed dev servers
- #1703 — chore(tooling): self-host PR image + HTML snapshot host
- #1704 — feat(feed): render every report as its own comment-bubble row
- #1705 — feat(workflows): reframe Rule Foundation rule handling as backfill choice
- #1706 — fix(ui): side-drawer scrim dims the sidebar, not just the content

## Changes

- `internal/admin/getting_started.go:66-100` — drop the parallel `completedSteps++` if-ladder; count inside the existing `stepsDone` loop that already iterates the same five booleans.
- `internal/service/notify_channels.go:136-272` — delete `persistedOrMigratedChannels`. It duplicated `loadNotificationChannels` (same `KeyNotifyChannels` read, same legacy fallback); both functions return the same slice for every input. All five mutator callers (`AddNotificationChannel`, `UpdateNotificationChannel`, `SetNotificationChannelEnabled`, `DeleteNotificationChannel`, `SendTestToChannel`) now go through `loadNotificationChannels`.
- `internal/service/notify.go:111-120` — drop the redundant second `KeyNotifyChannels` read in `SendWorkflowNotification`. The legacy synth always carries `ID == "legacy"` (a 6-char literal that can't collide with the 8-char shortids `AddNotificationChannel` mints), so `persisted := chans[0].ID != "legacy"` derives the same flag from the slice we already loaded.
- `internal/service/notify.go:487-545` — factor `buildSlackRequest` and `buildGoogleChatRequest` through a shared `buildSlackMrkdwnRequest`. The two builders were identical except for the priority-emoji helper (shortcode vs. unicode).
- `static/js/admin/components/notifications_settings.js:18-66` — extract `_runTest(url, set)` to dedupe the `testAll` / `testChannel` fetch dance. Both POSTs shared the same response handling; only the URL and the state setter differed.

Net: **4 files, +42/-89.**

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (the pre-existing `TestSidecarRun_ProcessGroupReapsGrandchild` flake in `internal/agent` reproduces on untouched `origin/main` and is unrelated to this diff)


---
_Generated by [Claude Code](https://claude.ai/code/session_019NcfSJ9xghSKZ3ib6k3caR)_