### PR TITLE
feat(ui): polish api-keys page — one-click create, name a key inline at creation

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -141,6 +141,7 @@ func popAPIKeyReveal(r *http.Request, sm *scs.SessionManager) *pages.AccessRevea
 		return nil
 	}
 	return &pages.AccessReveal{
+		ID:     sm.PopString(r.Context(), "created_api_key_id"),
 		Name:   sm.PopString(r.Context(), "created_api_key_name"),
 		Secret: secret,
 		Scope:  sm.PopString(r.Context(), "created_api_key_scope"),
@@ -199,7 +200,7 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			FlashRedirect(w, r, sm, "error", "Failed to create API key", "/settings/api-keys")
 			return
 		}
-		reveal := &pages.AccessReveal{Name: result.Name, Secret: result.PlaintextKey, Scope: scope}
+		reveal := &pages.AccessReveal{ID: result.ID, Name: result.Name, Secret: result.PlaintextKey, Scope: scope}
 		// JS path: the in-page swapper POSTs with the fragment header.
 		// Render the Access tab fragment directly with the reveal inline —
 		// no redirect, no one-shot flash to race against.
@@ -210,6 +211,7 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		// No-JS fallback: stash the reveal in a flash and 303 back so a
 		// form post doesn't re-submit on refresh.
 		sm.Put(r.Context(), "created_api_key", result.PlaintextKey)
+		sm.Put(r.Context(), "created_api_key_id", result.ID)
 		sm.Put(r.Context(), "created_api_key_name", result.Name)
 		sm.Put(r.Context(), "created_api_key_scope", scope)
 		http.Redirect(w, r, "/settings/api-keys", http.StatusSeeOther)
@@ -230,6 +232,14 @@ func APIKeyRevokePageHandler(svc *service.Service, sm *scs.SessionManager) http.
 }
 
 // APIKeyRenamePageHandler serves POST /settings/api-keys/{id}/rename.
+//
+// Three callers, three response shapes:
+//   - The reveal's inline Name field saves in the background with
+//     `X-Requested-With: fetch` so the one-shot secret stays on screen —
+//     we answer 204 (no body, no swap).
+//   - The overflow "Edit label" modal posts as a settings fragment — we
+//     re-render the Access tab so the renamed row repaints in place.
+//   - No-JS form post — 303 back to the tab.
 func APIKeyRenamePageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
@@ -237,7 +247,16 @@ func APIKeyRenamePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		if name == "" {
 			name = "API key"
 		}
