### PR TITLE
feat(ui): redesign MCP settings as a Providers-style directory + edit drawers

### DIFF
--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -7,151 +7,283 @@ import (
 	"breadbox/internal/templates/components"
 )
 
-// AgentsSettings renders the MCP tab — Server Instructions, Review
-// Guidelines, Report Format, Tools Enabled, and a read-only Connection
-// cheatsheet. Each block is a SettingsSection
-// (.claude/rules/settings.md) with its own form / footer save.
+// AgentsSettings renders the MCP tab as a compact directory modeled on the
+// Providers tab: a short list of rows grouped into sections, each row
+// opening a slide-over Drawer for the actual editing. The heavy surfaces
+// — the three agent prompts (server instructions, review guidelines,
+// report format) and the per-tool enable list — plus the read-only
+// connection cheatsheet all live in drawers keyed `mcp-<resource>` on the
+// global $store.drawers store, so the page itself stays a scannable list
+// that scales by adding one row + one drawer. See .claude/rules/settings.md.
 //
-// POST targets remain at /mcp-settings/* — only the visual changed.
+// POST targets keep their /mcp-settings/* paths — only the chrome changed.
 templ AgentsSettings(p AgentsSettingsProps) {
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
 			Title:    "MCP",
-			Subtitle: "Server instructions, review guidelines, report format, and per-tool toggles",
+			Subtitle: "Agent prompts, tool access, and connection details for the MCP server",
 		})
-		<div class="space-y-6">
-			@agentsSettingsInstructionsSection(p)
-			@agentsSettingsReviewGuidelinesSection(p)
-			@agentsSettingsReportFormatSection(p)
-			@agentsSettingsToolsSection(p)
-			@agentsSettingsConnectionSection()
-		</div>
-	</div>
-	<script>
-		(function () {
-			if (!location.hash) return;
-			var el = document.querySelector(location.hash);
-			if (el) setTimeout(function () { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
-		})();
-	</script>
-}
-
-// ---------------------------------------------------------------------
-// Long-form textarea sections (Instructions, Guidelines, Report Format)
-// ---------------------------------------------------------------------
-
-templ agentsSettingsInstructionsSection(p AgentsSettingsProps) {
-	<div
-		id="instructions"
-		x-data={ fmt.Sprintf("{ instructions: %s, defaultInstructions: %s, async resetToDefaults() { const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current instructions will be replaced with the default server instructions.',confirmLabel:'Reset',variant:'warning'}); if (ok) { this.instructions = this.defaultInstructions; } } }", jsString(p.Instructions), jsString(p.DefaultInstructions)) }
-	>
 		@components.SettingsSection(components.SettingsSectionProps{
 			Icon:    "scroll-text",
-			Title:   "Server Instructions",
-			Caption: "Sent to agents when they connect via MCP",
-			Form: &components.SettingsSectionFormProps{
-				Action:    "/mcp-settings/instructions",
-				CSRFToken: p.CSRFToken,
-			},
-			Footer: agentsSettingsSaveResetFooter("Save Instructions"),
+			Title:   "Agent prompts",
+			Caption: "Guidance served to agents over MCP — open a row to edit",
 		}) {
-			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-				<div role="alert" class="alert alert-warning alert-soft text-xs">
-					@components.LucideIcon("triangle-alert", "w-4 h-4")
-					<span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
-				</div>
-			}
-			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-				<textarea name="instructions" class="textarea font-mono text-xs leading-relaxed w-full" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
-				<p class="text-xs text-base-content/40 mt-1.5" x-text="instructions.length + '/20000'"></p>
-			}
+			@mcpRow(mcpRowData{
+				ID:    "instructions",
+				Icon:  "scroll-text",
+				Name:  "Server instructions",
+				Desc:  "Sent to agents when they connect via MCP",
+				Right: mcpCustomizedStatus(p.Instructions != p.DefaultInstructions),
+			})
+			@mcpRow(mcpRowData{
+				ID:    "review-guidelines",
+				Icon:  "book-open",
+				Name:  "Review guidelines",
+				Desc:  "Served as breadbox://review-guidelines during reviews",
+				Right: mcpCustomizedStatus(p.ReviewGuidelines != p.DefaultReviewGuidelines),
+			})
+			@mcpRow(mcpRowData{
+				ID:    "report-format",
+				Icon:  "file-text",
+				Name:  "Report format",
+				Desc:  "Served as breadbox://report-format when submitting reports",
+				Right: mcpCustomizedStatus(p.ReportFormat != p.DefaultReportFormat),
+			})
 		}
