### PR TITLE
fix(ui): hide Logs from sidebar, command palette, and go-to shortcuts

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -82,7 +82,11 @@ templ Nav(p NavProps) {
 			@navLinkBadge("/connections", "link", "Connections", navActive(p.CurrentPage, "connections"), p.ConnectionsAttention, "bb-nav-badge--warn", fmt.Sprintf("%d connections need attention", p.ConnectionsAttention))
 			if p.IsAdmin {
 				@navLink("/household", "users", "Household", navActive(p.CurrentPage, "household"))
-				@navLink("/logs", "scroll-text", "Logs", navActive(p.CurrentPage, "logs"))
+				// Logs is intentionally hidden from the rail for now while we decide
+				// whether it stays a top-level page. The /logs route + handler remain
+				// live (still reachable via deep links from the activity feed); restore
+				// this @navLink — plus the command-palette entry and g-chord in
+				// base.html — to bring it back.
 			}
 		}
 		@navLink("/settings/account", "settings", "Settings", navSettingsActive(p.CurrentPage))

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2111,7 +2111,8 @@
         { id: 'sys-users', shortcutId: 'global.go.f', group: 'System', title: 'Household', desc: 'Manage household members', icon: 'users', href: '/household', keywords: 'people family members' },
         { id: 'sys-access', shortcutId: 'global.go.k', group: 'System', title: 'API Keys', desc: 'API keys and OAuth clients', icon: 'shield-check', href: '/settings/api-keys', keywords: 'tokens authentication api keys oauth connector claude access' },
         { id: 'sys-providers', shortcutId: 'global.go.p', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/settings/providers', keywords: 'plaid teller csv bank setup' },
-        { id: 'sys-logs', shortcutId: 'global.go.v', group: 'System', title: 'Logs', desc: 'Sync logs, webhook events, agent sessions', icon: 'scroll-text', href: '/logs', keywords: 'sync history errors status webhooks events sessions activity' },
+        // Logs is hidden from quick-nav for now (route still live, reachable via feed deep links);
+        // restore this entry + the g-chord below to re-list it as a top-level page.
         { id: 'sys-backups', shortcutId: 'global.go.b', group: 'System', title: 'Backups', desc: 'Database backup and restore', icon: 'hard-drive', href: '/settings/backups', keywords: 'backup restore database dump export' },
         { id: 'sys-settings', shortcutId: 'global.go.s', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
         { id: 'sys-design', shortcutId: 'global.go.d', group: 'System', title: 'Design system', desc: 'DaisyUI + bb-* component sandbox', icon: 'palette', href: '/design', keywords: 'sandbox gallery components ui daisyui tailwind preview' },
@@ -2768,8 +2769,7 @@
         r: { path: '/reviews',            label: 'Go to Reviews' },
         u: { path: '/rules',              label: 'Go to Rules' },
         a: { path: '/categories',         label: 'Go to Categories' },
-        v: { path: '/logs',               label: 'Go to Logs' },
-        l: { path: '/logs',               label: 'Go to Logs' },
+        // g+v / g+l → /logs disabled while Logs is hidden from top-level nav; restore with the sidebar link.
         b: { path: '/settings/backups',   label: 'Go to Backups' },
         s: { path: '/settings',           label: 'Go to Settings' },
         p: { path: '/settings/providers', label: 'Go to Providers' },


### PR DESCRIPTION
Hide `/logs` from the three top-level navigation surfaces while we evaluate whether it should stay a top-level page — the route and page remain fully live, just no longer advertised in the chrome.

## Changes
- **Sidebar** (`nav.templ`): drop the `Logs` link from the admin System section.
- **Command palette** (`base.html`): drop the `sys-logs` Cmd+K entry — its own code comment says this group "matches the sidebar's System section," so the two stay in sync.
- **Keyboard chords** (`base.html`): drop the `g v` / `g l` go-to shortcuts that jumped to `/logs`.
- Each removal leaves a breadcrumb comment explaining it's a temporary hide and how to restore it.

**Preserved** (page stays reachable): the `/logs` route + handler, the activity feed's "Last sync" card and sync-log/session deep-links, session/rule-detail breadcrumbs, and onboarding CTAs.

## Screenshot — sidebar after
The **System** section now reads Connections · Household · Settings (Logs removed). Page renders cleanly with interactivity intact (Cmd+K, filter tabs, feed).

<img src="https://i.img402.dev/iq687ukije.jpg" width="800" alt="Feed page — sidebar System section without Logs">

## Test plan
- [x] `go build ./...` clean; generated `nav_templ.go` has zero `/logs` references
- [x] `go test ./internal/templates/...` passes (incl. the inline-script lint test)
- [x] Browser smoke test: sidebar dropped Logs, no JS regression from the palette/shortcut edits
- [ ] `/logs` still reachable directly and via the feed's "Last sync" deep-link
