### PR TITLE
feat(mcp): token-optimize tool set — lean-default fields, currency hoisting, response cap

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -10,6 +10,12 @@ Tools are classified as **Read** or **Write**:
 - **Write tools** require the MCP mode to be set to `read_write` (configurable in the admin dashboard under MCP Settings)
 - Individual tools can be disabled from the admin dashboard
 
+## Response size
+
+Token-heavy read tools are **lean by default** — they return a compact field projection and let you opt into more via the `fields` parameter (`fields=all` for the full payload). See `query_transactions`, `list_series`, and `list_transaction_rules`.
+
+Every tool response is also subject to a **byte cap** (default ~100 KB ≈ 25K tokens). A response over the cap returns a `RESPONSE_TOO_LARGE` error asking you to narrow the query (add filters, lower `limit`, paginate via `next_cursor`, or use `fields`) rather than emitting an oversized payload. Operators can raise or disable the cap via the `BREADBOX_MCP_MAX_RESPONSE_BYTES` environment variable (`0` disables it).
+
 ## Sessions
 
 Before using any tools, agents should call `create_session` to establish a session. This provides the agent with dataset context and server instructions.
@@ -21,6 +27,8 @@ Before using any tools, agents should call `create_session` to establish a sessi
 ### query_transactions (Read)
 
 Query transactions with composable filters and cursor pagination.
+
+**Lean by default.** When `fields` is omitted the response is a compact projection (`core,category`) rather than all ~22 fields — pass `fields=all` for the full row, or any explicit alias/field list. When every returned row shares one currency, `iso_currency_code` is emitted once at the top level of the envelope and dropped from each row (per-row fallback when a page mixes currencies). This default is MCP-only; the REST API (`GET /api/v1/transactions`) still returns full objects when `?fields=` is omitted.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -39,7 +47,7 @@ Query transactions with composable filters and cursor pagination.
 | `any_tag` | array | OR filter — must have at least one slug. |
 | `sort_by` | string | `date` (default), `amount`, `provider_name` |
 | `sort_order` | string | `desc` (default), `asc` |
-| `fields` | string | Field selection. Aliases: `minimal`, `core`, `category`, `timestamps` |
+| `fields` | string | Field selection. Aliases: `minimal`, `core`, `category`, `timestamps`. Omitted → `core,category` (lean default); `all` → every field. `id` always included. |
 | `cursor` | string | Pagination cursor |
 | `limit` | int | Results per page (default 50, max 500) |
 
@@ -251,7 +259,7 @@ Admin-only tag CRUD. Agents typically don't need these — `add_transaction_tag`
 
 ### list_series (Read)
 
-List detected recurring series. Optional `status` filter (`active` | `candidate` | `paused` | `cancelled`). Each row carries `type` (`subscription` | `bill` | `loan` | `other` — inferred from category, set via `set_series_type`), `cadence`, `expected_amount` + `iso_currency_code` (never sum across currencies), `next_expected_date`, `occurrence_count`, `confidence` (`auto` | `confirmed` | `rejected`), and `detection_signals` — the raw evidence the detector used. Active series also carry a derived `renewal_health` (`active` | `due_soon` | `overdue` | `stale` | `unknown`) and signed `days_until_renewal` (negative = overdue) so you can answer "what renews soon" and "what looks cancelled" without re-deriving cadence math — `stale` means a full cadence cycle elapsed past the expected charge. Read `status=candidate` to find series awaiting a verdict.
+List detected recurring series. Optional `status` filter (`active` | `candidate` | `paused` | `cancelled`). **Lean by default** (`fields` omitted → `overview` projection): each row carries `type` (`subscription` | `bill` | `loan` | `other` — inferred from category, set via `set_series_type`), `cadence`, `expected_amount` + `iso_currency_code` (never sum across currencies), `next_expected_date`, `occurrence_count`, and `confidence` (`auto` | `confirmed` | `rejected`). Active series also carry a derived `renewal_health` (`active` | `due_soon` | `overdue` | `stale` | `unknown`) and signed `days_until_renewal` (negative = overdue) so you can answer "what renews soon" and "what looks cancelled" without re-deriving cadence math — `stale` means a full cadence cycle elapsed past the expected charge. The verbose `detection_signals` evidence is **omitted** from the lean list — pass `fields=all`, or use `get_series` for one series' full detail. Read `status=candidate` to find series awaiting a verdict.
 
 ### get_series (Read)
 
