### PR TITLE
feat(household): redesign member page to focus on profiles

### DIFF
--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -237,23 +237,6 @@ func buildUsersProps(in usersListInput) pages.UsersProps {
 			row.LoginUsername = la.Username
 			row.LoginSetupPending = len(la.HashedPassword) == 0
 		}
-		for _, a := range eu.Accounts {
-			row.Accounts = append(row.Accounts, pages.UsersAccountRow{
-				ID:               a.ID,
-				Name:             a.Name,
-				Type:             a.Type,
-				SubtypeLabel:     a.Subtype,
-				HasSubtype:       a.Subtype != "",
-				Mask:             a.Mask,
-				HasMask:          a.Mask != "",
-				InstitutionName:  a.InstitutionName,
-				BalanceValue:     a.BalanceCurrent,
-				IsoCurrencyCode:  a.IsoCurrencyCode,
-				IsLiability:      a.IsLiability,
-				HasBalance:       a.HasBalance,
-				ConnectionStatus: a.ConnectionStatus,
-			})
-		}
 		props.EnrichedUsers = append(props.EnrichedUsers, row)
 	}
 

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -7,11 +7,7 @@ import (
 )
 
 // Users renders the household-members page. Hosts inside the base layout
-// via TemplateRenderer.RenderWithTempl. Markup mirrors the prior
-// pages/users.html byte-for-byte: sticky page header with the keyboard
-// shortcut scope sentinel, a "created" success alert, the
-// admin-not-linked warning panel (create-new / link-existing tabs), and
-// a grid of member cards with avatar, login badge, and account list.
+// via TemplateRenderer.RenderWithTempl.
 templ Users(p UsersProps) {
 	<script src="/static/js/admin/components/users.js"></script>
 	{{
@@ -35,7 +31,7 @@ templ Users(p UsersProps) {
 		@usersUnlinkedPrompt(p)
 	}
 	if len(p.EnrichedUsers) > 0 {
-		<div class="flex flex-col gap-5">
+		<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 			for _, u := range p.EnrichedUsers {
 				@usersMemberCard(u)
 			}
@@ -127,26 +123,25 @@ templ usersUnlinkedPrompt(p UsersProps) {
 	</div>
 }
 
-// usersMemberCard renders one household member's card: avatar header,
-// optional login badge, accounts list (or no-accounts state), and a
-// member-since footer.
+// usersMemberCard renders one household member's card: avatar, profile
+// info, login badge, and a compact stats footer. Account details are
+// intentionally omitted — the focus is the member profile.
 templ usersMemberCard(u UsersEnrichedRow) {
-	<div class="bb-card overflow-hidden flex flex-col">
-		<!-- Member Header -->
-		<div class="p-4 sm:p-6 pb-4">
-			<div class="flex items-center justify-between gap-3">
-				<div class="flex items-center gap-4 min-w-0">
-					@components.UserAvatar(components.UserAvatarProps{
-						ID:         u.ID,
-						Name:       u.Name,
-						Version:    u.AvatarVersion,
-						Size:       components.UserAvatar2XL,
-						Decorative: true,
-						Class:      "shrink-0",
-					})
-					<div>
-						<div class="flex items-center gap-2 flex-wrap">
-							<h3 class="font-semibold text-base">{ u.Name }</h3>
+	<div class="bb-card p-4 sm:p-5 flex flex-col gap-4">
+		<div class="flex items-start gap-4">
+			@components.UserAvatar(components.UserAvatarProps{
+				ID:         u.ID,
+				Name:       u.Name,
+				Version:    u.AvatarVersion,
+				Size:       components.UserAvatar2XL,
+				Decorative: true,
+				Class:      "shrink-0",
+			})
+			<div class="flex-1 min-w-0">
+				<div class="flex items-start justify-between gap-2">
+					<div class="min-w-0">
+						<div class="flex items-center gap-1.5 flex-wrap">
+							<h3 class="font-semibold text-base leading-snug">{ u.Name }</h3>
 							if u.HasLogin {
 								<span class={ "badge badge-xs", usersLoginRoleBadgeClass(u.LoginRole) }>{ u.LoginRole }</span>
 								if u.LoginSetupPending {
@@ -164,106 +159,31 @@ templ usersMemberCard(u UsersEnrichedRow) {
 							<p class="text-xs text-base-content/30 italic mt-0.5">No email</p>
 						}
 					</div>
+					@components.OverflowMenu(components.OverflowMenuProps{
+						AriaLabel: fmt.Sprintf("Actions for %s", u.Name),
+						Items:     usersOverflowItems(u),
+					})
 				</div>
-				@components.OverflowMenu(components.OverflowMenuProps{
-					AriaLabel: fmt.Sprintf("Actions for %s", u.Name),
-					Items:     usersOverflowItems(u),
-				})
 			</div>
 		</div>
-		<!-- Accounts List -->
-		if len(u.Accounts) > 0 {
-			<div class="border-t border-base-300">
-				<div class="px-4 sm:px-5 py-2.5 flex items-center justify-between bg-base-200/30">
-					<span class="text-xs font-medium text-base-content/40">{ usersAccountsSummary(u.AccountCount, u.ConnectionCount) }</span>
-				</div>
-				<div class="divide-y divide-base-300/50">
-					for _, a := range u.Accounts {
-						@usersAccountRow(a)
-					}
-				</div>
-			</div>
-		} else {
-			<!-- No accounts state -->
-			<div class="border-t border-base-300 px-4 sm:px-5 py-8 bg-base-200/20 flex-1 flex flex-col items-center justify-center text-center">
-				<div class="w-12 h-12 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
-					@components.LucideIcon("landmark", "w-6 h-6 text-base-content opacity-25")
-				</div>
-				<p class="text-sm text-base-content/40 mb-3">No bank accounts connected</p>
-				<a href="/connections/new" class="btn btn-ghost btn-sm">
+		<!-- Footer: account stats + member since -->
+		<div class="flex items-center justify-between gap-2 pt-3 border-t border-base-300/60">
+			if u.AccountCount > 0 {
+				<span class="flex items-center gap-1.5 text-xs text-base-content/50">
+					@components.LucideIcon("landmark", "w-3.5 h-3.5")
+					{ usersAccountsSummary(u.AccountCount, u.ConnectionCount) }
+				</span>
+			} else {
+				<a href="/connections/new" class="flex items-center gap-1 text-xs text-base-content/40 hover:text-primary transition-colors">
 					@components.LucideIcon("plus", "w-3.5 h-3.5")
 					Connect a bank
 				</a>
-			</div>
-		}
-		<!-- Footer -->
-		if u.HasCreatedAt {
-			<div class="mt-auto px-4 sm:px-5 py-2.5 border-t border-base-300 text-xs text-base-content/30 bg-base-200/20">
-				<span>Member since { u.CreatedAtLabel }</span>
-			</div>
-		}
+			}
+			if u.HasCreatedAt {
+				<span class="text-xs text-base-content/30 shrink-0">Since { u.CreatedAtLabel }</span>
+			}
+		</div>
 	</div>
-}
-
-// usersAccountRow renders one account inside a member's card. Routes to
-// /accounts/{id} with the same icon-by-type / status-pill / balance
-// layout the prior html/template version used.
-templ usersAccountRow(a UsersAccountRow) {
-	<a href={ templ.SafeURL(fmt.Sprintf("/accounts/%s", a.ID)) } class="flex items-center gap-3 px-4 sm:px-5 py-3 hover:bg-base-200/40 transition-colors no-underline group">
-		<div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0 hidden sm:flex">
-			switch a.Type {
-				case "depository":
-					@components.LucideIcon("landmark", "w-3.5 h-3.5 text-base-content opacity-40")
-				case "credit":
-					@components.LucideIcon("credit-card", "w-3.5 h-3.5 text-base-content opacity-40")
-				case "loan":
-					@components.LucideIcon("banknote", "w-3.5 h-3.5 text-base-content opacity-40")
-				case "investment":
-					@components.LucideIcon("trending-up", "w-3.5 h-3.5 text-base-content opacity-40")
-				default:
-					@components.LucideIcon("wallet", "w-3.5 h-3.5 text-base-content opacity-40")
-			}
-		</div>
-		<div class="flex-1 min-w-0">
-			<div class="flex items-center gap-1.5">
-				<span class="text-sm font-medium group-hover:text-primary transition-colors truncate">{ a.Name }</span>
-				if a.ConnectionStatus != "" && a.ConnectionStatus != "active" {
-					<span class={ "shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full", usersConnStatusPillClass(a.ConnectionStatus) }>{ usersConnStatusLabel(a.ConnectionStatus) }</span>
-				}
-			</div>
-			<div class="text-xs text-base-content/40 truncate">
-				<span>{ a.InstitutionName }</span>
-				if a.HasMask {
-					<span class="text-base-content/20">&middot;</span>
-					<span>{ a.Mask }</span>
-				}
-				if a.HasSubtype {
-					<span class="text-base-content/20">&middot;</span>
-					<span class="capitalize">{ a.SubtypeLabel }</span>
-				}
-			</div>
-		</div>
-		<div class="text-right shrink-0">
-			if a.HasBalance {
-				if a.IsLiability {
-					@components.Amount(components.AmountProps{
-						Value:  a.BalanceValue,
-						Intent: components.AmountBalance,
-						Class:  "text-sm font-semibold text-error",
-					})
-				} else {
-					@components.Amount(components.AmountProps{
-						Value:  a.BalanceValue,
-						Intent: components.AmountBalance,
-						Class:  "text-sm font-semibold",
-					})
-				}
-				<div class="text-[0.65rem] text-base-content/30 mt-0.5 hidden sm:block">{ a.IsoCurrencyCode }</div>
-			} else {
-				<span class="text-xs text-base-content/30">—</span>
-			}
-		</div>
-	</a>
 }
 
 // usersEmpty renders the "no family members" empty state.

--- a/internal/templates/components/pages/users_types.go
+++ b/internal/templates/components/pages/users_types.go
@@ -38,7 +38,6 @@ type UsersEnrichedRow struct {
 	LoginRole         string // "admin", "editor", "viewer" — empty when no login
 	LoginUsername     string // auth_accounts.username — typically the email-style admin login
 	LoginSetupPending bool
-	Accounts          []UsersAccountRow
 }
 
 // usersLoginRoleBadgeClass returns the DaisyUI badge color modifier for a
@@ -71,44 +70,3 @@ func usersAccountsSummary(accountCount int, connectionCount int64) string {
 	return fmt.Sprintf("%d %s across %d %s", accountCount, acctsWord, connectionCount, connsWord)
 }
 
-// usersConnStatusPillClass returns the per-status pill color classes used
-// on the in-card account row. Matches the {{if eq .ConnectionStatus "error"}}
-// chain in the prior html/template version.
-func usersConnStatusPillClass(status string) string {
-	switch status {
-	case "error":
-		return "bg-error/8 text-error/70"
-	case "pending_reauth":
-		return "bg-warning/8 text-warning"
-	case "disconnected":
-		return "bg-base-300/60 text-base-content/40"
-	default:
-		return ""
-	}
-}
-
-// usersConnStatusLabel collapses "pending_reauth" → "reauth" so the pill
-// stays compact; other statuses render as-is.
-func usersConnStatusLabel(status string) string {
-	if status == "pending_reauth" {
-		return "reauth"
-	}
-	return status
-}
-
-// UsersAccountRow is one account row inside a household-member card.
-type UsersAccountRow struct {
-	ID               string
-	Name             string
-	Type             string // "depository" | "credit" | "loan" | "investment" | other
-	SubtypeLabel     string // pre-humanized (underscores → spaces)
-	HasSubtype       bool
-	Mask             string
-	HasMask          bool
-	InstitutionName  string
-	BalanceValue     float64 // rendered via components.Amount(Intent: AmountBalance)
-	IsoCurrencyCode  string
-	IsLiability      bool
-	HasBalance       bool
-	ConnectionStatus string // "active" | "error" | "pending_reauth" | "disconnected"
-}


### PR DESCRIPTION
Closes #1730

Redesigns the `/household` page so the focus is on **members and their profiles** rather than account details. The full per-account list with balances, masks, and institution names is removed; a compact stat line takes its place.

## What changed

**Visual / layout:**
- Cards switch from a single-column flex list to a **responsive 2-col grid** (`sm:grid-cols-2`), making better use of space on desktop while stacking cleanly on mobile
- Each card is now a flat, padded tile: avatar + name + role badge + email, then a divider footer showing `X accounts · Y connections` (or a "Connect a bank" nudge if none) and "Since &lt;month year&gt;"
- Removed the inner account table rows, the per-account balance/mask/type detail, and the no-accounts empty section that previously lived inside the card

**Code cleanup:**
- Removed `UsersAccountRow` type and `Accounts []UsersAccountRow` field from `UsersEnrichedRow` — `AccountCount` and `ConnectionCount` are the only stats shown
- Removed `usersConnStatusPillClass` / `usersConnStatusLabel` helpers (no longer needed)
- Removed the `usersAccountRow` templ component
- Removed the account-to-row loop from `buildUsersProps` in `admin/users.go`

## Screenshots

<table>
  <tr><th>Desktop (1280px)</th><th>Mobile (390px)</th></tr>
  <tr>
    <td>`&lt;img src="https://i.img402.dev/ec562gn6zt.jpg" width="480" alt="household — desktop after"&gt;`</td>
    <td>`&lt;img src="https://i.img402.dev/xohudjobnz.jpg" width="240" alt="household — mobile after"&gt;`</td>
  </tr>
</table>

---
_Generated by [Claude Code](https://claude.ai/code/session_017SCXekuE2mYAQCGdN8CXoG)_