### PR TITLE
fix(auth): set session-cookie Secure per request so plain-HTTP installs can log in

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,6 +17,13 @@ ENCRYPTION_KEY=
 SERVER_PORT=8080
 ENVIRONMENT=docker
 
+# Session-cookie Secure attribute: auto (default) | always | never.
+# "auto" sets Secure only when the request is actually HTTPS (direct TLS, or a
+# trusted reverse proxy's X-Forwarded-Proto=https), so a plain-HTTP LAN or
+# localhost install can still log in. Set "always" if you terminate HTTPS in
+# front but the proxy doesn't forward X-Forwarded-Proto.
+# SECURE_COOKIES=auto
+
 # --- Plaid (optional) ---
 # PLAID_CLIENT_ID=
 # PLAID_SECRET=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -253,6 +253,7 @@ rm -rf ~/.breadbox
 | `ENCRYPTION_KEY` | Yes* | — | 64-char hex key for encrypting bank credentials |
 | `SERVER_PORT` | No | `8080` | HTTP listen port |
 | `ENVIRONMENT` | No | `docker` | Runtime environment (`local`, `docker`) |
+| `SECURE_COOKIES` | No | `auto` | Session-cookie `Secure` policy: `auto` (follows request scheme), `always`, `never`. `auto` lets plain-HTTP LAN/localhost installs log in while HTTPS deployments stay hardened. |
 | `LOG_LEVEL` | No | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 | `POSTGRES_USER` | Yes | `breadbox` | PostgreSQL user (used by db service) |
 | `POSTGRES_PASSWORD` | Yes | — | PostgreSQL password (used by db service) |

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -7,6 +7,7 @@ import (
 
 	"breadbox/internal/app"
 	breadboxmcp "breadbox/internal/mcp"
+	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -18,6 +19,10 @@ import (
 // (dashboard, connections, users, admin API).
 func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service, mcpServer *breadboxmcp.MCPServer) chi.Router {
 	r := chi.NewRouter()
+
+	// Stamp Secure on the session cookie per request — must wrap the writer
+	// scs sets the cookie on, so it goes before LoadAndSave.
+	r.Use(mw.SecureSessionCookie(a.Config.SecureCookies, sm.Cookie.Name))
 
 	// Session middleware wraps everything so session data is available.
 	r.Use(sm.LoadAndSave)

--- a/internal/admin/session.go
+++ b/internal/admin/session.go
@@ -13,14 +13,18 @@ import (
 
 // NewSessionManager creates a new scs session manager backed by PostgreSQL.
 // The pgxstore adapter creates its sessions table automatically on first use.
-func NewSessionManager(pool *pgxpool.Pool, isSecure bool) *scs.SessionManager {
+func NewSessionManager(pool *pgxpool.Pool) *scs.SessionManager {
 	sm := scs.New()
 	sm.Store = pgxstore.New(pool)
 	sm.Lifetime = 30 * 24 * time.Hour
 	sm.IdleTimeout = 14 * 24 * time.Hour
 	sm.Cookie.HttpOnly = true
 	sm.Cookie.SameSite = http.SameSiteLaxMode
-	sm.Cookie.Secure = isSecure
+	// Secure is stamped per request by middleware.SecureSessionCookie so a
+	// plain-HTTP LAN/localhost install can still store the cookie while HTTPS
+	// deployments stay hardened. scs's flag is process-global, so it can't be
+	// set per request here without racing across concurrent requests.
+	sm.Cookie.Secure = false
 	sm.Cookie.Path = "/"
 	// Default to a browser-session cookie; LoginHandler flips this to a
 	// persistent cookie when the user opts into "Keep me signed in".

--- a/internal/admin/stubs_headless.go
+++ b/internal/admin/stubs_headless.go
@@ -50,7 +50,7 @@ func (*TemplateRenderer) SetAppConfigReader(any) {}
 // NewSessionManager mirrors the real signature. Returns a real (empty)
 // scs.SessionManager so chi middleware that handles it as an interface
 // continues to type-check.
-func NewSessionManager(_ *pgxpool.Pool, _ bool) *scs.SessionManager {
+func NewSessionManager(_ *pgxpool.Pool) *scs.SessionManager {
 	return scs.New()
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -61,8 +61,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 	// behaves exactly as before — API-key / Bearer only.
 	var sm *scs.SessionManager
 	if !a.Config.NoDashboard {
-		isSecure := a.Config.Environment == "production" || a.Config.Environment == "docker"
-		sm = admin.NewSessionManager(a.DB, isSecure)
+		sm = admin.NewSessionManager(a.DB)
 	}
 
 	r.Route("/api/v1", func(r chi.Router) {
@@ -72,6 +71,9 @@ func NewRouter(a *app.App, version string) http.Handler {
 		// and are intentionally not rate-limited (cheap, used by load
 		// balancers / monitoring).
 		if sm != nil {
+			// Stamp Secure on the session cookie per request — must wrap the
+			// writer scs sets the cookie on, so it goes before LoadAndSave.
+			r.Use(mw.SecureSessionCookie(a.Config.SecureCookies, sm.Cookie.Name))
 			r.Use(sm.LoadAndSave)
 		}
 		r.Use(sessionOrAPIKeyAuth(svc, sm))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,14 @@ type Config struct {
 	Environment   string
 	LogLevel      string // LOG_LEVEL: debug, info, warn, error
 
+	// SecureCookies controls the Secure attribute on the session cookie:
+	// "always", "never", or "auto" (default). In "auto" the Secure flag
+	// follows the actual request scheme (direct HTTPS, or a trusted proxy's
+	// X-Forwarded-Proto=https), so a plain-HTTP LAN/localhost install can
+	// still log in while HTTPS deployments stay hardened. From SECURE_COOKIES;
+	// applied per request by middleware.SecureSessionCookie.
+	SecureCookies string
+
 	// DataDir is the root directory for persistent runtime data (agent
 	// transcripts, scheduled pg_dump backups, future cached blobs).
 	// Sourced from BB_DATA_DIR; defaults to "/var/lib/breadbox" when

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -110,7 +110,23 @@ func Load() (*Config, error) {
 	// Dashboard gate. Truthy values: "1", "true", "yes", "on" (case-insensitive).
 	cfg.NoDashboard = parseBool(os.Getenv("BREADBOX_NO_DASHBOARD"))
 
+	// Session-cookie Secure policy: "always" | "never" | "auto" (default).
+	cfg.SecureCookies = parseSecureCookieMode(os.Getenv("SECURE_COOKIES"))
+
 	return cfg, nil
+}
+
+// parseSecureCookieMode maps SECURE_COOKIES to "always" | "never" | "auto".
+// Unset or unrecognized → "auto" (the Secure flag follows the request scheme).
+func parseSecureCookieMode(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on", "always", "secure":
+		return "always"
+	case "0", "false", "no", "off", "never", "insecure":
+		return "never"
+	default:
+		return "auto"
+	}
 }
 
 // parseBool returns true for "1", "true", "yes", "on" (case-insensitive); false otherwise.

--- a/internal/middleware/securecookie.go
+++ b/internal/middleware/securecookie.go
@@ -1,0 +1,144 @@
+//go:build !lite
+
+package middleware
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// SecureCookie policy modes (values of Config.SecureCookies).
+const (
+	secureCookieAlways = "always"
+	secureCookieNever  = "never"
+	// anything else (including "auto" and "") follows the request scheme.
+)
+
+var errNotHijacker = errors.New("securecookie: underlying ResponseWriter is not an http.Hijacker")
+
+// RequestIsHTTPS reports whether the browser-facing connection is HTTPS —
+// either a direct TLS connection or a request forwarded by a trusted reverse
+// proxy that set X-Forwarded-Proto=https (Caddy and Cloudflare do this by
+// default). Mirrors the scheme detection already used in apikey.go and the
+// admin requestBaseURL helpers.
+func RequestIsHTTPS(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}
+
+// SecureSessionCookie returns middleware that stamps the Secure attribute onto
+// the Set-Cookie header for the cookie named cookieName, according to mode:
+//
+//   - "always" — always mark Secure.
+//   - "never"  — never mark Secure.
+//   - anything else ("auto", the default) — mark Secure only when the request
+//     is actually HTTPS (see RequestIsHTTPS).
+//
+// Why a header rewrite instead of scs's own Cookie.Secure: that flag is
+// process-global (set once on the SessionManager), so toggling it per request
+// would race across concurrent requests. Instead we leave scs's cookie
+// non-Secure and append "; Secure" here, per request. The payoff: a plain-HTTP
+// LAN/localhost install can store the session cookie and log in, while any
+// HTTPS (or HTTPS-proxied) deployment keeps the Secure hardening automatically.
+//
+// Wire this OUTSIDE scs's LoadAndSave (add it with an earlier r.Use) so the
+// wrapped ResponseWriter is the one scs writes its Set-Cookie into.
+func SecureSessionCookie(mode, cookieName string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var secure bool
+			switch mode {
+			case secureCookieAlways:
+				secure = true
+			case secureCookieNever:
+				secure = false
+			default:
+				secure = RequestIsHTTPS(r)
+			}
+			// When we won't add anything, stay fully transparent — no wrapper,
+			// so streaming/hijacking paths are byte-for-byte unchanged.
+			if !secure {
+				next.ServeHTTP(w, r)
+				return
+			}
+			sw := &secureCookieWriter{ResponseWriter: w, cookieName: cookieName}
+			next.ServeHTTP(sw, r)
+			// Handle responses that finish without ever writing a header or
+			// body (Set-Cookie set, empty 200): the header map is still
+			// mutable here, so the fixup still lands.
+			sw.fixup()
+		})
+	}
+}
+
+// secureCookieWriter appends "; Secure" to the session Set-Cookie header the
+// first time the response is committed (WriteHeader / Write / Flush), and
+// preserves the Flusher and Hijacker interfaces so SSE streams and websocket
+// upgrades keep working.
+type secureCookieWriter struct {
+	http.ResponseWriter
+	cookieName string
+	fixed      bool
+}
+
+func (w *secureCookieWriter) fixup() {
+	if w.fixed {
+		return
+	}
+	w.fixed = true
+	appendSecureAttr(w.Header(), w.cookieName)
+}
+
+func (w *secureCookieWriter) WriteHeader(code int) {
+	w.fixup()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *secureCookieWriter) Write(b []byte) (int, error) {
+	w.fixup()
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *secureCookieWriter) Flush() {
+	w.fixup()
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *secureCookieWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errNotHijacker
+}
+
+// Unwrap lets http.ResponseController reach the underlying writer (Go 1.20+).
+func (w *secureCookieWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// appendSecureAttr appends "; Secure" to the Set-Cookie entry for cookieName
+// when it isn't already present. Other cookies are left untouched.
+func appendSecureAttr(h http.Header, cookieName string) {
+	cookies := h["Set-Cookie"]
+	prefix := cookieName + "="
+	for i, c := range cookies {
+		if !strings.HasPrefix(c, prefix) || hasSecureAttr(c) {
+			continue
+		}
+		cookies[i] = c + "; Secure"
+	}
+}
+
+func hasSecureAttr(cookie string) bool {
+	for _, part := range strings.Split(cookie, ";") {
+		if strings.EqualFold(strings.TrimSpace(part), "Secure") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/middleware/securecookie_test.go
+++ b/internal/middleware/securecookie_test.go
@@ -1,0 +1,160 @@
+//go:build !lite
+
+package middleware
+
+import (
+	"bufio"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sessionCookieHandler sets a cookie named `name` then commits the response,
+// mimicking what scs does on login.
+func sessionCookieHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: name, Value: "tok", Path: "/", HttpOnly: true})
+		w.WriteHeader(http.StatusSeeOther)
+	})
+}
+
+func runAndGetSetCookie(mode, cookieName string, r *http.Request) string {
+	rec := httptest.NewRecorder()
+	h := SecureSessionCookie(mode, cookieName)(sessionCookieHandler(cookieName))
+	h.ServeHTTP(rec, r)
+	return rec.Header().Get("Set-Cookie")
+}
+
+func httpsReq() *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/login", nil)
+	r.TLS = &tls.ConnectionState{}
+	return r
+}
+
+func fwdHTTPSReq() *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/login", nil)
+	r.Header.Set("X-Forwarded-Proto", "https")
+	return r
+}
+
+func plainReq() *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/login", nil)
+}
+
+func TestSecureSessionCookie_AutoFollowsScheme(t *testing.T) {
+	cases := []struct {
+		name    string
+		req     *http.Request
+		wantSec bool
+	}{
+		{"plain http → not secure", plainReq(), false},
+		{"direct TLS → secure", httpsReq(), true},
+		{"x-forwarded-proto https → secure", fwdHTTPSReq(), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runAndGetSetCookie("auto", "session", tc.req)
+			if has := hasSecureAttr(got); has != tc.wantSec {
+				t.Fatalf("Set-Cookie=%q: Secure=%v, want %v", got, has, tc.wantSec)
+			}
+		})
+	}
+}
+
+func TestSecureSessionCookie_AlwaysAndNever(t *testing.T) {
+	if got := runAndGetSetCookie("always", "session", plainReq()); !hasSecureAttr(got) {
+		t.Fatalf("mode=always over http: want Secure, got %q", got)
+	}
+	if got := runAndGetSetCookie("never", "session", httpsReq()); hasSecureAttr(got) {
+		t.Fatalf("mode=never over https: want no Secure, got %q", got)
+	}
+}
+
+func TestSecureSessionCookie_OnlyTargetsNamedCookie(t *testing.T) {
+	r := httpsReq()
+	rec := httptest.NewRecorder()
+	h := SecureSessionCookie("auto", "session")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "other", Value: "x", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(rec, r)
+	for _, c := range rec.Header()["Set-Cookie"] {
+		if strings.HasPrefix(c, "other=") && hasSecureAttr(c) {
+			t.Fatalf("unrelated cookie should be untouched: %q", c)
+		}
+	}
+}
+
+func TestSecureSessionCookie_NoDoubleSecure(t *testing.T) {
+	r := httpsReq()
+	rec := httptest.NewRecorder()
+	h := SecureSessionCookie("always", "session")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Cookie already Secure (e.g. scs configured Secure=true).
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "tok", Path: "/", Secure: true})
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(rec, r)
+	got := rec.Header().Get("Set-Cookie")
+	if n := strings.Count(strings.ToLower(got), "secure"); n != 1 {
+		t.Fatalf("expected exactly one Secure attr, got %d in %q", n, got)
+	}
+}
+
+// flushHijackRW is an underlying writer that records Flush/Hijack delegation.
+type flushHijackRW struct {
+	http.ResponseWriter
+	flushed  bool
+	hijacked bool
+}
+
+func (f *flushHijackRW) Flush() { f.flushed = true }
+func (f *flushHijackRW) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	f.hijacked = true
+	return nil, nil, nil
+}
+
+func TestSecureSessionCookie_PreservesFlusherAndHijacker(t *testing.T) {
+	base := &flushHijackRW{ResponseWriter: httptest.NewRecorder()}
+	var seen http.ResponseWriter
+	h := SecureSessionCookie("always", "session")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seen = w
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		if hj, ok := w.(http.Hijacker); ok {
+			_, _, _ = hj.Hijack()
+		}
+	}))
+	h.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if _, ok := seen.(http.Flusher); !ok {
+		t.Fatal("wrapped writer should expose http.Flusher")
+	}
+	if _, ok := seen.(http.Hijacker); !ok {
+		t.Fatal("wrapped writer should expose http.Hijacker")
+	}
+	if !base.flushed {
+		t.Fatal("Flush was not delegated to the underlying writer")
+	}
+	if !base.hijacked {
+		t.Fatal("Hijack was not delegated to the underlying writer")
+	}
+}
+
+func TestSecureSessionCookie_NeverModeIsTransparent(t *testing.T) {
+	// In "never" mode the middleware must not wrap the writer at all, so a
+	// plain ResponseRecorder (no Flusher/Hijacker addition) flows through.
+	base := httptest.NewRecorder()
+	var seen http.ResponseWriter
+	h := SecureSessionCookie("never", "session")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seen = w
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(base, plainReq())
+	if _, wrapped := seen.(*secureCookieWriter); wrapped {
+		t.Fatal("never mode should not wrap the ResponseWriter")
+	}
+}


