### PR TITLE
fix(account): fix profile section mobile layout (#1732)

### DIFF
--- a/internal/templates/components/pages/my_account.templ
+++ b/internal/templates/components/pages/my_account.templ
@@ -94,107 +94,127 @@ templ myAccountProfileSection(p MyAccountProps) {
 		data-success-redirect="/settings/account"
 	>
 		@components.SettingsSection(components.SettingsSectionProps{
-				Icon:    "user",
-				Title:   "Profile",
-				Caption: "Name, email, and avatar",
-				Form: &components.SettingsSectionFormProps{
-					Action: "/settings/account/profile",
-					Extra:  templ.Attributes{"@submit.prevent": "submitForm()"},
-				},
-				Footer: myAccountProfileFooter(),
+			Icon:    "user",
+			Title:   "Profile",
+			Caption: "Name, email, and avatar",
+			Form: &components.SettingsSectionFormProps{
+				Action: "/settings/account/profile",
+				Extra:  templ.Attributes{"@submit.prevent": "submitForm()"},
+			},
+			Footer: myAccountProfileFooter(),
+		}) {
+			// Stack=true so the avatar+actions render below the label on
+			// mobile — sharing one flex row caused the caption to wrap into
+			// many narrow lines at ~400px viewport width.
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Avatar",
+				Caption: "Upload a photo or regenerate",
+				Stack:   true,
 			}) {
-				@components.SettingsRow(components.SettingsRowProps{
-					Label:   "Avatar",
-					Caption: "Upload a photo or regenerate the auto-identicon",
-				}) {
-					<div class="flex items-center gap-3">
-						<div class="relative group shrink-0">
-							<img :src="avatarSrc" alt="" class="w-10 h-10 rounded-full object-cover ring-2 ring-base-300"/>
-							<button
-								type="button"
-								@click="$refs.fileInput.click()"
-								class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-								title="Upload photo"
-							>
-								@components.LucideIcon("camera", "w-4 h-4 text-white")
+				<div class="flex items-center gap-4">
+					// Avatar: click-to-upload overlay on hover/focus, inline
+					// loading spinner while the upload is in flight (matches
+					// the EditableAvatar animation pattern).
+					<div class="relative group shrink-0">
+						<img
+							:src="avatarSrc"
+							alt=""
+							x-bind:class="avatarUploading ? 'opacity-40 scale-90' : 'scale-100'"
+							class="w-14 h-14 rounded-full object-cover ring-2 ring-base-300 transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)]"
+						/>
+						<button
+							type="button"
+							@click="$refs.fileInput.click()"
+							class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity cursor-pointer"
+							title="Upload photo"
+							aria-label="Upload photo"
+						>
+							@components.LucideIcon("camera", "w-5 h-5 text-white")
+						</button>
+						<span
+							x-show="avatarUploading"
+							x-cloak
+							x-transition:enter="transition-opacity ease-out duration-200"
+							x-transition:enter-start="opacity-0"
+							x-transition:enter-end="opacity-100"
+							x-transition:leave="transition-opacity ease-in duration-150"
+							x-transition:leave-start="opacity-100"
+							x-transition:leave-end="opacity-0"
+							class="absolute inset-0 flex items-center justify-center"
+							aria-hidden="true"
+						>
+							<span class="loading loading-spinner loading-sm text-primary"></span>
+						</span>
+						<input type="file" x-ref="fileInput" accept="image/png,image/jpeg,image/gif" class="hidden" @change="onFileSelect"/>
+					</div>
+					// Action buttons — btn-xs gives proper touch targets on
+					// mobile; flex-wrap handles narrow viewports gracefully.
+					<div class="flex flex-wrap gap-2">
+						<button type="button" @click="$refs.fileInput.click()" class="btn btn-ghost btn-xs gap-1.5">
+							@components.LucideIcon("upload", "w-3.5 h-3.5")
+							Upload
+						</button>
+						<button type="button" @click="regenerate()" class="btn btn-ghost btn-xs gap-1.5">
+							@components.LucideIcon("refresh-cw", "w-3.5 h-3.5")
+							Regenerate
+						</button>
+						<template x-if="hasCustomAvatar">
+							<button type="button" @click="removeAvatar()" class="btn btn-ghost btn-xs gap-1.5 text-error/80 hover:text-error">
+								@components.LucideIcon("x", "w-3.5 h-3.5")
+								Remove
 							</button>
-							<input type="file" x-ref="fileInput" accept="image/png,image/jpeg,image/gif" class="hidden" @change="onFileSelect"/>
-						</div>
-						<div class="flex items-center gap-2 text-xs">
-							<button type="button" @click="$refs.fileInput.click()" class="link link-hover inline-flex items-center gap-1">
-								@components.LucideIcon("upload", "w-3 h-3")
-								Upload
-							</button>
-							<span class="text-base-content/20">·</span>
-							<button type="button" @click="regenerate()" class="link link-hover inline-flex items-center gap-1">
-								@components.LucideIcon("refresh-cw", "w-3 h-3")
-								Regenerate
-							</button>
-							<template x-if="hasCustomAvatar">
-								<span class="inline-flex items-center gap-2">
-									<span class="text-base-content/20">·</span>
-									<button type="button" @click="removeAvatar()" class="link link-hover text-error/70 hover:text-error">Remove</button>
-								</span>
-							</template>
-						</div>
+						</template>
+					</div>
+				</div>
+			}
+			<template x-if="avatarError">
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<div role="alert" class="bb-form-error">
+						@components.LucideIcon("alert-circle", "w-4 h-4 shrink-0")
+						<span x-text="avatarError"></span>
 					</div>
 				}
-				<template x-if="avatarError">
-					@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-						<div role="alert" class="bb-form-error">
-							@components.LucideIcon("alert-circle", "w-4 h-4 shrink-0")
-							<span x-text="avatarError"></span>
-						</div>
-					}
-				</template>
-				<template x-if="avatarUploading">
-					@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-						<p class="text-xs text-base-content/50 inline-flex items-center gap-1.5">
-							<span class="loading loading-spinner loading-xs"></span>
-							Uploading photo...
-						</p>
-					}
-				</template>
-				@components.SettingsRow(components.SettingsRowProps{
-					Label: "Name",
-					Stack: true,
-					For:   "name",
-				}) {
-					<input
-						type="text"
-						id="name"
-						name="name"
-						class="bb-form-input"
-						required
-						maxlength="128"
-						value={ p.UserName }
-						placeholder="e.g., Alex Canales"
-					/>
-				}
-				@components.SettingsRow(components.SettingsRowProps{
-					Label:   "Email",
-					Caption: "Optional",
-					Stack:   true,
-					For:     "email",
-				}) {
-					<input
-						type="email"
-						id="email"
-						name="email"
-						class="bb-form-input"
-						value={ p.UserEmail }
-						placeholder="e.g., alex@example.com"
-					/>
-				}
-				<template x-if="formError">
-					@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-						<div role="alert" class="bb-form-error">
-							@components.LucideIcon("alert-circle", "w-4 h-4 shrink-0")
-							<span x-text="formError"></span>
-						</div>
-					}
-				</template>
+			</template>
+			@components.SettingsRow(components.SettingsRowProps{
+				Label: "Name",
+				Stack: true,
+				For:   "name",
+			}) {
+				<input
+					type="text"
+					id="name"
+					name="name"
+					class="bb-form-input"
+					required
+					maxlength="128"
+					value={ p.UserName }
+					placeholder="e.g., Alex Canales"
+				/>
 			}
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Email",
+				Caption: "Optional",
+				Stack:   true,
+				For:     "email",
+			}) {
+				<input
+					type="email"
+					id="email"
+					name="email"
+					class="bb-form-input"
+					value={ p.UserEmail }
+					placeholder="e.g., alex@example.com"
+				/>
+			}
+			<template x-if="formError">
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<div role="alert" class="bb-form-error">
+						@components.LucideIcon("alert-circle", "w-4 h-4 shrink-0")
+						<span x-text="formError"></span>
+					</div>
+				}
+			</template>
+		}
 	</div>
 }
 