@@ -324,13 +332,16 @@ Create a rule that fires during sync. Actions compose (`set_category` + `add_tag
 
 ### list_transaction_rules (Read)
 
-List rules with optional filters. Returns actions, priority, hit_count, last_hit_at.
+List rules with optional filters and cursor pagination. **Lean by default** (`fields` omitted → `summary` projection): each row carries `name`, `enabled`, `priority`, `trigger`, `category_slug` / `category_display_name`, `hit_count`, `last_hit_at`, `created_by_type` — the roster view, **without** the `conditions` / `actions` trees. Pass `fields=all` to inspect or audit full rule definitions. Mirror of `breadbox://rules` (which always returns full).
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `search` | string | Substring / words / fuzzy search on rule name |
 | `category_slug` | string | Filter by target category |
 | `enabled` | bool | Filter by enabled status |
+| `fields` | string | Field selection. Alias: `summary` (default). `all` → full definition incl. `conditions`/`actions`. |
+| `cursor` | string | Pagination cursor |
+| `limit` | int | Results per page (default 50, max 500) |
 
 ### update_transaction_rule (Write)
 

--- a/internal/mcp/currency_hoist_test.go
+++ b/internal/mcp/currency_hoist_test.go
@@ -1,0 +1,117 @@
+//go:build !lite
+
+package mcp
+
+import "testing"
+
+func strptr(s string) *string { return &s }
+
+func TestHoistUniformCurrency(t *testing.T) {
+	tests := []struct {
+		name      string
+		rows      []map[string]any
+		wantCur   string
+		wantOK    bool
+		wantStrip bool // per-row iso_currency_code removed on success
+	}{
+		{
+			name:      "all USD via *string hoists and strips",
+			rows:      []map[string]any{{"iso_currency_code": strptr("USD")}, {"iso_currency_code": strptr("USD")}},
+			wantCur:   "USD",
+			wantOK:    true,
+			wantStrip: true,
+		},
+		{
+			name:    "all USD via plain string hoists",
+			rows:    []map[string]any{{"iso_currency_code": "USD"}, {"iso_currency_code": "USD"}},
+			wantCur: "USD",
+			wantOK:  true,
+		},
+		{
+			name:   "mixed currencies stays per-row",
+			rows:   []map[string]any{{"iso_currency_code": strptr("USD")}, {"iso_currency_code": strptr("EUR")}},
+			wantOK: false,
+		},
+		{
+			name:   "a nil currency disables hoisting",
+			rows:   []map[string]any{{"iso_currency_code": strptr("USD")}, {"iso_currency_code": (*string)(nil)}},
+			wantOK: false,
+		},
+		{
+			name:   "an empty-string currency disables hoisting",
+			rows:   []map[string]any{{"iso_currency_code": "USD"}, {"iso_currency_code": ""}},
+			wantOK: false,
+		},
+		{
+			name:   "field absent (not in projection) disables hoisting",
+			rows:   []map[string]any{{"amount": 1.0}, {"amount": 2.0}},
+			wantOK: false,
+		},
+		{
+			name:   "empty list disables hoisting",
+			rows:   []map[string]any{},
+			wantOK: false,
+		},
+		{
+			name:      "single row hoists",
+			rows:      []map[string]any{{"iso_currency_code": strptr("GBP")}},
+			wantCur:   "GBP",
+			wantOK:    true,
+			wantStrip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cur, ok := hoistUniformCurrency(tt.rows)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && cur != tt.wantCur {
+				t.Errorf("cur = %q, want %q", cur, tt.wantCur)
+			}
+			if tt.wantStrip {
+				for i, r := range tt.rows {
+					if _, present := r["iso_currency_code"]; present {
+						t.Errorf("row %d still carries iso_currency_code after successful hoist", i)
+					}
+				}
+			}
+			if !tt.wantOK {
+				// Non-hoist outcomes must leave rows untouched.
+				for i, r := range tt.rows {
+					if _, hadCur := r["iso_currency_code"]; !hadCur {
+						continue
+					}
+					if _, present := r["iso_currency_code"]; !present {
+						t.Errorf("row %d lost iso_currency_code despite no hoist", i)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCurrencyString(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      any
+		wantStr string
+		wantOK  bool
+	}{
+		{"plain string", "USD", "USD", true},
+		{"empty string", "", "", false},
+		{"non-nil pointer", strptr("EUR"), "EUR", true},
+		{"nil pointer", (*string)(nil), "", false},
+		{"empty pointer", strptr(""), "", false},
+		{"wrong type", 42, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ok := currencyString(tt.in)
+			if ok != tt.wantOK || s != tt.wantStr {
+				t.Errorf("currencyString(%v) = (%q, %v), want (%q, %v)", tt.in, s, ok, tt.wantStr, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/mcp/response_cap_test.go
+++ b/internal/mcp/response_cap_test.go
@@ -1,0 +1,95 @@
+//go:build !lite
+
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// bigPayload builds a value whose JSON encoding exceeds n bytes.
+func bigPayload(n int) map[string]any {
+	return map[string]any{"blob": strings.Repeat("x", n)}
+}
+
+func TestJSONResult_ResponseCap(t *testing.T) {
+	orig := maxResponseBytes
+	t.Cleanup(func() { maxResponseBytes = orig })
+
+	// Cap at 1 KB; a ~5 KB payload must be rejected with RESPONSE_TOO_LARGE.
+	maxResponseBytes = 1000
+	res, _, err := jsonResult(bigPayload(5000))
+	if err != nil {
+		t.Fatalf("jsonResult returned a transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError for oversized response")
+	}
+	var payload map[string]string
+	if uerr := json.Unmarshal([]byte(textOf(t, res)), &payload); uerr != nil {
+		t.Fatalf("decode error payload: %v", uerr)
+	}
+	if payload["code"] != "RESPONSE_TOO_LARGE" {
+		t.Errorf("code = %q, want RESPONSE_TOO_LARGE", payload["code"])
+	}
+
+	// A small payload under the cap passes.
+	res, _, _ = jsonResult(map[string]any{"ok": true})
+	if res.IsError {
+		t.Errorf("small payload should not error: %s", textOf(t, res))
+	}
+}
+
+func TestJSONResult_CapDisabledWhenZero(t *testing.T) {
+	orig := maxResponseBytes
+	t.Cleanup(func() { maxResponseBytes = orig })
+
+	maxResponseBytes = 0 // disabled
+	res, _, _ := jsonResult(bigPayload(50_000))
+	if res.IsError {
+		t.Errorf("cap=0 must disable the limit, got error: %s", textOf(t, res))
+	}
+}
+
+func TestResolveMaxResponseBytes(t *testing.T) {
+	t.Setenv("BREADBOX_MCP_MAX_RESPONSE_BYTES", "")
+	if got := resolveMaxResponseBytes(); got != defaultMaxResponseBytes {
+		t.Errorf("empty env → %d, want default %d", got, defaultMaxResponseBytes)
+	}
+
+	t.Setenv("BREADBOX_MCP_MAX_RESPONSE_BYTES", "5000")
+	if got := resolveMaxResponseBytes(); got != 5000 {
+		t.Errorf("env=5000 → %d, want 5000", got)
+	}
+
+	t.Setenv("BREADBOX_MCP_MAX_RESPONSE_BYTES", "0")
+	if got := resolveMaxResponseBytes(); got != 0 {
+		t.Errorf("env=0 → %d, want 0 (disabled)", got)
+	}
+
+	t.Setenv("BREADBOX_MCP_MAX_RESPONSE_BYTES", "garbage")
+	if got := resolveMaxResponseBytes(); got != defaultMaxResponseBytes {
+		t.Errorf("invalid env → %d, want default %d", got, defaultMaxResponseBytes)
+	}
+
+	t.Setenv("BREADBOX_MCP_MAX_RESPONSE_BYTES", "-10")
+	if got := resolveMaxResponseBytes(); got != defaultMaxResponseBytes {
+		t.Errorf("negative env → %d, want default %d (rejected)", got, defaultMaxResponseBytes)
+	}
+}
+
+// textOf extracts the first text content block from a tool result.
+func textOf(t *testing.T, res *mcpsdk.CallToolResult) string {
+	t.Helper()
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("tool result has no content")
+	}
+	tc, ok := res.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	return tc.Text
+}

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -461,8 +461,9 @@ func TestTransactionSummaryResponseShape(t *testing.T) {
 }
 
 // TestMerchantSummaryResponseShape pins {merchants, totals, filters} + row fields.
-// TestQueryTransactionsResponseShape pins category as an object (not a slug
-// string) and the wrapper envelope.
+// TestQueryTransactionsResponseShape pins the lean-by-default projection
+// (core,category), category as an object (not a slug string), the wrapper
+// envelope, and top-level currency hoisting when rows share one currency.
 func TestQueryTransactionsResponseShape(t *testing.T) {
 	f := seedFixtures(t)
 	res, _, err := f.svc.handleQueryTransactions(f.ctx, nil, queryTransactionsInput{
@@ -477,8 +478,14 @@ func TestQueryTransactionsResponseShape(t *testing.T) {
 		t.Fatal("expected at least one transaction")
 	}
 	txn := asObject(t, "query_transactions.transactions[0]", txns[0])
+	// Lean default = core,category. id is always included; fields outside the
+	// default projection (account_id, provider_merchant_name, timestamps,
+	// metadata) must be absent unless explicitly requested.
 	requireKeys(t, "query_transactions.transactions[0]", txn,
-		"id", "account_id", "amount", "date", "provider_name", "category",
+		"id", "amount", "date", "provider_name", "category",
+	)
+	requireAbsent(t, "query_transactions.transactions[0]", txn,
+		"account_id", "provider_merchant_name", "created_at", "updated_at", "metadata", "short_id",
 	)
 	switch v := txn["category"].(type) {
 	case map[string]any:
@@ -489,6 +496,41 @@ func TestQueryTransactionsResponseShape(t *testing.T) {
 	default:
 		t.Errorf("category must be object or null, got %T (%v)", v, v)
 	}
+	// Currency hoisting: the seeded rows are all USD, so iso_currency_code is
+	// emitted once at the top level and dropped from each row. (Written to
+	// tolerate the per-row fallback too, in case fixtures ever go multi-currency.)
+	if cur, hoisted := out["iso_currency_code"]; hoisted {
+		if s, _ := cur.(string); s == "" {
+			t.Errorf("top-level iso_currency_code must be a non-empty string, got %v", cur)
+		}
+		requireAbsent(t, "query_transactions.transactions[0]", txn, "iso_currency_code")
+	} else {
+		requireKeys(t, "query_transactions.transactions[0]", txn, "iso_currency_code")
+	}
+}
+
+// TestQueryTransactionsFieldsAll pins that fields=all restores the full
+// per-row struct (the pre-lean-default contract) and suppresses currency
+// hoisting — full fidelity is full fidelity.
+func TestQueryTransactionsFieldsAll(t *testing.T) {
+	f := seedFixtures(t)
+	res, _, err := f.svc.handleQueryTransactions(f.ctx, nil, queryTransactionsInput{
+		Limit:  10,
+		Fields: "all",
+	})
+	out := decodeToolResult[map[string]any](t, "query_transactions(all)", res, err)
+	requireKeys(t, "query_transactions(all)", out, "transactions", "has_more", "limit")
+	// fields=all means no projection map, so no top-level hoisting.
+	requireAbsent(t, "query_transactions(all)", out, "iso_currency_code")
+	txns := asArray(t, "query_transactions(all).transactions", out["transactions"])
+	if len(txns) == 0 {
+		t.Fatal("expected at least one transaction")
+	}
+	txn := asObject(t, "query_transactions(all).transactions[0]", txns[0])
+	requireKeys(t, "query_transactions(all).transactions[0]", txn,
+		"id", "account_id", "amount", "date", "provider_name",
+		"iso_currency_code", "provider_merchant_name", "category", "created_at", "metadata",
+	)
 }
 
 // TestPreviewRuleResponseShape pins `sample_matches` (not `sample`) + sample

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -533,6 +533,35 @@ func TestQueryTransactionsFieldsAll(t *testing.T) {
 	)
 }
 
+// TestListTransactionRulesLeanDefault pins that the rule roster is lean by
+// default (summary projection — no conditions/actions trees) and that
+// fields=all restores the full definition.
+func TestListTransactionRulesLeanDefault(t *testing.T) {
+	f := seedFixtures(t)
+
+	// Default (no fields) → summary projection.
+	res, _, err := f.svc.handleListTransactionRules(f.ctx, nil, listTransactionRulesInput{})
+	out := decodeToolResult[map[string]any](t, "list_transaction_rules", res, err)
+	requireKeys(t, "list_transaction_rules", out, "rules")
+	rules := asArray(t, "list_transaction_rules.rules", out["rules"])
+	if len(rules) == 0 {
+		t.Fatal("expected at least the seeded rule")
+	}
+	rule := asObject(t, "list_transaction_rules.rules[0]", rules[0])
+	requireKeys(t, "list_transaction_rules.rules[0]", rule, "id", "name", "enabled", "priority", "trigger", "hit_count")
+	requireAbsent(t, "list_transaction_rules.rules[0]", rule, "conditions", "actions", "created_at", "short_id")
+
+	// fields=all → full definition restored.
+	resAll, _, errAll := f.svc.handleListTransactionRules(f.ctx, nil, listTransactionRulesInput{Fields: "all"})
+	outAll := decodeToolResult[map[string]any](t, "list_transaction_rules(all)", resAll, errAll)
+	rulesAll := asArray(t, "list_transaction_rules(all).rules", outAll["rules"])
+	if len(rulesAll) == 0 {
+		t.Fatal("expected at least the seeded rule")
+	}
+	ruleAll := asObject(t, "list_transaction_rules(all).rules[0]", rulesAll[0])
+	requireKeys(t, "list_transaction_rules(all).rules[0]", ruleAll, "id", "name", "conditions", "actions", "created_at")
+}
+
 // TestPreviewRuleResponseShape pins `sample_matches` (not `sample`) + sample
 // row fields (transaction_id, not id).
 func TestPreviewRuleResponseShape(t *testing.T) {
@@ -1045,8 +1074,14 @@ func TestReferenceMirrorTools_ParityWithResources(t *testing.T) {
 			name:        "list_transaction_rules <-> breadbox://rules",
 			envelopeKey: "", // both surfaces return the same {rules, has_more, total} object
 			toolFn: func() (*mcpsdk.CallToolResult, any, error) {
+				// list_transaction_rules is lean-by-default (summary projection,
+				// no conditions/actions trees). The resource has no fields knob
+				// and returns the full payload, so parity is asserted against
+				// the tool's full mode (fields=all) — that's the invariant that
+				// must hold: same service call, same full shape.
 				return f.svc.handleListTransactionRules(f.ctx, nil, listTransactionRulesInput{
-					Limit: rulesResourceLimit,
+					Limit:  rulesResourceLimit,
+					Fields: "all",
 				})
 			},
 			resourceFn: func() (*mcpsdk.ReadResourceResult, error) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -368,7 +368,7 @@ func (s *MCPServer) buildToolRegistry() {
 		}, s.handleGetSyncStatus, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_transaction_rules", Title: "List Rules", Classification: ToolRead,
-			Description: "List transaction rules with their conditions, actions, and pipeline stage. Mirror of breadbox://rules. Filter by category_slug, enabled, or search by name. Read this before authoring new rules to avoid duplicates.",
+			Description: "List transaction rules. Filter by category_slug, enabled, or search by name. Read this before authoring new rules to avoid duplicates. Lean by default: returns a summary projection (name, enabled, priority, trigger, category, hit_count) without the conditions/actions trees — pass fields=all to inspect or audit full rule definitions. Mirror of breadbox://rules (which always returns full).",
 		}, s.handleListTransactionRules, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_workflows", Title: "List Workflows", Classification: ToolRead,
@@ -376,7 +376,7 @@ func (s *MCPServer) buildToolRegistry() {
 		}, s.handleListWorkflows, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_series", Title: "List Recurring Series", Classification: ToolRead,
-			Description: "List detected recurring series (subscriptions, bills, loans). Optional status filter (active|candidate|paused|cancelled). Each row carries cadence, expected_amount + iso_currency_code (never sum across currencies), next_expected_date, occurrence_count, confidence (auto|confirmed|rejected), and detection_signals — the raw evidence the detector used (interval_cv, amount_branch, merchant_key_is_fallback). Read status=candidate to find series awaiting a confirm/reject verdict; calibrate from the signals before deciding.",
+			Description: "List detected recurring series (subscriptions, bills, loans). Optional status filter (active|candidate|paused|cancelled). Lean by default: each row carries identity + renewal prediction (cadence, expected_amount + iso_currency_code — never sum across currencies, next_expected_date, occurrence_count, confidence), but NOT the verbose detection_signals evidence. Read status=candidate to find series awaiting a confirm/reject verdict; pass fields=all (or use get_series for one series) to see detection_signals — interval_cv, amount_branch, merchant_key_is_fallback — before deciding.",
 		}, s.handleListSeries, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "get_series", Title: "Get Recurring Series", Classification: ToolRead,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -426,7 +426,7 @@ func (s *MCPServer) buildToolRegistry() {
 		// --- Query + aggregate ---
 		makeToolDefLogged(ToolSpec{
 			Name: "query_transactions", Title: "Query Transactions", Classification: ToolRead,
-			Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (see breadbox://categories for the slug list); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
+			Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (see breadbox://categories for the slug list); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Responses are lean by default — a compact field set (core,category) is returned unless you pass fields=all or an explicit field/alias list. When every row shares one currency, iso_currency_code is returned once at the top level instead of on each row; otherwise each row carries its own.",
 		}, s.handleQueryTransactions, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "count_transactions", Title: "Count Transactions", Classification: ToolRead,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 
 	"breadbox/internal/service"
@@ -688,6 +689,29 @@ func parseConditions(m map[string]any) (service.Condition, error) {
 	return c, nil
 }
 
+// defaultMaxResponseBytes caps a single MCP tool response as a safety net
+// against pathological payloads (e.g. query_transactions with fields=all and
+// limit=500). Bytes are a proxy for tokens (~4 bytes/token), so ~100 KB ≈
+// 25K tokens — the same order as the cap GitHub's MCP server enforces. When a
+// response exceeds the cap the tool returns a RESPONSE_TOO_LARGE error telling
+// the caller to narrow the query, rather than dumping or silently truncating.
+const defaultMaxResponseBytes = 100_000
+
+// maxResponseBytes is the active response cap, resolved once at process start.
+// Override with BREADBOX_MCP_MAX_RESPONSE_BYTES (operator env knob, consistent
+// with Breadbox's env → app_config → default precedence); set it to 0 to
+// disable the cap entirely.
+var maxResponseBytes = resolveMaxResponseBytes()
+
+func resolveMaxResponseBytes() int {
+	if v := os.Getenv("BREADBOX_MCP_MAX_RESPONSE_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return defaultMaxResponseBytes
+}
+
 func jsonResult(v any) (*mcpsdk.CallToolResult, any, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
@@ -698,6 +722,17 @@ func jsonResult(v any) (*mcpsdk.CallToolResult, any, error) {
 	// This reduces token usage by ~75% per ID without changing the schema agents see.
 	// Operates directly on JSON bytes to avoid unmarshal→remarshal overhead.
 	data = compactIDsBytes(data)
+
+	// Safety cap: refuse to emit a response larger than the configured byte
+	// ceiling. Better to return an actionable error than to blow the caller's
+	// context with a payload they didn't expect. Checked on the post-compaction
+	// wire bytes (what actually ships).
+	if maxResponseBytes > 0 && len(data) > maxResponseBytes {
+		return errorResultWithCode("RESPONSE_TOO_LARGE", fmt.Sprintf(
+			"response is %d bytes, over the %d-byte cap. Narrow the result: add filters, lower limit, paginate via next_cursor, or use the fields parameter to request fewer fields. Operators can raise or disable the cap via BREADBOX_MCP_MAX_RESPONSE_BYTES.",
+			len(data), maxResponseBytes,
+		)), nil, nil
+	}
 
 	// StructuredContent is the post-2025-06-18 spec slot for typed tool
 	// output. We populate it alongside the TextContent block so:

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -35,7 +35,7 @@ type queryTransactionsInput struct {
 	Cursor        string   `json:"cursor,omitempty" jsonschema:"Pagination cursor from previous result"`
 	SortBy        string   `json:"sort_by,omitempty" jsonschema:"Sort: date (default), amount, provider_name"`
 	SortOrder     string   `json:"sort_order,omitempty" jsonschema:"Sort direction: desc (default) or asc"`
-	Fields        string   `json:"fields,omitempty" jsonschema:"Comma-separated list of fields to include in response. Aliases: minimal (provider_name,amount,date), core (id,date,amount,provider_name,iso_currency_code), category (category,provider_category_primary,provider_category_detailed), timestamps (created_at,updated_at,datetime,authorized_datetime). Default: all fields. id is always included."`
+	Fields        string   `json:"fields,omitempty" jsonschema:"Comma-separated fields to include, to cut response size. Aliases: minimal (provider_name,amount,date), core (id,date,amount,provider_name,iso_currency_code), category (category,provider_category_primary,provider_category_detailed), timestamps (created_at,updated_at,datetime,authorized_datetime). Default when omitted: core,category (a compact projection). Pass fields=all for every field. id is always included."`
 }
 
 type countTransactionsInput struct {
@@ -120,7 +120,21 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 		return errorResult(err), nil, nil
 	}
 
-	fieldSet, err := service.ParseFields(input.Fields)
+	// Lean-by-default: an omitted fields param returns a compact projection
+	// (core identity + category) rather than all ~22 fields. Agents rarely set
+	// fields and the full row is mostly unused, so the default response is the
+	// cheap one. Pass fields=all for the complete struct (the legacy default),
+	// or any explicit field/alias list to widen or narrow. This default is
+	// MCP-only — the REST API (which shares service.ParseFields) keeps
+	// returning full objects when ?fields= is omitted.
+	fieldsRaw := input.Fields
+	switch fieldsRaw {
+	case "":
+		fieldsRaw = defaultTransactionFields
+	case "all":
+		fieldsRaw = "" // ParseFields("") → nil → full struct
+	}
+	fieldSet, err := service.ParseFields(fieldsRaw)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}
@@ -142,15 +156,79 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 		for i, t := range result.Transactions {
 			filtered[i] = service.FilterTransactionFields(t, fieldSet)
 		}
-		return jsonResult(map[string]any{
+		resp := map[string]any{
 			"transactions": filtered,
 			"next_cursor":  result.NextCursor,
 			"has_more":     result.HasMore,
 			"limit":        result.Limit,
-		})
+		}
+		// Currency hoisting: when every returned row shares one currency (the
+		// overwhelmingly common single-currency household case), emit it once
+		// at the top level and drop the per-row copies. A response that mixes
+		// currencies (or carries a null one) falls back to per-row. Agents read
+		// the top-level iso_currency_code when present, else the per-row field.
+		if cur, ok := hoistUniformCurrency(filtered); ok {
+			resp["iso_currency_code"] = cur
+		}
+		return jsonResult(resp)
 	}
 
 	return jsonResult(result)
+}
+
+// defaultTransactionFields is the compact projection query_transactions returns
+// when the caller omits fields. core = id,date,amount,provider_name,
+// iso_currency_code; category = the resolved category + provider category
+// hints. Callers widen with fields=all or any explicit alias/field list.
+const defaultTransactionFields = "core,category"
+
+// hoistUniformCurrency strips the per-row iso_currency_code from a projected
+// transaction list when every row shares one non-empty currency, returning the
+// common code so the caller can emit it once at the top level. It returns
+// ("", false) — leaving the rows untouched — when the list is empty, when any
+// row omits the field (it wasn't in the projection), or when currencies differ
+// or are null. This is the single-currency optimization: one top-level
+// iso_currency_code instead of N identical copies, with a safe per-row fallback
+// the moment a response actually mixes currencies.
+func hoistUniformCurrency(rows []map[string]any) (string, bool) {
+	if len(rows) == 0 {
+		return "", false
+	}
+	common := ""
+	for _, r := range rows {
+		v, present := r["iso_currency_code"]
+		if !present {
+			return "", false
+		}
+		c, ok := currencyString(v)
+		if !ok {
+			return "", false
+		}
+		if common == "" {
+			common = c
+		} else if c != common {
+			return "", false
+		}
+	}
+	for _, r := range rows {
+		delete(r, "iso_currency_code")
+	}
+	return common, true
+}
+
+// currencyString coerces a projected iso_currency_code value (string or
+// *string, per FilterTransactionFields) to a non-empty currency code.
+func currencyString(v any) (string, bool) {
+	switch s := v.(type) {
+	case string:
+		return s, s != ""
+	case *string:
+		if s == nil || *s == "" {
+			return "", false
+		}
+		return *s, true
+	}
+	return "", false
 }
 
 func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToolRequest, input countTransactionsInput) (*mcpsdk.CallToolResult, any, error) {

--- a/internal/mcp/tools_reads.go
+++ b/internal/mcp/tools_reads.go
@@ -47,6 +47,7 @@ type listTransactionRulesInput struct {
 	SearchMode   string `json:"search_mode,omitempty" jsonschema:"Search mode: contains (default), words, fuzzy"`
 	Limit        int    `json:"limit,omitempty" jsonschema:"Max results (default 50, max 500)"`
 	Cursor       string `json:"cursor,omitempty" jsonschema:"Pagination cursor from previous result"`
+	Fields       string `json:"fields,omitempty" jsonschema:"Comma-separated fields to include, to cut response size. Alias: summary (name,enabled,priority,trigger,category,hit_count,last_hit_at; the default — omits the conditions and actions trees). Default when omitted: summary. Pass fields=all for every field including the full conditions/actions. id is always included."`
 }
 
 // --- Handlers ---
@@ -120,9 +121,37 @@ func (s *MCPServer) handleListTransactionRules(_ context.Context, _ *mcpsdk.Call
 		return errorResult(err), nil, nil
 	}
 
+	// Lean-by-default: the rule roster omits the conditions/actions trees (the
+	// heavy, deeply-nested part) unless the caller asks. Pass fields=all to
+	// inspect or audit full rule definitions.
+	fieldsRaw := input.Fields
+	switch fieldsRaw {
+	case "":
+		fieldsRaw = service.DefaultRuleFields
+	case "all":
+		fieldsRaw = "" // ParseRuleFields("") → nil → full struct
+	}
+	fieldSet, err := service.ParseRuleFields(fieldsRaw)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
 	result, err := s.svc.ListTransactionRules(ctx, params)
 	if err != nil {
 		return errorResult(err), nil, nil
+	}
+
+	if fieldSet != nil {
+		projected := make([]map[string]any, len(result.Rules))
+		for i, r := range result.Rules {
+			projected[i] = service.FilterRuleFields(r, fieldSet)
+		}
+		return jsonResult(map[string]any{
+			"rules":       projected,
+			"next_cursor": result.NextCursor,
+			"has_more":    result.HasMore,
+			"total":       result.Total,
+		})
 	}
 	return jsonResult(result)
 }

--- a/internal/mcp/tools_series.go
+++ b/internal/mcp/tools_series.go
@@ -14,6 +14,7 @@ import (
 
 type listSeriesInput struct {
 	Status string `json:"status,omitempty" jsonschema:"Optional status filter: active, candidate, paused, or cancelled."`
+	Fields string `json:"fields,omitempty" jsonschema:"Comma-separated fields to include, to cut response size. Aliases: minimal (name,status,type,cadence), overview (identity + renewal prediction; the default — omits the verbose detection_signals blob). Default when omitted: overview. Pass fields=all for every field including detection_signals. Use get_series for a single series' full detail. id is always included."`
 }
 
 type getSeriesInput struct {
@@ -46,9 +47,33 @@ func (s *MCPServer) handleListSeries(_ context.Context, _ *mcpsdk.CallToolReques
 	if input.Status != "" {
 		status = &input.Status
 	}
+	// Lean-by-default: list_series returns the overview projection (identity +
+	// renewal prediction) unless the caller asks for more. The verbose
+	// detection_signals blob is excluded by default — fetch a single series'
+	// full detail via get_series, or pass fields=all here.
+	fieldsRaw := input.Fields
+	switch fieldsRaw {
+	case "":
+		fieldsRaw = service.DefaultSeriesFields
+	case "all":
+		fieldsRaw = "" // ParseSeriesFields("") → nil → full struct
+	}
+	fieldSet, err := service.ParseSeriesFields(fieldsRaw)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
 	series, err := s.svc.ListSeries(ctx, status)
 	if err != nil {
 		return errorResult(err), nil, nil
+	}
+
+	if fieldSet != nil {
+		projected := make([]map[string]any, len(series))
+		for i, sr := range series {
+			projected[i] = service.FilterSeriesFields(sr, fieldSet)
+		}
+		return jsonResult(map[string]any{"series": projected})
 	}
 	return jsonResult(map[string]any{"series": series})
 }

--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -44,9 +44,18 @@ var fieldAliases = map[string][]string{
 	"timestamps": {"created_at", "updated_at", "datetime", "authorized_datetime"},
 }
 
-// ParseFields parses and validates the fields query parameter.
+// ParseFields parses and validates the transaction fields query parameter.
 // Returns nil if no field selection (return all fields).
 func ParseFields(raw string) (map[string]bool, error) {
+	return parseFieldsWith(raw, validFields, fieldAliases)
+}
+
+// parseFieldsWith is the generic field-selection parser shared by every
+// entity's Parse*Fields wrapper. valid is the set of selectable JSON field
+// names; aliases expand shorthand names to groups. It returns nil for an empty
+// selection (caller should return the full struct). id and short_id are always
+// included so a row is always identifiable.
+func parseFieldsWith(raw string, valid map[string]bool, aliases map[string][]string) (map[string]bool, error) {
 	if raw == "" {
 		return nil, nil
 	}
@@ -57,24 +66,24 @@ func ParseFields(raw string) (map[string]bool, error) {
 		if f == "" {
 			continue
 		}
-		if expanded, ok := fieldAliases[f]; ok {
+		if expanded, ok := aliases[f]; ok {
 			for _, ef := range expanded {
 				fields[ef] = true
 			}
 			continue
 		}
-		if !validFields[f] {
+		if !valid[f] {
 			unknown = append(unknown, f)
 			continue
 		}
 		fields[f] = true
 	}
 	if len(unknown) > 0 {
-		validList := make([]string, 0, len(validFields)+len(fieldAliases))
-		for k := range validFields {
+		validList := make([]string, 0, len(valid)+len(aliases))
+		for k := range valid {
 			validList = append(validList, k)
 		}
-		for k := range fieldAliases {
+		for k := range aliases {
 			validList = append(validList, k)
 		}
 		sort.Strings(validList)

--- a/internal/service/fields_entities.go
+++ b/internal/service/fields_entities.go
@@ -1,0 +1,235 @@
+//go:build !lite
+
+package service
+
+// Field projection for recurring series and transaction rules, mirroring the
+// transaction projection in fields.go. The heavy, rarely-needed payloads —
+// a series' detection_signals JSON blob, a rule's conditions/actions trees —
+// are excluded from each entity's lean default alias and only returned when
+// the caller asks (fields=all, or names them explicitly).
+
+// --- Recurring series ---
+
+var seriesValidFields = map[string]bool{
+	"id":                 true,
+	"short_id":           true,
+	"user_id":            true,
+	"name":               true,
+	"merchant_key":       true,
+	"cadence":            true,
+	"expected_day":       true,
+	"expected_amount":    true,
+	"amount_tolerance":   true,
+	"iso_currency_code":  true,
+	"category_id":        true,
+	"status":             true,
+	"type":               true,
+	"detection_source":   true,
+	"confidence":         true,
+	"confirmed_by_type":  true,
+	"last_amount":        true,
+	"last_seen_date":     true,
+	"next_expected_date": true,
+	"renewal_health":     true,
+	"days_until_renewal": true,
+	"occurrence_count":   true,
+	"detection_signals":  true,
+	"tags":               true,
+	"created_at":         true,
+	"updated_at":         true,
+}
+
+var seriesFieldAliases = map[string][]string{
+	// minimal: just enough to recognize a series in a list.
+	"minimal": {"name", "status", "type", "cadence"},
+	// overview: identity + lifecycle + renewal prediction — the useful default
+	// for list_series. Deliberately omits detection_signals (verbose, only
+	// needed for the get_series detail view), merchant_key/category_id internals,
+	// detection_source, confirmed_by_type, tolerances, and timestamps.
+	"overview": {
+		"name", "status", "type", "cadence", "confidence",
+		"expected_amount", "iso_currency_code", "expected_day",
+		"last_amount", "last_seen_date", "next_expected_date",
+		"renewal_health", "days_until_renewal", "occurrence_count", "tags",
+	},
+}
+
+// DefaultSeriesFields is the lean projection list_series returns when the caller
+// omits fields.
+const DefaultSeriesFields = "overview"
+
+// ParseSeriesFields parses the fields selector for recurring series.
+func ParseSeriesFields(raw string) (map[string]bool, error) {
+	return parseFieldsWith(raw, seriesValidFields, seriesFieldAliases)
+}
+
+// FilterSeriesFields projects a SeriesResponse down to the requested fields.
+// Returns nil when fields is nil (caller uses the full struct).
+func FilterSeriesFields(s SeriesResponse, fields map[string]bool) map[string]any {
+	if fields == nil {
+		return nil
+	}
+	m := make(map[string]any, len(fields))
+	for key, want := range fields {
+		if !want {
+			continue
+		}
+		switch key {
+		case "id":
+			m["id"] = s.ID
+		case "short_id":
+			m["short_id"] = s.ShortID
+		case "user_id":
+			m["user_id"] = s.UserID
+		case "name":
+			m["name"] = s.Name
+		case "merchant_key":
+			m["merchant_key"] = s.MerchantKey
+		case "cadence":
+			m["cadence"] = s.Cadence
+		case "expected_day":
+			m["expected_day"] = s.ExpectedDay
+		case "expected_amount":
+			m["expected_amount"] = s.ExpectedAmount
+		case "amount_tolerance":
+			m["amount_tolerance"] = s.AmountTolerance
+		case "iso_currency_code":
+			m["iso_currency_code"] = s.IsoCurrencyCode
+		case "category_id":
+			m["category_id"] = s.CategoryID
+		case "status":
+			m["status"] = s.Status
+		case "type":
+			m["type"] = s.Type
+		case "detection_source":
+			m["detection_source"] = s.DetectionSource
+		case "confidence":
+			m["confidence"] = s.Confidence
+		case "confirmed_by_type":
+			m["confirmed_by_type"] = s.ConfirmedByType
+		case "last_amount":
+			m["last_amount"] = s.LastAmount
+		case "last_seen_date":
+			m["last_seen_date"] = s.LastSeenDate
+		case "next_expected_date":
+			m["next_expected_date"] = s.NextExpectedDate
+		case "renewal_health":
+			m["renewal_health"] = s.RenewalHealth
+		case "days_until_renewal":
+			m["days_until_renewal"] = s.DaysUntilRenewal
+		case "occurrence_count":
+			m["occurrence_count"] = s.OccurrenceCount
+		case "detection_signals":
+			m["detection_signals"] = s.DetectionSignals
+		case "tags":
+			m["tags"] = s.Tags
+		case "created_at":
+			m["created_at"] = s.CreatedAt
+		case "updated_at":
+			m["updated_at"] = s.UpdatedAt
+		}
+	}
+	return m
+}
+
+// --- Transaction rules ---
+
+var ruleValidFields = map[string]bool{
+	"id":                    true,
+	"short_id":              true,
+	"name":                  true,
+	"conditions":            true,
+	"actions":               true,
+	"trigger":               true,
+	"category_slug":         true,
+	"category_display_name": true,
+	"category_icon":         true,
+	"category_color":        true,
+	"priority":              true,
+	"enabled":               true,
+	"expires_at":            true,
+	"created_by_type":       true,
+	"created_by_id":         true,
+	"created_by_name":       true,
+	"hit_count":             true,
+	"last_hit_at":           true,
+	"created_at":            true,
+	"updated_at":            true,
+}
+
+var ruleFieldAliases = map[string][]string{
+	// summary: roster view — what a rule is, whether it's on, how it's firing —
+	// without the conditions and actions trees (the heavy, deeply-nested part
+	// only needed when inspecting or editing a specific rule).
+	"summary": {
+		"name", "enabled", "priority", "trigger",
+		"category_slug", "category_display_name",
+		"created_by_type", "hit_count", "last_hit_at",
+	},
+}
+
+// DefaultRuleFields is the lean projection list_transaction_rules returns when
+// the caller omits fields.
+const DefaultRuleFields = "summary"
+
+// ParseRuleFields parses the fields selector for transaction rules.
+func ParseRuleFields(raw string) (map[string]bool, error) {
+	return parseFieldsWith(raw, ruleValidFields, ruleFieldAliases)
+}
+
+// FilterRuleFields projects a TransactionRuleResponse down to the requested
+// fields. Returns nil when fields is nil (caller uses the full struct).
+func FilterRuleFields(r TransactionRuleResponse, fields map[string]bool) map[string]any {
+	if fields == nil {
+		return nil
+	}
+	m := make(map[string]any, len(fields))
+	for key, want := range fields {
+		if !want {
+			continue
+		}
+		switch key {
+		case "id":
+			m["id"] = r.ID
+		case "short_id":
+			m["short_id"] = r.ShortID
+		case "name":
+			m["name"] = r.Name
+		case "conditions":
+			m["conditions"] = r.Conditions
+		case "actions":
+			m["actions"] = r.Actions
+		case "trigger":
+			m["trigger"] = r.Trigger
+		case "category_slug":
+			m["category_slug"] = r.CategorySlug
+		case "category_display_name":
+			m["category_display_name"] = r.CategoryName
+		case "category_icon":
+			m["category_icon"] = r.CategoryIcon
+		case "category_color":
+			m["category_color"] = r.CategoryColor
+		case "priority":
+			m["priority"] = r.Priority
+		case "enabled":
+			m["enabled"] = r.Enabled
+		case "expires_at":
+			m["expires_at"] = r.ExpiresAt
+		case "created_by_type":
+			m["created_by_type"] = r.CreatedByType
+		case "created_by_id":
+			m["created_by_id"] = r.CreatedByID
+		case "created_by_name":
+			m["created_by_name"] = r.CreatedByName
+		case "hit_count":
+			m["hit_count"] = r.HitCount
+		case "last_hit_at":
+			m["last_hit_at"] = r.LastHitAt
+		case "created_at":
+			m["created_at"] = r.CreatedAt
+		case "updated_at":
+			m["updated_at"] = r.UpdatedAt
+		}
+	}
+	return m
+}

--- a/internal/service/fields_entities_test.go
+++ b/internal/service/fields_entities_test.go
@@ -1,0 +1,126 @@
+//go:build !lite
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseSeriesFields(t *testing.T) {
+	// Empty → nil (full struct).
+	f, err := ParseSeriesFields("")
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if f != nil {
+		t.Errorf("empty selection should be nil, got %v", f)
+	}
+
+	// overview alias excludes detection_signals; id/short_id always present.
+	f, err = ParseSeriesFields("overview")
+	if err != nil {
+		t.Fatalf("overview: %v", err)
+	}
+	if f["detection_signals"] {
+		t.Error("overview must not include detection_signals")
+	}
+	for _, want := range []string{"id", "short_id", "name", "status", "next_expected_date"} {
+		if !f[want] {
+			t.Errorf("overview missing %q", want)
+		}
+	}
+
+	// Unknown field rejected.
+	if _, err := ParseSeriesFields("bogus_series_field"); err == nil {
+		t.Error("expected error for unknown field")
+	}
+}
+
+func TestFilterSeriesFields_DropsDetectionSignals(t *testing.T) {
+	s := SeriesResponse{
+		ID:               "uuid",
+		ShortID:          "abc123",
+		Name:             "Netflix",
+		Status:           "active",
+		DetectionSignals: json.RawMessage(`{"interval_cv":0.02}`),
+	}
+	f, err := ParseSeriesFields(DefaultSeriesFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := FilterSeriesFields(s, f)
+	if _, present := m["detection_signals"]; present {
+		t.Error("default projection must omit detection_signals")
+	}
+	if m["name"] != "Netflix" {
+		t.Errorf("name = %v, want Netflix", m["name"])
+	}
+	if m["id"] != "uuid" || m["short_id"] != "abc123" {
+		t.Errorf("id/short_id must always be present, got id=%v short_id=%v", m["id"], m["short_id"])
+	}
+
+	// fields=all path → nil set → full struct (caller uses struct directly).
+	all, err := ParseSeriesFields("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if FilterSeriesFields(s, all) != nil {
+		t.Error("nil field set must return nil (full struct)")
+	}
+}
+
+func TestParseRuleFields(t *testing.T) {
+	f, err := ParseRuleFields("summary")
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if f["conditions"] || f["actions"] {
+		t.Error("summary must not include conditions/actions trees")
+	}
+	for _, want := range []string{"id", "short_id", "name", "enabled", "priority", "hit_count"} {
+		if !f[want] {
+			t.Errorf("summary missing %q", want)
+		}
+	}
+}
+
+func TestFilterRuleFields_DropsTrees(t *testing.T) {
+	r := TransactionRuleResponse{
+		ID:         "uuid",
+		ShortID:    "rul456",
+		Name:       "Groceries",
+		Enabled:    true,
+		Priority:   10,
+		Conditions: Condition{Field: "provider_name", Op: "contains", Value: "Whole Foods"},
+		Actions:    []RuleAction{{Type: "set_category"}},
+		HitCount:   42,
+	}
+	f, err := ParseRuleFields(DefaultRuleFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := FilterRuleFields(r, f)
+	if _, present := m["conditions"]; present {
+		t.Error("default projection must omit conditions")
+	}
+	if _, present := m["actions"]; present {
+		t.Error("default projection must omit actions")
+	}
+	if m["name"] != "Groceries" || m["hit_count"] != 42 {
+		t.Errorf("summary fields wrong: name=%v hit_count=%v", m["name"], m["hit_count"])
+	}
+
+	// Explicit conditions request includes the tree.
+	withCond, err := ParseRuleFields("summary,conditions,actions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m2 := FilterRuleFields(r, withCond)
+	if _, present := m2["conditions"]; !present {
+		t.Error("explicit conditions request must include the tree")
+	}
+	if _, present := m2["actions"]; !present {
+		t.Error("explicit actions request must include the tree")
+	}
+}


### PR DESCRIPTION
## MCP tool-set token optimization

Reduces the token cost of Breadbox's MCP tools, motivated by agents rarely setting the optional `fields` param on `query_transactions` and so paying for full ~22-field rows by default. The fix: **make the cheap path the default** on the token-heavy read tools, plus a global response-size guardrail.

### Changes

**1. `query_transactions` — lean by default + currency hoisting**
- Omitted `fields` now returns a compact projection (`core,category`) instead of all ~22 fields; pass `fields=all` for the full row.
- When every returned row shares one currency (the common single-currency case), `iso_currency_code` is emitted **once at the top level** of the envelope and dropped from each row — automatic per-row fallback the moment a page mixes currencies.
- **MCP-only:** `service.ParseFields` is shared with the REST API, so the signature stays stable and `GET /api/v1/transactions` still returns full objects when `?fields=` is omitted.

**2. `list_series` — lean `overview` default**
- Drops the verbose `detection_signals` blob from the list view (≈50–70%/series). Use `get_series` or `fields=all` for full detection detail.

**3. `list_transaction_rules` — lean `summary` default**
- Drops the `conditions`/`actions` trees from the roster view (≈30–50%/rule); `fields=all` restores the full definition. The `breadbox://rules` resource still returns full, and the tool↔resource parity test now asserts that via `fields=all`.

**4. Per-response byte cap (all tools)**
- A safety ceiling enforced at the `jsonResult` chokepoint (default 100 KB ≈ 25K tokens, the pattern GitHub's MCP server uses). Over the cap → an actionable `RESPONSE_TOO_LARGE` error (narrow filters / lower `limit` / paginate / use `fields`) instead of dumping a context-blowing payload.
- Operator override via `BREADBOX_MCP_MAX_RESPONSE_BYTES` env (`0` disables).

### Infrastructure
`fields.go`'s parser is generalized into `parseFieldsWith(raw, valid, aliases)`; `ParseFields` stays a thin wrapper (REST untouched). Per-entity field maps + `FilterSeriesFields`/`FilterRuleFields` live in the new `internal/service/fields_entities.go`.

### Researched but NOT adopted: `defer_loading` / Tool Search Tool
It's a client-side Messages-API beta; our agent runner uses the Claude Agent SDK, which passes tool defs opaquely and exposes no such knob (agent-sdk-ts #124/#281, unshipped). Adopting it would mean dropping the SDK and reimplementing the whole runner. At 41 tools / ~4–4.5K tokens of defs we're below Anthropic's own >10K-token / 30–50-tool threshold, and those tokens are cache-reads after turn 1. Revisit only past ~50–80 tools or multi-server agent runs.

### Testing
- `go build` / `go vet ./...` clean; all unit tests pass.
- Integration green against `breadbox_test`: mcp, service, api.
- New tests: currency hoisting + helpers, response cap + env resolver, series/rules projection, updated response-shape + tool↔resource parity integration tests.
- Canonical `docs/mcp-tools-reference.md` synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
