### PR TITLE
feat(providers): add SimpleFIN bank provider (token-paste, poll-only)

### DIFF
--- a/.claude/rules/providers.md
+++ b/.claude/rules/providers.md
@@ -8,9 +8,13 @@ paths:
 
 ## Interface
 
-`internal/provider.Provider` (in `provider.go`) is the abstraction. Implementations: `plaid/`, `teller/`, `csv/`.
+`internal/provider.Provider` (in `provider.go`) is the abstraction. Implementations: `plaid/`, `teller/`, `simplefin/`, `csv/`.
 
 Methods take a `Connection` **struct** (not an ID) so implementations can decrypt credentials internally without re-fetching from the DB.
+
+### `ReconcilesPendingByPolling() bool`
+
+A capability method on the interface: returns true for **poll-based** providers that re-return their full transaction window each sync (Teller, SimpleFIN), so the sync engine soft-deletes pending rows no longer present in the window. Returns false for cursor/webhook providers (Plaid) and import-only (CSV). The engine gates `cleanStalePending` on this instead of a hardcoded provider name — add a poll-based provider and it inherits the cleanup for free.
 
 ## Error sentinels
 
@@ -41,6 +45,16 @@ Connection storage uses generic columns: `external_id` + `encrypted_credentials`
 - **Amount sign is opposite Plaid**: Teller negative=debit, Plaid positive=debit. Provider negates before returning — downstream sees Plaid convention.
 - Sync: date-range polling with 10-day overlap (no cursor). Post-sync, soft-delete stale *pending* transactions not returned by the API. Posted transactions are **never** auto-deleted.
 - Raw Teller category strings (`dining`, `groceries`, etc.) stored directly in `category_primary`. Rules handle categorization.
