### PR TITLE
feat(feed): inline "Load older activity" pagination — append in place

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -50,29 +50,17 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 
 		// Per-query timings, emitted as a single structured slog line at the
 		// end of the request so we can spot regressions in production logs.
-		// Zero-value durations indicate "skipped" — e.g. q_categories=0 when
-		// there are no bulk_action events to resolve.
+		// The reports/events/category/tag timings come back from
+		// feedWindowItems; the alerts query is timed inline below.
 		reqStart := time.Now()
-		var qCategories, qTags, qEvents, qReports, qAlerts time.Duration
+		var qAlerts time.Duration
 
-		// `?before=<rfc3339>` lets the user roll the 3-day window backward
-		// in chunks via the "Load older activity" footer button. Cap at
-		// 30 days back from now — the service layer enforces the same
-		// ceiling, but clamping here keeps the rendered window/footer
-		// consistent and makes the cap discoverable from a single layer.
-		var beforeTime time.Time
-		if rawBefore := strings.TrimSpace(r.URL.Query().Get("before")); rawBefore != "" {
-			if parsed, err := time.Parse(time.RFC3339, rawBefore); err == nil {
-				beforeTime = parsed
-				minBefore := now.Add(-service.FeedMaxLookback)
-				if beforeTime.Before(minBefore) {
-					beforeTime = minBefore
-				}
-				if beforeTime.After(now) {
-					beforeTime = time.Time{}
-				}
-			}
-		}
+		// `?before=<rfc3339>` lets the user roll the 3-day window backward in
+		// chunks via the "Load older activity" footer. Parsed + clamped to the
+		// 30-day lookback ceiling here and again in the service layer (defence
+		// in depth). The home feed's inline pagination (FeedRowsHandler) shares
+		// the same parse helper so its cursor honours the identical bounds.
+		beforeTime := parseFeedBefore(r.URL.Query().Get("before"), now)
 
 		// Resolve the session actor for the "me" chip. Prefer the linked
 		// household user_id; fall back to the auth_account id for the
@@ -90,197 +78,45 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 1. Reports — windowed to match the feed bound. Fetched ahead of
-		// the events call so the service can fold matching reports into
-		// bulk_action / agent_session events (one card per agent run
-		// instead of two adjacent cards). Skipped under the
-		// syncs/comments/sessions/me chips, which scope the page to events
-		// the service layer produces.
-		var reports []service.AgentReportResponse
-		if filter == "" || filter == "reports" {
-			t0 := time.Now()
-			var rerr error
-			reports, rerr = svc.ListAgentReports(ctx, 50)
-			qReports = time.Since(t0)
-			if rerr != nil {
-				a.Logger.Error("feed: list agent reports", "error", rerr)
-			}
-		}
-
-		// 2. Grouped events from the service. The windowed report list is
-		// returned straight back as `standaloneReports` — every report
-		// renders as its own comment-bubble row, never folded into the
-		// session/bulk card it came from. We also decide here whether the
-		// (relatively expensive) tag + category lookups are needed — they
-		// only feed bulk_action subject rendering. Skipping them on the
-		// common no-bulk path saves 5-10ms per request.
-		t0 := time.Now()
-		events, standaloneReports, err := svc.ListFeedEventsWithReports(ctx, service.FeedEventsParams{
-			Window:        window,
-			BulkThreshold: 3,
-			SampleLimit:   5,
-			Filter:        filter,
-			ActorID:       sessionActorID,
-			Before:        beforeTime,
-		}, reports)
-		qEvents = time.Since(t0)
+		// Aggregate the window: agent reports + grouped events projected onto
+		// FeedItems, newest-first. FeedRowsHandler runs the same helper so the
+		// inline "Load older activity" rows are byte-identical to a full page
+		// render. `reports` is the windowed report list, kept here only for the
+		// unread-count hero tile below.
+		items, reports, timings, err := feedWindowItems(ctx, a, svc, feedQuery{
+			now:            now,
+			window:         window,
+			before:         beforeTime,
+			filter:         filter,
+			sessionActorID: sessionActorID,
+		})
 		if err != nil {
-			a.Logger.Error("feed: list events", "error", err)
+			// Already logged inside the helper. Render with whatever items came
+			// back (nil → empty state) rather than 500-ing the home page.
+			items = nil
 		}
 
-		// Display lookups so bulk-action subjects render with friendly tag
-		// and category display names instead of raw slugs. Only fetched when
-		// at least one bulk_action event is present — the common case (sync
-		// + comment + agent_session events only) skips both queries.
-		hasBulkAction := false
-		for _, ev := range events {
-			if ev.Type == "bulk_action" {
-				hasBulkAction = true
-				break
-			}
-		}
-		var categoryDetail func(string) categoryDisplay
-		var tagDisplayFn func(string) tagDisplay
-		if hasBulkAction {
-			t0 = time.Now()
-			categoryTree, cerr := svc.ListCategories(ctx)
-			qCategories = time.Since(t0)
-			if cerr != nil {
-				a.Logger.Error("feed: list categories", "error", cerr)
-			}
-			categoryDetail = categoryDetailLookup(categoryTree)
-			t0 = time.Now()
-			tags, terr := svc.ListTags(ctx)
-			qTags = time.Since(t0)
-			if terr != nil {
-				a.Logger.Error("feed: list tags", "error", terr)
-			}
-			tagDisplayFn = tagDisplayLookup(tags)
-		} else {
-			// projectFeedBulkAction won't fire on this path, but
-			// projectFeedEvent unconditionally accepts the lookups. Provide
-			// no-op stubs so the call site stays simple.
-			categoryDetail = func(string) categoryDisplay { return categoryDisplay{} }
-			tagDisplayFn = func(string) tagDisplay { return tagDisplay{} }
-		}
-
-		// 3. Connection alerts + empty-state meta — current state, not
-		// windowed. Alerts hide under any active chip so the filtered view
-		// is exclusively the chip's scope; the alerts re-appear on the
-		// unfiltered "All" page. The meta (hasConnections + global last-
-		// sync-at) is always collected so the empty-state branch can pick
-		// the right copy regardless of filter.
-		t0 = time.Now()
+		// Connection alerts + empty-state meta — current state, not windowed.
+		// Alerts hide under any active chip so the filtered view is exclusively
+		// the chip's scope; they re-appear on the unfiltered "All" page. The
+		// meta (hasConnections + global last-sync-at) is always collected so the
+		// empty-state branch can pick the right copy regardless of filter.
+		t0 := time.Now()
 		alerts, hasConnections, globalLastSyncAt := buildFeedConnectionMeta(ctx, a)
 		qAlerts = time.Since(t0)
 		if filter != "" {
 			alerts = nil
 		}
 
