### PR TITLE
feat(ui): privacy mode — animated transitions, softer blur, numeric obfuscation, stat coverage

### DIFF
--- a/input.css
+++ b/input.css
@@ -1288,6 +1288,18 @@
     user-select: none;
   }
 
+  /* Let the hide blur's halo feather out softly instead of being clipped to a
+   * hard rectangular edge by a tight line-box / `truncate` wrapper. `filter:
+   * blur()` paints a halo beyond the element box; an `overflow: hidden` value
+   * cell (or the value's own `truncate`) was cropping that halo to a crisp
+   * rectangle. Scoped to hide mode and only to a private value + its direct
+   * wrapper, so real-mode truncation/ellipsis is untouched. `!important` beats
+   * the Tailwind `.truncate` utility, which sits in a later cascade layer. */
+  html[data-privacy="hide"] [data-private],
+  html[data-privacy="hide"] :has(> [data-private]) {
+    overflow: visible !important;
+  }
+
   html[data-privacy="obfuscate"]:not(.privacy-pending) [data-private] {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
     letter-spacing: 0.02em;

--- a/input.css
+++ b/input.css
@@ -1294,6 +1294,18 @@
     opacity: 0.92;
   }
 
+  /* Once the initial reveal is done, privacy.js adds `.privacy-anim` to <html>
+   * so mode switches ease the hide blur in/out (and the obfuscate opacity
+   * shift) instead of snapping. Deliberately off during `.privacy-pending` /
+   * first paint so the pre-paint blur→content swap on load stays instant. The
+   * text-decode "scramble" is animated in JS; this only smooths the
+   * CSS-driven properties. Respect reduced-motion. */
+  @media (prefers-reduced-motion: no-preference) {
+    html.privacy-anim:not(.privacy-pending) [data-private] {
+      transition: filter 0.24s ease, opacity 0.24s ease;
+    }
+  }
+
   /* ── Sparkline (inline mini charts in summary pills) ── */
   svg.bb-sparkline {
     width: 64px;

--- a/internal/templates/components/pages/agent_detail.templ
+++ b/internal/templates/components/pages/agent_detail.templ
@@ -112,11 +112,12 @@ templ agentDetailStats(s AgentDetailStatsProps) {
 				Tone:        agentDetailErrorTone(s),
 			})
 			@components.StatTile(components.StatTileProps{
-				Icon:        "dollar-sign",
-				Label:       "Total cost",
-				Value:       agentRunsFormatMoney(s.TotalCostUSD),
-				Description: "Across every non-skipped run",
-				Tone:        components.StatToneNeutral,
+				Icon:             "dollar-sign",
+				Label:            "Total cost",
+				Value:            agentRunsFormatMoney(s.TotalCostUSD),
+				Description:      "Across every non-skipped run",
+				Tone:             components.StatToneNeutral,
+				ValuePrivateKind: "amount",
 			})
 			@components.StatTile(components.StatTileProps{
 				Icon:        "timer",

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -75,11 +75,12 @@ templ agentRunsStats(s AgentRunsStatsProps) {
 			Tone:        agentRunsErrorTone(s),
 		})
 		@components.StatTile(components.StatTileProps{
-			Icon:        "dollar-sign",
-			Label:       "Cost · 30d",
-			Value:       agentRunsFormatMoney(s.TotalCostUSD30d),
-			Description: "Across every completed run",
-			Tone:        components.StatToneNeutral,
+			Icon:             "dollar-sign",
+			Label:            "Cost · 30d",
+			Value:            agentRunsFormatMoney(s.TotalCostUSD30d),
+			Description:      "Across every completed run",
+			Tone:             components.StatToneNeutral,
+			ValuePrivateKind: "amount",
 		})
 		@components.StatTile(components.StatTileProps{
 			Icon:        "timer",

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -35,18 +35,21 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 					Description: "tracked",
 				})
 				@components.StatTile(components.StatTileProps{
-					Icon:        "calendar",
-					Label:       "Monthly equivalent",
-					Value:       subTileMoney(p.MonthlyTotals),
-					Description: subTileMoneyExtra(p.MonthlyTotals),
-					Tone:        components.StatTonePrimary,
+					Icon:                   "calendar",
+					Label:                  "Monthly equivalent",
+					Value:                  subTileMoney(p.MonthlyTotals),
+					Description:            subTileMoneyExtra(p.MonthlyTotals),
+					Tone:                   components.StatTonePrimary,
+					ValuePrivateKind:       "amount",
+					DescriptionPrivateKind: "amount", // extra-currency totals are money too
 				})
 				@components.StatTile(components.StatTileProps{
-					Icon:        "clock",
-					Label:       "Due in 30 days",
-					Value:       subTileMoney(p.UpcomingTotals),
-					Description: subUpcomingDesc(p.UpcomingCount),
-					Tone:        components.StatToneInfo,
+					Icon:             "clock",
+					Label:            "Due in 30 days",
+					Value:            subTileMoney(p.UpcomingTotals),
+					Description:      subUpcomingDesc(p.UpcomingCount), // "N charges" — a count, stays visible
+					Tone:             components.StatToneInfo,
+					ValuePrivateKind: "amount",
 				})
 				@components.StatTile(components.StatTileProps{
 					Icon:        "inbox",

--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -40,6 +40,13 @@ type StatTileProps struct {
 	Description string
 	Tone        StatTileTone
 	Href        templ.SafeURL // optional; if set, tile becomes a link
+	// ValuePrivateKind / DescriptionPrivateKind opt the tile into the
+	// client-side privacy mode: when non-empty, the value / description is
+	// marked with `data-private="<kind>"` (typically "amount" for money
+	// tiles) so it obfuscates/blurs alongside the rest. Leave empty for
+	// non-sensitive tiles (counts, labels) — they stay visible by design.
+	ValuePrivateKind       string
+	DescriptionPrivateKind string
 }
 
 func statTileBg(t StatTileTone) string {
@@ -96,10 +103,20 @@ templ statTileBody(p StatTileProps) {
 			</div>
 		}
 		<div class="min-w-0 flex-1">
-			<div class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate">{ p.Value }</div>
+			<div
+				class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate"
+				if p.ValuePrivateKind != "" {
+					data-private={ p.ValuePrivateKind }
+				}
+			>{ p.Value }</div>
 			<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">{ p.Label }</div>
 			if p.Description != "" {
-				<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate">{ p.Description }</div>
+				<div
+					class="text-[0.65rem] text-base-content/45 mt-0.5 truncate"
+					if p.DescriptionPrivateKind != "" {
+						data-private={ p.DescriptionPrivateKind }
+					}
+				>{ p.Description }</div>
 			}
 		</div>
 	</div>

--- a/static/js/admin/privacy.js
+++ b/static/js/admin/privacy.js
@@ -13,6 +13,12 @@
 // one glitch function preserves each character class, so every kind is handled
 // uniformly today; the attribute keeps the door open for per-kind strategies.
 //
+// TRANSITIONS: switching to/from obfuscate runs a brief "decode" scramble —
+// each marked value flickers through random same-class glyphs and locks in
+// left-to-right (the matrix read). Only on-screen nodes animate (off-screen
+// ones snap), it respects prefers-reduced-motion, and a token cancels an
+// in-flight run so rapid toggles don't pile up. The hide blur eases via CSS.
+//
 // THREAT MODEL: presentation-only. Real values still exist in the DOM /
 // devtools / network — this defends against shoulder-surfing, screenshots, and
 // screen-shares, NOT against someone with browser access. Mirrors the
@@ -29,6 +35,9 @@
   var KEY = 'bb-privacy';
   var MODES = { real: 1, obfuscate: 1, hide: 1 };
   var DONE = 'data-bb-glitched'; // marks an element whose text we've replaced
+
+  var REDUCED = false;
+  try { REDUCED = window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (_) {}
 
   function readMode() {
     try {
@@ -82,7 +91,37 @@
     return out;
   }
 
-  // ----- DOM application -----
+  // Is this char glyph an obfuscatable class (digit / letter)? Punctuation and
+  // whitespace are left alone, both by glitch() and the decode scramble.
+  function isGlyph(code) {
+    return (code >= 48 && code <= 57) || (code >= 97 && code <= 122) || (code >= 65 && code <= 90);
+  }
+
+  // A random same-class glyph for the decode flicker (non-deterministic — the
+  // flicker is meant to churn; only the locked, settled value is deterministic).
+  function randGlyph(code) {
+    if (code >= 48 && code <= 57) return HEX[(Math.random() * 16) | 0];
+    if (code >= 97 && code <= 122) return LOWER[(Math.random() * 26) | 0];
+    return UPPER[(Math.random() * 26) | 0];
+  }
+
+  // Partially-decoded string at progress `prog` (0..1): glyph positions before
+  // the lock front show the final char; the rest flicker through random
+  // same-class glyphs. Punctuation/spaces are always the final char. `real` is
+  // used only for per-position character class (it shares length with target).
+  function scramble(real, target, prog) {
+    var len = target.length;
+    var locked = Math.floor(prog * len + 1e-6);
+    var out = '';
+    for (var i = 0; i < len; i++) {
+      if (i < locked) { out += target.charAt(i); continue; }
+      var code = (real.charCodeAt(i) || target.charCodeAt(i));
+      out += isGlyph(code) ? randGlyph(code) : target.charAt(i);
+    }
+    return out;
+  }
+
+  // ----- DOM application (instant) -----
 
   // Replace every non-whitespace text node under `el` with its glitch. Only
   // text nodes are touched, so child elements (category dots, icons, badges)
@@ -110,8 +149,9 @@
     el.removeAttribute(DONE);
   }
 
-  // Apply the current mode to all marked nodes under `root`. obfuscate rewrites
-  // text; real/hide restore the real text (hide blurs it via CSS).
+  // Apply the current mode to all marked nodes under `root`, instantly.
+  // obfuscate rewrites text; real/hide restore the real text (hide blurs it via
+  // CSS). Used on first paint and for dynamically-inserted nodes.
   function applyAll(root) {
     root = root || document.body;
     if (!root || !root.querySelectorAll) return;
@@ -119,6 +159,77 @@
     if (root.nodeType === 1 && root.matches && root.matches('[data-private]')) fn(root);
     var els = root.querySelectorAll('[data-private]');
     for (var i = 0; i < els.length; i++) fn(els[i]);
+  }
+
+  // ----- DOM application (animated decode) -----
+
+  var animToken = 0; // bumped on every transition so a stale rAF loop bails
+
+  // Animate the text transition between `from` and `to`. The decode scramble
+  // only runs when the underlying text actually changes between obfuscated and
+  // real (real↔obfuscate); transitions into/out of hide keep the text and let
+  // the CSS blur do the work, so we just snap the text and return. Off-screen
+  // marked elements snap instantly; only visible ones animate (bounds the
+  // per-frame DOM writes to what the user can actually see).
+  function animateTo(from, to) {
+    var obf = to === 'obfuscate';
+    var doScramble = obf || (to === 'real' && from === 'obfuscate');
+
+    var els = document.querySelectorAll('[data-private]');
+    var vh = window.innerHeight || document.documentElement.clientHeight || 0;
+    var jobs = []; // [{nodes:[{node,real,target}], delay}]
+
+    for (var i = 0; i < els.length; i++) {
+      var el = els[i];
+      var nodes = [];
+      var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null);
+      var n;
+      while ((n = walker.nextNode())) {
+        if (!n.nodeValue || !n.nodeValue.trim()) continue;
+        if (n.__bbReal == null) n.__bbReal = n.nodeValue;
+        nodes.push({ node: n, real: n.__bbReal, target: obf ? glitch(n.__bbReal) : n.__bbReal });
+      }
+      // Keep the DONE bookkeeping in lock-step with the instant path so a later
+      // applyAll() / observer pass doesn't re-touch these elements.
+      if (obf) el.setAttribute(DONE, '1'); else el.removeAttribute(DONE);
+      if (!nodes.length) continue;
+
+      var rect = el.getBoundingClientRect();
+      var visible = rect.bottom > -40 && rect.top < vh + 40 && rect.width > 0 && rect.height > 0;
+      if (!doScramble || !visible || REDUCED) {
+        for (var k = 0; k < nodes.length; k++) nodes[k].node.nodeValue = nodes[k].target;
+      } else {
+        jobs.push({ nodes: nodes, delay: Math.random() * 130 });
+      }
+    }
+
+    animToken++;
+    if (!jobs.length) return;
+    var myToken = animToken;
+    var DURATION = 320; // per-node decode window (after its stagger delay)
+    var start = null;
+
+    function tick(ts) {
+      if (myToken !== animToken) return; // superseded by a newer transition
+      if (start == null) start = ts;
+      var elapsed = ts - start;
+      var allDone = true;
+      for (var a = 0; a < jobs.length; a++) {
+        var job = jobs[a];
+        var p = (elapsed - job.delay) / DURATION;
+        if (p < 0) { allDone = false; continue; }
+        if (p >= 1) p = 1; else allDone = false;
+        var eased = 1 - Math.pow(1 - p, 3); // easeOutCubic — quick, soft settle
+        var ns = job.nodes;
+        for (var b = 0; b < ns.length; b++) {
+          var it = ns[b];
+          if (it.real === it.target) { it.node.nodeValue = it.target; continue; }
+          it.node.nodeValue = p >= 1 ? it.target : scramble(it.real, it.target, eased);
+        }
+      }
+      if (!allDone) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
   }
 
   // ----- observer: catch dynamically-inserted nodes (fetch+innerHTML swaps,
@@ -144,23 +255,28 @@
 
   // ----- public API -----
 
-  function setMode(mode) {
+  function setMode(mode, animate) {
     if (!MODES[mode]) return;
+    var from = state;
+    if (mode === from) return;
     state = mode;
     try { localStorage.setItem(KEY, mode); } catch (_) {}
     var root = document.documentElement;
     if (mode === 'real') root.removeAttribute('data-privacy');
     else root.setAttribute('data-privacy', mode);
-    applyAll(document.body);
+    if (animate && !REDUCED) animateTo(from, mode);
+    else applyAll(document.body);
     root.classList.remove('privacy-pending');
   }
 
   window.bbPrivacy = {
     get mode() { return state; },
-    set: setMode,
+    // User-initiated changes (avatar menu, command palette, Shift+P) animate;
+    // pass animate=false for a silent set.
+    set: function (mode) { setMode(mode, true); },
     cycle: function () {
       var order = { real: 'obfuscate', obfuscate: 'hide', hide: 'real' };
-      setMode(order[state] || 'real');
+      setMode(order[state] || 'real', true);
     },
   };
 
@@ -169,8 +285,11 @@
     var root = document.documentElement;
     if (state === 'real') root.removeAttribute('data-privacy');
     else root.setAttribute('data-privacy', state);
-    applyAll(document.body);
+    applyAll(document.body);             // first paint is instant — no decode
     root.classList.remove('privacy-pending'); // reveal fakes / drop the gap blur
+    // Enable the CSS blur transition only AFTER the initial reveal, so the
+    // pre-paint blur→content swap on load stays instant (no fade-in flash).
+    requestAnimationFrame(function () { root.classList.add('privacy-anim'); });
     startObserver();
   }
 

--- a/static/js/admin/privacy.js
+++ b/static/js/admin/privacy.js
@@ -62,30 +62,54 @@
     return h >>> 0;
   }
 
-  var HEX = '0123456789abcdef';
+  var DIGITS = '0123456789';
+  var HEXL = 'abcdef';            // the occasional "matrix" hex letter
   var LOWER = 'abcdefghijklmnopqrstuvwxyz';
   var UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-  // Glitch a string in place: digits → hex (the "matrix" read), letters →
-  // scrambled same-case letters, everything else (spaces, $ , . - · / etc.)
-  // verbatim. Length, grouping, currency symbols, and word boundaries survive,
-  // so layout and tabular-nums alignment hold.
+  // Glitch a string in place: digits stay MOSTLY numeric with the occasional
+  // hex letter (a-f) for the matrix read, letters → scrambled same-case
+  // letters, everything else (spaces, $ , . - · / etc.) verbatim. Length,
+  // grouping, currency symbols, and word boundaries survive, so layout and
+  // tabular-nums alignment hold.
+  //
+  // Numbers are kept reading as numbers: the first and last digit of the value
+  // are always numeric, two letters never land adjacent, and a letter only
+  // appears on a ~35% roll — so a glitched amount is always <50% letters and
+  // never collapses into "$ab,cd.ef". Deterministic per value (no shimmer).
   function glitch(text) {
     if (!text) return text;
     var seed = hash32(text);
+    // Locate the first/last digit so a number always begins and ends numeric.
+    var firstD = -1, lastD = -1;
+    for (var p = 0; p < text.length; p++) {
+      var cc = text.charCodeAt(p);
+      if (cc >= 48 && cc <= 57) { if (firstD < 0) firstD = p; lastD = p; }
+    }
     var out = '';
+    var prevLetter = false; // did the previous digit position become a letter?
     for (var i = 0; i < text.length; i++) {
       var c = text.charCodeAt(i);
       // advance an LCG per position so adjacent same-class chars differ
       seed = (Math.imul(seed, 1664525) + 1013904223 + i) >>> 0;
-      if (c >= 48 && c <= 57) {            // 0-9
-        out += HEX[seed % 16];
+      if (c >= 48 && c <= 57) {            // 0-9 → stay mostly numeric
+        var canLetter = i !== firstD && i !== lastD && !prevLetter;
+        if (canLetter && ((seed >>> 8) % 100) < 35) {
+          out += HEXL[(seed >>> 3) % 6];
+          prevLetter = true;
+        } else {
+          out += DIGITS[seed % 10];
+          prevLetter = false;
+        }
       } else if (c >= 97 && c <= 122) {    // a-z
         out += LOWER[seed % 26];
+        prevLetter = false;
       } else if (c >= 65 && c <= 90) {     // A-Z
         out += UPPER[seed % 26];
+        prevLetter = false;
       } else {
         out += text[i];                    // punctuation / whitespace verbatim
+        prevLetter = false;
       }
     }
     return out;
@@ -99,8 +123,12 @@
 
   // A random same-class glyph for the decode flicker (non-deterministic — the
   // flicker is meant to churn; only the locked, settled value is deterministic).
+  // Digits churn mostly through 0-9 (with the occasional hex letter) so the
+  // flicker matches the mostly-numeric settled value instead of going letter-heavy.
   function randGlyph(code) {
-    if (code >= 48 && code <= 57) return HEX[(Math.random() * 16) | 0];
+    if (code >= 48 && code <= 57) {
+      return Math.random() < 0.72 ? DIGITS[(Math.random() * 10) | 0] : HEXL[(Math.random() * 6) | 0];
+    }
     if (code >= 97 && code <= 122) return LOWER[(Math.random() * 26) | 0];
     return UPPER[(Math.random() * 26) | 0];
   }


### PR DESCRIPTION
Privacy-mode refinements following #1717: an animated transition between modes, a coverage fix for stat tiles that were leaking real money, and two polish passes (softer hide blur + mostly-numeric obfuscation).

## Animated mode transitions

Switching to/from **obfuscate** runs a brief **decode scramble** — each marked value flickers through random same-class glyphs and locks in left-to-right (the matrix read), settling on the deterministic glitch. The **hide** blur eases in/out via CSS. Toggling on `/accounts`:

<img src="https://i.img402.dev/30bhzq9jwd.gif" width="820" alt="privacy mode decode + blur transitions">

Implementation (`static/js/admin/privacy.js`, `input.css`):

- **On-screen only.** Only marked elements in the viewport animate; off-screen ones snap instantly.
- **Reduced-motion aware.** `prefers-reduced-motion: reduce` skips the scramble and CSS transition entirely.
- **Cancel-safe.** A token cancels an in-flight decode so rapid toggles (or `Shift+P` mashing) don't pile up rAF loops.
- **No load flash.** The CSS blur transition is gated on a `.privacy-anim` class added *after* first paint, so the pre-paint reveal stays instant.

## Polish

**Softer hide blur.** `filter: blur()` paints a halo beyond the element box; a tight `truncate` / `overflow-hidden` value cell was cropping that halo to a hard rectangular edge. Now overflow is relaxed on a private value + its direct wrapper in hide mode (scoped to hide; real-mode truncation untouched) so the blur feathers out:

<img src="https://i.img402.dev/1tpetk2li0.png" width="820" alt="hide mode — blur feathers softly, no hard edge">

**Mostly-numeric obfuscation.** Numbers were sometimes obfuscating into letter-heavy strings (`$ab,cd.ef`). A digit now only becomes a hex letter on a ~35% roll, never as the first/last digit and never adjacent to another letter — so an amount is **always <50% letters** by construction and keeps reading as a number. Still deterministic:

<img src="https://i.img402.dev/d5log1p9ws.png" width="820" alt="obfuscate mode — amounts stay mostly numeric">

## Stat-tile coverage fix

`/recurring` (and the agents pages) leaked money through privacy mode: the shared **`StatTile`** rendered its value/description as plain strings with no `data-private`. Per-row amounts (via `Amount`) were already covered — only the top stat tiles leaked. Added opt-in `ValuePrivateKind` / `DescriptionPrivateKind`:

- **`/recurring`** — "Monthly equivalent" (value + extra-currency description) and "Due in 30 days" (value; its "N charges" description is a count, stays visible). "Active" / "Needs review" counts stay real.
- **Agents** — "Cost · 30d" and "Total cost". These are Claude API spend, not household money — marked for consistency, but say the word if you'd rather keep agent costs always visible.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- Browser-validated: `/recurring` money tiles obfuscate while counts stay real; decode flickers through glyphs and settles deterministically; reduced-motion snaps instantly; hide blur feathers (no hard edge); obfuscated amounts measured <50% letters across samples (`$96,594.73`, `$45b,2b1.41`, …) with first/last digit always numeric.

> Independent of #1718 (command-palette actions + menu padding) — disjoint file set; both branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
