### PR TITLE
fix(connections): soft warning for reauth banner, remove duplicate button

### DIFF
--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -26,7 +26,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 	<script src="/static/js/admin/components/connection_detail.js"></script>
 	<div class="max-w-full overflow-x-hidden" x-data="connectionDetail" data-conn-id={ p.ConnID }>
 		if p.Status == "error" || p.Status == "pending_reauth" {
-			<div role="alert" class="alert alert-error rounded-xl mb-6">
+			<div role="alert" class="alert alert-warning alert-soft items-start rounded-xl mb-6">
 				@components.LucideIcon("alert-triangle", "w-5 h-5 shrink-0")
 				<div class="flex-1 min-w-0">
 					<p class="font-semibold text-sm">This connection needs re-authentication</p>
@@ -36,7 +36,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 						<p class="text-xs opacity-80 mt-0.5 truncate">{ p.ErrorMessage }</p>
 					}
 				</div>
-				<a href={ templ.SafeURL("/connections/" + p.ConnID + "/reauth") } class="btn btn-sm btn-error shrink-0">Re-authenticate</a>
+				<a href={ templ.SafeURL("/connections/" + p.ConnID + "/reauth") } class="btn btn-sm btn-warning shrink-0">Re-authenticate</a>
 			</div>
 		}
 		if p.ConsecutiveFailures >= 3 && !(p.Status == "error" || p.Status == "pending_reauth") {
@@ -177,9 +177,6 @@ templ connDetailMeta(p ConnectionDetailProps) {
 // to the "one primary + one secondary" PageHeader rule — collapsing to
 // an OverflowMenu is tracked as follow-up work for connection_detail.
 templ connDetailActions(p ConnectionDetailProps) {
-	if p.Status == "error" || p.Status == "pending_reauth" {
-		<a href={ templ.SafeURL("/connections/" + p.ConnID + "/reauth") } class="btn btn-sm btn-outline">Re-authenticate</a>
-	}
 	if p.Provider == "csv" {
 		<a href={ templ.SafeURL("/connections/import-csv?connection_id=" + p.ConnID) } class="btn btn-sm btn-outline">
 			@components.LucideIcon("upload", "w-3.5 h-3.5")


### PR DESCRIPTION
Fixes #1749.

Two issues on the connection detail page when status is `error` or `pending_reauth`:

1. **Wrong banner color** — the alert used `alert-error` (red), which signals a system failure. Re-authentication is a user action needed, not an error. Changed to `alert-warning alert-soft` to match the soft yellow tone used by the consecutive-failures banner.

2. **Duplicate Re-authenticate button** — the button appeared both inside the banner _and_ in the `EntityHeader` action cluster (`connDetailActions`). Removed the duplicate from `connDetailActions`; the banner is the canonical CTA for this state.

## Changes

`internal/templates/components/pages/connection_detail.templ`

- `alert alert-error` → `alert alert-warning alert-soft items-start` on the reauth banner
- `btn-error` → `btn-warning` on the banner's Re-authenticate button  
- Removed the `if p.Status == "error" || p.Status == "pending_reauth"` Re-authenticate block from `connDetailActions`

## Evidence

`&lt;img src="https://i.img402.dev/n3kuiolitd.jpg" width="800" alt="before/after: soft warning banner, one Re-authenticate action"&gt;`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXxDjA8UHrABZvewHaVRC4)_