-		// 4. Project FeedEvents onto templ-side FeedItems. The window is
-		// anchored at `windowEnd` (now, or the `?before=` timestamp when
-		// paginating); `windowStart` is `windowEnd - window`.
-		windowEnd := now
-		if !beforeTime.IsZero() {
-			windowEnd = beforeTime
-		}
-		windowStart := windowEnd.Add(-window)
-
-		items := make([]pages.FeedItem, 0, len(events)+len(reports))
+		// Hero-stat collection over the projected items. Sync items carry the
+		// same AddedCount / RuleOutcomes / Status / StartedAt the raw events do,
+		// so the hero tiles derive entirely from `items`; reports drive the
+		// unread count below.
+		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 		var lastSyncAt time.Time
 		var lastSyncStatus, lastSyncInstitution string
 		var totalNewTransactionsToday, ruleHitsToday int
-		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-
-		for _, ev := range events {
-			if ev.Timestamp.Before(windowStart) || ev.Timestamp.After(windowEnd) {
-				continue
-			}
-			it := projectFeedEvent(ev, tagDisplayFn, categoryDetail)
-			if it == nil {
-				continue
-			}
-			items = append(items, *it)
-
-			// Hero-stat collection over the same loop.
-			switch ev.Type {
-			case "sync":
-				if ev.Sync != nil && ev.Sync.StartedAt.After(lastSyncAt) {
-					lastSyncAt = ev.Sync.StartedAt
-					lastSyncStatus = ev.Sync.Status
-					lastSyncInstitution = ev.Sync.InstitutionName
-				}
-				if ev.Sync != nil && ev.Timestamp.After(startOfDay) {
-					totalNewTransactionsToday += ev.Sync.AddedCount
-					for _, ro := range ev.Sync.RuleOutcomes {
-						ruleHitsToday += ro.Count
-					}
-				}
-			}
-		}
-
-		// 5. Append every report as its own comment-bubble feed item. A
-		// report that came from an agent session / bulk action sorts next to
-		// that card on the timeline (same actor + timeframe) but renders as
-		// its own row — reports are no longer folded into a card headline.
-		//
-		// agentSeedCache memoizes the report-author → avatar-seed resolution
-		// across the loop so repeat agents don't re-query; "" is cached too
-		// (a miss is a decision, not a retry).
-		agentSeedCache := map[string]string{}
-		for _, rep := range standaloneReports {
-			if rep.CreatedAt == "" {
-				continue
-			}
-			ts, err := time.Parse(time.RFC3339, rep.CreatedAt)
-			if err != nil {
-				continue
-			}
-			if ts.Before(windowStart) || ts.After(windowEnd) {
-				continue
-			}
-			// Seed the report's avatar from the agent it ran under so the
-			// row shows the same robot as the agent's other activity,
-			// instead of the generic bot tile. Only agent-authored reports
-			// can resolve — the actor_type guard skips a DB query for
-			// operator/system reports, and the cache dedups repeat agents.
-			reportAvatarSeed := ""
-			if rep.CreatedByType == "agent" && rep.CreatedByID != nil {
-				id := *rep.CreatedByID
-				seed, cached := agentSeedCache[id]
-				if !cached {
-					if slug, ok := svc.ResolveAgentSlugForActor(ctx, id); ok {
-						seed = slug
-					}
-					agentSeedCache[id] = seed
-				}
-				reportAvatarSeed = seed
-			}
-			items = append(items, pages.FeedItem{
-				Type:         "report",
-				Timestamp:    ts,
-				TimestampStr: ts.UTC().Format(time.RFC3339),
-				Report: &pages.FeedReport{
-					ID:            rep.ID,
-					ShortID:       rep.ShortID,
-					Title:         rep.Title,
-					BodyExcerpt:   excerpt(rep.Body, 220),
-					Priority:      rep.Priority,
-					DisplayAuthor: reportDisplayAuthor(rep.CreatedByName, rep.Author),
-					IsUnread:      rep.ReadAt == nil,
-					AvatarSeed:    reportAvatarSeed,
-				},
-			})
-		}
-
-		// 6. Sort + day-bucket.
-		sort.Slice(items, func(i, j int) bool {
-			return items[i].Timestamp.After(items[j].Timestamp)
-		})
-		days := groupFeedByDay(items, now, loc)
-
-		// 7. Hero band.
-		var commentsToday, eventsToday, unreadReports int
+		var eventsToday, commentsToday int
 		for _, it := range items {
 			if it.Timestamp.After(startOfDay) {
 				eventsToday++
@@ -288,9 +124,25 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 					commentsToday++
 				}
 			}
+			if it.Type == "sync" && it.Sync != nil {
+				if it.Sync.StartedAt.After(lastSyncAt) {
+					lastSyncAt = it.Sync.StartedAt
+					lastSyncStatus = it.Sync.Status
+					lastSyncInstitution = it.Sync.InstitutionName
+				}
+				if it.Timestamp.After(startOfDay) {
+					totalNewTransactionsToday += it.Sync.AddedCount
+					for _, ro := range it.Sync.RuleOutcomes {
+						ruleHitsToday += ro.Count
+					}
+				}
+			}
 		}
