### PR TITLE
feat(sync): cron-anchored, many-to-many sync schedules

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -140,7 +140,6 @@ See the Transactions table — comments are nested under `/transactions/{transac
 | POST | `/connections` | W | Create from a provider payload (`provider` discriminator: `plaid`, `teller`) |
 | POST | `/connections/{id}/sync` | W | Trigger sync for one connection (202; runs async) |
 | POST | `/connections/{id}/paused` | W | Pause or resume scheduled syncs |
-| POST | `/connections/{id}/sync-interval` | W | Set or clear per-connection interval override |
 | POST | `/connections/{id}/reauth` | W | Start re-auth flow; returns a fresh link token |
 | POST | `/connections/{id}/reauth-complete` | W | Mark connection active again after the user finishes re-auth |
 | DELETE | `/connections/{id}` | W | Soft-disconnect (wipes encrypted tokens, transactions soft-deleted) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -318,7 +318,6 @@ Errors on `POST /connections`:
 | GET | `/connections/{id}/status` | Read | Get connection status and last sync info |
 | POST | `/connections/{id}/sync` | Write | Trigger a sync for this single connection |
 | POST | `/connections/{id}/paused` | Write | Pause or resume scheduled syncs for a connection |
-| POST | `/connections/{id}/sync-interval` | Write | Set or clear a per-connection sync-interval override |
 | DELETE | `/connections/{id}` | Write | Soft-disconnect a connection (clears tokens, hides from list) |
 | POST | `/connections/{id}/reauth` | Write | Start the provider re-auth flow — returns a fresh link token |
 | POST | `/connections/{id}/reauth-complete` | Write | Mark connection active again after the user finishes the re-auth flow |
@@ -432,18 +431,6 @@ Toggle the `paused` flag — paused connections are skipped by the cron schedule
 | `paused` | bool | Required. `true` to pause, `false` to resume. |
 
 Returns `200` with the full connection detail (same shape as `GET /connections/{id}`). `404 NOT_FOUND` if the connection is missing.
-
-### POST `/connections/{id}/sync-interval`
-
-Set or clear the per-connection sync-interval override (minutes). When cleared, the connection falls back to the global default.
-
-**Body**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `interval_minutes` | int / null | Minutes between scheduled syncs. Pass `null` (or omit) to clear the override and revert to the global default. Values `<= 0` are treated as a clear. |
-
-Returns `200` with the full connection detail. `404 NOT_FOUND` if the connection is missing.
 
 ### DELETE `/connections/{id}`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -504,7 +504,7 @@ bank_connections
 ├── error_code              TEXT nullable
 ├── error_message           TEXT nullable
 ├── paused                  BOOLEAN DEFAULT FALSE
-├── sync_interval_override_minutes  INTEGER nullable
+├── sync_interval_override_minutes  INTEGER nullable  (deprecated — see sync_schedules)
 ├── new_accounts_available  BOOLEAN DEFAULT FALSE
 ├── consent_expiration_time TIMESTAMPTZ nullable
 ├── last_synced_at          TIMESTAMPTZ nullable

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -43,6 +43,8 @@ This document defines the complete PostgreSQL database schema for the Breadbox M
 | `accounts` | Individual bank accounts (checking, savings, credit cards) within a connection. Mirrors the Plaid Account object. |
 | `transactions` | Financial transactions synced from providers. Soft-deleted on removal. |
 | `sync_logs` | Immutable audit trail of every sync operation attempt. |
+| `sync_schedules` | Wall-clock cron sync schedules; the household's sync cadence (replaces the global interval). |
+| `sync_schedule_connections` | Many-to-many join mapping schedules to the connections they cover. |
 | `api_keys` | Hashed API keys for REST API and MCP access. |
 | `app_config` | Key-value store for runtime configuration set during the first-run setup wizard. |
 | `tags` | Reusable labels attached to transactions (e.g. `needs-review`). |
@@ -298,7 +300,7 @@ CREATE TYPE connection_status AS ENUM (
 | `new_accounts_available` | `BOOLEAN` | No | `FALSE` | Set to `TRUE` when Plaid reports that new accounts are available to add for this item (from `NEW_ACCOUNTS_AVAILABLE` webhook). Cleared after the user reviews the accounts in the dashboard. |
 | `consent_expiration_time` | `TIMESTAMPTZ` | Yes | `NULL` | When the user's consent for this Plaid item expires, as reported by Plaid. `NULL` if the institution does not enforce consent expiration. |
 | `paused` | `BOOLEAN` | No | `FALSE` | When `TRUE`, cron-scheduled syncs skip this connection. Manual "Sync Now" still works. Orthogonal to `status`. Added in Phase 10 (migration 00015). |
-| `sync_interval_override_minutes` | `INTEGER` | Yes | `NULL` | Per-connection sync interval override. When set, cron checks this connection's staleness individually. `NULL` uses the global `sync_interval_minutes`. Added in Phase 10 (migration 00015). |
+| `sync_interval_override_minutes` | `INTEGER` | Yes | `NULL` | **Deprecated** (no longer consulted by the scheduler). Per-connection cadence is now expressed via `sync_schedules` + `sync_schedule_connections`. Column retained to avoid a destructive migration; still feeds the coarse list-page "stale" heuristic. Added in Phase 10 (migration 00015). |
 | `last_synced_at` | `TIMESTAMPTZ` | Yes | `NULL` | Timestamp of the most recently completed successful sync. `NULL` if never synced. Used to compute "last seen" display and detect stale connections. Note: `last_attempted_sync_at` (the time of the most recent sync attempt regardless of outcome) does not need its own column — it can be derived from `sync_logs` with `SELECT MAX(started_at) FROM sync_logs WHERE connection_id = $1`. |
 | `created_at` | `TIMESTAMPTZ` | No | `NOW()` | Record creation timestamp. |
 | `updated_at` | `TIMESTAMPTZ` | No | `NOW()` | Last modification timestamp. |
@@ -848,6 +850,46 @@ There is **no** unique constraint on the dedup signature `(merchant_key, iso_cur
 #### Field ownership (edit surface)
 
 User/agent-editable (via `PATCH /series/{id}` / `update_series`, protected from re-detection): `name`, `expected_amount` (+ `iso_currency_code`, `amount_tolerance`), `cadence`, `expected_day`, `category_id`, `user_id`. `type` is edited via `set_series_type`; `merchant_key` via `rekey_series`; `status`/`confidence` via verdicts (`review_series`). Detector-owned (read-only): `detection_source`, `last_amount`, `last_seen_date`, `occurrence_count`, `detection_signals`. Derived (read-only): `next_expected_date`.
+
+---
+
+### 2.13 `sync_schedules`
+
+Wall-clock-anchored sync schedules. Replaces the legacy single global interval
+(`app_config.sync_interval_minutes`, which re-anchored to each connection's last
+sync and drifted) with named cron schedules. Each tick (every 15 min) resolves a
+connection's **effective schedules** — the union of all `applies_to_all=TRUE`
+schedules plus any explicitly targeting it via `sync_schedule_connections` — and
+syncs when ANY of them has fired since the connection's last successful sync.
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| `id` | `UUID` | No | `gen_random_uuid()` | Primary key. |
+| `short_id` | `TEXT` | No | trigger | 8-char base62, via `set_short_id()`. |
+| `name` | `TEXT` | No | — | Display name (e.g. "Nightly"). |
+| `cron` | `TEXT` | No | — | Standard 5-field cron, evaluated in the server's local timezone. |
+| `preset` | `TEXT` | Yes | `NULL` | Catalog preset key (`nightly`, `hourly`, …) or `custom`; drives humanization. |
+| `applies_to_all` | `BOOLEAN` | No | `FALSE` | When `TRUE`, covers every connection (including ones added later); `sync_schedule_connections` rows are ignored. |
+| `enabled` | `BOOLEAN` | No | `TRUE` | Disabled schedules are skipped by the scheduler and excluded from resolution. |
+| `created_at` / `updated_at` | `TIMESTAMPTZ` | No | `NOW()` | Audit timestamps. |
+
+Seeded on migration from the prior `sync_interval_minutes` so cadence is preserved
+on the first tick. The legacy `sync_interval_minutes` remains only as the
+empty-table fallback and a coarse list-page staleness threshold.
+
+### 2.14 `sync_schedule_connections`
+
+Many-to-many join: a schedule targets X connections; a connection has N schedules.
+A connection's effective schedules are the **union** of `applies_to_all` schedules
+plus its explicit rows here — there is no "override vs stack" distinction.
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| `schedule_id` | `UUID` | No | — | FK → `sync_schedules.id`, `ON DELETE CASCADE`. |
+| `connection_id` | `UUID` | No | — | FK → `bank_connections.id`, `ON DELETE CASCADE`. |
+
+Primary key is `(schedule_id, connection_id)`; a reverse index on `connection_id`
+accelerates "which schedules target this connection" during resolution.
 
 ---
 

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"breadbox/internal/app"
+	"breadbox/internal/cronspec"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
@@ -44,8 +45,9 @@ type NextSyncInfo struct {
 	IsPaused bool
 	// IsDisconnected is true when the connection is disconnected or CSV.
 	IsDisconnected bool
-	// EffectiveIntervalMinutes is the sync interval including backoff.
-	EffectiveIntervalMinutes int
+	// ScheduleNames are the names of the schedules covering this connection,
+	// for a "Syncs on: Nightly, Hourly" subline.
+	ScheduleNames []string
 }
 
 // ConnectionWithAccounts pairs a connection row with its accounts and computed totals.
@@ -135,6 +137,9 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 		// next-sync schedule, and staleness.
 		now := time.Now()
 		globalInterval := a.Config.SyncIntervalMinutes
+		// Load the schedule resolution once for the whole list (two queries),
+		// then resolve each connection's effective schedules from it.
+		allSchedules, perConnSchedules, _ := svc.SyncScheduleResolution(ctx)
 		for i := range enriched {
 			if enriched[i].HasBalance {
 				total := 0.0
@@ -146,13 +151,11 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 				enriched[i].TotalBalance = total
 			}
 			enriched[i].NextSync = computeNextSync(syncScheduleParams{
-				Status:                      enriched[i].Status,
-				Provider:                    enriched[i].Provider,
-				Paused:                      enriched[i].Paused,
-				SyncIntervalOverrideMinutes: enriched[i].SyncIntervalOverrideMinutes,
-				ConsecutiveFailures:         enriched[i].ConsecutiveFailures,
-				LastSyncedAt:                enriched[i].LastSyncedAt,
-			}, globalInterval, now)
+				Status:       enriched[i].Status,
+				Provider:     enriched[i].Provider,
+				Paused:       enriched[i].Paused,
+				LastSyncedAt: enriched[i].LastSyncedAt,
+			}, effectiveSchedules(allSchedules, perConnSchedules, enriched[i].ID), now)
 
 			// Compute staleness.
 			if string(enriched[i].Status) != "disconnected" {
@@ -722,15 +725,14 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			}
 		}
 
-		// Compute next sync schedule.
+		// Compute next sync from this connection's effective schedules.
+		allSchedules, perConnSchedules, _ := a.Service.SyncScheduleResolution(ctx)
 		nextSync := computeNextSync(syncScheduleParams{
-			Status:                      conn.Status,
-			Provider:                    conn.Provider,
-			Paused:                      conn.Paused,
-			SyncIntervalOverrideMinutes: conn.SyncIntervalOverrideMinutes,
-			ConsecutiveFailures:         conn.ConsecutiveFailures,
-			LastSyncedAt:                conn.LastSyncedAt,
-		}, a.Config.SyncIntervalMinutes, now)
+			Status:       conn.Status,
+			Provider:     conn.Provider,
+			Paused:       conn.Paused,
+			LastSyncedAt: conn.LastSyncedAt,
+		}, effectiveSchedules(allSchedules, perConnSchedules, conn.ID), now)
 
 		data := map[string]any{
 			"PageTitle":   conn.InstitutionName.String,
@@ -802,22 +804,22 @@ func buildConnectionDetailProps(in connectionDetailInput) pages.ConnectionDetail
 		ConnID:    in.ConnID,
 		CSRFToken: in.CSRFToken,
 		// Connection fields
-		Provider:                          string(in.Conn.Provider),
-		Status:                            string(in.Conn.Status),
-		InstitutionName:                   in.Conn.InstitutionName.String,
-		UserName:                          in.Conn.UserName.String,
-		UserNameValid:                     in.Conn.UserName.Valid,
-		Paused:                            in.Conn.Paused,
-		ConsecutiveFailures:               in.Conn.ConsecutiveFailures,
-		HasErrorCode:                      in.Conn.ErrorCode.Valid,
-		ErrorCode:                         in.Conn.ErrorCode.String,
-		HasErrorMessage:                   in.Conn.ErrorMessage.Valid,
-		ErrorMessage:                      in.Conn.ErrorMessage.String,
-		LastSyncedAtValid:                 in.Conn.LastSyncedAt.Valid,
-		CreatedAtValid:                    in.Conn.CreatedAt.Valid,
-		LastErrorAtValid:                  in.Conn.LastErrorAt.Valid,
-		SyncIntervalOverrideMinutesValid:  in.Conn.SyncIntervalOverrideMinutes.Valid,
-		SyncIntervalOverrideMinutesValue:  in.Conn.SyncIntervalOverrideMinutes.Int32,
+		Provider:                         string(in.Conn.Provider),
+		Status:                           string(in.Conn.Status),
+		InstitutionName:                  in.Conn.InstitutionName.String,
+		UserName:                         in.Conn.UserName.String,
+		UserNameValid:                    in.Conn.UserName.Valid,
+		Paused:                           in.Conn.Paused,
+		ConsecutiveFailures:              in.Conn.ConsecutiveFailures,
+		HasErrorCode:                     in.Conn.ErrorCode.Valid,
+		ErrorCode:                        in.Conn.ErrorCode.String,
+		HasErrorMessage:                  in.Conn.ErrorMessage.Valid,
+		ErrorMessage:                     in.Conn.ErrorMessage.String,
+		LastSyncedAtValid:                in.Conn.LastSyncedAt.Valid,
+		CreatedAtValid:                   in.Conn.CreatedAt.Valid,
+		LastErrorAtValid:                 in.Conn.LastErrorAt.Valid,
+		SyncIntervalOverrideMinutesValid: in.Conn.SyncIntervalOverrideMinutes.Valid,
+		SyncIntervalOverrideMinutesValue: in.Conn.SyncIntervalOverrideMinutes.Int32,
 
 		LastSyncStatus:             in.LastSyncStatus,
 		LastSyncErrorMessageValid:  in.LastSyncErrorMessage.Valid,
@@ -838,11 +840,11 @@ func buildConnectionDetailProps(in connectionDetailInput) pages.ConnectionDetail
 		HasBalance:   in.HasBalance,
 
 		NextSync: pages.NextSyncInfo{
-			Label:                    in.NextSync.Label,
-			IsOverdue:                in.NextSync.IsOverdue,
-			IsPaused:                 in.NextSync.IsPaused,
-			IsDisconnected:           in.NextSync.IsDisconnected,
-			EffectiveIntervalMinutes: in.NextSync.EffectiveIntervalMinutes,
+			Label:          in.NextSync.Label,
+			IsOverdue:      in.NextSync.IsOverdue,
+			IsPaused:       in.NextSync.IsPaused,
+			IsDisconnected: in.NextSync.IsDisconnected,
+			ScheduleNames:  in.NextSync.ScheduleNames,
 		},
 	}
 
@@ -1346,18 +1348,31 @@ func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) htt
 // syncScheduleParams holds the fields needed to compute next-sync info.
 // Works with both ListBankConnectionsRow and GetBankConnectionRow.
 type syncScheduleParams struct {
-	Status                      db.ConnectionStatus
-	Provider                    db.ProviderType
-	Paused                      bool
-	SyncIntervalOverrideMinutes pgtype.Int4
-	ConsecutiveFailures         int32
-	LastSyncedAt                pgtype.Timestamptz
+	Status       db.ConnectionStatus
+	Provider     db.ProviderType
+	Paused       bool
+	LastSyncedAt pgtype.Timestamptz
 }
 
