### PR TITLE
fix(devmode): inline CSS so captures render styled; drop issue-label setting, add filed-via-bug marker

### DIFF
--- a/internal/admin/developer_settings.go
+++ b/internal/admin/developer_settings.go
@@ -15,8 +15,8 @@ import (
 )
 
 // DeveloperSettingsHandler serves GET /settings/developer — the Developer Mode
-// configuration tab: an enable toggle plus the GitHub repo + issue label the
-// floating reporter opens issue drafts against.
+// configuration tab: an enable toggle plus the GitHub repo the floating
+// reporter opens issue drafts against.
 func DeveloperSettingsHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		settings, err := svc.GetDevModeSettings(r.Context())
@@ -40,7 +40,6 @@ func DeveloperSettingsHandler(a *app.App, svc *service.Service, sm *scs.SessionM
 			Form: pages.DeveloperSettingsFormFields{
 				Enabled:    settings.Enabled,
 				GithubRepo: settings.GithubRepo,
-				IssueLabel: settings.IssueLabel,
 			},
 			FieldErrors: map[string]string{},
 			FormError:   formError,
@@ -56,7 +55,7 @@ func DeveloperSettingsHandler(a *app.App, svc *service.Service, sm *scs.SessionM
 }
 
 // DeveloperSettingsPostHandler handles POST /settings/developer — the enable
-// toggle, repo, and label save together.
+// toggle and repo save together.
 func DeveloperSettingsPostHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -66,12 +65,10 @@ func DeveloperSettingsPostHandler(a *app.App, svc *service.Service, sm *scs.Sess
 
 		enabled := r.FormValue("enabled") == "true"
 		repo := strings.TrimSpace(r.FormValue("github_repo"))
-		label := strings.TrimSpace(r.FormValue("issue_label"))
 
 		params := service.UpdateDevModeSettingsParams{
 			Enabled:    &enabled,
 			GithubRepo: &repo,
-			IssueLabel: &label,
 		}
 
 		if _, err := svc.UpdateDevModeSettings(r.Context(), params); err != nil {

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -133,16 +133,7 @@ const (
 	// drafts against (e.g. "canalesb93/breadbox"). Defaults to
 	// DevModeDefaultRepo when unset.
 	KeyDevModeGithubRepo = "devmode.github_repo"
-
-	// KeyDevModeIssueLabel is the label applied to every filed issue. The
-	// reporter creates it on the repo if it doesn't exist yet. Default:
-	// DevModeDefaultLabel.
-	KeyDevModeIssueLabel = "devmode.issue_label"
 )
-
-// DevModeDefaultLabel is the label applied to filed Developer Mode issues
-// when KeyDevModeIssueLabel is unset.
-const DevModeDefaultLabel = "dev-report"
 
 // DevModeDefaultRepo is the repository Developer Mode files against when
 // KeyDevModeGithubRepo is unset — the upstream Breadbox repo, so a fresh

--- a/internal/service/devmode_integration_test.go
+++ b/internal/service/devmode_integration_test.go
@@ -21,25 +21,20 @@ func TestDevModeSettings_RoundTrip(t *testing.T) {
 	if got.Enabled {
 		t.Error("expected developer mode off by default")
 	}
-	if got.IssueLabel != "dev-report" {
-		t.Errorf("default label = %q, want dev-report", got.IssueLabel)
-	}
 	if got.GithubRepo != "canalesb93/breadbox" {
 		t.Errorf("default repo = %q, want canalesb93/breadbox", got.GithubRepo)
 	}
 
 	enabled := true
 	repo := "acme/widgets"
-	label := "internal-report"
 	updated, err := svc.UpdateDevModeSettings(ctx, service.UpdateDevModeSettingsParams{
 		Enabled:    &enabled,
 		GithubRepo: &repo,
-		IssueLabel: &label,
 	})
 	if err != nil {
 		t.Fatalf("UpdateDevModeSettings: %v", err)
 	}
-	if !updated.Enabled || updated.GithubRepo != repo || updated.IssueLabel != label {
+	if !updated.Enabled || updated.GithubRepo != repo {
 		t.Errorf("unexpected updated settings: %+v", updated)
 	}
 	if !svc.DevModeEnabled(ctx) {
@@ -82,5 +77,10 @@ func TestCreateDevReport_BuildsDraft(t *testing.T) {
 	}
 	if !strings.Contains(res.DraftURL, "Task") {
 		t.Errorf("draft URL should carry the [Task] title: %q", res.DraftURL)
+	}
+	// Every draft carries the type tag + the fixed filed-via-bug marker
+	// (URL-encoded as task%2Cfiled-via-bug in the labels param).
+	if !strings.Contains(res.DraftURL, "filed-via-bug") || !strings.Contains(res.DraftURL, "task") {
+		t.Errorf("draft URL should carry task + filed-via-bug labels: %q", res.DraftURL)
 	}
 }

--- a/internal/service/devmode_reports.go
+++ b/internal/service/devmode_reports.go
@@ -14,6 +14,12 @@ import (
 const (
 	devReportTypeBug  = "bug"
 	devReportTypeTask = "task"
+
+	// devModeFiledLabel is a fixed marker applied to every issue filed through
+	// Developer Mode, alongside the type tag (bug/task). It lets the household
+	// find or triage everything that came in via the in-app reporter. The label
+	// must already exist on the target repo for GitHub to apply it on submit.
+	devModeFiledLabel = "filed-via-bug"
 )
 
 // CreateDevReportInput is the decoded payload from the floating reporter. The
@@ -51,7 +57,6 @@ func (s *Service) CreateDevReport(ctx context.Context, in CreateDevReportInput) 
 	}
 
 	repo := appconfig.String(ctx, s.Queries, appconfig.KeyDevModeGithubRepo, appconfig.DevModeDefaultRepo)
-	label := appconfig.String(ctx, s.Queries, appconfig.KeyDevModeIssueLabel, appconfig.DevModeDefaultLabel)
 
 	var imageURL, htmlURL string
 	if len(in.ScreenshotData) > 0 {
@@ -66,7 +71,7 @@ func (s *Service) CreateDevReport(ctx context.Context, in CreateDevReportInput) 
 	}
 
 	body := buildDevReportIssueBody(rtype, in, imageURL, htmlURL)
-	draftURL := buildDraftURL(repo, issueTitle(rtype, title), body, dedupeLabels(label, rtype))
+	draftURL := buildDraftURL(repo, issueTitle(rtype, title), body, reportLabels(rtype))
 	if draftURL == "" {
 		return nil, fmt.Errorf("%w: invalid GitHub repository", ErrInvalidParameter)
 	}
@@ -90,11 +95,12 @@ func issueTitle(rtype, title string) string {
 	return prefix + " " + title
 }
 
-// dedupeLabels returns [flow, type] minus any empty/duplicate entries.
-func dedupeLabels(flow, rtype string) []string {
+// reportLabels returns the labels for a filed issue: the type tag (bug/task)
+// plus the fixed filed-via-bug marker, de-duplicated and never empty.
+func reportLabels(rtype string) []string {
 	seen := map[string]bool{}
 	var out []string
-	for _, l := range []string{strings.TrimSpace(flow), rtype} {
+	for _, l := range []string{strings.TrimSpace(rtype), devModeFiledLabel} {
 		if l == "" || seen[l] {
 			continue
 		}

--- a/internal/service/devmode_reports_test.go
+++ b/internal/service/devmode_reports_test.go
@@ -57,15 +57,16 @@ func TestIssueTitle(t *testing.T) {
 	}
 }
 
-func TestDedupeLabels(t *testing.T) {
-	if got := dedupeLabels("dev-report", "bug"); strings.Join(got, ",") != "dev-report,bug" {
-		t.Errorf("got %v", got)
+func TestReportLabels(t *testing.T) {
+	if got := reportLabels("bug"); strings.Join(got, ",") != "bug,filed-via-bug" {
+		t.Errorf("bug labels = %v", got)
 	}
-	if got := dedupeLabels("bug", "bug"); strings.Join(got, ",") != "bug" {
-		t.Errorf("got %v", got)
+	if got := reportLabels("task"); strings.Join(got, ",") != "task,filed-via-bug" {
+		t.Errorf("task labels = %v", got)
 	}
-	if got := dedupeLabels("", "task"); strings.Join(got, ",") != "task" {
-		t.Errorf("got %v", got)
+	// The marker is never duplicated even if the type happens to match it.
+	if got := reportLabels(devModeFiledLabel); strings.Join(got, ",") != devModeFiledLabel {
+		t.Errorf("dedup labels = %v", got)
 	}
 }
 

--- a/internal/service/devmode_settings.go
+++ b/internal/service/devmode_settings.go
@@ -15,16 +15,14 @@ import (
 type DevModeSettingsResponse struct {
 	Enabled    bool   `json:"enabled"`
 	GithubRepo string `json:"github_repo"`
-	IssueLabel string `json:"issue_label"`
 }
 
 // UpdateDevModeSettingsParams holds the writable Developer-Mode settings.
 // Nil = leave untouched. An empty GithubRepo clears it (falls back to the
-// default); an empty IssueLabel resets to the default.
+// default).
 type UpdateDevModeSettingsParams struct {
 	Enabled    *bool
 	GithubRepo *string
-	IssueLabel *string
 }
 
 // GetDevModeSettings reads the devmode.* keys from app_config.
@@ -32,7 +30,6 @@ func (s *Service) GetDevModeSettings(ctx context.Context) (*DevModeSettingsRespo
 	return &DevModeSettingsResponse{
 		Enabled:    appconfig.Bool(ctx, s.Queries, appconfig.KeyDevModeEnabled, false),
 		GithubRepo: appconfig.String(ctx, s.Queries, appconfig.KeyDevModeGithubRepo, appconfig.DevModeDefaultRepo),
-		IssueLabel: appconfig.String(ctx, s.Queries, appconfig.KeyDevModeIssueLabel, appconfig.DevModeDefaultLabel),
 	}, nil
 }
 
@@ -59,15 +56,6 @@ func (s *Service) UpdateDevModeSettings(ctx context.Context, p UpdateDevModeSett
 		}
 		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyDevModeGithubRepo, repo)); err != nil {
 			return nil, fmt.Errorf("set devmode_github_repo: %w", err)
-		}
-	}
-	if p.IssueLabel != nil {
-		label := strings.TrimSpace(*p.IssueLabel)
-		if label == "" {
-			label = appconfig.DevModeDefaultLabel
-		}
-		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyDevModeIssueLabel, label)); err != nil {
-			return nil, fmt.Errorf("set devmode_issue_label: %w", err)
 		}
 	}
 	return s.GetDevModeSettings(ctx)

--- a/internal/templates/components/pages/developer_settings.templ
+++ b/internal/templates/components/pages/developer_settings.templ
@@ -3,9 +3,10 @@ package pages
 import "breadbox/internal/templates/components"
 
 // DeveloperSettings renders the Settings → Developer tab. One multi-input form
-// owns developer mode (enable toggle + GitHub repo/label, saved together).
-// Filing opens a prefilled GitHub issue draft the user submits — no token.
-// See .claude/rules/settings.md for the section/row vocabulary.
+// owns developer mode (enable toggle + GitHub repo, saved together). Filing
+// opens a prefilled GitHub issue draft the user submits — no token. Every
+// draft is pre-labelled with its type (bug/task) plus a fixed filed-via-bug
+// marker. See .claude/rules/settings.md for the section/row vocabulary.
 templ DeveloperSettings(p DeveloperSettingsProps) {
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
@@ -41,7 +42,7 @@ templ DeveloperSettings(p DeveloperSettingsProps) {
 }
 
 // developerModeSection is the single multi-input form: the enable toggle and
-// the GitHub repo/label all save together via one Save button.
+// the GitHub repo save together via one Save button.
 templ developerModeSection(p DeveloperSettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "bug",
@@ -87,19 +88,16 @@ templ developerModeSection(p DeveloperSettingsProps) {
 			}
 		}
 		@components.SettingsRow(components.SettingsRowProps{
-			Label:   "Issue label",
-			Caption: "Pre-selected on every draft (add it to the repo once so GitHub applies it).",
-			For:     "issue_label",
+			Label:   "Issue labels",
+			Caption: "Applied automatically — add these to the repo so GitHub keeps them.",
 		}) {
-			<input
-				id="issue_label"
-				type="text"
-				name="issue_label"
-				value={ p.Form.IssueLabel }
-				placeholder="dev-report"
-				autocomplete="off"
-				class="bb-form-input font-mono min-w-56"
-			/>
+			<div class="flex items-center gap-1.5">
+				<span class="badge badge-soft badge-neutral badge-sm font-mono">bug</span>
+				<span class="text-base-content/40">/</span>
+				<span class="badge badge-soft badge-neutral badge-sm font-mono">task</span>
+				<span class="text-base-content/40">+</span>
+				<span class="badge badge-soft badge-primary badge-sm font-mono">filed-via-bug</span>
+			</div>
 		}
 	}
 }

--- a/internal/templates/components/pages/developer_settings_types.go
+++ b/internal/templates/components/pages/developer_settings_types.go
@@ -17,5 +17,4 @@ type DeveloperSettingsProps struct {
 type DeveloperSettingsFormFields struct {
 	Enabled    bool
 	GithubRepo string
-	IssueLabel string
 }

--- a/static/js/admin/components/dev_reporter.js
+++ b/static/js/admin/components/dev_reporter.js
@@ -115,10 +115,55 @@
     bbScrubAttrPII(root);
   }
 
+  // Fetch every same-origin stylesheet's text once and cache it. Two call sites
+  // need the raw CSS:
+  //   1. The screenshot — html2canvas clones the page into an iframe that
+  //      re-fetches the external <link href="/static/css/styles.css">. On a cold
+  //      run those rules can still be unapplied when it rasterizes, producing an
+  //      UNSTYLED capture (default margins, blue underlined links). Injecting the
+  //      CSS as an inline <style> in the clone removes that race entirely.
+  //   2. The HTML snapshot — opened standalone from the artifact store, its
+  //      /static/* <link> resolves off-origin and 404s, so the page renders
+  //      unstyled. Inlining the CSS makes the snapshot self-contained.
+  var _bbCssPromise = null;
+  function bbFetchAppCss() {
+    if (_bbCssPromise) return _bbCssPromise;
+    _bbCssPromise = (function () {
+      var links = Array.prototype.slice.call(
+        document.querySelectorAll('link[rel="stylesheet"]')
+      ).filter(function (l) {
+        try { return new URL(l.href, location.href).origin === location.origin; }
+        catch (e) { return false; }
+      });
+      return Promise.all(links.map(function (l) {
+        return fetch(l.href).then(function (r) { return r.ok ? r.text() : ''; }).catch(function () { return ''; });
+      })).then(function (parts) { return parts.join('\n'); }).catch(function () { return ''; });
+    })();
+    return _bbCssPromise;
+  }
+
+  // Replace the same-origin stylesheet <link>s on a cloned document with a single
+  // inline <style> carrying the fetched CSS, so the clone renders styled with no
+  // external fetch. No-op when css is empty (keeps the original <link> fallback).
+  function bbInlineCss(root, css) {
+    if (!css) return;
+    try {
+      root.querySelectorAll('link[rel="stylesheet"]').forEach(function (el) {
+        try { if (new URL(el.href, location.href).origin === location.origin) el.remove(); } catch (e) {}
+      });
+      var doc = root.ownerDocument || document;
+      var head = root.querySelector ? (root.querySelector('head') || root) : root;
+      var st = doc.createElement('style');
+      st.textContent = css;
+      head.appendChild(st);
+    } catch (e) {}
+  }
+
   // Build the HTML snapshot string. ALWAYS strips scripts, the CSRF meta, the
-  // reporter widget, and input values (code/secrets). When redact=true it also
-  // masks visible data text, hides media, and clears image sources.
-  function bbBuildSnapshot(redact) {
+  // reporter widget, and input values (code/secrets). Inlines the app CSS (css)
+  // so the snapshot renders styled standalone. When redact=true it also masks
+  // visible data text, hides media, and clears image sources.
+  function bbBuildSnapshot(redact, css) {
     try {
       var clone = document.documentElement.cloneNode(true);
       // Always strip code + secrets.
@@ -132,8 +177,10 @@
         bbRedactClone(clone);
         clone.querySelectorAll('img').forEach(function (el) { el.removeAttribute('src'); el.removeAttribute('srcset'); });
       }
+      // Inline CSS after redaction so the stylesheet text is never masked.
+      bbInlineCss(clone, css);
       var html = '<!DOCTYPE html>\n' + clone.outerHTML;
-      var cap = 1500000;
+      var cap = 3000000;
       return html.length > cap ? html.slice(0, cap) : html;
     } catch (e) {
       return '';
@@ -222,18 +269,22 @@
         },
 
         // recapture builds both artifacts (screenshot + HTML snapshot) honoring
-        // the current redact setting.
+        // the current redact setting. It resolves the app CSS once up front so
+        // both the capture and the snapshot render with the page's real styles.
         recapture: function () {
           var self = this;
           this.capturing = true;
-          this._snapshot = bbBuildSnapshot(this.redact);
-          return this.capture().finally(function () { self.capturing = false; });
+          return bbFetchAppCss().then(function (css) {
+            self._snapshot = bbBuildSnapshot(self.redact, css);
+            return self.capture(css);
+          }).finally(function () { self.capturing = false; });
         },
 
         // capture renders the current viewport to a JPEG data URL. Redaction
-        // (when on) runs in html2canvas's onclone hook so the live page is
-        // never mutated. Best-effort: any failure leaves screenshot empty.
-        capture: function () {
+        // (when on) and CSS inlining both run in html2canvas's onclone hook so
+        // the live page is never mutated. Best-effort: any failure leaves
+        // screenshot empty.
+        capture: function (css) {
           var self = this;
           var redact = this.redact;
           return this.loadHtml2Canvas().then(function (h2c) {
@@ -261,6 +312,10 @@
                 if (redact && clonedDoc && clonedDoc.body) {
                   try { bbRedactClone(clonedDoc.body); } catch (e) {}
                 }
+                // Inline the app CSS so styling is deterministic — the clone
+                // iframe otherwise re-fetches the external stylesheet and can
+                // rasterize before it applies, yielding an unstyled capture.
+                bbInlineCss(clonedDoc.documentElement || clonedDoc, css);
               },
             }).then(function (canvas) {
               self.screenshot = self.canvasToJpeg(canvas, 2560, 0.92);


### PR DESCRIPTION
Follow-up to #1701 (Developer Mode). Fixes the unstyled captures reported on [issue #1710](https://github.com/canalesb93/breadbox/issues/1710) and reworks the labels.

## The bug

The reporter's **screenshot and HTML snapshot both rendered unstyled** — raw DOM with default margins, blue underlined links, and full-size avatars (see Before). Useless for triage.

### Root cause

`html2canvas-pro` captures by cloning the page into an `about:blank` iframe that **re-fetches the external `/static/css/styles.css`**. On a cold run (first capture) those rules can still be unapplied when it rasterizes, so `getComputedStyle` returns browser defaults and the whole capture is unstyled. I confirmed this in a live browser:

| clone state | `body` bg | `body` margin | link color |
|---|---|---|---|
| stylesheet **not** applied (the bug) | transparent | `8px` | `rgb(0,0,238)` underlined |
| inline `<style>` injected (the fix) | `oklch(0.971 …)` | `0px` | themed, no underline |

The **HTML snapshot** hit the same wall from the other side: opened off-origin from `bb-artifacts.exe.xyz`, its `/static/*` `<link>` 404s, so it rendered unstyled too.

## The fix

Fetch the same-origin stylesheet text **once** (cached) and inline it as a `<style>`:

- **Screenshot** — injected into the html2canvas clone via `onclone`. Styling is now deterministic; no external fetch happens in the clone, so there's no race.
- **HTML snapshot** — the `/static` `<link>` is swapped for the inlined CSS, making the snapshot **self-contained** so it renders correctly standalone from the artifact store.

## Labels & settings

Per feedback:

- **Removed the configurable "Issue label" setting** — it did little and silently dropped non-existent labels. The Developer tab now shows the auto-applied labels read-only.
- Every filed issue now carries a fixed **`filed-via-bug`** marker alongside its type tag (`bug` / `task`), so the household can find everything filed via the reporter. Draft label param is now `bug,filed-via-bug` (or `task,filed-via-bug`). The `filed-via-bug` label was created on this repo.

## Before / after (the captured screenshot)

<table>
  <tr><th>Before — #1710 (unstyled)</th><th>After — styled + redacted</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/8k9215zdw2.jpg" width="420" alt="before — unstyled capture"></td>
    <td><img src="https://i.img402.dev/brr4sn1vld.jpg" width="420" alt="after — styled capture"></td>
  </tr>
</table>

The "after" image is the **actual artifact fetched back from bb-artifacts.exe.xyz** — i.e. exactly what would embed in a GitHub issue. Financial data is masked; app-shell chrome stays readable.

## Settings → Developer (after)

<img src="https://i.img402.dev/n618c0qtl8.jpg" width="800" alt="Settings → Developer after: no issue-label input, read-only labels row">

## Validation

- Reproduced the unstyled failure and proved the inline-`<style>` fix in a live browser.
- Drove the **real reporter widget** end-to-end: uploaded screenshot + snapshot to bb-artifacts, both render styled; draft URL carries `labels=bug,filed-via-bug`.
- `go build` / `go vet` / `go test ./...` green on **default**, **headless**, and **lite**; devmode integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
