### PR TITLE
feat(ui): privacy mode — obfuscate/hide sensitive financial data

### DIFF
--- a/input.css
+++ b/input.css
@@ -1254,6 +1254,30 @@
     @apply text-right tabular-nums;
   }
 
+  /* ── Privacy mode ──
+   *
+   * Client-side presentation layer (see static/js/admin/privacy.js). Sensitive
+   * financial values carry `data-private="<kind>"`; the active mode lives on
+   * `<html data-privacy="obfuscate|hide">`.
+   *   - hide:      blur the real text via CSS — no JS rewrite.
+   *   - obfuscate: privacy.js swaps the text for a matrix/hex glitch; a subtle
+   *                monospace finish makes it read as synthetic at a glance.
+   * `.privacy-pending` is set pre-paint (base.html) and dropped once privacy.js
+   * runs its first pass, so obfuscate never flashes real values before the
+   * rewrite. `user-select: none` keeps the real (blurred) text from being
+   * casually selected/copied; pointer-events stay on so links still work. */
+  html[data-privacy="hide"] [data-private],
+  html.privacy-pending [data-private] {
+    filter: blur(0.4rem);
+    user-select: none;
+  }
+
+  html[data-privacy="obfuscate"]:not(.privacy-pending) [data-private] {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    letter-spacing: 0.02em;
+    opacity: 0.92;
+  }
+
   /* ── Sparkline (inline mini charts in summary pills) ── */
   svg.bb-sparkline {
     width: 64px;

--- a/internal/templates/components/amount.go
+++ b/internal/templates/components/amount.go
@@ -53,6 +53,13 @@ type AmountProps struct {
 	Precision int          // decimals for AmountCost; ignored for other intents (defaults to 2)
 	Pending   bool
 	Class     string
+	// Public opts this amount out of privacy mode. Every Amount is treated as
+	// private user data by default (marked data-private="amount" so the
+	// client-side privacy toggle can obfuscate/blur it). Set Public for the
+	// rare monetary value that isn't household-sensitive — e.g. a documented
+	// example figure. Real balances, transaction amounts, costs, and totals
+	// must stay private (the default).
+	Public bool
 }
 
 // amountClasses returns the space-separated class list for an Amount

--- a/internal/templates/components/amount.templ
+++ b/internal/templates/components/amount.templ
@@ -57,7 +57,11 @@ package components
 //	    Format: components.AmountFormatAbbreviated,
 //	    Class:  "text-2xl font-semibold",
 //	})
-
 templ Amount(p AmountProps) {
-	<span class={ amountClasses(p) }>{ AmountText(p) }</span>
+	<span
+		class={ amountClasses(p) }
+		if !p.Public {
+			data-private="amount"
+		}
+	>{ AmountText(p) }</span>
 }

--- a/internal/templates/components/entity_header.templ
+++ b/internal/templates/components/entity_header.templ
@@ -68,15 +68,21 @@ const (
 )
 
 type EntityHeaderProps struct {
-	Title           string
-	TitleClass      string
-	Icon            string
-	IconTone        IconTone
-	IconComponent   templ.Component
-	Badges          templ.Component
-	Meta            templ.Component
-	Action          templ.Component
-	SecondaryAction templ.Component
+	Title      string
+	TitleClass string
+	// TitlePrivateKind marks the title as private user data for the
+	// client-side privacy mode — set it to the data-private kind
+	// ("account" | "institution" | "merchant") when the title is an account
+	// name, institution name, or merchant/series name. Empty = not private
+	// (the default; e.g. a rule name or sync-log title).
+	TitlePrivateKind string
+	Icon             string
+	IconTone         IconTone
+	IconComponent    templ.Component
+	Badges           templ.Component
+	Meta             templ.Component
+	Action           templ.Component
+	SecondaryAction  templ.Component
 }
 
 templ EntityHeader(p EntityHeaderProps) {
@@ -93,7 +99,12 @@ templ EntityHeader(p EntityHeaderProps) {
 			}
 			<div class="min-w-0 flex-1">
 				<div class="flex items-center gap-2 sm:gap-2.5 flex-wrap min-w-0">
-					<h1 class={ "bb-page-title min-w-0 max-w-full", p.TitleClass }>{ p.Title }</h1>
+					<h1
+						class={ "bb-page-title min-w-0 max-w-full", p.TitleClass }
+						if p.TitlePrivateKind != "" {
+							data-private={ p.TitlePrivateKind }
+						}
+					>{ p.Title }</h1>
 					if p.Badges != nil {
 						<span class="hidden sm:contents">
 							@p.Badges

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -52,11 +52,12 @@ templ AccountDetail(p AccountDetailProps) {
 
 templ acctHeader(p AccountDetailProps) {
 	@components.EntityHeader(components.EntityHeaderProps{
-		Title:    acctDisplayLabel(p.Account),
-		Icon:     acctTypeIcon(p.Account.Type),
-		IconTone: components.IconToneNeutral,
-		Badges:   acctHeaderBadges(p),
-		Meta:     acctHeaderMeta(p),
+		Title:            acctDisplayLabel(p.Account),
+		TitlePrivateKind: "account",
+		Icon:             acctTypeIcon(p.Account.Type),
+		IconTone:         components.IconToneNeutral,
+		Badges:           acctHeaderBadges(p),
+		Meta:             acctHeaderMeta(p),
 	})
 }
 
@@ -92,7 +93,7 @@ templ acctHeaderMeta(p AccountDetailProps) {
 	}
 	if p.Account.Mask != nil && *p.Account.Mask != "" {
 		<span class="text-base-content/20">·</span>
-		<span>{ "••••" + *p.Account.Mask }</span>
+		<span data-private="mask">{ "••••" + *p.Account.Mask }</span>
 	}
 }
 
@@ -196,7 +197,7 @@ templ acctSettings(p AccountDetailProps) {
 					</div>
 					<div>
 						<p class="text-xs text-base-content/40 mb-1">Connection</p>
-						<a href={ templ.SafeURL("/connections/" + p.Account.ConnectionID) } class="text-sm font-medium hover:text-primary transition-colors no-underline">{ p.Account.InstitutionName }</a>
+						<a data-private="institution" href={ templ.SafeURL("/connections/" + p.Account.ConnectionID) } class="text-sm font-medium hover:text-primary transition-colors no-underline">{ p.Account.InstitutionName }</a>
 					</div>
 					if p.Account.UserName != "" {
 						<div>

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -183,7 +183,7 @@ templ accountsListRow(a AccountsListRow, csrfToken string) {
 				</div>
 				<div class="min-w-0">
 					<div class="flex items-center gap-1.5 flex-wrap">
-						<span class="text-sm font-medium truncate text-base-content">{ a.DisplayName }</span>
+						<span data-private="account" class="text-sm font-medium truncate text-base-content">{ a.DisplayName }</span>
 						if a.IsDependentLinked {
 							<span class="badge badge-soft badge-info badge-xs" title="Dependent-linked: balance attributed to a linked user">Linked</span>
 						}
@@ -192,10 +192,10 @@ templ accountsListRow(a AccountsListRow, csrfToken string) {
 						}
 					</div>
 					<div class="text-xs text-base-content/40 md:hidden">
-						{ a.InstitutionName }
+						@components.Private("institution", a.InstitutionName)
 						if a.MaskValid {
 							<span class="text-base-content/25">&middot;</span>
-							{ " ····" + a.Mask }
+							@components.Private("mask", " ····"+a.Mask)
 						}
 					</div>
 				</div>
@@ -204,9 +204,9 @@ templ accountsListRow(a AccountsListRow, csrfToken string) {
 		<!-- Institution (md+) -->
 		<td class="hidden md:table-cell text-sm text-base-content/70">
 			<div class="flex items-center gap-2 min-w-0">
-				<span class="truncate">{ a.InstitutionName }</span>
+				<span data-private="institution" class="truncate">{ a.InstitutionName }</span>
 				if a.MaskValid {
-					<span class="text-xs text-base-content/40">&middot; ····{ a.Mask }</span>
+					<span data-private="mask" class="text-xs text-base-content/40">&middot; ····{ a.Mask }</span>
 				}
 				if a.ConnectionStatus == "error" || a.ConnectionStatus == "pending_reauth" {
 					<span class="badge badge-soft badge-warning badge-xs" title="Connection needs attention">Reauth</span>

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -53,13 +53,14 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 			</div>
 		}
 		@components.EntityHeader(components.EntityHeaderProps{
-			Title:         p.InstitutionName,
-			TitleClass:    "truncate",
-			IconComponent: connDetailIcon(p.Provider),
-			IconTone:      connDetailIconTone(p.Provider),
-			Badges:        connDetailBadges(p),
-			Meta:          connDetailMeta(p),
-			Action:        connDetailActions(p),
+			Title:            p.InstitutionName,
+			TitlePrivateKind: "institution",
+			TitleClass:       "truncate",
+			IconComponent:    connDetailIcon(p.Provider),
+			IconTone:         connDetailIconTone(p.Provider),
+			Badges:           connDetailBadges(p),
+			Meta:             connDetailMeta(p),
+			Action:           connDetailActions(p),
 		})
 		<!-- Sync Health Stats -->
 		if p.TotalSyncs > 0 {
@@ -124,7 +125,8 @@ templ connDetailBadges(p ConnectionDetailProps) {
 				<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 				if p.LastSyncErrorMessageValid {
 					<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-						<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3") Last sync failed</span>
+						<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3")
+Last sync failed</span>
 						<span class="text-base-content/70">{ p.LastSyncErrorMessageString }</span>
 					</span>
 				}
@@ -430,16 +432,16 @@ templ connDetailAccountCard(a AccountRow) {
 				<div class="flex items-start justify-between gap-2 mb-3">
 					<div class="flex items-center gap-2.5 min-w-0">
 						<div class={ "w-8 h-8 rounded-lg flex items-center justify-center shrink-0", connDetailAccountTileBg(a.Type) }>
-							@components.LucideIcon(connDetailAccountIcon(a.Type), "w-4 h-4 " + connDetailAccountIconColor(a.Type))
+							@components.LucideIcon(connDetailAccountIcon(a.Type), "w-4 h-4 "+connDetailAccountIconColor(a.Type))
 						</div>
 						<div class="min-w-0">
-							<a href={ templ.SafeURL("/accounts/" + a.ID) } class="text-sm font-medium hover:text-primary transition-colors no-underline block truncate">
+							<a data-private="account" href={ templ.SafeURL("/accounts/" + a.ID) } class="text-sm font-medium hover:text-primary transition-colors no-underline block truncate">
 								{ a.Name }
 							</a>
 							<div class="text-xs text-base-content/40">
 								{ connDetailAccountTypeLabel(a.Type, a.SubtypeString, a.SubtypeValid) }
 								if a.MaskValid {
-									{ " · ····" + a.MaskString }
+									@components.Private("mask", " · ····"+a.MaskString)
 								}
 							</div>
 						</div>

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -159,7 +159,8 @@ templ Connections(p ConnectionsProps) {
 							If two family members connect the same credit card, linking prevents double-counting.
 						</p>
 						<button class="btn btn-primary btn-sm" onclick="document.getElementById('create-link-modal').showModal()">
-							@components.LucideIcon("plus", "w-4 h-4") Create First Link
+							@components.LucideIcon("plus", "w-4 h-4")
+							Create First Link
 						</button>
 					</div>
 				</div>
@@ -220,7 +221,7 @@ templ connectionsCard(c ConnectionsRow) {
 					     chip here — the banner is canonical. Neutral badges (Stale,
 					     Paused) remain because they're orthogonal signals. -->
 					<div class="flex items-center gap-2 flex-wrap">
-						<h3 class="font-semibold text-sm sm:text-base group-hover:text-primary transition-colors truncate max-w-[8rem] xs:max-w-[10rem] sm:max-w-none">{ c.InstitutionName }</h3>
+						<h3 data-private="institution" class="font-semibold text-sm sm:text-base group-hover:text-primary transition-colors truncate max-w-[8rem] xs:max-w-[10rem] sm:max-w-none">{ c.InstitutionName }</h3>
 						if c.IsStale {
 							<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning shrink-0">Stale</span>
 						} else if !c.ErrorMessageValid {
@@ -229,7 +230,8 @@ templ connectionsCard(c ConnectionsRow) {
 									<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 									if c.LastSyncErrorMessage != "" {
 										<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-											<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3") Last sync failed</span>
+											<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3")
+Last sync failed</span>
 											<span class="text-base-content/70">{ c.LastSyncErrorMessage }</span>
 										</span>
 									}
@@ -351,7 +353,7 @@ templ connectionsAccountRow(a ConnectionsAccountRow) {
 			</div>
 			<div class="min-w-0">
 				<div class="flex items-center gap-1.5 flex-wrap">
-					<span class="text-sm font-medium truncate group-hover/acct:text-primary transition-colors">
+					<span data-private="account" class="text-sm font-medium truncate group-hover/acct:text-primary transition-colors">
 						if a.DisplayNameValid {
 							{ a.DisplayName }
 						} else {
@@ -368,7 +370,7 @@ templ connectionsAccountRow(a ConnectionsAccountRow) {
 					}
 					if a.MaskValid {
 						<span class="text-base-content/25">&middot;</span>
-						{ " ····" + a.Mask }
+						@components.Private("mask", " ····"+a.Mask)
 					}
 					if a.Excluded {
 						<span class="text-base-content/25">&middot;</span>
@@ -410,7 +412,7 @@ templ connectionsLinkRow(l ConnectionsLinkRow, csrfToken string) {
 							@components.LucideIcon("credit-card", "w-4 h-4 text-primary")
 						</div>
 						<div class="min-w-0">
-							<span class="font-semibold text-sm truncate block">{ l.PrimaryAccountName }</span>
+							<span data-private="account" class="font-semibold text-sm truncate block">{ l.PrimaryAccountName }</span>
 							<span class="text-xs text-base-content/40">{ l.PrimaryUserName }</span>
 						</div>
 					</div>
@@ -421,7 +423,7 @@ templ connectionsLinkRow(l ConnectionsLinkRow, csrfToken string) {
 							@components.LucideIcon("credit-card", "w-4 h-4 text-secondary")
 						</div>
 						<div class="min-w-0">
-							<span class="font-semibold text-sm truncate block">{ l.DependentAccountName }</span>
+							<span data-private="account" class="font-semibold text-sm truncate block">{ l.DependentAccountName }</span>
 							<span class="text-xs text-base-content/40">{ l.DependentUserName }</span>
 						</div>
 					</div>

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -25,12 +25,13 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 	@components.CategoryPickerStyles()
 	<div x-data="seriesDetail" data-series-id={ p.Series.ShortID }>
 		@components.EntityHeader(components.EntityHeaderProps{
-			Title:    p.Series.Name,
-			Icon:     seriesTypeIcon(p.Series.Type),
-			IconTone: seriesStatusIconTone(p.Series.Status),
-			Badges:   seriesDetailBadges(p.Series),
-			Meta:     components.EntityHeaderMeta(p.Series.CadenceLabel, p.Series.MerchantKey),
-			Action:   seriesDetailActions(p.Series),
+			Title:            p.Series.Name,
+			TitlePrivateKind: "merchant",
+			Icon:             seriesTypeIcon(p.Series.Type),
+			IconTone:         seriesStatusIconTone(p.Series.Status),
+			Badges:           seriesDetailBadges(p.Series),
+			Meta:             components.EntityHeaderMeta(p.Series.CadenceLabel, p.Series.MerchantKey),
+			Action:           seriesDetailActions(p.Series),
 		})
 		@components.SeriesDetectionPanel(p.Detection)
 		<!-- Rule (edit) + Evidence (read) -->

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -172,7 +172,7 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 		<div class="flex items-start justify-between gap-4">
 			<div class="min-w-0 flex-1">
 				<div class="flex items-center gap-2 flex-wrap">
-					<a href={ templ.SafeURL("/recurring/" + s.ShortID) } class="text-sm font-semibold text-base-content truncate hover:underline">{ s.Name }</a>
+					<a data-private="merchant" href={ templ.SafeURL("/recurring/" + s.ShortID) } class="text-sm font-semibold text-base-content truncate hover:underline">{ s.Name }</a>
 					@components.SeriesTypeChip(s.TypeLabel, "xs")
 				</div>
 				<!-- Detection strength reads with the rationale, not as a second
@@ -307,7 +307,7 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 				</div>
 				<div class="min-w-0">
 					<div class="flex items-center gap-2 min-w-0">
-						<span class="text-sm font-medium truncate text-base-content">{ s.Name }</span>
+						<span data-private="merchant" class="text-sm font-medium truncate text-base-content">{ s.Name }</span>
 						@components.SeriesTypeChip(s.TypeLabel, "xs")
 					</div>
 					if s.CategoryName != "" {

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -64,12 +64,13 @@ templ TransactionDetail(p TransactionDetailProps) {
 
 templ txdHero(p TransactionDetailProps) {
 	@components.EntityHeader(components.EntityHeaderProps{
-		Title:      p.Transaction.ProviderName,
-		TitleClass: "break-words",
-		Icon:       txdHeroIcon(p.Transaction.Amount),
-		IconTone:   txdHeroIconTone(p.Transaction.Amount),
-		Meta:       txdHeroMeta(p),
-		Action:     txdHeroAmount(p),
+		Title:            p.Transaction.ProviderName,
+		TitlePrivateKind: "merchant",
+		TitleClass:       "break-words",
+		Icon:             txdHeroIcon(p.Transaction.Amount),
+		IconTone:         txdHeroIconTone(p.Transaction.Amount),
+		Meta:             txdHeroMeta(p),
+		Action:           txdHeroAmount(p),
 	})
 }
 
@@ -77,7 +78,7 @@ templ txdHeroMeta(p TransactionDetailProps) {
 	<span>{ components.FormatDate(p.Transaction.Date) }</span>
 	if p.Transaction.ProviderMerchantName != nil && *p.Transaction.ProviderMerchantName != "" {
 		<span class="text-base-content/20">·</span>
-		<span>{ components.TitleCase(*p.Transaction.ProviderMerchantName) }</span>
+		<span data-private="merchant">{ components.TitleCase(*p.Transaction.ProviderMerchantName) }</span>
 	}
 	if p.Transaction.Pending {
 		<span class="text-base-content/20">·</span>
@@ -120,14 +121,14 @@ templ txdAccountBanner(p TransactionDetailProps) {
 			</div>
 			<div class="flex-1 min-w-0">
 				<div class="flex items-center gap-2 flex-wrap">
-					<a href={ templ.SafeURL("/accounts/" + p.AccountID) } class="text-sm font-semibold hover:text-primary transition-colors no-underline truncate">{ p.AccountName }</a>
+					<a data-private="account" href={ templ.SafeURL("/accounts/" + p.AccountID) } class="text-sm font-semibold hover:text-primary transition-colors no-underline truncate">{ p.AccountName }</a>
 					if p.AccountMask != "" {
 						<span class="text-xs text-base-content/30 font-mono">&middot;&middot;&middot;&middot;{ p.AccountMask }</span>
 					}
 				</div>
 				<div class="flex items-center gap-x-2 gap-y-0 mt-0.5 flex-wrap">
 					if p.InstitutionName != "" {
-						<span class="text-xs text-base-content/40">{ p.InstitutionName }</span>
+						<span data-private="institution" class="text-xs text-base-content/40">{ p.InstitutionName }</span>
 					}
 					if p.AccountType != "" {
 						<span class="text-xs text-base-content/30">&middot;</span>
@@ -172,7 +173,7 @@ templ txdMain(p TransactionDetailProps) {
 				if p.Transaction.ProviderMerchantName != nil && *p.Transaction.ProviderMerchantName != "" {
 					<div>
 						<p class="text-xs text-base-content/40 mb-1">Merchant</p>
-						<p class="text-sm font-medium">{ components.TitleCase(*p.Transaction.ProviderMerchantName) }</p>
+						<p data-private="merchant" class="text-sm font-medium">{ components.TitleCase(*p.Transaction.ProviderMerchantName) }</p>
 					</div>
 				}
 				if p.Transaction.ProviderPaymentChannel != nil && *p.Transaction.ProviderPaymentChannel != "" {
@@ -542,9 +543,9 @@ templ txdSystemIcon(e service.ActivityEntry) {
 	if e.Type == "tag" {
 		<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", txdTagOuterBg(e.TagAction) } aria-hidden="true">
 			if e.TagAction == "removed" {
-				@components.LucideIcon("minus", "w-3 h-3 " + txdTagIconColor(e.TagAction))
+				@components.LucideIcon("minus", "w-3 h-3 "+txdTagIconColor(e.TagAction))
 			} else {
-				@components.LucideIcon("plus", "w-3 h-3 " + txdTagIconColor(e.TagAction))
+				@components.LucideIcon("plus", "w-3 h-3 "+txdTagIconColor(e.TagAction))
 			}
 		</span>
 	} else if e.Type == "category" {
@@ -591,9 +592,9 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 			aria-hidden="true"
 		>
 			if e.CategoryIcon != nil && *e.CategoryIcon != "" {
-				@components.LucideIconWithStyle(*e.CategoryIcon, "w-3 h-3", "color: " + *e.CategoryColor)
+				@components.LucideIconWithStyle(*e.CategoryIcon, "w-3 h-3", "color: "+*e.CategoryColor)
 			} else {
-				@components.LucideIconWithStyle("folder", "w-3 h-3", "color: " + *e.CategoryColor)
+				@components.LucideIconWithStyle("folder", "w-3 h-3", "color: "+*e.CategoryColor)
 			}
 		</span>
 	} else if e.CategoryIcon != nil && *e.CategoryIcon != "" {
@@ -887,7 +888,7 @@ templ txdInlineCategoryChip(e service.ActivityEntry) {
 		}
 		if e.CategoryIcon != nil && *e.CategoryIcon != "" {
 			if e.CategoryColor != nil && *e.CategoryColor != "" {
-				@components.LucideIconWithStyle(*e.CategoryIcon, "w-3.5 h-3.5 shrink-0", "color: " + *e.CategoryColor)
+				@components.LucideIconWithStyle(*e.CategoryIcon, "w-3.5 h-3.5 shrink-0", "color: "+*e.CategoryColor)
 			} else {
 				@components.LucideIcon(*e.CategoryIcon, "w-3.5 h-3.5 shrink-0 text-base-content opacity-60")
 			}
@@ -1036,7 +1037,6 @@ func relativeTimeStr(s string) string {
 func relativeTimeStrAt(s string, now time.Time) string {
 	return timefmt.RelativeRFC3339At(s, now)
 }
-
 
 // txdCategoryInitial returns the current category UUID for the picker's
 // data-initial attribute, or an empty string when the transaction has no

--- a/internal/templates/components/private.templ
+++ b/internal/templates/components/private.templ
@@ -1,0 +1,21 @@
+package components
+
+// Private wraps a sensitive financial value (a bare string) so the
+// client-side privacy mode can obfuscate or blur it. The `kind` records what
+// the value is — amount | merchant | account | institution | mask — and is
+// emitted as `data-private="<kind>"`. privacy.js (loaded from base.html) reads
+// every `[data-private]` element; the kind is advisory today (one glitch
+// preserves each character class) but keeps the door open for per-kind
+// strategies later.
+//
+// Use Private for values rendered as a standalone string. When a value already
+// has its own wrapping element (an <a>, <h1>, <span class="truncate">…), prefer
+// adding the `data-private="<kind>"` attribute to that element directly rather
+// than nesting another span — fewer nodes, same effect.
+//
+// See `docs/design-system.md` (privacy mode) and the catalog in
+// `.claude/rules/` for which fields count as private (scope: money + accounts &
+// merchants).
+templ Private(kind, s string) {
+	<span data-private={ kind }>{ s }</span>
+}

--- a/internal/templates/components/topbar_user_menu.templ
+++ b/internal/templates/components/topbar_user_menu.templ
@@ -17,9 +17,10 @@ templ TopbarUserMenu(p SidebarUserMenuProps) {
 	<button
 		type="button"
 		popovertarget={ popoverID }
-		class="btn btn-ghost btn-sm btn-circle p-0"
+		class="btn btn-ghost btn-sm btn-circle p-0 relative"
 		aria-label="Open user menu"
 		style={ "anchor-name:" + anchorName }
+		x-data
 	>
 		if p.HasLinkedUser {
 			@UserAvatar(UserAvatarProps{
@@ -33,6 +34,15 @@ templ TopbarUserMenu(p SidebarUserMenuProps) {
 		} else {
 			@LucideIcon("user-circle", "w-6 h-6 text-base-content/50")
 		}
+		<!-- Privacy-mode active dot: signals the page is showing
+		     obfuscated/blurred values so glitched figures aren't mistaken for
+		     real data. Driven by the global $store.privacy. -->
+		<span
+			x-show="$store.privacy && $store.privacy.active"
+			x-cloak
+			class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-warning border-2 border-base-100"
+			:title="'Privacy mode: ' + ($store.privacy ? $store.privacy.mode : '')"
+		></span>
 	</button>
 	<ul
 		id={ popoverID }

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -59,7 +59,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 			<!-- Description + meta line -->
 			<div class="flex-1 min-w-0">
 				<div class="flex items-center gap-2">
-					<a href={ templ.URL("/transactions/" + tx.ID) } @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate">{ tx.Name }</a>
+					<a href={ templ.URL("/transactions/" + tx.ID) } @click.stop data-private="merchant" class="font-medium text-sm hover:text-primary transition-colors truncate">{ tx.Name }</a>
 				</div>
 				<!-- Meta line (sm+). Canonical order across every breakpoint:
 				     [Lead] · {Merchant | Category} · Tags · Comments.
@@ -68,13 +68,13 @@ templ TxRow(tx service.AdminTransactionRow) {
 				     the viewport shrinks. Mobile (<sm) uses the same order in
 				     its dedicated sub-line below, with Date in the lead. -->
 				<div class="hidden sm:flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 min-w-0">
-					<span class="truncate min-w-0">{ tx.AccountName }</span>
+					<span data-private="account" class="truncate min-w-0">{ tx.AccountName }</span>
 					<!-- Slot 2 — Merchant (xl+) | Category (sub-xl). Both render
 					     a leading separator inside their conditional so the row
 					     stays clean when neither piece is present. -->
 					if tx.MerchantName != nil && !strings.EqualFold(tx.Name, deref(tx.MerchantName)) {
 						<span class="text-base-content/20 hidden xl:inline">&middot;</span>
-						<span class="text-base-content/40 truncate hidden xl:inline">{ titleCase(deref(tx.MerchantName)) }</span>
+						<span data-private="merchant" class="text-base-content/40 truncate hidden xl:inline">{ titleCase(deref(tx.MerchantName)) }</span>
 					}
 					if tx.CategoryDisplayName != nil {
 						<span class="xl:hidden text-base-content/20 shrink-0">&middot;</span>
@@ -248,17 +248,17 @@ templ TxRow(tx service.AdminTransactionRow) {
 							     on sm+ the date column in the row header already shows it. -->
 							<div class="sm:hidden">
 								<span class="text-base-content/30">Account</span>
-								<span class="text-base-content/60 ml-1.5">{ tx.AccountName }</span>
+								<span data-private="account" class="text-base-content/60 ml-1.5">{ tx.AccountName }</span>
 							</div>
 							if tx.MerchantName != nil {
 								<div>
 									<span class="text-base-content/30">Merchant</span>
-									<span class="text-base-content/60 ml-1.5">{ titleCase(deref(tx.MerchantName)) }</span>
+									<span data-private="merchant" class="text-base-content/60 ml-1.5">{ titleCase(deref(tx.MerchantName)) }</span>
 								</div>
 							}
 							<div class="hidden sm:block">
 								<span class="text-base-content/30">Account</span>
-								<span class="text-base-content/60 ml-1.5">{ tx.AccountName } ({ tx.InstitutionName })</span>
+								<span data-private="account" class="text-base-content/60 ml-1.5">{ tx.AccountName } ({ tx.InstitutionName })</span>
 							</div>
 							<div>
 								<span class="text-base-content/30">Member</span>

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -37,10 +37,10 @@ templ txRowCompactBody(tx service.AdminTransactionRow, hideDate bool) {
 		<!-- Name + meta line -->
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-1.5 min-w-0">
-				<span class="text-sm font-medium truncate">{ tx.Name }</span>
+				<span data-private="merchant" class="text-sm font-medium truncate">{ tx.Name }</span>
 			</div>
 			<div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
-				<span class="truncate shrink min-w-0">{ tx.AccountName }</span>
+				<span data-private="account" class="truncate shrink min-w-0">{ tx.AccountName }</span>
 				if tx.CategoryDisplayName != nil {
 					<span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
 					<!-- Container shrinks (not shrink-0) so the category can take

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -55,7 +55,7 @@ templ TxRowFeed(p TxRowFeedProps) {
 		     merchant name — see component doc. Title-cased so all-caps
 		     bank descriptors ("WHOLEFDS NEW YORK 12345") match the
 		     /transactions list visual. -->
-		<span class={ "text-sm font-medium truncate flex-1 min-w-0", templ.KV("text-base-content/65", p.Dimmed) }>
+		<span data-private="merchant" class={ "text-sm font-medium truncate flex-1 min-w-0", templ.KV("text-base-content/65", p.Dimmed) }>
 			{ TitleCase(p.Description) }
 		</span>
 		<!-- Tag chip — surfaces a `[tag] N` hint when the tx already

--- a/internal/templates/components/user_menu.templ
+++ b/internal/templates/components/user_menu.templ
@@ -49,12 +49,55 @@ templ userMenuItems(p SidebarUserMenuProps, logoutFormID string) {
 		</li>
 	}
 	<hr class="border-base-300 my-1 mx-2"/>
+	@privacyControlRow()
+	<hr class="border-base-300 my-1 mx-2"/>
 	<li>
 		<button type="submit" form={ logoutFormID } class="text-error">
 			@LucideIcon("log-out", "w-3.5 h-3.5")
 			<span class="flex-1">Sign out</span>
 		</button>
 	</li>
+}
+
+// privacyControlRow is the in-menu segmented control for the client-side
+// privacy mode (real / obfuscate / hide). It binds to the global
+// `$store.privacy` (registered in base.html) — the same store the topbar
+// avatar indicator and the Shift+P shortcut drive — so the active segment
+// stays in sync everywhere. Rendered as a non-link menu row (a <li> wrapping a
+// div, mirroring the identity-header row) so daisy's menu hover/active
+// treatment doesn't fight the join control. Selecting a mode deliberately does
+// NOT close the popover, so members can flip modes and compare.
+templ privacyControlRow() {
+	<li x-data>
+		<div class="flex flex-col items-stretch gap-1.5 px-1 py-1 hover:bg-transparent cursor-default">
+			<span class="flex items-center gap-1.5 text-[0.65rem] uppercase tracking-wide text-base-content/40 font-medium">
+				@LucideIcon("eye-off", "w-3 h-3")
+				<span class="flex-1">Privacy</span>
+				<span class="normal-case tracking-normal text-base-content/30" x-show="$store.privacy.active" x-cloak>on</span>
+			</span>
+			<div class="join w-full" role="group" aria-label="Privacy mode">
+				@privacyControlButton("real", "eye", "Real")
+				@privacyControlButton("obfuscate", "venetian-mask", "Fake")
+				@privacyControlButton("hide", "eye-off", "Hide")
+			</div>
+		</div>
+	</li>
+}
+
+// Inactive segments are plain (neutral) btns so the unselected states keep a
+// surface and the control reads as a group; the active one is btn-primary —
+// same shape as ThemeControl. Compact btn-xs to fit the 224px popover.
+templ privacyControlButton(value, icon, label string) {
+	<button
+		type="button"
+		class="join-item btn btn-xs flex-1 gap-1 px-1.5"
+		:class={ "$store.privacy.mode === '" + value + "' ? 'btn-primary' : ''" }
+		:aria-pressed={ "$store.privacy.mode === '" + value + "'" }
+		@click={ "$store.privacy.set('" + value + "')" }
+	>
+		@LucideIcon(icon, "w-3.5 h-3.5")
+		{ label }
+	</button>
 }
 
 // userMenuLogoutForm is the hidden POST /logout form the Sign-out button

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -38,6 +38,28 @@
       } catch (_) { /* best-effort */ }
     })();
   </script>
+  <script>
+    // Apply the persisted privacy mode before paint so sensitive values never
+    // flash before privacy.js rewrites (obfuscate) or blurs (hide) them.
+    //   'obfuscate'/'hide' — set data-privacy (CSS keys off it) AND add the
+    //     'privacy-pending' class, which blurs every [data-private] until
+    //     privacy.js's first pass runs and removes the class.
+    //   'real' / absent    — no-op.
+    // See static/js/admin/privacy.js + the privacy block in input.css.
+    (function () {
+      try {
+        var p = localStorage.getItem('bb-privacy');
+        if (p === 'obfuscate' || p === 'hide') {
+          document.documentElement.setAttribute('data-privacy', p);
+          document.documentElement.classList.add('privacy-pending');
+        }
+      } catch (_) { /* best-effort */ }
+    })();
+  </script>
+  <!-- Privacy engine: defines window.bbPrivacy and rewrites/restores
+       [data-private] nodes. Non-deferred so it exists before Alpine's
+       `privacy` store inits; its own pass waits for DOMContentLoaded. -->
+  <script src="/static/js/admin/privacy.js"></script>
   <!-- fetchpriority="high" hints that the app stylesheet is render-blocking and
        critical. Safari 17.2+ and Chrome 102+ honor it; older browsers ignore. -->
   <link rel="stylesheet" href="/static/css/styles.css" fetchpriority="high">
@@ -254,6 +276,32 @@
           var self = this;
           mq.addEventListener('change', function(e) { self.systemDark = e.matches; });
         },
+      });
+    });
+  </script>
+
+  <script>
+    // Alpine store: $store.privacy
+    //
+    // Reactive façade over window.bbPrivacy (static/js/admin/privacy.js), which
+    // owns the actual mode state + DOM rewriting. This store exists so the
+    // avatar-menu control can bind to `$store.privacy.mode` for active-segment
+    // highlighting; every mutation delegates to window.bbPrivacy so the engine
+    // stays the single source of truth. Three modes: 'real' / 'obfuscate' /
+    // 'hide'. Persisted per-browser (never server-stored — a privacy preference
+    // shouldn't leak across devices or members), mirroring $store.theme.
+    document.addEventListener('alpine:init', function() {
+      Alpine.store('privacy', {
+        mode: (window.bbPrivacy && window.bbPrivacy.mode) || 'real',
+        set: function(m) {
+          if (window.bbPrivacy) window.bbPrivacy.set(m);
+          this.mode = (window.bbPrivacy && window.bbPrivacy.mode) || m;
+        },
+        cycle: function() {
+          if (window.bbPrivacy) window.bbPrivacy.cycle();
+          this.mode = (window.bbPrivacy && window.bbPrivacy.mode) || this.mode;
+        },
+        get active() { return this.mode !== 'real'; },
       });
     });
   </script>
@@ -2857,6 +2905,19 @@
           group: 'Actions',
           scope: 'global',
           action: function() { if (Alpine.store('theme')) Alpine.store('theme').toggle(); }
+        });
+
+        // Cycle privacy mode: real → obfuscate → hide → real. Bound to
+        // 'shift+p' (a bare 'p' would collide with page-level single-key
+        // bindings); the dispatcher folds Shift into e.key and tries the
+        // 'shift+<key>' spec first, same path as the theme toggle above.
+        reg.register({
+          id: 'global.privacy.cycle',
+          keys: 'shift+p',
+          description: 'Cycle privacy (real → obfuscate → hide)',
+          group: 'Actions',
+          scope: 'global',
+          action: function() { if (Alpine.store('privacy')) Alpine.store('privacy').cycle(); }
         });
 
         Object.keys(goRoutes).forEach(function(k) {

--- a/static/js/admin/privacy.js
+++ b/static/js/admin/privacy.js
@@ -1,0 +1,182 @@
+// Privacy mode — client-side presentation layer for sensitive financial data.
+//
+// Three modes, persisted per-browser in localStorage('bb-privacy'):
+//   'real'      — actual data (default).
+//   'obfuscate' — same-shape but obviously-fake "matrix/hex" glitch
+//                 ($12,456.00 → $3a,4d4.0f, Starbucks → Xq7v8bn2). The real
+//                 text is replaced in the DOM; deterministic per value so it's
+//                 stable across renders (no shimmer).
+//   'hide'      — blur the real value via CSS (see input.css). No JS rewrite.
+//
+// Sensitive nodes are marked server-side with `data-private="<kind>"`
+// (amount | merchant | account | institution | mask). The kind is advisory —
+// one glitch function preserves each character class, so every kind is handled
+// uniformly today; the attribute keeps the door open for per-kind strategies.
+//
+// THREAT MODEL: presentation-only. Real values still exist in the DOM /
+// devtools / network — this defends against shoulder-surfing, screenshots, and
+// screen-shares, NOT against someone with browser access. Mirrors the
+// "privacy mode" in YNAB/Copilot/Mint.
+//
+// Loaded non-deferred in <head> (base.html) so window.bbPrivacy exists before
+// Alpine's `privacy` store initializes. The matching pre-paint IIFE in
+// base.html sets `data-privacy` + the `privacy-pending` blur class before first
+// paint, so obfuscate never flashes real values before this script rewrites
+// them.
+(function () {
+  'use strict';
+
+  var KEY = 'bb-privacy';
+  var MODES = { real: 1, obfuscate: 1, hide: 1 };
+  var DONE = 'data-bb-glitched'; // marks an element whose text we've replaced
+
+  function readMode() {
+    try {
+      var v = localStorage.getItem(KEY);
+      if (v && MODES[v]) return v;
+    } catch (_) { /* private-mode Safari */ }
+    return 'real';
+  }
+
+  var state = readMode();
+
+  // ----- deterministic glitch -----
+
+  // FNV-1a-ish 32-bit hash, seeds the per-value glitch so a given input always
+  // maps to the same output.
+  function hash32(str) {
+    var h = 0x811c9dc5 >>> 0;
+    for (var i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 0x01000193) >>> 0;
+    }
+    return h >>> 0;
+  }
+
+  var HEX = '0123456789abcdef';
+  var LOWER = 'abcdefghijklmnopqrstuvwxyz';
+  var UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  // Glitch a string in place: digits → hex (the "matrix" read), letters →
+  // scrambled same-case letters, everything else (spaces, $ , . - · / etc.)
+  // verbatim. Length, grouping, currency symbols, and word boundaries survive,
+  // so layout and tabular-nums alignment hold.
+  function glitch(text) {
+    if (!text) return text;
+    var seed = hash32(text);
+    var out = '';
+    for (var i = 0; i < text.length; i++) {
+      var c = text.charCodeAt(i);
+      // advance an LCG per position so adjacent same-class chars differ
+      seed = (Math.imul(seed, 1664525) + 1013904223 + i) >>> 0;
+      if (c >= 48 && c <= 57) {            // 0-9
+        out += HEX[seed % 16];
+      } else if (c >= 97 && c <= 122) {    // a-z
+        out += LOWER[seed % 26];
+      } else if (c >= 65 && c <= 90) {     // A-Z
+        out += UPPER[seed % 26];
+      } else {
+        out += text[i];                    // punctuation / whitespace verbatim
+      }
+    }
+    return out;
+  }
+
+  // ----- DOM application -----
+
+  // Replace every non-whitespace text node under `el` with its glitch. Only
+  // text nodes are touched, so child elements (category dots, icons, badges)
+  // inside a marked container survive untouched. The original is stashed on the
+  // node so restore() is exact.
+  function obfuscateEl(el) {
+    if (el.getAttribute(DONE) === '1') return;
+    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null);
+    var n;
+    while ((n = walker.nextNode())) {
+      if (!n.nodeValue || !n.nodeValue.trim()) continue;
+      if (n.__bbReal == null) n.__bbReal = n.nodeValue;
+      n.nodeValue = glitch(n.__bbReal);
+    }
+    el.setAttribute(DONE, '1');
+  }
+
+  function restoreEl(el) {
+    if (el.getAttribute(DONE) !== '1') return;
+    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null);
+    var n;
+    while ((n = walker.nextNode())) {
+      if (n.__bbReal != null) n.nodeValue = n.__bbReal;
+    }
+    el.removeAttribute(DONE);
+  }
+
+  // Apply the current mode to all marked nodes under `root`. obfuscate rewrites
+  // text; real/hide restore the real text (hide blurs it via CSS).
+  function applyAll(root) {
+    root = root || document.body;
+    if (!root || !root.querySelectorAll) return;
+    var fn = state === 'obfuscate' ? obfuscateEl : restoreEl;
+    if (root.nodeType === 1 && root.matches && root.matches('[data-private]')) fn(root);
+    var els = root.querySelectorAll('[data-private]');
+    for (var i = 0; i < els.length; i++) fn(els[i]);
+  }
+
+  // ----- observer: catch dynamically-inserted nodes (fetch+innerHTML swaps,
+  // Alpine re-renders). Only does work in obfuscate; hide is pure CSS and real
+  // needs nothing. Our own text-node edits are characterData mutations, which
+  // we don't observe, so this never re-triggers on itself.
+  var observer = null;
+  function startObserver() {
+    if (observer) return;
+    observer = new MutationObserver(function (muts) {
+      if (state !== 'obfuscate') return;
+      for (var i = 0; i < muts.length; i++) {
+        var added = muts[i].addedNodes;
+        for (var j = 0; j < added.length; j++) {
+          var node = added[j];
+          if (node.nodeType !== 1) continue;
+          applyAll(node);
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  // ----- public API -----
+
+  function setMode(mode) {
+    if (!MODES[mode]) return;
+    state = mode;
+    try { localStorage.setItem(KEY, mode); } catch (_) {}
+    var root = document.documentElement;
+    if (mode === 'real') root.removeAttribute('data-privacy');
+    else root.setAttribute('data-privacy', mode);
+    applyAll(document.body);
+    root.classList.remove('privacy-pending');
+  }
+
+  window.bbPrivacy = {
+    get mode() { return state; },
+    set: setMode,
+    cycle: function () {
+      var order = { real: 'obfuscate', obfuscate: 'hide', hide: 'real' };
+      setMode(order[state] || 'real');
+    },
+  };
+
+  // ----- init: run the first pass once the body exists, then reveal -----
+  function init() {
+    var root = document.documentElement;
+    if (state === 'real') root.removeAttribute('data-privacy');
+    else root.setAttribute('data-privacy', state);
+    applyAll(document.body);
+    root.classList.remove('privacy-pending'); // reveal fakes / drop the gap blur
+    startObserver();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
A client-side **privacy mode** that masks sensitive financial data on every admin screen — for screenshots, demos, and public spaces — without a page reload or any server round-trip.

A control in the avatar menu (and `Shift+P`) cycles three modes:

- **Real** — actual data (default).
- **Obfuscate** — deterministic, same-shape **matrix/hex** fakes: `$12,456.00 → $3a,4d4.0f`, `Platinum Card → Ggzjuqll Spva`. Obviously synthetic, never mistaken for real data, but the layout (digit grouping, currency symbol, column alignment, word boundaries) is preserved.
- **Hide** — values blurred via CSS.

## Modes

<table>
  <tr><th>Real</th><th>Obfuscate</th><th>Hide</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/w8jiqjthlt.jpg" width="280" alt="transactions — real"></td>
    <td><img src="https://i.img402.dev/8u78drcteo.jpg" width="280" alt="transactions — obfuscate"></td>
    <td><img src="https://i.img402.dev/tr542xmlvg.jpg" width="280" alt="transactions — hide"></td>
  </tr>
</table>

The obfuscation is deterministic — the same merchant/amount renders the same glitch on every row and every page (no shimmer), so the screen still reads as a coherent dataset:

<img src="https://i.img402.dev/r0ypwcqgr6.jpg" width="760" alt="accounts — obfuscate">

The control lives in the avatar menu; an active mode shows a warning dot on the topbar avatar so fakes are never mistaken for real data:

<img src="https://i.img402.dev/l46p9j5lzu.jpg" width="420" alt="avatar-menu privacy control">

## How it works

- **Presentation-only.** Real data still ships to the DOM — this defends shoulder-surfing, screenshots, and screen-shares, **not** devtools/page-source. Same threat model as YNAB/Copilot privacy mode.
- Sensitive values are marked server-side with `data-private="<kind>"` (`amount | merchant | account | institution | mask`).
- Engine: `static/js/admin/privacy.js`. Obfuscate is a deterministic per-character glitch (digits → `0-9a-f`, letters → scrambled same-case, punctuation/whitespace verbatim), seeded by an FNV-1a hash so a value always maps to the same fake. Hide is pure CSS (`filter: blur`). A `MutationObserver` re-glitches fetch-swapped nodes (e.g. the transactions search/filter swap). A pre-paint guard + `.privacy-pending` blur prevents a real-data flash before the JS runs.
- State in `localStorage['bb-privacy']` + Alpine `$store.privacy`, mirroring the existing `bb-theme` store. `Shift+P` cycles modes (ignored while typing in an input).

## Marking chokepoints

- The **`Amount`** component covers ~all money in one place (`data-private="amount"` by default; opt out via `AmountProps.Public`).
- **`EntityHeader.TitlePrivateKind`** covers the four detail-page title headers.
- **`components.Private(kind, s)`** wraps bare-string leafs; the rest are leaf `data-private` attrs across the tx rows and account/connection/subscription pages.

## Scope

Money + accounts & merchants. **Deliberately left visible:** people (names/emails/avatars/agent identity), free-text notes & report bodies, tags, and category names. Extending to any of those later is one line — mark its render with `data-private` (the glitch already handles every character class).

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- Browser-validated across `/transactions` and `/accounts` in all three modes: money tiles/balances/amounts, account names, `····####` masks, institution and merchant/series names all obfuscate or blur; categories, review badges, account-type column, and people/owner names stay real (scope correct).
- Verified determinism (same value → same glitch across pages), the `MutationObserver` swap path, localStorage persistence, the pre-paint no-flash guard, and `Shift+P` cycling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
