### PR TITLE
feat(workflows): drawer polish, run cancellation, unlimited-turns default

### DIFF
--- a/input.css
+++ b/input.css
@@ -1038,6 +1038,22 @@
     @apply bg-warning/22 text-warning;
   }
 
+  /* Error tone — a failed workflow run lights the Workflows nav badge red.
+     error is one of the vivid dark-theme tones, so the soft fill stays
+     visible in both modes (unlike primary/neutral soft badges). The
+     active/hover selectors are scoped to --error so they out-specify the
+     generic .bb-sidebar-link--active .bb-nav-badge neutral override — the
+     badge must stay red even on the /workflows page itself. */
+  .bb-nav-badge--error,
+  .bb-sidebar-link--active .bb-nav-badge--error {
+    @apply bg-error/15 text-error;
+  }
+
+  .bb-sidebar-link:hover .bb-nav-badge--error,
+  .bb-sidebar-link--active:hover .bb-nav-badge--error {
+    @apply bg-error/22 text-error;
+  }
+
   /* ── Update-available callout card ──
      A small "what's new"-style nudge pinned to the foot of the rail (above
      the Collapse button) when an admin runs an older release than the latest
@@ -3808,6 +3824,91 @@
 .bb-prose .bb-prose-table .text-right { text-align: right; }
 .bb-prose .bb-prose-table .text-center { text-align: center; }
 .bb-prose .bb-prose-table .text-left { text-align: left; }
+
+/* ── Plain-tag prose — the marked.js (bbRenderMarkdown) path emits UNclassed
+ * HTML (<h2>, <p>, <ul>, <code>, <table>…), not the .bb-prose-* classed tags
+ * the Go components.Markdown renderer emits. Every production markdown surface
+ * actually runs through marked (reports, agent-run prompts + transcript, the
+ * workflows prompt preview); the ones wrapped in .bb-prose previously fell
+ * through almost entirely unstyled (only the generic sibling-margin rule
+ * applied) — that's the "broken" prompt preview. These rules mirror the
+ * .bb-prose-* values above on bare tags so marked output renders identically.
+ *
+ * Purely additive: where both match (the Go-rendered /design sandbox) the
+ * classed selectors above win by specificity, so the sandbox is untouched.
+ * Colors inherit (never hard-set base-content) so a .bb-prose on a colored
+ * chat bubble in the run-detail thread stays legible. */
+.bb-prose h1, .bb-prose h2, .bb-prose h3, .bb-prose h4 {
+  font-weight: 600;
+  margin-top: 0.75rem;
+  line-height: 1.3;
+  letter-spacing: -0.005em;
+}
+.bb-prose h1 { font-size: 1.05rem; }
+.bb-prose h2 { font-size: 1rem; }
+.bb-prose h3 { font-size: 0.95rem; }
+.bb-prose h4 { font-size: 0.875rem; opacity: 0.8; }
+.bb-prose p { margin: 0; }
+.bb-prose strong { font-weight: 600; }
+.bb-prose em { font-style: italic; }
+.bb-prose del, .bb-prose s { opacity: 0.55; text-decoration: line-through; }
+.bb-prose a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--color-primary) 40%, transparent);
+  text-underline-offset: 2px;
+}
+.bb-prose a:hover { text-decoration-color: var(--color-primary); }
+.bb-prose code:not(pre code) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 0.25rem;
+  background: color-mix(in oklch, var(--color-base-200) 90%, transparent);
+  border: 1px solid color-mix(in oklch, var(--color-base-300) 70%, transparent);
+}
+.bb-prose pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  background: color-mix(in oklch, var(--color-base-200) 70%, transparent);
+  border: 1px solid color-mix(in oklch, var(--color-base-300) 60%, transparent);
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+.bb-prose pre code { background: transparent; padding: 0; border: 0; font-size: inherit; }
+.bb-prose ul, .bb-prose ol { margin: 0; padding-inline-start: 1.25rem; }
+.bb-prose ul { list-style-type: disc; }
+.bb-prose ol { list-style-type: decimal; }
+.bb-prose li { margin: 0.125rem 0; }
+.bb-prose li::marker { color: color-mix(in oklch, var(--color-base-content) 45%, transparent); }
+.bb-prose blockquote {
+  margin: 0;
+  padding: 0.25rem 0 0.25rem 0.75rem;
+  border-inline-start: 3px solid color-mix(in oklch, var(--color-primary) 35%, transparent);
+  color: color-mix(in oklch, var(--color-base-content) 80%, transparent);
+  font-style: italic;
+}
+.bb-prose hr {
+  border: 0;
+  border-top: 1px solid color-mix(in oklch, var(--color-base-300) 80%, transparent);
+  margin: 0.875rem 0;
+}
+.bb-prose .bb-report-table-wrap { overflow-x: auto; }
+.bb-prose table { border-collapse: collapse; font-size: 0.8125rem; min-width: 100%; }
+.bb-prose th, .bb-prose td {
+  padding: 0.375rem 0.625rem;
+  border-bottom: 1px solid color-mix(in oklch, var(--color-base-300) 60%, transparent);
+  text-align: start;
+  vertical-align: top;
+}
+.bb-prose thead th {
+  font-weight: 600;
+  background: color-mix(in oklch, var(--color-base-200) 60%, transparent);
+  border-bottom: 1px solid var(--color-base-300);
+}
 
 /* ── bb-json: server-rendered JSON viewer with collapsible objects +
  * arrays. Pairs with components.JSONViewer. Token classes are coloured

--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -265,6 +265,44 @@ func RunWorkflowPresetAdminHandler(a *app.App, svc *service.Service) http.Handle
 	}
 }
 
+// CancelWorkflowRunAdminHandler handles POST /-/workflows/runs/{shortId}/cancel.
+// It aborts an in-progress run by asking the orchestrator to cancel that run's
+// context — which SIGKILLs the sidecar process group (see internal/agent/
+// sidecar.go). The run goroutine then persists a terminal 'cancelled' status,
+// which the run-detail live poller picks up on its next refresh. Editor-level,
+// mirroring the run/enable/disable surface (managing an existing run, not
+// authorizing new recurring spend).
+func CancelWorkflowRunAdminHandler(a *app.App, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		shortID := chi.URLParam(r, "shortId")
+		orchestrator := a.AgentOrchestrator
+		if orchestrator == nil {
+			writeError(w, http.StatusServiceUnavailable, "AGENTS_DISABLED", "Agent orchestrator not configured")
+			return
+		}
+		run, err := svc.GetAgentRun(r.Context(), shortID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Run not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load run")
+			return
+		}
+		if run.Status != "in_progress" {
+			writeError(w, http.StatusConflict, "INVALID_STATE", "Run is not in progress")
+			return
+		}
+		if !orchestrator.CancelRun(shortID) {
+			// Not in this process's in-flight set — it just finished, or is owned
+			// by another instance. Nothing to abort here.
+			writeError(w, http.StatusConflict, "NOT_CANCELLABLE", "Run is no longer cancellable")
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "cancelling"})
+	}
+}
+
 // WorkflowRunStatusAdminHandler handles GET /-/workflows/runs/{shortId}/status —
 // a lightweight JSON status poll for the gallery's one-off Run button, which
 // keeps its spinner up for the whole run (not just the async dispatch). Returns

--- a/internal/admin/agent_run_live.go
+++ b/internal/admin/agent_run_live.go
@@ -179,6 +179,8 @@ func agentRunLiveSummaryStatusHTML(status string) string {
 		return `<span class="badge badge-soft badge-error badge-sm">timeout</span>`
 	case "skipped":
 		return `<span class="badge badge-ghost badge-sm">skipped</span>`
+	case "cancelled":
+		return `<span class="badge badge-soft badge-warning badge-sm">cancelled</span>`
 	case "in_progress":
 		return `<span class="inline-flex items-center gap-1.5 text-primary text-sm"><span class="loading loading-spinner loading-xs"></span>running</span>`
 	default:

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -25,7 +25,11 @@ type NavBadges struct {
 	UnreadReports        int64
 	// SeriesCandidates is the count of recurring-series candidates awaiting a
 	// confirm/reject verdict. Displayed next to the Subscriptions nav link.
-	SeriesCandidates   int64
+	SeriesCandidates int64
+	// WorkflowFailures is the count of preset-instantiated workflows whose most
+	// recent run errored. Drives a red dot on the Workflows nav link so a failed
+	// automation is visible from any page (mirrors the /workflows card red dot).
+	WorkflowFailures   int64
 	ShowGettingStarted bool
 }
 
@@ -61,6 +65,12 @@ func NavBadgesMiddleware(queries *db.Queries, logger *slog.Logger) func(http.Han
 				badges.SeriesCandidates = cand
 			} else {
 				logger.Debug("nav badges: count candidate series", "error", err)
+			}
+
+			if failed, err := queries.CountWorkflowsWithFailedLastRun(ctx); err == nil {
+				badges.WorkflowFailures = failed
+			} else {
+				logger.Debug("nav badges: count failed workflows", "error", err)
 			}
 
 			// Check if getting started guide should show in nav.

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -516,6 +516,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/workflows/{slug}/disable", DisableAgentAdminHandler(svc))
 			r.Post("/workflows/{slug}/run", RunAgentNowAdminHandler(a, svc))
 			r.Post("/workflows/runs/{shortId}/note", UpdateAgentRunNoteAdminHandler(svc, sm))
+			// Abort an in-progress run mid-flight (run-detail "Cancel run" button).
+			// Editor-level, like run/enable/disable above.
+			r.Post("/workflows/runs/{shortId}/cancel", CancelWorkflowRunAdminHandler(a, svc))
+			r.Post("/agents/runs/{shortId}/cancel", CancelWorkflowRunAdminHandler(a, svc))
 			// Lightweight JSON status poll (short_id + status) for the gallery's
 			// one-off Run button spinner. Static "runs" segment never shadows
 			// the {slug}/* routes above.
@@ -534,6 +538,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			// because a reconfigure re-authorizes recurring AI spend behavior.
 			r.With(RequireAdmin(sm)).Get("/workflows/{slug}/config", WorkflowConfigAdminHandler(svc))
 			r.With(RequireAdmin(sm)).Post("/workflows/{slug}/reconfigure", ReconfigureWorkflowAdminHandler(svc))
+			// Remove an instantiated workflow, resetting the preset card back to
+			// "Set up". Admin-only — deleting de-authorizes the recurring spend the
+			// enable gesture authorized, mirroring the enable/reconfigure guard.
+			r.With(RequireAdmin(sm)).Post("/workflows/{slug}/delete", DeleteWorkflowAdminHandler(svc))
 		})
 
 		// Admin-only API routes.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -322,6 +322,7 @@ func navPropsFromData(m map[string]any) components.NavProps {
 		p.ConnectionsAttention = badges.ConnectionsAttention
 		p.PendingReviews = badges.PendingReviews
 		p.SeriesCandidates = badges.SeriesCandidates
+		p.WorkflowFailures = badges.WorkflowFailures
 	}
 	return p
 }

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -134,6 +134,7 @@ func groupWorkflowPresets(views []service.WorkflowPresetView, lastRuns map[strin
 			EstCostPerRunUSD: v.EstCostPerRunUSD,
 			Model:            model,
 			MaxTurns:         maxTurns,
+			MaxBudgetUSD:     v.MaxBudgetUSD,
 			OneOff:           v.OneOff,
 			Enabled:          v.Enabled,
 		}

--- a/internal/admin/workflows_reconfigure_handler.go
+++ b/internal/admin/workflows_reconfigure_handler.go
@@ -35,6 +35,28 @@ func WorkflowConfigAdminHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// DeleteWorkflowAdminHandler handles POST /-/workflows/{slug}/delete. It removes
+// the instantiated workflow (its agent_definition), resetting the preset card
+// back to its un-configured "Set up" state. Run history is preserved (the FK is
+// SET NULL), and the scheduler hot-reloads off the definition-changed hook so
+// the cron entry is dropped immediately. Admin-only — deleting de-authorizes
+// the recurring AI spend the enable gesture authorized, mirroring that guard.
+// Returns JSON {ok:true} for the gallery's async fetch (no full-page redirect).
+func DeleteWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		if err := svc.DeleteAgentDefinition(r.Context(), slug); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
+				return
+			}
+			writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_DELETE_FAILED", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+}
+
 // ReconfigureWorkflowAdminHandler handles POST /-/workflows/{slug}/reconfigure.
 // It re-composes the configurable layers of an already-enabled workflow
 // (schedule, additional-instructions tail, chosen options) without touching

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -10,6 +10,10 @@ const (
 	StatusError   = "error"
 	StatusTimeout = "timeout"
 	StatusSkipped = "skipped"
+	// StatusCancelled is an operator-initiated stop mid-run (the run-detail
+	// "Cancel run" button). Distinct from error (a failure) and timeout (the
+	// run ceiling) — the operator chose to abort, so it reads as intentional.
+	StatusCancelled = "cancelled"
 )
 
 // RunResult is the structured outcome of one agent run.

--- a/internal/db/migrations/20260604055155_workflow_runs_cancelled_status.sql
+++ b/internal/db/migrations/20260604055155_workflow_runs_cancelled_status.sql
@@ -1,0 +1,17 @@
+-- Add 'cancelled' to the workflow_runs.status set so an operator can stop a run
+-- mid-flight (the run-detail "Cancel run" button) and have it land as an
+-- intentional terminal status rather than a generic 'error'. The new set is a
+-- strict superset of the old, so this is additive: existing rows and concurrent
+-- inserts (which only ever write the prior statuses) keep validating. The
+-- constraint kept its original auto-generated name (agent_runs_status_check)
+-- when the table was renamed agent_runs -> workflow_runs.
+
+-- +goose Up
+ALTER TABLE workflow_runs DROP CONSTRAINT agent_runs_status_check;
+ALTER TABLE workflow_runs ADD CONSTRAINT agent_runs_status_check
+    CHECK (status IN ('in_progress', 'success', 'error', 'timeout', 'skipped', 'cancelled'));
+
+-- +goose Down
+ALTER TABLE workflow_runs DROP CONSTRAINT agent_runs_status_check;
+ALTER TABLE workflow_runs ADD CONSTRAINT agent_runs_status_check
+    CHECK (status IN ('in_progress', 'success', 'error', 'timeout', 'skipped'));

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -107,6 +107,25 @@ FROM ranked
 WHERE rn <= 5
 GROUP BY agent_definition_id;
 
+-- name: CountWorkflowsWithFailedLastRun :one
+-- Sidebar failure badge: how many preset-instantiated workflows have a most
+-- recent run that ended in error. Mirrors the per-card red dot on /workflows so
+-- the nav badge and the gallery agree. source_template IS NOT NULL scopes this
+-- to gallery workflows (excludes hand-authored agent definitions). Not gated on
+-- enabled — a paused-but-failing workflow still shows its dot on the card.
+WITH last_run AS (
+    SELECT DISTINCT ON (agent_definition_id)
+           agent_definition_id, status
+    FROM workflow_runs
+    WHERE agent_definition_id IS NOT NULL
+    ORDER BY agent_definition_id, started_at DESC
+)
+SELECT COUNT(*)::bigint
+FROM workflows w
+JOIN last_run lr ON lr.agent_definition_id = w.id
+WHERE w.source_template IS NOT NULL
+  AND lr.status = 'error';
+
 -- name: GetAgentCostStats30d :many
 -- Per-definition cost rollup over the last 30 days. Used by the admin
 -- list page to surface lifetime spend at a glance. Excludes skipped runs

--- a/internal/service/agent_orchestrator.go
+++ b/internal/service/agent_orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"breadbox/internal/agent"
@@ -78,18 +79,55 @@ type Orchestrator struct {
 	// sched is the agent scheduler this orchestrator notifies on CRUD changes.
 	// Wired via AttachScheduler after construction (avoids a chicken-and-egg).
 	sched *AgentScheduler
+
+	// inFlight maps an in-progress run's short_id to its run-context CancelFunc,
+	// so CancelRun can abort a specific run mid-flight (the run-detail "Cancel
+	// run" button). Registered when the async run goroutine starts and removed
+	// when it exits. Only this process's runs appear here.
+	inFlightMu sync.Mutex
+	inFlight   map[string]context.CancelFunc
 }
 
 // NewOrchestrator constructs an Orchestrator.
 // maxConcurrent < 1 is clamped to 1.
 func NewOrchestrator(svc *Service, runner agent.Runner, maxConcurrent int, encKey []byte, logger *slog.Logger) *Orchestrator {
 	return &Orchestrator{
-		svc:    svc,
-		runner: runner,
-		sem:    agent.NewSemaphore(maxConcurrent),
-		encKey: encKey,
-		logger: logger,
+		svc:      svc,
+		runner:   runner,
+		sem:      agent.NewSemaphore(maxConcurrent),
+		encKey:   encKey,
+		logger:   logger,
+		inFlight: make(map[string]context.CancelFunc),
 	}
+}
+
+// registerInFlight records an in-progress run's CancelFunc so CancelRun can
+// abort it. unregisterInFlight removes it (deferred on goroutine exit).
+func (o *Orchestrator) registerInFlight(shortID string, cancel context.CancelFunc) {
+	o.inFlightMu.Lock()
+	o.inFlight[shortID] = cancel
+	o.inFlightMu.Unlock()
+}
+
+func (o *Orchestrator) unregisterInFlight(shortID string) {
+	o.inFlightMu.Lock()
+	delete(o.inFlight, shortID)
+	o.inFlightMu.Unlock()
+}
+
+// CancelRun aborts an in-progress run by cancelling its run context, which
+// SIGKILLs the sidecar process group (see internal/agent/sidecar.go). The run
+// goroutine then persists a terminal 'cancelled' status. Returns true if the
+// run was found in-flight in THIS process; false means it already finished (or
+// is unknown here), and the caller should treat that as a no-op / conflict.
+func (o *Orchestrator) CancelRun(shortID string) bool {
+	o.inFlightMu.Lock()
+	cancel, ok := o.inFlight[shortID]
+	o.inFlightMu.Unlock()
+	if ok {
+		cancel()
+	}
+	return ok
 }
 
 // AttachScheduler wires the scheduler so NotifyDefinitionChanged can trigger
@@ -289,6 +327,10 @@ func (o *Orchestrator) RunNowAsyncWith(ctx context.Context, def *AgentDefinition
 	go func() {
 		runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
+		// Expose this run's cancel to CancelRun for the duration of the work, so
+		// the run-detail "Cancel run" button can abort it mid-flight.
+		o.registerInFlight(resp.ShortID, cancel)
+		defer o.unregisterInFlight(resp.ShortID)
 		defer o.sem.Release()
 		// Panic recovery — without this a panic from anywhere downstream
 		// (sidecar NDJSON parser, slog handler, DB driver) takes the whole
@@ -396,6 +438,18 @@ func (o *Orchestrator) prepareRun(ctx context.Context, def *AgentDefinitionRespo
 			return nil
 		}
 		result, runErr := o.runner.Run(runCtx, *spec, handler)
+
+		// Operator cancellation: CancelRun cancels runCtx (context.Canceled),
+		// which SIGKILLs the sidecar and surfaces here as a generic run error.
+		// Re-tag it as the terminal 'cancelled' status so the row reads as an
+		// intentional stop, not a failure. The 30-minute ceiling cancels with
+		// context.DeadlineExceeded instead, so this only catches operator (and
+		// shutdown) cancellation — timeout keeps its own status.
+		if errors.Is(runCtx.Err(), context.Canceled) {
+			result.Status = agent.StatusCancelled
+			result.Err = nil
+			runErr = nil
+		}
 
 		// Use a FRESH context for persist + hit-cap updates so a cancelled
 		// runCtx (timeout, server shutdown, or future caller passing a

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -46,7 +46,29 @@ var defaultAgentSystemPrompt = func() string {
 }()
 
 // DefaultAgentMaxTurns is the per-run turn cap when a definition omits one.
-const DefaultAgentMaxTurns = 10
+// 0 means UNLIMITED — the per-run cost budget (max_budget_usd) and the run
+// timeout are the real ceilings. A turn cap that bites before the budget just
+// abandons a half-finished run with money still on the table (the next run
+// redoes the setup work), so we don't impose one by default; an operator can
+// still set an explicit 1-100 cap in Advanced as a belt-and-suspenders backstop.
+const DefaultAgentMaxTurns = 0
+
+// sidecarMaxTurnsCap is the positive turn value handed to the sidecar when a
+// definition's cap is "unlimited" (0). The Claude Agent SDK / sidecar schema
+// requires a positive integer, so unlimited is expressed as a ceiling high
+// enough that the budget + 30-minute run timeout always bind first. Resolved
+// via sidecarMaxTurns() at spec-assembly time only — the DB still stores 0.
+const sidecarMaxTurnsCap = 1000
+
+// sidecarMaxTurns maps a definition's stored cap to the value the sidecar runs
+// with: an explicit positive cap passes through; 0/unlimited becomes the high
+// sidecarMaxTurnsCap so the budget is the practical ceiling.
+func sidecarMaxTurns(n int) int {
+	if n <= 0 {
+		return sidecarMaxTurnsCap
+	}
+	return n
+}
 
 // DefaultAgentMaxBudgetUSD mirrors the workflows migration default.
 // The column is NOT NULL, so we always send a value to sqlc.
@@ -1258,7 +1280,7 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 		Prompt:            def.Prompt,
 		SystemPrompt:      systemPrompt,
 		Model:             def.Model,
-		MaxTurns:          def.MaxTurns,
+		MaxTurns:          sidecarMaxTurns(def.MaxTurns),
 		MaxBudgetUsd:      maxBudget,
 		ToolScope:         def.ToolScope,
 		AllowedTools:      allowedTools,

--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -26,11 +26,12 @@ type WorkflowPreset struct {
 	PromptBlocks []string
 
 	// Default run configuration applied when the preset is enabled.
-	ToolScope             string // "read_only" | "read_write"
-	Model                 string // empty = DefaultAgentModel
-	MaxTurns              int    // 0 = DefaultAgentMaxTurns
-	ScheduleCron          string // empty = no cron
-	TriggerOnSyncComplete bool   // fire after each successful sync
+	ToolScope             string  // "read_only" | "read_write"
+	Model                 string  // empty = DefaultAgentModel
+	MaxTurns              int     // 0 = DefaultAgentMaxTurns
+	MaxBudgetUSD          float64 // 0 = DefaultAgentMaxBudgetUSD
+	ScheduleCron          string  // empty = no cron
+	TriggerOnSyncComplete bool    // fire after each successful sync
 
 	// OneOff marks an on-demand workflow: it has no recurring trigger (no cron,
 	// no post-sync) and runs only when a human hits "Run now". The gallery
@@ -81,10 +82,10 @@ var applyModeOption = WorkflowPresetOption{
 	Help:    "How it handles categories it's confident about.",
 	Default: "auto",
 	Choices: []WorkflowPresetChoice{
-		{Value: "auto", Label: "Auto-apply categories", Directive: ""},
+		{Value: "auto", Label: "Auto-apply", Directive: ""},
 		{
 			Value:     "flag_only",
-			Label:     "Flag only — don't categorize",
+			Label:     "Flag only",
 			Directive: "APPLY MODE — FLAG ONLY: Do NOT set, change, or clear any transaction category, and do NOT call update_transactions to write a category. Your job in this mode is review-and-flag only: flag transactions that need a human's attention (and leave a brief comment explaining why), but leave all categorization decisions to the user.",
 		},
 	},
@@ -101,10 +102,10 @@ var ruleApplyModeOption = WorkflowPresetOption{
 	Help:    "Both create the rules — choose whether to also backfill existing transactions.",
 	Default: "create_apply",
 	Choices: []WorkflowPresetChoice{
-		{Value: "create_apply", Label: "Create rules & backfill history", Directive: ""},
+		{Value: "create_apply", Label: "Create & backfill", Directive: ""},
 		{
 			Value:     "create_only",
-			Label:     "Create rules only — skip backfill",
+			Label:     "Create only",
 			Directive: "RULE HANDLING — CREATE ONLY: Create the vetted rules as usual (dry-run each first), but do NOT call apply_rules — skip the backfill. Rules take effect on the next sync; leave existing transactions untouched. In your report, give each rule's dry-run match count and note that nothing was backfilled.",
 		},
 	},
@@ -120,15 +121,15 @@ var lookbackWindowOption = WorkflowPresetOption{
 	Help:    "How far back each run scans for anomalies.",
 	Default: "7",
 	Choices: []WorkflowPresetChoice{
-		{Value: "7", Label: "Last 7 days", Directive: ""},
+		{Value: "7", Label: "7 days", Directive: ""},
 		{
 			Value:     "30",
-			Label:     "Last 30 days",
+			Label:     "30 days",
 			Directive: "LOOKBACK WINDOW — 30 DAYS: Scan the last 30 days, not the default 7. Wherever a step says \"last 7 days\", read it as \"last 30 days\". Establish baselines from the period immediately preceding the window so a one-month scan still has something to compare against.",
 		},
 		{
 			Value:     "90",
-			Label:     "Last 90 days",
+			Label:     "90 days",
 			Directive: "LOOKBACK WINDOW — 90 DAYS: Scan the last 90 days, not the default 7. Wherever a step says \"last 7 days\", read it as \"last 90 days\". This is a wide, catch-up sweep — prioritize the highest-signal findings and don't re-flag items a prior run already surfaced.",
 		},
 	},
@@ -143,10 +144,10 @@ var reportVerbosityOption = WorkflowPresetOption{
 	Help:    "How much detail each report carries.",
 	Default: "concise",
 	Choices: []WorkflowPresetChoice{
-		{Value: "concise", Label: "Concise — headline findings", Directive: ""},
+		{Value: "concise", Label: "Concise", Directive: ""},
 		{
 			Value:     "detailed",
-			Label:     "Detailed — full evidence",
+			Label:     "Detailed",
 			Directive: "REPORT VERBOSITY — DETAILED: Write a thorough report. For every flagged item include the full evidence trail (amounts, dates, merchant, account, and the baseline you compared against) and a one-line rationale. Open with a short summary of what you scanned and the headline count, then the itemized findings. When nothing is flagged, still summarize what you checked and why the window is clean.",
 		},
 	},
@@ -201,9 +202,13 @@ var workflowPresets = []WorkflowPreset{
 			"strategy-rule-foundation",
 			"category-system",
 		},
-		ToolScope:        "read_write", // creates + applies rules (dry-run first)
-		Model:            "claude-sonnet-4-6",
-		OneOff:           true,
+		ToolScope: "read_write", // creates + applies rules (dry-run first)
+		Model:     "claude-sonnet-4-6",
+		OneOff:    true,
+		// Foundational one-off: a single deep pass over 1000+ transactions that
+		// drafts and applies rules. Turns stay unlimited (budget-bound) so a large
+		// history isn't cut off mid-pass; the generous budget is the real ceiling.
+		MaxBudgetUSD:     3.00,
 		EstCostPerRunUSD: 0.50, // analyzes 1000+ transactions on Sonnet + drafts rules
 		Options:          []WorkflowPresetOption{ruleApplyModeOption},
 	},
@@ -218,9 +223,13 @@ var workflowPresets = []WorkflowPreset{
 			"review-depth-efficient",
 			"category-system",
 		},
-		ToolScope:        "read_write", // categorizes + clears needs-review on resolved items
-		Model:            "claude-haiku-4-5",
-		OneOff:           true,
+		ToolScope: "read_write", // categorizes + clears needs-review on resolved items
+		Model:     "claude-haiku-4-5",
+		OneOff:    true,
+		// Batch one-off: clears a large backlog in one pass. Haiku keeps the
+		// per-turn cost low, and turns stay unlimited so a deep backlog isn't
+		// abandoned mid-pass — the forgiving budget is what bounds the run.
+		MaxBudgetUSD:     2.00,
 		EstCostPerRunUSD: 0.20, // hundreds–thousands of transactions on Haiku
 		Options:          []WorkflowPresetOption{applyModeOption},
 	},
@@ -265,9 +274,12 @@ var workflowPresets = []WorkflowPreset{
 			"review-depth-thorough",
 			"category-system",
 		},
-		ToolScope:        "read_write",
-		ScheduleCron:     "0 7 * * 1", // Mondays at 07:00 (canonical "Weekly" — drawer-selectable)
-		EstCostPerRunUSD: 0.08,        // thorough pass over an accumulated backlog
+		ToolScope:    "read_write",
+		ScheduleCron: "0 7 * * 1", // Mondays at 07:00 (canonical "Weekly" — drawer-selectable)
+		// Weekly deep-clean over an aged backlog — heavier than the per-sync
+		// reviewer, so it gets a moderately higher budget; turns stay unlimited.
+		MaxBudgetUSD:     1.50,
+		EstCostPerRunUSD: 0.08, // thorough pass over an accumulated backlog
 		Options:          []WorkflowPresetOption{applyModeOption},
 	},
 	{
@@ -463,6 +475,13 @@ func (s *Service) EnableWorkflowFromPreset(ctx context.Context, slug string, par
 		if m := strings.TrimSpace(*params.Model); m != "" {
 			create.Model = m
 		}
+	}
+	// Preset budget default (e.g. the forgiving caps on the foundational/batch
+	// one-offs). A non-zero preset budget seeds the instance; the form override
+	// below still wins when the operator sets one explicitly.
+	if preset.MaxBudgetUSD > 0 {
+		b := preset.MaxBudgetUSD
+		create.MaxBudgetUSD = &b
 	}
 	if params.MaxTurns != nil && *params.MaxTurns > 0 {
 		create.MaxTurns = *params.MaxTurns

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -240,6 +240,8 @@ func agentRunAvatarTone(status string) string {
 		return "bg-error/10"
 	case "in_progress":
 		return "bg-info/10"
+	case "cancelled":
+		return "bg-warning/10"
 	case "skipped":
 		return "bg-base-200"
 	default:
@@ -255,6 +257,8 @@ func agentRunAvatarIcon(status string) string {
 		return "x"
 	case "timeout":
 		return "clock-alert"
+	case "cancelled":
+		return "ban"
 	case "skipped":
 		return "circle-dashed"
 	default:
@@ -268,6 +272,8 @@ func agentRunAvatarIconColor(status string) string {
 		return "text-success"
 	case "error", "timeout":
 		return "text-error"
+	case "cancelled":
+		return "text-warning"
 	default:
 		return "text-base-content/50"
 	}

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -21,6 +21,9 @@ type NavProps struct {
 	ConnectionsAttention int64
 	PendingReviews       int64
 	SeriesCandidates     int64
+	// WorkflowFailures is the count of workflows whose most recent run errored;
+	// > 0 lights a red badge on the Workflows link (mirrors the gallery red dot).
+	WorkflowFailures int64
 
 	// Profile footer
 	HasLinkedUser        bool
@@ -63,7 +66,7 @@ templ Nav(p NavProps) {
 		}
 		<div class="bb-sidebar-section">Manage</div>
 		if p.IsEditor {
-			@navLink("/workflows", "workflow", "Workflows", navActive(p.CurrentPage, "workflows"))
+			@navLinkBadge("/workflows", "workflow", "Workflows", navActive(p.CurrentPage, "workflows"), p.WorkflowFailures, "bb-nav-badge--error", workflowFailureTitle(p.WorkflowFailures))
 		}
 		if p.IsAdmin {
 			@navLink("/rules", "zap", "Rules", navActive(p.CurrentPage, "rules"))
@@ -235,4 +238,13 @@ func badgeCount(n int64) string {
 		return "99+"
 	}
 	return strconv.FormatInt(n, 10)
+}
+
+// workflowFailureTitle is the hover/collapsed-rail tooltip for the Workflows
+// failure badge, pluralized so "1 workflow" doesn't read as "1 workflows".
+func workflowFailureTitle(n int64) string {
+	if n == 1 {
+		return "1 workflow has a failed run"
+	}
+	return fmt.Sprintf("%d workflows have a failed run", n)
 }

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -144,6 +144,27 @@ templ agentRunDetailHeader(p AgentRunDetailProps) {
 			</div>
 		</div>
 		<div class="bb-run-header__actions">
+			<!-- Cancel run — only while in_progress. status is reactive (the live
+			     poll updates it), so this hides itself the moment the run lands
+			     a terminal status. x-cloak avoids a flash on terminal runs. -->
+			<button
+				type="button"
+				class="btn btn-sm btn-error btn-soft gap-2"
+				x-show="status === 'in_progress'"
+				x-cloak
+				title="Stop this run now"
+				@click="cancelRun()"
+				:disabled="cancelling"
+			>
+				<span x-show="!cancelling" class="contents">
+					@components.LucideIcon("square", "w-4 h-4")
+					Cancel run
+				</span>
+				<span x-show="cancelling" x-cloak class="contents">
+					<span class="loading loading-spinner loading-xs"></span>
+					Cancelling…
+				</span>
+			</button>
 			if effectiveRunPrompt(p) != "" {
 				<button
 					type="button"
@@ -193,6 +214,8 @@ templ agentRunSummaryStatus(status string) {
 			<span class="badge badge-soft badge-error badge-sm">timeout</span>
 		case "skipped":
 			<span class="badge badge-ghost badge-sm">skipped</span>
+		case "cancelled":
+			<span class="badge badge-soft badge-warning badge-sm">cancelled</span>
 		case "in_progress":
 			<span class="inline-flex items-center gap-1.5 text-primary text-sm">
 				<span class="loading loading-spinner loading-xs"></span>

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1548,6 +1548,70 @@ func kbdGlyphRefs() []kbdGlyphRef {
 
 // ─── Keyboard shortcut badges ──────────────────────────────────────────
 
+templ SectionRadioCard() {
+	<div class="flex flex-col gap-6">
+		@designExample("Trigger selector (2-up)", "The Workflows drawer's \"When should the workflow run?\" choice. Native radios share a name, so selection + the lit state work with no JS — click a card, tab between them, and watch the border / fill / icon flip to primary and the check appear.") {
+			<div class="grid grid-cols-2 gap-2 max-w-md">
+				@components.RadioCard(components.RadioCardProps{
+					Name:     "demo-trigger",
+					Value:    "custom",
+					Icon:     "calendar-clock",
+					Title:    "Custom schedule",
+					Subtitle: "On a recurring cron schedule",
+					Checked:  true,
+				})
+				@components.RadioCard(components.RadioCardProps{
+					Name:     "demo-trigger",
+					Value:    "sync",
+					Icon:     "refresh-cw",
+					Title:    "After each sync",
+					Subtitle: "Right after new data lands",
+				})
+			</div>
+		}
+		@designExample("Title only", "Drop the subtitle for a denser choice where the title carries the whole meaning.") {
+			<div class="grid grid-cols-3 gap-2 max-w-md">
+				@components.RadioCard(components.RadioCardProps{
+					Name:    "demo-scope",
+					Value:   "read",
+					Icon:    "eye",
+					Title:   "Read only",
+					Checked: true,
+				})
+				@components.RadioCard(components.RadioCardProps{
+					Name:  "demo-scope",
+					Value: "write",
+					Icon:  "pencil",
+					Title: "Read & write",
+				})
+				@components.RadioCard(components.RadioCardProps{
+					Name:  "demo-scope",
+					Value: "admin",
+					Icon:  "shield",
+					Title: "Full access",
+				})
+			</div>
+		}
+		@designExample("No icon", "Icons are optional — a card works with just a title (+ subtitle). Equal heights hold across the row even when one card's subtitle wraps.") {
+			<div class="grid grid-cols-2 gap-2 max-w-md">
+				@components.RadioCard(components.RadioCardProps{
+					Name:     "demo-plain",
+					Value:    "concise",
+					Title:    "Concise",
+					Subtitle: "Headline findings only",
+					Checked:  true,
+				})
+				@components.RadioCard(components.RadioCardProps{
+					Name:     "demo-plain",
+					Value:    "detailed",
+					Title:    "Detailed",
+					Subtitle: "Full evidence trail for every flagged item",
+				})
+			</div>
+		}
+	</div>
+}
+
 templ SectionThemeControls() {
 	<div class="flex flex-col gap-6">
 		@designExample("ThemeToggle (compact)", "Cycling icon button used in the sidebar + design navbar. One click steps system → light → dark → system; the glyph (monitor / sun / moon) reflects the current preference, so \"system\" stays distinguishable. Backed by $store.theme — try it and watch the navbar toggle above stay in sync.") {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -227,6 +227,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionFormControls() },
 		},
 		{
+			Slug:        "radio-card",
+			Title:       "Radio card",
+			Description: "components.RadioCard — a radio styled as a selectable icon+title+subtitle tile. The \"pick one of a few, each worth a sentence\" control (roomier than a bare radio list, lighter than a wizard step). Powers the Workflows drawer trigger choice (Custom schedule vs After each sync). Hover lifts the surface, keyboard focus rings the card, the chosen tile flips to primary with a check; native or Alpine-bound.",
+			Group:       "forms",
+			Render:      func() templ.Component { return SectionRadioCard() },
+		},
+		{
 			Slug:        "filter-search-input",
 			Title:       "Filter search input",
 			Description: "Client-side filter input — daisy input + leading search icon + x-model binding for Alpine-driven row filtering. Use components.FilterSearchInput on /categories, /tags, and future inline-filter list pages.",

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -159,6 +159,20 @@ templ workflowReconfigureDrawer() {
 				@workflowAdvancedFields("reconfigure.maxTurns", "reconfigure.maxBudget")
 			</div>
 			@components.DrawerFooter() {
+				<!-- Destructive reset: removes the instantiated workflow and
+				     returns the card to its un-configured "Set up" state. Subtle
+				     ghost-error icon button so it reads as available-but-quiet,
+				     not a primary action. Confirms via bbConfirm before deleting. -->
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm btn-square text-error/70 hover:text-error tooltip tooltip-top"
+					data-tip="Remove workflow"
+					@click="removeWorkflow()"
+					x-bind:disabled="reconfigure.loading"
+					aria-label="Remove workflow"
+				>
+					@components.LucideIcon("trash-2", "w-4 h-4")
+				</button>
 				<button
 					type="button"
 					class="btn btn-soft btn-sm gap-1.5 mr-auto"
@@ -378,7 +392,7 @@ templ workflowOneOffControls(preset WorkflowPresetCardProps, isAdmin bool) {
 			type="button"
 			class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
 			data-tip="Run now"
-			@click={ "runOneOff('" + preset.Slug + "')" }
+			@click={ "runOneOff('" + preset.Slug + "', '" + preset.Name + "')" }
 			x-bind:disabled={ "runningOneOff['" + preset.Slug + "']" }
 			aria-label={ "Run " + preset.Name + " now" }
 		>
@@ -431,26 +445,23 @@ templ workflowTriggerFields(triggerVar, cronVar string) {
 	<div>
 		<div class="text-sm font-medium mb-2">When should the workflow run?</div>
 		<div class="grid grid-cols-2 gap-2">
-			<label class="cursor-pointer">
-				<input type="radio" name="trigger_on_sync" value="false" x-model={ triggerVar } @change={ "describeCron(" + cronVar + ")" } class="peer sr-only"/>
-				<div class="rounded-xl border border-base-300 p-3 h-full transition-colors peer-checked:border-primary peer-checked:bg-primary/5">
-					<div class="flex items-center gap-2">
-						@components.LucideIcon("calendar-clock", "w-4 h-4 text-base-content/60")
-						<span class="text-sm font-medium">Custom schedule</span>
-					</div>
-					<div class="text-xs text-base-content/55 mt-1">On a recurring cron schedule</div>
-				</div>
-			</label>
-			<label class="cursor-pointer">
-				<input type="radio" name="trigger_on_sync" value="true" x-model={ triggerVar } class="peer sr-only"/>
-				<div class="rounded-xl border border-base-300 p-3 h-full transition-colors peer-checked:border-primary peer-checked:bg-primary/5">
-					<div class="flex items-center gap-2">
-						@components.LucideIcon("refresh-cw", "w-4 h-4 text-base-content/60")
-						<span class="text-sm font-medium">After each sync</span>
-					</div>
-					<div class="text-xs text-base-content/55 mt-1">Right after new data lands</div>
-				</div>
-			</label>
+			@components.RadioCard(components.RadioCardProps{
+				Name:       "trigger_on_sync",
+				Value:      "false",
+				Icon:       "calendar-clock",
+				Title:      "Custom schedule",
+				Subtitle:   "On a recurring cron schedule",
+				ModelExpr:  triggerVar,
+				ChangeExpr: "describeCron(" + cronVar + ")",
+			})
+			@components.RadioCard(components.RadioCardProps{
+				Name:      "trigger_on_sync",
+				Value:     "true",
+				Icon:      "refresh-cw",
+				Title:     "After each sync",
+				Subtitle:  "Right after new data lands",
+				ModelExpr: triggerVar,
+			})
 		</div>
 		<div x-show={ triggerVar + " === 'false'" } x-cloak class="mt-3 space-y-2">
 			<div class="text-xs font-medium text-base-content/70">Schedule</div>
@@ -540,7 +551,7 @@ templ workflowAdvancedFields(turnsVar, budgetVar string) {
 				<div>
 					<div class="text-xs font-medium text-base-content/60 mb-1.5">Max turns</div>
 					<label class="input input-sm flex items-center gap-1.5 w-full">
-						<input type="number" name="max_turns" x-model={ turnsVar } min="0" max="100" step="1" class="grow tabular-nums" placeholder="10"/>
+						<input type="number" name="max_turns" x-model={ turnsVar } min="0" max="100" step="1" class="grow tabular-nums" placeholder="∞ unlimited"/>
 						<span class="text-[11px] text-base-content/35 font-medium">turns</span>
 					</label>
 				</div>
@@ -553,7 +564,7 @@ templ workflowAdvancedFields(turnsVar, budgetVar string) {
 					</label>
 				</div>
 			</div>
-			<p class="text-[11px] text-base-content/40 mt-2">A run stops at whichever limit it reaches first. Leave blank for the workflow's defaults.</p>
+			<p class="text-[11px] text-base-content/40 mt-2">Cost is the real ceiling — a run stops when it's done or hits the budget. Leave turns blank for unlimited (recommended); set a cap only as a backstop against runaway loops.</p>
 		</div>
 	</div>
 }
@@ -563,7 +574,8 @@ templ workflowAdvancedFields(turnsVar, budgetVar string) {
 // to the workflow default (10 turns / $1.00); an explicit 0 is preserved
 // (0 = no cap), so the ternaries test for empty/null rather than falsiness.
 func workflowAdvancedSummaryExpr(turnsVar, budgetVar string) string {
-	turns := "(" + turnsVar + " === '' || " + turnsVar + " == null ? '10' : " + turnsVar + ")"
+	// Blank/0 turns = unlimited (budget-bound) → render ∞ rather than a number.
+	turns := "(" + turnsVar + " === '' || " + turnsVar + " == null || Number(" + turnsVar + ") <= 0 ? '∞' : " + turnsVar + ")"
 	budget := "(" + budgetVar + " === '' || " + budgetVar + " == null ? '1.00' : Number(" + budgetVar + ").toFixed(2))"
 	return turns + " + ' turns · $' + " + budget
 }

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -22,13 +22,20 @@ func workflowConfigDrawerData(p WorkflowPresetCardProps) string {
 	if cron == "" {
 		cron = "0 8 * * *"
 	}
-	turns := p.MaxTurns
-	if turns <= 0 {
-		turns = 10
+	// max_turns: 0/unset means unlimited (budget is the ceiling), so seed the
+	// field BLANK rather than a number — the Advanced summary + placeholder then
+	// render it as ∞ / unlimited.
+	turnsStr := ""
+	if p.MaxTurns > 0 {
+		turnsStr = fmt.Sprintf("%d", p.MaxTurns)
+	}
+	budget := p.MaxBudgetUSD
+	if budget <= 0 {
+		budget = 1.0
 	}
 	return fmt.Sprintf(
-		"{ triggerOnSync: '%s', cron: '%s', model: '%s', maxTurns: '%d', maxBudget: '%s', consent: false }",
-		trigger, cron, p.Model, turns, "1",
+		"{ triggerOnSync: '%s', cron: '%s', model: '%s', maxTurns: '%s', maxBudget: '%.2f', consent: false }",
+		trigger, cron, p.Model, turnsStr, budget,
 	)
 }
 
@@ -150,10 +157,12 @@ type WorkflowPresetCardProps struct {
 	TriggerOnSync    bool    // default trigger: true = post-sync; user-switchable in the drawer
 	EstCostPerRunUSD float64 // rough per-run cost estimate for the projected-cost hint
 
-	// Model / MaxTurns seed the setup drawer's model select + Advanced
-	// section. Resolved to non-empty/non-zero defaults by the page handler.
-	Model    string
-	MaxTurns int
+	// Model / MaxTurns / MaxBudgetUSD seed the setup drawer's model select +
+	// Advanced section. Resolved to non-empty/non-zero defaults by the page
+	// handler (a preset may carry a more forgiving budget for larger tasks).
+	Model        string
+	MaxTurns     int
+	MaxBudgetUSD float64
 
 	// OneOff marks an on-demand workflow: the card renders copy/run/settings
 	// icon buttons instead of a run toggle, and the setup drawer drops the

--- a/internal/templates/components/radio_card.templ
+++ b/internal/templates/components/radio_card.templ
@@ -1,0 +1,79 @@
+package components
+
+// RadioCard is a radio input styled as a selectable card — an icon + title +
+// optional subtitle in a bordered tile that lights up (primary border, soft
+// primary fill, primary icon, a check affordance) when chosen. It's the
+// "pick one of a few options, each worth a sentence" control: roomier and more
+// legible than a bare radio list, lighter than a wizard step. The Workflows
+// drawer uses a 2-up pair for the trigger choice (Custom schedule vs After each
+// sync); drop N of them into a grid for more.
+//
+// Binding is flexible so the same card works server-rendered or Alpine-driven:
+//   - Native: set Checked on the default card and share Name across the group;
+//     the browser owns selection and the CSS (peer-checked / has-checked)
+//     reacts live — no JS needed (this is how the sandbox renders them).
+//   - Alpine: pass ModelExpr (an x-model target) and, if needed, ChangeExpr
+//     (an @change handler). The same checked-state CSS reacts to the DOM state
+//     Alpine maintains.
+//
+// Interactions: hover lifts the border + surface; keyboard focus (the visually
+// hidden input is still tabbable) draws a focus-visible ring on the card; the
+// chosen card flips its border, fill, and icon to primary and reveals a check.
+type RadioCardProps struct {
+	// Name is the radio group's form field — shared across the cards in one
+	// choice. Required.
+	Name string
+	// Value is this card's submitted value. Required.
+	Value string
+	// Icon is an optional lucide name shown left of the title; it inherits the
+	// card's color so it tints primary when selected.
+	Icon string
+	// Title is the card's headline. Required.
+	Title string
+	// Subtitle is an optional one-line caption under the title.
+	Subtitle string
+	// ModelExpr is an Alpine x-model target (e.g. "reconfigure.triggerOnSync").
+	// Empty = native/server-rendered selection via Checked.
+	ModelExpr string
+	// ChangeExpr is an optional Alpine @change handler expression.
+	ChangeExpr string
+	// Checked server-renders this card as the default selection (used for the
+	// native path; with ModelExpr, Alpine drives the state instead).
+	Checked bool
+	// Class adds extra classes to the label wrapper (rare).
+	Class string
+}
+
+templ RadioCard(p RadioCardProps) {
+	<label class={ "group block h-full cursor-pointer", p.Class }>
+		<input
+			type="radio"
+			name={ p.Name }
+			value={ p.Value }
+			if p.ModelExpr != "" {
+				x-model={ p.ModelExpr }
+			}
+			if p.ChangeExpr != "" {
+				@change={ p.ChangeExpr }
+			}
+			if p.Checked {
+				checked
+			}
+			class="peer sr-only"
+		/>
+		<div class="flex h-full flex-col rounded-xl border border-base-300 bg-base-100 p-3 text-base-content/55 transition-all duration-150 hover:border-base-content/25 hover:bg-base-200/40 peer-focus-visible:border-primary peer-focus-visible:ring-2 peer-focus-visible:ring-primary/30 peer-checked:border-primary peer-checked:bg-primary/5 peer-checked:text-primary peer-checked:hover:bg-primary/5">
+			<div class="flex items-center gap-2">
+				if p.Icon != "" {
+					@LucideIcon(p.Icon, "w-4 h-4 shrink-0")
+				}
+				<span class="text-sm font-medium text-base-content">{ p.Title }</span>
+				<span class="ml-auto inline-flex shrink-0 text-primary opacity-0 scale-90 transition-all duration-150 group-has-[:checked]:opacity-100 group-has-[:checked]:scale-100">
+					@LucideIcon("check", "w-4 h-4")
+				</span>
+			</div>
+			if p.Subtitle != "" {
+				<div class="mt-1 text-xs text-base-content/55">{ p.Subtitle }</div>
+			}
+		</div>
+	</label>
+}

--- a/static/js/admin/components/agent_run_detail.js
+++ b/static/js/admin/components/agent_run_detail.js
@@ -41,6 +41,7 @@ document.addEventListener('alpine:init', function () {
       workflowSlug: '',
       csrfToken: '',
       rerunning: false,
+      cancelling: false,
       copiedPrompt: false,
 
       init: function () {
@@ -212,12 +213,13 @@ document.addEventListener('alpine:init', function () {
           }
           // Fire a toast on terminal transition so the operator notices
           // even if they scrolled away.
-          if (body.status === 'success' || body.status === 'error') {
+          if (body.status === 'success' || body.status === 'error' || body.status === 'cancelled') {
+            var doneMsg = 'Run completed.';
+            var doneType = 'success';
+            if (body.status === 'error') { doneMsg = 'Run failed.'; doneType = 'error'; }
+            else if (body.status === 'cancelled') { doneMsg = 'Run cancelled.'; doneType = 'warning'; }
             window.dispatchEvent(new CustomEvent('bb-toast', {
-              detail: {
-                message: 'Run ' + (body.status === 'success' ? 'completed' : 'failed') + '.',
-                type: body.status === 'success' ? 'success' : 'error',
-              },
+              detail: { message: doneMsg, type: doneType },
             }));
           }
         }
@@ -328,6 +330,63 @@ document.addEventListener('alpine:init', function () {
               detail: { message: err.message || 'Could not start the run.', type: 'error' },
             }));
             console.warn('[agent run rerun]', err);
+          });
+      },
+
+      // cancelRun aborts an in-progress run. Confirms first (work done so far is
+      // kept, the rest is abandoned), then POSTs to the cancel endpoint. The
+      // server SIGKILLs the sidecar and lands the row as 'cancelled'; the live
+      // poll picks that up and the button hides itself (x-show on status).
+      cancelRun: function () {
+        if (this.cancelling || this.status !== 'in_progress') return;
+        var self = this;
+        var go = function () { self._doCancel(); };
+        if (typeof window.bbConfirm !== 'function') {
+          if (window.confirm('Stop this run now? Work done so far is kept; the rest is abandoned.')) go();
+          return;
+        }
+        window.bbConfirm({
+          title: 'Cancel this run?',
+          message: 'Stop the run now. Anything it has already written is kept; the remaining work is abandoned. You can re-run it afterwards.',
+          confirmLabel: 'Cancel run',
+          variant: 'danger',
+        }).then(function (ok) { if (ok) go(); });
+      },
+
+      _doCancel: function () {
+        if (this.cancelling) return;
+        this.cancelling = true;
+        var self = this;
+        fetch('/-/workflows/runs/' + encodeURIComponent(this.shortId) + '/cancel', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Accept': 'application/json', 'X-CSRF-Token': this.csrfToken },
+        })
+          .then(function (res) {
+            return res.json().catch(function () { return null; }).then(function (body) {
+              return { ok: res.ok || res.status === 202, body: body };
+            });
+          })
+          .then(function (r) {
+            if (!r.ok) {
+              var msg = (r.body && r.body.error && r.body.error.message) || 'Could not cancel the run.';
+              throw new Error(msg);
+            }
+            window.dispatchEvent(new CustomEvent('bb-toast', {
+              detail: { message: 'Cancelling run…', type: 'info' },
+            }));
+            // Nudge a poll soon so the terminal status lands promptly instead of
+            // waiting a full cadence; the poller hides the button once it flips.
+            if (self.pollTimer) clearTimeout(self.pollTimer);
+            self.pollTimer = setTimeout(function () { self.poll(); }, 1200);
+          })
+          .catch(function (err) {
+            self.cancelling = false;
+            self.restorePageState();
+            window.dispatchEvent(new CustomEvent('bb-toast', {
+              detail: { message: err.message || 'Could not cancel the run.', type: 'error' },
+            }));
+            console.warn('[agent run cancel]', err);
           });
       },
     };

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -336,7 +336,30 @@ document.addEventListener('alpine:init', function () {
       // instant, then a goroutine does the actual work). So we hold the spinner
       // up (runningOneOff[slug]) through the whole run by polling the run's
       // status until it reaches a terminal state — not just for the dispatch.
-      runOneOff: function (slug) {
+      runOneOff: function (slug, name) {
+        var self = this;
+        if (self.runningOneOff[slug]) return; // guard against a double-click
+        name = name || slug;
+        var go = function () { self._dispatchOneOff(slug); };
+        // Confirm before spending: a one-off runs Claude over the household's
+        // ledger and bills the Anthropic account, so gate the click behind the
+        // shared confirm overlay (amber/cost tone, not destructive-red).
+        if (typeof window.bbConfirm !== 'function') {
+          if (window.confirm('Run "' + name + '" now? This runs Claude over your financial data and incurs API cost.')) go();
+          return;
+        }
+        window.bbConfirm({
+          title: 'Run workflow now?',
+          message: 'Run "' + name + '" now? It runs Claude over your household’s financial data and incurs Anthropic API cost.',
+          confirmLabel: 'Run now',
+          variant: 'warning',
+        }).then(function (ok) { if (ok) go(); });
+      },
+
+      // _dispatchOneOff performs the actual run dispatch (instantiate-on-first-use
+      // + async run + spinner poll). Split out of runOneOff so the confirm gate
+      // wraps it without duplicating the dispatch logic.
+      _dispatchOneOff: function (slug) {
         var self = this;
         if (self.runningOneOff[slug]) return; // guard against a double-click
         self.runningOneOff[slug] = true;
@@ -588,6 +611,44 @@ document.addEventListener('alpine:init', function () {
           .catch(function (e) {
             console.error('submitReconfigure failed', e);
             if (btn) btn.disabled = false;
+            self.restorePageState();
+          });
+      },
+
+      // Remove a configured workflow — deletes its agent_definition, resetting
+      // the preset card back to "Set up". Confirms first via the shared
+      // bbConfirm overlay (the schedule stops; run history survives the
+      // SET NULL FK), then POSTs to /-/workflows/{slug}/delete and reloads.
+      // Falls back to a native confirm only if bbConfirm hasn't loaded.
+      removeWorkflow: function (slug, name) {
+        var self = this;
+        slug = slug || self.reconfigure.slug;
+        if (!slug) return;
+        name = name || self.reconfigure.name || 'this workflow';
+        var doRemove = function () { self._doRemoveWorkflow(slug); };
+        if (typeof window.bbConfirm !== 'function') {
+          if (window.confirm('Remove "' + name + '"? This resets it back to a preset. Run history is kept.')) doRemove();
+          return;
+        }
+        window.bbConfirm({
+          title: 'Remove workflow?',
+          message: 'Remove "' + name + '"? It resets back to a preset you can set up again. The schedule stops and run history is kept.',
+          confirmLabel: 'Remove workflow',
+          variant: 'danger',
+        }).then(function (ok) { if (ok) doRemove(); });
+      },
+
+      _doRemoveWorkflow: function (slug) {
+        var self = this;
+        self._post('/-/workflows/' + encodeURIComponent(slug) + '/delete')
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            self.toast('Workflow removed.', 'success');
+            setTimeout(function () { window.location.reload(); }, 500);
+          })
+          .catch(function (e) {
+            console.error('removeWorkflow failed', e);
+            self.toast('Could not remove the workflow.', 'error');
             self.restorePageState();
           });
       },


### PR DESCRIPTION
Polishes the Workflows gallery/drawer surface and adds run controls — segment + label cleanup, a reusable RadioCard trigger selector, run cancellation, unlimited-by-default turns (budget is the real cap), an app-wide markdown-prose fix, and a sidebar failure badge.

## Changes

- **Drawer polish.** Shorten option segment labels (the `Help:` line already carries the detail), extract a reusable `components.RadioCard` for the trigger selector (hover / keyboard-focus / selected states) and sandbox it at `/design/c/radio-card`, and add a destructive **Remove** control to the reconfigure drawer (deletes the workflow → resets the card to "Set up").
- **Cancel a run mid-run.** A "Cancel run" button on `/workflows/runs/{id}` aborts an in-progress run via a new orchestrator in-flight registry that cancels the run context — SIGKILLing the sidecar process group (existing `Setpgid` + `Cmd.Cancel`). The run lands a new terminal **`cancelled`** status (additive `CHECK` migration; `ctx.Canceled` → cancelled, the 30-min ceiling still → timeout). Single-writer, no status race.
- **Unlimited turns by default.** `max_turns` now defaults to `0 = unlimited` so the **cost budget is the real ceiling** — a turn cap that bites first abandons half-finished work and pays for the redo. The sidecar (which requires a positive int) gets a high cap; presets keep their forgiving budgets and drop explicit turn caps. Advanced copy reframed (placeholder `∞ unlimited`, summary `∞ turns · $X`).
- **Confirm before running a one-off** workflow (it runs Claude over the ledger and incurs API cost).
- **Markdown app-wide.** Production already uses marked.js everywhere; `.bb-prose` only styled the design-sandbox Go renderer's classed output, so marked's plain tags fell through unstyled. Teach `.bb-prose` to style plain tags (color-inherit-safe) → the prompt preview + agent-run prompts/transcript render styled (matching `/reports`). No new dependency.
- **Sidebar failure badge.** A red badge on the Workflows nav when a workflow's most recent run errored (mirrors the gallery card red dot), via a cheap `CountWorkflowsWithFailedLastRun` + the existing `NavBadgesMiddleware`.

## Screenshots

<table>
  <tr><th>Setup drawer (segments + trigger cards + budget)</th><th>Reconfigure (Remove button)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/i0i7weeilc.jpg" width="420" alt="setup drawer"></td>
    <td><img src="https://i.img402.dev/nkn906ok6l.jpg" width="420" alt="reconfigure drawer with remove"></td>
  </tr>
  <tr><th>Prompt preview (markdown fixed)</th><th>Cancel run button</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/lhfc9ab1yq.jpg" width="420" alt="prompt preview markdown"></td>
    <td><img src="https://i.img402.dev/ghkazwv61w.jpg" width="420" alt="cancel run button"></td>
  </tr>
</table>

RadioCard sandbox section:

<img src="https://i.img402.dev/cfv1fsuqpk.jpg" width="800" alt="radio card design sandbox">

## Test plan

- [x] `go build ./...` + `-tags=headless` + `-tags=lite` + `go vet ./...` green
- [x] Full unit suite (`go test ./...`) green
- [x] Full integration suite (`go test -tags integration -p 1 ./...`) green — new `cancelled` CHECK migration applies cleanly to `breadbox_test`
- [x] Browser-validated: setup/reconfigure drawers, shortened segments, RadioCard states, prompt-preview markdown, sidebar failure badge, Cancel-run button (in-progress) + `cancelled` badge
- [ ] Reviewer: confirm the `cancelled` status migration is acceptable on the shared/prod DB (additive `CHECK` superset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