### PR DESCRIPTION
## The bug

Setting up a real self-host (a fresh Docker/installer deploy reached over its **LAN IP**), login was an infinite loop: enter correct credentials → land back on `/login`, fields cleared, **no error**.

Server logs showed the auth was actually *succeeding*:

```
POST /login → 303   (login OK — wrong creds would re-render /login, not redirect)
GET  /      → 303    (…but no session cookie on the next request, so it bounces)
GET  /login → 200    (back to login. repeat.)
```

Cause: `internal/api/router.go` set the session cookie's `Secure` flag from a static environment guess —

```go
isSecure := cfg.Environment == "production" || cfg.Environment == "docker"
```

— so a `docker` deploy *always* got `Secure` cookies. Over plain `http://` (the LAN IP, before any TLS is set up) the browser silently refuses to store a `Secure` cookie, so the session never sticks. Every self-hoster who visits their LAN IP over HTTP before configuring TLS hits this — and the installer now prints that LAN URL.

## The fix

Decide `Secure` **per request from the actual scheme** instead of guessing from `ENVIRONMENT`, reusing the exact `r.TLS` / `X-Forwarded-Proto` detection already used in `apikey.go` and the admin `requestBaseURL` helpers.

New `SECURE_COOKIES` env (default `auto`):

| value | behavior |
| --- | --- |
| `auto` (default) | `Secure` only when the request is actually HTTPS — direct TLS, or a trusted proxy's `X-Forwarded-Proto=https` |
| `always` | force `Secure` (e.g. HTTPS edge that doesn't forward `X-Forwarded-Proto`) |
| `never` | never `Secure` (debugging) |

This means:
- **Plain-HTTP LAN/localhost installs can log in.** ✅
- **HTTPS deployments stay hardened automatically** — Caddy and Cloudflare both set `X-Forwarded-Proto`, so proxied installs get `Secure` with zero config (the repo's own Caddyfile included).
- No installer change needed; it just works.

## Why a header rewrite

`scs`'s `cookie.Secure` is process-global (set once on the `SessionManager`); toggling it per request would race across concurrent requests. So the base cookie is left non-`Secure` and a tiny middleware (`middleware.SecureSessionCookie`) appends `; Secure` to the session `Set-Cookie` per request, wired **outside** `LoadAndSave` so it wraps the writer scs sets the cookie on.

Safety properties:
- **Fully transparent** when not adding `Secure` (plain-HTTP path is unwrapped — byte-for-byte unchanged).
- **Preserves `Flusher` + `Hijacker`**, so the SSE agent-run live streams keep working.
- Only ever **appends** the attribute to the **named** cookie; never parses/strips, never touches other cookies, never double-adds.

## Tests

`internal/middleware/securecookie_test.go`:
- scheme → `Secure` mapping: plain HTTP (no), direct TLS (yes), `X-Forwarded-Proto: https` (yes)
- `always` / `never` overrides
- only the named session cookie is touched (unrelated cookies untouched)
- no double `Secure` when scs already set it
- `Flusher` + `Hijacker` delegation preserved; `never` mode doesn't wrap the writer

All green; `go build ./...`, `go vet`, and the full unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
