### PR TITLE
fix(agents): decode over-escaped unicode in agent report titles/bodies

### DIFF
--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
+	"unicode/utf16"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
@@ -82,6 +84,17 @@ func (s *Service) CreateAgentReport(ctx context.Context, title, body string, act
 	if body == "" {
 		return AgentReportResponse{}, fmt.Errorf("%w: body is required", ErrInvalidParameter)
 	}
+	// Repair over-escaped Unicode in the agent-authored prose. Models
+	// occasionally emit a literal backslash-u escape (the six ASCII
+	// characters backslash, u, 2, 0, 1, 4) inside the submit_report tool
+	// argument instead of the em-dash rune it names. The JSON layer hands us
+	// those bytes verbatim, so without this they get stored and then rendered
+	// as that raw escape across every surface that shows the report: the runs
+	// page, the report table, the activity feed, and notification payloads.
+	// Decode here, at the single ingestion chokepoint, so the stored value is
+	// clean everywhere.
+	title = decodeStrayUnicodeEscapes(title)
+	body = decodeStrayUnicodeEscapes(body)
 	if priority == "" {
 		priority = "info"
 	}
@@ -337,4 +350,89 @@ func (s *Service) DeleteAgentReport(ctx context.Context, reportID string) error 
 		return ErrNotFound
 	}
 	return nil