+
+## SimpleFIN
+
+- No SDK. Token-paste, poll-only protocol (`internal/provider/simplefin/`). Full details in `docs/simplefin-integration.md`.
+- **Connect = claim.** `ExchangeToken` receives the pasted base64 *setup token*, decodes it to a one-time claim URL, `POST`s for the **access URL** (`https://user:pass@host/path`), and stores the encrypted access URL as the credential. `CreateLinkSession` returns `ErrNotSupported`.
+- **`external_id` is minted** (`internal/shortid`) — SimpleFIN exposes no stable upstream id and a single access URL spans many banks. Reauth keeps the row and rotates only `encrypted_credentials` (`UpdateBankConnectionCredentials`).
+- **Sign is inverted vs Plaid**: SimpleFIN positive = money in; negate uniformly (no per-account-type rule, unlike Teller).
+- **Sync**: date-range polling chunked into **≤90-day windows** (bridge cap). Cursor = last-sync RFC3339 timestamp. `ReconcilesPendingByPolling()` is true. New connections default to a **daily** `sync_interval_override_minutes` (bridge expects ≤24 req/day).
+- `HandleWebhook`/`CreateReauthSession` → `ErrNotSupported`; `RemoveConnection` → `nil` (no revoke endpoint). Account type defaults to `depository` (not exposed by SimpleFIN).
+- **Opt-in**: gated by `SIMPLEFIN_ENABLED` env / `simplefin_enabled` app_config (no server-level credential). Admin-page connect/relink only in v1 — no REST endpoint, not in the hosted-link allowlist.
 
 ## CSV
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ New admin UI pieces are authored as [`a-h/templ`](https://templ.guide) component
 - `internal/api/` — REST handlers. See `.claude/rules/api.md`.
 - `internal/admin/` — admin dashboard handlers. See `.claude/rules/api.md`.
 - `internal/mcp/` — MCP tool registry + server. See `.claude/rules/mcp.md`.
-- `internal/provider/` — provider interface + error sentinels. Subdirs: `plaid/`, `teller/`, `csv/`. See `.claude/rules/providers.md`.
+- `internal/provider/` — provider interface + error sentinels. Subdirs: `plaid/`, `teller/`, `simplefin/`, `csv/`. See `.claude/rules/providers.md`.
 - `internal/sync/` — sync engine, matcher, rule application. See `.claude/rules/sync.md`.
 - `internal/db/` — sqlc-generated code (`*.sql.go`), queries (`queries/*.sql`), migrations (`migrations/*.sql`). See `.claude/rules/migrations.md`.
 - `internal/templates/` — `html/template` admin UI. See `.claude/rules/ui.md`.
@@ -55,7 +55,7 @@ These bite in every session regardless of what you're touching.
 - Connection status: `active`, `error`, `pending_reauth`, `disconnected`
 - Sync status: `in_progress`, `success`, `error`
 - Sync trigger: `cron`, `webhook`, `manual`, `initial`
-- Provider type: `plaid`, `teller`, `csv`
+- Provider type: `plaid`, `teller`, `simplefin`, `csv`
 - API key scope: `full_access`, `read_only`
 - MCP mode: `read_only`, `read_write`
 - MCP tool classification: `read`, `write`
@@ -124,7 +124,7 @@ Canonical specs in `docs/`:
 - `rule-dsl.md` — **canonical transaction-rule DSL**: condition grammar, actions, triggers, pipeline-stage priority, sync-vs-retroactive, chaining
 - `design-system.md` — CSS framework, components, icons
 - `activity-timeline.md` — activity-timeline component contract (rendering, dedup, soft-delete tombstones, optimistic updates, how to add a new system-event kind)
-- `plaid-integration.md`, `teller-integration.md`, `csv-import.md` — provider specifics
+- `plaid-integration.md`, `teller-integration.md`, `simplefin-integration.md`, `csv-import.md` — provider specifics
 - `admin-dashboard.md`, `mcp-server.md`, `rest-api.md`, `backup.md` — subsystem details
 - `stacked-prs.md` — when and how to split work across stacked PRs using `gt`
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -268,7 +268,7 @@ UNIQUE (username)
 #### Enum Types (defined before the table)
 
 ```sql
-CREATE TYPE provider_type AS ENUM ('plaid', 'teller', 'csv');
+CREATE TYPE provider_type AS ENUM ('plaid', 'teller', 'simplefin', 'csv');
 
 CREATE TYPE connection_status AS ENUM (
     'active',           -- connection is healthy and syncing normally
@@ -1188,7 +1188,7 @@ DROP EXTENSION IF EXISTS "pgcrypto";
 
 ```sql
 -- +goose Up
-CREATE TYPE provider_type AS ENUM ('plaid', 'teller', 'csv');
+CREATE TYPE provider_type AS ENUM ('plaid', 'teller', 'simplefin', 'csv');
 
 CREATE TYPE connection_status AS ENUM (
     'active',

--- a/docs/simplefin-integration.md
+++ b/docs/simplefin-integration.md
@@ -1,0 +1,98 @@
+# SimpleFIN integration
+
+SimpleFIN ([simplefin.org](https://www.simplefin.org/protocol.html)) is a
+token-paste, poll-only bank-data protocol — the aggregator the self-hosting
+community commonly uses (via the hosted [SimpleFIN Bridge](https://bridge.simplefin.org)
+or a self-run server). It is the simplest provider Breadbox supports: no OAuth,
+no SDK, no webhooks.
+
+Provider package: `internal/provider/simplefin/`. It implements the standard
+`internal/provider.Provider` interface and is structurally between CSV (stubs the
+unsupported methods) and Teller (real HTTP client + date-range polling).
+
+## How it differs from Plaid/Teller
+
+| Aspect | SimpleFIN |
+|---|---|
+| Connect | **Token paste.** User gets a one-time base64 *setup token* from their bridge's `/create` page and pastes it. No SDK popup, no `CreateLinkSession`. |
+| Credential | The claimed **access URL** `https://user:pass@host/path` (HTTP Basic creds embedded), stored AES-GCM encrypted. |
+| Fetch | **Poll only.** `GET {accessURL}/accounts?start-date&end-date&pending=1` returns accounts with nested transactions. No cursor, no webhooks. |
+| Scope | **One access URL spans every bank** the user linked at the bridge (multi-bank aggregator) → one Breadbox connection, many accounts. |
+| Amount sign | **Inverted.** SimpleFIN positive = money in; Breadbox positive = debit (money out). The mapper negates uniformly. |
+| Reauth | Paste a **new** setup token; the old access URL 403s once revoked. |
+| Enablement | **Opt-in toggle** (`SIMPLEFIN_ENABLED` env / `simplefin_enabled` app_config). No server-level credential. |
+
+## The connect flow (claim)
+
+1. User pastes the setup token in the admin **Add connection** screen.
+2. `ExchangeToken` base64-decodes it to a one-time **claim URL** and `POST`s to it
+   (unauthenticated, empty body). A `200` returns the **access URL**; a `403`
+   means the token was already used or is invalid.
+3. The access URL is AES-GCM encrypted (`internal/crypto`) and stored in
+   `bank_connections.encrypted_credentials`. The embedded `user:pass` is the
+   credential — it never appears in `external_id` or logs.
+4. `GET {accessURL}/accounts?balances-only=1` discovers the accounts.
+
+### Connection identity
+
+SimpleFIN exposes no stable upstream connection id (the access URL host is the
+shared bridge; re-claiming yields a brand-new URL). So the provider **mints its
+own opaque `external_id`** (`internal/shortid`) at connect time, satisfying the
+`UNIQUE (provider, external_id)` constraint without leaking the secret URL.
+Reauth keeps the same row and only rotates `encrypted_credentials`.
+
+## Sync
+
+`SyncTransactions` polls `/accounts` over a date range, **chunked into ≤90-day
+windows** (the bridge caps a single request's range at 90 days):
+
+- Empty cursor → ~1 year backfill (≈5 windowed requests).
+- Non-empty cursor → from `lastSync − 10 days` (overlap for late-posting txns) to
+  now. The cursor is the RFC3339 timestamp of the last sync (same scheme as
+  Teller).
+
+Each transaction's amount is **negated** (uniform — SimpleFIN has no per-account
+sign rule), `pending` is taken from the `pending` flag / `posted == 0`, and the
+raw JSON is preserved in `Transaction.Raw`. Because SimpleFIN re-returns the full
+window each sync, the engine soft-deletes stale pending rows via the
+`ReconcilesPendingByPolling()` capability (shared with Teller — see
+`.claude/rules/providers.md`).
+
+### Rate limits
+
+The SimpleFIN Bridge expects **≤ 24 requests/day** ("daily updates"). New
+SimpleFIN connections are therefore given a **daily** `sync_interval_override_minutes`
+at connect time so the default cron cadence doesn't blow the budget. Severe
+overages disable the access token at the bridge.
+
+## Reauth
+
+`CreateReauthSession` returns `ErrNotSupported` (there's nothing server-mintable).
+The admin reauth page renders a token-paste form instead of launching an SDK; on
+submit, `POST /-/connections/{id}/reauth-complete` claims the new token and
+updates `encrypted_credentials` in place on the existing connection
+(`UpdateBankConnectionCredentials`), flipping status back to `active`.
+
+## Unsupported / limitations (v1)
+
+- `CreateLinkSession`, `HandleWebhook`, `CreateReauthSession` → `ErrNotSupported`.
+  `RemoveConnection` is a no-op (SimpleFIN has no documented revoke endpoint; the
+  user disables the token at the bridge).
+- **Account type** is not exposed by SimpleFIN, so accounts default to
+  `depository`. Credit cards therefore sync as depository in v1.
+- **No REST endpoint** (`POST /api/v1/connections/simplefin`) and no hosted-link
+  support — connect/relink is admin-page-only. A REST handler mirroring
+  `connections_teller_setup.go` is a clean fast-follow if automation demand
+  appears.
+- Soft errors the server reports in the `errors`/`errlist` array are logged, not
+  surfaced on the connection (no channel without an interface change).
+
+## Testing
+
+- Unit tests: `internal/provider/simplefin/simplefin_test.go` run against a fake
+  bridge HTTP server (claim flow, amount negation, 90-day windowing, pending
+  mapping, 403 → reauth, balances, errlist parsing). No DB required.
+- **Demo token** for manual testing (decodes to the bridge's DEMO claim URL):
+  `aHR0cHM6Ly9iZXRhLWJyaWRnZS5zaW1wbGVmaW4ub3JnL3NpbXBsZWZpbi9jbGFpbS9ERU1PLXYyLTFBOEY4QkM3QkUxQTAyMTM5QkUw`
+  Enable SimpleFIN in `/settings/providers`, then paste this on the Add-connection
+  screen.

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -261,6 +262,8 @@ func providerLabel(p string) string {
 		return "Plaid"
 	case "teller":
 		return "Teller"
+	case "simplefin":
+		return "SimpleFIN"
 	case "csv":
 		return "CSV"
 	default:
@@ -276,6 +279,8 @@ func providerIcon(p string) string {
 		return "building-2"
 	case "teller":
 		return "landmark"
+	case "simplefin":
+		return "key-round"
 	case "csv":
 		return "file-spreadsheet"
 	default:
@@ -402,7 +407,7 @@ func NewConnectionHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			"CurrentPage": "connections",
 			"CSRFToken":   GetCSRFToken(r),
 		}
-		renderConnectionNew(w, r, tr, data, users, a.Providers["plaid"] != nil, a.Providers["teller"] != nil, a.Config.TellerEnv)
+		renderConnectionNew(w, r, tr, data, users, a.Providers["plaid"] != nil, a.Providers["teller"] != nil, a.Providers["simplefin"] != nil, a.Config.TellerEnv)
 	}
 }
 
@@ -416,7 +421,7 @@ func renderConnectionNew(
 	tr *TemplateRenderer,
 	data map[string]any,
 	users []db.User,
-	hasPlaid, hasTeller bool,
+	hasPlaid, hasTeller, hasSimpleFin bool,
 	tellerEnv string,
 ) {
 	data["Breadcrumbs"] = []components.Breadcrumb{
@@ -424,10 +429,11 @@ func renderConnectionNew(
 		{Label: "Connect New Bank"},
 	}
 	props := pages.ConnectionNewProps{
-		CSRFToken: GetCSRFToken(r),
-		HasPlaid:  hasPlaid,
-		HasTeller: hasTeller,
-		TellerEnv: tellerEnv,
+		CSRFToken:    GetCSRFToken(r),
+		HasPlaid:     hasPlaid,
+		HasTeller:    hasTeller,
+		HasSimpleFin: hasSimpleFin,
+		TellerEnv:    tellerEnv,
 	}
 	for _, u := range users {
 		props.Users = append(props.Users, pages.ConnectionNewUser{
@@ -551,6 +557,14 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		// SimpleFIN discovers the real institution name during the claim (the
+		// browser only sends the "SimpleFIN" placeholder), so prefer what the
+		// provider returned.
+		institutionName := req.InstitutionName
+		if providerName == "simplefin" && conn.InstitutionName != "" {
+			institutionName = conn.InstitutionName
+		}
+
 		// Persist the connection + accounts via the shared service helper.
 		// REST (api.PlaidExchangeHandler) calls the same path so both
 		// surfaces stay byte-identical on what lands in the DB.
@@ -558,7 +572,7 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 			UserID:          userID,
 			Provider:        providerName,
 			InstitutionID:   req.InstitutionID,
-			InstitutionName: req.InstitutionName,
+			InstitutionName: institutionName,
 			Conn:            conn,
 			Accounts:        accounts,
 		})
@@ -568,13 +582,29 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		// SimpleFIN's bridge expects ≤24 requests/day, so default new SimpleFIN
+		// connections to a daily sync cadence rather than the global interval.
+		if providerName == "simplefin" {
+			if _, err := a.Queries.UpdateConnectionSyncInterval(r.Context(), db.UpdateConnectionSyncIntervalParams{
+				ID:                          result.ID,
+				SyncIntervalOverrideMinutes: pgconv.Int4(simplefinSyncIntervalMinutes),
+			}); err != nil {
+				a.Logger.Warn("set simplefin sync interval", "error", err, "connection_id", pgconv.FormatUUID(result.ID))
+			}
+		}
+
 		writeJSON(w, http.StatusCreated, exchangeTokenResponse{
 			ConnectionID:    pgconv.FormatUUID(result.ID),
-			InstitutionName: req.InstitutionName,
+			InstitutionName: institutionName,
 			Status:          "active",
 		})
 	}
 }
+
+// simplefinSyncIntervalMinutes is the default per-connection sync cadence for
+// SimpleFIN connections (daily), chosen to stay within the bridge's expected
+// ~24-requests/day budget.
+const simplefinSyncIntervalMinutes = 24 * 60
 
 // ConnectionDetailHandler serves GET /admin/connections/{id}.
 func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
@@ -1045,21 +1075,40 @@ func ConnectionReauthAPIHandler(a *app.App) http.HandlerFunc {
 }
 
 // ConnectionReauthCompleteHandler serves POST /admin/api/connections/{id}/reauth-complete.
+//
+// For SDK providers (Plaid/Teller) the relink happens client-side and this
+// handler only flips the connection back to active. SimpleFIN has no SDK: the
+// browser posts a freshly pasted setup token, which we claim and store as the
+// new credential on the existing connection row (keeping its identity).
 func ConnectionReauthCompleteHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
 		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
 		if !ok {
 			return
 		}
 
-		// Update connection status to active and clear errors.
-		err := a.Queries.UpdateBankConnectionStatus(r.Context(), db.UpdateBankConnectionStatusParams{
+		conn, err := a.Queries.GetBankConnection(ctx, connID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "Connection not found"})
+			return
+		}
+
+		if string(conn.Provider) == "simplefin" {
+			if !reauthSimplefin(a, w, r, connID) {
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"status": "active"})
+			return
+		}
+
+		// SDK providers: just clear errors and reactivate.
+		if err := a.Queries.UpdateBankConnectionStatus(ctx, db.UpdateBankConnectionStatusParams{
 			ID:           connID,
 			Status:       db.ConnectionStatusActive,
 			ErrorCode:    pgtype.Text{},
 			ErrorMessage: pgtype.Text{},
-		})
-		if err != nil {
+		}); err != nil {
 			a.Logger.Error("reactivate bank connection", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update connection status"})
 			return
@@ -1067,6 +1116,49 @@ func ConnectionReauthCompleteHandler(a *app.App) http.HandlerFunc {
 
 		writeJSON(w, http.StatusOK, map[string]string{"status": "active"})
 	}
+}
+
+// reauthSimplefin claims a freshly pasted SimpleFIN setup token and rotates the
+// connection's stored credentials in place. It writes the JSON error response
+// itself and returns false on failure.
+func reauthSimplefin(a *app.App, w http.ResponseWriter, r *http.Request, connID pgtype.UUID) bool {
+	var req struct {
+		PublicToken string `json:"public_token"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return false
+	}
+	if strings.TrimSpace(req.PublicToken) == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "Setup token is required"})
+		return false
+	}
+
+	prov, ok := a.Providers["simplefin"]
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "simplefin provider not configured"})
+		return false
+	}
+
+	// Claim the token (verifies it works + refreshes account discovery). Only
+	// the rotated credential is kept; the existing connection row's identity is
+	// preserved.
+	newConn, _, err := prov.ExchangeToken(r.Context(), req.PublicToken)
+	if err != nil {
+		a.Logger.Error("simplefin reauth claim", "error", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "Failed to claim token: " + err.Error()})
+		return false
+	}
+
+	if err := a.Queries.UpdateBankConnectionCredentials(r.Context(), db.UpdateBankConnectionCredentialsParams{
+		ID:                   connID,
+		EncryptedCredentials: newConn.EncryptedCredentials,
+	}); err != nil {
+		a.Logger.Error("simplefin reauth update credentials", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update connection"})
+		return false
+	}
+
+	return true
 }
 
 // DeleteConnectionHandler serves DELETE /admin/api/connections/{id}.

--- a/internal/admin/providers.go
+++ b/internal/admin/providers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"breadbox/internal/app"
@@ -37,7 +38,7 @@ func ProvidersGetHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 		}
 
 		// Ensure entries exist for all providers even if they have no connections.
-		for _, p := range []string{"plaid", "teller", "csv"} {
+		for _, p := range []string{"plaid", "teller", "simplefin", "csv"} {
 			if _, ok := providerHealth[p]; !ok {
 				providerHealth[p] = &service.ProviderHealthSummary{Provider: p}
 			}
@@ -67,6 +68,9 @@ func ProvidersGetHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 			TellerCertFromEnv:       a.Config.TellerCertPath != "",
 			TellerCertConfigured:    a.Config.TellerCertPath != "" || len(a.Config.TellerCertPEM) > 0,
 			TellerWebhookConfigured: a.Config.TellerWebhookSecret != "",
+
+			SimpleFINEnabled: a.Config.SimpleFINEnabled,
+			SimpleFINFromEnv: os.Getenv("SIMPLEFIN_ENABLED") != "",
 
 			HasEncryptionKey:    len(a.Config.EncryptionKey) > 0,
 			SyncIntervalMinutes: a.Config.SyncIntervalMinutes,
@@ -335,6 +339,43 @@ func readTellerCertFiles(r *http.Request) (certPEM, keyPEM []byte, err error) {
 	return certPEM, keyPEM, nil
 }
 
+// ProvidersSaveSimpleFINHandler serves POST /admin/settings/providers/simplefin.
+// SimpleFIN has no server-level credential, so this only toggles whether the
+// provider is offered at connect time.
+func ProvidersSaveSimpleFINHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if os.Getenv("SIMPLEFIN_ENABLED") != "" {
+			FlashRedirect(w, r, sm, "error", "SimpleFIN is configured via environment variables and cannot be changed here.", "/settings/providers")
+			return
+		}
+
+		val := strings.ToLower(strings.TrimSpace(r.FormValue("simplefin_enabled")))
+		enabled := val == "on" || val == "true" || val == "1" || val == "yes"
+		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+			Key:   "simplefin_enabled",
+			Value: pgconv.Text(strconv.FormatBool(enabled)),
+		}); err != nil {
+			a.Logger.Error("save simplefin config", "error", err)
+			FlashRedirect(w, r, sm, "error", "Failed to save SimpleFIN setting.", "/settings/providers")
+			return
+		}
+
+		a.Config.SimpleFINEnabled = enabled
+		a.Config.ConfigSources["simplefin_enabled"] = "db"
+		if err := a.ReinitProvider("simplefin"); err != nil {
+			a.Logger.Error("reinit simplefin provider", "error", err)
+		}
+
+		msg := "SimpleFIN disabled."
+		if enabled {
+			msg = "SimpleFIN enabled. It's now available when adding a connection."
+		}
+		FlashRedirect(w, r, sm, "success", msg, "/settings/providers")
+	}
+}
+
 // ProvidersTestHandler serves POST /admin/api/test-provider/{provider}.
 func ProvidersTestHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -380,6 +421,15 @@ func ProvidersTestHandler(a *app.App) http.HandlerFunc {
 				return
 			}
 			writeJSON(w, http.StatusOK, testResult{Provider: "teller", Success: false, Message: "Teller certificate not configured"})
+
+		case "simplefin":
+			// SimpleFIN has no server-level credential to validate — each
+			// connection carries its own access token. Report the toggle state.
+			if a.Config.SimpleFINEnabled {
+				writeJSON(w, http.StatusOK, testResult{Provider: "simplefin", Success: true, Message: "Enabled — add a connection and paste a setup token"})
+				return
+			}
+			writeJSON(w, http.StatusOK, testResult{Provider: "simplefin", Success: false, Message: "SimpleFIN is disabled"})
 
 		default:
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Unknown provider: " + providerName})

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -392,6 +392,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings/providers", ProvidersGetHandler(a, svc, sm, tr))
 		r.Post("/settings/providers/plaid", ProvidersSavePlaidHandler(a, sm))
 		r.Post("/settings/providers/teller", ProvidersSaveTellerHandler(a, sm))
+		r.Post("/settings/providers/simplefin", ProvidersSaveSimpleFINHandler(a, sm))
 		r.Get("/providers", redirectGET("/settings/providers"))
 		r.Post("/providers/plaid", redirectPreserveMethod("/settings/providers/plaid"))
 		r.Post("/providers/teller", redirectPreserveMethod("/settings/providers/teller"))

--- a/internal/api/connections_plaid_link_integration_test.go
+++ b/internal/api/connections_plaid_link_integration_test.go
@@ -92,6 +92,7 @@ func (f *fakePlaidProvider) HandleWebhook(context.Context, provider.WebhookPaylo
 func (f *fakePlaidProvider) RemoveConnection(context.Context, provider.Connection) error {
 	panic("fakePlaidProvider.RemoveConnection not implemented")
 }
+func (f *fakePlaidProvider) ReconcilesPendingByPolling() bool { return false }
 
 // plaidLinkEnv is the per-test harness for the link-flow endpoints.
 type plaidLinkEnv struct {

--- a/internal/api/connections_reauth_integration_test.go
+++ b/internal/api/connections_reauth_integration_test.go
@@ -67,6 +67,7 @@ func (f *fakeProvider) HandleWebhook(context.Context, provider.WebhookPayload) (
 func (f *fakeProvider) RemoveConnection(context.Context, provider.Connection) error {
 	panic("fakeProvider.RemoveConnection not implemented")
 }
+func (f *fakeProvider) ReconcilesPendingByPolling() bool { return false }
 
 // reauthEnv is the per-test harness for the reauth endpoints.
 type reauthEnv struct {

--- a/internal/api/connections_teller_setup_integration_test.go
+++ b/internal/api/connections_teller_setup_integration_test.go
@@ -71,6 +71,7 @@ func (f *fakeTellerProvider) HandleWebhook(context.Context, provider.WebhookPayl
 func (f *fakeTellerProvider) RemoveConnection(context.Context, provider.Connection) error {
 	panic("fakeTellerProvider.RemoveConnection not implemented")
 }
+func (f *fakeTellerProvider) ReconcilesPendingByPolling() bool { return false }
 
 // tellerSetupEnv is the per-test harness for the setup endpoint.
 type tellerSetupEnv struct {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,6 +74,8 @@ func New(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*App, er
 		return nil, err
 	}
 
+	initSimpleFINProvider(cfg, providers, logger)
+
 	csvProv := csvprovider.NewProvider()
 	providers["csv"] = csvProv
 	logger.Info("csv provider registered")

--- a/internal/app/providers.go
+++ b/internal/app/providers.go
@@ -9,8 +9,20 @@ import (
 	"breadbox/internal/config"
 	"breadbox/internal/provider"
 	plaidprovider "breadbox/internal/provider/plaid"
+	simplefinprovider "breadbox/internal/provider/simplefin"
 	tellerprovider "breadbox/internal/provider/teller"
 )
+
+// initSimpleFINProvider registers the SimpleFIN provider when the opt-in toggle
+// is enabled. SimpleFIN needs no server-level credential — the access token is
+// per-connection — so the only gate is cfg.SimpleFINEnabled.
+func initSimpleFINProvider(cfg *config.Config, providers map[string]provider.Provider, logger *slog.Logger) {
+	if !cfg.SimpleFINEnabled {
+		return
+	}
+	providers["simplefin"] = simplefinprovider.NewProvider(simplefinprovider.NewClient(), cfg.EncryptionKey, logger)
+	logger.Info("simplefin provider initialized")
+}
 
 // initTellerProvider creates the Teller provider from config (file paths or PEM bytes).
 func initTellerProvider(cfg *config.Config, providers map[string]provider.Provider, logger *slog.Logger) error {
@@ -63,6 +75,10 @@ func (a *App) ReinitProvider(name string) error {
 		if err := initTellerProvider(a.Config, a.Providers, a.Logger); err != nil {
 			return err
 		}
+
+	case "simplefin":
+		delete(a.Providers, "simplefin")
+		initSimpleFINProvider(a.Config, a.Providers, a.Logger)
 
 	default:
 		return fmt.Errorf("unknown provider: %s", name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,12 @@ type Config struct {
 	TellerEnv           string // "sandbox" | "production"
 	TellerWebhookSecret string
 
+	// SimpleFIN — opt-in toggle (env SIMPLEFIN_ENABLED overrides app_config).
+	// SimpleFIN has no server-level credential: the access token is per
+	// connection (pasted at connect time), so the only global config is whether
+	// the provider is offered as a connect option at all.
+	SimpleFINEnabled bool
+
 	// From app_config table only
 	SyncIntervalMinutes int
 	WebhookURL          string

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -90,6 +90,13 @@ func Load() (*Config, error) {
 		cfg.ConfigSources["teller_env"] = "env"
 	}
 
+	// SimpleFIN opt-in. If the env var is present at all it wins over app_config
+	// (even when set to a falsey value), matching env-overrides-db precedence.
+	if raw := os.Getenv("SIMPLEFIN_ENABLED"); raw != "" {
+		cfg.SimpleFINEnabled = parseBool(raw)
+		cfg.ConfigSources["simplefin_enabled"] = "env"
+	}
+
 	// Connection pool tuning.
 	cfg.DBMaxConns = int32(getEnvInt("DB_MAX_CONNS", 25))
 	cfg.DBMinConns = int32(getEnvInt("DB_MIN_CONNS", 2))
@@ -247,6 +254,16 @@ func LoadWithDB(ctx context.Context, cfg *Config, pool *pgxpool.Pool) error {
 		cfg.ConfigSources["webhook_url"] = "db"
 	} else {
 		cfg.ConfigSources["webhook_url"] = "default"
+	}
+
+	// SimpleFIN opt-in from app_config (unless already set from env).
+	if cfg.ConfigSources["simplefin_enabled"] != "env" {
+		if v, ok := appCfg["simplefin_enabled"]; ok {
+			cfg.SimpleFINEnabled = parseBool(v)
+			cfg.ConfigSources["simplefin_enabled"] = "db"
+		} else {
+			cfg.ConfigSources["simplefin_enabled"] = "default"
+		}
 	}
 
 	// Set defaults for any untracked config sources.

--- a/internal/db/migrations/20260603231900_provider_type_simplefin.sql
+++ b/internal/db/migrations/20260603231900_provider_type_simplefin.sql
@@ -1,0 +1,18 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Add 'simplefin' to the provider_type enum so SimpleFIN connections can be
+-- stored alongside Plaid/Teller/CSV. Appending an enum value at the end is the
+-- shared-DB-safe form (per .claude/rules/migrations.md): older `breadbox serve`
+-- processes keep working since they never write the new value until they pick
+-- up the SimpleFIN code.
+--
+-- ALTER TYPE ... ADD VALUE cannot run inside a transaction block (and the new
+-- value isn't usable until commit), so this migration is marked NO TRANSACTION.
+-- IF NOT EXISTS makes it idempotent across re-runs / shared dev DBs.
+ALTER TYPE provider_type ADD VALUE IF NOT EXISTS 'simplefin';
+
+-- +goose Down
+-- PostgreSQL cannot remove a value from an enum type, so the down migration is
+-- intentionally a no-op. Removing 'simplefin' would require recreating the type
+-- and rewriting every dependent column — never safe on a shared DB.
+SELECT 1;

--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -69,6 +69,11 @@ UPDATE bank_connections
 SET sync_cursor = $2, last_synced_at = NOW(), updated_at = NOW()
 WHERE id = $1;
 
+-- name: UpdateBankConnectionCredentials :exec
+UPDATE bank_connections
+SET encrypted_credentials = $2, status = 'active', error_code = NULL, error_message = NULL, updated_at = NOW()
+WHERE id = $1;
+
 -- name: DeleteBankConnection :exec
 UPDATE bank_connections
 SET status = 'disconnected', encrypted_credentials = NULL, updated_at = NOW()

--- a/internal/provider/csv/provider.go
+++ b/internal/provider/csv/provider.go
@@ -48,3 +48,7 @@ func (p *CSVProvider) CreateReauthSession(ctx context.Context, conn provider.Con
 func (p *CSVProvider) RemoveConnection(ctx context.Context, conn provider.Connection) error {
 	return nil
 }
+
+// ReconcilesPendingByPolling reports false: CSV is import-only and never
+// re-polls, so the engine must not soft-delete pending rows.
+func (p *CSVProvider) ReconcilesPendingByPolling() bool { return false }

--- a/internal/provider/plaid/provider.go
+++ b/internal/provider/plaid/provider.go
@@ -38,3 +38,8 @@ func NewProvider(client *plaidgo.APIClient, encryptionKey []byte, webhookURL str
 func (p *PlaidProvider) HandleWebhook(ctx context.Context, payload provider.WebhookPayload) (provider.WebhookEvent, error) {
 	return p.handleWebhook(ctx, payload)
 }
+
+// ReconcilesPendingByPolling reports false: Plaid uses cursor-based sync and
+// links pending→posted via pending_transaction_id, so the engine must not
+// soft-delete pending rows that weren't re-returned.
+func (p *PlaidProvider) ReconcilesPendingByPolling() bool { return false }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,6 +32,13 @@ type Provider interface {
 
 	// RemoveConnection revokes the provider's access and marks the connection removed.
 	RemoveConnection(ctx context.Context, conn Connection) error
+
+	// ReconcilesPendingByPolling reports whether this provider re-returns its
+	// full transaction window on every sync (date-range polling), so the sync
+	// engine should soft-delete pending rows no longer present in the window.
+	// True for poll-based providers (Teller, SimpleFIN); false for cursor/
+	// webhook providers (Plaid) and import-only providers (CSV).
+	ReconcilesPendingByPolling() bool
 }
 
 type LinkSession struct {

--- a/internal/provider/simplefin/balances.go
+++ b/internal/provider/simplefin/balances.go
@@ -1,0 +1,54 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/crypto"
+	"breadbox/internal/provider"
+
+	"github.com/shopspring/decimal"
+)
+
+// GetBalances fetches current balances for every account reachable through the
+// connection's access URL (balances only — no transactions). SimpleFIN exposes
+// no credit limit, so AccountBalance.Limit is always nil.
+func (p *SimpleFINProvider) GetBalances(ctx context.Context, conn provider.Connection) ([]provider.AccountBalance, error) {
+	accessURLBytes, err := crypto.Decrypt(conn.EncryptedCredentials, p.encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("simplefin: decrypt access URL: %w", err)
+	}
+
+	set, err := p.fetchAccountSet(ctx, string(accessURLBytes), "balances-only=1")
+	if err != nil {
+		return nil, err
+	}
+
+	balances := make([]provider.AccountBalance, 0, len(set.Accounts))
+	for _, acct := range set.Accounts {
+		current, err := decimal.NewFromString(acct.Balance)
+		if err != nil {
+			p.logger.WarnContext(ctx, "simplefin: skipping balance with parse error",
+				"account_id", acct.ID, "balance", acct.Balance, "error", err)
+			continue
+		}
+
+		ab := provider.AccountBalance{
+			AccountExternalID: acct.ID,
+			Current:           current,
+			ISOCurrencyCode:   acct.Currency,
+		}
+
+		if acct.AvailableBalance != "" {
+			if avail, err := decimal.NewFromString(acct.AvailableBalance); err == nil {
+				ab.Available = &avail
+			}
+		}
+
+		balances = append(balances, ab)
+	}
+
+	return balances, nil
+}

--- a/internal/provider/simplefin/client.go
+++ b/internal/provider/simplefin/client.go
@@ -1,0 +1,141 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"breadbox/internal/provider"
+)
+
+// Client is a thin HTTP client for the SimpleFIN protocol. It carries no
+// credentials of its own — auth is per-connection (the HTTP Basic user:pass is
+// embedded in each connection's decrypted access URL).
+type Client struct {
+	httpClient *http.Client
+}
+
+// NewClient creates a new SimpleFIN HTTP client.
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// claim exchanges a one-time claim URL (the base64-decoded setup token) for a
+// long-lived access URL. Per the protocol, this is an unauthenticated POST with
+// an empty body; a 200 returns the access URL as the plain-text response body,
+// and a 403 means the token was invalid or already claimed.
+func (c *Client) claim(ctx context.Context, claimURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, claimURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("simplefin: build claim request: %w", err)
+	}
+	req.Header.Set("Content-Length", "0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("simplefin: claim request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden {
+			return "", fmt.Errorf("simplefin: claim rejected (403) — setup token is invalid or already used")
+		}
+		return "", fmt.Errorf("simplefin: claim failed (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	accessURL := strings.TrimSpace(string(body))
+	if accessURL == "" {
+		return "", fmt.Errorf("simplefin: claim returned an empty access URL")
+	}
+	if _, err := splitAccessURL(accessURL); err != nil {
+		return "", fmt.Errorf("simplefin: claim returned a malformed access URL: %w", err)
+	}
+	return accessURL, nil
+}
+
+// getAccounts calls GET {accessURL}/accounts with the given raw query string
+// (no leading "?"), authenticating with the credentials embedded in accessURL.
+// Rate-limited (429) responses are retried with backoff.
+func (c *Client) getAccounts(ctx context.Context, accessURL, rawQuery string) (*http.Response, error) {
+	base, creds, err := splitAccessURLWithCreds(accessURL)
+	if err != nil {
+		return nil, err
+	}
+
+	reqURL := base + "/accounts"
+	if rawQuery != "" {
+		reqURL += "?" + rawQuery
+	}
+
+	var resp *http.Response
+	retryErr := provider.DoWithRetry(ctx, provider.DefaultRetryConfig(), func() (bool, error) {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if reqErr != nil {
+			return false, fmt.Errorf("simplefin: build accounts request: %w", reqErr)
+		}
+		if creds.user != "" || creds.pass != "" {
+			req.SetBasicAuth(creds.user, creds.pass)
+		}
+
+		var doErr error
+		resp, doErr = c.httpClient.Do(req)
+		if doErr != nil {
+			return false, fmt.Errorf("simplefin: accounts request: %w", doErr)
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resp.Body.Close()
+			return true, fmt.Errorf("simplefin: rate limited (429)")
+		}
+		return false, nil
+	})
+	if retryErr != nil {
+		return nil, retryErr
+	}
+	return resp, nil
+}
+
+type basicCreds struct {
+	user string
+	pass string
+}
+
+// splitAccessURL validates an access URL and returns it with userinfo stripped.
+func splitAccessURL(accessURL string) (string, error) {
+	base, _, err := splitAccessURLWithCreds(accessURL)
+	return base, err
+}
+
+// splitAccessURLWithCreds parses an access URL of the form
+// https://user:pass@host/path and returns the base URL (userinfo removed) and
+// the embedded HTTP Basic credentials.
+func splitAccessURLWithCreds(accessURL string) (string, basicCreds, error) {
+	u, err := url.Parse(strings.TrimSpace(accessURL))
+	if err != nil {
+		return "", basicCreds{}, fmt.Errorf("parse access URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", basicCreds{}, fmt.Errorf("access URL missing scheme or host")
+	}
+
+	var creds basicCreds
+	if u.User != nil {
+		creds.user = u.User.Username()
+		creds.pass, _ = u.User.Password()
+	}
+
+	// Rebuild the base URL without the userinfo so credentials never leak into
+	// logs or the request line; they travel only in the Authorization header.
+	u.User = nil
+	base := strings.TrimRight(u.String(), "/")
+	return base, creds, nil
+}

--- a/internal/provider/simplefin/errors.go
+++ b/internal/provider/simplefin/errors.go
@@ -1,0 +1,85 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"breadbox/internal/provider"
+)
+
+// ErrReauthRequired indicates the SimpleFIN access URL has been revoked or
+// disabled and the user must paste a fresh setup token.
+var ErrReauthRequired = fmt.Errorf("simplefin: access revoked: %w", provider.ErrReauthRequired)
+
+// decodeSetupToken base64-decodes a SimpleFIN setup token into its claim URL.
+// SimpleFIN setup tokens are standard-base64-encoded URLs; some servers omit
+// padding, so both padded and raw encodings are accepted.
+func decodeSetupToken(setupToken string) (string, error) {
+	s := strings.TrimSpace(setupToken)
+	if s == "" {
+		return "", fmt.Errorf("simplefin: empty setup token")
+	}
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
+		if decoded, err := enc.DecodeString(s); err == nil {
+			claimURL := strings.TrimSpace(string(decoded))
+			if strings.HasPrefix(claimURL, "http://") || strings.HasPrefix(claimURL, "https://") {
+				return claimURL, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("simplefin: setup token is not a base64-encoded claim URL")
+}
+
+// fetchAccountSet performs an authenticated GET {accessURL}/accounts with the
+// given raw query, maps transport/HTTP failures onto the provider sentinels,
+// decodes the response, and logs any soft errors the server reported.
+func (p *SimpleFINProvider) fetchAccountSet(ctx context.Context, accessURL, rawQuery string) (accountSet, error) {
+	resp, err := p.client.getAccounts(ctx, accessURL, rawQuery)
+	if err != nil {
+		return accountSet{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden {
+		return accountSet{}, ErrReauthRequired
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return accountSet{}, classifyHTTPError("accounts get", resp.StatusCode, body)
+	}
+
+	set, err := decodeAccountSet(resp.Body)
+	if err != nil {
+		return accountSet{}, err
+	}
+
+	if errs := set.errorStrings(); len(errs) > 0 {
+		p.logger.WarnContext(ctx, "simplefin: server reported errors", "errors", errs)
+	}
+
+	return set, nil
+}
+
+// classifyHTTPError maps a non-OK SimpleFIN response to a descriptive error.
+// As with Teller, 429s are already retried at the HTTP layer (DoWithRetry) and
+// nothing here is wrapped in ErrSyncRetryable — the engine's cursor-reset retry
+// loop is Plaid-specific, so a failed SimpleFIN sync simply retries next tick.
+func classifyHTTPError(operation string, statusCode int, body []byte) error {
+	trimmed := strings.TrimSpace(string(body))
+	switch {
+	case statusCode == http.StatusPaymentRequired:
+		return fmt.Errorf("simplefin %s: payment required (402) — the SimpleFIN subscription may have lapsed", operation)
+	case statusCode == http.StatusTooManyRequests:
+		return fmt.Errorf("simplefin %s: rate limited (429) — exceeded the daily request budget", operation)
+	case statusCode >= 500:
+		return fmt.Errorf("simplefin %s: server error (status %d): %s", operation, statusCode, trimmed)
+	default:
+		return fmt.Errorf("simplefin %s: status %d: %s", operation, statusCode, trimmed)
+	}
+}

--- a/internal/provider/simplefin/link.go
+++ b/internal/provider/simplefin/link.go
@@ -1,0 +1,107 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/crypto"
+	"breadbox/internal/provider"
+	"breadbox/internal/shortid"
+)
+
+// CreateLinkSession is unsupported: SimpleFIN has no server-side token mint. The
+// user obtains a setup token from their SimpleFIN bridge's /create page and
+// pastes it; the admin connect flow passes it straight to ExchangeToken.
+func (p *SimpleFINProvider) CreateLinkSession(ctx context.Context, userID string) (provider.LinkSession, error) {
+	return provider.LinkSession{}, provider.ErrNotSupported
+}
+
+// ExchangeToken claims a pasted SimpleFIN setup token for a long-lived access
+// URL, encrypts the access URL as the connection credential, and discovers the
+// accounts reachable through it.
+//
+// SimpleFIN exposes no stable upstream connection identifier (a single access
+// URL spans every bank the user linked, and re-claiming yields a brand-new
+// URL), so we mint our own opaque external_id. Reauth keeps the same row and
+// only rotates the encrypted credential (see the admin relink path).
+func (p *SimpleFINProvider) ExchangeToken(ctx context.Context, publicToken string) (provider.Connection, []provider.Account, error) {
+	claimURL, err := decodeSetupToken(publicToken)
+	if err != nil {
+		return provider.Connection{}, nil, err
+	}
+
+	accessURL, err := p.client.claim(ctx, claimURL)
+	if err != nil {
+		return provider.Connection{}, nil, err
+	}
+
+	encrypted, err := crypto.Encrypt([]byte(accessURL), p.encryptionKey)
+	if err != nil {
+		return provider.Connection{}, nil, fmt.Errorf("simplefin: encrypt access URL: %w", err)
+	}
+
+	externalID, err := shortid.Generate()
+	if err != nil {
+		return provider.Connection{}, nil, fmt.Errorf("simplefin: mint external id: %w", err)
+	}
+
+	accounts, err := p.discoverAccounts(ctx, accessURL)
+	if err != nil {
+		return provider.Connection{}, nil, fmt.Errorf("simplefin: discover accounts after claim: %w", err)
+	}
+
+	conn := provider.Connection{
+		ProviderName:         "simplefin",
+		ExternalID:           externalID,
+		EncryptedCredentials: encrypted,
+		InstitutionName:      institutionName(accounts),
+	}
+
+	return conn, accounts, nil
+}
+
+// discoverAccounts fetches the account list (balances only — no transactions)
+// for initial connection setup.
+func (p *SimpleFINProvider) discoverAccounts(ctx context.Context, accessURL string) ([]provider.Account, error) {
+	set, err := p.fetchAccountSet(ctx, accessURL, "balances-only=1")
+	if err != nil {
+		return nil, err
+	}
+
+	accounts := make([]provider.Account, 0, len(set.Accounts))
+	for _, a := range set.Accounts {
+		accounts = append(accounts, a.toAccount())
+	}
+
+	if len(accounts) == 0 {
+		if errs := set.errorStrings(); len(errs) > 0 {
+			return nil, fmt.Errorf("simplefin: no accounts returned; server reported: %v", errs)
+		}
+		return nil, fmt.Errorf("simplefin: no accounts returned for this access URL")
+	}
+
+	return accounts, nil
+}
+
+// institutionName summarizes the connection's institution label. A SimpleFIN
+// access URL can span multiple banks, so we use the single org name when there's
+// only one, and a generic label otherwise.
+func institutionName(accounts []provider.Account) string {
+	seen := map[string]struct{}{}
+	var only string
+	for _, a := range accounts {
+		if a.OfficialName == "" {
+			continue
+		}
+		if _, ok := seen[a.OfficialName]; !ok {
+			seen[a.OfficialName] = struct{}{}
+			only = a.OfficialName
+		}
+	}
+	if len(seen) == 1 {
+		return only
+	}
+	return "SimpleFIN"
+}

--- a/internal/provider/simplefin/provider.go
+++ b/internal/provider/simplefin/provider.go
@@ -1,0 +1,38 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"log/slog"
+
+	"breadbox/internal/provider"
+)
+
+// Compile-time check that SimpleFINProvider implements provider.Provider.
+var _ provider.Provider = (*SimpleFINProvider)(nil)
+
+// SimpleFINProvider implements provider.Provider using the SimpleFIN protocol
+// (https://www.simplefin.org/protocol.html). SimpleFIN is a token-paste,
+// poll-only protocol: there is no OAuth handshake and no webhooks. The user
+// pastes a one-time setup token which is claimed for a long-lived access URL
+// (HTTP Basic credentials embedded), and transactions are fetched by polling
+// GET {accessURL}/accounts over a date range.
+type SimpleFINProvider struct {
+	client        *Client
+	encryptionKey []byte
+	logger        *slog.Logger
+}
+
+// NewProvider creates a new SimpleFINProvider.
+func NewProvider(client *Client, encryptionKey []byte, logger *slog.Logger) *SimpleFINProvider {
+	return &SimpleFINProvider{
+		client:        client,
+		encryptionKey: encryptionKey,
+		logger:        logger,
+	}
+}
+
+// ReconcilesPendingByPolling reports that SimpleFIN re-returns its full
+// transaction window on every sync (date-range polling), so the sync engine
+// should soft-delete pending rows no longer present in the window.
+func (p *SimpleFINProvider) ReconcilesPendingByPolling() bool { return true }

--- a/internal/provider/simplefin/simplefin_test.go
+++ b/internal/provider/simplefin/simplefin_test.go
@@ -1,0 +1,337 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/crypto"
+	"breadbox/internal/provider"
+)
+
+// testKey is a 32-byte AES-256 key for encrypt/decrypt in tests.
+var testKey = []byte("0123456789abcdef0123456789abcdef")
+
+func testProvider() *SimpleFINProvider {
+	return NewProvider(NewClient(), testKey, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// fakeBridge is a stand-in SimpleFIN server. It serves a claim endpoint that
+// returns an access URL pointing back at itself (with embedded credentials) and
+// an /accounts endpoint guarded by HTTP Basic auth.
+type fakeBridge struct {
+	server       *httptest.Server
+	user, pass   string
+	accountSet   string // JSON body returned by /accounts
+	accountsHits int
+	lastQuery    url.Values
+	accountsCode int // override status (0 = 200)
+}
+
+func newFakeBridge(t *testing.T, accountSetJSON string) *fakeBridge {
+	t.Helper()
+	fb := &fakeBridge{user: "u", pass: "p", accountSet: accountSetJSON}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/simplefin/claim/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, fb.accessURL())
+	})
+	mux.HandleFunc("/simplefin/accounts", func(w http.ResponseWriter, r *http.Request) {
+		fb.accountsHits++
+		fb.lastQuery = r.URL.Query()
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != fb.user || pass != fb.pass {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if fb.accountsCode != 0 {
+			w.WriteHeader(fb.accountsCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, fb.accountSet)
+	})
+	fb.server = httptest.NewServer(mux)
+	t.Cleanup(fb.server.Close)
+	return fb
+}
+
+// accessURL returns the credentialed access URL for this bridge.
+func (fb *fakeBridge) accessURL() string {
+	u, _ := url.Parse(fb.server.URL)
+	return fmt.Sprintf("%s://%s:%s@%s/simplefin", u.Scheme, fb.user, fb.pass, u.Host)
+}
+
+// setupToken returns a base64 setup token that decodes to this bridge's claim URL.
+func (fb *fakeBridge) setupToken() string {
+	claimURL := fb.server.URL + "/simplefin/claim/ABC123"
+	return base64.StdEncoding.EncodeToString([]byte(claimURL))
+}
+
+func TestDecodeSetupToken(t *testing.T) {
+	want := "https://bridge.example.com/simplefin/claim/XYZ"
+	tok := base64.StdEncoding.EncodeToString([]byte(want))
+	got, err := decodeSetupToken(tok)
+	if err != nil {
+		t.Fatalf("decodeSetupToken: %v", err)
+	}
+	if got != want {
+		t.Errorf("claim URL = %q, want %q", got, want)
+	}
+
+	// The published DEMO token must decode to an https claim URL.
+	demo := "aHR0cHM6Ly9iZXRhLWJyaWRnZS5zaW1wbGVmaW4ub3JnL3NpbXBsZWZpbi9jbGFpbS9ERU1PLXYyLTFBOEY4QkM3QkUxQTAyMTM5QkUw"
+	if u, err := decodeSetupToken(demo); err != nil || !strings.HasPrefix(u, "https://") {
+		t.Errorf("demo token decode = %q, err=%v", u, err)
+	}
+
+	if _, err := decodeSetupToken("not base64!!!"); err == nil {
+		t.Error("expected error for non-base64 token")
+	}
+	if _, err := decodeSetupToken(base64.StdEncoding.EncodeToString([]byte("ftp://nope"))); err == nil {
+		t.Error("expected error for non-http claim URL")
+	}
+}
+
+func TestSplitAccessURLWithCreds(t *testing.T) {
+	base, creds, err := splitAccessURLWithCreds("https://user:secret@bridge.example.com/simplefin")
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if base != "https://bridge.example.com/simplefin" {
+		t.Errorf("base = %q (userinfo should be stripped)", base)
+	}
+	if creds.user != "user" || creds.pass != "secret" {
+		t.Errorf("creds = %+v", creds)
+	}
+	if _, _, err := splitAccessURLWithCreds("://bad"); err == nil {
+		t.Error("expected error for malformed URL")
+	}
+}
+
+func TestExchangeToken(t *testing.T) {
+	fb := newFakeBridge(t, `{"errors":[],"accounts":[
+		{"org":{"name":"Test Bank","domain":"testbank.com"},"id":"acct-1","name":"Checking","currency":"USD","balance":"100.00","available-balance":"90.00","balance-date":1700000000},
+		{"org":{"name":"Test Bank","domain":"testbank.com"},"id":"acct-2","name":"Savings","currency":"USD","balance":"500.00","balance-date":1700000000}
+	]}`)
+	p := testProvider()
+
+	conn, accounts, err := p.ExchangeToken(context.Background(), fb.setupToken())
+	if err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+	if conn.ProviderName != "simplefin" {
+		t.Errorf("provider name = %q", conn.ProviderName)
+	}
+	if conn.ExternalID == "" {
+		t.Error("expected a minted external_id")
+	}
+	if conn.InstitutionName != "Test Bank" {
+		t.Errorf("institution = %q, want single-org name", conn.InstitutionName)
+	}
+	// Credential must round-trip to the access URL.
+	dec, err := crypto.Decrypt(conn.EncryptedCredentials, testKey)
+	if err != nil || string(dec) != fb.accessURL() {
+		t.Errorf("decrypted credential = %q, err=%v", dec, err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("accounts = %d, want 2", len(accounts))
+	}
+	if accounts[0].OfficialName != "Test Bank" || accounts[0].Type != "depository" {
+		t.Errorf("account mapping unexpected: %+v", accounts[0])
+	}
+	// Discovery must use balances-only.
+	if fb.lastQuery.Get("balances-only") != "1" {
+		t.Errorf("discovery query = %v, want balances-only=1", fb.lastQuery)
+	}
+}
+
+func TestExchangeToken_NoAccountsIsError(t *testing.T) {
+	fb := newFakeBridge(t, `{"errors":["Bank needs attention"],"accounts":[]}`)
+	p := testProvider()
+	if _, _, err := p.ExchangeToken(context.Background(), fb.setupToken()); err == nil {
+		t.Error("expected error when no accounts returned")
+	}
+}
+
+func TestSyncTransactions_MappingAndSigns(t *testing.T) {
+	fb := newFakeBridge(t, `{"errors":[],"accounts":[
+		{"org":{"name":"Bank"},"id":"acct-1","name":"Checking","currency":"USD","balance":"50.00","transactions":[
+			{"id":"t-out","posted":1700000000,"amount":"-25.50","description":"Coffee","payee":"Cafe"},
+			{"id":"t-in","posted":1700100000,"amount":"1000.00","description":"Paycheck"},
+			{"id":"t-pending","posted":0,"amount":"-10.00","description":"Hold","pending":true}
+		]}
+	]}`)
+	p := testProvider()
+	accessURL := fb.accessURL()
+	enc, _ := crypto.Encrypt([]byte(accessURL), testKey)
+	conn := provider.Connection{ProviderName: "simplefin", EncryptedCredentials: enc}
+
+	res, err := p.SyncTransactions(context.Background(), conn, time.Now().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+	if len(res.Added) != 3 {
+		t.Fatalf("added = %d, want 3", len(res.Added))
+	}
+	byID := map[string]provider.Transaction{}
+	for _, tx := range res.Added {
+		byID[tx.ExternalID] = tx
+	}
+	// Withdrawal (SimpleFIN -25.50) → Breadbox positive 25.50 (debit/out).
+	if got := byID["t-out"].Amount.String(); got != "25.5" {
+		t.Errorf("t-out amount = %s, want 25.5 (negated)", got)
+	}
+	if byID["t-out"].MerchantName == nil || *byID["t-out"].MerchantName != "Cafe" {
+		t.Errorf("t-out merchant not mapped")
+	}
+	// Deposit (SimpleFIN +1000) → Breadbox negative 1000 (credit/in).
+	if got := byID["t-in"].Amount.String(); got != "-1000" {
+		t.Errorf("t-in amount = %s, want -1000 (negated)", got)
+	}
+	// posted=0 → pending.
+	if !byID["t-pending"].Pending {
+		t.Errorf("t-pending should be pending")
+	}
+	if res.Cursor == "" || res.HasMore {
+		t.Errorf("expected a fresh cursor and HasMore=false")
+	}
+}
+
+func TestSyncTransactions_WindowsLongBackfill(t *testing.T) {
+	fb := newFakeBridge(t, `{"errors":[],"accounts":[{"org":{"name":"Bank"},"id":"a","name":"Checking","currency":"USD","balance":"0","transactions":[]}]}`)
+	p := testProvider()
+	enc, _ := crypto.Encrypt([]byte(fb.accessURL()), testKey)
+	conn := provider.Connection{ProviderName: "simplefin", EncryptedCredentials: enc}
+
+	// Empty cursor → 365-day backfill, chunked into ≤90-day windows.
+	if _, err := p.SyncTransactions(context.Background(), conn, ""); err != nil {
+		t.Fatalf("SyncTransactions: %v", err)
+	}
+	wantWindows := len(windows(time.Now().UTC().AddDate(0, 0, -initialBackfillDays), time.Now().UTC(), maxWindowDays))
+	if fb.accountsHits != wantWindows {
+		t.Errorf("accounts requests = %d, want %d (one per window)", fb.accountsHits, wantWindows)
+	}
+	if fb.accountsHits < 4 {
+		t.Errorf("expected the 365-day backfill to span ≥4 windows, got %d", fb.accountsHits)
+	}
+}
+
+func TestSyncTransactions_ReauthOn403(t *testing.T) {
+	fb := newFakeBridge(t, `{}`)
+	fb.user = "different" // force a 403 from the auth check
+	p := testProvider()
+	enc, _ := crypto.Encrypt([]byte(fmt.Sprintf("%s://wrong:creds@%s/simplefin", mustScheme(fb), mustHost(fb))), testKey)
+	conn := provider.Connection{ProviderName: "simplefin", EncryptedCredentials: enc}
+
+	_, err := p.SyncTransactions(context.Background(), conn, time.Now().Format(time.RFC3339))
+	if err == nil || !isReauth(err) {
+		t.Fatalf("expected ErrReauthRequired, got %v", err)
+	}
+}
+
+func TestGetBalances(t *testing.T) {
+	fb := newFakeBridge(t, `{"errors":[],"accounts":[
+		{"org":{"name":"Bank"},"id":"acct-1","name":"Checking","currency":"USD","balance":"123.45","available-balance":"120.00"},
+		{"org":{"name":"Bank"},"id":"acct-2","name":"Savings","currency":"USD","balance":"999.99"}
+	]}`)
+	p := testProvider()
+	enc, _ := crypto.Encrypt([]byte(fb.accessURL()), testKey)
+	conn := provider.Connection{ProviderName: "simplefin", EncryptedCredentials: enc}
+
+	bals, err := p.GetBalances(context.Background(), conn)
+	if err != nil {
+		t.Fatalf("GetBalances: %v", err)
+	}
+	if len(bals) != 2 {
+		t.Fatalf("balances = %d, want 2", len(bals))
+	}
+	if bals[0].Current.String() != "123.45" || bals[0].Available == nil || bals[0].Available.String() != "120" {
+		t.Errorf("acct-1 balance mapping unexpected: %+v", bals[0])
+	}
+	if bals[1].Available != nil {
+		t.Errorf("acct-2 should have nil Available")
+	}
+}
+
+func TestUnsupportedOps(t *testing.T) {
+	p := testProvider()
+	ctx := context.Background()
+	if _, err := p.CreateLinkSession(ctx, "u"); err != provider.ErrNotSupported {
+		t.Errorf("CreateLinkSession err = %v", err)
+	}
+	if _, err := p.HandleWebhook(ctx, provider.WebhookPayload{}); err != provider.ErrNotSupported {
+		t.Errorf("HandleWebhook err = %v", err)
+	}
+	if _, err := p.CreateReauthSession(ctx, provider.Connection{}); err != provider.ErrNotSupported {
+		t.Errorf("CreateReauthSession err = %v", err)
+	}
+	if err := p.RemoveConnection(ctx, provider.Connection{}); err != nil {
+		t.Errorf("RemoveConnection err = %v", err)
+	}
+	if !p.ReconcilesPendingByPolling() {
+		t.Error("ReconcilesPendingByPolling should be true")
+	}
+}
+
+func TestWindows(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// 200 days, 90-day windows → 3 windows (90+90+20), contiguous.
+	ws := windows(now.AddDate(0, 0, -200), now, 90)
+	if len(ws) != 3 {
+		t.Fatalf("windows = %d, want 3", len(ws))
+	}
+	for i := 1; i < len(ws); i++ {
+		if !ws[i].start.Equal(ws[i-1].end) {
+			t.Errorf("windows not contiguous at %d", i)
+		}
+	}
+	if !ws[len(ws)-1].end.Equal(now) {
+		t.Errorf("last window end = %v, want %v", ws[len(ws)-1].end, now)
+	}
+	if windows(now, now.AddDate(0, 0, -1), 90) != nil {
+		t.Error("expected nil for empty/inverted range")
+	}
+}
+
+func TestErrorStrings(t *testing.T) {
+	var set accountSet
+	if err := json.Unmarshal([]byte(`{"errors":["plain warning"],"errlist":[{"code":"con.mfa","msg":"MFA needed"}]}`), &set); err != nil {
+		t.Fatal(err)
+	}
+	got := set.errorStrings()
+	if len(got) != 2 || got[0] != "plain warning" || !strings.Contains(got[1], "MFA needed") {
+		t.Errorf("errorStrings = %v", got)
+	}
+}
+
+// --- helpers ---
+
+func isReauth(err error) bool {
+	return err != nil && (err == ErrReauthRequired || strings.Contains(err.Error(), "access revoked"))
+}
+
+func mustScheme(fb *fakeBridge) string {
+	u, _ := url.Parse(fb.server.URL)
+	return u.Scheme
+}
+
+func mustHost(fb *fakeBridge) string {
+	u, _ := url.Parse(fb.server.URL)
+	return u.Host
+}

--- a/internal/provider/simplefin/stubs.go
+++ b/internal/provider/simplefin/stubs.go
@@ -1,0 +1,27 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+
+	"breadbox/internal/provider"
+)
+
+// HandleWebhook is unsupported: SimpleFIN is poll-only and never pushes events.
+func (p *SimpleFINProvider) HandleWebhook(ctx context.Context, payload provider.WebhookPayload) (provider.WebhookEvent, error) {
+	return provider.WebhookEvent{}, provider.ErrNotSupported
+}
+
+// CreateReauthSession is unsupported: SimpleFIN reauth is a fresh token paste,
+// not a server-mintable session. The admin relink flow re-runs the token-paste
+// exchange against the existing connection and rotates its access URL in place.
+func (p *SimpleFINProvider) CreateReauthSession(ctx context.Context, conn provider.Connection) (provider.LinkSession, error) {
+	return provider.LinkSession{}, provider.ErrNotSupported
+}
+
+// RemoveConnection is a no-op. SimpleFIN has no documented revoke endpoint; the
+// user disables the access token at their bridge. Local cleanup proceeds.
+func (p *SimpleFINProvider) RemoveConnection(ctx context.Context, conn provider.Connection) error {
+	return nil
+}

--- a/internal/provider/simplefin/sync.go
+++ b/internal/provider/simplefin/sync.go
@@ -1,0 +1,126 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"breadbox/internal/crypto"
+	"breadbox/internal/provider"
+)
+
+const (
+	// maxWindowDays is the SimpleFIN Bridge's hard cap on the date range of a
+	// single /accounts request (start-date..end-date). Larger spans must be
+	// fetched in chunks.
+	maxWindowDays = 90
+	// initialBackfillDays bounds the first sync. ~1 year ≈ 5 windowed requests,
+	// well under the bridge's ~24-requests/day budget.
+	initialBackfillDays = 365
+	// overlapDays re-fetches recent history on incremental syncs to catch
+	// late-posting transactions. Idempotent upserts absorb the duplicates.
+	overlapDays = 10
+)
+
+// SyncTransactions fetches transactions via date-range polling, chunked into
+// windows no larger than the bridge's 90-day limit. The cursor is the RFC3339
+// timestamp of the last sync (same scheme as Teller).
+func (p *SimpleFINProvider) SyncTransactions(ctx context.Context, conn provider.Connection, cursor string) (provider.SyncResult, error) {
+	accessURLBytes, err := crypto.Decrypt(conn.EncryptedCredentials, p.encryptionKey)
+	if err != nil {
+		return provider.SyncResult{}, fmt.Errorf("simplefin: decrypt access URL: %w", err)
+	}
+	accessURL := string(accessURLBytes)
+
+	now := time.Now().UTC()
+	fromDate, err := syncStart(cursor, now)
+	if err != nil {
+		return provider.SyncResult{}, err
+	}
+
+	var allTxns []provider.Transaction
+	for _, w := range windows(fromDate, now, maxWindowDays) {
+		txns, err := p.fetchWindow(ctx, accessURL, w.start, w.end)
+		if err != nil {
+			return provider.SyncResult{}, err
+		}
+		allTxns = append(allTxns, txns...)
+	}
+
+	return provider.SyncResult{
+		Added:   allTxns,
+		HasMore: false,
+		Cursor:  now.Format(time.RFC3339),
+	}, nil
+}
+
+// syncStart computes the start of the sync window from the stored cursor.
+func syncStart(cursor string, now time.Time) (time.Time, error) {
+	if cursor == "" {
+		return now.AddDate(0, 0, -initialBackfillDays), nil
+	}
+	parsed, err := time.Parse(time.RFC3339, cursor)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("simplefin: parse cursor %q: %w", cursor, err)
+	}
+	return parsed.AddDate(0, 0, -overlapDays), nil
+}
+
+// fetchWindow fetches one date-bounded /accounts page and maps every nested
+// transaction. start-date is inclusive, end-date is exclusive.
+func (p *SimpleFINProvider) fetchWindow(ctx context.Context, accessURL string, start, end time.Time) ([]provider.Transaction, error) {
+	query := strings.Join([]string{
+		"start-date=" + strconv.FormatInt(start.Unix(), 10),
+		"end-date=" + strconv.FormatInt(end.Unix(), 10),
+		"pending=1",
+	}, "&")
+
+	set, err := p.fetchAccountSet(ctx, accessURL, query)
+	if err != nil {
+		return nil, err
+	}
+
+	var txns []provider.Transaction
+	for _, acct := range set.Accounts {
+		for _, t := range acct.Transactions {
+			mapped, err := t.toTransaction(acct.ID, acct.Currency)
+			if err != nil {
+				p.logger.WarnContext(ctx, "simplefin: skipping transaction with parse error",
+					"transaction_id", t.ID, "account_id", acct.ID, "error", err)
+				continue
+			}
+			txns = append(txns, mapped)
+		}
+	}
+	return txns, nil
+}
+
+type window struct {
+	start time.Time
+	end   time.Time
+}
+
+// windows splits [from, to) into consecutive spans no longer than maxDays. The
+// windows are contiguous and non-overlapping; since SimpleFIN treats end-date as
+// exclusive and start-date as inclusive, boundary transactions are not double
+// counted across adjacent windows.
+func windows(from, to time.Time, maxDays int) []window {
+	if !from.Before(to) {
+		return nil
+	}
+	var out []window
+	span := time.Duration(maxDays) * 24 * time.Hour
+	for start := from; start.Before(to); {
+		end := start.Add(span)
+		if end.After(to) {
+			end = to
+		}
+		out = append(out, window{start: start, end: end})
+		start = end
+	}
+	return out
+}

--- a/internal/provider/simplefin/types.go
+++ b/internal/provider/simplefin/types.go
@@ -1,0 +1,170 @@
+//go:build !lite
+
+package simplefin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"breadbox/internal/provider"
+
+	"github.com/shopspring/decimal"
+)
+
+// decodeAccountSet decodes a SimpleFIN /accounts response body.
+func decodeAccountSet(r io.Reader) (accountSet, error) {
+	var set accountSet
+	if err := json.NewDecoder(r).Decode(&set); err != nil {
+		return accountSet{}, fmt.Errorf("simplefin: decode accounts response: %w", err)
+	}
+	return set, nil
+}
+
+// accountSet is the top-level SimpleFIN /accounts response. The error list is
+// captured under both "errors" (what bridge.simplefin.org actually returns) and
+// "errlist" (the name used in the protocol spec) for robustness.
+type accountSet struct {
+	Errors   []json.RawMessage `json:"errors"`
+	Errlist  []json.RawMessage `json:"errlist"`
+	Accounts []sfinAccount     `json:"accounts"`
+}
+
+// errorStrings returns the combined error/errlist entries as display strings.
+func (a accountSet) errorStrings() []string {
+	var out []string
+	for _, raw := range append(append([]json.RawMessage{}, a.Errors...), a.Errlist...) {
+		out = append(out, rawErrorString(raw))
+	}
+	return out
+}
+
+// rawErrorString renders a SimpleFIN error entry, which may be a bare string or
+// an object ({code,msg,...}), as a human-readable string.
+func rawErrorString(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		Code string `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		switch {
+		case obj.Msg != "" && obj.Code != "":
+			return fmt.Sprintf("%s: %s", obj.Code, obj.Msg)
+		case obj.Msg != "":
+			return obj.Msg
+		case obj.Code != "":
+			return obj.Code
+		}
+	}
+	return string(raw)
+}
+
+// sfinOrg is the institution an account belongs to. A single access URL can
+// span multiple orgs (SimpleFIN is a multi-bank aggregator).
+type sfinOrg struct {
+	Domain  string `json:"domain"`
+	Name    string `json:"name"`
+	SFINURL string `json:"sfin-url"`
+	URL     string `json:"url"`
+	ID      string `json:"id"`
+}
+
+// displayName returns the best human label for the org.
+func (o sfinOrg) displayName() string {
+	if o.Name != "" {
+		return o.Name
+	}
+	return o.Domain
+}
+
+// sfinAccount is a single account in the /accounts response.
+type sfinAccount struct {
+	Org              sfinOrg           `json:"org"`
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	Currency         string            `json:"currency"`
+	Balance          string            `json:"balance"`
+	AvailableBalance string            `json:"available-balance"`
+	BalanceDate      int64             `json:"balance-date"`
+	Transactions     []sfinTransaction `json:"transactions"`
+}
+
+// sfinTransaction is a single transaction nested under an account.
+type sfinTransaction struct {
+	ID           string `json:"id"`
+	Posted       int64  `json:"posted"`
+	Amount       string `json:"amount"`
+	Description  string `json:"description"`
+	Payee        string `json:"payee"`
+	Memo         string `json:"memo"`
+	TransactedAt int64  `json:"transacted_at"`
+	Pending      bool   `json:"pending"`
+}
+
+// toAccount maps a SimpleFIN account to a provider.Account. SimpleFIN does not
+// expose an account type/subtype/mask, so type defaults to "depository" and the
+// owning org's name is carried in OfficialName for institution context.
+func (a sfinAccount) toAccount() provider.Account {
+	return provider.Account{
+		ExternalID:      a.ID,
+		Name:            a.Name,
+		OfficialName:    a.Org.displayName(),
+		Type:            "depository",
+		ISOCurrencyCode: a.Currency,
+	}
+}
+
+// toTransaction maps a SimpleFIN transaction to a provider.Transaction.
+//
+// Sign convention: SimpleFIN amounts are positive for money IN (deposits);
+// Breadbox uses positive for money OUT (debits), so we negate uniformly.
+func (t sfinTransaction) toTransaction(accountID, currency string) (provider.Transaction, error) {
+	amount, err := decimal.NewFromString(t.Amount)
+	if err != nil {
+		return provider.Transaction{}, fmt.Errorf("parse amount %q: %w", t.Amount, err)
+	}
+	amount = amount.Neg()
+
+	pending := t.Pending || t.Posted == 0
+	date := t.date()
+
+	out := provider.Transaction{
+		ExternalID:        t.ID,
+		AccountExternalID: accountID,
+		Amount:            amount,
+		Date:              date,
+		Name:              t.Description,
+		Pending:           pending,
+		PaymentChannel:    "other",
+		ISOCurrencyCode:   currency,
+	}
+
+	if t.Payee != "" {
+		payee := t.Payee
+		out.MerchantName = &payee
+	}
+
+	if raw, err := json.Marshal(t); err == nil {
+		out.Raw = raw
+	}
+
+	return out, nil
+}
+
+// date resolves the transaction's effective date, preferring the settlement
+// timestamp (posted) and falling back to transacted_at, then now.
+func (t sfinTransaction) date() time.Time {
+	switch {
+	case t.Posted > 0:
+		return time.Unix(t.Posted, 0).UTC()
+	case t.TransactedAt > 0:
+		return time.Unix(t.TransactedAt, 0).UTC()
+	default:
+		return time.Now().UTC()
+	}
+}

--- a/internal/provider/teller/provider.go
+++ b/internal/provider/teller/provider.go
@@ -33,3 +33,8 @@ func NewProvider(client *Client, appID, env, webhookSecret string, encryptionKey
 	}
 }
 
+// ReconcilesPendingByPolling reports that Teller re-returns its full
+// transaction window on every sync (date-range polling), so the sync engine
+// should soft-delete pending rows no longer present in the window.
+func (p *TellerProvider) ReconcilesPendingByPolling() bool { return true }
+

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -405,8 +405,10 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, syncLogS
 			logger.Debug("skipped transactions for excluded accounts", "skipped", skipped)
 		}
 
-		// Clean up stale pending transactions for Teller connections.
-		if string(conn.Provider) == "teller" {
+		// Clean up stale pending transactions for poll-based providers that
+		// re-return their full window each sync (Teller, SimpleFIN). Cursor/
+		// webhook providers (Plaid) manage pending→posted themselves.
+		if prov.ReconcilesPendingByPolling() {
 			staleCount := e.cleanStalePending(ctx, tx, connectionID, pendingAdded, previousCursor, logger)
 			removed += staleCount
 		}
@@ -1095,8 +1097,9 @@ func (e *Engine) updateBalances(ctx context.Context, q *db.Queries, prov provide
 }
 
 // cleanStalePending soft-deletes pending transactions that were not returned by
-// the Teller API during this sync window. This handles the case where a pending
-// transaction disappears without posting (e.g., holds that expire).
+// a poll-based provider during this sync window. This handles the case where a
+// pending transaction disappears without posting (e.g., holds that expire).
+// Only invoked for providers whose ReconcilesPendingByPolling() is true.
 func (e *Engine) cleanStalePending(ctx context.Context, tx pgx.Tx, connectionID pgtype.UUID, addedTxns []provider.Transaction, previousCursor string, logger *slog.Logger) int {
 	// Calculate date window.
 	toDate := time.Now()

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -22,11 +22,12 @@ import (
 
 // mockProvider implements provider.Provider for testing the sync engine.
 type mockProvider struct {
-	syncResult  provider.SyncResult
-	syncErr     error
-	balances    []provider.AccountBalance
-	balancesErr error
-	syncCalls   int
+	syncResult        provider.SyncResult
+	syncErr           error
+	balances          []provider.AccountBalance
+	balancesErr       error
+	syncCalls         int
+	reconcilesPending bool
 }
 
 func (m *mockProvider) CreateLinkSession(ctx context.Context, userID string) (provider.LinkSession, error) {
@@ -64,6 +65,8 @@ func (m *mockProvider) RemoveConnection(ctx context.Context, conn provider.Conne
 	return nil
 }
 
+func (m *mockProvider) ReconcilesPendingByPolling() bool { return m.reconcilesPending }
+
 // paginatingMockProvider returns HasMore=true on first call, then results on second call.
 type paginatingMockProvider struct {
 	pages     []provider.SyncResult
@@ -97,6 +100,7 @@ func (m *paginatingMockProvider) CreateReauthSession(ctx context.Context, conn p
 func (m *paginatingMockProvider) RemoveConnection(ctx context.Context, conn provider.Connection) error {
 	return nil
 }
+func (m *paginatingMockProvider) ReconcilesPendingByPolling() bool { return false }
 
 // retryMockProvider returns ErrSyncRetryable on first call, then succeeds.
 type retryMockProvider struct {
@@ -130,6 +134,7 @@ func (m *retryMockProvider) CreateReauthSession(ctx context.Context, conn provid
 func (m *retryMockProvider) RemoveConnection(ctx context.Context, conn provider.Connection) error {
 	return nil
 }
+func (m *retryMockProvider) ReconcilesPendingByPolling() bool { return false }
 
 func newEngine(t *testing.T, pool *pgxpool.Pool, queries *db.Queries, providers map[string]provider.Provider) *sync.Engine {
 	t.Helper()
@@ -995,6 +1000,7 @@ func TestSync_TellerStalePendingCleanup(t *testing.T) {
 	_ = postedTxn
 
 	mock := &mockProvider{
+		reconcilesPending: true,
 		syncResult: provider.SyncResult{
 			Added: []provider.Transaction{
 				{

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -23,7 +23,7 @@ templ ConnectionNew(p ConnectionNewProps) {
 			<p class="text-sm text-base-content/50 mt-1">Link a bank account to start syncing transactions</p>
 		</div>
 	</div>
-	if !p.HasPlaid && !p.HasTeller {
+	if !p.HasPlaid && !p.HasTeller && !p.HasSimpleFin {
 		<!-- No providers configured -->
 		<div class="bb-card p-8 max-w-lg">
 			<div class="flex flex-col items-center text-center">
@@ -33,7 +33,8 @@ templ ConnectionNew(p ConnectionNewProps) {
 				<h2 class="text-lg font-semibold mb-1">No Providers Configured</h2>
 				<p class="text-sm text-base-content/50 mb-6">You need to configure at least one bank provider before creating connections.</p>
 				<a href="/settings/providers" class="btn btn-primary btn-sm">
-					@components.LucideIcon("settings", "w-4 h-4") Configure Providers
+					@components.LucideIcon("settings", "w-4 h-4")
+					Configure Providers
 				</a>
 			</div>
 		</div>
@@ -80,6 +81,22 @@ templ ConnectionNew(p ConnectionNewProps) {
 										</div>
 									</label>
 								}
+								if p.HasSimpleFin {
+									<label class="relative cursor-pointer">
+										if !p.HasPlaid && !p.HasTeller {
+											<input type="radio" name="provider" value="simplefin" class="peer sr-only" checked/>
+										} else {
+											<input type="radio" name="provider" value="simplefin" class="peer sr-only"/>
+										}
+										<div
+											class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
+                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300"
+										>
+											@components.LucideIcon("key-round", "w-6 h-6 text-base-content opacity-60")
+											<span class="text-sm font-medium">SimpleFIN</span>
+										</div>
+									</label>
+								}
 								<label class="relative cursor-pointer">
 									<input type="radio" name="provider" value="csv" class="peer sr-only"/>
 									<div
@@ -121,15 +138,52 @@ templ ConnectionNew(p ConnectionNewProps) {
 						<p id="link-status" class="text-sm text-base-content/50 mb-6">Opening bank connection dialog...</p>
 						<div class="flex items-center gap-3">
 							<button id="retry-btn" class="btn btn-primary btn-sm hidden">
-								@components.LucideIcon("refresh-cw", "w-4 h-4") Retry
+								@components.LucideIcon("refresh-cw", "w-4 h-4")
+								Retry
 							</button>
 							<button id="back-btn" class="btn btn-ghost btn-sm">
-								@components.LucideIcon("arrow-left", "w-4 h-4") Back
+								@components.LucideIcon("arrow-left", "w-4 h-4")
+								Back
 							</button>
 						</div>
 					</div>
 				</div>
 			</div>
+			if p.HasSimpleFin {
+				<div id="step-simplefin" class="hidden">
+					<div class="bb-card p-8 max-w-lg">
+						<div class="flex items-center gap-3 mb-6">
+							@components.IconTile("primary", "key-round")
+							<div>
+								<h2 class="text-base font-semibold">Connect SimpleFIN</h2>
+								<p class="text-xs text-base-content/45">Connecting for: <span id="simplefin-member-name" class="font-medium text-base-content"></span></p>
+							</div>
+						</div>
+						<div class="flex flex-col gap-4">
+							<p class="text-sm text-base-content/60">
+								Paste the one-time setup token from your SimpleFIN bridge. Don't have one yet?
+								<a href="https://bridge.simplefin.org/simplefin/create" target="_blank" rel="noopener" class="link link-primary">Get a token</a>
+								— or use your own server's <code class="text-xs">/create</code> page if self-hosted.
+							</p>
+							<fieldset class="fieldset">
+								<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="simplefin-token">Setup token</label>
+								<textarea id="simplefin-token" rows="4" class="textarea w-full font-mono text-xs" placeholder="Paste your SimpleFIN setup token…"></textarea>
+							</fieldset>
+							<p id="simplefin-status" class="text-sm text-base-content/50 min-h-5"></p>
+							<div class="flex items-center gap-3">
+								<button id="simplefin-submit" class="btn btn-primary btn-sm">
+									@components.LucideIcon("link", "w-4 h-4")
+									Connect
+								</button>
+								<button id="simplefin-back" class="btn btn-ghost btn-sm">
+									@components.LucideIcon("arrow-left", "w-4 h-4")
+									Back
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			}
 		</div>
 	}
 }

--- a/internal/templates/components/pages/connection_new_types.go
+++ b/internal/templates/components/pages/connection_new_types.go
@@ -8,17 +8,20 @@ package pages
 // flat {ID, Name} slice so the templ side stays free of pgtype/pgconv
 // plumbing.
 //
-// HasPlaid / HasTeller drive the provider radio cards on the select step.
-// When neither is true the page renders the "no providers configured"
-// empty state instead of the wizard. TellerEnv is interpolated into the
-// inline <script> so TellerConnect.setup picks up sandbox/development/
-// production from the running config.
+// HasPlaid / HasTeller / HasSimpleFin drive the provider radio cards on the
+// select step. When none is true the page renders the "no providers
+// configured" empty state instead of the wizard. TellerEnv is interpolated
+// into the inline <script> so TellerConnect.setup picks up sandbox/
+// development/production from the running config. SimpleFIN is token-paste
+// (no SDK): selecting it reveals an inline setup-token form instead of
+// launching a provider popup.
 type ConnectionNewProps struct {
-	Users       []ConnectionNewUser
-	CSRFToken   string
-	HasPlaid    bool
-	HasTeller   bool
-	TellerEnv   string
+	Users        []ConnectionNewUser
+	CSRFToken    string
+	HasPlaid     bool
+	HasTeller    bool
+	HasSimpleFin bool
+	TellerEnv    string
 }
 
 // ConnectionNewUser is the flat view of a User the family-member <select>

--- a/internal/templates/components/pages/connection_reauth.templ
+++ b/internal/templates/components/pages/connection_reauth.templ
@@ -68,6 +68,15 @@ templ ConnectionReauth(p ConnectionReauthProps) {
 				:class="isError ? 'text-error' : 'text-base-content/50'"
 				x-text="status"
 			></p>
+			if p.Provider == "simplefin" {
+				<div class="w-full mb-6 text-left">
+					<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="simplefin-reauth-token">New setup token</label>
+					<textarea id="simplefin-reauth-token" rows="4" class="textarea w-full font-mono text-xs" placeholder="Paste a fresh SimpleFIN setup token…"></textarea>
+					<button type="button" class="btn btn-primary btn-sm mt-3" @click="submitSimplefin()">
+						@components.LucideIcon("link", "w-4 h-4") Reconnect
+					</button>
+				</div>
+			}
 			<div class="flex items-center gap-3">
 				<button
 					type="button"

--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -46,6 +46,14 @@ templ Providers(p ProvidersProps) {
 				Configured: p.TellerConfigured,
 				Health:     p.ProviderHealth["teller"],
 			})
+			@providerRow(providerRowData{
+				ID:         "simplefin",
+				Icon:       "key-round",
+				Name:       "SimpleFIN",
+				Desc:       "Paste a setup token — multi-bank, poll-only",
+				Configured: p.SimpleFINEnabled,
+				Health:     p.ProviderHealth["simplefin"],
+			})
 		}
 		@components.SettingsSection(components.SettingsSectionProps{
 			Icon:    "upload",
@@ -66,8 +74,84 @@ templ Providers(p ProvidersProps) {
 		// (plus its scrim) shows.
 		@providersPlaidDrawer(p, p.ProviderHealth["plaid"])
 		@providersTellerDrawer(p, p.ProviderHealth["teller"])
+		@providersSimplefinDrawer(p, p.ProviderHealth["simplefin"])
 		@providersCSVDrawer(p.ProviderHealth["csv"])
 	</div>
+}
+
+// providersSimplefinDrawer holds the SimpleFIN opt-in. SimpleFIN has no
+// server-level credential — the access token is pasted per connection — so the
+// only setting is whether the provider is offered when adding a connection.
+templ providersSimplefinDrawer(p ProvidersProps, h *service.ProviderHealthSummary) {
+	@components.Drawer(components.DrawerProps{
+		ID:    "provider-simplefin",
+		Title: "SimpleFIN",
+		Size:  "md",
+	}) {
+		<div class="flex flex-col h-full">
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     "key-round",
+				Title:    "SimpleFIN",
+				Subtitle: "Token-paste, poll-only bank aggregation",
+			})
+			if p.SimpleFINFromEnv {
+				<div class="flex-1 overflow-y-auto p-5 space-y-5">
+					@providerHealthBlock(h, p.SimpleFINEnabled)
+					<p class="text-sm text-base-content/70 leading-relaxed">
+						SimpleFIN is { simplefinEnabledWord(p.SimpleFINEnabled) } via the
+						<code class="font-mono text-xs">SIMPLEFIN_ENABLED</code> environment
+						variable and can't be changed here.
+					</p>
+				</div>
+				@providerDrawerCloseFooter(false)
+			} else {
+				<form
+					method="POST"
+					action="/settings/providers/simplefin"
+					autocomplete="off"
+					class="flex flex-col h-full"
+					x-data="providerCard"
+					data-provider="simplefin"
+					@submit="saving = true"
+				>
+					<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+					<div class="flex-1 overflow-y-auto p-5 space-y-5">
+						<p class="text-sm text-base-content/70 leading-relaxed">
+							SimpleFIN connects to many banks through a one-time setup token you
+							paste when adding a connection — no app credentials to configure
+							here. Enable it to offer SimpleFIN on the connect screen.
+						</p>
+						@providerField(providerFieldProps{Label: "Offer SimpleFIN", For: "simplefin_enabled"}) {
+							<label class="flex items-center gap-3 cursor-pointer">
+								if p.SimpleFINEnabled {
+									<input type="checkbox" id="simplefin_enabled" name="simplefin_enabled" value="on" class="toggle toggle-primary" checked/>
+								} else {
+									<input type="checkbox" id="simplefin_enabled" name="simplefin_enabled" value="on" class="toggle toggle-primary"/>
+								}
+								<span class="text-sm text-base-content/70">Available when adding a connection</span>
+							</label>
+						}
+						<p class="text-xs text-base-content/45 leading-relaxed">
+							New SimpleFIN connections sync once a day to stay within the bridge's
+							request budget. Get a token from
+							<a href="https://bridge.simplefin.org/simplefin/create" target="_blank" rel="noopener" class="link link-primary">bridge.simplefin.org</a>
+							or your own SimpleFIN server.
+						</p>
+					</div>
+					@providerDrawerSaveFooter(p.SimpleFINEnabled)
+				</form>
+			}
+		</div>
+	}
+}
+
+// simplefinEnabledWord renders the env-managed state as a word for the
+// read-only SimpleFIN drawer copy.
+func simplefinEnabledWord(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
 }
 
 // ---------------------------------------------------------------------

--- a/internal/templates/components/pages/providers_types.go
+++ b/internal/templates/components/pages/providers_types.go
@@ -27,6 +27,12 @@ type ProvidersProps struct {
 	TellerCertConfigured    bool
 	TellerWebhookConfigured bool
 
+	// SimpleFIN state. SimpleFIN has no server-level credential — it's an
+	// opt-in toggle deciding whether the provider is offered at connect time
+	// (the access token is pasted per connection).
+	SimpleFINEnabled bool
+	SimpleFINFromEnv bool
+
 	// Encryption-key availability (needed to store cert PEM bytes).
 	HasEncryptionKey bool
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2701,6 +2701,10 @@
 
       // Handle form submissions
       document.addEventListener('submit', function(e) {
+        // A handler that called preventDefault() is taking over client-side —
+        // no navigation is coming, so starting the nav bar would leave it
+        // trickling forever (e.g. the connect wizard's step transition).
+        if (e.defaultPrevented) return;
         var form = e.target;
         if (form && form.method && form.method.toLowerCase() === 'get') {
           start();

--- a/static/js/admin/components/connection_new.js
+++ b/static/js/admin/components/connection_new.js
@@ -36,6 +36,15 @@ document.addEventListener('alpine:init', function () {
             window.location.href = '/connections/import-csv';
             return;
           }
+          if (selectedProvider === 'simplefin') {
+            // Token-paste flow — no SDK, no /-/link-token round trip.
+            var sfName = document.getElementById('simplefin-member-name');
+            if (sfName) sfName.textContent = select.options[select.selectedIndex].text;
+            stepSelect.classList.add('hidden');
+            document.getElementById('step-simplefin').classList.remove('hidden');
+            setTimeout(function () { if (typeof lucide !== 'undefined') lucide.createIcons(); }, 50);
+            return;
+          }
           memberNameEl.textContent = select.options[select.selectedIndex].text;
           stepSelect.classList.add('hidden');
           stepLink.classList.remove('hidden');
@@ -194,6 +203,65 @@ document.addEventListener('alpine:init', function () {
         }
 
         retryBtn.addEventListener('click', startLink);
+
+        // SimpleFIN token-paste flow. The textarea + buttons only exist when
+        // the SimpleFIN provider is enabled, so guard on their presence.
+        var sfSubmit = document.getElementById('simplefin-submit');
+        if (sfSubmit) {
+          var sfStep = document.getElementById('step-simplefin');
+          var sfToken = document.getElementById('simplefin-token');
+          var sfStatus = document.getElementById('simplefin-status');
+          var sfBack = document.getElementById('simplefin-back');
+
+          sfBack.addEventListener('click', function (e) {
+            e.preventDefault();
+            sfStep.classList.add('hidden');
+            stepSelect.classList.remove('hidden');
+            sfStatus.textContent = '';
+            sfStatus.classList.remove('text-error');
+          });
+
+          sfSubmit.addEventListener('click', function (e) {
+            e.preventDefault();
+            var token = (sfToken.value || '').trim();
+            if (!token) {
+              sfStatus.textContent = 'Paste your SimpleFIN setup token first.';
+              sfStatus.classList.add('text-error');
+              return;
+            }
+            sfStatus.textContent = 'Claiming token and discovering accounts…';
+            sfStatus.classList.remove('text-error');
+            sfStatus.classList.add('text-base-content/50');
+            sfSubmit.disabled = true;
+
+            fetch('/-/exchange-token', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({
+                public_token: token,
+                user_id: selectedUserId,
+                institution_id: 'simplefin',
+                institution_name: 'SimpleFIN',
+                provider: 'simplefin'
+              })
+            })
+            .then(function (res) { return res.json(); })
+            .then(function (data) {
+              if (data.connection_id) {
+                window.location.href = '/connections/' + data.connection_id;
+              } else {
+                sfStatus.textContent = data.error || 'Failed to connect. Check the token and try again.';
+                sfStatus.classList.add('text-error');
+                sfSubmit.disabled = false;
+              }
+            })
+            .catch(function () {
+              sfStatus.textContent = 'Network error. Please try again.';
+              sfStatus.classList.add('text-error');
+              sfSubmit.disabled = false;
+            });
+          });
+        }
       }
     };
   });

--- a/static/js/admin/components/connection_reauth.js
+++ b/static/js/admin/components/connection_reauth.js
@@ -24,7 +24,43 @@ document.addEventListener('alpine:init', function () {
         this.provider = root.dataset.provider || '';
         this.tellerAppId = root.dataset.tellerAppId || '';
         this.tellerEnv = root.dataset.tellerEnv || '';
+        if (this.provider === 'simplefin') {
+          // Token-paste reauth: no SDK to launch. Wait for the user to paste a
+          // fresh setup token and submit it.
+          this.showMessage('Paste a fresh SimpleFIN setup token to reconnect.');
+          return;
+        }
         this.startReauth();
+      },
+
+      // submitSimplefin claims a freshly pasted setup token and rotates the
+      // connection's stored credentials in place.
+      submitSimplefin: function () {
+        var self = this;
+        var ta = document.getElementById('simplefin-reauth-token');
+        var token = ta ? (ta.value || '').trim() : '';
+        if (!token) {
+          self.showError('Paste your new SimpleFIN setup token first.');
+          return;
+        }
+        self.showMessage('Claiming token and reconnecting…');
+        self.canRetry = false;
+        fetch('/-/connections/' + this.connId + '/reauth-complete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ public_token: token }),
+        })
+          .then(function (res) { return res.json(); })
+          .then(function (data) {
+            if (data.status === 'active') {
+              window.location.href = '/connections/' + self.connId;
+            } else {
+              self.showError(data.error || 'Re-authentication failed.');
+            }
+          })
+          .catch(function () {
+            self.showError('Network error. Please try again.');
+          });
       },
 
       showError: function (msg) {


### PR DESCRIPTION
Adds **SimpleFIN** as the next bank provider after Plaid and Teller — the aggregator the self-hosting / Actual-Budget crowd already uses (~$1.50/mo). The protocol is the simplest possible: a pasted setup token, HTTP Basic auth, and a single poll endpoint. No OAuth, no SDK, no webhooks.

## What's in here

**Interface improvement (precursor)**
- New `ReconcilesPendingByPolling()` capability on the `Provider` interface (teller/simplefin = `true`; plaid/csv = `false`), replacing the hardcoded `conn.Provider == "teller"` stale-pending gate in the sync engine. Poll-based providers now share the cleanup without a name check.

**The provider** (`internal/provider/simplefin/`)
- Claim flow in `ExchangeToken`: base64 setup token → `POST` claim URL → access URL, stored **AES-GCM encrypted**. Mints an opaque `shortid` `external_id` (SimpleFIN has no stable upstream connection id, and the access URL embeds credentials — it never lands in `external_id` or logs).
- 90-day windowed polling (stays under the ~24 req/day budget), **amount sign negated** (SimpleFIN positive = money in; Breadbox positive = debit), pending mapped from the flag / `posted == 0`.
- `403` → `ErrReauthRequired`; `402`/`429`/`5xx` classified; `errlist[]` surfaced to the user.
- Balances via `balances-only=1`; link/webhook/reauth stub `ErrNotSupported`.

**Admin wiring**
- `SIMPLEFIN_ENABLED` opt-in flag (env + `app_config`), providers-settings card + toggle with hot-reload.
- Connect via a token-paste panel (bypasses `/-/link-token`); reauth rotates `encrypted_credentials` in place (same connection row); new connections get a daily sync interval to respect the rate limit.

**Migration** — additive enum value `simplefin` (`ALTER TYPE ... ADD VALUE`, `NO TRANSACTION`).

**Docs** — `docs/simplefin-integration.md`, providers rule, data-model + CLAUDE enum updates.

## Two connect-wizard bug fixes (found in manual testing)
- `#step-simplefin` was authored **inside** the hidden `#step-link` div, so selecting SimpleFIN → Continue left the panel collapsed at 0×0 ("stuck loading"). Made it a sibling.
- The global `submit` handler in `base.html` started the SPA nav progress bar for **any** GET-method form — including the `preventDefault()`-handled connect form — so the bar trickled forever. Now skips when `e.defaultPrevented`. (Pre-existing latent bug; affected every provider.)

## v1 scope / limitations
- **Admin-page connect/relink only** — no REST `POST /api/v1/connections/simplefin`, not in the hosted-link allowlist. SimpleFIN doesn't fit the interactive OAuth/SDK redirect model; REST parity is a clean fast-follow if automation demand appears.
- Account type defaults to `depository` (SimpleFIN doesn't expose it).

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` green (one unrelated flaky timing test in `internal/agent` passed on retry).
- Provider unit tests against a fake bridge: claim, sign negation, 90-day windowing, pending, 403→reauth, balances, errlist.
- End-to-end in a real browser (Chrome MCP): panel renders, claim hits the live bridge, a used demo token surfaces a clean inline `403 — setup token is invalid or already used` with no hang; nav progress bar stays dormant after Continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