-		for _, r := range reports {
-			if r.ReadAt == nil {
+		days := groupFeedByDay(items, now, loc)
+
+		var unreadReports int
+		for _, rep := range reports {
+			if rep.ReadAt == nil {
 				unreadReports++
 			}
 		}
@@ -364,14 +216,328 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			"duration_ms", time.Since(reqStart).Milliseconds(),
 			"events", len(items),
 			"reports", len(reports),
-			"q_categories_ms", qCategories.Milliseconds(),
-			"q_tags_ms", qTags.Milliseconds(),
-			"q_events_total_ms", qEvents.Milliseconds(),
-			"q_reports_ms", qReports.Milliseconds(),
+			"q_categories_ms", timings.Categories.Milliseconds(),
+			"q_tags_ms", timings.Tags.Milliseconds(),
+			"q_events_total_ms", timings.Events.Milliseconds(),
+			"q_reports_ms", timings.Reports.Milliseconds(),
 			"q_alerts_ms", qAlerts.Milliseconds(),
 		)
 
 		tr.RenderWithTempl(w, r, data, body)
+	}
+}
+
+// feedQuery carries the windowing inputs shared by the full-page feed handler
+// and the inline-pagination rows endpoint.
+type feedQuery struct {
+	now            time.Time
+	window         time.Duration
+	before         time.Time // zero → window anchored at now
+	filter         string
+	sessionActorID string
+}
+
+// feedQueryTimings reports the per-query durations feedWindowItems spent, so
+// the page handler can keep emitting its structured timing log. Zero values
+// mean "skipped" (e.g. category/tag lookups only run when a bulk_action event
+// is present).
+type feedQueryTimings struct {
+	Reports    time.Duration
+	Events     time.Duration
+	Categories time.Duration
+	Tags       time.Duration
+}
+
+// parseFeedBefore parses the `?before=` pagination cursor (RFC3339) and clamps
+// it into the valid (now-FeedMaxLookback, now] range. Returns the zero time
+// when absent, unparseable, or in the future — callers treat that as "no
+// cursor, anchor the window at now". The service layer re-clamps, so this is
+// defence in depth that also keeps the rendered window/footer consistent.
+func parseFeedBefore(raw string, now time.Time) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	if parsed.After(now) {
+		return time.Time{}
+	}
+	if minBefore := now.Add(-service.FeedMaxLookback); parsed.Before(minBefore) {
+		parsed = minBefore
+	}
+	return parsed
+}
+
+// feedWindowItems runs the feed aggregation pipeline for a single window and
+// returns the projected, newest-first items plus the agent reports fetched for
+// the window. Both FeedHandler (initial page) and FeedRowsHandler (inline
+// "Load older activity") call this so the rendered rows + windowing stay
+// byte-identical — the rows endpoint grafts onto the same rail the page drew.
+//
+// The returned reports slice is the full windowed report set (the page uses it
+// for the unread-count hero tile; the rows endpoint ignores it). All errors are
+// logged here and surfaced to the caller, which degrades to an empty render
+// rather than failing the request.
+func feedWindowItems(ctx context.Context, a *app.App, svc *service.Service, q feedQuery) ([]pages.FeedItem, []service.AgentReportResponse, feedQueryTimings, error) {
+	var timings feedQueryTimings
+
+	// Reports — windowed; gated to the chips that actually surface them.
+	var reports []service.AgentReportResponse
+	if q.filter == "" || q.filter == "reports" {
+		t0 := time.Now()
+		var rerr error
+		reports, rerr = svc.ListAgentReports(ctx, 50)
+		timings.Reports = time.Since(t0)
+		if rerr != nil {
+			a.Logger.Error("feed: list agent reports", "error", rerr)
+		}
+	}
+
+	// Grouped events. The windowed report list comes straight back as
+	// `standaloneReports` — every report renders as its own comment-bubble row.
+	t0 := time.Now()
+	events, standaloneReports, err := svc.ListFeedEventsWithReports(ctx, service.FeedEventsParams{
+		Window:        q.window,
+		BulkThreshold: 3,
+		SampleLimit:   5,
+		Filter:        q.filter,
+		ActorID:       q.sessionActorID,
+		Before:        q.before,
+	}, reports)
+	timings.Events = time.Since(t0)
+	if err != nil {
+		a.Logger.Error("feed: list events", "error", err)
+		return nil, reports, timings, err
+	}
+
+	// Display lookups for bulk-action subjects — only fetched when at least one
+	// bulk_action event is present (the common sync/comment/session path skips
+	// both queries).
+	hasBulkAction := false
+	for _, ev := range events {
+		if ev.Type == "bulk_action" {
+			hasBulkAction = true
+			break
+		}
+	}
+	var categoryDetail func(string) categoryDisplay
+	var tagDisplayFn func(string) tagDisplay
+	if hasBulkAction {
+		t0 = time.Now()
+		categoryTree, cerr := svc.ListCategories(ctx)
+		timings.Categories = time.Since(t0)
+		if cerr != nil {
+			a.Logger.Error("feed: list categories", "error", cerr)
+		}
+		categoryDetail = categoryDetailLookup(categoryTree)
+		t0 = time.Now()
+		tags, terr := svc.ListTags(ctx)
+		timings.Tags = time.Since(t0)
+		if terr != nil {
+			a.Logger.Error("feed: list tags", "error", terr)
+		}
+		tagDisplayFn = tagDisplayLookup(tags)
+	} else {
+		categoryDetail = func(string) categoryDisplay { return categoryDisplay{} }
+		tagDisplayFn = func(string) tagDisplay { return tagDisplay{} }
+	}
+
+	// Window bounds — anchored at now, or at `before` when paginating.
+	windowEnd := q.now
+	if !q.before.IsZero() {
+		windowEnd = q.before
+	}
+	windowStart := windowEnd.Add(-q.window)
+
+	items := make([]pages.FeedItem, 0, len(events)+len(reports))
+	for _, ev := range events {
+		if ev.Timestamp.Before(windowStart) || ev.Timestamp.After(windowEnd) {
+			continue
+		}
+		it := projectFeedEvent(ev, tagDisplayFn, categoryDetail)
+		if it == nil {
+			continue
+		}
+		items = append(items, *it)
+	}
+
+	// Every report renders as its own comment-bubble feed item. agentSeedCache
+	// memoizes the report-author → avatar-seed resolution so repeat agents
+	// don't re-query ("" is cached too — a miss is a decision, not a retry).
+	agentSeedCache := map[string]string{}
+	for _, rep := range standaloneReports {
+		if rep.CreatedAt == "" {
+			continue
+		}
+		ts, perr := time.Parse(time.RFC3339, rep.CreatedAt)
+		if perr != nil {
+			continue
+		}
+		if ts.Before(windowStart) || ts.After(windowEnd) {
+			continue
+		}
+		reportAvatarSeed := ""
+		if rep.CreatedByType == "agent" && rep.CreatedByID != nil {
+			id := *rep.CreatedByID
+			seed, cached := agentSeedCache[id]
+			if !cached {
+				if slug, ok := svc.ResolveAgentSlugForActor(ctx, id); ok {
+					seed = slug
+				}
+				agentSeedCache[id] = seed
+			}
+			reportAvatarSeed = seed
+		}
+		items = append(items, pages.FeedItem{
+			Type:         "report",
+			Timestamp:    ts,
+			TimestampStr: ts.UTC().Format(time.RFC3339),
+			Report: &pages.FeedReport{
+				ID:            rep.ID,
+				ShortID:       rep.ShortID,
+				Title:         rep.Title,
+				BodyExcerpt:   excerpt(rep.Body, 220),
+				Priority:      rep.Priority,
+				DisplayAuthor: reportDisplayAuthor(rep.CreatedByName, rep.Author),
+				IsUnread:      rep.ReadAt == nil,
+				AvatarSeed:    reportAvatarSeed,
+			},
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Timestamp.After(items[j].Timestamp)
+	})
+	return items, reports, timings, nil
+}
+
+// FeedRowsHandler serves GET /-/feed/rows?before=<rfc3339>[&filter=<slug>][&last_day=<YYYY-MM-DD>].
+//
+// Powers the inline "Load older activity" pagination on the home Feed: the
+// feedPagination Alpine factory GETs this endpoint, appends the returned rail
+// <li> rows to the existing <ol class="bb-timeline">, and advances its cursor
+// from the response headers — so the timeline continues in place instead of
+// reloading the whole page from the top.
+//
+// It reuses feedWindowItems (the same aggregation the page handler runs) so the
+// appended rows are byte-identical to a full render. Empty 3-day windows are
+// skipped server-side (walking `before` backward by the window up to the 30-day
+// lookback cap) so a single tap always lands on content while older events
+// remain.
+//
+// Response:
+//   - Body: rendered <li> rows for the next non-empty window (day separators +
+//     feed rows). The leading day separator is omitted when its calendar day
+//     equals `last_day` (the tail day already on the client) so the rows
+//     continue under the existing heading instead of repeating it.
+//   - X-Feed-Next-Before: RFC3339 cursor to pass as `before` on the next tap
+//     (the oldest item just rendered).
+//   - X-Feed-Last-Day: the oldest day key just rendered (the client's new
+//     dedup anchor).
+//   - X-Feed-At-Max: "1" once the lookback cap is reached (the client swaps the
+//     button for "End of feed"); "0" otherwise.
+//
+// An empty body with X-Feed-At-Max:1 means no older events remain.
+func FeedRowsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		loc := UserLocation(r)
+		now := time.Now().In(loc)
+		window := time.Duration(feedWindowDays) * 24 * time.Hour
+		filter := strings.TrimSpace(r.URL.Query().Get("filter"))
+		lastDay := strings.TrimSpace(r.URL.Query().Get("last_day"))
+
+		// A rows request with no usable cursor has nothing to page from.
+		before := parseFeedBefore(r.URL.Query().Get("before"), now)
+		if before.IsZero() {
+			w.Header().Set("X-Feed-At-Max", "1")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Resolve the "me" actor the same way the page does.
+		var sessionActorID string
+		if filter == "me" {
+			sessionActorID = SessionUserID(tr.sm, r)
+			if sessionActorID == "" {
+				sessionActorID = SessionAccountID(tr.sm, r)
+			}
+			if sessionActorID == "" {
+				filter = ""
+			}
+		}
+
+		// Skip empty windows so a tap always lands on content. Bounded by the
+		// lookback span (≤ FeedMaxLookback/window iterations) — once the cursor
+		// reaches the cap we do one final clamped fetch and stop.
+		minBefore := now.Add(-service.FeedMaxLookback)
+		var items []pages.FeedItem
+		cursor := before
+		for {
+			winItems, _, _, err := feedWindowItems(ctx, a, svc, feedQuery{
+				now:            now,
+				window:         window,
+				before:         cursor,
+				filter:         filter,
+				sessionActorID: sessionActorID,
+			})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load feed")
+				return
+			}
+			if len(winItems) > 0 {
+				items = winItems
+				break
+			}
+			cursor = cursor.Add(-window)
+			if !cursor.After(minBefore) {
+				break
+			}
+		}
+
+		if len(items) == 0 {
+			// No older events remain within the lookback window.
+			w.Header().Set("X-Feed-At-Max", "1")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		var oldest time.Time
+		for _, it := range items {
+			if oldest.IsZero() || it.Timestamp.Before(oldest) {
+				oldest = it.Timestamp
+			}
+		}
+
+		days := groupFeedByDay(items, now, loc)
+		omitLeading := ""
+		if len(days) > 0 && days[0].Key == lastDay {
+			omitLeading = lastDay
+		}
+		lastRenderedDay := ""
+		if len(days) > 0 {
+			lastRenderedDay = days[len(days)-1].Key
+		}
+
+		w.Header().Set("X-Feed-Next-Before", oldest.UTC().Format(time.RFC3339))
+		w.Header().Set("X-Feed-Last-Day", lastRenderedDay)
+		if oldest.Before(minBefore) {
+			w.Header().Set("X-Feed-At-Max", "1")
+		} else {
+			w.Header().Set("X-Feed-At-Max", "0")
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		comp := pages.FeedRows(pages.FeedRowsProps{
+			Days:              days,
+			Now:               now,
+			OmitLeadingDayKey: omitLeading,
+		})
+		if err := comp.Render(ctx, w); err != nil {
+			a.Logger.Error("feed rows: render", "error", err)
+		}
 	}
 }
 

--- a/internal/admin/feed_rows_integration_test.go
+++ b/internal/admin/feed_rows_integration_test.go
@@ -1,0 +1,149 @@
+//go:build integration && !headless && !lite
+
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestFeedRowsHandler exercises the inline "Load older activity" endpoint
+// (GET /-/feed/rows). It seeds backdated comment annotations across multiple
+// 3-day windows and asserts:
+//
+//   - a `before` cursor with events in the older window returns rendered <li>
+//     rows plus the X-Feed-Next-Before / X-Feed-Last-Day / X-Feed-At-Max
+//     pagination headers;
+//   - empty 3-day windows are skipped server-side so a single call still
+//     lands on the next non-empty window;
+//   - a missing cursor (or one past the lookback cap with nothing older)
+//     returns an empty body flagged X-Feed-At-Max:1 so the client renders
+//     "End of feed".
+func TestFeedRowsHandler(t *testing.T) {
+	pool, q := testutil.ServicePool(t)
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	a := &app.App{DB: pool, Queries: q, Logger: slog.Default()}
+	tr := &TemplateRenderer{sm: &scs.SessionManager{}}
+	handler := FeedRowsHandler(a, svc, tr)
+
+	user := testutil.MustCreateUser(t, q, "Alice")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "feed-rows-conn")
+	acct := testutil.MustCreateAccount(t, q, conn.ID, "feed-rows-acct", "Checking")
+	actor := service.Actor{Type: "user", ID: pgconv.FormatUUID(user.ID), Name: "Alice"}
+
+	now := time.Now()
+
+	// seedComment creates one comment on a fresh transaction and backdates the
+	// annotation's created_at so the feed treats it as historical activity.
+	seedComment := func(extID, txName, body string, ts time.Time) pgtype.UUID {
+		t.Helper()
+		txn := testutil.MustCreateTransaction(t, q, acct.ID, extID, txName, 500, "2026-04-01")
+		if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+			TransactionID: pgconv.FormatUUID(txn.ID),
+			Content:       body,
+			Actor:         actor,
+		}); err != nil {
+			t.Fatalf("CreateComment: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			"UPDATE annotations SET created_at = $1 WHERE transaction_id = $2 AND kind = 'comment'",
+			ts, txn.ID,
+		); err != nil {
+			t.Fatalf("backdate comment: %v", err)
+		}
+		return txn.ID
+	}
+
+	call := func(query string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/-/feed/rows?"+query, nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+		return w
+	}
+
+	// One comment 5 days old (in the window just past the default 3-day page)
+	// and one 10 days old (two empty windows further back).
+	seedComment("feed-rows-tx-5d", "Coffee Bar", "five days ago", now.Add(-5*24*time.Hour))
+	seedComment("feed-rows-tx-10d", "Old Diner", "ten days ago", now.Add(-10*24*time.Hour))
+
+	t.Run("returns_older_rows_with_pagination_headers", func(t *testing.T) {
+		// before = 3 days ago → window [6d, 3d) contains the 5-day-old comment.
+		w := call("before=" + now.Add(-3*24*time.Hour).UTC().Format(time.RFC3339))
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "<li") {
+			t.Fatalf("expected <li> rows in body, got: %s", body)
+		}
+		if !strings.Contains(body, "Coffee Bar") {
+			t.Errorf("expected the 5-day-old comment's transaction in body, got: %s", body)
+		}
+		if w.Header().Get("X-Feed-Next-Before") == "" {
+			t.Errorf("expected X-Feed-Next-Before header to be set")
+		}
+		if w.Header().Get("X-Feed-Last-Day") == "" {
+			t.Errorf("expected X-Feed-Last-Day header to be set")
+		}
+		if got := w.Header().Get("X-Feed-At-Max"); got != "0" {
+			t.Errorf("expected X-Feed-At-Max=0 (more history remains), got %q", got)
+		}
+	})
+
+	t.Run("skips_empty_windows_to_next_content", func(t *testing.T) {
+		// before = 6 days ago → window [9d, 6d) is empty; the handler must walk
+		// back to [12d, 9d) and surface the 10-day-old comment in one call.
+		w := call("before=" + now.Add(-6*24*time.Hour).UTC().Format(time.RFC3339))
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Old Diner") {
+			t.Fatalf("expected the 10-day-old comment after skipping an empty window, got: %s", body)
+		}
+	})
+
+	t.Run("no_cursor_signals_end_of_feed", func(t *testing.T) {
+		w := call("")
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if strings.TrimSpace(w.Body.String()) != "" {
+			t.Errorf("expected empty body with no cursor, got: %s", w.Body.String())
+		}
+		if got := w.Header().Get("X-Feed-At-Max"); got != "1" {
+			t.Errorf("expected X-Feed-At-Max=1 with no cursor, got %q", got)
+		}
+	})
+
+	t.Run("past_cap_with_no_history_signals_end", func(t *testing.T) {
+		// before = 29 days ago, no events that old → walk to the 30-day cap
+		// and return an empty, end-flagged response.
+		w := call("before=" + now.Add(-29*24*time.Hour).UTC().Format(time.RFC3339))
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if strings.TrimSpace(w.Body.String()) != "" {
+			t.Errorf("expected empty body past the lookback cap, got: %s", w.Body.String())
+		}
+		if got := w.Header().Get("X-Feed-At-Max"); got != "1" {
+			t.Errorf("expected X-Feed-At-Max=1 past the cap, got %q", got)
+		}
+	})
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -424,6 +424,11 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Quick search — accessible to all roles.
 		r.Get("/search/transactions", QuickSearchTransactionsHandler(svc))
 
