### PR TITLE
fix(ui): move /recurring Beta badge beside the title with a higher-contrast tone

### DIFF
--- a/internal/templates/components/page_header.templ
+++ b/internal/templates/components/page_header.templ
@@ -12,6 +12,11 @@ package components
 //               an agent's DiceBear avatar on /agents/<slug>. Takes
 //               precedence over the inline Icon visually; pass one or the
 //               other, not both.
+//   - TitleBadge: optional templ.Component rendered inline immediately
+//               to the RIGHT of the title text (e.g. a "Beta" badge).
+//               Vertically centred with the title; sits above the
+//               subtitle. Use for status/qualifier chips that belong to
+//               the title, not the trailing action cluster.
 //   - Action:   optional templ.Component for the page's PRIMARY action
 //               (typically a btn-primary). Right-aligned.
 //   - SecondaryAction: optional templ.Component for one secondary action
@@ -49,6 +54,9 @@ type PageHeaderProps struct {
 	// title block (e.g. an identity avatar). Nil keeps the classic
 	// title-only layout.
 	Leading templ.Component
+	// TitleBadge is an optional chip rendered inline to the right of the
+	// title text (e.g. a "Beta" badge). Nil keeps the title bare.
+	TitleBadge templ.Component
 	// SecondaryAction is rendered before Action in the trailing slot.
 	// Convention: secondary-styled button (use PageHeaderSecondaryAction).
 	SecondaryAction templ.Component
@@ -86,14 +94,19 @@ templ PageHeader(p PageHeaderProps) {
 // drift apart.
 templ pageHeaderTitleBlock(p PageHeaderProps) {
 	<div class="min-w-0">
-		if p.Icon != "" {
-			<h1 class="bb-page-title flex items-center gap-2">
-				@LucideIcon(p.Icon, "w-6 h-6 text-primary shrink-0")
-				<span>{ p.Title }</span>
-			</h1>
-		} else {
-			<h1 class="bb-page-title">{ p.Title }</h1>
-		}
+		<div class="flex items-center gap-2 min-w-0">
+			if p.Icon != "" {
+				<h1 class="bb-page-title flex items-center gap-2">
+					@LucideIcon(p.Icon, "w-6 h-6 text-primary shrink-0")
+					<span>{ p.Title }</span>
+				</h1>
+			} else {
+				<h1 class="bb-page-title">{ p.Title }</h1>
+			}
+			if p.TitleBadge != nil {
+				@p.TitleBadge
+			}
+		</div>
 		if p.Subtitle != "" {
 			if p.SubtitleHideOnMobile {
 				<p class="text-sm text-base-content/50 mt-1 hidden sm:block">{ p.Subtitle }</p>

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -22,7 +22,7 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 			Title:                "Recurring",
 			Subtitle:             "Recurring charges Breadbox has detected — subscriptions, bills, and more — plus the candidates waiting on your call.",
 			SubtitleHideOnMobile: true,
-			SecondaryAction:      subscriptionsBetaBadge(),
+			TitleBadge:           subscriptionsBetaBadge(),
 			Action:               components.PageHeaderAction(templ.SafeURL("/recurring/new"), "plus", "New series"),
 		})
 		<!-- Stat row: Active · Monthly-equivalent · Due in 30 days · Needs review -->
@@ -352,7 +352,7 @@ templ subscriptionsActiveRow(s SubscriptionRow) {
 
 // subscriptionsBetaBadge marks Recurring as a v1/beta feature.
 templ subscriptionsBetaBadge() {
-	<span class="badge badge-soft badge-info badge-sm" title="Recurring is a new feature — detection is still being tuned">Beta</span>
+	<span class="badge badge-soft badge-warning badge-sm" title="Recurring is a new feature — detection is still being tuned">Beta</span>
 }
 
 func intPtr(n int) *int { return &n }


### PR DESCRIPTION
Moves the **Beta** marker on `/recurring` from the far-right action cluster to sit directly beside the page title, and recolors it to an amber tone that stays legible in dark mode.

## Changes
- Add a reusable `TitleBadge` slot to `PageHeader` — renders a chip inline to the right of the title text (vertically centered, above the subtitle).
- `/recurring` now passes the Beta badge via `TitleBadge:` instead of `SecondaryAction:` (which parked it next to "New series").
- Recolor the badge `badge-info` → `badge-warning`. The previous blue soft tone — and an interim `accent`/`secondary` attempt — wash out in this theme's dark mode, where `primary`/`secondary`/`accent`/`neutral` resolve to desaturated grays; only the semantic tones (info/success/warning/error) stay vivid. Amber also avoids clashing with the green "Active" and blue "Renews" badges on the same page.

## Screenshot
<img src="https://i.img402.dev/xi0wkmbzde.jpg" width="800" alt="/recurring — Beta badge beside the title in amber">

## Test plan
- [ ] `/recurring` renders the amber "Beta" badge immediately right of the "Recurring" title
- [ ] Badge is clearly legible in dark mode (verified live: text `oklch(0.828 0.189 84.429)`)
- [ ] No regression to the title-only `PageHeader` layout on other pages (`TitleBadge` is nil-default)
- [ ] `go build ./...` and `go vet ./...` pass
