### PR TITLE
fix(devmode): capture the on-screen viewport + glitch money in File-a-Task screenshots

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -834,7 +834,7 @@
               <span class="text-xs font-medium flex items-center gap-1">
                 {{ lucide "shield-check" "w-3.5 h-3.5 text-success" }} Redact financial data
               </span>
-              <span class="block text-xs text-base-content/50 leading-snug">Masks amounts, names, and other data in the screenshot and HTML before anything leaves this instance.</span>
+              <span class="block text-xs text-base-content/50 leading-snug">Obfuscates amounts and balances, and masks names and other data, in the screenshot and HTML before anything leaves this instance.</span>
             </span>
           </label>
           <p x-show="!redact" x-cloak class="text-xs text-warning flex items-start gap-1">
@@ -881,6 +881,7 @@
                 class="btn btn-primary btn-sm gap-2">
           <span x-show="!submitting && !capturing" class="flex items-center gap-1.5">
             {{ brand "github" "brand-onbtn w-3.5 h-3.5" }} File issue
+            {{ lucide "external-link" "w-3 h-3 opacity-70" }}
           </span>
           <span x-show="capturing && !submitting" x-cloak class="flex items-center gap-1.5">
             <span class="loading loading-spinner loading-xs"></span> Preparing…

--- a/static/js/admin/components/dev_reporter.js
+++ b/static/js/admin/components/dev_reporter.js
@@ -41,8 +41,12 @@
 
   // Walk every text node under root. Content text (not app chrome) is fully
   // masked; chrome text (nav labels, buttons) stays readable but still has PII
-  // like emails scrubbed.
-  function bbMaskTextNodes(root) {
+  // like emails scrubbed. When skipPrivate is true, text inside a
+  // [data-private] element is left alone here — those financial values are
+  // obfuscated separately with the privacy-mode glitch (legible, same-shape)
+  // rather than blanked to dots. skipPrivate is only set when the glitch pass
+  // actually ran, so a missing privacy engine safely falls back to dot-masking.
+  function bbMaskTextNodes(root, skipPrivate) {
     var doc = root.ownerDocument || document;
     var walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
       acceptNode: function (node) {
@@ -51,6 +55,7 @@
         if (!p) return NodeFilter.FILTER_REJECT;
         var tag = p.nodeName;
         if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'TITLE' || tag === 'NOSCRIPT') return NodeFilter.FILTER_REJECT;
+        if (skipPrivate && p.closest && p.closest('[data-private]')) return NodeFilter.FILTER_REJECT;
         return NodeFilter.FILTER_ACCEPT;
       },
     });
@@ -106,10 +111,29 @@
     });
   }
 
-  // Redact a cloned document/element in place: mask data text, hide media,
-  // strip data-bearing attributes, and scrub PII from attributes.
+  // Obfuscate the financial values (everything tagged data-private — amounts,
+  // accounts, merchants, balances) with the shared privacy-mode glitch, on the
+  // CLONE only. Returns true when it ran so the dot-masker can skip those nodes
+  // and leave the legible same-shape glitch in place. Reads the real value off
+  // the clone regardless of the user's live privacy mode, so it never leaks.
+  function bbGlitchPrivate(root) {
+    try {
+      if (window.bbPrivacy && typeof window.bbPrivacy.glitchTree === 'function') {
+        window.bbPrivacy.glitchTree(root);
+        return true;
+      }
+    } catch (e) {}
+    return false;
+  }
+
+  // Redact a cloned document/element in place: glitch financial values, mask
+  // the remaining data text, hide media, strip data-bearing attributes, and
+  // scrub PII from attributes. The glitch must run BEFORE bbStripDataAttrs
+  // (which removes data-private) and before bbMaskTextNodes (which would
+  // otherwise dot-mask the glitched values back into •).
   function bbRedactClone(root) {
-    bbMaskTextNodes(root);
+    var glitched = bbGlitchPrivate(root);
+    bbMaskTextNodes(root, glitched);
     bbHideMedia(root);
     bbStripDataAttrs(root);
     bbScrubAttrPII(root);
@@ -301,12 +325,18 @@
               allowTaint: false,
               logging: false,
               scale: Math.min(Math.max(window.devicePixelRatio || 1, 2), 3),
+              // Capture exactly the on-screen viewport at the user's current
+              // scroll. windowWidth/Height MUST be the viewport size, not the
+              // full document size: passing scrollWidth/scrollHeight makes
+              // html2canvas lay the clone out as a full-height window scrolled
+              // to the top, so the (x,y) crop never reaches the visible region
+              // and every capture comes out scrolled to the top of the page.
               x: window.scrollX,
               y: window.scrollY,
               width: window.innerWidth,
               height: window.innerHeight,
-              windowWidth: document.documentElement.scrollWidth,
-              windowHeight: document.documentElement.scrollHeight,
+              windowWidth: window.innerWidth,
+              windowHeight: window.innerHeight,
               ignoreElements: function (el) { return el.id === 'bb-dev-reporter'; },
               onclone: function (clonedDoc) {
                 if (redact && clonedDoc && clonedDoc.body) {

--- a/static/js/admin/privacy.js
+++ b/static/js/admin/privacy.js
@@ -281,6 +281,28 @@
     observer.observe(document.body, { childList: true, subtree: true });
   }
 
+  // Bake the obfuscation glitch into a DETACHED / cloned subtree's
+  // [data-private] values, in place, without touching live page state,
+  // animations, the persisted mode, or the DONE/__bbReal bookkeeping the
+  // live path relies on. Walks `root` once and glitches any text node that
+  // has a [data-private] ancestor (so nested marks and the root itself are
+  // covered; the glitch of an already-glitched value is still obfuscated, so
+  // it stays safe no matter the caller's current mode). The dev-mode reporter
+  // uses this to redact financial values in a screenshot / HTML-snapshot clone.
+  function glitchTree(root) {
+    if (!root) return;
+    var doc = root.ownerDocument || document;
+    var walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+    var nodes = [], n;
+    while ((n = walker.nextNode())) nodes.push(n);
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (!node.nodeValue || !node.nodeValue.trim()) continue;
+      var p = node.parentElement;
+      if (p && p.closest && p.closest('[data-private]')) node.nodeValue = glitch(node.nodeValue);
+    }
+  }
+
   // ----- public API -----
 
   function setMode(mode, animate) {
@@ -306,6 +328,9 @@
       var order = { real: 'obfuscate', obfuscate: 'hide', hide: 'real' };
       setMode(order[state] || 'real', true);
     },
+    // Obfuscate a detached/cloned subtree's financial values in place. Does
+    // NOT change the live page or the persisted mode — see glitchTree above.
+    glitchTree: glitchTree,
   };
 
   // ----- init: run the first pass once the body exists, then reveal -----


