### PR TITLE
fix(ci): pull Postgres test image from ECR Public mirror, not Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,14 @@ jobs:
             run_unit: true
     services:
       postgres:
-        image: postgres:16-alpine
+        # Pull the official image from AWS ECR Public's mirror rather than
+        # Docker Hub. Docker Hub throttles anonymous pulls from shared GitHub
+        # runner IPs, which surfaces as `context deadline exceeded` on the
+        # service-container pull; the runner's built-in 3-retry isn't enough and
+        # the whole shard fails, gating Build & Push + Deploy on a flake (the
+        # post-merge run for #1699 went red this way). ECR Public mirrors the
+        # Docker Official Images byte-for-byte with no anonymous rate limit.
+        image: public.ecr.aws/docker/library/postgres:16-alpine
         env:
           POSTGRES_USER: breadbox
           POSTGRES_PASSWORD: breadbox


### PR DESCRIPTION
The post-merge CI run for #1699 went red — and skipped Build & Push + Deploy — because the `Test (service)` shard couldn't pull the Postgres service-container image from Docker Hub (`registry-1.docker.io`: `context deadline exceeded` on all retries). This swaps that image to AWS ECR Public's mirror so a Docker Hub throttle/blip can't gate deploys.

## Changes
- `Test (service)` shard now pulls `public.ecr.aws/docker/library/postgres:16-alpine` instead of `postgres:16-alpine`. ECR Public mirrors the Docker Official Image byte-for-byte and has **no anonymous pull rate limit** — the usual root of `context deadline exceeded` pulls from shared GitHub runner IPs. One-line, content-identical change; tag verified present in the mirror.

## Why this happened
The runner's built-in 3-retry on service-container pulls wasn't enough during a Docker Hub throttle. The shard failed → the aggregated `Test` gate failed → `build` (`needs: [test, …]`) and `deploy` were skipped. No code regression — purely a registry-availability flake.

## Test plan
- [ ] CI green on this PR (this PR exercises the changed `Test (service)` shard).
- [ ] On merge to `main`, the push-triggered run reaches **Build & Push** → **Deploy** and the health check passes (this also re-deploys prod, which #1699's run never did).