+}
+
+// decodeStrayUnicodeEscapes repairs a string in which a model over-escaped a
+// Unicode character: it emitted the literal text of a backslash-u escape (a
+// backslash, the letter u, and four hex digits) rather than the rune that
+// escape denotes. We see this in agent-authored report titles, where an
+// em-dash arrives as the six characters backslash u 2 0 1 4. Decode any such
+// sequence, combining a UTF-16 surrogate pair when present, back into the rune
+// it names. A string with no backslash-u marker takes a fast path unchanged.
+//
+// Only backslash-u escapes are touched. Other escapes (newline, tab, quote)
+// are left alone: they are either intentional or harmless in markdown, and
+// rewriting them risks mangling legitimate content. The reported breakage is
+// purely Unicode escapes.
+func decodeStrayUnicodeEscapes(s string) string {
+	if !strings.Contains(s, `\u`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if r, size, ok := readUnicodeEscapeAt(s, i); ok {
+			b.WriteRune(r)
+			i += size
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// readUnicodeEscapeAt tries to decode a backslash-u escape beginning at byte
+// offset i, combining a following low surrogate when the first code unit is a
+// high surrogate. It returns the decoded rune, the number of source bytes
+// consumed, and whether a valid escape was found. A malformed or partial
+// escape — a non-hex tail, an unpaired surrogate — reports ok=false so the
+// caller copies the bytes through untouched.
+func readUnicodeEscapeAt(s string, i int) (rune, int, bool) {
+	if i+6 > len(s) || !strings.HasPrefix(s[i:], `\u`) {
+		return 0, 0, false
+	}
+	hi, ok := parseHex4(s[i+2 : i+6])
+	if !ok {
+		return 0, 0, false
+	}
+	switch {
+	case hi >= 0xD800 && hi <= 0xDBFF:
+		// High surrogate: only valid when paired with a trailing low surrogate.
+		if i+12 <= len(s) && strings.HasPrefix(s[i+6:], `\u`) {
+			if lo, ok := parseHex4(s[i+8 : i+12]); ok && lo >= 0xDC00 && lo <= 0xDFFF {
+				return utf16.DecodeRune(rune(hi), rune(lo)), 12, true
+			}
+		}
+		return 0, 0, false
+	case hi >= 0xDC00 && hi <= 0xDFFF:
+		// Lone low surrogate: invalid on its own.
+		return 0, 0, false
+	default:
+		return rune(hi), 6, true
+	}
+}
+
+// parseHex4 parses exactly four hex digits into their integer value.
+func parseHex4(s string) (uint32, bool) {
+	if len(s) != 4 {
+		return 0, false
+	}
+	var v uint32
+	for i := 0; i < 4; i++ {
+		c := s[i]
+		var d uint32
+		switch {
+		case c >= '0' && c <= '9':
+			d = uint32(c - '0')
+		case c >= 'a' && c <= 'f':
+			d = uint32(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			d = uint32(c-'A') + 10
+		default:
+			return 0, false
+		}
+		v = v<<4 | d
+	}
+	return v, true
 }

--- a/internal/service/reports_text_test.go
+++ b/internal/service/reports_text_test.go
@@ -1,0 +1,97 @@
+//go:build !lite
+
+package service
+
+import "testing"
+
+// TestDecodeStrayUnicodeEscapes exercises the repair applied to agent-authored
+// report prose: a model that emits the literal text of a backslash-u escape
+// (instead of the rune it names) should have it decoded on ingestion.
+//
+// The escape inputs are assembled at runtime via u() from a lone backslash so
+// the test source itself never contains a backslash-u sequence — Go (and the
+// tools that author this file) would otherwise fold such a sequence into the
+// very rune under test, making the cases pass vacuously.
+func TestDecodeStrayUnicodeEscapes(t *testing.T) {
+	bs := "\\" // a single backslash, kept out of every literal below
+	u := func(hex string) string { return bs + "u" + hex }
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "em dash escape decoded",
+			in:   "Routine review complete " + u("2014") + " cleared all 8 transactions",
+			want: "Routine review complete — cleared all 8 transactions",
+		},
+		{
+			name: "already-correct em dash untouched",
+			in:   "Reviewed 47 transactions — no suspicious activity",
+			want: "Reviewed 47 transactions — no suspicious activity",
+		},
+		{
+			name: "no escape marker is a no-op",
+			in:   "Weekly review complete",
+			want: "Weekly review complete",
+		},
+		{
+			name: "mixed en-dash and em-dash",
+			in:   "range 10" + u("2013") + "20 " + u("2014") + " done",
+			want: "range 10–20 — done",
+		},
+		{
+			name: "curly quotes and ellipsis",
+			in:   u("201c") + "Budget" + u("201d") + " alert" + u("2026"),
+			want: "“Budget” alert…",
+		},
+		{
+			name: "lowercase hex",
+			in:   "caf" + u("00e9") + " spend",
+			want: "café spend",
+		},
+		{
+			name: "uppercase hex",
+			in:   "caf" + u("00E9") + " spend",
+			want: "café spend",
+		},
+		{
+			name: "surrogate pair emoji",
+			in:   "nice " + u("d83d") + u("de00") + " work",
+			want: "nice 😀 work",
+		},
+		{
+			name: "non-hex tail left literal",
+			in:   "path" + u("nknown") + " segment",
+			want: "path" + u("nknown") + " segment",
+		},
+		{
+			name: "truncated escape left literal",
+			in:   "abc " + bs + "u20",
+			want: "abc " + bs + "u20",
+		},
+		{
+			name: "unpaired high surrogate left literal",
+			in:   "x " + u("d83d") + " y",
+			want: "x " + u("d83d") + " y",
+		},
+		{
+			name: "lone low surrogate left literal",
+			in:   "x " + u("de00") + " y",
+			want: "x " + u("de00") + " y",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := decodeStrayUnicodeEscapes(c.in); got != c.want {
+				t.Errorf("decodeStrayUnicodeEscapes(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Agent report titles sometimes render as a raw escape instead of the glyph. Example seen in the app:

> `Routine review complete — cleared all 8 needs-review transactions and added 2 new merchant rules (Cactus Kirkland, ReSupply).`

The `—` (em-dash) shows as literal text. Because the report title surfaces in many places, the broken text appears "throughout the app".

## Root cause

The title/body of a report come straight from the `submit_report` MCP tool argument into `Service.CreateAgentReport`, which stores them verbatim. Models occasionally **over-escape** a unicode character when emitting that argument — writing the literal six characters of a JSON-style backslash-u escape rather than the rune it names. The JSON layer passes those bytes through unchanged, so the literal escape gets persisted and then rendered everywhere the report appears (runs page, report table, activity feed, notification payloads).

This is intermittent and data-dependent — confirmed by inspecting the dev DB, where existing reports store correct em-dashes (`—`), matching the "sometimes" in the report. The render paths are plain templ text nodes, so a *real* em-dash renders fine; only a *stored* literal escape breaks. The fix therefore belongs at ingestion, not at render.

## Fix

Decode stray backslash-u escapes in `title` and `body` at the single ingestion chokepoint (`CreateAgentReport`), which both the MCP and REST report-create paths flow through:

- Combines UTF-16 surrogate pairs (so escaped emoji decode correctly).
- Leaves malformed/partial escapes (non-hex tail, unpaired surrogate, truncated) untouched.
- Only unicode escapes are decoded — `\n`/`\t`/`\"` are left alone to avoid mangling legitimate markdown.
- Strings without the marker take a fast path (no allocation).

## Tests

`go test ./internal/service/ -run TestDecodeStrayUnicodeEscapes` — 13 table-driven cases (em/en-dash, curly quotes, ellipsis, upper/lowercase hex, surrogate-pair emoji, and the leave-literal edge cases). `go build ./...`, `go vet ./...`, and the service unit suite all pass.

## Scope note

This is forward-only — it cleans newly created reports. Existing rows that already contain a literal escape are not rewritten (the broken titles age out of the feed). The decoder is an unexported service helper, so it can be extended to other agent-authored free-text paths if the same over-escaping turns up elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
