### PR TITLE
fix(devmode): use the GitHub mark on the reporter's File issue button

### DIFF
--- a/input.css
+++ b/input.css
@@ -333,6 +333,21 @@
   [data-theme="dark"] svg.brand-github path,
   [data-theme="dark"] svg.brand-anthropic path { fill: #fff; }
 
+  /* `brand-onbtn`: the GitHub mark sitting on a solid-tone button
+   * (btn-primary) must track the *button's* text color, not the page
+   * background. primary inverts against the surface in both themes
+   * (dark button / light text in light mode, and the reverse in dark),
+   * while the baked-fill flip above keys off the page theme — so the
+   * unmodified mark renders black-on-black in light mode and
+   * white-on-white in dark. Opt into currentColor to follow
+   * primary-content instead. Mirrors the base / media / data-theme
+   * shape above so it wins on specificity + source order, no !important. */
+  svg.brand-github.brand-onbtn path { fill: currentColor; }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) svg.brand-github.brand-onbtn path { fill: currentColor; }
+  }
+  [data-theme="dark"] svg.brand-github.brand-onbtn path { fill: currentColor; }
+
   /*
    * Pre-hydration size for Lucide placeholders.
    *

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -880,7 +880,7 @@
                 :disabled="!title.trim() || submitting || capturing"
                 class="btn btn-primary btn-sm gap-2">
           <span x-show="!submitting && !capturing" class="flex items-center gap-1.5">
-            {{ lucide "send" "w-3.5 h-3.5" }} File issue
+            {{ brand "github" "brand-onbtn w-3.5 h-3.5" }} File issue
           </span>
           <span x-show="capturing && !submitting" x-cloak class="flex items-center gap-1.5">
             <span class="loading loading-spinner loading-xs"></span> Preparing…


### PR DESCRIPTION
Leads the Developer Mode reporter's submit button with the GitHub brand mark instead of the generic send icon, signaling that the action files a GitHub issue.

## Changes
- `base.html` — swap `{{ lucide "send" … }}` → `{{ brand "github" "brand-onbtn …" }}` on the reporter's "File issue" button.
- `input.css` — add a scoped `brand-onbtn` modifier so the mark follows the button's text color via `currentColor`.

## Why the CSS modifier
The GitHub brand SVG ships a baked-in near-black fill that the existing rules flip to white based on the **page** theme. But `btn-primary` inverts against the page in both themes (dark button in light mode, light button in dark mode), so the unmodified mark would render **black-on-black in light mode** and **white-on-white in dark** — invisible. `brand-onbtn` makes the mark track `primary-content` instead, mirroring the existing base/media/`data-theme` selector shape so it wins on specificity without `!important`.

> Note: `lucide "github"` isn't available — Lucide dropped brand icons — so this uses the vendored `brand "github"` mark (already registered for `html/template`).

## Before / after
<img src="https://i.img402.dev/myzz7ijxg3.png" width="800" alt="File issue button — send icon (before) vs GitHub mark (after), light and dark themes">

## Test plan
- [ ] Enable Developer Mode at `/settings/developer`
- [ ] Open the floating reporter on any page → "File issue" button shows the GitHub mark
- [ ] Verify the mark is crisp on the primary button in **light** mode
- [ ] Verify the mark is crisp on the primary button in **dark** mode