-// computeNextSync calculates when a connection will next be eligible for cron
-// sync, using the same staleness logic as the scheduler. This mirrors the logic
-// in internal/sync/scheduler.go syncAllScheduled.
-func computeNextSync(p syncScheduleParams, globalIntervalMinutes int, now time.Time) NextSyncInfo {
+// effectiveSchedules returns the schedules that apply to a connection: the
+// union of the household's applies_to_all schedules plus any explicitly
+// targeting it. Resolved from a single service.SyncScheduleResolution call.
+func effectiveSchedules(all []service.ScheduleRef, perConn map[string][]service.ScheduleRef, connID pgtype.UUID) []service.ScheduleRef {
+	extra := perConn[pgconv.FormatUUID(connID)]
+	if len(all) == 0 {
+		return extra
+	}
+	out := make([]service.ScheduleRef, 0, len(all)+len(extra))
+	out = append(out, all...)
+	out = append(out, extra...)
+	return out
+}
+
+// computeNextSync calculates when a connection will next sync from its effective
+// sync schedules (the union of applies_to_all + connection-targeted schedules,
+// resolved via service.SyncScheduleResolution). Wall-clock anchored — mirrors
+// the scheduler's scheduleDue/scheduleNextRun, minus jitter.
+func computeNextSync(p syncScheduleParams, schedules []service.ScheduleRef, now time.Time) NextSyncInfo {
 	// Disconnected or CSV connections don't sync on a schedule.
 	if string(p.Status) == "disconnected" || string(p.Provider) == "csv" {
 		return NextSyncInfo{IsDisconnected: true, Label: "No schedule"}
@@ -1368,48 +1383,39 @@ func computeNextSync(p syncScheduleParams, globalIntervalMinutes int, now time.T
 		return NextSyncInfo{IsPaused: true, Label: "Paused"}
 	}
 
-	// Compute effective interval with backoff (mirrors scheduler.go backoffInterval).
-	baseMinutes := globalIntervalMinutes
-	if p.SyncIntervalOverrideMinutes.Valid {
-		baseMinutes = int(p.SyncIntervalOverrideMinutes.Int32)
-	}
-	effectiveMinutes := syncBackoffInterval(baseMinutes, p.ConsecutiveFailures)
-
-	info := NextSyncInfo{
-		EffectiveIntervalMinutes: effectiveMinutes,
+	// No schedule covers this connection — it won't auto-sync (manual/webhook
+	// still work).
+	if len(schedules) == 0 {
+		return NextSyncInfo{Label: "No schedule"}
 	}
 
-	// Never synced — eligible immediately on next cron tick.
+	names := make([]string, 0, len(schedules))
+	crons := make([]string, 0, len(schedules))
+	for _, s := range schedules {
+		names = append(names, s.Name)
+		crons = append(crons, s.Cron)
+	}
+	info := NextSyncInfo{ScheduleNames: names}
+
+	// Never synced — eligible on the next tick.
 	if !p.LastSyncedAt.Valid {
 		info.IsOverdue = true
 		info.Label = "Pending first sync"
 		return info
 	}
 
-	nextSyncAt := p.LastSyncedAt.Time.Add(time.Duration(effectiveMinutes) * time.Minute)
-	info.NextSyncAt = nextSyncAt
-
-	if nextSyncAt.Before(now) || nextSyncAt.Equal(now) {
+	// A scheduled fire passed since the last sync → due now.
+	if cronspec.DuePassed(crons, p.LastSyncedAt.Time, now) {
 		info.IsOverdue = true
 		info.Label = "Due now"
 		return info
 	}
 
-	info.Label = relativeTimeUntil(nextSyncAt, now)
+	if next, ok := cronspec.NextRun(crons, now); ok {
+		info.NextSyncAt = next
+		info.Label = relativeTimeUntil(next, now)
+	}
 	return info
-}
-
-// syncBackoffInterval returns an adjusted sync interval in minutes based on
-// consecutive failures. Mirrors internal/sync/scheduler.go backoffInterval.
-func syncBackoffInterval(baseMinutes int, consecutiveFailures int32) int {
-	if consecutiveFailures <= 0 {
-		return baseMinutes
-	}
-	exp := int(consecutiveFailures)
-	if exp > 4 {
-		exp = 4
-	}
-	return baseMinutes * (1 << exp)
 }
 
 // relativeTimeUntil formats a future time as a human-readable duration string
@@ -1439,4 +1445,3 @@ func relativeTimeUntil(target, now time.Time) string {
 		return "in <1m"
 	}
 }
-

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -804,22 +804,20 @@ func buildConnectionDetailProps(in connectionDetailInput) pages.ConnectionDetail
 		ConnID:    in.ConnID,
 		CSRFToken: in.CSRFToken,
 		// Connection fields
-		Provider:                         string(in.Conn.Provider),
-		Status:                           string(in.Conn.Status),
-		InstitutionName:                  in.Conn.InstitutionName.String,
-		UserName:                         in.Conn.UserName.String,
-		UserNameValid:                    in.Conn.UserName.Valid,
-		Paused:                           in.Conn.Paused,
-		ConsecutiveFailures:              in.Conn.ConsecutiveFailures,
-		HasErrorCode:                     in.Conn.ErrorCode.Valid,
-		ErrorCode:                        in.Conn.ErrorCode.String,
-		HasErrorMessage:                  in.Conn.ErrorMessage.Valid,
-		ErrorMessage:                     in.Conn.ErrorMessage.String,
-		LastSyncedAtValid:                in.Conn.LastSyncedAt.Valid,
-		CreatedAtValid:                   in.Conn.CreatedAt.Valid,
-		LastErrorAtValid:                 in.Conn.LastErrorAt.Valid,
-		SyncIntervalOverrideMinutesValid: in.Conn.SyncIntervalOverrideMinutes.Valid,
-		SyncIntervalOverrideMinutesValue: in.Conn.SyncIntervalOverrideMinutes.Int32,
+		Provider:            string(in.Conn.Provider),
+		Status:              string(in.Conn.Status),
+		InstitutionName:     in.Conn.InstitutionName.String,
+		UserName:            in.Conn.UserName.String,
+		UserNameValid:       in.Conn.UserName.Valid,
+		Paused:              in.Conn.Paused,
+		ConsecutiveFailures: in.Conn.ConsecutiveFailures,
+		HasErrorCode:        in.Conn.ErrorCode.Valid,
+		ErrorCode:           in.Conn.ErrorCode.String,
+		HasErrorMessage:     in.Conn.ErrorMessage.Valid,
+		ErrorMessage:        in.Conn.ErrorMessage.String,
+		LastSyncedAtValid:   in.Conn.LastSyncedAt.Valid,
+		CreatedAtValid:      in.Conn.CreatedAt.Valid,
+		LastErrorAtValid:    in.Conn.LastErrorAt.Valid,
 
 		LastSyncStatus:             in.LastSyncStatus,
 		LastSyncErrorMessageValid:  in.LastSyncErrorMessage.Valid,
@@ -1303,40 +1301,6 @@ func UpdateConnectionPausedHandler(a *app.App, sm *scs.SessionManager) http.Hand
 		})
 		if err != nil {
 			a.Logger.Error("update connection paused", "error", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update connection"})
-			return
-		}
-
-		writeJSON(w, http.StatusOK, conn)
-	}
-}
-
-// UpdateConnectionSyncIntervalHandler serves POST /admin/api/connections/{id}/sync-interval.
-func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
-		if !ok {
-			return
-		}
-
-		var req struct {
-			Minutes *int32 `json:"minutes"`
-		}
-		if !decodeJSON(w, r, &req) {
-			return
-		}
-
-		var interval pgtype.Int4
-		if req.Minutes != nil {
-			interval = pgconv.Int4(*req.Minutes)
-		}
-
-		conn, err := a.Queries.UpdateConnectionSyncInterval(r.Context(), db.UpdateConnectionSyncIntervalParams{
-			ID:                          connID,
-			SyncIntervalOverrideMinutes: interval,
-		})
-		if err != nil {
-			a.Logger.Error("update connection sync interval", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update connection"})
 			return
 		}

--- a/internal/admin/connections_test.go
+++ b/internal/admin/connections_test.go
@@ -7,39 +7,10 @@ import (
 	"time"
 
 	"breadbox/internal/db"
-	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
-
-func TestSyncBackoffInterval(t *testing.T) {
-	tests := []struct {
-		name                string
-		baseMinutes         int
-		consecutiveFailures int32
-		want                int
-	}{
-		{"no failures", 720, 0, 720},
-		{"1 failure doubles", 720, 1, 1440},
-		{"2 failures 4x", 720, 2, 2880},
-		{"3 failures 8x", 60, 3, 480},
-		{"4 failures 16x", 60, 4, 960},
-		{"5 failures capped at 16x", 60, 5, 960},
-		{"10 failures capped at 16x", 60, 10, 960},
-		{"negative failures treated as zero", 720, -1, 720},
-		{"15 min base no failures", 15, 0, 15},
-		{"15 min base 2 failures", 15, 2, 60},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := syncBackoffInterval(tt.baseMinutes, tt.consecutiveFailures)
-			if got != tt.want {
-				t.Errorf("syncBackoffInterval(%d, %d) = %d, want %d", tt.baseMinutes, tt.consecutiveFailures, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestRelativeTimeUntil(t *testing.T) {
 	now := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
@@ -73,148 +44,127 @@ func TestRelativeTimeUntil(t *testing.T) {
 }
 
 func TestComputeNextSync(t *testing.T) {
-	now := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
-	globalInterval := 720 // 12 hours
+	// 2026-03-26 09:00 UTC. A nightly (03:00) + hourly schedule give clear
+	// fire boundaries to assert against.
+	now := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
+	nightly := []service.ScheduleRef{{Name: "Nightly", Cron: "0 3 * * *"}}
+	hourly := []service.ScheduleRef{{Name: "Hourly", Cron: "0 * * * *"}}
+
+	tsAt := func(tt time.Time) pgtype.Timestamptz {
+		return pgtype.Timestamptz{Time: tt, Valid: true}
+	}
 
 	t.Run("disconnected connection", func(t *testing.T) {
-		p := syncScheduleParams{
+		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusDisconnected,
 			Provider: db.ProviderTypePlaid,
-		}
-		info := computeNextSync(p, globalInterval, now)
-		if !info.IsDisconnected {
-			t.Error("expected IsDisconnected=true")
-		}
-		if info.Label != "No schedule" {
-			t.Errorf("expected label 'No schedule', got %q", info.Label)
+		}, nightly, now)
+		if !info.IsDisconnected || info.Label != "No schedule" {
+			t.Errorf("expected disconnected/No schedule, got %+v", info)
 		}
 	})
 
 	t.Run("CSV provider", func(t *testing.T) {
-		p := syncScheduleParams{
+		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypeCsv,
-		}
-		info := computeNextSync(p, globalInterval, now)
+		}, nightly, now)
 		if !info.IsDisconnected {
 			t.Error("expected IsDisconnected=true for CSV")
 		}
 	})
 
 	t.Run("paused connection", func(t *testing.T) {
-		p := syncScheduleParams{
+		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypePlaid,
 			Paused:   true,
-		}
-		info := computeNextSync(p, globalInterval, now)
-		if !info.IsPaused {
-			t.Error("expected IsPaused=true")
-		}
-		if info.Label != "Paused" {
-			t.Errorf("expected label 'Paused', got %q", info.Label)
+		}, nightly, now)
+		if !info.IsPaused || info.Label != "Paused" {
+			t.Errorf("expected paused, got %+v", info)
 		}
 	})
 
-	t.Run("never synced", func(t *testing.T) {
-		p := syncScheduleParams{
+	t.Run("no schedules covers connection", func(t *testing.T) {
+		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypePlaid,
-		}
-		info := computeNextSync(p, globalInterval, now)
-		if !info.IsOverdue {
-			t.Error("expected IsOverdue=true for never-synced connection")
-		}
-		if info.Label != "Pending first sync" {
-			t.Errorf("expected label 'Pending first sync', got %q", info.Label)
+		}, nil, now)
+		if info.Label != "No schedule" || info.IsOverdue {
+			t.Errorf("expected 'No schedule' with no schedules, got %+v", info)
 		}
 	})
 
-	t.Run("recently synced - next sync in future", func(t *testing.T) {
-		lastSynced := now.Add(-6 * time.Hour) // 6h ago, interval is 12h => 6h remaining
-		p := syncScheduleParams{
+	t.Run("never synced is overdue", func(t *testing.T) {
+		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypePlaid,
-			LastSyncedAt: pgtype.Timestamptz{
-				Time:  lastSynced,
-				Valid: true,
-			},
+		}, nightly, now)
+		if !info.IsOverdue || info.Label != "Pending first sync" {
+			t.Errorf("expected pending first sync, got %+v", info)
 		}
-		info := computeNextSync(p, globalInterval, now)
-		if info.IsOverdue {
-			t.Error("expected IsOverdue=false")
-		}
-		if info.Label != "in 6h" {
-			t.Errorf("expected label 'in 6h', got %q", info.Label)
-		}
-		if info.EffectiveIntervalMinutes != 720 {
-			t.Errorf("expected EffectiveIntervalMinutes=720, got %d", info.EffectiveIntervalMinutes)
+		if len(info.ScheduleNames) != 1 || info.ScheduleNames[0] != "Nightly" {
+			t.Errorf("expected ScheduleNames=[Nightly], got %v", info.ScheduleNames)
 		}
 	})
 
-	t.Run("overdue - last synced long ago", func(t *testing.T) {
-		lastSynced := now.Add(-24 * time.Hour) // 24h ago, interval is 12h => overdue
-		p := syncScheduleParams{
-			Status:   db.ConnectionStatusActive,
-			Provider: db.ProviderTypePlaid,
-			LastSyncedAt: pgtype.Timestamptz{
-				Time:  lastSynced,
-				Valid: true,
-			},
+	t.Run("synced after last fire - next in future", func(t *testing.T) {
+		// Last synced 04:00 (after the 03:00 nightly fire) → next fire is
+		// tomorrow 03:00, 18h away.
+		info := computeNextSync(syncScheduleParams{
+			Status:       db.ConnectionStatusActive,
+			Provider:     db.ProviderTypePlaid,
+			LastSyncedAt: tsAt(time.Date(2026, 3, 26, 4, 0, 0, 0, time.UTC)),
+		}, nightly, now)
+		if info.IsOverdue {
+			t.Errorf("expected not overdue, got %+v", info)
 		}
-		info := computeNextSync(p, globalInterval, now)
-		if !info.IsOverdue {
-			t.Error("expected IsOverdue=true")
-		}
-		if info.Label != "Due now" {
-			t.Errorf("expected label 'Due now', got %q", info.Label)
+		if info.Label != "in 18h" {
+			t.Errorf("expected 'in 18h', got %q", info.Label)
 		}
 	})
 
-	t.Run("per-connection override interval", func(t *testing.T) {
-		lastSynced := now.Add(-10 * time.Minute) // 10m ago, override is 30m => 20m remaining
-		p := syncScheduleParams{
-			Status:   db.ConnectionStatusActive,
-			Provider: db.ProviderTypeTeller,
-			LastSyncedAt: pgtype.Timestamptz{
-				Time:  lastSynced,
-				Valid: true,
-			},
-			SyncIntervalOverrideMinutes: pgconv.Int4(30),
-		}
-		info := computeNextSync(p, globalInterval, now)
-		if info.IsOverdue {
-			t.Error("expected IsOverdue=false")
-		}
-		if info.EffectiveIntervalMinutes != 30 {
-			t.Errorf("expected EffectiveIntervalMinutes=30, got %d", info.EffectiveIntervalMinutes)
-		}
-		if info.Label != "in 20m" {
-			t.Errorf("expected label 'in 20m', got %q", info.Label)
+	t.Run("scheduled fire passed since last sync - due now", func(t *testing.T) {
+		// Last synced 02:00 (before the 03:00 nightly fire), now is 09:00 →
+		// the 03:00 fire was missed → due.
+		info := computeNextSync(syncScheduleParams{
+			Status:       db.ConnectionStatusActive,
+			Provider:     db.ProviderTypePlaid,
+			LastSyncedAt: tsAt(time.Date(2026, 3, 26, 2, 0, 0, 0, time.UTC)),
+		}, nightly, now)
+		if !info.IsOverdue || info.Label != "Due now" {
+			t.Errorf("expected due now, got %+v", info)
 		}
 	})
 
-	t.Run("backoff doubles interval on failures", func(t *testing.T) {
-		lastSynced := now.Add(-30 * time.Minute) // 30m ago, base=60m, 1 failure => effective=120m, remaining=90m
-		p := syncScheduleParams{
-			Status:              db.ConnectionStatusActive,
-			Provider:            db.ProviderTypePlaid,
-			ConsecutiveFailures: 1,
-			LastSyncedAt: pgtype.Timestamptz{
-				Time:  lastSynced,
-				Valid: true,
-			},
-			SyncIntervalOverrideMinutes: pgconv.Int4(60),
-		}
-		info := computeNextSync(p, globalInterval, now)
+	t.Run("hourly - next fire within the hour", func(t *testing.T) {
+		// Synced at 09:00 exactly; next hourly fire is 10:00, 1h away.
+		info := computeNextSync(syncScheduleParams{
+			Status:       db.ConnectionStatusActive,
+			Provider:     db.ProviderTypeTeller,
+			LastSyncedAt: tsAt(now),
+		}, hourly, now)
 		if info.IsOverdue {
-			t.Error("expected IsOverdue=false")
+			t.Errorf("expected not overdue, got %+v", info)
 		}
-		if info.EffectiveIntervalMinutes != 120 {
-			t.Errorf("expected EffectiveIntervalMinutes=120, got %d", info.EffectiveIntervalMinutes)
+		if info.Label != "in 1h" {
+			t.Errorf("expected 'in 1h', got %q", info.Label)
 		}
-		if info.Label != "in 1h 30m" {
-			t.Errorf("expected label 'in 1h 30m', got %q", info.Label)
+	})
+
+	t.Run("union of multiple schedules picks earliest", func(t *testing.T) {
+		// Synced at 09:00 with both nightly (next 03:00) and hourly (next
+		// 10:00) → earliest next fire is 10:00, 1h away.
+		info := computeNextSync(syncScheduleParams{
+			Status:       db.ConnectionStatusActive,
+			Provider:     db.ProviderTypePlaid,
+			LastSyncedAt: tsAt(now),
+		}, append(append([]service.ScheduleRef{}, nightly...), hourly...), now)
+		if info.Label != "in 1h" {
+			t.Errorf("expected earliest 'in 1h', got %q", info.Label)
+		}
+		if len(info.ScheduleNames) != 2 {
+			t.Errorf("expected 2 schedule names, got %v", info.ScheduleNames)
 		}
 	})
 }

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -425,6 +425,16 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
 		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
+
+		// Sync schedules — wall-clock cron schedules that replace the single
+		// global interval. List lives in Settings → Sync; create/edit is a
+		// standalone form page.
+		r.Get("/settings/sync/schedules/new", ScheduleFormPageHandler(a, svc, sm, tr))
+		r.Post("/settings/sync/schedules", ScheduleCreateHandler(a, svc, sm))
+		r.Get("/settings/sync/schedules/{shortID}/edit", ScheduleFormPageHandler(a, svc, sm, tr))
+		r.Post("/settings/sync/schedules/{shortID}", ScheduleUpdateHandler(a, svc, sm))
+		r.Post("/settings/sync/schedules/{shortID}/toggle", ScheduleToggleHandler(a, svc, sm))
+		r.Post("/settings/sync/schedules/{shortID}/delete", ScheduleDeleteHandler(a, svc, sm))
 		r.Post("/settings/avatar-style", SettingsAvatarStylePostHandler(a, sm))
 	})
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -423,7 +423,6 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings/developer", DeveloperSettingsHandler(a, svc, sm, tr))
 		r.Post("/settings/developer", DeveloperSettingsPostHandler(a, svc, sm))
 
-		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
 		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
 
 		// Sync schedules — wall-clock cron schedules that replace the single
@@ -571,7 +570,6 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Get("/connections/{id}/sync-status", SyncConnectionStatusHandler(a))
 			r.Post("/connections/sync-all", SyncAllConnectionsHandler(a))
 			r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a, sm))
-			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a, sm))
 			r.Delete("/connections/{id}", DeleteConnectionHandler(a, sm, svc))
 			r.Post("/accounts/{id}/excluded", UpdateAccountExcludedHandler(a, sm))
 			r.Post("/accounts/{id}/display-name", UpdateAccountDisplayNameHandler(a, sm))

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -137,34 +137,6 @@ func HelpSettingsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 	}
 }
 
-// SettingsSyncPostHandler serves POST /admin/settings/sync.
-func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		syncIntervalStr := r.FormValue("sync_interval_minutes")
-
-		syncInterval, err := strconv.Atoi(syncIntervalStr)
-		if err != nil || !isValidSyncInterval(syncInterval) {
-			FlashRedirect(w, r, sm, "error", "Invalid sync interval.", "/settings")
-			return
-		}
-
-		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
-			Key:   "sync_interval_minutes",
-			Value: pgconv.Text(strconv.Itoa(syncInterval)),
-		}); err != nil {
-			a.Logger.Error("save sync interval", "error", err)
-			FlashRedirect(w, r, sm, "error", "Failed to save sync interval.", "/settings")
-			return
-		}
-		a.Config.SyncIntervalMinutes = syncInterval
-
-		SetFlash(ctx, sm, "success", "Sync settings saved.")
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-	}
-}
-
 // ChangePasswordHandler serves POST /admin/settings/password.
 // Works for all account types via the unified auth_accounts table.
 func ChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
@@ -283,4 +255,3 @@ func formatUptime(d time.Duration) string {
 	}
 	return fmt.Sprintf("%dm", minutes)
 }
-

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -65,6 +65,8 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		nextSyncTime = formatNextSync(a.Scheduler.NextRun())
 	}
 
+	syncSchedules, _ := a.Service.ListSyncSchedules(ctx)
+
 	props := pages.SettingsProps{
 		CSRFToken:            GetCSRFToken(r),
 		SyncIntervalMinutes:  a.Config.SyncIntervalMinutes,
@@ -78,6 +80,7 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		HasEncryptionKey:     len(a.Config.EncryptionKey) > 0,
 		OnboardingDismissed:  onboardingDismissed,
 		NextSyncTime:         nextSyncTime,
+		SyncSchedules:        syncSchedules,
 		ConfigSources:        a.Config.ConfigSources,
 		AvatarUserStyle:      userAvatarStyle,
 		AvatarAgentStyle:     agentAvatarStyle,

--- a/internal/admin/sync_schedules.go
+++ b/internal/admin/sync_schedules.go
@@ -1,0 +1,195 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"breadbox/internal/app"
+	"breadbox/internal/cronspec"
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components/pages"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// scheduleFormConnections loads the connection list for the target picker.
+func scheduleFormConnections(svc *service.Service, r *http.Request) []service.ConnectionResponse {
+	conns, err := svc.ListConnections(r.Context(), nil)
+	if err != nil {
+		return nil
+	}
+	return conns
+}
+
+// ScheduleFormPageHandler serves GET /settings/sync/schedules/new and
+// /settings/sync/schedules/{shortID}/edit.
+func ScheduleFormPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		props := pages.ScheduleFormProps{
+			CSRFToken:     GetCSRFToken(r),
+			Presets:       cronspec.Presets,
+			Connections:   scheduleFormConnections(svc, r),
+			SelectedConns: map[string]bool{},
+			Enabled:       true,
+			AppliesToAll:  true,
+			PresetKey:     "twice_daily",
+		}
+
+		shortID := chi.URLParam(r, "shortID")
+		if shortID != "" {
+			sched, err := findScheduleByShortID(svc, r, shortID)
+			if err != nil {
+				FlashRedirect(w, r, sm, "error", "Schedule not found.", "/settings/general#sync")
+				return
+			}
+			props.IsEdit = true
+			props.ShortID = sched.ShortID
+			props.Name = sched.Name
+			props.PresetKey = sched.Preset
+			if props.PresetKey == "" {
+				props.PresetKey = cronspec.CustomKey
+			}
+			props.Cron = sched.Cron
+			props.AppliesToAll = sched.AppliesToAll
+			props.Enabled = sched.Enabled
+			props.SelectedConns = scheduleSelectedConns(svc, r, sched.ShortID)
+		}
+
+		title := "New sync schedule"
+		if props.IsEdit {
+			title = "Edit sync schedule"
+		}
+		tr.RenderWithTempl(w, r, map[string]any{
+			"PageTitle":   title,
+			"CurrentPage": "settings",
+			"CSRFToken":   GetCSRFToken(r),
+		}, pages.ScheduleForm(props))
+	}
+}
+
+// findScheduleByShortID looks up a single schedule via the list (the service
+// exposes list + mutations; a single-row read isn't needed elsewhere).
+func findScheduleByShortID(svc *service.Service, r *http.Request, shortID string) (service.SyncScheduleView, error) {
+	all, err := svc.ListSyncSchedules(r.Context())
+	if err != nil {
+		return service.SyncScheduleView{}, err
+	}
+	for _, s := range all {
+		if s.ShortID == shortID {
+			return s, nil
+		}
+	}
+	return service.SyncScheduleView{}, errors.New("not found")
+}
+
+// scheduleSelectedConns returns the set of connection short IDs targeted by a
+// schedule, for pre-checking the edit form.
+func scheduleSelectedConns(svc *service.Service, r *http.Request, shortID string) map[string]bool {
+	out := map[string]bool{}
+	ids, err := svc.ListScheduleConnectionShortIDs(r.Context(), shortID)
+	if err != nil {
+		return out
+	}
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out
+}
+
+// ScheduleCreateHandler serves POST /settings/sync/schedules.
+func ScheduleCreateHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		in, err := parseScheduleForm(r)
+		if err != nil {
+			FlashRedirect(w, r, sm, "error", err.Error(), "/settings/sync/schedules/new")
+			return
+		}
+		if _, err := svc.CreateSyncSchedule(r.Context(), in); err != nil {
+			FlashRedirect(w, r, sm, "error", "Failed to create schedule: "+err.Error(), "/settings/sync/schedules/new")
+			return
+		}
+		reloadScheduler(a, r)
+		FlashRedirect(w, r, sm, "success", "Schedule created.", "/settings/general#sync")
+	}
+}
+
+// ScheduleUpdateHandler serves POST /settings/sync/schedules/{shortID}.
+func ScheduleUpdateHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		shortID := chi.URLParam(r, "shortID")
+		in, err := parseScheduleForm(r)
+		if err != nil {
+			FlashRedirect(w, r, sm, "error", err.Error(), "/settings/sync/schedules/"+shortID+"/edit")
+			return
+		}
+		if _, err := svc.UpdateSyncSchedule(r.Context(), shortID, in); err != nil {
+			if errors.Is(err, service.ErrScheduleNotFound) {
+				FlashRedirect(w, r, sm, "error", "Schedule not found.", "/settings/general#sync")
+				return
+			}
+			FlashRedirect(w, r, sm, "error", "Failed to save schedule: "+err.Error(), "/settings/sync/schedules/"+shortID+"/edit")
+			return
+		}
+		reloadScheduler(a, r)
+		FlashRedirect(w, r, sm, "success", "Schedule saved.", "/settings/general#sync")
+	}
+}
+
+// ScheduleToggleHandler serves POST /settings/sync/schedules/{shortID}/toggle.
+func ScheduleToggleHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		shortID := chi.URLParam(r, "shortID")
+		_ = r.ParseForm()
+		enabled := r.FormValue("enabled") != ""
+		if err := svc.SetSyncScheduleEnabled(r.Context(), shortID, enabled); err != nil {
+			FlashRedirect(w, r, sm, "error", "Failed to update schedule.", "/settings/general#sync")
+			return
+		}
+		reloadScheduler(a, r)
+		// Toggle posts via the in-modal auto-save form; respond 204 so the
+		// Alpine handler shows its inline toast without a full redirect.
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ScheduleDeleteHandler serves POST /settings/sync/schedules/{shortID}/delete.
+func ScheduleDeleteHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		shortID := chi.URLParam(r, "shortID")
+		if err := svc.DeleteSyncSchedule(r.Context(), shortID); err != nil {
+			FlashRedirect(w, r, sm, "error", "Failed to delete schedule.", "/settings/general#sync")
+			return
+		}
+		reloadScheduler(a, r)
+		FlashRedirect(w, r, sm, "success", "Schedule deleted.", "/settings/general#sync")
+	}
+}
+
+// parseScheduleForm builds a service input from the submitted form.
+func parseScheduleForm(r *http.Request) (service.SyncScheduleInput, error) {
+	if err := r.ParseForm(); err != nil {
+		return service.SyncScheduleInput{}, errors.New("invalid form")
+	}
+	name := strings.TrimSpace(r.FormValue("name"))
+	if name == "" {
+		return service.SyncScheduleInput{}, errors.New("Name is required.")
+	}
+	return service.SyncScheduleInput{
+		Name:          name,
+		PresetKey:     strings.TrimSpace(r.FormValue("preset")),
+		Cron:          strings.TrimSpace(r.FormValue("cron")),
+		AppliesToAll:  r.FormValue("applies_to_all") != "",
+		Enabled:       r.FormValue("enabled") != "",
+		ConnectionIDs: r.Form["connection_ids"],
+	}, nil
+}
+
+// reloadScheduler is a hook point: schedule mutations take effect on the next
+// 15-minute tick automatically (the scheduler reloads schedules from the DB
+// every tick), so there is nothing to push. Kept as a named no-op so callers
+// read intentionally and a future hot-reload has one wiring site.
+func reloadScheduler(a *app.App, r *http.Request) {}

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -197,7 +197,6 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Post("/connections/{id}/relink", CreateHostedLinkRelinkHandler(svc))
 			r.Post("/connections/{id}/sync", SyncConnectionHandler(svc))
 			r.Post("/connections/{id}/paused", PauseConnectionHandler(svc))