-		if err := svc.RenameAPIKey(r.Context(), id, name); err != nil {
+		err := svc.RenameAPIKey(r.Context(), id, name)
+		if r.Header.Get("X-Requested-With") == "fetch" {
+			if err != nil {
+				http.Error(w, "rename failed", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to rename API key")
 			http.Redirect(w, r, "/settings/api-keys", http.StatusSeeOther)
 			return

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -228,3 +228,24 @@ func APIKeyRevokePageHandler(svc *service.Service, sm *scs.SessionManager) http.
 		http.Redirect(w, r, "/settings/api-keys", http.StatusSeeOther)
 	}
 }
+
+// APIKeyRenamePageHandler serves POST /settings/api-keys/{id}/rename.
+func APIKeyRenamePageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		name := strings.TrimSpace(r.FormValue("name"))
+		if name == "" {
+			name = "API key"
+		}
+		if err := svc.RenameAPIKey(r.Context(), id, name); err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to rename API key")
+			http.Redirect(w, r, "/settings/api-keys", http.StatusSeeOther)
+			return
+		}
+		if r.Header.Get(settingsFragmentHeader) == "1" {
+			renderAccessTab(svc, sm, tr, w, r, nil, nil)
+			return
+		}
+		http.Redirect(w, r, "/settings/api-keys", http.StatusSeeOther)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -178,6 +178,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// plaintext inline (no /new form or /created subpage).
 		r.Get("/settings/api-keys", AccessPageHandler(svc, sm, tr))
 		r.Post("/settings/api-keys/new", APIKeyCreatePageHandler(svc, sm, tr))
+		r.Post("/settings/api-keys/{id}/rename", APIKeyRenamePageHandler(svc, sm, tr))
 
 		r.Get("/settings/oauth-clients", redirectGET("/settings/api-keys"))
 		r.Post("/settings/oauth-clients/new", OAuthClientCreatePageHandler(svc, sm, tr))

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -154,6 +154,22 @@ func (s *Service) RevokeAPIKey(ctx context.Context, id string) error {
 	return nil
 }
 
+func (s *Service) RenameAPIKey(ctx context.Context, id, name string) error {
+	uid, err := pgconv.ParseUUID(id)
+	if err != nil {
+		return ErrNotFound
+	}
+	tag, err := s.Pool.Exec(ctx,
+		"UPDATE api_keys SET name = $2 WHERE id = $1 AND revoked_at IS NULL", uid, name)
+	if err != nil {
+		return fmt.Errorf("rename api key: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*db.ApiKey, error) {
 	hash := sha256.Sum256([]byte(key))
 	keyHash := fmt.Sprintf("%x", hash)

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -150,7 +150,7 @@ templ agentRunRowAvatar(status string) {
 		if status == "in_progress" {
 			<span class="loading loading-spinner loading-sm text-info"></span>
 		} else {
-			@LucideIcon(agentRunAvatarIcon(status), "w-4 h-4 " + agentRunAvatarIconColor(status))
+			@LucideIcon(agentRunAvatarIcon(status), "w-4 h-4 "+agentRunAvatarIconColor(status))
 		}
 	</div>
 }

--- a/internal/templates/components/layout/wizard.templ
+++ b/internal/templates/components/layout/wizard.templ
@@ -33,7 +33,15 @@ templ Wizard(p WizardProps) {
 			     cross-origin font swap on hard-reload. @font-face declarations
 			     live in styles.css so this layout and base.html share them. -->
 			<link rel="preload" href="/static/fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin/>
-			<style>body { font-family: 'Inter var', system-ui, -apple-system, sans-serif; }</style>
+			<style>
+				body {
+					font-family:
+						"Inter var",
+						system-ui,
+						-apple-system,
+						sans-serif;
+				}
+			</style>
 			<!-- Lucide: self-hosted + deferred. See base.html for rationale. -->
 			<script defer src="/static/js/vendor/lucide.min.js"></script>
 		</head>
@@ -65,10 +73,12 @@ templ Wizard(p WizardProps) {
 			<script>
 				// Lucide is loaded via `<script defer>` from `<head>`. Run createIcons
 				// once both the DOM is ready and the library has executed.
-				(function() {
-					function init() { if (typeof lucide !== 'undefined') lucide.createIcons(); }
-					if (document.readyState === 'loading') {
-						document.addEventListener('DOMContentLoaded', init);
+				(function () {
+					function init() {
+						if (typeof lucide !== "undefined") lucide.createIcons();
+					}
+					if (document.readyState === "loading") {
+						document.addEventListener("DOMContentLoaded", init);
 					} else {
 						init();
 					}

--- a/internal/templates/components/onboarding_alt_path.templ
+++ b/internal/templates/components/onboarding_alt_path.templ
@@ -5,8 +5,8 @@ package components
 // AllComplete). It de-risks the "I don't have a supported bank / I'm stuck"
 // drop-off by:
 //
-//   1. surfacing the CSV-import alternative for people without Plaid/Teller, and
-//   2. listing a few documentation resources.
+//  1. surfacing the CSV-import alternative for people without Plaid/Teller, and
+//  2. listing a few documentation resources.
 //
 // It is deliberately QUIET — a helpful aside, not a primary CTA — so it sits
 // below the active step without competing with it. Use a soft surface and ghost

--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -362,7 +362,7 @@ templ accessRevealNameField() {
 		<label class="text-[0.7rem] font-medium text-base-content/50 mb-1 flex items-center justify-between">
 			<span>Name</span>
 			<span x-show="saved" x-cloak class="inline-flex items-center gap-1 text-success font-normal lowercase">
-				<i data-lucide="check" class="w-3 h-3"></i>
+				@components.LucideIcon("check", "w-3 h-3")
 				Saved
 			</span>
 		</label>

--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -8,10 +8,9 @@ import (
 
 // Access renders the combined API Keys + OAuth Clients tab. Each is a
 // borderless SettingsSection (.claude/rules/settings.md). Creating a key
-// or client is a one-click action: an inline bar carries an optional
-// label + a permission toggle (defaults to full access), so the bare
-// button still mints in one click. The plaintext is revealed inline. No
-// subpages.
+// or client is a one-click action: a split button mints full-access in one
+// click, or drops down to reveal "Create 'read-only' key/client". The
+// plaintext is revealed inline. No subpages.
 templ Access(p AccessProps) {
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
@@ -26,7 +25,6 @@ templ Access(p AccessProps) {
 // ---------------------------------------------------------------------
 // API Keys
 // ---------------------------------------------------------------------
-
 templ accessAPIKeysSection(p AccessProps) {
 	<div id="api-keys">
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -36,11 +34,10 @@ templ accessAPIKeysSection(p AccessProps) {
 			Bare:    true,
 		}) {
 			@accessCreateBar(accessCreateBarProps{
-				Action:     "/settings/api-keys/new",
-				CSRFToken:  p.CSRFToken,
-				CreateText: "Create key",
-				NameHint:   "e.g. Claude MCP, Dashboard",
-				ScopeNote:  "Read-only keys can query data but can't trigger syncs, categorize, or use write MCP tools.",
+				Action:       "/settings/api-keys/new",
+				CSRFToken:    p.CSRFToken,
+				CreateText:   "Create key",
+				ReadOnlyText: "Create 'read-only' key",
 			})
 			if p.JustCreatedKey != nil {
 				@accessReveal(p.JustCreatedKey, "API key")
@@ -77,10 +74,14 @@ func accessKeysCaption(p AccessProps) string {
 }
 
 templ accessActiveKeyRow(k AccessKeyRow, isAdmin bool, csrfToken string) {
-	<div class="bb-settings-row" x-data="{ confirming: false }">
+	<div
+		class="bb-settings-row"
+		x-data="{ confirming: false, editing: false, label: $el.dataset.label, origLabel: $el.dataset.label }"
+		data-label={ k.Name }
+	>
 		<div class="bb-settings-row__main">
 			<div class="bb-settings-row__label">
-				<span class="truncate">{ k.Name }</span>
+				<span class="truncate" x-text="label">{ k.Name }</span>
 				@accessScopeBadge(k.Scope)
 			</div>
 			<div class="bb-settings-row__caption flex items-center gap-x-2 gap-y-0.5 flex-wrap">
@@ -93,9 +94,76 @@ templ accessActiveKeyRow(k AccessKeyRow, isAdmin bool, csrfToken string) {
 		</div>
 		if isAdmin {
 			<div class="bb-settings-row__control">
-				@accessRevokeControl(accessAPIKeyRevokeURL(k.ID), csrfToken, "API key "+k.Name)
+				@accessAPIKeyControl(k, csrfToken)
 			</div>
+			@accessEditLabelDialog(accessAPIKeyRenameURL(k.ID), csrfToken)
 		}
+	</div>
+}
+
+// accessAPIKeyControl renders the overflow menu + inline confirm for API key rows.
+// State (confirming, editing, label) is owned by the parent accessActiveKeyRow x-data.
+templ accessAPIKeyControl(k AccessKeyRow, csrfToken string) {
+	<div class="contents">
+		<div x-show="!confirming" class="contents">
+			@components.OverflowMenu(components.OverflowMenuProps{
+				AriaLabel: "Actions for API key " + k.Name,
+				Size:      "xs",
+				Items: []components.OverflowMenuItem{
+					{
+						Label:   "Edit label",
+						Icon:    "pencil",
+						OnClick: "editing = true; document.activeElement.blur()",
+					},
+					{
+						Label:       "Revoke…",
+						Icon:        "trash-2",
+						OnClick:     "confirming = true; document.activeElement.blur()",
+						Destructive: true,
+					},
+				},
+			})
+		</div>
+		<form method="POST" action={ templ.SafeURL(accessAPIKeyRevokeURL(k.ID)) } x-show="confirming" x-cloak>
+			<input type="hidden" name="_csrf" value={ csrfToken }/>
+			<span class="flex items-center gap-1.5 justify-end">
+				<button type="submit" class="btn btn-error btn-xs btn-soft">Confirm</button>
+				<button type="button" class="btn btn-ghost btn-xs" @click="confirming = false">Cancel</button>
+			</span>
+		</form>
+	</div>
+}
+
+// accessEditLabelDialog renders the modal for renaming an API key.
+// It reads/writes the `label` and `origLabel` vars from the parent row's x-data.
+// Uses a DaisyUI div-based modal (not native <dialog>) so Alpine's :class
+// binding controls visibility without needing the native showModal() API.
+templ accessEditLabelDialog(renameURL, csrfToken string) {
+	<div class="modal" :class="{ 'modal-open': editing }" role="dialog" aria-modal="true">
+		<div class="modal-box max-w-xs p-5" @click.stop>
+			<h3 class="font-medium text-sm mb-3">Edit label</h3>
+			<form method="POST" action={ templ.SafeURL(renameURL) }>
+				<input type="hidden" name="_csrf" value={ csrfToken }/>
+				<input
+					type="text"
+					name="name"
+					x-model="label"
+					class="input input-sm w-full mb-4"
+					placeholder="API key"
+					required
+					x-effect="editing && $nextTick(() => $el.focus())"
+				/>
+				<div class="flex justify-end gap-2">
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm"
+						@click="editing = false; label = origLabel"
+					>Cancel</button>
+					<button type="submit" class="btn btn-primary btn-sm">Save</button>
+				</div>
+			</form>
+		</div>
+		<label class="modal-backdrop" @click="editing = false; label = origLabel"></label>
 	</div>
 }
 
@@ -117,7 +185,6 @@ templ accessRevokedKeyRow(k AccessKeyRow) {
 // ---------------------------------------------------------------------
 // OAuth Clients
 // ---------------------------------------------------------------------
-
 templ accessOAuthClientsSection(p AccessProps) {
 	<div id="oauth-clients">
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -127,11 +194,10 @@ templ accessOAuthClientsSection(p AccessProps) {
 			Bare:    true,
 		}) {
 			@accessCreateBar(accessCreateBarProps{
-				Action:     "/settings/oauth-clients/new",
-				CSRFToken:  p.CSRFToken,
-				CreateText: "Create client",
-				NameHint:   "e.g. Claude Desktop",
-				ScopeNote:  "Scope applies to every connection authorized through this client.",
+				Action:       "/settings/oauth-clients/new",
+				CSRFToken:    p.CSRFToken,
+				CreateText:   "Create client",
+				ReadOnlyText: "Create 'read-only' client",
 			})
 			if p.JustCreatedClient != nil {
 				@accessReveal(p.JustCreatedClient, "OAuth client")
@@ -207,61 +273,43 @@ templ accessRevokedClientRow(c AccessClientRow) {
 // ---------------------------------------------------------------------
 
 type accessCreateBarProps struct {
-	Action     string // POST endpoint that mints + reveals the secret
-	CSRFToken  string
-	CreateText string // "Create key" / "Create client"
-	NameHint   string // placeholder for the optional label input
-	ScopeNote  string // one-line note shown when "Read only" is picked
+	Action       string // POST endpoint that mints + reveals the secret
+	CSRFToken    string
+	CreateText   string // "Create key" / "Create client"
+	ReadOnlyText string // dropdown label: "Create 'read-only' key" / "Create 'read-only' client"
 }
 
-// accessCreateBar is the one-click create affordance: one inline bar with
-// an optional label, a full-access/read-only permission toggle (daisy
-// join segmented control, defaults to full access), and the create
-// button. Leaving the label blank and hitting create still mints in one
-// click. The in-page swapper intercepts the POST so the reveal lands
-// inline without a navigation.
+// accessCreateBar is the one-click create affordance: a split button that
+// mints a full-access key in one click, or drops down to reveal a read-only
+// creation option. The in-page swapper intercepts the POST so the reveal
+// lands inline without a navigation.
 templ accessCreateBar(p accessCreateBarProps) {
-	<form
-		method="POST"
-		action={ templ.SafeURL(p.Action) }
-		x-data="{ scope: 'full_access' }"
-		class="flex flex-col gap-2 mb-5"
-	>
-		<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
-		<input type="hidden" name="scope" :value="scope"/>
-		<div class="flex flex-col sm:flex-row sm:items-end gap-3">
-			<label class="flex flex-col gap-1.5 flex-1 min-w-0">
-				<span class="text-xs font-medium text-base-content/60">
-					Label <span class="font-normal text-base-content/40">optional</span>
-				</span>
-				<input type="text" name="name" class="input input-sm w-full" placeholder={ p.NameHint } autocomplete="off"/>
-			</label>
-			<div class="flex flex-col gap-1.5">
-				<span class="text-xs font-medium text-base-content/60">Permission</span>
-				<div class="join w-full sm:w-auto" role="group" aria-label="Permission scope">
-					<button
-						type="button"
-						class="join-item btn btn-sm flex-1 sm:flex-none"
-						:class="{ 'btn-active': scope === 'full_access' }"
-						:aria-pressed="scope === 'full_access'"
-						@click="scope = 'full_access'"
-					>Full access</button>
-					<button
-						type="button"
-						class="join-item btn btn-sm flex-1 sm:flex-none"
-						:class="{ 'btn-active': scope === 'read_only' }"
-						:aria-pressed="scope === 'read_only'"
-						@click="scope = 'read_only'"
-					>Read only</button>
+	<div class="mb-5" x-data="{ scope: 'full_access' }">
+		<form method="POST" action={ templ.SafeURL(p.Action) } x-ref="form">
+			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+			<input type="hidden" name="scope" :value="scope"/>
+			<div class="join">
+				<button type="submit" class="btn btn-primary btn-sm join-item gap-2">
+					@components.LucideIcon("plus", "w-4 h-4")
+					{ p.CreateText }
+				</button>
+				<div class="dropdown dropdown-end">
+					<button type="button" tabindex="0" class="btn btn-primary btn-sm join-item px-2">
+						@components.LucideIcon("chevron-down", "w-3.5 h-3.5")
+					</button>
+					<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-56 p-1 mt-1">
+						<li>
+							<button
+								type="button"
+								class="text-sm"
+								@click="scope = 'read_only'; $nextTick(() => $refs.form.requestSubmit())"
+							>{ p.ReadOnlyText }</button>
+						</li>
+					</ul>
 				</div>
 			</div>
-			<button type="submit" class="btn btn-primary btn-sm gap-2 w-full sm:w-auto">
-				@components.LucideIcon("plus", "w-4 h-4")
-				{ p.CreateText }
-			</button>
-		</div>
-		<p class="text-xs text-base-content/45 leading-snug" x-show="scope === 'read_only'" x-cloak>{ p.ScopeNote }</p>
-	</form>
+		</form>
+	</div>
 }
 
 // accessReveal renders the one-time plaintext block shown right after a
@@ -341,7 +389,7 @@ templ accessScopeBadge(scope string) {
 }
 
 // accessRevokeControl is the inline two-step revoke affordance shared by
-// key + client rows.
+// client rows (API key rows use accessAPIKeyControl instead).
 templ accessRevokeControl(action, csrfToken, ariaLabel string) {
 	<div x-data="{ confirming: false }" class="contents">
 		<div x-show="!confirming" class="contents">

--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -12,6 +12,7 @@ import (
 // click, or drops down to reveal "Create 'read-only' key/client". The
 // plaintext is revealed inline. No subpages.
 templ Access(p AccessProps) {
+	<script src="/static/js/admin/components/access.js"></script>
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
 			Title:    "API Keys",
@@ -26,6 +27,7 @@ templ Access(p AccessProps) {
 // API Keys
 // ---------------------------------------------------------------------
 templ accessAPIKeysSection(p AccessProps) {
+	{{ others := accessActiveKeysExcluding(p.ActiveKeys, p.JustCreatedKey) }}
 	<div id="api-keys">
 		@components.SettingsSection(components.SettingsSectionProps{
 			Icon:    "key",
@@ -40,15 +42,17 @@ templ accessAPIKeysSection(p AccessProps) {
 				ReadOnlyText: "Create 'read-only' key",
 			})
 			if p.JustCreatedKey != nil {
-				@accessReveal(p.JustCreatedKey, "API key")
+				@accessReveal(p.JustCreatedKey, "API key", p.CSRFToken)
 			}
-			@components.SettingsCard(components.SettingsCardProps{}) {
-				if len(p.ActiveKeys) == 0 && len(p.RevokedKeys) == 0 && p.JustCreatedKey == nil {
-					@accessEmptyRow("Create one to connect MCP agents or integrate with external tools.")
-				} else {
-					for _, k := range p.ActiveKeys {
+			if len(others) > 0 {
+				@components.SettingsCard(components.SettingsCardProps{}) {
+					for _, k := range others {
 						@accessActiveKeyRow(k, p.IsAdmin, p.CSRFToken)
 					}
+				}
+			} else if len(p.RevokedKeys) == 0 && p.JustCreatedKey == nil {
+				@components.SettingsCard(components.SettingsCardProps{}) {
+					@accessEmptyRow("Create one to connect MCP agents or integrate with external tools.")
 				}
 			}
 			if len(p.RevokedKeys) > 0 {
@@ -200,7 +204,7 @@ templ accessOAuthClientsSection(p AccessProps) {
 				ReadOnlyText: "Create 'read-only' client",
 			})
 			if p.JustCreatedClient != nil {
-				@accessReveal(p.JustCreatedClient, "OAuth client")
+				@accessReveal(p.JustCreatedClient, "OAuth client", p.CSRFToken)
 			}
 			@components.SettingsCard(components.SettingsCardProps{}) {
 				if len(p.ActiveClients) == 0 && len(p.RevokedClients) == 0 && p.JustCreatedClient == nil {
@@ -315,20 +319,65 @@ templ accessCreateBar(p accessCreateBarProps) {
 // accessReveal renders the one-time plaintext block shown right after a
 // mint. The whole point is "copy it now" — so it's prominent (success
 // tint), copyable in one tap, and gone on the next render.
-templ accessReveal(rv *AccessReveal, kind string) {
-	<div class="rounded-xl border border-success/30 bg-success/[0.06] p-4 mb-5">
-		<div class="flex items-center gap-2 text-sm font-medium text-success mb-1">
+//
+// For API keys (rv.ID set) it doubles as the naming moment: a pre-focused
+// Name field background-saves to the rename endpoint (accessReveal Alpine
+// factory in access.js), so the user names the key while it's in front of
+// them instead of hunting it down in the list afterward. OAuth clients have
+// no rename endpoint, so they skip the field and just show the secret.
+templ accessReveal(rv *AccessReveal, kind, csrfToken string) {
+	<div
+		class="rounded-xl border border-success/30 bg-success/[0.06] p-4 mb-5"
+		if rv.ID != "" {
+			x-data="accessReveal"
+			data-rename-url={ accessAPIKeyRenameURL(rv.ID) }
+			data-csrf={ csrfToken }
+			data-initial-label={ rv.Name }
+		}
+	>
+		<div class="flex items-center gap-2 text-sm font-medium text-success mb-3">
 			@components.LucideIcon("circle-check", "w-4 h-4 shrink-0")
 			<span>{ kind } created</span>
 			@accessScopeBadge(rv.Scope)
 		</div>
-		<p class="text-xs text-base-content/55 mb-3">
-			Copy { accessSecretLabel(kind) } now — for security it won't be shown again.
-		</p>
+		if rv.ID != "" {
+			@accessRevealNameField()
+		}
 		if rv.ClientID != "" {
 			@accessCopyField("Client ID", rv.ClientID, false)
 		}
 		@accessCopyField(accessSecretFieldLabel(kind), rv.Secret, true)
+		<p class="text-xs text-base-content/55 mt-2">
+			Copy { accessSecretLabel(kind) } now — for security it won't be shown again.
+		</p>
+	</div>
+}
+
+// accessRevealNameField is the inline, auto-saving Name input at the top of
+// an API-key reveal. Commit-on-blur (`@change`) keeps it quiet — no Save
+// button, no per-keystroke POST — matching the settings "auto-save when you
+// can" rule. State (label / saved) lives in the parent accessReveal x-data.
+templ accessRevealNameField() {
+	<div class="mb-3">
+		<label class="text-[0.7rem] font-medium text-base-content/50 mb-1 flex items-center justify-between">
+			<span>Name</span>
+			<span x-show="saved" x-cloak class="inline-flex items-center gap-1 text-success font-normal lowercase">
+				<i data-lucide="check" class="w-3 h-3"></i>
+				Saved
+			</span>
+		</label>
+		<input
+			type="text"
+			x-ref="labelInput"
+			x-model="label"
+			@change="save()"
+			@input="saved = false"
+			@keydown.enter.prevent="$el.blur()"
+			class="input input-sm w-full bg-base-100 text-sm"
+			placeholder="API key"
+			maxlength="80"
+			autocomplete="off"
+		/>
 	</div>
 }
 

--- a/internal/templates/components/pages/access_types.go
+++ b/internal/templates/components/pages/access_types.go
@@ -64,6 +64,11 @@ func accessAPIKeyRevokeURL(id string) string {
 	return "/settings/api-keys/" + id + "/revoke"
 }
 
+// accessAPIKeyRenameURL returns the POST endpoint that renames the given API key.
+func accessAPIKeyRenameURL(id string) string {
+	return "/settings/api-keys/" + id + "/rename"
+}
+
 // accessOAuthClientRevokeURL returns the POST endpoint that revokes the
 // given OAuth client.
 func accessOAuthClientRevokeURL(id string) string {

--- a/internal/templates/components/pages/access_types.go
+++ b/internal/templates/components/pages/access_types.go
@@ -27,11 +27,36 @@ type AccessProps struct {
 // it's popped from the session flash on the redirect-back render and shown
 // once. ClientID is set only for OAuth clients (the public half, shown
 // alongside the secret); empty for API keys.
+//
+// ID is the new entity's id. When set (API keys), the reveal renders an
+// inline, pre-focused Name field that background-saves to the rename
+// endpoint — naming happens in the same breath as copying the secret — and
+// the just-created key is omitted from the list below so it isn't shown
+// twice. Empty for OAuth clients (no rename endpoint yet).
 type AccessReveal struct {
+	ID       string
 	Name     string
 	ClientID string
 	Secret   string
 	Scope    string
+}
+
+// accessActiveKeysExcluding returns the active key rows minus the one that's
+// currently shown in the reveal block (matched by ID). While the reveal is
+// up it IS that key's row — an editable-name, copy-the-secret expansion — so
+// rendering it again in the list below would duplicate it under a stale name.
+func accessActiveKeysExcluding(keys []AccessKeyRow, reveal *AccessReveal) []AccessKeyRow {
+	if reveal == nil || reveal.ID == "" {
+		return keys
+	}
+	out := make([]AccessKeyRow, 0, len(keys))
+	for _, k := range keys {
+		if k.ID == reveal.ID {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
 }
 
 // AccessKeyRow is the per-row shape for the API keys section. CreatedAtShort

--- a/internal/templates/components/pages/account_link_detail.templ
+++ b/internal/templates/components/pages/account_link_detail.templ
@@ -25,7 +25,8 @@ templ AccountLinkDetail(p AccountLinkDetailProps) {
 		<form method="POST" action={ templ.SafeURL(fmt.Sprintf("/-/account-links/%s/reconcile", p.LinkID)) } class="inline">
 			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 			<button type="submit" class="btn btn-primary btn-sm">
-				@components.LucideIcon("refresh-cw", "w-4 h-4") <span class="hidden sm:inline">Reconcile Now</span><span class="sm:hidden">Reconcile</span>
+				@components.LucideIcon("refresh-cw", "w-4 h-4")
+				<span class="hidden sm:inline">Reconcile Now</span><span class="sm:hidden">Reconcile</span>
 			</button>
 		</form>
 	</div>
@@ -151,13 +152,15 @@ templ accountLinkDetailMobileCard(m AccountLinkDetailMatchRow, csrfToken string)
 				<form method="POST" action={ templ.SafeURL(fmt.Sprintf("/-/transaction-matches/%s/confirm", m.ID)) } class="inline">
 					<input type="hidden" name="_csrf" value={ csrfToken }/>
 					<button type="submit" class="btn btn-success btn-xs btn-soft">
-						@components.LucideIcon("check", "w-3.5 h-3.5") Confirm
+						@components.LucideIcon("check", "w-3.5 h-3.5")
+						Confirm
 					</button>
 				</form>
 				<form method="POST" action={ templ.SafeURL(fmt.Sprintf("/-/transaction-matches/%s/reject", m.ID)) } class="inline">
 					<input type="hidden" name="_csrf" value={ csrfToken }/>
 					<button type="submit" class="btn btn-error btn-xs btn-soft">
-						@components.LucideIcon("x", "w-3.5 h-3.5") Reject
+						@components.LucideIcon("x", "w-3.5 h-3.5")
+						Reject
 					</button>
 				</form>
 			</div>

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -105,7 +105,9 @@ templ AccountsList(p AccountsListProps) {
 		</template>
 	</div>
 	<script>
-		document.addEventListener('DOMContentLoaded', function() { lucide.createIcons(); });
+		document.addEventListener("DOMContentLoaded", function () {
+			lucide.createIcons();
+		});
 	</script>
 }
 

--- a/internal/templates/components/pages/agent_form.templ
+++ b/internal/templates/components/pages/agent_form.templ
@@ -591,14 +591,14 @@ func agentFormToolScopeOrDefault(v string) string {
 // and restore them when they flip back to Automatic.
 func agentFormInitialJSON(f AgentFormFields) map[string]any {
 	return map[string]any{
-		"cron":                      f.ScheduleCron,
-		"system_prompt":             f.SystemPrompt,
-		"quiet_hours_start":         f.QuietHoursStart,
-		"quiet_hours_end":           f.QuietHoursEnd,
-		"allowed_tools":             f.AllowedTools,
-		"max_turns":                 f.MaxTurns,
-		"max_budget_usd":            f.MaxBudgetUSD,
-		"enabled":                   f.Enabled,
-		"trigger_on_sync_complete":  f.TriggerOnSyncComplete,
+		"cron":                     f.ScheduleCron,
+		"system_prompt":            f.SystemPrompt,
+		"quiet_hours_start":        f.QuietHoursStart,
+		"quiet_hours_end":          f.QuietHoursEnd,
+		"allowed_tools":            f.AllowedTools,
+		"max_turns":                f.MaxTurns,
+		"max_budget_usd":           f.MaxBudgetUSD,
+		"enabled":                  f.Enabled,
+		"trigger_on_sync_complete": f.TriggerOnSyncComplete,
 	}
 }

--- a/internal/templates/components/pages/agent_run_detail.templ
+++ b/internal/templates/components/pages/agent_run_detail.templ
@@ -414,7 +414,8 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 			<li class="bb-tool-row">
 				<details class="bb-tool" data-tool-event="use">
 					<summary class="bb-tool__summary">
-						<div class="bb-tool__icon">@components.LucideIcon("wrench", "w-3.5 h-3.5")</div>
+						<div class="bb-tool__icon">@components.LucideIcon("wrench", "w-3.5 h-3.5")
+</div>
 						<span class="bb-tool__label">
 							if ev.ToolResultJSON != "" {
 								Tool
@@ -433,7 +434,8 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 					</summary>
 					<div class="bb-tool__body bb-tool__body--paired">
 						<div class="bb-tool__section">
-							<div class="bb-tool__section-label">@components.LucideIcon("arrow-right", "w-3 h-3") Input</div>
+							<div class="bb-tool__section-label">@components.LucideIcon("arrow-right", "w-3 h-3")
+Input</div>
 							if ev.ToolInputJSON != "" {
 								@components.JSONViewer(components.JSONViewerProps{Source: ev.ToolInputJSON, MaxDepth: 0, ShowCopy: true})
 							} else {
@@ -442,7 +444,8 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 						</div>
 						if ev.ToolResultJSON != "" {
 							<div class="bb-tool__section">
-								<div class="bb-tool__section-label bb-tool__section-label--result">@components.LucideIcon("arrow-left", "w-3 h-3") Result</div>
+								<div class="bb-tool__section-label bb-tool__section-label--result">@components.LucideIcon("arrow-left", "w-3 h-3")
+Result</div>
 								@components.JSONViewer(components.JSONViewerProps{Source: ev.ToolResultJSON, MaxDepth: 0, ShowCopy: true})
 							</div>
 						}
@@ -453,7 +456,8 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 			<li class="bb-tool-row">
 				<details class="bb-tool" data-tool-event="result">
 					<summary class="bb-tool__summary">
-						<div class="bb-tool__icon bb-tool__icon--result">@components.LucideIcon("check-check", "w-3.5 h-3.5")</div>
+						<div class="bb-tool__icon bb-tool__icon--result">@components.LucideIcon("check-check", "w-3.5 h-3.5")
+</div>
 						<span class="bb-tool__label">Tool result</span>
 						if ev.ToolName != "" {
 							<span class="bb-tool__name font-mono">{ agentRunToolDisplay(ev.ToolName) }</span>
@@ -530,7 +534,8 @@ templ agentRunTranscriptEvent(ev TranscriptEvent, idx int) {
 			<li class="bb-tool-row">
 				<details class="bb-tool">
 					<summary class="bb-tool__summary">
-						<div class="bb-tool__icon bb-tool__icon--raw">@components.LucideIcon("code-2", "w-3.5 h-3.5")</div>
+						<div class="bb-tool__icon bb-tool__icon--raw">@components.LucideIcon("code-2", "w-3.5 h-3.5")
+</div>
 						<span class="bb-tool__label">Raw event</span>
 						if ev.Type != "" {
 							<span class="bb-tool__name font-mono">{ ev.Type }</span>
@@ -557,7 +562,6 @@ func agentRunToolDisplay(name string) string {
 }
 
 // ─── Side panel ─────────────────────────────────────────────────────
-
 templ agentRunStatsCard(p AgentRunDetailProps) {
 	<div class="bb-card p-4" x-ref="stats">
 		<h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-3">Usage</h3>

--- a/internal/templates/components/pages/agent_runs.templ
+++ b/internal/templates/components/pages/agent_runs.templ
@@ -97,9 +97,12 @@ templ agentRunsStats(s AgentRunsStatsProps) {
 // summary line shows the active filter chips so the operator can see
 // what's applied without expanding.
 templ agentRunsFilterBar(p AgentRunsListProps) {
-	<details class="collapse collapse-arrow bg-base-100 border border-base-300 rounded-xl mt-4 mb-4" if agentRunsHasActiveFilter(p) {
-		open
-	}>
+	<details
+		class="collapse collapse-arrow bg-base-100 border border-base-300 rounded-xl mt-4 mb-4"
+		if agentRunsHasActiveFilter(p) {
+			open
+		}
+	>
 		<summary class="collapse-title text-sm font-medium">
 			<div class="flex items-center gap-2 flex-wrap">
 				@components.LucideIcon("filter", "w-4 h-4 text-base-content/50")

--- a/internal/templates/components/pages/agent_wizard.templ
+++ b/internal/templates/components/pages/agent_wizard.templ
@@ -185,7 +185,7 @@ templ wizardCard(c wizardCardData) {
 				"bg-" + c.Color + "/10",
 				"group-hover:bg-" + c.Color + "/15" }
 			>
-				@components.LucideIcon(c.Icon, "w-5 h-5 " + "text-" + c.Color)
+				@components.LucideIcon(c.Icon, "w-5 h-5 "+"text-"+c.Color)
 			</div>
 			<div class="flex-1 px-4 py-3.5 min-w-0">
 				<div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">

--- a/internal/templates/components/pages/agents_list.templ
+++ b/internal/templates/components/pages/agents_list.templ
@@ -143,10 +143,12 @@ templ agentsListEmpty() {
 templ agentsListEmptyCTAs() {
 	<div class="flex items-center gap-2">
 		<a href="/agents/new" class="btn btn-primary btn-sm">
-			@components.LucideIcon("plus", "w-4 h-4") Create your first agent
+			@components.LucideIcon("plus", "w-4 h-4")
+			Create your first agent
 		</a>
 		<a href="/agent-prompts" class="btn btn-ghost btn-sm">
-			@components.LucideIcon("book-open", "w-4 h-4") Prompt library
+			@components.LucideIcon("book-open", "w-4 h-4")
+			Prompt library
 		</a>
 	</div>
 }

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -354,12 +354,16 @@ templ mcpConnectionDrawer() {
 							@click.stop="navigator.clipboard.writeText(JSON.stringify({mcpServers:{breadbox:{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
 						>
 							<template x-if="!copiedConfig">
-								<span class="flex items-center gap-1">@components.LucideIcon("copy", "w-4 h-4")
-Copy</span>
+								<span class="flex items-center gap-1">
+									@components.LucideIcon("copy", "w-4 h-4")
+									Copy
+								</span>
 							</template>
 							<template x-if="copiedConfig">
-								<span class="flex items-center gap-1 text-success">@components.LucideIcon("check", "w-4 h-4")
-Copied!</span>
+								<span class="flex items-center gap-1 text-success">
+									@components.LucideIcon("check", "w-4 h-4")
+									Copied!
+								</span>
 							</template>
 						</button>
 					</div>

--- a/internal/templates/components/pages/agents_shell.templ
+++ b/internal/templates/components/pages/agents_shell.templ
@@ -1,8 +1,6 @@
 package pages
 
-import (
-	"breadbox/internal/templates/components"
-)
+import "breadbox/internal/templates/components"
 
 // agentsTabBar renders the Runs / Agents two-tab nav shared between
 // /agents (runs landing) and /agents/definitions (agents list). Both
@@ -67,6 +65,7 @@ templ agentsHeaderActions(modalID string, runDisabled bool) {
 // openAgentRunModal is the click handler that opens the run-an-agent
 // modal dialog. Kept as a Go-side helper so the inline `onclick`
 // stays a single statement and the lint passes.
+
 script openAgentRunModal(modalID string) {
 	var el = document.getElementById(modalID);
 	if (el && typeof el.showModal === 'function') el.showModal();
@@ -190,4 +189,3 @@ type agentRunModalPayload struct {
 	Agents       []AgentRunsAgentOption `json:"agents"`
 	LastPrefixes map[string]string      `json:"last_prefixes"`
 }
-

--- a/internal/templates/components/pages/backups.templ
+++ b/internal/templates/components/pages/backups.templ
@@ -90,7 +90,6 @@ templ backupsStats(p BackupsProps) {
 // ---------------------------------------------------------------------
 // Schedule
 // ---------------------------------------------------------------------
-
 templ backupsScheduleSection(p BackupsProps) {
 	<div id="schedule">
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -175,7 +174,6 @@ templ backupsRetentionOption(value int, label string, current int) {
 // ---------------------------------------------------------------------
 // File list
 // ---------------------------------------------------------------------
-
 templ backupsFilesSection(p BackupsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "archive",
@@ -292,7 +290,6 @@ templ backupsTriggerBadge(trigger string) {
 // ---------------------------------------------------------------------
 // Restore from upload
 // ---------------------------------------------------------------------
-
 templ backupsRestoreSection(p BackupsProps) {
 	<div id="restore">
 		@components.SettingsSection(components.SettingsSectionProps{

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -29,7 +29,7 @@ templ Categories(p CategoriesProps) {
 		Title:                "Categories",
 		Subtitle:             "Organize transactions with a two-level taxonomy",
 		SubtitleHideOnMobile: true,
-		Action: categoriesNewCategoryAction(),
+		Action:               categoriesNewCategoryAction(),
 	})
 	<!--
 		Set the shortcut-registry scope so base.html's global dispatcher routes
@@ -67,7 +67,9 @@ templ Categories(p CategoriesProps) {
 	</div>
 	@deleteCategoryModal()
 	<script>
-		document.addEventListener('DOMContentLoaded', function() { lucide.createIcons(); });
+		document.addEventListener("DOMContentLoaded", function () {
+			lucide.createIcons();
+		});
 	</script>
 }
 

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -125,8 +125,10 @@ templ connDetailBadges(p ConnectionDetailProps) {
 				<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 				if p.LastSyncErrorMessageValid {
 					<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-						<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3")
-Last sync failed</span>
+						<span class="flex items-center gap-1.5 text-error font-medium mb-1">
+							@components.LucideIcon("alert-circle", "w-3 h-3")
+							Last sync failed
+						</span>
 						<span class="text-base-content/70">{ p.LastSyncErrorMessageString }</span>
 					</span>
 				}

--- a/internal/templates/components/pages/connection_reauth.templ
+++ b/internal/templates/components/pages/connection_reauth.templ
@@ -73,7 +73,8 @@ templ ConnectionReauth(p ConnectionReauthProps) {
 					<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="simplefin-reauth-token">New setup token</label>
 					<textarea id="simplefin-reauth-token" rows="4" class="textarea w-full font-mono text-xs" placeholder="Paste a fresh SimpleFIN setup token…"></textarea>
 					<button type="button" class="btn btn-primary btn-sm mt-3" @click="submitSimplefin()">
-						@components.LucideIcon("link", "w-4 h-4") Reconnect
+						@components.LucideIcon("link", "w-4 h-4")
+						Reconnect
 					</button>
 				</div>
 			}
@@ -85,10 +86,12 @@ templ ConnectionReauth(p ConnectionReauthProps) {
 					x-cloak
 					@click="startReauth()"
 				>
-					@components.LucideIcon("refresh-cw", "w-4 h-4") Retry
+					@components.LucideIcon("refresh-cw", "w-4 h-4")
+					Retry
 				</button>
 				<a href={ templ.SafeURL("/connections/" + p.ConnID) } class="btn btn-ghost btn-sm">
-					@components.LucideIcon("x", "w-4 h-4") Cancel
+					@components.LucideIcon("x", "w-4 h-4")
+					Cancel
 				</a>
 			</div>
 		</div>

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -230,8 +230,10 @@ templ connectionsCard(c ConnectionsRow) {
 									<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 									if c.LastSyncErrorMessage != "" {
 										<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-											<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3")
-Last sync failed</span>
+											<span class="flex items-center gap-1.5 text-error font-medium mb-1">
+												@components.LucideIcon("alert-circle", "w-3 h-3")
+												Last sync failed
+											</span>
 											<span class="text-base-content/70">{ c.LastSyncErrorMessage }</span>
 										</span>
 									}

--- a/internal/templates/components/pages/create_login.templ
+++ b/internal/templates/components/pages/create_login.templ
@@ -74,11 +74,13 @@ templ createLoginManage(p CreateLoginProps) {
 			<!-- Action row -->
 			<div class="bb-action-row">
 				<span x-show="saved" x-transition.opacity class="text-xs text-success inline-flex items-center gap-1 mr-2">
-					@components.LucideIcon("check", "w-3.5 h-3.5") Saved
+					@components.LucideIcon("check", "w-3.5 h-3.5")
+					Saved
 				</span>
 				<a href="/household" class="btn btn-sm btn-ghost">Cancel</a>
 				<button @click="save()" :disabled="!dirty || saving" class="btn btn-sm btn-primary gap-1.5 min-w-32">
-					<span x-show="!saving" class="inline-flex items-center gap-1.5">@components.LucideIcon("save", "w-3.5 h-3.5") Save Changes</span>
+					<span x-show="!saving" class="inline-flex items-center gap-1.5">@components.LucideIcon("save", "w-3.5 h-3.5")
+Save Changes</span>
 					<span x-show="saving" class="loading loading-spinner loading-xs"></span>
 				</button>
 			</div>
@@ -146,7 +148,8 @@ templ createLoginManage(p CreateLoginProps) {
 							<button @click="confirming = false" :disabled="deleting" class="btn btn-ghost btn-sm">Cancel</button>
 							<button @click="confirmDelete()" :disabled="deleting" class="btn btn-error btn-sm gap-1.5 min-w-28">
 								<span x-show="!deleting" class="inline-flex items-center gap-1.5">
-									@components.LucideIcon("user-x", "w-3.5 h-3.5") Confirm Delete
+									@components.LucideIcon("user-x", "w-3.5 h-3.5")
+									Confirm Delete
 								</span>
 								<span x-show="deleting" class="loading loading-spinner loading-xs"></span>
 							</button>
@@ -218,7 +221,8 @@ templ createLoginNew(p CreateLoginProps) {
 				<div class="bb-action-row">
 					<a href="/household" class="btn btn-sm btn-ghost">Cancel</a>
 					<button type="submit" class="btn btn-sm btn-primary gap-1.5 min-w-32" :disabled="submitting">
-						<span x-show="!submitting" class="inline-flex items-center gap-1.5">@components.LucideIcon("user-plus", "w-3.5 h-3.5") Create Login</span>
+						<span x-show="!submitting" class="inline-flex items-center gap-1.5">@components.LucideIcon("user-plus", "w-3.5 h-3.5")
+Create Login</span>
 						<span x-show="submitting" class="loading loading-spinner loading-xs"></span>
 					</button>
 				</div>

--- a/internal/templates/components/pages/csv_import.templ
+++ b/internal/templates/components/pages/csv_import.templ
@@ -47,7 +47,8 @@ templ CSVImport(p CSVImportProps) {
 								class="w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold transition-all duration-200 shrink-0"
 								:class="step > s.n ? 'bg-success text-success-content' : step === s.n ? 'bg-primary text-primary-content' : 'bg-base-200 text-base-content/40'"
 							>
-								<template x-if="step > s.n">@components.LucideIcon("check", "w-4 h-4")</template>
+								<template x-if="step > s.n">@components.LucideIcon("check", "w-4 h-4")
+</template>
 								<template x-if="step <= s.n"><span x-text="s.n"></span></template>
 							</div>
 							<span
@@ -108,7 +109,8 @@ templ CSVImport(p CSVImportProps) {
 				</div>
 				<div class="flex items-center gap-3 pt-2">
 					<button type="button" id="upload-btn" class="btn btn-primary btn-sm" onclick="uploadFile()">
-						@components.LucideIcon("upload", "w-4 h-4") Upload &amp; Parse
+						@components.LucideIcon("upload", "w-4 h-4")
+						Upload &amp; Parse
 					</button>
 					<p id="upload-progress" class="text-sm text-base-content/60"></p>
 				</div>
@@ -196,10 +198,12 @@ templ CSVImport(p CSVImportProps) {
 				}
 				<div class="flex items-center gap-3 pt-2">
 					<button type="button" class="btn btn-ghost btn-sm" onclick="window._csvWizard.setStep(1)">
-						@components.LucideIcon("arrow-left", "w-4 h-4") Back
+						@components.LucideIcon("arrow-left", "w-4 h-4")
+						Back
 					</button>
 					<button type="button" class="btn btn-sm btn-outline" onclick="previewData()">
-						@components.LucideIcon("eye", "w-4 h-4") Preview
+						@components.LucideIcon("eye", "w-4 h-4")
+						Preview
 					</button>
 					<button type="button" id="continue-btn" class="btn btn-primary btn-sm hidden" onclick="goToStep3()">
 						Continue @components.LucideIcon("arrow-right", "w-4 h-4")
@@ -260,10 +264,12 @@ templ CSVImport(p CSVImportProps) {
 				</div>
 				<div class="flex items-center gap-3">
 					<button type="button" class="btn btn-ghost btn-sm" onclick="goToStep(2)">
-						@components.LucideIcon("arrow-left", "w-4 h-4") Back
+						@components.LucideIcon("arrow-left", "w-4 h-4")
+						Back
 					</button>
 					<button type="button" id="import-btn" class="btn btn-primary btn-sm" onclick="doImport()">
-						@components.LucideIcon("download", "w-4 h-4") Import Transactions
+						@components.LucideIcon("download", "w-4 h-4")
+						Import Transactions
 					</button>
 				</div>
 				<p id="import-status" class="text-sm text-error mt-3"></p>

--- a/internal/templates/components/pages/design_agent_run_chat.templ
+++ b/internal/templates/components/pages/design_agent_run_chat.templ
@@ -17,7 +17,6 @@ import (
 //                            /agents/runs/{id} page composes.
 
 // ─── Markdown prose ─────────────────────────────────────────────────
-
 templ SectionMarkdownProse() {
 	<div class="flex flex-col gap-6">
 		@designExample(
@@ -78,7 +77,6 @@ func designMarkdownSampleSafety() string {
 }
 
 // ─── JSON viewer ────────────────────────────────────────────────────
-
 templ SectionJSONViewer() {
 	<div class="flex flex-col gap-6">
 		@designExample(
@@ -166,7 +164,6 @@ func designJSONLargeSample() string {
 }
 
 // ─── Agent run chat thread ──────────────────────────────────────────
-
 templ SectionAgentRunChat() {
 	<div class="flex flex-col gap-6">
 		@designExample(

--- a/internal/templates/components/pages/design_component.templ
+++ b/internal/templates/components/pages/design_component.templ
@@ -1,7 +1,7 @@
 package pages
 
-
 import "breadbox/internal/templates/components"
+
 // DesignComponent renders /design/c/{slug} — a single component family
 // rendered in isolation on the page. Same admin shell as the gallery
 // (so navigation back is one click), but the main column hosts just one

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -2100,16 +2100,7 @@ templ SectionCategoryPicker() {
 	@components.CategoryPickerStyles()
 	@templ.JSONScript("design-cat-picker-cats", designTxRowsCategories())
 	<script>
-		(function () {
-			var e = document.getElementById("design-cat-picker-cats");
-			if (e) {
-				try {
-					window.__bbCategories = JSON.parse(e.textContent);
-				} catch (_) {
-					window.__bbCategories = [];
-				}
-			}
-		})();
+		(function(){var e=document.getElementById('design-cat-picker-cats');if(e){try{window.__bbCategories=JSON.parse(e.textContent);}catch(_){window.__bbCategories=[];}}})();
 	</script>
 	<div class="flex flex-col gap-6">
 		@designExample("Inline (transaction row)", "btn btn-ghost btn-xs gap-1.5 — the per-row quick-set picker shown xl+ on /transactions and /accounts/{id}. assign mode, allow-empty 'Uncategorized'. Used by tx_row.templ.") {
@@ -2327,16 +2318,7 @@ templ SectionTransactionRows() {
 	@components.CategoryPickerStyles()
 	@templ.JSONScript("design-tx-rows-cats", designTxRowsCategories())
 	<script>
-		(function () {
-			var e = document.getElementById("design-tx-rows-cats");
-			if (e) {
-				try {
-					window.__bbCategories = JSON.parse(e.textContent);
-				} catch (_) {
-					window.__bbCategories = [];
-				}
-			}
-		})();
+		(function(){var e=document.getElementById('design-tx-rows-cats');if(e){try{window.__bbCategories=JSON.parse(e.textContent);}catch(_){window.__bbCategories=[];}}})();
 	</script>
 	<div class="flex flex-col gap-6">
 		<!-- Variant policy: when to use which row component. The three layouts

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -15,7 +15,6 @@ import (
 // bottom of this file so individual sections stay focused on markup.
 
 // ─── Foundations ───────────────────────────────────────────────────────
-
 templ SectionFoundations() {
 	<div class="flex flex-col gap-6">
 		@designExample("Color tokens", "DaisyUI semantic surfaces — adapt automatically across light/dark.") {
@@ -57,7 +56,6 @@ templ SectionFoundations() {
 }
 
 // ─── Buttons ───────────────────────────────────────────────────────────
-
 templ SectionButtons() {
 	<div class="flex flex-col gap-6">
 		@designExample("Sizes (sm + xs)", "Two sizes only. Vanilla daisy — no per-caller radius override. Future visual changes go through the daisy theme builder.") {
@@ -171,7 +169,6 @@ templ SectionButtons() {
 }
 
 // ─── Badges ────────────────────────────────────────────────────────────
-
 templ SectionBadges() {
 	<div class="flex flex-col gap-6">
 		@designExample("Status (badge-soft)", "Use statusBadge() / syncBadge() helpers — emits the canonical shape with badge-soft + badge-sm.") {
@@ -241,7 +238,6 @@ templ SectionRecurringChips() {
 }
 
 // ─── Recurring detail panels ─────────────────────────────────────────────
-
 templ SectionRecurringDetail() {
 	<div class="flex flex-col gap-6">
 		@designExample("Detection panel (SeriesDetectionPanel)", "The detection-forward hero: a match-strength badge, a plain-language summary, and the match-window range viz. Reframes a series as a detection rule, not a settings form.") {
@@ -328,7 +324,6 @@ templ SectionRecurringDetail() {
 }
 
 // ─── Alerts ────────────────────────────────────────────────────────────
-
 templ SectionAlerts() {
 	<div class="flex flex-col gap-6">
 		@designExample("Page-level alerts", "role=\"alert\" + rounded-xl + mb-6. Use the matching alert-{type} color.") {
@@ -367,7 +362,6 @@ templ SectionAlerts() {
 }
 
 // ─── Cards ─────────────────────────────────────────────────────────────
-
 templ SectionCards() {
 	<div class="flex flex-col gap-6">
 		@designExample("Simple (bb-card p-5)", "Direct content, no internal sections.") {
@@ -414,7 +408,6 @@ templ SectionCards() {
 }
 
 // ─── Form controls ─────────────────────────────────────────────────────
-
 templ SectionFormControls() {
 	<div class="flex flex-col gap-6">
 		@designExample("Text input", "Daisy 5 input is bordered by default — no input-bordered modifier needed. Pair with the text-xs label.") {
@@ -487,7 +480,6 @@ templ SectionFormControls() {
 }
 
 // ─── Tables ────────────────────────────────────────────────────────────
-
 templ SectionTables() {
 	<div class="flex flex-col gap-6">
 		@designExample("Standard (table-sm table-zebra)", "Default for most list pages. Use hover:bg-base-200 on <tr>.") {
@@ -545,7 +537,6 @@ templ SectionTables() {
 }
 
 // ─── Tags ──────────────────────────────────────────────────────────────
-
 templ SectionTags() {
 	<div class="flex flex-col gap-6">
 		@designExample("Tag sizes", "Pill-shaped, colored via --tag-color CSS variable. Size variants are modifiers — always pair with the base .bb-tag class.") {
@@ -676,23 +667,28 @@ templ SectionTagPicker() {
 		@designExample("Chip states", "Each chip in the picker grid carries one of five states. Click cycles a chip through the right column.") {
 			<div class="flex flex-wrap items-center gap-2 max-w-xl">
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--absent" style="--tag-color:#0ea5e9">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")</span>
+					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
+</span>
 					<span class="truncate">absent</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--present" style="--tag-color:#10b981">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("check", "")</span>
+					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("check", "")
+</span>
 					<span class="truncate">present</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--mixed" style="--tag-color:#f59e0b">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("minus", "")</span>
+					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("minus", "")
+</span>
 					<span class="truncate">mixed</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-add" style="--tag-color:#6366f1">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")</span>
+					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
+</span>
 					<span class="truncate">pending-add</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-remove" style="--tag-color:#ef4444">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("x", "")</span>
+					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("x", "")
+</span>
 					<span class="truncate">pending-remove</span>
 				</span>
 			</div>
@@ -714,23 +710,28 @@ templ SectionTagPicker() {
 				<div class="bb-tagpicker-body">
 					<div class="bb-tagpicker-grid">
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--present" style="--tag-color:#10b981">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("check", "")</span>
+							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("check", "")
+</span>
 							<span class="truncate">recurring</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--mixed" style="--tag-color:#f59e0b">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("minus", "")</span>
+							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("minus", "")
+</span>
 							<span class="truncate">needs-review</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-add" style="--tag-color:#6366f1">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")</span>
+							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
+</span>
 							<span class="truncate">subscription</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--absent" style="--tag-color:#0ea5e9">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")</span>
+							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
+</span>
 							<span class="truncate">business</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-remove" style="--tag-color:#ef4444">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("x", "")</span>
+							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("x", "")
+</span>
 							<span class="truncate">refund</span>
 						</button>
 					</div>
@@ -818,7 +819,6 @@ templ SectionTagPicker() {
 }
 
 // ─── Menus & dropdowns ─────────────────────────────────────────────────
-
 templ SectionMenusDropdowns() {
 	<div class="flex flex-col gap-6">
 		@designExample("Overflow action menu", "When a card has ≥2 secondary actions, prefer one ellipsis dropdown over a cluster of icon buttons. Use the shared components.OverflowMenu — same shape, native popover that escapes overflow-clipped ancestors.") {
@@ -842,16 +842,18 @@ templ SectionMenusDropdowns() {
 		@designExample("Menu (vertical nav list)", "menu-md / menu-sm.") {
 			<ul class="menu bg-base-100 rounded-xl border border-base-300 w-56">
 				<li class="menu-title">Settings</li>
-				<li><a class="menu-active">@components.LucideIcon("key", "w-4 h-4") API keys</a></li>
-				<li><a>@components.LucideIcon("users", "w-4 h-4") Household</a></li>
-				<li><a>@components.LucideIcon("bot", "w-4 h-4") MCP</a></li>
+				<li><a class="menu-active">@components.LucideIcon("key", "w-4 h-4")
+API keys</a></li>
+				<li><a>@components.LucideIcon("users", "w-4 h-4")
+Household</a></li>
+				<li><a>@components.LucideIcon("bot", "w-4 h-4")
+MCP</a></li>
 			</ul>
 		}
 	</div>
 }
 
 // ─── Modals ────────────────────────────────────────────────────────────
-
 templ SectionModals() {
 	<div class="flex flex-col gap-6">
 		@designExample("Standard modal trigger", "modal-bottom on mobile, modal-middle on sm+. rounded-xl modal-box.") {
@@ -956,7 +958,6 @@ templ designDrawerSizeBody(label, width string) {
 }
 
 // ─── Loading & skeletons ───────────────────────────────────────────────
-
 templ SectionLoading() {
 	<div class="flex flex-col gap-6">
 		@designExample("Spinners", "DaisyUI loading variants in xs/sm/md.") {
@@ -1035,7 +1036,6 @@ templ SectionLoading() {
 }
 
 // ─── Icons & tiles ─────────────────────────────────────────────────────
-
 templ SectionIcons() {
 	<div class="flex flex-col gap-6">
 		@designExample("Lucide sizes", "Buttons → w-4 h-4 (sm) / w-3.5 h-3.5 (xs). Section headers → w-5 h-5. Empty states → w-8 h-8.") {
@@ -1070,7 +1070,6 @@ templ SectionIcons() {
 }
 
 // ─── Page header ───────────────────────────────────────────────────────
-
 templ SectionPageHeader() {
 	<div class="flex flex-col gap-6">
 		@designExample("Title only", "Just the page title. Use for pages whose section is named by its breadcrumb.") {
@@ -1117,7 +1116,6 @@ templ SectionPageHeader() {
 }
 
 // ─── Entity header ─────────────────────────────────────────────────────
-
 templ SectionEntityHeader() {
 	<div class="flex flex-col gap-6">
 		@designExample("Default — neutral tile", "Icon tile + title + bullet-separated meta.") {
@@ -1139,12 +1137,12 @@ templ SectionEntityHeader() {
 		@designExample("Error tone + actions", "Trailing slot supports one secondary + one primary action.") {
 			@components.EntityHeader(components.EntityHeaderProps{
 				Title:           "Bank of America",
-				Icon:             "building-2",
-				IconTone:         components.IconToneError,
-				Badges:           designEntityHeaderBadgesError(),
-				Meta:             components.EntityHeaderMeta("plaid", "Jane", "Last sync failed 1h ago"),
-				SecondaryAction:  components.PageHeaderSecondaryAction("#", "refresh-cw", "Sync"),
-				Action:           components.PageHeaderAction("#", "key-round", "Re-authenticate"),
+				Icon:            "building-2",
+				IconTone:        components.IconToneError,
+				Badges:          designEntityHeaderBadgesError(),
+				Meta:            components.EntityHeaderMeta("plaid", "Jane", "Last sync failed 1h ago"),
+				SecondaryAction: components.PageHeaderSecondaryAction("#", "refresh-cw", "Sync"),
+				Action:          components.PageHeaderAction("#", "key-round", "Re-authenticate"),
 			})
 		}
 		@designExample("Long title — truncates", "Pass TitleClass=\"truncate\" or \"break-words\" for long provider strings.") {
@@ -1169,7 +1167,6 @@ templ designEntityHeaderBadgesError() {
 }
 
 // ─── Empty states ──────────────────────────────────────────────────────
-
 templ SectionEmptyStates() {
 	<div class="flex flex-col gap-6">
 		@designExample("Standard (no data yet)", "Card-wrapped, icon + title + description + CTA.") {
@@ -1227,7 +1224,6 @@ templ SectionEmptyStates() {
 }
 
 // ─── Stat tiles ────────────────────────────────────────────────────────
-
 templ SectionStatTiles() {
 	<div class="flex flex-col gap-6">
 		@designExample("4-up tile row (canonical dashboard pattern)", "StatTileRow lays out the 2-up / 4-up grid. Tones drive the icon-tile color.") {
@@ -1271,7 +1267,6 @@ templ SectionStatTiles() {
 }
 
 // ─── Tabs ──────────────────────────────────────────────────────────────
-
 templ SectionTabs() {
 	<div class="flex flex-col gap-6">
 		@designExample("Navigation tabs (tabs-border)", "Top-of-page tab navigation. Use Variant=\"border\" or omit (default).") {
@@ -1310,7 +1305,6 @@ templ SectionTabs() {
 }
 
 // ─── Overflow menu ─────────────────────────────────────────────────────
-
 templ SectionOverflowMenu() {
 	<div class="flex flex-col gap-6">
 		@designExample("Standard kebab", "Mix link items (Href) and button items (OnClick). Mark destructive items with Destructive: true.") {
@@ -1387,7 +1381,6 @@ templ SectionOverflowMenu() {
 }
 
 // ─── Topbar breadcrumb ─────────────────────────────────────────────────
-
 templ SectionTopbarBreadcrumb() {
 	<div class="flex flex-col gap-6">
 		@designExample("Section + navigable trail", "The common detail-page shape. The section group (muted) is non-link; ancestor crumbs link; the last crumb is the bold current page.") {
@@ -1439,7 +1432,6 @@ templ SectionTopbarBreadcrumb() {
 }
 
 // ─── Sidebar user menu ─────────────────────────────────────────────────
-
 templ SectionSidebarUserMenu() {
 	<div class="flex flex-col gap-6">
 		@designExample("Linked household member (editor)", "Avatar comes from the linked household user. Editor role unlocks the `/design` shortcut. Click the trigger to open the popover — Settings, the external links, and the destructive Sign out (below an `<hr>`) live inside.") {
@@ -1488,7 +1480,6 @@ templ SectionSidebarUserMenu() {
 }
 
 // ─── Section header ────────────────────────────────────────────────────
-
 templ SectionSectionHeader() {
 	<div class="flex flex-col gap-6">
 		@designExample("Bare (icon + title)", "For section dividers inside a card.") {
@@ -1580,7 +1571,6 @@ func kbdGlyphRefs() []kbdGlyphRef {
 }
 
 // ─── Keyboard shortcut badges ──────────────────────────────────────────
-
 templ SectionRadioCard() {
 	<div class="flex flex-col gap-6">
 		@designExample("Trigger selector (2-up)", "The Workflows drawer's \"When should the workflow run?\" choice. Native radios share a name, so selection + the lit state work with no JS — click a card, tab between them, and watch the border / fill / icon flip to primary and the check appear.") {
@@ -1861,7 +1851,6 @@ templ SectionKbd() {
 }
 
 // ─── Toast ─────────────────────────────────────────────────────────────
-
 templ SectionToast() {
 	<div class="flex flex-col gap-6">
 		@designExample("Trigger via bb-toast event", "Every admin page mounts one global Toast container (see internal/templates/components/toast.templ — also inlined in base.html). Dispatch the event from anywhere; no per-page wiring.") {
@@ -1925,7 +1914,6 @@ templ SectionToast() {
 }
 
 // ─── Multi-select toolbar ──────────────────────────────────────────────
-
 templ SectionMultiSelectToolbar() {
 	<div x-data="{ open: false, count: 3 }" class="flex flex-col gap-6">
 		@designExample("Live demo", "Toggle the floating toolbar. Narrow the viewport to see the mobile collapse: ghost actions go icon-only, the primary action stays expanded, and the count chip is hidden when CountHideOnMobile is true. Real-world wiring listens for `multi-select-close` and `multi-select-toggle-all` events to clear / select-all.") {
@@ -2112,7 +2100,16 @@ templ SectionCategoryPicker() {
 	@components.CategoryPickerStyles()
 	@templ.JSONScript("design-cat-picker-cats", designTxRowsCategories())
 	<script>
-		(function(){var e=document.getElementById('design-cat-picker-cats');if(e){try{window.__bbCategories=JSON.parse(e.textContent);}catch(_){window.__bbCategories=[];}}})();
+		(function () {
+			var e = document.getElementById("design-cat-picker-cats");
+			if (e) {
+				try {
+					window.__bbCategories = JSON.parse(e.textContent);
+				} catch (_) {
+					window.__bbCategories = [];
+				}
+			}
+		})();
 	</script>
 	<div class="flex flex-col gap-6">
 		@designExample("Inline (transaction row)", "btn btn-ghost btn-xs gap-1.5 — the per-row quick-set picker shown xl+ on /transactions and /accounts/{id}. assign mode, allow-empty 'Uncategorized'. Used by tx_row.templ.") {
@@ -2220,7 +2217,6 @@ templ SectionCategoryPicker() {
 }
 
 // ─── Amounts ───────────────────────────────────────────────────────────
-
 templ SectionAmounts() {
 	<div class="flex flex-col gap-6">
 		@designExample("Transaction intent (default)", "Income (negative in our convention) renders as '+$X' in success green. Expense renders as '$X' with NO sign in the default text color. Use for transaction rows, day totals, transaction detail, activity feed.") {
@@ -2331,7 +2327,16 @@ templ SectionTransactionRows() {
 	@components.CategoryPickerStyles()
 	@templ.JSONScript("design-tx-rows-cats", designTxRowsCategories())
 	<script>
-		(function(){var e=document.getElementById('design-tx-rows-cats');if(e){try{window.__bbCategories=JSON.parse(e.textContent);}catch(_){window.__bbCategories=[];}}})();
+		(function () {
+			var e = document.getElementById("design-tx-rows-cats");
+			if (e) {
+				try {
+					window.__bbCategories = JSON.parse(e.textContent);
+				} catch (_) {
+					window.__bbCategories = [];
+				}
+			}
+		})();
 	</script>
 	<div class="flex flex-col gap-6">
 		<!-- Variant policy: when to use which row component. The three layouts
@@ -2536,7 +2541,6 @@ templ amountAntiPatternRow(legacy string, p components.AmountProps) {
 // examples below mirror the shapes those callers compose, so a reviewer
 // can pin one variant on /design/c/timeline and compare side-by-side with
 // the live pages without booting both.
-
 templ SectionTimeline() {
 	<div class="flex flex-col gap-6">
 		@designExample("Prominent variant", "Variant: \"prominent\" — used on /feed and /transactions/{id}. Larger heading, top divider, scaled-up tiles via .bb-timeline-prominent in input.css.") {
@@ -2585,7 +2589,7 @@ templ SectionTimeline() {
 					Now:       designTimelineNow(),
 				}) {
 					<span class="font-medium text-base-content">12 new transactions</span>
-					<span class="text-base-content/55"> from Chase</span>
+					<span class="text-base-content/55">from Chase</span>
 				}
 			}
 		}
@@ -2824,7 +2828,8 @@ templ SectionCommandPalette() {
 						<div class="bb-cmdk-group-label">Overview</div>
 						<div class="bb-cmdk-item">
 							<div class="bb-cmdk-generic">
-								<div class="bb-cmdk-item-icon">@components.LucideIcon("rss", "")</div>
+								<div class="bb-cmdk-item-icon">@components.LucideIcon("rss", "")
+</div>
 								<div class="bb-cmdk-item-label">
 									<div class="bb-cmdk-item-title">Feed</div>
 									<div class="bb-cmdk-item-desc">Activity feed across the household</div>
@@ -2836,7 +2841,8 @@ templ SectionCommandPalette() {
 						</div>
 						<div class="bb-cmdk-item" data-active="true">
 							<div class="bb-cmdk-generic">
-								<div class="bb-cmdk-item-icon">@components.LucideIcon("receipt", "")</div>
+								<div class="bb-cmdk-item-icon">@components.LucideIcon("receipt", "")
+</div>
 								<div class="bb-cmdk-item-label">
 									<div class="bb-cmdk-item-title">Transactions</div>
 									<div class="bb-cmdk-item-desc">View all transactions</div>
@@ -2880,7 +2886,8 @@ templ SectionCommandPalette() {
 			<div class="border border-base-300 rounded-xl bg-base-100 max-w-[560px] mx-auto py-2">
 				<div class="bb-cmdk-item">
 					<div class="bb-cmdk-generic">
-						<div class="bb-cmdk-item-icon">@components.LucideIcon("rss", "")</div>
+						<div class="bb-cmdk-item-icon">@components.LucideIcon("rss", "")
+</div>
 						<div class="bb-cmdk-item-label">
 							<div class="bb-cmdk-item-title">Feed</div>
 							<div class="bb-cmdk-item-desc">Default — neutral icon tile</div>
@@ -2892,7 +2899,8 @@ templ SectionCommandPalette() {
 				</div>
 				<div class="bb-cmdk-item" data-active="true">
 					<div class="bb-cmdk-generic">
-						<div class="bb-cmdk-item-icon">@components.LucideIcon("receipt", "")</div>
+						<div class="bb-cmdk-item-icon">@components.LucideIcon("receipt", "")
+</div>
 						<div class="bb-cmdk-item-label">
 							<div class="bb-cmdk-item-title">Transactions</div>
 							<div class="bb-cmdk-item-desc">Active — primary tint on tile + bg-primary/8 on row</div>
@@ -2904,7 +2912,8 @@ templ SectionCommandPalette() {
 				</div>
 				<div class="bb-cmdk-item">
 					<div class="bb-cmdk-generic">
-						<div class="bb-cmdk-item-icon">@components.LucideIcon("plus-circle", "")</div>
+						<div class="bb-cmdk-item-icon">@components.LucideIcon("plus-circle", "")
+</div>
 						<div class="bb-cmdk-item-label">
 							<div class="bb-cmdk-item-title">Connect a Bank</div>
 						</div>
@@ -2963,7 +2972,6 @@ templ SectionCommandPalette() {
 }
 
 // ─── User avatar ───────────────────────────────────────────────────────
-
 templ SectionUserAvatar() {
 	<div class="flex flex-col gap-6">
 		@designExample("Size scale", "Seven sizes cover every surface that renders a person/agent identity. Pick the one that matches the call site, not the largest that fits. The component threads the pixel size through to /avatars/{id}?size=N so the backend fetches a pre-sized SVG.") {
@@ -3241,7 +3249,6 @@ func designSampleColor() *string {
 // ─── Settings primitives ───────────────────────────────────────────────
 // Live reference for SettingsSection / SettingsRow / SettingsAutoSaveForm.
 // See .claude/rules/settings.md for the design language.
-
 templ SectionSettings() {
 	<div class="flex flex-col gap-6">
 		@designExample("Section + rows (inline controls)", "The default shape — label/caption left, control right. Used by General > Sync and Backups > Schedule.") {
@@ -3316,8 +3323,8 @@ templ SectionSettings() {
 		@designExample("Stacked row (Stack: true)", "Use when the control is too wide for inline — textareas, file inputs, code blocks, credential editors.") {
 			<div>
 				@components.SettingsSection(components.SettingsSectionProps{
-					Icon:    "plug",
-					Title:   "Connection",
+					Icon:  "plug",
+					Title: "Connection",
 				}) {
 					@components.SettingsRow(components.SettingsRowProps{
 						Label: "HTTP endpoint",
@@ -3381,8 +3388,8 @@ templ SectionSettings() {
 		@designExample("Link-style row (SettingsRowLink)", "The whole row is a link/button. Use for action lists — Help > Resources, Backups > Restore From Upload. Icon on the LEFT because the row IS the affordance.") {
 			<div>
 				@components.SettingsSection(components.SettingsSectionProps{
-					Icon:    "life-buoy",
-					Title:   "Resources",
+					Icon:  "life-buoy",
+					Title: "Resources",
 				}) {
 					@components.SettingsRowLink(components.SettingsRowLinkProps{
 						Href:    "/design",

--- a/internal/templates/components/pages/errors.templ
+++ b/internal/templates/components/pages/errors.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components/layout"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/layout"
 )
 
 // NotFound renders the 404 page body hosted inside the base layout via

--- a/internal/templates/components/pages/login.templ
+++ b/internal/templates/components/pages/login.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components/layout"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/layout"
 )
 
 // Login renders the full login page (wizard layout + form body).

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -134,7 +134,7 @@ templ logsSyncStats(p LogsProps) {
 			<div class="bb-card p-4">
 				<div class="flex items-center gap-3">
 					<div class={ "w-9 h-9 rounded-lg flex items-center justify-center shrink-0", errorBg(p.Stats.ErrorCount > 0) }>
-						@components.LucideIcon("alert-circle", "w-4 h-4 " + errorIconClass(p.Stats.ErrorCount > 0))
+						@components.LucideIcon("alert-circle", "w-4 h-4 "+errorIconClass(p.Stats.ErrorCount > 0))
 					</div>
 					<div>
 						<div class={ "text-2xl font-semibold tabular-nums leading-none", errorTextClass(p.Stats.ErrorCount > 0) }>
@@ -352,7 +352,8 @@ templ logsSyncRow(l LogsSyncRow) {
 				}
 				if l.WarningMessage != nil && *l.WarningMessage != "" {
 					<span class="badge badge-soft badge-warning badge-sm gap-1">
-						@components.LucideIcon("alert-triangle", "w-3 h-3") warning
+						@components.LucideIcon("alert-triangle", "w-3 h-3")
+						warning
 					</span>
 				}
 			</div>
@@ -429,7 +430,7 @@ templ logsWebhookStats(p LogsProps) {
 			<div class="bb-card p-4">
 				<div class="flex items-center gap-3">
 					<div class={ "w-9 h-9 rounded-lg flex items-center justify-center shrink-0", errorBg(p.WHStats.ErrorCount > 0) }>
-						@components.LucideIcon("alert-circle", "w-4 h-4 " + errorIconClass(p.WHStats.ErrorCount > 0))
+						@components.LucideIcon("alert-circle", "w-4 h-4 "+errorIconClass(p.WHStats.ErrorCount > 0))
 					</div>
 					<div>
 						<div class={ "text-2xl font-semibold tabular-nums leading-none", errorTextClass(p.WHStats.ErrorCount > 0) }>

--- a/internal/templates/components/pages/mcp_guide.templ
+++ b/internal/templates/components/pages/mcp_guide.templ
@@ -1,7 +1,7 @@
 package pages
 
-
 import "breadbox/internal/templates/components"
+
 // MCPGuide renders the Getting Started tab inside /agents. Originally
 // pages/mcp_guide.html in the html/template tree. The Alpine factory
 // lives in static/js/admin/components/mcp_guide.js and reads the MCP
@@ -103,10 +103,12 @@ templ MCPGuide(p MCPGuideProps) {
 					</div>
 					<div x-show="showFlavorToggle" x-cloak class="join rounded-lg border border-base-300">
 						<button class="join-item btn btn-xs gap-1.5 border-0" :class="flavor === 'guide' ? 'btn-active' : 'btn-ghost'" @click="flavor = 'guide'">
-							@components.LucideIcon("book-open", "w-3.5 h-3.5") Guide
+							@components.LucideIcon("book-open", "w-3.5 h-3.5")
+							Guide
 						</button>
 						<button class="join-item btn btn-xs gap-1.5 border-0" :class="flavor === 'config' ? 'btn-active' : 'btn-ghost'" @click="flavor = 'config'">
-							@components.LucideIcon("code", "w-3.5 h-3.5") Config
+							@components.LucideIcon("code", "w-3.5 h-3.5")
+							Config
 						</button>
 					</div>
 				</div>

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -296,9 +296,11 @@ templ notificationChannelDrawerStatus(c NotificationChannelView) {
 	<div class="space-y-1.5 border-t border-base-200 pt-4">
 		if c.HasStatus {
 			if c.StatusOK {
-				<p class="text-xs text-success/80 inline-flex items-center gap-1.5">@components.LucideIcon("circle-check", "w-3.5 h-3.5") Last delivery: { c.StatusText }</p>
+				<p class="text-xs text-success/80 inline-flex items-center gap-1.5">@components.LucideIcon("circle-check", "w-3.5 h-3.5")
+Last delivery: { c.StatusText }</p>
 			} else {
-				<p class="text-xs text-error/80 inline-flex items-center gap-1.5">@components.LucideIcon("circle-x", "w-3.5 h-3.5") Last delivery: { c.StatusText }</p>
+				<p class="text-xs text-error/80 inline-flex items-center gap-1.5">@components.LucideIcon("circle-x", "w-3.5 h-3.5")
+Last delivery: { c.StatusText }</p>
 			}
 		} else {
 			<p class="text-xs text-base-content/50">No delivery yet — use Test to send a sample.</p>

--- a/internal/templates/components/pages/oauth_authorize.templ
+++ b/internal/templates/components/pages/oauth_authorize.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components/layout"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/layout"
 )
 
 // OAuthAuthorizeProps carries the data the OAuth consent page needs.

--- a/internal/templates/components/pages/prompt_builder.templ
+++ b/internal/templates/components/pages/prompt_builder.templ
@@ -1,7 +1,7 @@
 package pages
 
-
 import "breadbox/internal/templates/components"
+
 // PromptBuilder renders the /agent-prompts/builder/{type} prompt builder page. Hosts
 // inside the base layout via TemplateRenderer.RenderWithTempl — the handler
 // passes the typed props and the bridge drops the rendered HTML into
@@ -355,22 +355,87 @@ templ PromptBuilder(p PromptBuilderProps) {
 							</template>
 						</div>
 						<style>
-							.bb-markdown { font-size: 0.875rem; line-height: 1.7; color: var(--color-base-content); }
-							.bb-markdown h1 { font-size: 1.5rem; font-weight: 700; margin: 1.5rem 0 0.75rem; border-bottom: 1px solid oklch(var(--bc) / 0.1); padding-bottom: 0.5rem; }
-							.bb-markdown h2 { font-size: 1.15rem; font-weight: 700; margin: 1.5rem 0 0.5rem; color: oklch(var(--bc) / 0.8); }
-							.bb-markdown h3 { font-size: 1rem; font-weight: 600; margin: 1.25rem 0 0.5rem; }
-							.bb-markdown p { margin: 0.5rem 0; }
-							.bb-markdown ul { list-style-type: disc; padding-left: 1.5rem; margin: 0.5rem 0; }
-							.bb-markdown ol { list-style-type: decimal; padding-left: 1.5rem; margin: 0.5rem 0; }
-							.bb-markdown li { margin: 0.25rem 0; }
-							.bb-markdown li > p { margin: 0; display: inline; }
-							.bb-markdown code { font-size: 0.8em; background: oklch(var(--bc) / 0.06); padding: 0.15rem 0.35rem; border-radius: 0.25rem; font-family: ui-monospace, monospace; }
-							.bb-markdown pre { background: oklch(var(--bc) / 0.04); border: 1px solid oklch(var(--bc) / 0.08); border-radius: 0.5rem; padding: 0.75rem 1rem; overflow-x: auto; margin: 0.75rem 0; }
-							.bb-markdown pre code { background: none; padding: 0; font-size: 0.8rem; }
-							.bb-markdown strong { font-weight: 600; }
-							.bb-markdown hr { border: none; border-top: 1px solid oklch(var(--bc) / 0.1); margin: 1.5rem 0; }
-							.bb-markdown blockquote { border-left: 3px solid oklch(var(--p)); padding-left: 1rem; margin: 0.75rem 0; color: oklch(var(--bc) / 0.6); }
-							.bb-markdown ul ul, .bb-markdown ol ul { margin: 0.15rem 0; }
+							.bb-markdown {
+								font-size: 0.875rem;
+								line-height: 1.7;
+								color: var(--color-base-content);
+							}
+							.bb-markdown h1 {
+								font-size: 1.5rem;
+								font-weight: 700;
+								margin: 1.5rem 0 0.75rem;
+								border-bottom: 1px solid oklch(var(--bc) / 0.1);
+								padding-bottom: 0.5rem;
+							}
+							.bb-markdown h2 {
+								font-size: 1.15rem;
+								font-weight: 700;
+								margin: 1.5rem 0 0.5rem;
+								color: oklch(var(--bc) / 0.8);
+							}
+							.bb-markdown h3 {
+								font-size: 1rem;
+								font-weight: 600;
+								margin: 1.25rem 0 0.5rem;
+							}
+							.bb-markdown p {
+								margin: 0.5rem 0;
+							}
+							.bb-markdown ul {
+								list-style-type: disc;
+								padding-left: 1.5rem;
+								margin: 0.5rem 0;
+							}
+							.bb-markdown ol {
+								list-style-type: decimal;
+								padding-left: 1.5rem;
+								margin: 0.5rem 0;
+							}
+							.bb-markdown li {
+								margin: 0.25rem 0;
+							}
+							.bb-markdown li > p {
+								margin: 0;
+								display: inline;
+							}
+							.bb-markdown code {
+								font-size: 0.8em;
+								background: oklch(var(--bc) / 0.06);
+								padding: 0.15rem 0.35rem;
+								border-radius: 0.25rem;
+								font-family: ui-monospace, monospace;
+							}
+							.bb-markdown pre {
+								background: oklch(var(--bc) / 0.04);
+								border: 1px solid oklch(var(--bc) / 0.08);
+								border-radius: 0.5rem;
+								padding: 0.75rem 1rem;
+								overflow-x: auto;
+								margin: 0.75rem 0;
+							}
+							.bb-markdown pre code {
+								background: none;
+								padding: 0;
+								font-size: 0.8rem;
+							}
+							.bb-markdown strong {
+								font-weight: 600;
+							}
+							.bb-markdown hr {
+								border: none;
+								border-top: 1px solid oklch(var(--bc) / 0.1);
+								margin: 1.5rem 0;
+							}
+							.bb-markdown blockquote {
+								border-left: 3px solid oklch(var(--p));
+								padding-left: 1rem;
+								margin: 0.75rem 0;
+								color: oklch(var(--bc) / 0.6);
+							}
+							.bb-markdown ul ul,
+							.bb-markdown ol ul {
+								margin: 0.15rem 0;
+							}
 						</style>
 					</div>
 				</div>

--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -586,8 +586,10 @@ templ providerEnvNotice() {
 templ providerTestFooterButton() {
 	<div class="flex items-center gap-3 mr-auto min-w-0">
 		<button type="button" class="btn btn-sm btn-ghost gap-1.5" @click="testConnection()" :disabled="testing">
-			<span x-show="!testing" class="flex items-center gap-1.5">@components.LucideIcon("plug", "w-3.5 h-3.5")
-Test connection</span>
+			<span x-show="!testing" class="flex items-center gap-1.5">
+				@components.LucideIcon("plug", "w-3.5 h-3.5")
+				Test connection
+			</span>
 			<span x-show="testing" x-cloak class="flex items-center gap-2"><span class="loading loading-spinner loading-xs"></span> Testing…</span>
 		</button>
 		<span x-show="testResult" x-cloak class="text-xs truncate" :class="testSuccess ? 'text-success' : 'text-error'" x-text="testResult" x-transition></span>

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -106,7 +106,8 @@ templ ruleDetailMeta(p RuleDetailProps) {
 
 templ ruleDetailEditBtn(p RuleDetailProps) {
 	<a href={ templ.SafeURL(fmt.Sprintf("/rules/%s/edit", p.Rule.ID)) } class="btn btn-sm btn-outline">
-		@components.LucideIcon("pencil", "w-3.5 h-3.5") Edit
+		@components.LucideIcon("pencil", "w-3.5 h-3.5")
+		Edit
 	</a>
 }
 

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -142,7 +142,8 @@ templ RuleForm(p RuleFormProps) {
 								<button type="button" class="px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors" :class="form.logic === 'or' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/40 hover:text-base-content/60'" @click="form.logic = 'or'; syncToJson()">OR</button>
 							</div>
 							<button type="button" class="btn btn-ghost btn-xs gap-1.5" @click="addCondition()">
-								@components.LucideIcon("plus", "w-3.5 h-3.5") Add
+								@components.LucideIcon("plus", "w-3.5 h-3.5")
+								Add
 							</button>
 						</div>
 					</div>
@@ -156,7 +157,8 @@ templ RuleForm(p RuleFormProps) {
 							<p class="text-xs text-base-content/50">This rule will apply to every transaction. Use sparingly.</p>
 						</div>
 						<button type="button" class="btn btn-xs btn-outline" @click="addCondition()">
-							@components.LucideIcon("plus", "w-3 h-3") Add condition
+							@components.LucideIcon("plus", "w-3 h-3")
+							Add condition
 						</button>
 					</div>
 					<!-- Condition rows. Mobile: stacks as IF + Field on row 1, then
@@ -269,7 +271,8 @@ templ RuleForm(p RuleFormProps) {
 							<p class="text-xs text-base-content/40 mt-1">Add one or more. Only "Set category" is limited to a single action per rule.</p>
 						</div>
 						<button type="button" class="btn btn-ghost btn-xs gap-1.5 shrink-0" @click="addAction()" :disabled="!canAddAction()" :title="addActionTooltip()">
-							@components.LucideIcon("plus", "w-3.5 h-3.5") Add action
+							@components.LucideIcon("plus", "w-3.5 h-3.5")
+							Add action
 						</button>
 					</div>
 					<!-- Action row: stacks on mobile (Action select + remove button on row 1,

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -51,7 +51,7 @@ templ Rules(p RulesProps) {
 				}
 				{ fmt.Sprintf("%d rule%s", p.Total, components.PluralS(p.Total)) }
 				if p.FiltersActive {
-					<span class="text-base-content/30"> match your filters</span>
+					<span class="text-base-content/30">match your filters</span>
 				}
 			</div>
 			if len(p.Rules) > 0 {

--- a/internal/templates/components/pages/session_detail.templ
+++ b/internal/templates/components/pages/session_detail.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"strconv"
 	"breadbox/internal/templates/components"
+	"strconv"
 )
 
 // SessionDetail renders the per-MCP-session detail page body. Hosts

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -90,7 +90,6 @@ templ SettingsHelp(p SettingsProps) {
 // ---------------------------------------------------------------------
 // General — Sync
 // ---------------------------------------------------------------------
-
 templ settingsSyncSection(p SettingsProps) {
 	<div id="sync">
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -159,7 +158,6 @@ func settingsNextSyncCaption(p SettingsProps) string {
 // ---------------------------------------------------------------------
 // General — Avatars
 // ---------------------------------------------------------------------
-
 templ settingsAvatarsSection(p SettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "user-circle",
@@ -220,7 +218,6 @@ templ settingsAvatarPickerRow(p SettingsProps, actor, label, current string, see
 // ---------------------------------------------------------------------
 // System — Security
 // ---------------------------------------------------------------------
-
 templ settingsSecuritySection(p SettingsProps) {
 	<div id="security">
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -268,7 +265,6 @@ func settingsEncryptionCaption(p SettingsProps) string {
 // ---------------------------------------------------------------------
 // System — Runtime
 // ---------------------------------------------------------------------
-
 templ settingsRuntimeSection(p SettingsProps) {
 	<div id="system">
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -323,7 +319,6 @@ templ settingsRuntimeUpdateBadge(p SettingsProps) {
 // ---------------------------------------------------------------------
 // Help
 // ---------------------------------------------------------------------
-
 templ settingsResourcesSection(p SettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "life-buoy",
@@ -384,7 +379,6 @@ templ settingsDeveloperSection() {
 // ---------------------------------------------------------------------
 // Helpers reused by handlers + by other settings tabs
 // ---------------------------------------------------------------------
-
 templ syncIntervalOption(value, current int, label string) {
 	if value == current {
 		<option value={ strconv.Itoa(value) } selected>{ label }</option>

--- a/internal/templates/components/pages/setup_account.templ
+++ b/internal/templates/components/pages/setup_account.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components/layout"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/layout"
 )
 
 // SetupAccountProps carries what the token-based account setup page needs.

--- a/internal/templates/components/pages/setup_create_admin.templ
+++ b/internal/templates/components/pages/setup_create_admin.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components/layout"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/layout"
 )
 
 // CreateAdminProps carries the data the first-run admin setup page needs.

--- a/internal/templates/components/pages/setup_save_key.templ
+++ b/internal/templates/components/pages/setup_save_key.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"breadbox/internal/templates/components/layout"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/templates/components/layout"
 )
 
 // SaveKey renders the /setup/save-key page — a one-time reveal of the

--- a/internal/templates/components/pages/sync_log_detail.templ
+++ b/internal/templates/components/pages/sync_log_detail.templ
@@ -136,22 +136,30 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 						<div class="flex items-center gap-3 text-xs tabular-nums shrink-0">
 							if a.AddedCount != 0 {
 								<span class="text-success font-medium flex items-center gap-1">
-									@components.LucideIcon("plus", "w-3 h-3"){ strconv.FormatInt(int64(a.AddedCount), 10) }
+									@components.LucideIcon("plus", "w-3 h-3") {
+										strconv.FormatInt(int64(a.AddedCount), 10) 
+									}
 								</span>
 							}
 							if a.ModifiedCount != 0 {
 								<span class="text-info font-medium flex items-center gap-1">
-									@components.LucideIcon("pencil", "w-3 h-3"){ strconv.FormatInt(int64(a.ModifiedCount), 10) }
+									@components.LucideIcon("pencil", "w-3 h-3") {
+										strconv.FormatInt(int64(a.ModifiedCount), 10) 
+									}
 								</span>
 							}
 							if a.RemovedCount != 0 {
 								<span class="text-error font-medium flex items-center gap-1">
-									@components.LucideIcon("minus", "w-3 h-3"){ strconv.FormatInt(int64(a.RemovedCount), 10) }
+									@components.LucideIcon("minus", "w-3 h-3") {
+										strconv.FormatInt(int64(a.RemovedCount), 10) 
+									}
 								</span>
 							}
 							if a.UnchangedCount != 0 {
 								<span class="text-base-content/30 font-medium flex items-center gap-1" title="Unchanged">
-									@components.LucideIcon("equal", "w-3 h-3"){ strconv.FormatInt(int64(a.UnchangedCount), 10) }
+									@components.LucideIcon("equal", "w-3 h-3") {
+										strconv.FormatInt(int64(a.UnchangedCount), 10) 
+									}
 								</span>
 							}
 						</div>

--- a/internal/templates/components/pages/user_form.templ
+++ b/internal/templates/components/pages/user_form.templ
@@ -155,7 +155,8 @@ templ userFormCreate() {
 					</template>
 					<div class="flex gap-3 pt-2">
 						<button type="submit" class="btn btn-primary btn-sm whitespace-nowrap" :disabled="submitting">
-							<span x-show="!submitting" class="inline-flex items-center gap-1.5">@components.LucideIcon("plus", "w-4 h-4") Create Member</span>
+							<span x-show="!submitting" class="inline-flex items-center gap-1.5">@components.LucideIcon("plus", "w-4 h-4")
+Create Member</span>
 							<span x-show="submitting" class="loading loading-spinner loading-sm"></span>
 						</button>
 						<a href="/household" class="btn btn-ghost btn-sm">Cancel</a>
@@ -191,9 +192,11 @@ templ userFormEdit(p UserFormProps) {
 					<div class="bb-icon-header__text">
 						<h2 class="text-sm font-semibold truncate">{ userFormName(p.User) }</h2>
 						<p class="text-xs text-base-content/45">
-							<button type="button" @click="$refs.fileInput.click()" class="link link-hover inline-flex items-center gap-1">@components.LucideIcon("upload", "w-3 h-3") Upload photo</button>
+							<button type="button" @click="$refs.fileInput.click()" class="link link-hover inline-flex items-center gap-1">@components.LucideIcon("upload", "w-3 h-3")
+Upload photo</button>
 							<span class="text-base-content/20">·</span>
-							<button type="button" @click="regenerate()" class="link link-hover inline-flex items-center gap-1">@components.LucideIcon("refresh-cw", "w-3 h-3") Regenerate</button>
+							<button type="button" @click="regenerate()" class="link link-hover inline-flex items-center gap-1">@components.LucideIcon("refresh-cw", "w-3 h-3")
+Regenerate</button>
 							<template x-if="hasCustomAvatar">
 								<span>
 									<span class="text-base-content/20">·</span>
@@ -257,7 +260,8 @@ templ userFormEdit(p UserFormProps) {
 			<div class="bb-action-row">
 				<a href="/household" class="btn btn-sm btn-ghost">Cancel</a>
 				<button type="submit" class="btn btn-sm btn-primary gap-1.5 min-w-32" :disabled="submitting">
-					<span x-show="!submitting" class="inline-flex items-center gap-1.5">@components.LucideIcon("save", "w-3.5 h-3.5") Save Changes</span>
+					<span x-show="!submitting" class="inline-flex items-center gap-1.5">@components.LucideIcon("save", "w-3.5 h-3.5")
+Save Changes</span>
 					<span x-show="submitting" class="loading loading-spinner loading-xs"></span>
 				</button>
 			</div>

--- a/internal/templates/components/settings_section.templ
+++ b/internal/templates/components/settings_section.templ
@@ -14,7 +14,7 @@ package components
 // Variant tints the section for special-case visuals:
 //   - "" (default) — neutral, base-300 border
 //   - "danger"     — error-tinted border + error-tinted icon (use for
-//                    destructive sections like "Danger zone")
+//     destructive sections like "Danger zone")
 type SettingsSectionProps struct {
 	Icon string
 	// BrandIcon, when set, replaces Icon with a vendored brand SVG

--- a/internal/templates/components/setup_step.templ
+++ b/internal/templates/components/setup_step.templ
@@ -53,10 +53,10 @@ const (
 
 type SetupStepProps struct {
 	Number       int
-	Icon         string        // topical lucide name (e.g. "users","landmark","link-2","refresh-cw","bot")
+	Icon         string // topical lucide name (e.g. "users","landmark","link-2","refresh-cw","bot")
 	Title        string
-	Description  string        // shown in active/in_progress/pending states
-	Summary      string        // shown when Complete (compact confirmation line)
+	Description  string // shown in active/in_progress/pending states
+	Summary      string // shown when Complete (compact confirmation line)
 	State        SetupStepState
 	TimeEstimate string        // "~1 min" — shown in active/pending meta row; hide when ""
 	Optional     bool          // render an "Optional" badge

--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -99,7 +99,7 @@ templ statTileBody(p StatTileProps) {
 	<div class="flex items-center gap-2.5 sm:gap-3">
 		if p.Icon != "" {
 			<div class={ "w-8 h-8 sm:w-9 sm:h-9 rounded-lg flex items-center justify-center shrink-0", statTileBg(p.Tone) }>
-				@LucideIcon(p.Icon, "w-4 h-4 " + statTileIcon(p.Tone))
+				@LucideIcon(p.Icon, "w-4 h-4 "+statTileIcon(p.Tone))
 			</div>
 		}
 		<div class="min-w-0 flex-1">

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -212,7 +212,7 @@ templ TimelineSystemRow(p TimelineRowProps) {
 			if p.IconTone != "custom" {
 				<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", timelineIconBg(p.IconTone) } aria-hidden="true">
 					if p.Icon != "" {
-						@LucideIcon(p.Icon, "w-3 h-3 " + timelineIconColor(p.IconTone))
+						@LucideIcon(p.Icon, "w-3 h-3 "+timelineIconColor(p.IconTone))
 					}
 				</span>
 			}

--- a/internal/templates/components/toast.templ
+++ b/internal/templates/components/toast.templ
@@ -21,7 +21,6 @@ package components
 //
 // Markup is intentionally identical to the inline copy in
 // `internal/templates/layout/base.html` so the two never drift.
-
 templ Toast() {
 	<div
 		class="fixed bottom-8 left-1/2 z-50 -translate-x-1/2 flex flex-col items-center gap-2 pointer-events-none"
@@ -57,10 +56,14 @@ templ Toast() {
 				x-transition:leave-end="opacity-0 translate-y-2"
 				class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2 pointer-events-auto max-w-[calc(100vw-2rem)]"
 			>
-				<template x-if="t.type === 'success'">@LucideIcon("check", "w-4 h-4 text-success shrink-0")</template>
-				<template x-if="t.type === 'error'">@LucideIcon("x-circle", "w-4 h-4 text-error shrink-0")</template>
-				<template x-if="t.type === 'warning'">@LucideIcon("alert-triangle", "w-4 h-4 text-warning shrink-0")</template>
-				<template x-if="t.type === 'info'">@LucideIcon("info", "w-4 h-4 text-info shrink-0")</template>
+				<template x-if="t.type === 'success'">@LucideIcon("check", "w-4 h-4 text-success shrink-0")
+</template>
+				<template x-if="t.type === 'error'">@LucideIcon("x-circle", "w-4 h-4 text-error shrink-0")
+</template>
+				<template x-if="t.type === 'warning'">@LucideIcon("alert-triangle", "w-4 h-4 text-warning shrink-0")
+</template>
+				<template x-if="t.type === 'info'">@LucideIcon("info", "w-4 h-4 text-info shrink-0")
+</template>
 				<span class="text-sm font-medium" x-text="t.message"></span>
 				<button
 					type="button"

--- a/static/js/admin/components/access.js
+++ b/static/js/admin/components/access.js
@@ -1,0 +1,70 @@
+// Access tab scripts for /settings/api-keys.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+// `accessReveal` powers the one-time secret block shown right after a key
+// is minted. Its job is to let the user *name the key in the same breath as
+// copying the secret*: the Name field is pre-focused with its text selected,
+// so a single keystroke renames the just-created "API key" default.
+//
+// The save is a background fetch, never a form submit — the settings shell
+// swaps the whole body on any in-tab POST, which would tear down the reveal
+// (and the one-shot secret) before the user copied it. The fetch carries
+// `X-Requested-With: fetch`; the rename handler answers 204 so nothing
+// re-renders and the secret stays put.
+//
+// Implementation note: `save` closes over `self` (captured in `init`, the
+// one lifecycle hook where `this` is reliably the component) rather than
+// reading `this`. Alpine invokes `@change="save()"` as a bare call, so the
+// method's own `this` isn't guaranteed to be the reactive data — `self`
+// sidesteps that entirely.
+document.addEventListener('alpine:init', function () {
+  Alpine.data('accessReveal', function () {
+    var self;
+    return {
+      label: '',
+      saving: false,
+      saved: false,
+
+      init: function () {
+        self = this;
+        this.label = this.$el.dataset.initialLabel || '';
+        // Focus + select-all so the default name is one keystroke from gone.
+        this.$nextTick(function () {
+          var input = self.$refs.labelInput;
+          if (input) {
+            input.focus();
+            input.select();
+          }
+        });
+      },
+
+      // save persists the current label to the rename endpoint. Fires on
+      // `change` (commit-on-blur) so we don't POST on every keystroke. Empty
+      // names are ignored — the server keeps the "API key" default.
+      save: function () {
+        var name = (self.label || '').trim();
+        if (!name) return;
+        self.saving = true;
+        self.saved = false;
+        fetch(self.$el.dataset.renameUrl, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-Requested-With': 'fetch',
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            _csrf: self.$el.dataset.csrf || '',
+            name: name,
+          }).toString(),
+        }).then(function (res) {
+          self.saving = false;
+          self.saved = res.ok;
+        }).catch(function () {
+          self.saving = false;
+        });
+      },
+    };
+  });
+});


### PR DESCRIPTION
Closes #1744.

Polishes the API Keys page so creating and naming a key is a single, fluid motion instead of a form-then-hunt chore.

## What changed

**Create bar** — removed the label input and the full-access/read-only permission toggle. The create bar is now a single split button:

- **Left half** (`Create key`) — mints a full-access key in one click, no fields to fill.
- **Right half** (`▾`) — drops a DaisyUI menu revealing `Create 'read-only' key` (or `Create 'read-only' client` for OAuth clients).

**Name it inline, the instant it's created** — the natural moment to name a key is while you're looking at it. The reveal block now leads with a pre-focused, select-all **Name** field that **background-saves** to the rename endpoint while the one-time secret stays on screen. Name it, copy it, done — with a quiet `✓ saved` confirmation. No hunting through the list afterward.

The just-created key is omitted from the list below while the reveal is up (the reveal *is* its row this render), so it's never shown twice under the stale "API key" default.

**Edit label later** — established key rows keep a two-item overflow menu (`Edit label` → inline modal, `Revoke…` → two-step confirm). OAuth client rows keep their Revoke-only overflow.

## The one constraint that shaped the implementation

The plaintext secret is shown exactly once, and the settings shell swaps the whole tab body on any in-tab form POST — which would tear down the reveal (and the secret) before the user copied it. So the inline name save is a **background `fetch`**, not a form submit. It carries `X-Requested-With: fetch`; the rename handler answers `204 No Content` so nothing re-renders and the secret survives until the user navigates away.

## Screenshots

**Reveal after create — pre-focused, select-all Name field; secret stays copyable:**

`&lt;img src="https://i.img402.dev/rzxnn4zv3d.jpg" width="800" alt="reveal with inline name field pre-focused"&gt;`

**Named inline — `✓ saved`, secret still on screen:**

`&lt;img src="https://i.img402.dev/28uns8foep.jpg" width="800" alt="reveal after naming the key, showing saved indicator"&gt;`

**After reload — key carries its chosen name; `Edit label` / `Revoke…` for later:**

`&lt;img src="https://i.img402.dev/m64jdp29qj.jpg" width="800" alt="key row named Laptop CLI with overflow menu open"&gt;`

**Split button dropdown — read-only option:**

`&lt;img src="https://i.img402.dev/zn6ceo1lag.jpg" width="800" alt="split button dropdown showing Create read-only key"&gt;`

## Implementation

| Layer | Change |
|---|---|
| `internal/service/apikeys.go` | `RenameAPIKey(ctx, id, name)` via direct `Pool.Exec` (same pattern as `RevokeAPIKey`) |
| `internal/admin/apikeys.go` | `APIKeyRenamePageHandler` — three response shapes: **204** for the reveal's background save (`X-Requested-With: fetch`), fragment re-render for the overflow modal, 303 for no-JS. Create handler + flash now carry the new key's `ID` |
| `internal/admin/router.go` | `POST /settings/api-keys/{id}/rename` (editor scope) |
| `internal/templates/components/pages/access_types.go` | `AccessReveal.ID`; `accessActiveKeysExcluding` to drop the just-created key from the list; `accessAPIKeyRenameURL` |
| `internal/templates/components/pages/access.templ` | Split-button create bar; reveal redesign with inline `accessRevealNameField`; `accessAPIKeyControl` + `accessEditLabelDialog` |
| `static/js/admin/components/access.js` | New `accessReveal` Alpine factory — focus/select + the background save |

## Validation

Validated end-to-end in a real browser (headless Chromium): pre-focus + select-all confirmed, inline rename POSTs `204` and the `✓ saved` indicator appears, and the new name **persists across reload**. `go build` / `go vet` / `go test ./...` (incl. the `scripts_lint` ceiling) all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLR15y7c4jhFiEELJ8KJpy)_