### PR TITLE
fix(agents): clamp non-positive max_turns so agent runs pass spec validation

### DIFF
--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -684,3 +684,53 @@ func TestRunOrSkip_HouseholdCeiling(t *testing.T) {
 		t.Fatalf("want a skipped row, got %+v", resp)
 	}
 }
+
+// TestAssembleJobSpec_ClampsNonPositiveMaxTurns is the defense-in-depth half
+// of the max_turns=0 fix: even if a definition somehow holds 0 (a pre-fix prod
+// row, a future code path that skips normalization), spec assembly must clamp
+// it to DefaultAgentMaxTurns rather than forward maxTurns:0 — which the
+// sidecar's z.number().int().positive() schema rejects with spec_invalid.
+// The def is hand-constructed because create/update now both normalize 0 away,
+// so this exercises the spec-assembly clamp in isolation.
+func TestAssembleJobSpec_ClampsNonPositiveMaxTurns(t *testing.T) {
+	svc, _, _ := newService(t)
+	encKey := seedSubscriptionAuth(t, svc)
+
+	def := &service.AgentDefinitionResponse{
+		ID:           "00000000-0000-0000-0000-000000000000",
+		Prompt:       "review transactions",
+		ToolScope:    "read_write",
+		AllowedTools: []string{"mcp__breadbox__*"},
+		Model:        "claude-opus-4-7",
+		MaxTurns:     0,
+	}
+	run := &service.AgentRunResponse{ID: "11111111-1111-1111-1111-111111111111"}
+
+	spec, err := svc.AssembleJobSpec(context.Background(), def, run, "fake-run-key", encKey)
+	if err != nil {
+		t.Fatalf("AssembleJobSpec: %v", err)
+	}
+	if spec.MaxTurns != service.DefaultAgentMaxTurns {
+		t.Errorf("spec.MaxTurns = %d, want %d (clamped from 0)", spec.MaxTurns, service.DefaultAgentMaxTurns)
+	}
+
+	// A negative value clamps too.
+	def.MaxTurns = -5
+	spec, err = svc.AssembleJobSpec(context.Background(), def, run, "fake-run-key", encKey)
+	if err != nil {
+		t.Fatalf("AssembleJobSpec (negative): %v", err)
+	}
+	if spec.MaxTurns != service.DefaultAgentMaxTurns {
+		t.Errorf("spec.MaxTurns = %d, want %d (clamped from -5)", spec.MaxTurns, service.DefaultAgentMaxTurns)
+	}
+
+	// A positive value is preserved.
+	def.MaxTurns = 42
+	spec, err = svc.AssembleJobSpec(context.Background(), def, run, "fake-run-key", encKey)
+	if err != nil {
+		t.Fatalf("AssembleJobSpec (positive): %v", err)
+	}
+	if spec.MaxTurns != 42 {
+		t.Errorf("spec.MaxTurns = %d, want 42 (unchanged)", spec.MaxTurns)
+	}
+}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -552,6 +552,13 @@ func (s *Service) UpdateAgentDefinition(ctx context.Context, slugOrID string, p 
 		def := DefaultAgentMaxBudgetUSD
 		budget = &def
 	}
+	// Mirror CreateAgentDefinition: a cleared or zeroed max_turns falls back to
+	// the default. validateAgentDefinitionFields permits 0 (documented as
+	// "0 falls back to the default"), so without this an update could persist
+	// max_turns=0 — which AssembleJobSpec would forward and the sidecar reject.
+	if merged.MaxTurns <= 0 {
+		merged.MaxTurns = DefaultAgentMaxTurns
+	}
 
 	row, err := s.Queries.UpdateAgentDefinition(ctx, db.UpdateAgentDefinitionParams{
 		ID:                    existing.ID,
@@ -1243,6 +1250,17 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 		maxBudget = *def.MaxBudgetUSD
 	}
 
+	// Clamp max_turns to a positive value. The sidecar's spec schema requires
+	// maxTurns > 0 (z.number().int().positive()); a definition holding 0 — e.g.
+	// a pre-fix row, or a max_turns:0 edit that slipped past validation — would
+	// otherwise forward maxTurns:0 and fail the run with spec_invalid before it
+	// even starts. Last line of defense before the sidecar; mirrors the
+	// create-path default so any non-positive value resolves to the default.
+	maxTurns := def.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = DefaultAgentMaxTurns
+	}
+
 	// SystemPrompt: caller-defined override wins; otherwise the breadbox
 	// baseline is injected. Without this fallback the SDK silently uses
 	// its built-in "Claude Code"-style persona, which is optimized for
@@ -1258,7 +1276,7 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 		Prompt:            def.Prompt,
 		SystemPrompt:      systemPrompt,
 		Model:             def.Model,