-			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(svc))
 			r.Delete("/connections/{id}", DeleteConnectionHandler(svc))
 			r.Post("/users", CreateUserHandler(svc))
 			r.Patch("/users/{id}", UpdateUserHandler(svc))
@@ -347,7 +346,6 @@ func seedUncategorized(t *testing.T, q *db.Queries) db.Category {
 	}
 	return cat
 }
-
 
 // ============================================================
 // Authentication & Scope Tests

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -116,29 +116,3 @@ func PauseConnectionHandler(svc *service.Service) http.HandlerFunc {
 		writeData(w, conn)
 	}
 }
-
-// UpdateConnectionSyncIntervalHandler serves POST
-// /api/v1/connections/{id}/sync-interval — body:
-// {"interval_minutes": 30} or {"interval_minutes": null} to clear the
-// per-connection override.
-func UpdateConnectionSyncIntervalHandler(svc *service.Service) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		id := chi.URLParam(r, "id")
-
-		var body struct {
-			IntervalMinutes *int `json:"interval_minutes"`
-		}
-		if !decodeJSON(w, r, &body) {
-			return
-		}
-
-		actor := service.ActorFromContext(r.Context())
-		conn, err := svc.UpdateConnectionSyncInterval(r.Context(), id, body.IntervalMinutes, actor)
-		if err != nil {
-			writeServiceError(w, err, "Connection not found", "Failed to update connection")
-			return
-		}
-
-		writeData(w, conn)
-	}
-}

--- a/internal/api/connections_mgmt_integration_test.go
+++ b/internal/api/connections_mgmt_integration_test.go
@@ -168,46 +168,6 @@ func TestPauseConnection_NotFound(t *testing.T) {
 	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
 }
 
-func TestUpdateSyncInterval_Set(t *testing.T) {
-	env := setupTestEnv(t)
-	user := testutil.MustCreateUser(t, env.Queries, "Alice")
-	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_interval_set")
-
-	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/sync-interval", map[string]any{
-		"interval_minutes": 30,
-	})
-	assertStatus(t, resp, http.StatusOK)
-	var got connectionDetail
-	parseJSON(t, resp, &got)
-	if got.SyncIntervalOverrideMinutes == nil || *got.SyncIntervalOverrideMinutes != 30 {
-		t.Errorf("want sync_interval_override_minutes=30, got %v", got.SyncIntervalOverrideMinutes)
-	}
-}
-
-func TestUpdateSyncInterval_Clear(t *testing.T) {
-	env := setupTestEnv(t)
-	user := testutil.MustCreateUser(t, env.Queries, "Alice")
-	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_interval_clear")
-
-	// First set a non-default value.
-	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/sync-interval", map[string]any{
-		"interval_minutes": 45,
-	})
-	assertStatus(t, resp, http.StatusOK)
-	resp.Body.Close()
-
-	// Now clear via null.
-	resp = env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/sync-interval", map[string]any{
-		"interval_minutes": nil,
-	})
-	assertStatus(t, resp, http.StatusOK)
-	var got connectionDetail
-	parseJSON(t, resp, &got)
-	if got.SyncIntervalOverrideMinutes != nil {
-		t.Errorf("want nil after clear, got %v", *got.SyncIntervalOverrideMinutes)
-	}
-}
-
 func TestTriggerConnectionSync(t *testing.T) {
 	env := setupTestEnv(t)
 	waitForSyncDrain(t, env)
@@ -248,7 +208,6 @@ func TestConnectionMgmt_RequiresWriteScope(t *testing.T) {
 		{"delete", "DELETE", "/api/v1/connections/" + conn.ShortID, nil},
 		{"per-conn sync", "POST", "/api/v1/connections/" + conn.ShortID + "/sync", nil},
 		{"paused", "POST", "/api/v1/connections/" + conn.ShortID + "/paused", map[string]any{"paused": true}},
-		{"sync-interval", "POST", "/api/v1/connections/" + conn.ShortID + "/sync-interval", map[string]any{"interval_minutes": 30}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -150,7 +150,6 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/sync", TriggerSyncHandler(svc))
 			r.Post("/connections/{id}/sync", SyncConnectionHandler(svc))
 			r.Post("/connections/{id}/paused", PauseConnectionHandler(svc))
-			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(svc))
 			r.Delete("/connections/{id}", DeleteConnectionHandler(svc))
 			r.Post("/connections/{id}/reauth", ConnectionReauthHandler(a))
 			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))

--- a/internal/cronspec/cronspec.go
+++ b/internal/cronspec/cronspec.go
@@ -6,6 +6,7 @@ package cronspec
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/robfig/cron/v3"
 )
@@ -80,6 +81,42 @@ func ResolveCron(presetKey, customCron string) (expr string, preset string, err 
 		return "", "", err
 	}
 	return customCron, CustomKey, nil