### PR DESCRIPTION
## What

The **File-a-Task** (Developer Mode) reporter had two problems: its screenshot was **always scrolled to the top of the page** regardless of where you were looking, and it redacted everything to dots. This wires it up to the **privacy-mode obfuscation** that shipped in #1717/#1723 and fixes the viewport capture.

### 1. Capture the on-screen viewport (the "scrolled to top" bug)
`html2canvas` was given `windowWidth/windowHeight` = the **full document size** (`scrollWidth`/`scrollHeight`). That lays the clone out as a full-height window scrolled to the top, so the `(x, y)` crop at the user's scroll offset never maps to the visible region — every capture came out at the top of the page. The window is the scroll container here (the `drawer-content`/`main` don't scroll), so the fix is simply to set the render window to the **viewport size**. The point of the bug button is to show what the user was seeing the moment they clicked it — now it does.

### 2. Glitch the money, keep masking the rest
Financial values tagged `data-private` (amounts, balances, merchants, accounts, institutions) are now obfuscated with the shared privacy-mode **matrix/hex glitch** — legible and same-shape (`$1,240.55` → `$3a,4d4.0f`) — instead of blanked to `•`. Everything else stays dot-masked, emails scrubbed, and media hidden, so the public-destination privacy guarantee (bb-artifacts is public-read, issues are public) is unchanged.

A new `window.bbPrivacy.glitchTree(root)` bakes the glitch into the screenshot / HTML-snapshot **clone** only — it never touches live page state, the persisted mode, or the live decode animation. Reads the real value off the clone regardless of the user's current privacy mode, and the dot-masker only skips `[data-private]` when the glitch actually ran, so a missing privacy engine safely falls back to dot-masking those values.

### 3. external-link icon on "File issue"
Signals the button opens GitHub in a new tab.

## Before / After

Both captures are taken **scrolled ~1400px down** with redaction on. Before lands at the top of the page; after shows the actual viewport with money glitched and everything else dotted.

<table>
<tr><th>Before — ignores scroll, lands at top</th><th>After — actual viewport, glitch + mask</th></tr>
<tr>
<td><img src="https://bb-artifacts.exe.xyz/f/56b62c427972270d.jpg" width="420" alt="before"></td>
<td><img src="https://bb-artifacts.exe.xyz/f/8fbe14ad2780e7c6.jpg" width="420" alt="after"></td>
</tr>
</table>

## Validation

- Reproduced the scroll bug and confirmed the fix against the running app (puppeteer + system Chrome), exercising the **real** redaction helpers extracted from the served `dev_reporter.js` and the real `window.bbPrivacy.glitchTree`.
- HTML-snapshot leak check: **0** real `data-private` values survived into the redacted snapshot; non-private content dot-masked; amounts kept `$`+digit shape.
- `go build ./...`, `go test ./internal/admin/... ./internal/templates/...` green; JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