+		// Home-feed inline pagination — returns just the next window's rail
+		// rows so "Load older activity" appends in place instead of reloading
+		// the whole page. Read-only, all roles. See FeedRowsHandler.
+		r.Get("/feed/rows", FeedRowsHandler(a, svc, tr))
+
 		// Transaction comments — accessible to all roles.
 		r.Post("/transactions/{id}/comments", CreateTransactionCommentHandler(a, sm, svc))
 		r.Delete("/transactions/{id}/comments/{comment_id}", DeleteTransactionCommentHandler(a, sm, svc))

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -16,6 +16,10 @@ import (
 // transaction activity log on /transactions/{id}. The home feed is just a
 // global, grouped view of the same shape.
 templ Feed(p FeedProps) {
+	<!-- Feed Alpine factories (inline rail pagination + the empty-state sync
+	     button) live in feed.js. Loaded here, no defer, so the alpine:init
+	     listeners register before Alpine processes the x-data bindings below. -->
+	<script src="/static/js/admin/components/feed.js"></script>
 	<!-- Comment rows on the home feed render as a single-line system event:
 	     "<actor> commented on <merchant>". A tooltip on the "commented on"
 	     verb surfaces the first line of the comment body for a quick peek;
@@ -169,26 +173,39 @@ templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
 		@feedEmptyState(p)
 	} else {
-		@components.Timeline(components.TimelineProps{
-			Heading:     "Activity",
-			HeadingIcon: "rss",
-			EventCount:  p.TotalItems,
-			AriaLabel:   "Household feed",
-			Variant:     "prominent",
-		}) {
-			for _, day := range p.Days {
-				@components.TimelineDay(day.Label, day.First)
-				for _, item := range day.Items {
-					@feedRow(item, p.Now)
+		<!-- feedPagination scope: the footer button fetches the next window's
+		     rows from /-/feed/rows and appends them into this rail's <ol> in
+		     place, so the timeline continues instead of reloading the page from
+		     the top. data-* attrs seed the cursor + dedup anchor; the inner
+		     <a href> is the no-JS fallback. -->
+		<div
+			x-data="feedPagination"
+			data-feed-before={ feedPaginationCursor(p) }
+			data-feed-filter={ p.Filter }
+			data-feed-last-day={ feedPaginationLastDay(p) }
+			data-feed-at-max={ feedBoolAttr(p.AtMaxLookback) }
+		>
+			@components.Timeline(components.TimelineProps{
+				Heading:     "Activity",
+				HeadingIcon: "rss",
+				EventCount:  p.TotalItems,
+				AriaLabel:   "Household feed",
+				Variant:     "prominent",
+			}) {
+				for _, day := range p.Days {
+					@components.TimelineDay(day.Label, day.First)
+					for _, item := range day.Items {
+						@feedRow(item, p.Now)
+					}
 				}
 			}
-		}
-		if p.WindowDays > 0 {
-			<p class="text-xs text-base-content/40 text-center mt-6">
-				Showing the last { fmt.Sprintf("%d days", p.WindowDays) }.
-			</p>
-		}
-		@feedLoadOlder(p)
+			if p.WindowDays > 0 {
+				<p class="text-xs text-base-content/40 text-center mt-6" x-show="!expanded">
+					Showing the last { fmt.Sprintf("%d days", p.WindowDays) }.
+				</p>
+			}
+			@feedLoadOlder(p)
+		</div>
 	}
 }
 
@@ -197,21 +214,51 @@ templ feedTimeline(p FeedProps) {
 // don't get a "load older" since the user has no anchor). When the
 // earliest visible event is past the 30-day lookback ceiling we render
 // "End of feed" instead so users have a clear stop signal.
+//
+// Inside the feedPagination scope, the button's click is intercepted: JS
+// fetches the next window's rows and appends them to the rail in place,
+// then swaps the footer to "End of feed" once the cap is reached. The
+// plain href is the no-JS fallback (full-page roll-back to ?before=…).
 templ feedLoadOlder(p FeedProps) {
 	if !p.OldestVisible.IsZero() {
-		<div class="flex items-center justify-center mt-3">
+		<div class="flex items-center justify-center mt-3" x-ref="paginator">
 			if p.AtMaxLookback {
 				<p class="text-xs text-base-content/40">End of feed</p>
 			} else {
 				<a
 					href={ templ.SafeURL(feedLoadOlderHRef(p)) }
 					class="btn btn-sm btn-ghost border border-base-300 text-base-content/65"
+					x-on:click.prevent="loadOlder()"
+					x-bind:class="loading && 'pointer-events-none opacity-60'"
+					x-bind:aria-busy="loading"
 				>
-					@components.LucideIcon("arrow-down", "w-3.5 h-3.5")
-					Load older activity
+					<span class="loading loading-spinner loading-xs" x-show="loading" x-cloak></span>
+					<span x-show="!loading">
+						@components.LucideIcon("arrow-down", "w-3.5 h-3.5")
+					</span>
+					<span x-text="loading ? 'Loading…' : 'Load older activity'">Load older activity</span>
 				</a>
 			}
 		</div>
+	}
+}
+
+// FeedRows renders the rail rows for one older feed window as a bare fragment
+// of <li> elements (day separators + feed rows) — no <ol> wrapper, since the
+// client appends them into the existing timeline list. Served by
+// FeedRowsHandler and grafted on by the feedPagination Alpine factory. The
+// leading day separator is suppressed when its day key matches
+// OmitLeadingDayKey (the tail day already on the client) so appended rows
+// continue under the existing heading. Mirrors the transaction-detail
+// TimelineRows partial-render contract.
+templ FeedRows(p FeedRowsProps) {
+	for i, day := range p.Days {
+		if !(i == 0 && day.Key == p.OmitLeadingDayKey) {
+			@components.TimelineDay(day.Label, false)
+		}
+		for _, item := range day.Items {
+			@feedRow(item, p.Now)
+		}
 	}
 }
 
@@ -276,7 +323,6 @@ templ feedEmptyFiltered(filter string) {
 // browse-history link, since sync-all is admin-only.
 templ feedEmptyNoRecent(p FeedProps) {
 	if p.IsAdmin {
-		<script src="/static/js/admin/components/feed.js"></script>
 		<div class="bb-card p-10 sm:p-12 text-center" x-data="feedSyncNow">
 			@components.LucideIcon("moon", "w-10 h-10 mx-auto mb-3 text-base-content opacity-20")
 			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
@@ -1201,6 +1247,36 @@ func feedLoadOlderHRef(p FeedProps) string {
 		q = "filter=" + p.Filter + "&" + q
 	}
 	return "/?" + q
+}
+
+// feedPaginationCursor is the RFC3339 cursor the inline pagination starts
+// from — the oldest event currently on the rail. Mirrors the `before` value
+// the no-JS load-older link carries; seeds data-feed-before. Empty when the
+// rail has no events (the load-older affordance isn't rendered then).
+func feedPaginationCursor(p FeedProps) string {
+	if p.OldestVisible.IsZero() {
+		return ""
+	}
+	return p.OldestVisible.UTC().Format(time.RFC3339)
+}
+
+// feedPaginationLastDay is the calendar-day key (YYYY-MM-DD) of the oldest day
+// bucket currently rendered. The rows endpoint compares the next chunk's first
+// day against it to decide whether to repeat a day separator on append.
+func feedPaginationLastDay(p FeedProps) string {
+	if len(p.Days) == 0 {
+		return ""
+	}
+	return p.Days[len(p.Days)-1].Key
+}
+
+// feedBoolAttr renders a boolean as "1"/"0" for a data-* attribute the
+// feedPagination Alpine factory parses on init.
+func feedBoolAttr(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
 }
 
 // feedFilterLabel renders the chip-name string used in the active-filter

--- a/internal/templates/components/pages/feed_rows_test.go
+++ b/internal/templates/components/pages/feed_rows_test.go
@@ -1,0 +1,107 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedRows covers the inline-pagination partial render (FeedRows) used by
+// the home feed's "Load older activity" append flow:
+//
+//   - each day bucket renders a day separator plus its feed rows;
+//   - the leading day separator is omitted when its key matches
+//     OmitLeadingDayKey (the tail day already on the client) so appended rows
+//     continue under the existing heading — but that day's item rows still
+//     render;
+//   - the leading separator is kept when the key doesn't match.
+//
+// Pure templ render, no DB — runs under `go test ./...`.
+func TestFeedRows(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	syncItem := func(ts time.Time, inst string) FeedItem {
+		return FeedItem{
+			Type:         "sync",
+			Timestamp:    ts,
+			TimestampStr: ts.UTC().Format(time.RFC3339),
+			Sync: &FeedSync{
+				SyncLogID:       "sync-" + inst,
+				InstitutionName: inst,
+				Provider:        "plaid",
+				Status:          "success",
+				AddedCount:      2,
+				StartedAt:       ts,
+			},
+		}
+	}
+
+	days := []FeedDay{
+		{
+			Key:   "2026-04-25",
+			Label: "Apr 25",
+			Items: []FeedItem{syncItem(now.Add(-3*24*time.Hour), "Wells Fargo")},
+		},
+		{
+			Key:   "2026-04-24",
+			Label: "Apr 24",
+			Items: []FeedItem{syncItem(now.Add(-4*24*time.Hour), "Chase")},
+		},
+	}
+
+	t.Run("renders_both_day_separators_when_no_omit", func(t *testing.T) {
+		html := renderFeedRows(t, FeedRowsProps{Days: days, Now: now})
+		for _, want := range []string{
+			`aria-label="Apr 25"`, // day separator only emits aria-label
+			`aria-label="Apr 24"`,
+			"Wells Fargo",
+			"Chase",
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("expected rendered rows to contain %q", want)
+			}
+		}
+	})
+
+	t.Run("omits_leading_separator_matching_anchor", func(t *testing.T) {
+		html := renderFeedRows(t, FeedRowsProps{
+			Days:              days,
+			Now:               now,
+			OmitLeadingDayKey: "2026-04-25",
+		})
+		if strings.Contains(html, `aria-label="Apr 25"`) {
+			t.Errorf("expected leading day separator (Apr 25) to be omitted")
+		}
+		// Its item rows still render — only the duplicate heading is dropped.
+		if !strings.Contains(html, "Wells Fargo") {
+			t.Errorf("expected the omitted day's item rows to still render")
+		}
+		// The next day's separator is untouched.
+		if !strings.Contains(html, `aria-label="Apr 24"`) {
+			t.Errorf("expected the second day separator (Apr 24) to render")
+		}
+	})
+
+	t.Run("keeps_leading_separator_when_anchor_differs", func(t *testing.T) {
+		html := renderFeedRows(t, FeedRowsProps{
+			Days:              days,
+			Now:               now,
+			OmitLeadingDayKey: "2026-04-26", // not the first day's key
+		})
+		if !strings.Contains(html, `aria-label="Apr 25"`) {
+			t.Errorf("expected leading day separator (Apr 25) to render when anchor differs")
+		}
+	})
+}
+
+func renderFeedRows(t *testing.T, p FeedRowsProps) string {
+	t.Helper()
+	var buf strings.Builder
+	if err := FeedRows(p).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("FeedRows render: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -78,6 +78,27 @@ type FeedProps struct {
 	// pagination contract.
 }
 
+// FeedRowsProps drives the partial-render endpoint behind the inline "Load
+// older activity" pagination (GET /-/feed/rows). It renders only the rail
+// <li> rows — day separators + feed rows — for one older window so the client
+// can append them to the existing timeline without a full reload. Mirrors the
+// transaction-detail TimelineRows pattern.
+type FeedRowsProps struct {
+	// Days is the day-bucketed chunk to render, newest-first. Each FeedDay's
+	// items are already ordered newest-first within the day.
+	Days []FeedDay
+
+	// Now is the request-level time anchor for relative-time helpers, shared
+	// with the page render so labels never disagree across midnight.
+	Now time.Time
+
+	// OmitLeadingDayKey suppresses the first day's separator when it equals
+	// the day key already at the tail of the client's timeline — the appended
+	// rows then continue under the existing day heading instead of repeating
+	// it. Empty means always render the leading separator.
+	OmitLeadingDayKey string
+}
+
 // FeedHero powers the at-a-glance band above the feed rail.
 type FeedHero struct {
 	Generated            string

--- a/static/js/admin/components/feed.js
+++ b/static/js/admin/components/feed.js
@@ -8,8 +8,93 @@
 //     sync_logs surface in the feed timeline. Admin-only; the templ guards
 //     the button with `if p.IsAdmin`, so this factory is only ever bound
 //     under an admin session.
+//
+//   - `feedPagination` — backs the inline "Load older activity" pagination.
+//     Instead of navigating to `/?before=…` (which reloads the page from the
+//     top), it GETs the next window's rail rows from `/-/feed/rows` and
+//     appends them into the existing <ol class="bb-timeline">, so the timeline
+//     continues in place. State (cursor, dedup anchor, at-cap) seeds from the
+//     wrapper's data-* attrs and advances from the response headers. The
+//     plain <a href> is the no-JS fallback.
 
 document.addEventListener('alpine:init', function () {
+  Alpine.data('feedPagination', function () {
+    return {
+      before: '',
+      filter: '',
+      lastDay: '',
+      atMax: false,
+      loading: false,
+      expanded: false,
+
+      init: function () {
+        var d = this.$root.dataset;
+        this.before = d.feedBefore || '';
+        this.filter = d.feedFilter || '';
+        this.lastDay = d.feedLastDay || '';
+        this.atMax = d.feedAtMax === '1';
+      },
+
+      loadOlder: function () {
+        if (this.loading || this.atMax || !this.before) return;
+        this.loading = true;
+        var self = this;
+
+        var params = new URLSearchParams();
+        params.set('before', this.before);
+        if (this.filter) params.set('filter', this.filter);
+        if (this.lastDay) params.set('last_day', this.lastDay);
+
+        fetch('/-/feed/rows?' + params.toString())
+          .then(function (res) {
+            if (!res.ok) throw new Error('feed rows: ' + res.status);
+            var meta = {
+              nextBefore: res.headers.get('X-Feed-Next-Before') || '',
+              lastDay: res.headers.get('X-Feed-Last-Day') || '',
+              atMax: res.headers.get('X-Feed-At-Max') === '1',
+            };
+            return res.text().then(function (html) {
+              meta.html = html;
+              return meta;
+            });
+          })
+          .then(function (meta) {
+            var ol = self.$root.querySelector('ol.bb-timeline');
+            if (ol && meta.html.trim() !== '') {
+              ol.insertAdjacentHTML('beforeend', meta.html);
+              // Server rows ship as inline SVG, but render any JS-bound
+              // <i data-lucide> placeholders the rows may carry.
+              if (window.lucide && typeof window.lucide.createIcons === 'function') {
+                window.lucide.createIcons();
+              }
+            }
+            if (meta.nextBefore) self.before = meta.nextBefore;
+            if (meta.lastDay) self.lastDay = meta.lastDay;
+            self.expanded = true;
+            self.loading = false;
+            if (meta.atMax) {
+              self.atMax = true;
+              self.showEndOfFeed();
+            }
+          })
+          .catch(function () {
+            self.loading = false;
+            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Couldn’t load older activity. Please try again.', type: 'error' } }));
+          });
+      },
+
+      // Replace the footer button with the terminal "End of feed" note once
+      // the lookback cap is reached. Built in JS (not pre-rendered hidden) so
+      // the in-window server render never contains the end-of-feed copy.
+      showEndOfFeed: function () {
+        var footer = this.$refs.paginator;
+        if (footer) {
+          footer.innerHTML = '<p class="text-xs text-base-content/40">End of feed</p>';
+        }
+      },
+    };
+  });
+
   Alpine.data('feedSyncNow', function () {
     return {
       state: 'idle',


### PR DESCRIPTION
## What

Tapping **Load older activity** on the home feed reloaded the whole page to `/?before=…`, which dropped you at the *top* of a fresh 3-day window instead of continuing where you were. This wires up elegant in-line pagination: the tap now fetches only the next window's rail rows and **appends them in place**, so the timeline continues seamlessly.

## How

- **`GET /-/feed/rows`** — new partial-render endpoint returning the next window's `<li>` rows + pagination state in response headers (`X-Feed-Next-Before`, `X-Feed-Last-Day`, `X-Feed-At-Max`). Empty 3-day windows are skipped server-side up to the 30-day lookback cap, so a single tap always lands on content.
- **`feedWindowItems`** — extracted the feed aggregation/projection so the page handler and the rows endpoint share one code path; appended rows are byte-identical to a full render. Mirrors the existing transaction-detail `TimelineRows` partial-render pattern.
- **`feedPagination` Alpine factory** — appends fetched rows into the existing rail `<ol>`, advances its cursor from the response headers, and swaps the footer to **End of feed** at the cap. The `<a href="/?before=…">` stays as a no-JS fallback.
- **Day-separator dedupe** across the append boundary: the leading separator is omitted when it matches the client's current tail day, so rows continue under the existing heading rather than repeating it.

## Verification

- `go test ./...` green — new `TestFeedRows` render test (day-separator omission) + new `TestFeedRowsHandler` integration test (older rows + headers, empty-window skip, end-of-feed).
- Real browser: a tap grew the rail **42 → 65 rows** with **no page reload**, URL unchanged at `/`, and the top of the timeline unmoved.

<img src="https://i.img402.dev/10185020ie.jpg" width="800" alt="Feed after Load older activity — older events appended in place above the still-present button">

*After a tap: "4 days ago" / "5 days ago" events (older than the default 3-day window) are appended in place, the rail stays continuous, and the button remains for the next tap.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