+}
+
+// NextRun returns the earliest upcoming fire time across the given cron
+// expressions (strictly after `from`), and whether any valid expression was
+// found. Invalid expressions are skipped.
+func NextRun(exprs []string, from time.Time) (time.Time, bool) {
+	var earliest time.Time
+	found := false
+	for _, e := range exprs {
+		sc, err := cron.ParseStandard(e)
+		if err != nil {
+			continue
+		}
+		n := sc.Next(from)
+		if !found || n.Before(earliest) {
+			earliest = n
+			found = true
+		}
+	}
+	return earliest, found
+}
+
+// DuePassed reports whether any of the cron expressions has a fire time in the
+// half-open window (since, now] — i.e. a scheduled run was missed since `since`.
+// Used to render "due now" without re-deriving the scheduler's logic.
+func DuePassed(exprs []string, since, now time.Time) bool {
+	for _, e := range exprs {
+		sc, err := cron.ParseStandard(e)
+		if err != nil {
+			continue
+		}
+		if !sc.Next(since).After(now) {
+			return true
+		}
+	}
+	return false
 }
 
 // Humanize returns a friendly description for a stored (cron, presetKey) pair.

--- a/internal/cronspec/cronspec.go
+++ b/internal/cronspec/cronspec.go
@@ -1,0 +1,98 @@
+// Package cronspec defines the user-facing sync-schedule presets and helpers
+// for validating and humanizing cron expressions. It is intentionally tag-free
+// (pure, no DB or server deps) so both the service layer (!lite) and the admin
+// templates (!headless) can share one vocabulary.
+package cronspec
+
+import (
+	"fmt"
+
+	"github.com/robfig/cron/v3"
+)
+
+// Preset is a human-friendly sync cadence backed by a standard 5-field cron
+// expression. "custom" is special: it has no fixed Cron and the user supplies
+// the expression directly.
+type Preset struct {
+	Key   string // stored in sync_schedules.preset
+	Label string // shown in the UI
+	Cron  string // 5-field standard cron; empty for custom
+}
+
+// CustomKey marks a schedule whose cron was entered directly rather than chosen
+// from a preset.
+const CustomKey = "custom"
+
+// Presets is the ordered catalog shown in the schedule UI. Order matters — it's
+// the option order in the select.
+var Presets = []Preset{
+	{Key: "every_15m", Label: "Every 15 minutes", Cron: "*/15 * * * *"},
+	{Key: "every_30m", Label: "Every 30 minutes", Cron: "*/30 * * * *"},
+	{Key: "hourly", Label: "Every hour", Cron: "0 * * * *"},
+	{Key: "every_4h", Label: "Every 4 hours", Cron: "0 */4 * * *"},
+	{Key: "every_8h", Label: "Every 8 hours", Cron: "0 */8 * * *"},
+	{Key: "twice_daily", Label: "Twice daily (6 AM & 6 PM)", Cron: "0 6,18 * * *"},
+	{Key: "morning", Label: "Every morning (6 AM)", Cron: "0 6 * * *"},
+	{Key: "nightly", Label: "Nightly (3 AM)", Cron: "0 3 * * *"},
+	{Key: CustomKey, Label: "Custom…", Cron: ""},
+}
+
+// PresetByKey returns the preset for a key, or false if unknown.
+func PresetByKey(key string) (Preset, bool) {
+	for _, p := range Presets {
+		if p.Key == key {
+			return p, true
+		}
+	}
+	return Preset{}, false
+}
+
+// presetByCron returns the catalog preset whose cron exactly matches, if any.
+func presetByCron(expr string) (Preset, bool) {
+	for _, p := range Presets {
+		if p.Cron != "" && p.Cron == expr {
+			return p, true
+		}
+	}
+	return Preset{}, false
+}
+
+// Validate reports whether expr is a parseable standard cron expression.
+func Validate(expr string) error {
+	if expr == "" {
+		return fmt.Errorf("cron expression is empty")
+	}
+	if _, err := cron.ParseStandard(expr); err != nil {
+		return fmt.Errorf("invalid cron expression %q: %w", expr, err)
+	}
+	return nil
+}
+
+// ResolveCron turns a (presetKey, customCron) pair from a form into the concrete
+// cron expression to store, plus the preset key to persist. For a known preset
+// the custom value is ignored; for custom (or an unknown key) the supplied
+// expression is validated and returned with preset key "custom".
+func ResolveCron(presetKey, customCron string) (expr string, preset string, err error) {
+	if p, ok := PresetByKey(presetKey); ok && p.Key != CustomKey {
+		return p.Cron, p.Key, nil
+	}
+	if err := Validate(customCron); err != nil {
+		return "", "", err
+	}
+	return customCron, CustomKey, nil
+}
+
+// Humanize returns a friendly description for a stored (cron, presetKey) pair.
+// A recognized preset uses its label; otherwise it falls back to matching the
+// raw cron against the catalog, and finally to the literal expression.
+func Humanize(expr, presetKey string) string {
+	if presetKey != "" && presetKey != CustomKey {
+		if p, ok := PresetByKey(presetKey); ok {
+			return p.Label
+		}
+	}
+	if p, ok := presetByCron(expr); ok {
+		return p.Label
+	}
+	return "Custom (" + expr + ")"
+}

