### PR TITLE
fix(mobile): show avatar menu dropdown instead of navigating to settings

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -577,18 +577,7 @@
                   title="Search">
             {{ lucide "search" "w-5 h-5" }}
           </button>
-          {{if .AdminUsername}}
-          <a href="/settings/account"
-             class="btn btn-square btn-ghost"
-             aria-label="My Account"
-             title="My Account">
-            {{if .SessionUserID}}
-            {{renderComponent "UserAvatar" (userAvatarProps .SessionUserID .SessionAvatarVersion .AdminUsername "lg")}}
-            {{else}}
-            {{ lucide "user-circle" "w-5 h-5" }}
-            {{end}}
-          </a>
-          {{end}}
+          {{if .AdminUsername}}{{renderComponent "TopbarUserMenu" .}}{{end}}
         </div>
       </div>
       {{/* Mobile location trail — the desktop topbar is hidden < lg, so the


### PR DESCRIPTION
Fixes #1737.

On mobile the avatar button in the top navbar was an `<a href="/settings/account">` link, so tapping it navigated directly to the Settings page instead of opening the user menu popover.

## Root cause

`base.html` has two avatar presentations:

- **Desktop topbar** (`lg` and up): renders `TopbarUserMenu` — a `<button popovertarget>` that opens the user menu dropdown (sign out, docs, privacy controls).
- **Mobile navbar** (`< lg`): rendered a plain `<a href="/settings/account">` — so tapping it always navigated away, bypassing the menu entirely.

## Fix

Replace the mobile navbar `<a>` link with the same `{{renderComponent "TopbarUserMenu" .}}` call used by the desktop topbar. One line change; the component already handles avatar rendering, the privacy-mode dot, the identity header in the popover, and the logout form.

## Validation

Tested at 402×714 (the exact viewport from the bug report) with Playwright + headless Chromium:

<table>
  <tr><th>Mobile navbar (avatar visible)</th><th>After tapping avatar — menu opens</th></tr>
  <tr>
    <td>`&lt;img src="https://i.img402.dev/e3rhaj17w8.jpg" width="320" alt="Mobile home before click"&gt;`</td>
    <td>`&lt;img src="https://i.img402.dev/10ij2lic63.jpg" width="320" alt="Avatar menu open on mobile"&gt;`</td>
  </tr>
</table>

Page URL remains `/` after the tap — confirms no navigation to `/settings/account`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3a6xPoPKUty83GC3HEirc)_