-	</div>
-}
-
-templ agentsSettingsReviewGuidelinesSection(p AgentsSettingsProps) {
-	<div
-		id="review-guidelines"
-		x-data={ fmt.Sprintf("{ guidelines: %s, defaultGuidelines: %s, async resetToDefaults() { const ok = await bbConfirm({title:'Reset to defaults?',message:'Your review guidelines will be replaced with the defaults.',confirmLabel:'Reset',variant:'warning'}); if (ok) { this.guidelines = this.defaultGuidelines; } } }", jsString(p.ReviewGuidelines), jsString(p.DefaultReviewGuidelines)) }
-	>
-		@components.SettingsSection(components.SettingsSectionProps{
-			Icon:    "book-open",
-			Title:   "Review Guidelines",
-			Caption: "Served as breadbox://review-guidelines to agents during reviews",
-			Form: &components.SettingsSectionFormProps{
-				Action:    "/mcp-settings/review-guidelines",
-				CSRFToken: p.CSRFToken,
-			},
-			Footer: agentsSettingsSaveResetFooterGuidelines(),
-		}) {
-			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-				<textarea name="review_guidelines" class="textarea font-mono text-xs leading-relaxed w-full" style="min-height: 20rem" maxlength="30000" x-model="guidelines" placeholder="Review guidelines for agents..."></textarea>
-				<p class="text-xs text-base-content/40 mt-1.5" x-text="guidelines.length + '/30000'"></p>
-			}
-		}
-	</div>
-}
-
-templ agentsSettingsReportFormatSection(p AgentsSettingsProps) {
-	<div
-		id="report-format"
-		x-data={ fmt.Sprintf("{ reportFormat: %s, defaultReportFormat: %s, async resetToDefaults() { const ok = await bbConfirm({title:'Reset to defaults?',message:'Your report format will be replaced with the defaults.',confirmLabel:'Reset',variant:'warning'}); if (ok) { this.reportFormat = this.defaultReportFormat; } } }", jsString(p.ReportFormat), jsString(p.DefaultReportFormat)) }
-	>
-		@components.SettingsSection(components.SettingsSectionProps{
-			Icon:    "file-text",
-			Title:   "Report Format",
-			Caption: "Served as breadbox://report-format to agents when submitting reports",
-			Form: &components.SettingsSectionFormProps{
-				Action:    "/mcp-settings/report-format",
-				CSRFToken: p.CSRFToken,
-			},
-			Footer: agentsSettingsSaveResetFooterReport(),
-		}) {
-			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-				<textarea name="report_format" class="textarea font-mono text-xs leading-relaxed w-full" style="min-height: 20rem" maxlength="20000" x-model="reportFormat" placeholder="Report format guidelines for agents..."></textarea>
-				<p class="text-xs text-base-content/40 mt-1.5" x-text="reportFormat.length + '/20000'"></p>
-			}
-		}
-	</div>
-}
-
-// Footer slot variants — one per textarea section because the Reset
-// handler is bound to a sibling x-data scope that lives on the section
-// root and the templ component receives no props.
-templ agentsSettingsSaveResetFooter(saveLabel string) {
-	<button type="button" class="btn btn-ghost btn-sm" @click="resetToDefaults()">Reset to defaults</button>
-	<button type="submit" class="btn btn-primary btn-sm">{ saveLabel }</button>
-}
-
-templ agentsSettingsSaveResetFooterGuidelines() {
-	@agentsSettingsSaveResetFooter("Save Guidelines")
-}
-
-templ agentsSettingsSaveResetFooterReport() {
-	@agentsSettingsSaveResetFooter("Save Format")
-}
-
-// ---------------------------------------------------------------------
-// Tools toggle list
-// ---------------------------------------------------------------------
-
-templ agentsSettingsToolsSection(p AgentsSettingsProps) {
-	<div id="tools">
 		@components.SettingsSection(components.SettingsSectionProps{
 			Icon:    "wrench",
-			Title:   "Tools Enabled",
-			Caption: agentsSettingsToolsSummary(p),
-			Form: &components.SettingsSectionFormProps{
-				Action:    "/mcp-settings/tools",
-				CSRFToken: p.CSRFToken,
-			},
-			Footer: agentsSettingsToolsFooter(),
+			Title:   "Tools",
+			Caption: "Which MCP tools agents are allowed to call",
 		}) {
-			@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-				<p class="text-xs text-base-content/50">Disabled tools are hidden from all agents. Read-only API keys cannot invoke write tools regardless of this setting.</p>
+			@mcpRow(mcpRowData{
+				ID:    "tools",
+				Icon:  "wrench",
+				Name:  "Enabled tools",
+				Desc:  "Toggle individual tools on or off for every agent",
+				Right: mcpToolsCountStatus(p.ToolsEnabledCount, p.ToolsTotalCount),
+			})
+		}
+		@components.SettingsSection(components.SettingsSectionProps{
+			BrandIcon: "model-context-protocol",
+			Title:     "Connection",
+			Caption:   "Endpoints and Claude Desktop config for connecting agents",
+		}) {
+			@mcpRow(mcpRowData{
+				ID:   "connection",
+				Icon: "plug",
+				Name: "Connection details",
+				Desc: "HTTP endpoint, stdio command, and a ready-to-paste config",
+			})
+		}
+		// Drawers — fixed-position, rendered after the sections; only the
+		// one matching the open id (plus its scrim) shows.
+		@mcpPromptDrawer(mcpPromptDrawerData{
+			ID:        "instructions",
+			Icon:      "scroll-text",
+			Title:     "Server instructions",
+			Subtitle:  "Sent to agents when they connect via MCP",
+			Action:    "/mcp-settings/instructions",
+			Field:     "instructions",
+			Value:     p.Instructions,
+			Default:   p.DefaultInstructions,
+			MaxLength: 20000,
+			Warn:      true,
+			CSRFToken: p.CSRFToken,
+		})
+		@mcpPromptDrawer(mcpPromptDrawerData{
+			ID:        "review-guidelines",
+			Icon:      "book-open",
+			Title:     "Review guidelines",
+			Subtitle:  "Served as breadbox://review-guidelines during reviews",
+			Action:    "/mcp-settings/review-guidelines",
+			Field:     "review_guidelines",
+			Value:     p.ReviewGuidelines,
+			Default:   p.DefaultReviewGuidelines,
+			MaxLength: 30000,
+			CSRFToken: p.CSRFToken,
+		})
+		@mcpPromptDrawer(mcpPromptDrawerData{
+			ID:        "report-format",
+			Icon:      "file-text",
+			Title:     "Report format",
+			Subtitle:  "Served as breadbox://report-format when submitting reports",
+			Action:    "/mcp-settings/report-format",
+			Field:     "report_format",
+			Value:     p.ReportFormat,
+			Default:   p.DefaultReportFormat,
+			MaxLength: 20000,
+			CSRFToken: p.CSRFToken,
+		})
+		@mcpToolsDrawer(p)
+		@mcpConnectionDrawer()
+	</div>
+}
+
+// ---------------------------------------------------------------------
+// Directory rows
+// ---------------------------------------------------------------------
+
+// mcpRowData is one entry in the MCP directory. The whole row is the
+// affordance — it opens `mcp-<ID>` — so a leading icon is legitimate (the
+// action-list exception in settings.md). Right is the optional right-side
+// status component (customized indicator, tool count); the chevron is
+// always appended after it.
+type mcpRowData struct {
+	ID        string // drawer suffix → opens "mcp-<ID>"
+	Icon      string
+	BrandIcon string
+	Name      string
+	Desc      string
+	Right     templ.Component
+}
+
+templ mcpRow(d mcpRowData) {
+	<button
+		type="button"
+		class="bb-settings-row bb-settings-row--link w-full text-left"
+		@click={ "$store.drawers.open('mcp-" + d.ID + "')" }
+	>
+		if d.BrandIcon != "" {
+			@components.BrandIcon(d.BrandIcon, "w-5 h-5 shrink-0")
+		} else if d.Icon != "" {
+			@components.LucideIcon(d.Icon, "w-5 h-5 text-base-content opacity-60 shrink-0")
+		}
+		<div class="bb-settings-row__main">
+			<div class="bb-settings-row__label">{ d.Name }</div>
+			<p class="bb-settings-row__caption">{ d.Desc }</p>
+		</div>
+		<div class="bb-settings-row__control">
+			<div class="flex items-center gap-2.5">
+				if d.Right != nil {
+					@d.Right
+				}
+				@components.LucideIcon("chevron-right", "w-4 h-4 text-base-content opacity-40 shrink-0")
+			</div>
+		</div>
+	</button>
+}
+
+// mcpCustomizedStatus is the right-side indicator for a prompt row: a quiet
+// "Customized" chip when the saved text diverges from the built-in default,
+// or muted "Default" text otherwise. Ghost (not a soft palette tone) so it
+// stays legible in both themes per .claude/rules/daisyui.md.
+templ mcpCustomizedStatus(customized bool) {
+	if customized {
+		<span class="badge badge-ghost badge-sm">Customized</span>
+	} else {
+		<span class="text-xs text-base-content/40 whitespace-nowrap">Default</span>
+	}
+}
+
+templ mcpToolsCountStatus(enabled, total int) {
+	<span class="text-xs text-base-content/60 whitespace-nowrap tabular-nums">{ strconv.Itoa(enabled) } of { strconv.Itoa(total) } enabled</span>
+}
+
+// ---------------------------------------------------------------------
+// Prompt drawers (Server Instructions, Review Guidelines, Report Format)
+// ---------------------------------------------------------------------
+
+// mcpPromptDrawerData configures one full-height prompt-editing drawer. The
+// three agent-prompt textareas share this shape; only the copy, endpoint,
+// limit, and the editing-risk warning (instructions only) differ.
+type mcpPromptDrawerData struct {
+	ID        string // drawer suffix → "mcp-<ID>"
+	Icon      string
+	Title     string
+	Subtitle  string
+	Action    string // POST endpoint
+	Field     string // textarea name
+	Value     string
+	Default   string
+	MaxLength int
+	Warn      bool // show the editing-risk alert (instructions only)
+	CSRFToken string
+}
+
+templ mcpPromptDrawer(d mcpPromptDrawerData) {
+	@components.Drawer(components.DrawerProps{
+		ID:    "mcp-" + d.ID,
+		Title: d.Title,
+		Size:  "xl",
+	}) {
+		<form
+			method="POST"
+			action={ templ.SafeURL(d.Action) }
+			class="flex flex-col h-full"
+			x-data={ mcpPromptState(d.Value, d.Default) }
+			@submit="saving = true"
+		>
+			<input type="hidden" name="_csrf" value={ d.CSRFToken }/>
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     d.Icon,
+				Title:    d.Title,
+				Subtitle: d.Subtitle,
+			})
+			<div class="flex-1 flex flex-col min-h-0 p-5 gap-3">
+				if d.Warn {
+					<div role="alert" class="alert alert-warning alert-soft text-xs shrink-0">
+						@components.LucideIcon("triangle-alert", "w-4 h-4")
+						<span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
+					</div>
+				}
+				<textarea
+					name={ d.Field }
+					class="textarea font-mono text-xs leading-relaxed w-full flex-1 min-h-[16rem] resize-none"
+					maxlength={ strconv.Itoa(d.MaxLength) }
+					x-model="value"
+					placeholder="Prompt text for MCP agents…"
+				></textarea>
+				<p class="text-xs text-base-content/40 shrink-0" x-text={ fmt.Sprintf("value.length + '/%d'", d.MaxLength) }></p>
+			</div>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm mr-auto" @click="resetToDefaults()">Reset to defaults</button>
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm" :disabled="saving">
+					<span x-show="!saving">Save changes</span>
+					<span x-show="saving" x-cloak class="flex items-center gap-2"><span class="loading loading-spinner loading-xs"></span> Saving…</span>
+				</button>
 			}