--- a/internal/cronspec/cronspec_test.go
+++ b/internal/cronspec/cronspec_test.go
@@ -1,0 +1,85 @@
+package cronspec
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveCron(t *testing.T) {
+	// Known preset ignores the custom value.
+	expr, preset, err := ResolveCron("nightly", "0 0 * * *")
+	if err != nil {
+		t.Fatalf("preset resolve: %v", err)
+	}
+	if expr != "0 3 * * *" || preset != "nightly" {
+		t.Errorf("preset resolve = (%q, %q)", expr, preset)
+	}
+
+	// Custom uses the supplied expression.
+	expr, preset, err = ResolveCron("custom", "0 6,18 * * *")
+	if err != nil {
+		t.Fatalf("custom resolve: %v", err)
+	}
+	if expr != "0 6,18 * * *" || preset != CustomKey {
+		t.Errorf("custom resolve = (%q, %q)", expr, preset)
+	}
+
+	// Invalid custom cron errors.
+	if _, _, err := ResolveCron("custom", "nope"); err == nil {
+		t.Error("expected error for invalid custom cron")
+	}
+}
+
+func TestHumanize(t *testing.T) {
+	if got := Humanize("0 3 * * *", "nightly"); got != "Nightly (3 AM)" {
+		t.Errorf("preset humanize = %q", got)
+	}
+	// Unknown preset falls back to matching the raw cron.
+	if got := Humanize("0 3 * * *", ""); got != "Nightly (3 AM)" {
+		t.Errorf("cron-match humanize = %q", got)
+	}
+	// Truly custom cron echoes literally.
+	if got := Humanize("7 4 * * 1", "custom"); got != "Custom (7 4 * * 1)" {
+		t.Errorf("custom humanize = %q", got)
+	}
+}
+
+func TestNextRun(t *testing.T) {
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+	// Earliest across two exprs: 12:00 beats 18:00.
+	next, ok := NextRun([]string{"0 18 * * *", "0 12 * * *"}, now)
+	if !ok {
+		t.Fatal("expected a next run")
+	}
+	if want := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC); !next.Equal(want) {
+		t.Errorf("NextRun = %v, want %v", next, want)
+	}
+	// All invalid → not found.
+	if _, ok := NextRun([]string{"bad"}, now); ok {
+		t.Error("expected no next run for invalid expr")
+	}
+	if _, ok := NextRun(nil, now); ok {
+		t.Error("expected no next run for empty exprs")
+	}
+}
+
+func TestDuePassed(t *testing.T) {
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+	// Nightly 03:00 fired between 02:00 and 09:00 → due.
+	if !DuePassed([]string{"0 3 * * *"}, time.Date(2026, 6, 4, 2, 0, 0, 0, time.UTC), now) {
+		t.Error("expected due (03:00 fire passed since 02:00)")
+	}
+	// Synced 04:00, nightly's next fire is tomorrow 03:00 > now → not due.
+	if DuePassed([]string{"0 3 * * *"}, time.Date(2026, 6, 4, 4, 0, 0, 0, time.UTC), now) {
+		t.Error("expected not due (next fire is tomorrow)")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := Validate("0 6,18 * * *"); err != nil {
+		t.Errorf("valid cron rejected: %v", err)
+	}
+	if Validate("") == nil || Validate("nonsense") == nil {
+		t.Error("expected errors for empty/invalid cron")
+	}
+}

--- a/internal/db/migrations/20260605060000_sync_schedules.sql
+++ b/internal/db/migrations/20260605060000_sync_schedules.sql
@@ -1,0 +1,69 @@
+-- +goose Up
+
+-- sync_schedules: first-class, wall-clock-anchored sync schedules. Replaces the
+-- single global `sync_interval_minutes` interval (relative to last_synced_at,
+-- which drifted) with cron specs evaluated against the wall clock.
+--
+-- A schedule targets connections via the join table below, or every connection
+-- (incl. future ones) via applies_to_all. A connection's effective schedules are
+-- the UNION of all enabled schedules that apply to it; it is due when ANY of them
+-- has fired since its last successful sync. Many schedules per connection and many
+-- connections per schedule are both first-class — the one-vs-many distinction is
+-- purely how many rows exist, never a schema change.
+--
+-- Additive-only: two new tables + one app_config-derived seed row. Safe to apply
+-- to the shared dev DB alongside running servers.
+CREATE TABLE sync_schedules (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    short_id       TEXT        NOT NULL UNIQUE,
+    name           TEXT        NOT NULL,
+    cron           TEXT        NOT NULL,
+    preset         TEXT        NULL,
+    applies_to_all BOOLEAN     NOT NULL DEFAULT FALSE,
+    enabled        BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER set_short_id_sync_schedules
+    BEFORE INSERT ON sync_schedules
+    FOR EACH ROW EXECUTE FUNCTION set_short_id();
+
+-- The many-to-many mapping. CASCADE on both sides: deleting a schedule or a
+-- connection drops the mapping rows (the mapping is derived, never the source of
+-- truth for either entity).
+CREATE TABLE sync_schedule_connections (
+    schedule_id   UUID NOT NULL REFERENCES sync_schedules(id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL REFERENCES bank_connections(id) ON DELETE CASCADE,
+    PRIMARY KEY (schedule_id, connection_id)
+);
+
+-- Reverse lookup: "which schedules target this connection" during evaluation.
+CREATE INDEX sync_schedule_connections_conn_idx
+    ON sync_schedule_connections (connection_id);
+
+-- Seed one applies_to_all schedule from the existing global interval so every
+-- connection keeps an equivalent wall-clock cadence on the first tick after
+-- migrating. The old `sync_interval_minutes` app_config key stays readable for
+-- one release as a fallback (see internal/sync/scheduler.go) but is no longer the
+-- source of truth.
+INSERT INTO sync_schedules (name, cron, preset, applies_to_all, enabled)
+SELECT
+    'Default schedule',
+    CASE COALESCE((SELECT value FROM app_config WHERE key = 'sync_interval_minutes'), '720')
+        WHEN '15'   THEN '*/15 * * * *'
+        WHEN '30'   THEN '*/30 * * * *'
+        WHEN '60'   THEN '0 * * * *'
+        WHEN '240'  THEN '0 */4 * * *'
+        WHEN '480'  THEN '0 */8 * * *'
+        WHEN '720'  THEN '0 */12 * * *'
+        WHEN '1440' THEN '0 0 * * *'
+        ELSE             '0 */12 * * *'
+    END,
+    'interval-migrated',
+    TRUE,
+    TRUE;
+
+-- +goose Down
+DROP TABLE IF EXISTS sync_schedule_connections;
+DROP TABLE IF EXISTS sync_schedules;

--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -119,10 +119,6 @@ UPDATE bank_connections SET consent_expiration_time = $2, status = 'pending_reau
 UPDATE bank_connections SET paused = $2, updated_at = NOW()
 WHERE id = $1 RETURNING *;
 
--- name: UpdateConnectionSyncInterval :one
-UPDATE bank_connections SET sync_interval_override_minutes = $2, updated_at = NOW()
-WHERE id = $1 RETURNING *;
-
 -- name: ListActiveUnpausedConnections :many
 SELECT * FROM bank_connections WHERE status = 'active' AND paused = false;
 

--- a/internal/db/queries/sync_schedules.sql
+++ b/internal/db/queries/sync_schedules.sql
@@ -20,7 +20,7 @@ FROM sync_schedules s
 ORDER BY s.created_at ASC;
 
 -- name: ListEnabledSyncSchedules :many
-SELECT id, cron, applies_to_all FROM sync_schedules WHERE enabled = true;
+SELECT id, name, cron, applies_to_all FROM sync_schedules WHERE enabled = true;
 
 -- name: ListSyncScheduleConnectionPairs :many
 SELECT schedule_id, connection_id FROM sync_schedule_connections;

--- a/internal/db/queries/sync_schedules.sql
+++ b/internal/db/queries/sync_schedules.sql
@@ -1,0 +1,70 @@
+-- name: CreateSyncSchedule :one
+INSERT INTO sync_schedules (name, cron, preset, applies_to_all, enabled)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING *;
+
+-- name: GetSyncSchedule :one
+SELECT * FROM sync_schedules WHERE id = $1;
+
+-- name: GetSyncScheduleByShortID :one
+SELECT * FROM sync_schedules WHERE short_id = $1;
+
+-- name: ListSyncSchedules :many
+SELECT
+    s.*,
+    s.applies_to_all OR EXISTS (
+        SELECT 1 FROM sync_schedule_connections sc WHERE sc.schedule_id = s.id
+    ) AS has_targets,
+    (SELECT COUNT(*) FROM sync_schedule_connections sc WHERE sc.schedule_id = s.id) AS connection_count
+FROM sync_schedules s
+ORDER BY s.created_at ASC;
+
+-- name: ListEnabledSyncSchedules :many
+SELECT id, cron, applies_to_all FROM sync_schedules WHERE enabled = true;
+
+-- name: ListSyncScheduleConnectionPairs :many
+SELECT schedule_id, connection_id FROM sync_schedule_connections;
+
+-- name: UpdateSyncSchedule :one
+UPDATE sync_schedules
+SET name = $2, cron = $3, preset = $4, applies_to_all = $5, enabled = $6, updated_at = NOW()
+WHERE id = $1
+RETURNING *;
+
+-- name: SetSyncScheduleEnabled :one
+UPDATE sync_schedules SET enabled = $2, updated_at = NOW()
+WHERE id = $1 RETURNING *;
+
+-- name: DeleteSyncSchedule :exec
+DELETE FROM sync_schedules WHERE id = $1;
+
+-- name: ListConnectionIDsForSchedule :many
+SELECT connection_id FROM sync_schedule_connections WHERE schedule_id = $1;
+
+-- name: ListConnectionShortIDsForSchedule :many
+SELECT bc.short_id
+FROM sync_schedule_connections sc
+JOIN bank_connections bc ON bc.id = sc.connection_id
+WHERE sc.schedule_id = $1
+ORDER BY bc.created_at;
+
+-- name: AddScheduleConnection :exec
+INSERT INTO sync_schedule_connections (schedule_id, connection_id)
+VALUES ($1, $2)
+ON CONFLICT (schedule_id, connection_id) DO NOTHING;
+
+-- name: ClearScheduleConnections :exec
+DELETE FROM sync_schedule_connections WHERE schedule_id = $1;
+
+-- name: ListSchedulesForConnection :many
+SELECT s.*
+FROM sync_schedules s
+WHERE s.enabled = true
+  AND (
+    s.applies_to_all
+    OR EXISTS (
+      SELECT 1 FROM sync_schedule_connections sc
+      WHERE sc.schedule_id = s.id AND sc.connection_id = $1
+    )
+  )
+ORDER BY s.created_at ASC;

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -304,40 +304,6 @@ func (s *Service) UpdateConnectionPaused(ctx context.Context, id string, paused 
 	return buildConnectionDetailResponse(conn), nil
 }
 
-// UpdateConnectionSyncInterval sets the per-connection sync interval
-// override in minutes. Pass nil to revert to the global default. Returns
-// ErrNotFound when the connection doesn't exist.
-func (s *Service) UpdateConnectionSyncInterval(ctx context.Context, id string, intervalMinutes *int, _ Actor) (*ConnectionDetailResponse, error) {
-	uid, err := s.resolveConnectionID(ctx, id)
-	if err != nil {
-		return nil, ErrNotFound
-	}
-
-	var interval pgtype.Int4
-	if intervalMinutes != nil && *intervalMinutes > 0 {
-		interval = pgtype.Int4{Int32: int32(*intervalMinutes), Valid: true}
-	}
-
-	if _, err := s.Queries.UpdateConnectionSyncInterval(ctx, db.UpdateConnectionSyncIntervalParams{
-		ID:                          uid,
-		SyncIntervalOverrideMinutes: interval,
-	}); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update connection sync interval: %w", err)
-	}
-
-	conn, err := s.Queries.GetConnectionForAPI(ctx, uid)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("get connection: %w", err)
-	}
-	return buildConnectionDetailResponse(conn), nil
-}
-
 // ResolveConnectionUUID resolves a UUID-or-short_id input into a pgtype.UUID
 // without fetching the row. Returns ErrNotFound for an unknown short_id and a
 // wrapped parse error for an invalid UUID. Public so non-service callers

--- a/internal/service/sync_schedules.go
+++ b/internal/service/sync_schedules.go
@@ -1,0 +1,266 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"breadbox/internal/cronspec"
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// ErrScheduleNotFound is returned when a sync schedule lookup finds no row.
+var ErrScheduleNotFound = errors.New("sync schedule not found")
+
+// SyncScheduleView is the API/UI-facing shape of a sync schedule.
+type SyncScheduleView struct {
+	ID              string `json:"id"`
+	ShortID         string `json:"short_id"`
+	Name            string `json:"name"`
+	Cron            string `json:"cron"`
+	CronHuman       string `json:"cron_human"`
+	Preset          string `json:"preset"`
+	AppliesToAll    bool   `json:"applies_to_all"`
+	Enabled         bool   `json:"enabled"`
+	ConnectionCount int64  `json:"connection_count"`
+}
+
+// SyncScheduleInput is the create/update payload. PresetKey selects a catalog
+// preset; when it is "custom" (or unknown) Cron is used verbatim.
+type SyncScheduleInput struct {
+	Name         string
+	PresetKey    string
+	Cron         string
+	AppliesToAll bool
+	Enabled      bool
+	// ConnectionIDs are connection UUIDs or short IDs to target. Ignored when
+	// AppliesToAll is true.
+	ConnectionIDs []string
+}
+
+func scheduleViewFromRow(r db.ListSyncSchedulesRow) SyncScheduleView {
+	preset := pgconv.TextOr(r.Preset, "")
+	return SyncScheduleView{
+		ID:              pgconv.FormatUUID(r.ID),
+		ShortID:         r.ShortID,
+		Name:            r.Name,
+		Cron:            r.Cron,
+		CronHuman:       cronspec.Humanize(r.Cron, preset),
+		Preset:          preset,
+		AppliesToAll:    r.AppliesToAll,
+		Enabled:         r.Enabled,
+		ConnectionCount: r.ConnectionCount,
+	}
+}
+
+func scheduleViewFromModel(r db.SyncSchedule, connCount int64) SyncScheduleView {
+	preset := pgconv.TextOr(r.Preset, "")
+	return SyncScheduleView{
+		ID:              pgconv.FormatUUID(r.ID),
+		ShortID:         r.ShortID,
+		Name:            r.Name,
+		Cron:            r.Cron,
+		CronHuman:       cronspec.Humanize(r.Cron, preset),
+		Preset:          preset,
+		AppliesToAll:    r.AppliesToAll,
+		Enabled:         r.Enabled,
+		ConnectionCount: connCount,
+	}
+}
+
+// ListSyncSchedules returns every schedule with its connection-target count.
+func (s *Service) ListSyncSchedules(ctx context.Context) ([]SyncScheduleView, error) {
+	rows, err := s.Queries.ListSyncSchedules(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list sync schedules: %w", err)
+	}
+	out := make([]SyncScheduleView, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, scheduleViewFromRow(r))
+	}
+	return out, nil
+}
+
+// CreateSyncSchedule validates the input, persists the schedule, and (unless it
+// applies to all) sets its connection targets in one transaction.
+func (s *Service) CreateSyncSchedule(ctx context.Context, in SyncScheduleInput) (SyncScheduleView, error) {
+	name := in.Name
+	if name == "" {
+		return SyncScheduleView{}, fmt.Errorf("schedule name is required")
+	}
+	expr, preset, err := cronspec.ResolveCron(in.PresetKey, in.Cron)
+	if err != nil {
+		return SyncScheduleView{}, err
+	}
+
+	connIDs, err := s.resolveConnectionIDs(ctx, in)
+	if err != nil {
+		return SyncScheduleView{}, err
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return SyncScheduleView{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	row, err := qtx.CreateSyncSchedule(ctx, db.CreateSyncScheduleParams{
+		Name:         name,
+		Cron:         expr,
+		Preset:       pgconv.TextIfNotEmpty(preset),
+		AppliesToAll: in.AppliesToAll,
+		Enabled:      in.Enabled,
+	})
+	if err != nil {
+		return SyncScheduleView{}, fmt.Errorf("create sync schedule: %w", err)
+	}
+	for _, cid := range connIDs {
+		if err := qtx.AddScheduleConnection(ctx, db.AddScheduleConnectionParams{
+			ScheduleID:   row.ID,
+			ConnectionID: cid,
+		}); err != nil {
+			return SyncScheduleView{}, fmt.Errorf("add schedule connection: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return SyncScheduleView{}, fmt.Errorf("commit: %w", err)
+	}
+	return scheduleViewFromModel(row, int64(len(connIDs))), nil
+}
+
+// UpdateSyncSchedule updates a schedule's fields and replaces its connection
+// targets. idOrShort accepts a UUID or short ID.
+func (s *Service) UpdateSyncSchedule(ctx context.Context, idOrShort string, in SyncScheduleInput) (SyncScheduleView, error) {
+	id, err := s.resolveScheduleID(ctx, idOrShort)
+	if err != nil {
+		return SyncScheduleView{}, err
+	}
+	name := in.Name
+	if name == "" {
+		return SyncScheduleView{}, fmt.Errorf("schedule name is required")
+	}
+	expr, preset, err := cronspec.ResolveCron(in.PresetKey, in.Cron)
+	if err != nil {
+		return SyncScheduleView{}, err
+	}
+	connIDs, err := s.resolveConnectionIDs(ctx, in)
+	if err != nil {
+		return SyncScheduleView{}, err
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return SyncScheduleView{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	row, err := qtx.UpdateSyncSchedule(ctx, db.UpdateSyncScheduleParams{
+		ID:           id,
+		Name:         name,
+		Cron:         expr,
+		Preset:       pgconv.TextIfNotEmpty(preset),
+		AppliesToAll: in.AppliesToAll,
+		Enabled:      in.Enabled,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return SyncScheduleView{}, ErrScheduleNotFound
+		}
+		return SyncScheduleView{}, fmt.Errorf("update sync schedule: %w", err)
+	}
+	if err := qtx.ClearScheduleConnections(ctx, id); err != nil {
+		return SyncScheduleView{}, fmt.Errorf("clear schedule connections: %w", err)
+	}
+	for _, cid := range connIDs {
+		if err := qtx.AddScheduleConnection(ctx, db.AddScheduleConnectionParams{
+			ScheduleID:   id,
+			ConnectionID: cid,
+		}); err != nil {
+			return SyncScheduleView{}, fmt.Errorf("add schedule connection: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return SyncScheduleView{}, fmt.Errorf("commit: %w", err)
+	}
+	return scheduleViewFromModel(row, int64(len(connIDs))), nil
+}
+
+// SetSyncScheduleEnabled toggles a schedule's enabled flag.
+func (s *Service) SetSyncScheduleEnabled(ctx context.Context, idOrShort string, enabled bool) error {
+	id, err := s.resolveScheduleID(ctx, idOrShort)
+	if err != nil {
+		return err
+	}
+	if _, err := s.Queries.SetSyncScheduleEnabled(ctx, db.SetSyncScheduleEnabledParams{
+		ID:      id,
+		Enabled: enabled,
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrScheduleNotFound
+		}
+		return fmt.Errorf("set sync schedule enabled: %w", err)
+	}
+	return nil
+}
+
+// DeleteSyncSchedule removes a schedule (and its connection mappings via cascade).
+func (s *Service) DeleteSyncSchedule(ctx context.Context, idOrShort string) error {
+	id, err := s.resolveScheduleID(ctx, idOrShort)
+	if err != nil {
+		return err
+	}
+	if err := s.Queries.DeleteSyncSchedule(ctx, id); err != nil {
+		return fmt.Errorf("delete sync schedule: %w", err)
+	}
+	return nil
+}
+
+// ListScheduleConnectionShortIDs returns the connection short IDs a schedule
+// targets, for pre-checking the edit form.
+func (s *Service) ListScheduleConnectionShortIDs(ctx context.Context, idOrShort string) ([]string, error) {
+	id, err := s.resolveScheduleID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	return s.Queries.ListConnectionShortIDsForSchedule(ctx, id)
+}
+
+// resolveScheduleID accepts a UUID or short ID and returns the schedule UUID.
+func (s *Service) resolveScheduleID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+	lookup := func(ctx context.Context, short string) (pgtype.UUID, error) {
+		row, err := s.Queries.GetSyncScheduleByShortID(ctx, short)
+		if err != nil {
+			return pgtype.UUID{}, err
+		}
+		return row.ID, nil
+	}
+	return s.resolveID(ctx, idOrShort, lookup, ErrScheduleNotFound)
+}
+
+// resolveConnectionIDs maps the input's connection identifiers to UUIDs. Returns
+// nil when the schedule applies to all connections (targets are ignored).
+func (s *Service) resolveConnectionIDs(ctx context.Context, in SyncScheduleInput) ([]pgtype.UUID, error) {
+	if in.AppliesToAll {
+		return nil, nil
+	}
+	out := make([]pgtype.UUID, 0, len(in.ConnectionIDs))
+	for _, raw := range in.ConnectionIDs {
+		if raw == "" {
+			continue
+		}
+		uid, err := s.resolveConnectionID(ctx, raw)
+		if err != nil {
+			return nil, fmt.Errorf("resolve connection %q: %w", raw, err)
+		}
+		out = append(out, uid)
+	}
+	return out, nil
+}

--- a/internal/service/sync_schedules.go
+++ b/internal/service/sync_schedules.go
@@ -223,6 +223,53 @@ func (s *Service) DeleteSyncSchedule(ctx context.Context, idOrShort string) erro
 	return nil
 }
 
+// ScheduleRef is a lightweight (name, cron) pair used to describe the schedules
+// that apply to a connection — for rendering "next sync" / "syncs on" without
+// loading full schedule rows per connection.
+type ScheduleRef struct {
+	Name string `json:"name"`
+	Cron string `json:"cron"`
+}
+
+// SyncScheduleResolution loads the enabled schedules once and returns the
+// `applies_to_all` schedules plus a per-connection map (keyed by connection
+// UUID string) of explicitly-targeted schedules. A connection's effective
+// schedules are `all` + `perConn[uuid]` — mirroring the scheduler's resolver,
+// but name-carrying and for display. Cheap: two queries regardless of count.
+func (s *Service) SyncScheduleResolution(ctx context.Context) (all []ScheduleRef, perConn map[string][]ScheduleRef, err error) {
+	rows, err := s.Queries.ListEnabledSyncSchedules(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list enabled sync schedules: %w", err)
+	}
+	pairs, err := s.Queries.ListSyncScheduleConnectionPairs(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list sync schedule connection pairs: %w", err)
+	}
+
+	byID := make(map[[16]byte]ScheduleRef, len(rows))
+	appliesAll := make(map[[16]byte]bool, len(rows))
+	for _, row := range rows {
+		ref := ScheduleRef{Name: row.Name, Cron: row.Cron}
+		byID[row.ID.Bytes] = ref
+		appliesAll[row.ID.Bytes] = row.AppliesToAll
+		if row.AppliesToAll {
+			all = append(all, ref)
+		}
+	}
+
+	perConn = make(map[string][]ScheduleRef)
+	for _, p := range pairs {
+		if appliesAll[p.ScheduleID.Bytes] {
+			continue
+		}
+		if ref, ok := byID[p.ScheduleID.Bytes]; ok {
+			key := pgconv.FormatUUID(p.ConnectionID)
+			perConn[key] = append(perConn[key], ref)
+		}
+	}
+	return all, perConn, nil
+}
+
 // ListScheduleConnectionShortIDs returns the connection short IDs a schedule
 // targets, for pre-checking the edit form.
 func (s *Service) ListScheduleConnectionShortIDs(ctx context.Context, idOrShort string) ([]string, error) {

--- a/internal/service/sync_schedules_integration_test.go
+++ b/internal/service/sync_schedules_integration_test.go
@@ -1,0 +1,172 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+func TestSyncSchedules_CreateAppliesToAll(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	view, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name:         "Nightly",
+		PresetKey:    "nightly",
+		AppliesToAll: true,
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if view.Cron != "0 3 * * *" {
+		t.Errorf("expected nightly cron, got %q", view.Cron)
+	}
+	if !view.AppliesToAll || view.ConnectionCount != 0 {
+		t.Errorf("applies_to_all schedule should have 0 explicit connections, got %d", view.ConnectionCount)
+	}
+	if view.CronHuman != "Nightly (3 AM)" {
+		t.Errorf("unexpected human cron %q", view.CronHuman)
+	}
+}
+
+func TestSyncSchedules_CreateWithConnectionTargets(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	c1 := testutil.MustCreateConnection(t, queries, user.ID, "item_a")
+	c2 := testutil.MustCreateConnection(t, queries, user.ID, "item_b")
+
+	view, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name:          "Checking hourly",
+		PresetKey:     "hourly",
+		AppliesToAll:  false,
+		Enabled:       true,
+		ConnectionIDs: []string{c1.ShortID, c2.ShortID},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if view.ConnectionCount != 2 {
+		t.Errorf("expected 2 targeted connections, got %d", view.ConnectionCount)
+	}
+
+	shortIDs, err := svc.ListScheduleConnectionShortIDs(ctx, view.ShortID)
+	if err != nil {
+		t.Fatalf("list conn short ids: %v", err)
+	}
+	if len(shortIDs) != 2 {
+		t.Errorf("expected 2 short ids, got %d", len(shortIDs))
+	}
+}
+
+func TestSyncSchedules_UpdateReplacesTargets(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	c1 := testutil.MustCreateConnection(t, queries, user.ID, "item_a")
+	c2 := testutil.MustCreateConnection(t, queries, user.ID, "item_b")
+
+	view, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name: "S", PresetKey: "hourly", ConnectionIDs: []string{c1.ShortID},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Update to target only c2.
+	updated, err := svc.UpdateSyncSchedule(ctx, view.ShortID, service.SyncScheduleInput{
+		Name: "S2", PresetKey: "every_4h", ConnectionIDs: []string{c2.ShortID},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "S2" || updated.Cron != "0 */4 * * *" {
+		t.Errorf("update didn't persist fields: %+v", updated)
+	}
+	shortIDs, _ := svc.ListScheduleConnectionShortIDs(ctx, view.ShortID)
+	if len(shortIDs) != 1 || shortIDs[0] != c2.ShortID {
+		t.Errorf("expected targets replaced with [c2], got %v", shortIDs)
+	}
+}
+
+func TestSyncSchedules_CustomCronValidation(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if _, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name: "Bad", PresetKey: "custom", Cron: "not a cron",
+	}); err == nil {
+		t.Fatal("expected error for invalid custom cron")
+	}
+
+	view, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name: "Good", PresetKey: "custom", Cron: "0 6,18 * * *", AppliesToAll: true,
+	})
+	if err != nil {
+		t.Fatalf("valid custom cron should succeed: %v", err)
+	}
+	if view.Preset != "custom" || view.Cron != "0 6,18 * * *" {
+		t.Errorf("unexpected stored custom schedule: %+v", view)
+	}
+}
+
+func TestSyncSchedules_ToggleAndDelete(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	view, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name: "Toggle me", PresetKey: "hourly", AppliesToAll: true, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := svc.SetSyncScheduleEnabled(ctx, view.ShortID, false); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	list, _ := svc.ListSyncSchedules(ctx)
+	if len(list) != 1 || list[0].Enabled {
+		t.Errorf("expected schedule disabled, got %+v", list)
+	}
+
+	if err := svc.DeleteSyncSchedule(ctx, view.ShortID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	list, _ = svc.ListSyncSchedules(ctx)
+	if len(list) != 0 {
+		t.Errorf("expected 0 schedules after delete, got %d", len(list))
+	}
+}
+
+func TestSyncSchedules_DeleteCascadesTargets(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	c1 := testutil.MustCreateConnection(t, queries, user.ID, "item_a")
+
+	view, err := svc.CreateSyncSchedule(ctx, service.SyncScheduleInput{
+		Name: "S", PresetKey: "hourly", ConnectionIDs: []string{c1.ShortID},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := svc.DeleteSyncSchedule(ctx, view.ShortID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	// The join rows must be gone (ON DELETE CASCADE).
+	var count int
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM sync_schedule_connections").Scan(&count); err != nil {
+		t.Fatalf("count join rows: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected join rows cascaded away, got %d", count)
+	}
+}

--- a/internal/sync/schedule.go
+++ b/internal/sync/schedule.go
@@ -1,0 +1,177 @@
+//go:build !lite
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// jitterWindow spreads connections that share a fire time across a few minutes
+// so a popular schedule (e.g. everything at 6:00am) doesn't fire every
+// connection in the same 15-minute tick. The offset is deterministic per
+// connection, so a given connection always lands in the same slot.
+const jitterWindow = 10 * time.Minute
+
+// backoffBaseMinutes is the base unit for failure backoff. A connection with
+// consecutive failures is suppressed for backoffInterval(15, failures) minutes
+// past its last error before it is allowed to retry, regardless of how
+// frequently its schedule would otherwise fire.
+const backoffBaseMinutes = 15
+
+// scheduleResolver maps a connection to the cron schedules that apply to it:
+// the union of all `applies_to_all` schedules plus any explicitly targeting it.
+// Built once per tick from the DB so a single ListEnabledSyncSchedules +
+// ListSyncScheduleConnectionPairs covers every connection.
+type scheduleResolver struct {
+	all     []cron.Schedule
+	perConn map[[16]byte][]cron.Schedule
+}
+
+// forConnection returns every cron schedule that applies to the connection.
+// The slice is freshly allocated so callers may not mutate the resolver state.
+func (r *scheduleResolver) forConnection(id [16]byte) []cron.Schedule {
+	if len(r.all) == 0 {
+		return r.perConn[id]
+	}
+	out := make([]cron.Schedule, 0, len(r.all)+len(r.perConn[id]))
+	out = append(out, r.all...)
+	out = append(out, r.perConn[id]...)
+	return out
+}
+
+// loadScheduleResolver reads the enabled schedules and their connection
+// mappings and builds a resolver. Invalid cron specs are skipped with a warning
+// rather than failing the whole tick. If the schedules table is empty (e.g. a
+// brand-new deployment before the seed lands), a single fallback schedule is
+// synthesized from the legacy interval so auto-sync never silently stops.
+func (s *Scheduler) loadScheduleResolver(ctx context.Context, fallbackIntervalMinutes int) (*scheduleResolver, error) {
+	rows, err := s.queries.ListEnabledSyncSchedules(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list enabled sync schedules: %w", err)
+	}
+	pairs, err := s.queries.ListSyncScheduleConnectionPairs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list sync schedule connection pairs: %w", err)
+	}
+
+	r := &scheduleResolver{perConn: make(map[[16]byte][]cron.Schedule)}
+	parsed := make(map[[16]byte]cron.Schedule, len(rows))
+	appliesToAll := make(map[[16]byte]bool, len(rows))
+
+	for _, row := range rows {
+		sc, err := cron.ParseStandard(row.Cron)
+		if err != nil {
+			s.logger.Warn("skipping sync schedule with invalid cron", "cron", row.Cron, "error", err)
+			continue
+		}
+		parsed[row.ID.Bytes] = sc
+		appliesToAll[row.ID.Bytes] = row.AppliesToAll
+		if row.AppliesToAll {
+			r.all = append(r.all, sc)
+		}
+	}
+
+	for _, p := range pairs {
+		// `applies_to_all` schedules already cover every connection; their
+		// explicit mappings (if any) are redundant, so skip them here.
+		if appliesToAll[p.ScheduleID.Bytes] {
+			continue
+		}
+		if sc, ok := parsed[p.ScheduleID.Bytes]; ok {
+			r.perConn[p.ConnectionID.Bytes] = append(r.perConn[p.ConnectionID.Bytes], sc)
+		}
+	}
+
+	if len(rows) == 0 {
+		if sc := intervalFallbackSchedule(fallbackIntervalMinutes); sc != nil {
+			s.logger.Warn("no sync schedules configured, falling back to legacy interval",
+				"interval_minutes", fallbackIntervalMinutes)
+			r.all = append(r.all, sc)
+		}
+	}
+
+	return r, nil
+}
+
+// intervalFallbackSchedule turns the legacy interval (minutes) into a cron
+// schedule. Only used when the schedules table is empty.
+func intervalFallbackSchedule(minutes int) cron.Schedule {
+	if minutes <= 0 {
+		minutes = 720
+	}
+	sc, err := cron.ParseStandard(fmt.Sprintf("@every %dm", minutes))
+	if err != nil {
+		return nil
+	}
+	return sc
+}
+
+// scheduleDue reports whether a connection is due to sync now given its
+// applicable schedules and last successful sync. A connection with no schedules
+// is never due via cron (manual/webhook still work). A never-synced connection
+// (lastSynced zero) is due as long as it has at least one schedule.
+//
+// For each schedule we ask: has a fire time occurred between lastSynced and now
+// (offset by the connection's jitter)? `Next(lastSynced)` is the first fire
+// strictly after the last sync; if that moment (plus jitter) has already
+// passed, the scheduled sync was missed and is now due.
+func scheduleDue(schedules []cron.Schedule, lastSynced, now time.Time, jitter time.Duration) bool {
+	if len(schedules) == 0 {
+		return false
+	}
+	if lastSynced.IsZero() {
+		return true
+	}
+	for _, sc := range schedules {
+		fireAt := sc.Next(lastSynced).Add(jitter)
+		if !fireAt.After(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// scheduleNextRun returns the earliest upcoming fire time across the
+// connection's schedules (with jitter applied), for display. Zero if none.
+func scheduleNextRun(schedules []cron.Schedule, now time.Time, jitter time.Duration) time.Time {
+	var earliest time.Time
+	for _, sc := range schedules {
+		n := sc.Next(now).Add(jitter)
+		if earliest.IsZero() || n.Before(earliest) {
+			earliest = n
+		}
+	}
+	return earliest
+}
+
+// connectionJitter derives a stable per-connection offset in [0, window) from
+// the connection UUID so connections sharing a fire time stagger across ticks.
+func connectionJitter(id [16]byte, window time.Duration) time.Duration {
+	if window <= 0 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write(id[:])
+	secs := int64(window / time.Second)
+	if secs <= 0 {
+		return 0
+	}
+	return time.Duration(int64(h.Sum32())%secs) * time.Second
+}
+
+// backoffSuppressed reports whether a failing connection should be held back
+// from retrying: true while now is within backoffInterval(15, failures) minutes
+// of the last error. Layered on top of the schedule check so a frequently-firing
+// schedule doesn't hammer a broken connection every tick.
+func backoffSuppressed(consecutiveFailures int32, lastErrorAt time.Time, now time.Time) bool {
+	if consecutiveFailures <= 0 || lastErrorAt.IsZero() {
+		return false
+	}
+	delay := time.Duration(backoffInterval(backoffBaseMinutes, consecutiveFailures)) * time.Minute
+	return now.Before(lastErrorAt.Add(delay))
+}

--- a/internal/sync/schedule_resolver_integration_test.go
+++ b/internal/sync/schedule_resolver_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration && !lite
+
+package sync
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/testutil"
+)
+
+// TestLoadScheduleResolver verifies the DB → resolver mapping: applies_to_all
+// schedules reach every connection, targeted schedules reach only their
+// connection, and disabled schedules are excluded.
+func TestLoadScheduleResolver(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	c1 := testutil.MustCreateConnection(t, queries, user.ID, "item_a")
+	c2 := testutil.MustCreateConnection(t, queries, user.ID, "item_b")
+
+	// An applies_to_all nightly schedule.
+	all, err := queries.CreateSyncSchedule(ctx, db.CreateSyncScheduleParams{
+		Name: "All nightly", Cron: "0 3 * * *", Preset: pgconv.Text("nightly"),
+		AppliesToAll: true, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create all schedule: %v", err)
+	}
+	// A targeted hourly schedule on c1 only.
+	targeted, err := queries.CreateSyncSchedule(ctx, db.CreateSyncScheduleParams{
+		Name: "C1 hourly", Cron: "0 * * * *", Preset: pgconv.Text("hourly"),
+		AppliesToAll: false, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create targeted schedule: %v", err)
+	}
+	if err := queries.AddScheduleConnection(ctx, db.AddScheduleConnectionParams{
+		ScheduleID: targeted.ID, ConnectionID: c1.ID,
+	}); err != nil {
+		t.Fatalf("add schedule connection: %v", err)
+	}
+	// A disabled schedule that must NOT appear.
+	if _, err := queries.CreateSyncSchedule(ctx, db.CreateSyncScheduleParams{
+		Name: "Disabled", Cron: "*/15 * * * *", Preset: pgconv.Text("every_15m"),
+		AppliesToAll: true, Enabled: false,
+	}); err != nil {
+		t.Fatalf("create disabled schedule: %v", err)
+	}
+	_ = all
+
+	s := &Scheduler{queries: queries, logger: slog.Default(), syncTimeout: time.Minute}
+	resolver, err := s.loadScheduleResolver(ctx, 720)
+	if err != nil {
+		t.Fatalf("loadScheduleResolver: %v", err)
+	}
+
+	// c1 gets the all-schedule + its targeted one = 2.
+	if got := len(resolver.forConnection(c1.ID.Bytes)); got != 2 {
+		t.Errorf("c1 expected 2 schedules, got %d", got)
+	}
+	// c2 gets only the all-schedule = 1 (disabled one excluded).
+	if got := len(resolver.forConnection(c2.ID.Bytes)); got != 1 {
+		t.Errorf("c2 expected 1 schedule, got %d", got)
+	}
+	_ = pool
+}

--- a/internal/sync/schedule_test.go
+++ b/internal/sync/schedule_test.go
@@ -1,0 +1,158 @@
+//go:build !lite
+
+package sync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+func mustCron(t *testing.T, expr string) cron.Schedule {
+	t.Helper()
+	s, err := cron.ParseStandard(expr)
+	if err != nil {
+		t.Fatalf("parse %q: %v", expr, err)
+	}
+	return s
+}
+
+func TestScheduleDue(t *testing.T) {
+	// Nightly at 03:00.
+	nightly := mustCron(t, "0 3 * * *")
+	// Reference "now" = 2026-06-04 09:00 local.
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name       string
+		schedules  []cron.Schedule
+		lastSynced time.Time
+		want       bool
+	}{
+		{
+			name:      "no schedules is never due",
+			schedules: nil,
+			want:      false,
+		},
+		{
+			name:       "never synced is due when a schedule exists",
+			schedules:  []cron.Schedule{nightly},
+			lastSynced: time.Time{},
+			want:       true,
+		},
+		{
+			name:       "synced after last fire is not due",
+			schedules:  []cron.Schedule{nightly},
+			lastSynced: time.Date(2026, 6, 4, 3, 30, 0, 0, time.Local), // after 03:00 fire
+			want:       false,
+		},
+		{
+			name:       "synced before last fire is due",
+			schedules:  []cron.Schedule{nightly},
+			lastSynced: time.Date(2026, 6, 3, 23, 0, 0, 0, time.Local), // before the 03:00 fire
+			want:       true,
+		},
+		{
+			name: "union: due if ANY schedule fired since last sync",
+			schedules: []cron.Schedule{
+				mustCron(t, "0 3 * * *"), // last fired 03:00 — before lastSynced
+				mustCron(t, "0 8 * * *"), // last fired 08:00 — after lastSynced → due
+			},
+			lastSynced: time.Date(2026, 6, 4, 7, 0, 0, 0, time.Local),
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scheduleDue(tt.schedules, tt.lastSynced, now, 0); got != tt.want {
+				t.Errorf("scheduleDue = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduleDueNoDrift(t *testing.T) {
+	// A 12h schedule fires at 00:00 and 12:00 regardless of when the last sync
+	// landed — the wall-clock anchor, not last_synced + interval.
+	twelveH := mustCron(t, "0 */12 * * *")
+	// Last synced at an odd offset (02:47).
+	lastSynced := time.Date(2026, 6, 4, 2, 47, 0, 0, time.Local)
+
+	// At 11:59 the next fire (12:00) hasn't happened yet since 02:47 → not due.
+	at1159 := time.Date(2026, 6, 4, 11, 59, 0, 0, time.Local)
+	if scheduleDue([]cron.Schedule{twelveH}, lastSynced, at1159, 0) {
+		t.Errorf("should not be due at 11:59 (next fire is 12:00)")
+	}
+	// At 12:01 the 12:00 fire has passed → due, anchored to the wall clock.
+	at1201 := time.Date(2026, 6, 4, 12, 1, 0, 0, time.Local)
+	if !scheduleDue([]cron.Schedule{twelveH}, lastSynced, at1201, 0) {
+		t.Errorf("should be due at 12:01 (12:00 fire passed)")
+	}
+}
+
+func TestScheduleDueJitterDelays(t *testing.T) {
+	nightly := mustCron(t, "0 3 * * *")
+	lastSynced := time.Date(2026, 6, 3, 23, 0, 0, 0, time.Local)
+	// Exactly at the fire instant with a 5-minute jitter: not yet due.
+	at0300 := time.Date(2026, 6, 4, 3, 0, 0, 0, time.Local)
+	jitter := 5 * time.Minute
+	if scheduleDue([]cron.Schedule{nightly}, lastSynced, at0300, jitter) {
+		t.Errorf("should not be due at 03:00 with 5m jitter")
+	}
+	// Six minutes later, past the jitter window: due.
+	at0306 := time.Date(2026, 6, 4, 3, 6, 0, 0, time.Local)
+	if !scheduleDue([]cron.Schedule{nightly}, lastSynced, at0306, jitter) {
+		t.Errorf("should be due at 03:06 with 5m jitter")
+	}
+}
+
+func TestConnectionJitterDeterministic(t *testing.T) {
+	id := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	a := connectionJitter(id, jitterWindow)
+	b := connectionJitter(id, jitterWindow)
+	if a != b {
+		t.Errorf("jitter not deterministic: %v != %v", a, b)
+	}
+	if a < 0 || a >= jitterWindow {
+		t.Errorf("jitter %v out of range [0, %v)", a, jitterWindow)
+	}
+	// Zero window → zero jitter.
+	if connectionJitter(id, 0) != 0 {
+		t.Errorf("zero window should give zero jitter")
+	}
+}
+
+func TestScheduleNextRun(t *testing.T) {
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.Local)
+	schedules := []cron.Schedule{
+		mustCron(t, "0 18 * * *"), // next fire 18:00
+		mustCron(t, "0 12 * * *"), // next fire 12:00 — earliest
+	}
+	next := scheduleNextRun(schedules, now, 0)
+	want := time.Date(2026, 6, 4, 12, 0, 0, 0, time.Local)
+	if !next.Equal(want) {
+		t.Errorf("scheduleNextRun = %v, want %v", next, want)
+	}
+	if !scheduleNextRun(nil, now, 0).IsZero() {
+		t.Errorf("no schedules should give zero next run")
+	}
+}
+
+func TestBackoffSuppressed(t *testing.T) {
+	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.Local)
+	// 1 failure → backoffInterval(15,1)=30m suppression.
+	lastErr := now.Add(-10 * time.Minute)
+	if !backoffSuppressed(1, lastErr, now) {
+		t.Errorf("should be suppressed 10m after error with 1 failure (30m window)")
+	}
+	lastErrOld := now.Add(-31 * time.Minute)
+	if backoffSuppressed(1, lastErrOld, now) {
+		t.Errorf("should not be suppressed 31m after error with 1 failure (30m window)")
+	}
+	// No failures → never suppressed.
+	if backoffSuppressed(0, lastErr, now) {
+		t.Errorf("zero failures should never suppress")
+	}
+}

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -35,14 +35,15 @@ func NewScheduler(engine *Engine, queries *db.Queries, logger *slog.Logger, sync
 	}
 }
 
-// Start begins the cron scheduler. Cron fires every 15 minutes (the minimum
-// supported interval) and checks each connection's staleness individually.
+// Start begins the cron scheduler. The tick fires every 15 minutes (the
+// evaluation granularity) and checks each connection against its wall-clock sync
+// schedules. fallbackIntervalMinutes is only consulted if no schedules exist.
 // It also schedules a daily sync log cleanup job.
-func (s *Scheduler) Start(globalIntervalMinutes int) {
+func (s *Scheduler) Start(fallbackIntervalMinutes int) {
 	_, err := s.cron.AddFunc("@every 15m", func() {
 		ctx := context.Background()
 		s.logger.Info("cron sync starting")
-		synced, skipped := s.syncAllScheduled(ctx, globalIntervalMinutes)
+		synced, skipped := s.syncAllScheduled(ctx, fallbackIntervalMinutes)
 		s.logger.Info("cron sync completed", "synced", synced, "skipped", skipped)
 	})
 	if err != nil {
@@ -60,7 +61,7 @@ func (s *Scheduler) Start(globalIntervalMinutes int) {
 	}
 
 	s.cron.Start()
-	s.logger.Info("scheduler started", "check_interval", "15m", "global_sync_interval_minutes", globalIntervalMinutes)
+	s.logger.Info("scheduler started", "check_interval", "15m", "fallback_interval_minutes", fallbackIntervalMinutes)
 }
 
 // IsRunning returns true if the scheduler has any active cron entries.
@@ -108,9 +109,12 @@ func backoffInterval(baseMinutes int, consecutiveFailures int32) int {
 	return baseMinutes * (1 << exp)
 }
 
-// syncAllScheduled syncs all active, unpaused connections that are stale
-// according to their effective interval (per-connection override or global).
-func (s *Scheduler) syncAllScheduled(ctx context.Context, globalIntervalMinutes int) (synced, skipped int) {
+// syncAllScheduled syncs all active, unpaused connections that are due
+// according to their effective sync schedules (the union of `applies_to_all`
+// schedules plus any explicitly targeting the connection). Wall-clock anchored:
+// a connection is due when a scheduled fire time has passed since its last
+// successful sync. fallbackIntervalMinutes is only used if no schedules exist.
+func (s *Scheduler) syncAllScheduled(ctx context.Context, fallbackIntervalMinutes int) (synced, skipped int) {
 	connections, err := s.queries.ListActiveUnpausedConnections(ctx)
 	if err != nil {
 		s.logger.Error("list active unpaused connections", "error", err)
@@ -122,6 +126,12 @@ func (s *Scheduler) syncAllScheduled(ctx context.Context, globalIntervalMinutes 
 		return 0, 0
 	}
 
+	resolver, err := s.loadScheduleResolver(ctx, fallbackIntervalMinutes)
+	if err != nil {
+		s.logger.Error("load sync schedules", "error", err)
+		return 0, 0
+	}
+
 	now := time.Now()
 	const maxWorkers = 5
 	sem := make(chan struct{}, maxWorkers)
@@ -130,21 +140,24 @@ func (s *Scheduler) syncAllScheduled(ctx context.Context, globalIntervalMinutes 
 	done := make(chan result, len(connections))
 
 	for _, conn := range connections {
-		// Compute effective interval with backoff for consecutive failures.
-		baseMinutes := globalIntervalMinutes
-		if conn.SyncIntervalOverrideMinutes.Valid {
-			baseMinutes = int(conn.SyncIntervalOverrideMinutes.Int32)
+		// Hold back a failing connection until its backoff window elapses,
+		// regardless of how frequently its schedule would otherwise fire.
+		if conn.LastErrorAt.Valid && backoffSuppressed(conn.ConsecutiveFailures, conn.LastErrorAt.Time, now) {
+			skipped++
+			done <- result{}
+			continue
 		}
-		effectiveMinutes := backoffInterval(baseMinutes, conn.ConsecutiveFailures)
 
-		// Skip if not stale.
+		schedules := resolver.forConnection(conn.ID.Bytes)
+		jitter := connectionJitter(conn.ID.Bytes, jitterWindow)
+		lastSynced := time.Time{}
 		if conn.LastSyncedAt.Valid {
-			nextSync := conn.LastSyncedAt.Time.Add(time.Duration(effectiveMinutes) * time.Minute)
-			if nextSync.After(now) {
-				skipped++
-				done <- result{}
-				continue
-			}
+			lastSynced = conn.LastSyncedAt.Time
+		}
+		if !scheduleDue(schedules, lastSynced, now, jitter) {
+			skipped++
+			done <- result{}
+			continue
 		}
 
 		connID := conn.ID
@@ -172,9 +185,10 @@ func (s *Scheduler) syncAllScheduled(ctx context.Context, globalIntervalMinutes 
 	return synced, skipped
 }
 
-// RunStartupSync checks all active, unpaused connections and syncs any that
-// are stale (last synced more than their effective interval ago or never synced).
-func (s *Scheduler) RunStartupSync(ctx context.Context, globalIntervalMinutes int) {
+// RunStartupSync checks all active, unpaused connections and syncs any that are
+// due according to their schedules (a scheduled fire was missed while the server
+// was down, or the connection has never synced). This is the catch-up path.
+func (s *Scheduler) RunStartupSync(ctx context.Context, fallbackIntervalMinutes int) {
 	connections, err := s.queries.ListActiveUnpausedConnections(ctx)
 	if err != nil {
 		s.logger.Error("startup sync: failed to list connections", "error", err)
@@ -186,18 +200,26 @@ func (s *Scheduler) RunStartupSync(ctx context.Context, globalIntervalMinutes in
 		return
 	}
 
+	resolver, err := s.loadScheduleResolver(ctx, fallbackIntervalMinutes)
+	if err != nil {
+		s.logger.Error("startup sync: load sync schedules", "error", err)
+		return
+	}
+
 	now := time.Now()
 	var staleCount int
 
 	for _, conn := range connections {
-		baseMinutes := globalIntervalMinutes
-		if conn.SyncIntervalOverrideMinutes.Valid {
-			baseMinutes = int(conn.SyncIntervalOverrideMinutes.Int32)
+		if conn.LastErrorAt.Valid && backoffSuppressed(conn.ConsecutiveFailures, conn.LastErrorAt.Time, now) {
+			continue
 		}
-		effectiveMinutes := backoffInterval(baseMinutes, conn.ConsecutiveFailures)
-
-		threshold := now.Add(-time.Duration(effectiveMinutes) * time.Minute)
-		if !conn.LastSyncedAt.Valid || conn.LastSyncedAt.Time.Before(threshold) {
+		schedules := resolver.forConnection(conn.ID.Bytes)
+		jitter := connectionJitter(conn.ID.Bytes, jitterWindow)
+		lastSynced := time.Time{}
+		if conn.LastSyncedAt.Valid {
+			lastSynced = conn.LastSyncedAt.Time
+		}
+		if scheduleDue(schedules, lastSynced, now, jitter) {
 			staleCount++
 			syncCtx, cancel := context.WithTimeout(ctx, s.syncTimeout)
 			if err := s.engine.Sync(syncCtx, conn.ID, db.SyncTriggerCron); err != nil {

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strings"
 
 	"breadbox/internal/templates/components"
 )
@@ -125,8 +126,10 @@ templ connDetailBadges(p ConnectionDetailProps) {
 				<span class="badge badge-soft badge-error badge-sm cursor-help">Sync Error</span>
 				if p.LastSyncErrorMessageValid {
 					<span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-						<span class="flex items-center gap-1.5 text-error font-medium mb-1">@components.LucideIcon("alert-circle", "w-3 h-3")
-Last sync failed</span>
+						<span class="flex items-center gap-1.5 text-error font-medium mb-1">
+							@components.LucideIcon("alert-circle", "w-3 h-3")
+							Last sync failed
+						</span>
 						<span class="text-base-content/70">{ p.LastSyncErrorMessageString }</span>
 					</span>
 				}
@@ -241,8 +244,8 @@ templ connDetailSyncHealth(p ConnectionDetailProps) {
 						{ p.NextSync.Label }
 					}
 				</div>
-				if !p.NextSync.IsDisconnected && !p.NextSync.IsPaused {
-					<div class="text-[0.6rem] text-base-content/30 mt-0.5 tabular-nums">{ "every " + components.FormatIntervalMinutes(p.NextSync.EffectiveIntervalMinutes) }</div>
+				if !p.NextSync.IsDisconnected && !p.NextSync.IsPaused && len(p.NextSync.ScheduleNames) > 0 {
+					<div class="text-[0.6rem] text-base-content/30 mt-0.5 truncate">{ "Syncs on: " + strings.Join(p.NextSync.ScheduleNames, ", ") }</div>
 				}
 			</div>
 			<div class="p-4">
@@ -351,20 +354,17 @@ templ connDetailInfoGrid(p ConnectionDetailProps) {
 				</div>
 			</div>
 			<div class="p-4">
-				<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider mb-1.5">Sync Interval</div>
-				<div>
-					<select id="sync-interval" @change="updateSyncInterval($event.target.value)" class="select select-xs w-full">
-						@connDetailIntervalOption("", "Global default", !p.SyncIntervalOverrideMinutesValid, false, false)
-						@connDetailIntervalOption("15", "Every 15 min", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 15)
-						@connDetailIntervalOption("30", "Every 30 min", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 30)
-						@connDetailIntervalOption("60", "Every hour", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 60)
-						@connDetailIntervalOption("120", "Every 2 hours", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 120)
-						@connDetailIntervalOption("240", "Every 4 hours", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 240)
-						@connDetailIntervalOption("720", "Every 12 hours", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 720)
-						@connDetailIntervalOption("1440", "Every 24 hours", false, p.SyncIntervalOverrideMinutesValid, p.SyncIntervalOverrideMinutesValue == 1440)
-					</select>
-					<span id="interval-status" class="text-[0.6rem] text-base-content/30 mt-0.5 block"></span>
+				<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider mb-1.5">Sync Schedule</div>
+				<div class="text-sm font-semibold">
+					if len(p.NextSync.ScheduleNames) > 0 {
+						{ strings.Join(p.NextSync.ScheduleNames, ", ") }
+					} else if p.NextSync.IsDisconnected {
+						<span class="text-base-content/30">N/A</span>
+					} else {
+						<span class="text-base-content/30">No schedule</span>
+					}
 				</div>
+				<a href="/settings/general#sync" class="text-[0.6rem] text-info/80 hover:text-info mt-0.5 inline-block">Manage schedules</a>
 			</div>
 		</div>
 		if p.ConsecutiveFailures > 0 {
@@ -386,16 +386,6 @@ templ connDetailInfoGrid(p ConnectionDetailProps) {
 			</div>
 		}
 	</div>
-}
-
-templ connDetailIntervalOption(value, label string, defaultSelected, overrideValid, match bool) {
-	if defaultSelected {
-		<option value={ value } selected>{ label }</option>
-	} else if overrideValid && match {
-		<option value={ value } selected>{ label }</option>
-	} else {
-		<option value={ value }>{ label }</option>
-	}
 }
 
 templ connDetailAccounts(p ConnectionDetailProps) {

--- a/internal/templates/components/pages/connection_detail_types.go
+++ b/internal/templates/components/pages/connection_detail_types.go
@@ -6,47 +6,47 @@ package pages
 // read off the layout. Kept flat so admin/connections.go can copy fields
 // one-to-one.
 type ConnectionDetailProps struct {
-	ConnID      string
-	CSRFToken   string
+	ConnID    string
+	CSRFToken string
 
 	// Connection fields (flattened from db.GetBankConnectionRow)
-	Provider                          string
-	Status                            string
-	InstitutionName                   string
-	UserName                          string
-	UserNameValid                     bool
-	Paused                            bool
-	ConsecutiveFailures               int32
-	HasErrorCode                      bool
-	ErrorCode                         string
-	HasErrorMessage                   bool
-	ErrorMessage                      string
-	LastSyncedAtValid                 bool
-	LastSyncedAtRelative              string
-	CreatedAtValid                    bool
-	CreatedAtFormatted                string
-	LastErrorAtValid                  bool
-	LastErrorAtRelative               string
-	SyncIntervalOverrideMinutesValid  bool
-	SyncIntervalOverrideMinutesValue  int32
+	Provider                         string
+	Status                           string
+	InstitutionName                  string
+	UserName                         string
+	UserNameValid                    bool
+	Paused                           bool
+	ConsecutiveFailures              int32
+	HasErrorCode                     bool
+	ErrorCode                        string
+	HasErrorMessage                  bool
+	ErrorMessage                     string
+	LastSyncedAtValid                bool
+	LastSyncedAtRelative             string
+	CreatedAtValid                   bool
+	CreatedAtFormatted               string
+	LastErrorAtValid                 bool
+	LastErrorAtRelative              string
+	SyncIntervalOverrideMinutesValid bool
+	SyncIntervalOverrideMinutesValue int32
 
 	// Latest sync log status (for header badge — matches list page).
-	LastSyncStatus              string
-	LastSyncErrorMessageValid   bool
-	LastSyncErrorMessageString  string
+	LastSyncStatus             string
+	LastSyncErrorMessageValid  bool
+	LastSyncErrorMessageString string
 
 	// Sync health stats
-	TotalSyncs           int
-	SuccessSyncs         int
-	ErrorSyncs           int
-	SuccessRate          float64
-	TotalAdded           int
-	TotalModified        int
-	TotalRemoved         int
-	AvgDurationSec       float64
-	LastSuccessTime      string
-	LastSuccessRelative  string
-	DaySyncs             []DaySyncRow
+	TotalSyncs          int
+	SuccessSyncs        int
+	ErrorSyncs          int
+	SuccessRate         float64
+	TotalAdded          int
+	TotalModified       int
+	TotalRemoved        int
+	AvgDurationSec      float64
+	LastSuccessTime     string
+	LastSuccessRelative string
+	DaySyncs            []DaySyncRow
 
 	// Account totals
 	TotalBalance float64
@@ -76,11 +76,13 @@ type DaySyncRow struct {
 // connection. Mirrors admin.NextSyncInfo without the time.Time field
 // (the templ side only renders the precomputed Label).
 type NextSyncInfo struct {
-	Label                    string
-	IsOverdue                bool
-	IsPaused                 bool
-	IsDisconnected           bool
-	EffectiveIntervalMinutes int
+	Label          string
+	IsOverdue      bool
+	IsPaused       bool
+	IsDisconnected bool
+	// ScheduleNames are the schedules covering this connection, for a
+	// "Syncs on: Nightly, Hourly" subline.
+	ScheduleNames []string
 }
 
 // AccountRow is one account card in the Accounts grid.
@@ -102,18 +104,18 @@ type AccountRow struct {
 
 // SyncLogRow is one row in the Sync History list.
 type SyncLogRow struct {
-	ShortID         string
-	Status          string
-	Trigger         string
-	StartedAtValid  bool
-	StartedAtRelative string
-	DurationLabel   string // pre-formatted; empty when unavailable
-	HasDuration     bool
-	ErrorMessageValid  bool
-	ErrorMessageString string
+	ShortID              string
+	Status               string
+	Trigger              string
+	StartedAtValid       bool
+	StartedAtRelative    string
+	DurationLabel        string // pre-formatted; empty when unavailable
+	HasDuration          bool
+	ErrorMessageValid    bool
+	ErrorMessageString   string
 	ErrorMessageFriendly string // syncFriendlyError result; empty if no friendly fallback
-	AddedCount      int32
-	ModifiedCount   int32
-	RemovedCount    int32
-	UnchangedCount  int32
+	AddedCount           int32
+	ModifiedCount        int32
+	RemovedCount         int32
+	UnchangedCount       int32
 }

--- a/internal/templates/components/pages/connection_detail_types.go
+++ b/internal/templates/components/pages/connection_detail_types.go
@@ -10,25 +10,23 @@ type ConnectionDetailProps struct {
 	CSRFToken string
 
 	// Connection fields (flattened from db.GetBankConnectionRow)
-	Provider                         string
-	Status                           string
-	InstitutionName                  string
-	UserName                         string
-	UserNameValid                    bool
-	Paused                           bool
-	ConsecutiveFailures              int32
-	HasErrorCode                     bool
-	ErrorCode                        string
-	HasErrorMessage                  bool
-	ErrorMessage                     string
-	LastSyncedAtValid                bool
-	LastSyncedAtRelative             string
-	CreatedAtValid                   bool
-	CreatedAtFormatted               string
-	LastErrorAtValid                 bool
-	LastErrorAtRelative              string
-	SyncIntervalOverrideMinutesValid bool
-	SyncIntervalOverrideMinutesValue int32
+	Provider             string
+	Status               string
+	InstitutionName      string
+	UserName             string
+	UserNameValid        bool
+	Paused               bool
+	ConsecutiveFailures  int32
+	HasErrorCode         bool
+	ErrorCode            string
+	HasErrorMessage      bool
+	ErrorMessage         string
+	LastSyncedAtValid    bool
+	LastSyncedAtRelative string
+	CreatedAtValid       bool
+	CreatedAtFormatted   string
+	LastErrorAtValid     bool
+	LastErrorAtRelative  string
 
 	// Latest sync log status (for header badge — matches list page).
 	LastSyncStatus             string

--- a/internal/templates/components/pages/schedule_form.templ
+++ b/internal/templates/components/pages/schedule_form.templ
@@ -1,0 +1,130 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// ScheduleForm is the standalone create/edit page for a sync schedule.
+// Reached from Settings → Sync schedules → "New schedule" / edit.
+templ ScheduleForm(p ScheduleFormProps) {
+	<div class="max-w-2xl mx-auto px-4 py-6" x-data={ scheduleFormState(p) }>
+		@components.PageHeader(components.PageHeaderProps{
+			Title: scheduleFormTitle(p),
+		})
+		if p.Error != "" {
+			<div class="alert alert-error alert-soft rounded-xl mb-4">
+				@components.LucideIcon("alert-circle", "w-4 h-4")
+				<span>{ p.Error }</span>
+			</div>
+		}
+		<form method="POST" action={ templ.SafeURL(p.FormAction()) } class="bb-card p-5 space-y-5">
+			<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+			<!-- Name -->
+			<div class="space-y-1.5">
+				<label for="name" class="bb-settings-row__label">Name</label>
+				<input
+					id="name"
+					name="name"
+					type="text"
+					value={ p.Name }
+					placeholder="e.g. Nightly refresh"
+					class="bb-form-input input input-sm w-full"
+					required
+				/>
+			</div>
+			<!-- Cadence preset -->
+			<div class="space-y-1.5">
+				<label for="preset" class="bb-settings-row__label">Cadence</label>
+				<select id="preset" name="preset" class="bb-form-select select select-sm w-full bg-base-200" x-model="preset">
+					for _, preset := range p.Presets {
+						if preset.Key == p.PresetKey {
+							<option value={ preset.Key } selected>{ preset.Label }</option>
+						} else {
+							<option value={ preset.Key }>{ preset.Label }</option>
+						}
+					}
+				</select>
+			</div>
+			<!-- Custom cron (only when preset == custom) -->
+			<div class="space-y-1.5" x-show="preset === 'custom'" x-cloak>
+				<label for="cron" class="bb-settings-row__label">Custom cron expression</label>
+				<input
+					id="cron"
+					name="cron"
+					type="text"
+					value={ p.Cron }
+					placeholder="0 6,18 * * *"
+					class="bb-form-input input input-sm w-full font-mono"
+				/>
+				<p class="text-xs text-base-content/45 leading-snug">
+					Standard 5-field cron (minute hour day month weekday), evaluated in the server's local timezone.
+				</p>
+			</div>
+			<!-- Targets -->
+			<div class="space-y-2">
+				<label class="bb-settings-row__label">Applies to</label>
+				<label class="flex items-center gap-2 text-sm cursor-pointer">
+					<input type="checkbox" name="applies_to_all" class="checkbox checkbox-sm" x-model="all"/>
+					<span>All connections <span class="text-base-content/45">(including ones added later)</span></span>
+				</label>
+				<div class="mt-2 space-y-1.5 transition-opacity" :class="all ? 'opacity-40 pointer-events-none' : ''">
+					if len(p.Connections) == 0 {
+						<p class="text-sm text-base-content/55">No connections yet.</p>
+					}
+					for _, conn := range p.Connections {
+						<label class="flex items-center gap-2 text-sm cursor-pointer">
+							if p.SelectedConns[conn.ShortID] {
+								<input type="checkbox" name="connection_ids" value={ conn.ShortID } class="checkbox checkbox-sm" checked/>
+							} else {
+								<input type="checkbox" name="connection_ids" value={ conn.ShortID } class="checkbox checkbox-sm"/>
+							}
+							<span>{ connectionLabel(conn) }</span>
+						</label>
+					}
+				</div>
+			</div>
+			<!-- Enabled -->
+			<div class="space-y-1.5">
+				<label class="flex items-center gap-2 text-sm cursor-pointer">
+					if p.Enabled {
+						<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" checked/>
+					} else {
+						<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary"/>
+					}
+					<span>Enabled</span>
+				</label>
+			</div>
+			<!-- Actions -->
+			<div class="flex items-center justify-end gap-2 pt-2 border-t border-base-200">
+				<a href="/settings/general#sync" class="btn btn-ghost btn-sm">Cancel</a>
+				<button type="submit" class="btn btn-primary btn-sm">
+					if p.IsEdit {
+						Save changes
+					} else {
+						Create schedule
+					}
+				</button>
+			</div>
+		</form>
+	</div>
+}
+
+func scheduleFormTitle(p ScheduleFormProps) string {
+	if p.IsEdit {
+		return "Edit sync schedule"
+	}
+	return "New sync schedule"
+}
+
+// scheduleFormState is the inline Alpine x-data: tracks the selected preset
+// (to reveal the custom-cron field) and the applies-to-all flag (to dim the
+// connection picker). Short enough to stay inline per the UI rules.
+func scheduleFormState(p ScheduleFormProps) string {
+	preset := p.PresetKey
+	if preset == "" {
+		preset = "twice_daily"
+	}
+	all := "false"
+	if p.AppliesToAll {
+		all = "true"
+	}
+	return "{ preset: '" + preset + "', all: " + all + " }"
+}

--- a/internal/templates/components/pages/schedule_form_types.go
+++ b/internal/templates/components/pages/schedule_form_types.go
@@ -1,0 +1,66 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"breadbox/internal/cronspec"
+	"breadbox/internal/service"
+
+	"github.com/a-h/templ"
+)
+
+// scheduleEditURL / scheduleDeleteURL build the per-schedule action URLs.
+// Defined here (a .go file) rather than inline in the .templ so the
+// routes-drift scanner — which only reads .html/.templ and would mis-read the
+// concatenated literal as a static href — leaves them alone.
+func scheduleEditURL(shortID string) templ.SafeURL {
+	return templ.SafeURL("/settings/sync/schedules/" + shortID + "/edit")
+}
+
+func scheduleDeleteURL(shortID string) templ.SafeURL {
+	return templ.SafeURL("/settings/sync/schedules/" + shortID + "/delete")
+}
+
+// ScheduleFormProps drives the create/edit sync-schedule form page.
+type ScheduleFormProps struct {
+	CSRFToken string
+	// IsEdit toggles the form between create (POST /settings/sync/schedules)
+	// and update (POST /settings/sync/schedules/{shortID}) modes.
+	IsEdit  bool
+	ShortID string
+	Error   string
+
+	// Current field values (also used to repopulate on validation error).
+	Name         string
+	PresetKey    string
+	Cron         string
+	AppliesToAll bool
+	Enabled      bool
+
+	Presets     []cronspec.Preset
+	Connections []service.ConnectionResponse
+	// SelectedConns marks which connection short IDs are targeted.
+	SelectedConns map[string]bool
+}
+
+// FormAction returns the POST target for the form.
+func (p ScheduleFormProps) FormAction() string {
+	if p.IsEdit {
+		return "/settings/sync/schedules/" + p.ShortID
+	}
+	return "/settings/sync/schedules"
+}
+
+// connectionLabel renders a connection's display name for the target picker.
+func connectionLabel(c service.ConnectionResponse) string {
+	name := ""
+	if c.InstitutionName != nil && *c.InstitutionName != "" {
+		name = *c.InstitutionName
+	} else {
+		name = c.Provider
+	}
+	if c.UserName != nil && *c.UserName != "" {
+		name += " · " + *c.UserName
+	}
+	return name
+}

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
 
@@ -95,30 +96,25 @@ templ settingsSyncSection(p SettingsProps) {
 	<div id="sync">
 		@components.SettingsSection(components.SettingsSectionProps{
 			Icon:    "refresh-cw",
-			Title:   "Sync",
+			Title:   "Sync schedules",
 			Caption: settingsSyncCaption(p),
+			Right:   newScheduleButton(),
 		}) {
-			@components.SettingsRow(components.SettingsRowProps{
-				Label:   "Sync interval",
-				Caption: settingsNextSyncCaption(p),
-				For:     "sync_interval_minutes",
-			}) {
-				@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
-					Action:    "/settings/sync",
-					CSRFToken: p.CSRFToken,
-					Label:     "Sync schedule saved",
-				}) {
-					<select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm bg-base-200">
-						@syncIntervalOption(15, p.SyncIntervalMinutes, "Every 15 minutes")
-						@syncIntervalOption(30, p.SyncIntervalMinutes, "Every 30 minutes")
-						@syncIntervalOption(60, p.SyncIntervalMinutes, "Every hour")
-						@syncIntervalOption(240, p.SyncIntervalMinutes, "Every 4 hours")
-						@syncIntervalOption(480, p.SyncIntervalMinutes, "Every 8 hours")
-						@syncIntervalOption(720, p.SyncIntervalMinutes, "Every 12 hours")
-						@syncIntervalOption(1440, p.SyncIntervalMinutes, "Every 24 hours")
-					</select>
+			if len(p.SyncSchedules) == 0 {
+				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
+					<p class="text-sm text-base-content/55 leading-snug">
+						No sync schedules. Connections will not auto-sync until you add one.
+					</p>
 				}
 			}
+			for _, sched := range p.SyncSchedules {
+				@settingsScheduleRow(p, sched)
+			}
+		}
+		@components.SettingsSection(components.SettingsSectionProps{
+			Icon:  "scroll",
+			Title: "Sync logs",
+		}) {
 			@components.SettingsRow(components.SettingsRowProps{
 				Label:   "Log retention",
 				Caption: fmt.Sprintf("%d logs stored · cleanup runs daily at 3:00 AM", p.SyncLogCount),
@@ -145,15 +141,85 @@ templ settingsSyncSection(p SettingsProps) {
 	</div>
 }
 
-func settingsSyncCaption(p SettingsProps) string {
-	return "Every " + components.FormatIntervalMinutes(p.SyncIntervalMinutes)
+// newScheduleButton is the section's primary action — links to the
+// dedicated schedule form page.
+templ newScheduleButton() {
+	<a href="/settings/sync/schedules/new" class="btn btn-primary btn-sm gap-2">
+		@components.LucideIcon("plus", "w-4 h-4")
+		New schedule
+	</a>
 }
 
-func settingsNextSyncCaption(p SettingsProps) string {
-	if p.NextSyncTime == "" {
-		return ""
+// settingsScheduleRow renders one schedule: its name + human cadence and
+// target on the left, an enabled toggle plus edit/delete actions on the right.
+templ settingsScheduleRow(p SettingsProps, sched service.SyncScheduleView) {
+	@components.SettingsRow(components.SettingsRowProps{
+		Label:   sched.Name,
+		Caption: scheduleRowCaption(sched),
+	}) {
+		<div class="flex items-center gap-2">
+			@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
+				Action:    "/settings/sync/schedules/" + sched.ShortID + "/toggle",
+				CSRFToken: p.CSRFToken,
+				Label:     "Schedule updated",
+			}) {
+				if sched.Enabled {
+					<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" checked aria-label="Enabled"/>
+				} else {
+					<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" aria-label="Enabled"/>
+				}
+			}
+			<a href={ scheduleEditURL(sched.ShortID) } class="btn btn-ghost btn-sm btn-square" aria-label="Edit schedule">
+				@components.LucideIcon("pencil", "w-4 h-4")
+			</a>
+			<form method="POST" action={ scheduleDeleteURL(sched.ShortID) } onsubmit="return confirm('Delete this schedule?')">
+				<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+				<button type="submit" class="btn btn-ghost btn-sm btn-square text-error" aria-label="Delete schedule">
+					@components.LucideIcon("trash-2", "w-4 h-4")
+				</button>
+			</form>
+		</div>
 	}
-	return "Next sync: " + p.NextSyncTime
+}
+
+// scheduleRowCaption combines the human cadence with the target summary and a
+// disabled marker.
+func scheduleRowCaption(sched service.SyncScheduleView) string {
+	caption := sched.CronHuman + " · " + scheduleTargetSummary(sched)
+	if !sched.Enabled {
+		caption += " · paused"
+	}
+	return caption
+}
+
+// scheduleTargetSummary describes which connections a schedule covers.
+func scheduleTargetSummary(sched service.SyncScheduleView) string {
+	if sched.AppliesToAll {
+		return "All connections"
+	}
+	switch sched.ConnectionCount {
+	case 0:
+		return "No connections"
+	case 1:
+		return "1 connection"
+	default:
+		return fmt.Sprintf("%d connections", sched.ConnectionCount)
+	}
+}
+
+func settingsSyncCaption(p SettingsProps) string {
+	n := len(p.SyncSchedules)
+	if n == 0 {
+		return "No schedules configured"
+	}
+	next := ""
+	if p.NextSyncTime != "" {
+		next = " · next sync " + p.NextSyncTime
+	}
+	if n == 1 {
+		return "1 schedule" + next
+	}
+	return fmt.Sprintf("%d schedules%s", n, next)
 }
 
 // ---------------------------------------------------------------------
@@ -384,14 +450,6 @@ templ settingsDeveloperSection() {
 // ---------------------------------------------------------------------
 // Helpers reused by handlers + by other settings tabs
 // ---------------------------------------------------------------------
-
-templ syncIntervalOption(value, current int, label string) {
-	if value == current {
-		<option value={ strconv.Itoa(value) } selected>{ label }</option>
-	} else {
-		<option value={ strconv.Itoa(value) }>{ label }</option>
-	}
-}
 
 templ retentionOption(value, current int, label string) {
 	if value == current {

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -2,7 +2,10 @@
 
 package pages
 
-import "breadbox/internal/avatar"
+import (
+	"breadbox/internal/avatar"
+	"breadbox/internal/service"
+)
 
 // avatarPreviewExpr builds the Alpine `:src` expression for an
 // avatar-style preview tile. The seed is a fixed literal supplied by
@@ -47,6 +50,10 @@ type SettingsProps struct {
 	HasEncryptionKey     bool
 	OnboardingDismissed  bool
 	NextSyncTime         string
+	// SyncSchedules is the household's wall-clock sync schedules (the
+	// replacement for the single global interval). Rendered as a list in
+	// the General → Sync section.
+	SyncSchedules []service.SyncScheduleView
 	// ConfigSources maps config keys to their source: "env", "db", or "default".
 	ConfigSources map[string]string
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1038,27 +1038,6 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Connection" }
-  /api/v1/connections/{id}/sync-interval:
-    parameters: [{ $ref: "#/components/parameters/IDPath" }]
-    post:
-      tags: [Connections]
-      summary: Update connection sync interval
-      description: "**Requires `full_access` scope.**"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [interval_seconds]
-              properties:
-                interval_seconds: { type: integer }
-      responses:
-        "200":
-          description: Updated connection.
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/Connection" }
   /api/v1/connections/{id}/reauth:
     parameters: [{ $ref: "#/components/parameters/IDPath" }]
     post:

--- a/static/js/admin/components/connection_detail.js
+++ b/static/js/admin/components/connection_detail.js
@@ -13,9 +13,9 @@
 // - the header "remove" confirm-then-confirm UX (formerly inline x-data)
 //
 // Markup-side method names match the previous global-function names
-// (syncConnection, togglePause, removeConnection, updateSyncInterval,
-// updateDisplayName, toggleExcluded) so the inline handlers in the templ
-// component continue to read naturally as `@click="syncConnection"`.
+// (syncConnection, togglePause, removeConnection, updateDisplayName,
+// toggleExcluded) so the inline handlers in the templ component continue
+// to read naturally as `@click="syncConnection"`.
 document.addEventListener('alpine:init', function () {
   Alpine.data('connectionDetail', function () {
     var SYNC_POLL_INTERVAL_MS = 1500;
@@ -303,30 +303,6 @@ document.addEventListener('alpine:init', function () {
           .catch(function () {
             self.showToast('Network error. Please try again.');
             btn.disabled = false;
-          });
-      },
-
-      updateSyncInterval: function (val) {
-        var body = val === '' ? { minutes: null } : { minutes: parseInt(val, 10) };
-        var status = document.getElementById('interval-status');
-        status.textContent = 'Saving...';
-        fetch('/-/connections/' + this._connID + '/sync-interval', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body)
-        })
-          .then(function (res) {
-            if (res.ok) {
-              status.textContent = 'Saved';
-              setTimeout(function () { status.textContent = ''; }, 2000);
-            } else {
-              return res.json().then(function (data) {
-                status.textContent = data.error || 'Failed';
-              });
-            }
-          })
-          .catch(function () {
-            status.textContent = 'Network error';
           });
       },
 


### PR DESCRIPTION
## Redesign: cron-anchored, many-to-many sync schedules

Replaces the old "re-sync every X hours from the last sync" model — which was **relative and drifting** (each sync re-anchored the clock, so the time-of-day wandered and couldn't be reasoned about) — with first-class **wall-clock cron schedules** that any number of connections can share.

### The model
- A **`sync_schedules`** row is a named cron schedule (`Nightly` → `0 3 * * *`), with an `applies_to_all` flag and an `enabled` toggle.
- **`sync_schedule_connections`** is a many-to-many join: one schedule targets X connections; one connection has N schedules.
- A connection's **effective schedules** are the *union* of every `applies_to_all` schedule plus those explicitly targeting it. It syncs when **any** of them has fired since its last successful sync. There is no "override vs stack" distinction — it's always union.
- Migration seeds one `applies_to_all` schedule from the prior `sync_interval_minutes`, so every connection keeps an equivalent cadence on the first tick.

### Engine (`internal/sync`)
- The 15-minute tick resolves each connection's effective schedules and fires on a **wall-clock anchor** (no drift). Deterministic per-connection **jitter** spreads connections that share a fire time; failure **backoff** is preserved.
- Empty-table fallback synthesizes a schedule from the legacy interval so auto-sync never silently stops.

### UI (Settings → Sync)
- A **schedules list** (enable toggle / edit / delete) with a **New schedule** action; sync-log retention split into its own section.
- A standalone **create/edit form**: name, cadence preset (or custom cron), applies-to-all vs a per-connection multiselect, enabled.

<img src="https://i.img402.dev/9d83m2liby.jpg" width="800" alt="Settings → Sync schedules">

### Connection page is schedule-aware
- "Next Sync" now reads from the connection's actual schedules ("Due now · **Syncs on: Default schedule**") instead of the retired interval.
- The no-op per-connection interval-override dropdown is replaced by a read-only **Sync Schedule** tile + **Manage schedules** link.

<img src="https://i.img402.dev/fay9hxfbn4.jpg" width="800" alt="Connection detail — schedule-aware next sync">

### Retiring the interval model
- Removed the now-dead `POST /api/v1/connections/{id}/sync-interval` (+ admin twin), its service method, sqlc query, dead Alpine method, and the orphaned `POST /settings/sync` handler. `openapi.yaml` + `docs/` updated; `sync_interval_override_minutes` marked deprecated (column kept — dropping it would be a destructive migration — still feeds the coarse list-page "stale" heuristic). `sync_interval_minutes` remains only as the empty-table fallback.

### Tests
- Unit: evaluator (`due` / no-drift / jitter / backoff / next-run), `cronspec` (NextRun / DuePassed / presets / validation), rewritten `computeNextSync`.
- Integration: schedule CRUD + target replacement + cascade + custom-cron validation; resolver union mapping + disabled exclusion.
- Full integration suite green; `headless` + `lite` build variants compile; OpenAPI-drift + route-href guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