@@ -219,49 +239,49 @@ templ myAccountPasswordSection(csrfToken string) {
 		},
 		Footer: myAccountPasswordFooter(),
 	}) {
-			@components.SettingsRow(components.SettingsRowProps{
-				Label: "Current password",
-				Stack: true,
-				For:   "current_password",
-			}) {
-				<input
-					type="password"
-					id="current_password"
-					name="current_password"
-					required
-					autocomplete="current-password"
-					class="bb-form-input"
-				/>
-			}
-			@components.SettingsRow(components.SettingsRowProps{
-				Label: "New password",
-				Stack: true,
-				For:   "new_password",
-			}) {
-				<input
-					type="password"
-					id="new_password"
-					name="new_password"
-					required
-					autocomplete="new-password"
-					minlength="8"
-					class="bb-form-input"
-				/>
-			}
-			@components.SettingsRow(components.SettingsRowProps{
-				Label: "Confirm new password",
-				Stack: true,
-				For:   "confirm_password",
-			}) {
-				<input
-					type="password"
-					id="confirm_password"
-					name="confirm_password"
-					required
-					autocomplete="new-password"
-					class="bb-form-input"
-				/>
-			}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label: "Current password",
+			Stack: true,
+			For:   "current_password",
+		}) {
+			<input
+				type="password"
+				id="current_password"
+				name="current_password"
+				required
+				autocomplete="current-password"
+				class="bb-form-input"
+			/>
+		}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label: "New password",
+			Stack: true,
+			For:   "new_password",
+		}) {
+			<input
+				type="password"
+				id="new_password"
+				name="new_password"
+				required
+				autocomplete="new-password"
+				minlength="8"
+				class="bb-form-input"
+			/>
+		}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label: "Confirm new password",
+			Stack: true,
+			For:   "confirm_password",
+		}) {
+			<input
+				type="password"
+				id="confirm_password"
+				name="confirm_password"
+				required
+				autocomplete="new-password"
+				class="bb-form-input"
+			/>
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1732.

The Avatar `SettingsRow` was missing `Stack: true`, forcing the row label and avatar control to share one flex row on narrow viewports. At ~400px the label column was squeezed to ~102px, causing the caption to wrap many times and making the entire profile section look broken on mobile (iPhone Safari).

## What changed

- **`Stack: true` on Avatar row** — control now renders below the label instead of competing with it for horizontal space.
- **Larger avatar** — `w-14 h-14` (56px) instead of `w-10` (40px): more visible and a better touch target.
- **Proper touch-friendly buttons** — replaced the `text-xs` text links (Upload · Regenerate · Remove) with `btn btn-ghost btn-xs` buttons with `flex-wrap` so they reflow gracefully at any width.
- **Inline loading overlay** — borrowed the `EditableAvatar` pattern: the avatar dims + scales while an upload is in-flight and a spinner overlays it, eliminating the separate "Uploading photo…" status row.
- **Shorter caption** — trimmed to "Upload a photo or regenerate" so it fits on one line at mobile widths.

## Screenshots

### Mobile (390px) — after

<img src="https://i.img402.dev/i0jksogr1d.jpg" width="320" alt="Account settings — mobile after">

### Desktop (1280px) — after

<img src="https://i.img402.dev/yeqiindpni.jpg" width="800" alt="Account settings — desktop after">

### Bug report screenshot (before)

<img src="https://bb-artifacts.exe.xyz/f/13d0b14ae0a2b2e3.jpg" width="320" alt="Account settings — mobile before (from issue)">

https://claude.ai/code/session_013NEDeaErwY8DZ9qcL7FxZJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013NEDeaErwY8DZ9qcL7FxZJ)_