-		MaxTurns:          def.MaxTurns,
+		MaxTurns:          maxTurns,
 		MaxBudgetUsd:      maxBudget,
 		ToolScope:         def.ToolScope,
 		AllowedTools:      allowedTools,

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -156,6 +156,47 @@ func TestUpdateAgentDefinition_PatchSemantics(t *testing.T) {
 	}
 }
 
+// TestUpdateAgentDefinition_MaxTurnsZeroFallsBackToDefault guards the
+// create/update symmetry: an update that clears or zeroes max_turns must
+// normalize to DefaultAgentMaxTurns, never persist 0. A stored 0 flows
+// through AssembleJobSpec and the sidecar rejects it (spec_invalid: maxTurns
+// must be > 0), failing every run of that workflow.
+func TestUpdateAgentDefinition_MaxTurnsZeroFallsBackToDefault(t *testing.T) {
+	svc, _, _ := newService(t)
+	def := mustCreateAgentDefinition(t, svc, "svc-maxturns-zero", false)
+
+	zero := 0
+	updated, err := svc.UpdateAgentDefinition(context.Background(), def.Slug, service.UpdateAgentDefinitionParams{
+		MaxTurns: &zero,
+	})
+	if err != nil {
+		t.Fatalf("update with max_turns=0: %v", err)
+	}
+	if updated.MaxTurns != service.DefaultAgentMaxTurns {
+		t.Errorf("MaxTurns after zero update = %d, want %d", updated.MaxTurns, service.DefaultAgentMaxTurns)
+	}
+	// Confirm it persisted, not just the returned struct.
+	got, err := svc.GetAgentDefinition(context.Background(), def.Slug)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.MaxTurns != service.DefaultAgentMaxTurns {
+		t.Errorf("persisted MaxTurns = %d, want %d", got.MaxTurns, service.DefaultAgentMaxTurns)
+	}
+
+	// A positive value still passes through unchanged (no over-clamping).
+	twentyFive := 25
+	again, err := svc.UpdateAgentDefinition(context.Background(), def.Slug, service.UpdateAgentDefinitionParams{
+		MaxTurns: &twentyFive,
+	})
+	if err != nil {
+		t.Fatalf("update with max_turns=25: %v", err)
+	}
+	if again.MaxTurns != 25 {
+		t.Errorf("MaxTurns after positive update = %d, want 25", again.MaxTurns)
+	}
+}
+
 func TestSetAgentDefinitionEnabled_Toggle(t *testing.T) {
 	svc, _, _ := newService(t)
 	def := mustCreateAgentDefinition(t, svc, "svc-toggle", false)


### PR DESCRIPTION
Clamp non-positive `max_turns` so agent/workflow runs can't fail spec validation before they start.

## What broke

Prod run **`Wd2dipva`** (on `breadbox.exe.xyz`) failed immediately. The on-box transcript recorded a single event:

```json
{"type":"error","code":"spec_invalid",
 "data":{"message":"spec parse: [{ \"code\":\"too_small\", \"minimum\":0, \"inclusive\":false, \"path\":[\"maxTurns\"], \"message\":\"Number must be greater than 0\" }]"}}
```

The run never started — the TS sidecar rejected the job spec during Zod validation.

## Root cause

The sidecar schema requires a positive turn cap (`agent/sidecar/spec.ts`: `maxTurns: z.number().int().positive()`), but a definition can hold `max_turns = 0` because of a **create/update asymmetry**:

| Path | max_turns ≤ 0 handling |
|------|------------------------|
| `CreateAgentDefinition` | normalizes → `DefaultAgentMaxTurns` ✅ |
| `EnableWorkflowFromPreset` | override guarded by `> 0` ✅ |
| `UpdateAgentDefinition` | **wrote the value verbatim** ❌ |

`validateAgentDefinitionFields` explicitly permits `0` ("0 falls back to the default"), and `AssembleJobSpec` forwarded `def.MaxTurns` straight through. So editing a workflow and saving `max_turns: 0` persisted `0`, and every subsequent run failed the same way.

## Fix

- **`UpdateAgentDefinition`** now mirrors create: `max_turns <= 0` → `DefaultAgentMaxTurns` (stops persisting `0` going forward).
- **`AssembleJobSpec`** clamps `max_turns <= 0` → default as the last line of defense before the sidecar. This also **rescues any already-stored `0` row on its next run** — no DB edit or manual re-save required.

## Tests

- `TestUpdateAgentDefinition_MaxTurnsZeroFallsBackToDefault` — update with `0` normalizes & persists the default; a positive value passes through unchanged (no over-clamping).
- `TestAssembleJobSpec_ClampsNonPositiveMaxTurns` — zero and negative clamp to the default; positive is preserved.

Verified locally: `go build ./...`, `go vet ./...`, both new tests, and the broader `Agent|Orchestrator|AssembleJobSpec|Workflow` integration suite all green.