-			for _, g := range p.ToolGroups {
-				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+		</form>
+	}
+}
+
+// mcpPromptState is the Alpine scope for a prompt drawer — the live textarea
+// value, its default (for reset), a saving flag for the Save spinner, and a
+// reset-to-defaults action gated behind a bbConfirm. Returned as an inline
+// object literal (not a factory call) so it carries the per-drawer default
+// without tripping the x-data factory-args lint.
+func mcpPromptState(value, def string) string {
+	return fmt.Sprintf(
+		"{ value: %s, def: %s, saving: false, async resetToDefaults() { const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current text will be replaced with the built-in default. Save to apply.',confirmLabel:'Reset',variant:'warning'}); if (ok) { this.value = this.def; } } }",
+		jsString(value), jsString(def),
+	)
+}
+
+// ---------------------------------------------------------------------
+// Tools drawer
+// ---------------------------------------------------------------------
+templ mcpToolsDrawer(p AgentsSettingsProps) {
+	@components.Drawer(components.DrawerProps{
+		ID:    "mcp-tools",
+		Title: "Enabled tools",
+		Size:  "xl",
+	}) {
+		<form
+			method="POST"
+			action="/mcp-settings/tools"
+			class="flex flex-col h-full"
+			x-data="{ saving: false }"
+			@submit="saving = true"
+		>
+			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     "wrench",
+				Title:    "Enabled tools",
+				Subtitle: agentsSettingsToolsSummary(p),
+			})
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				<p class="text-xs text-base-content/50">Disabled tools are hidden from all agents. Read-only API keys cannot invoke write tools regardless of this setting.</p>
+				for _, g := range p.ToolGroups {
 					<div>
 						<h3 class="text-xs font-semibold text-base-content/40 uppercase tracking-wider mb-2">{ g.Name }</h3>
 						<div class="space-y-1">
@@ -161,13 +293,16 @@ templ agentsSettingsToolsSection(p AgentsSettingsProps) {
 						</div>
 					</div>
 				}
+			</div>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm" :disabled="saving">
+					<span x-show="!saving">Save tools</span>
+					<span x-show="saving" x-cloak class="flex items-center gap-2"><span class="loading loading-spinner loading-xs"></span> Saving…</span>
+				</button>
 			}
