### PR TITLE
feat(ui): privacy mode command-palette actions + menu padding polish

### DIFF
--- a/internal/templates/components/user_menu.templ
+++ b/internal/templates/components/user_menu.templ
@@ -69,7 +69,7 @@ templ userMenuItems(p SidebarUserMenuProps, logoutFormID string) {
 // NOT close the popover, so members can flip modes and compare.
 templ privacyControlRow() {
 	<li x-data>
-		<div class="flex flex-col items-stretch gap-1.5 px-1 py-1 hover:bg-transparent cursor-default">
+		<div class="flex flex-col items-stretch gap-1.5 px-3 py-1.5 hover:bg-transparent cursor-default">
 			<span class="flex items-center gap-1.5 text-[0.65rem] uppercase tracking-wide text-base-content/40 font-medium">
 				@LucideIcon("eye-off", "w-3 h-3")
 				<span class="flex-1">Privacy</span>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2130,6 +2130,17 @@
         { id: 'act-theme-light', group: 'Quick Actions', title: 'Light theme', desc: 'Always use the light theme', icon: 'sun', action: function() { if (window.Alpine && Alpine.store('theme')) Alpine.store('theme').set('light'); }, keywords: 'theme light mode appearance bright day color scheme set' },
         { id: 'act-theme-dark', group: 'Quick Actions', title: 'Dark theme', desc: 'Always use the dark theme', icon: 'moon', action: function() { if (window.Alpine && Alpine.store('theme')) Alpine.store('theme').set('dark'); }, keywords: 'theme dark mode appearance night color scheme set' },
         { id: 'act-theme-system', group: 'Quick Actions', title: 'System theme', desc: 'Match your OS appearance', icon: 'monitor', action: function() { if (window.Alpine && Alpine.store('theme')) Alpine.store('theme').set('system'); }, keywords: 'theme system auto os appearance default color scheme automatic set' },
+        // Privacy actions (no href) — drive $store.privacy directly, mirroring
+        // the theme block above. `act-privacy` is the smart cycle
+        // (real → obfuscate → hide); its shortcutId links to the 'shift+p'
+        // binding in seedRegistry() so the palette row shows the same keycap
+        // hint as the help modal. The three explicit actions jump straight to a
+        // specific mode (the palette is the only place you can land directly on
+        // Hide without cycling).
+        { id: 'act-privacy', shortcutId: 'global.privacy.cycle', group: 'Quick Actions', title: 'Toggle privacy mode', desc: 'Cycle real → obfuscate → hide', icon: 'shield', action: function() { if (window.Alpine && Alpine.store('privacy')) Alpine.store('privacy').cycle(); }, keywords: 'privacy obfuscate hide blur censor mask redact conceal sensitive screenshot demo screen share shoulder surf fake matrix hex' },
+        { id: 'act-privacy-real', group: 'Quick Actions', title: 'Show real data', desc: 'Turn privacy mode off', icon: 'eye', action: function() { if (window.Alpine && Alpine.store('privacy')) Alpine.store('privacy').set('real'); }, keywords: 'privacy real show reveal unmask actual disable off normal clear' },
+        { id: 'act-privacy-obfuscate', group: 'Quick Actions', title: 'Obfuscate data', desc: 'Replace values with obvious fakes', icon: 'venetian-mask', action: function() { if (window.Alpine && Alpine.store('privacy')) Alpine.store('privacy').set('obfuscate'); }, keywords: 'privacy obfuscate fake matrix hex scramble mask demo screenshot sensitive glitch' },
+        { id: 'act-privacy-hide', group: 'Quick Actions', title: 'Hide data', desc: 'Blur out sensitive values', icon: 'eye-off', action: function() { if (window.Alpine && Alpine.store('privacy')) Alpine.store('privacy').set('hide'); }, keywords: 'privacy hide blur censor redact conceal hidden sensitive screenshot' },
       ];
 
       // Turn a spec's `keys` into flat tokens for rendering:


### PR DESCRIPTION
Follow-up to #1717 — makes privacy mode a first-class **command-palette** action (mirroring the theme toggle) and fixes a small avatar-menu padding mismatch.

## Command palette

Typing "privacy" (or obfuscate / hide / blur / mask / fake …) in `⌘K` surfaces four actions under **Quick Actions**, exactly mirroring the theme block's "toggle + explicit setters" shape:

- **Toggle privacy mode** — cycles real → obfuscate → hide, and shows the `⇧P` hint pulled live from the shortcut registry (`shortcutId: 'global.privacy.cycle'`), same as theme shows `⇧*`.
- **Show real data** / **Obfuscate data** / **Hide data** — jump straight to one mode. The palette is the only place you can land directly on Hide without cycling.

<img src="https://i.img402.dev/bitnhqh2am.png" width="760" alt="command palette — privacy actions">

## Avatar-menu padding polish

The privacy row's horizontal inset is fixed — it used `px-1` (4px), under-insetting the title + segmented control vs daisy's native `px-3` (12px) menu-item padding; now `px-3 py-1.5`, aligned with the sibling menu links.

<table>
  <tr><th>Real (aligned)</th><th>Obfuscate active ("on" + segment)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/4a5hqllc4l.png" width="320" alt="menu — real, padding fixed"></td>
    <td><img src="https://i.img402.dev/n2ccp6d5ni.png" width="320" alt="menu — obfuscate active"></td>
  </tr>
</table>

## Notes

- `Shift+P` still cycles privacy mode (registered in #1717, listed in the `?` help modal). It's surfaced in the command palette like theme's `⇧*`, but **not** shown as a kbd pill inside the avatar menu.
- The `?` help modal already reads privacy from the shared `$store.shortcuts` registry, so no change was needed there.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- Browser-validated: palette search returns all four entries with the right icons and the `⇧P` hint on the toggle; clicking "Fake" sets `obfuscate`, lights the segment, shows the "on" indicator + avatar dot; computed `padding-left` of the privacy row is now `12px`, matching the sibling menu link (was `4px`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
