### PR TITLE
feat(design): sandbox missing recurring-detail components + fix privacy obfuscation

### DIFF
--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -540,7 +540,7 @@ func assembleSeriesFacts(s service.SeriesResponse, row pages.SubscriptionRow) co
 		lastCharge = subscriptionMoney(s.LastAmount, deref(s.IsoCurrencyCode))
 	}
 	return components.SeriesFactStripProps{Facts: []components.SeriesFact{
-		{Label: "Last charge", Value: lastCharge},
+		{Label: "Last charge", Value: lastCharge, Private: "amount"},
 		{Label: "Next renewal", Value: dash(formatSubDate(s.NextExpectedDate, "Jan 2, 2006"))},
 		{Label: "Last seen", Value: dash(formatSubDate(s.LastSeenDate, "Jan 2, 2006"))},
 		{Label: "Detected by", Value: dash(row.SourceLabel)},

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -269,6 +269,28 @@ templ SectionRecurringDetail() {
 				},
 			})
 		}
+		@designExample("Detection panel — no amount yet", "When the detector hasn't pinned an expected amount, the panel drops the match-window viz and reads as a weaker (warning-tone) match. The merchant key + cadence still anchor the rule.") {
+			@components.SeriesDetectionPanel(components.SeriesDetectionProps{
+				StrengthLabel: "Likely match",
+				StrengthTone:  "warning",
+				MerchantKey:   "acme*gym",
+				HasAmount:     false,
+				CadencePhrase: "on an irregular cadence",
+			})
+		}
+		@designExample("Match window (SeriesMatchWindow)", "The amount-axis range viz on its own — tolerance band, expected marker, and (optionally) a hollow prior-price marker when the charge stepped up. Embedded inside the detection panel on the live page; shown here standalone with no prior price.") {
+			@components.SeriesMatchWindow(components.SeriesMatchWindowProps{
+				RangeText:    "$8.99 – $10.99",
+				AxisMinText:  "$7",
+				AxisMaxText:  "$13",
+				ExpectedText: "$9.99 expected",
+				InWindowText: "4 charges",
+				BandLeftPct:  "33.3",
+				BandWidthPct: "33.3",
+				ExpectedPct:  "50",
+				HasPrior:     false,
+			})
+		}
 		@designExample("Evidence timeline (SeriesEvidenceTimeline)", "The charges a series was detected from: projected next (dashed), matched (✓), and prior-price (·) markers on a continuous rail, with a price-change inset where the amount stepped.") {
 			@components.SeriesEvidenceTimeline(components.SeriesEvidenceProps{
 				Rows: []components.SeriesEvidenceRow{
@@ -281,10 +303,21 @@ templ SectionRecurringDetail() {
 				},
 			})
 		}
-		@designExample("Fact strip (SeriesFactStrip)", "Read-only derived facts pinned to the page foot — last charge, next renewal, last seen, detected-by. Hairline-divided, no icons.") {
+		@designExample("Evidence timeline — unlinkable (live)", "On the detail page the timeline opts into a hover-revealed unlink control on each linked (non-projected) row, wired to the page's unlinkCharge() Alpine action. Hover a matched/prior row to reveal it.") {
+			@components.SeriesEvidenceTimeline(components.SeriesEvidenceProps{
+				Unlinkable:    true,
+				SeriesShortID: "demo1234",
+				Rows: []components.SeriesEvidenceRow{
+					{ShortID: "tx000001", Date: "May 15, 2026", AmountText: "$15.99", State: "matched"},
+					{ShortID: "tx000002", Date: "Apr 15, 2026", AmountText: "$15.99", State: "matched"},
+					{ShortID: "tx000003", Date: "Mar 15, 2026", AmountText: "$15.99", State: "prior"},
+				},
+			})
+		}
+		@designExample("Fact strip (SeriesFactStrip)", "Read-only derived facts pinned to the page foot — last charge, next renewal, last seen, detected-by. Hairline-divided, no icons. The money facts carry Private: \"amount\" so privacy mode obfuscates them.") {
 			@components.SeriesFactStrip(components.SeriesFactStripProps{
 				Facts: []components.SeriesFact{
-					{Label: "Last charge", Value: "$15.99"},
+					{Label: "Last charge", Value: "$15.99", Private: "amount"},
 					{Label: "Next renewal", Value: "Jun 15, 2026"},
 					{Label: "Last seen", Value: "May 15, 2026"},
 					{Label: "Detected by", Value: "Auto-matched"},

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -280,7 +280,7 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "recurring-detail",
 			Title:       "Recurring detail panels",
-			Description: "Detection-forward panels for the recurring-series detail page: SeriesDetectionPanel (match-strength badge + plain-language summary + match-window range viz), SeriesEvidenceTimeline (charge timeline with matched/prior/projected markers + price-change inset), and SeriesFactStrip (read-only derived facts). The handler assembles the values; these are pure presentation.",
+			Description: "Detection-forward panels for the recurring-series detail page: SeriesDetectionPanel (match-strength badge + plain-language summary + match-window range viz, with a no-amount variant), the standalone SeriesMatchWindow amount-axis viz, SeriesEvidenceTimeline (charge timeline with matched/prior/projected markers + price-change inset, read-only and unlinkable variants), and SeriesFactStrip (read-only derived facts). Money values carry data-private so privacy mode obfuscates them. The handler assembles the values; these are pure presentation.",
 			Group:       "data",
 			Render:      func() templ.Component { return SectionRecurringDetail() },
 		},

--- a/internal/templates/components/series_detail_panels.templ
+++ b/internal/templates/components/series_detail_panels.templ
@@ -52,9 +52,9 @@ templ SeriesDetectionPanel(p SeriesDetectionProps) {
 			</span>
 		</div>
 		<p class="text-sm leading-relaxed text-base-content/70">
-			Matches charges from <code class="font-mono text-xs bg-base-200 text-base-content/80 rounded px-1.5 py-0.5">{ p.MerchantKey }</code>
+			Matches charges from <code data-private="merchant" class="font-mono text-xs bg-base-200 text-base-content/80 rounded px-1.5 py-0.5">{ p.MerchantKey }</code>
 			if p.HasAmount {
-				near <span class="font-medium text-base-content">{ p.AmountText }</span> <span class="text-base-content/45">(±{ p.ToleranceText })</span>,
+				near <span data-private="amount" class="font-medium text-base-content">{ p.AmountText }</span> <span data-private="amount" class="text-base-content/45">(±{ p.ToleranceText })</span>,
 			} else {
 				,
 			}
@@ -77,7 +77,7 @@ templ SeriesMatchWindow(p SeriesMatchWindowProps) {
 	<div class="rounded-xl bg-base-200/50 border border-base-300/60 px-4 sm:px-6 pt-4 pb-3">
 		<div class="flex items-center justify-between text-xs mb-2">
 			<span class="font-medium text-base-content/60">Match window</span>
-			<span class="text-base-content/45 tabular-nums">{ p.RangeText }</span>
+			<span data-private="amount" class="text-base-content/45 tabular-nums">{ p.RangeText }</span>
 		</div>
 		<!-- Rail with room above (expected label) and below (prior / in-window). -->
 		<div class="relative mx-1 pt-7 pb-9">
@@ -89,11 +89,11 @@ templ SeriesMatchWindow(p SeriesMatchWindowProps) {
 				<!-- prior-price marker (hollow) -->
 				if p.HasPrior {
 					<div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full bg-base-100 border-2 border-base-content/30 z-10" style={ "left:" + p.PriorPct + "%" }></div>
-					<div class="absolute top-6 -translate-x-1/2 text-[0.7rem] text-base-content/45 whitespace-nowrap" style={ "left:" + p.PriorPct + "%" }>{ p.PriorText }</div>
+					<div data-private="amount" class="absolute top-6 -translate-x-1/2 text-[0.7rem] text-base-content/45 whitespace-nowrap" style={ "left:" + p.PriorPct + "%" }>{ p.PriorText }</div>
 				}
 				<!-- expected marker (filled, ringed) + labels -->
 				<div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3.5 h-3.5 rounded-full bg-success ring-4 ring-success/20 z-20" style={ "left:" + p.ExpectedPct + "%" }></div>
-				<div class="absolute -top-6 -translate-x-1/2 text-xs font-semibold text-success whitespace-nowrap" style={ "left:" + p.ExpectedPct + "%" }>{ p.ExpectedText }</div>
+				<div data-private="amount" class="absolute -top-6 -translate-x-1/2 text-xs font-semibold text-success whitespace-nowrap" style={ "left:" + p.ExpectedPct + "%" }>{ p.ExpectedText }</div>
 				<div class="absolute top-6 -translate-x-1/2 text-xs text-success whitespace-nowrap inline-flex items-center gap-1" style={ "left:" + p.ExpectedPct + "%" }>
 					{ p.InWindowText }
 					@LucideIcon("check", "w-3 h-3")
@@ -101,8 +101,8 @@ templ SeriesMatchWindow(p SeriesMatchWindowProps) {
 			</div>
 		</div>
 		<div class="flex items-center justify-between text-[0.7rem] text-base-content/35 tabular-nums">
-			<span>{ p.AxisMinText }</span>
-			<span>{ p.AxisMaxText }</span>
+			<span data-private="amount">{ p.AxisMinText }</span>
+			<span data-private="amount">{ p.AxisMaxText }</span>
 		</div>
 	</div>
 }
@@ -166,14 +166,14 @@ templ SeriesEvidenceTimeline(p SeriesEvidenceProps) {
 							@LucideIcon("unlink", "w-3.5 h-3.5")
 						</button>
 					}
-					<div class={ "text-sm font-semibold tabular-nums shrink-0", templ.KV("text-base-content/40 font-normal", row.State == "projected") }>{ row.AmountText }</div>
+					<div data-private="amount" class={ "text-sm font-semibold tabular-nums shrink-0", templ.KV("text-base-content/40 font-normal", row.State == "projected") }>{ row.AmountText }</div>
 				</div>
 				if row.HasPrice {
 					<div class="relative flex items-center gap-2 ml-10 mr-1 my-1 rounded-lg bg-warning/15 border border-warning/30 px-3 py-1.5">
 						@LucideIcon("trending-up", "w-3.5 h-3.5 text-warning shrink-0")
 						<span class="text-xs font-medium text-warning/90">Price change</span>
 						<span class="flex-1"></span>
-						<span class="text-xs tabular-nums text-warning/90">{ row.PriceFrom } → { row.PriceTo }</span>
+						<span data-private="amount" class="text-xs tabular-nums text-warning/90">{ row.PriceFrom } → { row.PriceTo }</span>
 					</div>
 				}
 			}
@@ -199,6 +199,10 @@ templ seriesEvidenceMarker(state string) {
 type SeriesFact struct {
 	Label string
 	Value string
+	// Private, when set, marks the value node with data-private="<kind>" so
+	// privacy mode obfuscates it (e.g. "amount" for the last-charge value).
+	// Left empty for non-sensitive facts (dates, the detected-by label).
+	Private string
 }
 
 type SeriesFactStripProps struct {
@@ -211,7 +215,11 @@ templ SeriesFactStrip(p SeriesFactStripProps) {
 			for _, f := range p.Facts {
 				<div class="px-4 py-3.5 min-w-0">
 					<div class="text-xs text-base-content/45 truncate">{ f.Label }</div>
-					<div class="text-sm font-semibold mt-1 tabular-nums truncate">{ f.Value }</div>
+					if f.Private != "" {
+						<div data-private={ f.Private } class="text-sm font-semibold mt-1 tabular-nums truncate">{ f.Value }</div>
+					} else {
+						<div class="text-sm font-semibold mt-1 tabular-nums truncate">{ f.Value }</div>
+					}
 				</div>
 			}
 		</div>


### PR DESCRIPTION
Sandboxes the previously-uncovered `/recurring/:id` detail components into the `/design` recurring-detail section, and fixes privacy mode leaking series amounts and merchant keys.

## Changes
- **Privacy fix** — `series_detail_panels.templ`: the detection panel, match-window viz, evidence timeline, and fact strip rendered amounts (`$15.99`, ranges, price-change, axis labels) and the merchant key with no `data-private` markers, so obfuscate/hide mode left them fully visible. Marked money values `data-private="amount"` and the merchant key `data-private="merchant"`.
- **Per-fact privacy** — added a `Private` field to `SeriesFact`; the handler marks only the "Last charge" money fact (dates and the detected-by label stay real, matching the money + accounts/merchants privacy scope).
- **Sandbox** — extended the `recurring-detail` section with the missing render paths: standalone `SeriesMatchWindow` (only ever shown nested before), the no-amount `SeriesDetectionPanel` variant, and the `Unlinkable` `SeriesEvidenceTimeline`. Fact-strip specimen now demonstrates the `Private` flag.

## Screenshots
`/design/c/recurring-detail` — real vs privacy-mode obfuscate (dates & counts correctly stay real; only money + merchant scramble):

<table>
  <tr><th>Real</th><th>Obfuscate</th></tr>
  <tr>
    <td><img src="https://bb-artifacts.exe.xyz/f/fded1bc4840780bf.jpg" width="400" alt="recurring-detail — real"></td>
    <td><img src="https://bb-artifacts.exe.xyz/f/f644ba9882fdf0b5.jpg" width="400" alt="recurring-detail — obfuscate"></td>
  </tr>
</table>

## Test plan
- [x] `templ generate && go build ./...`
- [x] `go vet ./internal/admin/... ./internal/templates/...`
- [x] `go test ./...` (incl. `TestDesignGalleryRenders` / `TestDesignComponentRenders`)
- [x] Validated `/design/c/recurring-detail` in a browser, real + obfuscate modes