-		}
-	</div>
-}
-
-templ agentsSettingsToolsFooter() {
-	<button type="submit" class="btn btn-primary btn-sm">Save Tools</button>
+		</form>
+	}
 }
 
 templ agentsSettingsToolRow(t AgentsSettingsTool) {
@@ -188,51 +323,67 @@ templ agentsSettingsToolRow(t AgentsSettingsTool) {
 }
 
 // ---------------------------------------------------------------------
-// Connection cheatsheet
+// Connection drawer (read-only cheatsheet)
 // ---------------------------------------------------------------------
+templ mcpConnectionDrawer() {
+	@components.Drawer(components.DrawerProps{
+		ID:    "mcp-connection",
+		Title: "Connection details",
+		Size:  "lg",
+	}) {
+		<div x-data="{ copiedConfig: false }" class="flex flex-col h-full">
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				BrandIcon: "model-context-protocol",
+				Title:     "Connection details",
+				Subtitle:  "Endpoints and config for connecting MCP agents",
+			})
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				@mcpConnectionField("HTTP endpoint") {
+					<div class="bg-base-200 rounded-lg px-3 py-2 font-mono text-sm break-all text-base-content/70 select-all">https://&lt;host&gt;/mcp</div>
+				}
+				@mcpConnectionField("Stdio command") {
+					<div class="bg-base-200 rounded-lg px-3 py-2 font-mono text-sm text-base-content/70 select-all">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio</div>
+				}
+				@mcpConnectionField("Claude Desktop config (stdio)") {
+					<p class="text-xs text-base-content/40 mb-1.5">Drop into ~/Library/Application Support/Claude/claude_desktop_config.json</p>
+					<div class="relative">
+						<pre class="bg-base-200 rounded-lg p-4 text-xs font-mono overflow-auto text-base-content/70">{ claudeDesktopConfigJSON() }</pre>
+						<button
+							type="button"
+							class="btn btn-sm btn-ghost absolute top-2 right-2"
+							@click.stop="navigator.clipboard.writeText(JSON.stringify({mcpServers:{breadbox:{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
+						>
+							<template x-if="!copiedConfig">
+								<span class="flex items-center gap-1">@components.LucideIcon("copy", "w-4 h-4")
+Copy</span>
+							</template>
+							<template x-if="copiedConfig">
+								<span class="flex items-center gap-1 text-success">@components.LucideIcon("check", "w-4 h-4")
+Copied!</span>
+							</template>
+						</button>
+					</div>
+				}
+			</div>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Close</button>
+			}
+		</div>
+	}
+}
 
-templ agentsSettingsConnectionSection() {
-	<div id="connection" x-data="{ copiedConfig: false }">
-		@components.SettingsSection(components.SettingsSectionProps{
-			BrandIcon: "model-context-protocol",
-			Title:     "Connection",
-			Caption:   "Endpoints and config for connecting MCP agents",
-		}) {
-			@components.SettingsRow(components.SettingsRowProps{
-				Label: "HTTP endpoint",
-				Stack: true,
-			}) {
-				<div class="bg-base-200 rounded-lg px-3 py-2 font-mono text-sm break-all text-base-content/70 select-all">https://&lt;host&gt;/mcp</div>
-			}
-			@components.SettingsRow(components.SettingsRowProps{
-				Label: "Stdio command",
-				Stack: true,
-			}) {
-				<div class="bg-base-200 rounded-lg px-3 py-2 font-mono text-sm text-base-content/70 select-all">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio</div>
-			}
-			@components.SettingsRow(components.SettingsRowProps{
-				Label:   "Claude Desktop config (stdio)",
-				Caption: "Drop into ~/Library/Application Support/Claude/claude_desktop_config.json",
-				Stack:   true,
-			}) {
-				<div class="relative">
-					<pre class="bg-base-200 rounded-lg p-4 text-xs font-mono overflow-auto text-base-content/70">{ claudeDesktopConfigJSON() }</pre>
-					<button
-						class="btn btn-sm btn-ghost absolute top-2 right-2"
-						@click.stop="navigator.clipboard.writeText(JSON.stringify({mcpServers:{breadbox:{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
-					>
-						<template x-if="!copiedConfig">
-							<span class="flex items-center gap-1">@components.LucideIcon("copy", "w-4 h-4") Copy</span>
-						</template>
-						<template x-if="copiedConfig">
-							<span class="flex items-center gap-1 text-success">@components.LucideIcon("check", "w-4 h-4") Copied!</span>
-						</template>
-					</button>
-				</div>
-			}
-		}
+// mcpConnectionField is a labeled read-only block inside the connection
+// drawer — mirrors providerReadonlyField but local to this tab.
+templ mcpConnectionField(label string) {
+	<div>
+		<div class="text-xs font-medium text-base-content/60 mb-1.5">{ label }</div>
+		{ children... }
 	</div>
 }
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
 
 func agentsSettingsToolsSummary(p AgentsSettingsProps) string {
 	base := strconv.Itoa(p.ToolsEnabledCount) + " of " + strconv.Itoa(p.ToolsTotalCount) + " tools enabled"


### PR DESCRIPTION
Redesigns the MCP settings tab into a clean, scannable directory modeled on the Providers tab — editing moves into shared slide-over drawers instead of five always-expanded sections.

## Changes
- Replaced the five stacked MCP sections (three tall textareas, a long toggle list, a connection block) with a 3-section / 5-row directory; each row opens a focused `components.Drawer`.
- **Agent prompts** → three rows (server instructions, review guidelines, report format), each showing a `Customized`/`Default` indicator and opening a full-height mono editor with char counter + reset-to-defaults.
- **Tools** → one row (`N of M enabled`) opening the grouped toggle list with a sticky save.
- **Connection** → one row opening the read-only HTTP/stdio/Claude-Desktop config with copy.
- Templ-only change — the handler and all `/mcp-settings/*` POST targets are untouched; reuses `SettingsSection`, `Drawer`, and `$store.drawers` exactly like Providers.

## Screenshots
<table>
  <tr><th>Directory</th><th>Prompt editor drawer</th><th>Tools drawer</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/7oz9d5q71e.jpg" width="280" alt="MCP settings directory"></td>
    <td><img src="https://i.img402.dev/pagw44sckx.jpg" width="280" alt="Server instructions drawer"></td>
    <td><img src="https://i.img402.dev/hqz468ddhq.jpg" width="280" alt="Enabled tools drawer"></td>
  </tr>
</table>

## Test plan
- [x] `go build ./...`, `go vet ./internal/templates/...` clean
- [x] `go test ./internal/templates/components/pages/` (scripts-lint) passes
- [x] Directory + all three drawer types validated in a real browser
- [x] Confirmed in-DOM that all tool toggles keep their `checked` state inside the drawer (no form-state regression)
