### PR TITLE
feat(ui): shared cron component, timezone-aware schedules, drawer + preset fix

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -141,6 +141,7 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 		// Load the schedule resolution once for the whole list (two queries),
 		// then resolve each connection's effective schedules from it.
 		allSchedules, perConnSchedules, _ := svc.SyncScheduleResolution(ctx)
+		tzName := svc.InstanceTimezone(ctx)
 		for i := range enriched {
 			if enriched[i].HasBalance {
 				total := 0.0
@@ -156,7 +157,7 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 				Provider:     enriched[i].Provider,
 				Paused:       enriched[i].Paused,
 				LastSyncedAt: enriched[i].LastSyncedAt,
-			}, effectiveSchedules(allSchedules, perConnSchedules, enriched[i].ID), now)
+			}, effectiveSchedules(allSchedules, perConnSchedules, enriched[i].ID), tzName, now)
 
 			// Compute staleness.
 			if string(enriched[i].Status) != "disconnected" {
@@ -792,7 +793,7 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			Provider:     conn.Provider,
 			Paused:       conn.Paused,
 			LastSyncedAt: conn.LastSyncedAt,
-		}, effectiveSchedules(allSchedules, perConnSchedules, conn.ID), now)
+		}, effectiveSchedules(allSchedules, perConnSchedules, conn.ID), a.Service.InstanceTimezone(ctx), now)
 
 		data := map[string]any{
 			"PageTitle":   conn.InstitutionName.String,
@@ -1458,7 +1459,7 @@ func effectiveSchedules(all []service.ScheduleRef, perConn map[string][]service.
 // sync schedules (the union of applies_to_all + connection-targeted schedules,
 // resolved via service.SyncScheduleResolution). Wall-clock anchored — mirrors
 // the scheduler's scheduleDue/scheduleNextRun, minus jitter.
-func computeNextSync(p syncScheduleParams, schedules []service.ScheduleRef, now time.Time) NextSyncInfo {
+func computeNextSync(p syncScheduleParams, schedules []service.ScheduleRef, tzName string, now time.Time) NextSyncInfo {
 	// Disconnected or CSV connections don't sync on a schedule.
 	if string(p.Status) == "disconnected" || string(p.Provider) == "csv" {
 		return NextSyncInfo{IsDisconnected: true, Label: "No schedule"}
@@ -1491,13 +1492,13 @@ func computeNextSync(p syncScheduleParams, schedules []service.ScheduleRef, now 
 	}
 
 	// A scheduled fire passed since the last sync → due now.
-	if cronspec.DuePassed(crons, p.LastSyncedAt.Time, now) {
+	if cronspec.DuePassed(crons, tzName, p.LastSyncedAt.Time, now) {
 		info.IsOverdue = true
 		info.Label = "Due now"
 		return info
 	}
 
-	if next, ok := cronspec.NextRun(crons, now); ok {
+	if next, ok := cronspec.NextRun(crons, tzName, now); ok {
 		info.NextSyncAt = next
 		info.Label = relativeTimeUntil(next, now)
 	}

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -1479,7 +1479,13 @@ func computeNextSync(p syncScheduleParams, schedules []service.ScheduleRef, tzNa
 	names := make([]string, 0, len(schedules))
 	crons := make([]string, 0, len(schedules))
 	for _, s := range schedules {
-		names = append(names, s.Name)
+		// "Name — every 15 minutes": both the label and the readable cadence,
+		// so "Default schedule" alone never looks opaque.
+		label := s.Name
+		if s.Human != "" {
+			label += " — " + s.Human
+		}
+		names = append(names, label)
 		crons = append(crons, s.Cron)
 	}
 	info := NextSyncInfo{ScheduleNames: names}

--- a/internal/admin/connections_test.go
+++ b/internal/admin/connections_test.go
@@ -58,7 +58,7 @@ func TestComputeNextSync(t *testing.T) {
 		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusDisconnected,
 			Provider: db.ProviderTypePlaid,
-		}, nightly, now)
+		}, nightly, "", now)
 		if !info.IsDisconnected || info.Label != "No schedule" {
 			t.Errorf("expected disconnected/No schedule, got %+v", info)
 		}
@@ -68,7 +68,7 @@ func TestComputeNextSync(t *testing.T) {
 		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypeCsv,
-		}, nightly, now)
+		}, nightly, "", now)
 		if !info.IsDisconnected {
 			t.Error("expected IsDisconnected=true for CSV")
 		}
@@ -79,7 +79,7 @@ func TestComputeNextSync(t *testing.T) {
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypePlaid,
 			Paused:   true,
-		}, nightly, now)
+		}, nightly, "", now)
 		if !info.IsPaused || info.Label != "Paused" {
 			t.Errorf("expected paused, got %+v", info)
 		}
@@ -89,7 +89,7 @@ func TestComputeNextSync(t *testing.T) {
 		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypePlaid,
-		}, nil, now)
+		}, nil, "", now)
 		if info.Label != "No schedule" || info.IsOverdue {
 			t.Errorf("expected 'No schedule' with no schedules, got %+v", info)
 		}
@@ -99,7 +99,7 @@ func TestComputeNextSync(t *testing.T) {
 		info := computeNextSync(syncScheduleParams{
 			Status:   db.ConnectionStatusActive,
 			Provider: db.ProviderTypePlaid,
-		}, nightly, now)
+		}, nightly, "", now)
 		if !info.IsOverdue || info.Label != "Pending first sync" {
 			t.Errorf("expected pending first sync, got %+v", info)
 		}
@@ -115,7 +115,7 @@ func TestComputeNextSync(t *testing.T) {
 			Status:       db.ConnectionStatusActive,
 			Provider:     db.ProviderTypePlaid,
 			LastSyncedAt: tsAt(time.Date(2026, 3, 26, 4, 0, 0, 0, time.UTC)),
-		}, nightly, now)
+		}, nightly, "", now)
 		if info.IsOverdue {
 			t.Errorf("expected not overdue, got %+v", info)
 		}
@@ -131,7 +131,7 @@ func TestComputeNextSync(t *testing.T) {
 			Status:       db.ConnectionStatusActive,
 			Provider:     db.ProviderTypePlaid,
 			LastSyncedAt: tsAt(time.Date(2026, 3, 26, 2, 0, 0, 0, time.UTC)),
-		}, nightly, now)
+		}, nightly, "", now)
 		if !info.IsOverdue || info.Label != "Due now" {
 			t.Errorf("expected due now, got %+v", info)
 		}
@@ -143,7 +143,7 @@ func TestComputeNextSync(t *testing.T) {
 			Status:       db.ConnectionStatusActive,
 			Provider:     db.ProviderTypeTeller,
 			LastSyncedAt: tsAt(now),
-		}, hourly, now)
+		}, hourly, "", now)
 		if info.IsOverdue {
 			t.Errorf("expected not overdue, got %+v", info)
 		}
@@ -159,7 +159,7 @@ func TestComputeNextSync(t *testing.T) {
 			Status:       db.ConnectionStatusActive,
 			Provider:     db.ProviderTypePlaid,
 			LastSyncedAt: tsAt(now),
-		}, append(append([]service.ScheduleRef{}, nightly...), hourly...), now)
+		}, append(append([]service.ScheduleRef{}, nightly...), hourly...), "", now)
 		if info.Label != "in 1h" {
 			t.Errorf("expected earliest 'in 1h', got %q", info.Label)
 		}

--- a/internal/admin/cron_preview.go
+++ b/internal/admin/cron_preview.go
@@ -1,0 +1,20 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"net/http"
+
+	"breadbox/internal/service"
+)
+
+// CronPreviewAdminHandler serves GET /-/cron/preview?cron=<expr> — the shared
+// live-preview backend for the cron-field component (sync schedules, workflows).
+// Returns the validity, English description, and next fire times, all in the
+// instance timezone. Read-only; no CSRF needed (GET).
+func CronPreviewAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		res := svc.CronPreview(r.Context(), r.URL.Query().Get("cron"), 3)
+		writeJSON(w, http.StatusOK, res)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -544,6 +544,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 			// Preview the composed internal base prompt for a preset (read-only JSON).
 			r.Get("/workflows/{slug}/prompt", WorkflowPromptPreviewAdminHandler(svc))
+			// Shared cron live-preview for the cron-field component (description
+			// + next fires, in the instance timezone). Read-only JSON.
+			r.Get("/cron/preview", CronPreviewAdminHandler(svc))
 			// Human-readable preview of a cron expression for the schedule field
 			// (read-only JSON). Single-segment path — never shadows {slug}/*.
 			r.Get("/workflows/cron-preview", WorkflowCronPreviewAdminHandler(svc))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -427,6 +427,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/settings/developer", DeveloperSettingsPostHandler(a, svc, sm))
 
 		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
+		r.Post("/settings/timezone", SettingsTimezonePostHandler(a, sm))
 
 		// Sync schedules — wall-clock cron schedules that replace the single
 		// global interval. List lives in Settings → Sync; create/edit is a

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -84,6 +84,7 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		SyncSchedules:        syncSchedules,
 		NewScheduleForm:      newScheduleForm,
 		EditScheduleForms:    editScheduleForms,
+		InstanceTimezone:     appconfig.String(ctx, a.Queries, appconfig.KeyInstanceTimezone, ""),
 		ConfigSources:        a.Config.ConfigSources,
 		AvatarUserStyle:      userAvatarStyle,
 		AvatarAgentStyle:     agentAvatarStyle,
@@ -181,6 +182,30 @@ func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.Handl
 			SetFlash(ctx, sm, "success", fmt.Sprintf("Sync log retention set to %d days.", retentionDays))
 		}
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	}
+}
+
+// SettingsTimezonePostHandler serves POST /settings/timezone — sets the
+// instance IANA timezone all cron schedules (sync + workflows) are evaluated
+// in. Empty clears it (back to the server's local zone). Auto-save: 204 on ok.
+func SettingsTimezonePostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tz := strings.TrimSpace(r.FormValue("instance_timezone"))
+		if tz != "" {
+			if _, err := time.LoadLocation(tz); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+			Key:   appconfig.KeyInstanceTimezone,
+			Value: pgconv.Text(tz),
+		}); err != nil {
+			a.Logger.Error("save instance timezone", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -66,6 +66,7 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 	}
 
 	syncSchedules, _ := a.Service.ListSyncSchedules(ctx)
+	newScheduleForm, editScheduleForms := buildScheduleDrawerForms(a, r, syncSchedules)
 
 	props := pages.SettingsProps{
 		CSRFToken:            GetCSRFToken(r),
@@ -81,6 +82,8 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		OnboardingDismissed:  onboardingDismissed,
 		NextSyncTime:         nextSyncTime,
 		SyncSchedules:        syncSchedules,
+		NewScheduleForm:      newScheduleForm,
+		EditScheduleForms:    editScheduleForms,
 		ConfigSources:        a.Config.ConfigSources,
 		AvatarUserStyle:      userAvatarStyle,
 		AvatarAgentStyle:     agentAvatarStyle,

--- a/internal/admin/sync_schedules.go
+++ b/internal/admin/sync_schedules.go
@@ -25,6 +25,44 @@ func scheduleFormConnections(svc *service.Service, r *http.Request) []service.Co
 	return conns
 }
 
+// buildScheduleDrawerForms assembles the create form + one edit form per
+// schedule for the server-rendered drawers in Settings → Sync. Each carries the
+// connection list, selected targets, and presets so the nested CronField and
+// connection picker hydrate correctly.
+func buildScheduleDrawerForms(a *app.App, r *http.Request, schedules []service.SyncScheduleView) (pages.ScheduleFormProps, []pages.ScheduleFormProps) {
+	conns := scheduleFormConnections(a.Service, r)
+	newForm := pages.ScheduleFormProps{
+		CSRFToken:     GetCSRFToken(r),
+		Presets:       cronspec.Presets,
+		Connections:   conns,
+		SelectedConns: map[string]bool{},
+		Enabled:       true,
+		AppliesToAll:  true,
+	}
+	editForms := make([]pages.ScheduleFormProps, 0, len(schedules))
+	for _, sched := range schedules {
+		selected := map[string]bool{}
+		if ids, err := a.Service.ListScheduleConnectionShortIDs(r.Context(), sched.ShortID); err == nil {
+			for _, id := range ids {
+				selected[id] = true
+			}
+		}
+		editForms = append(editForms, pages.ScheduleFormProps{
+			CSRFToken:     GetCSRFToken(r),
+			IsEdit:        true,
+			ShortID:       sched.ShortID,
+			Name:          sched.Name,
+			Cron:          sched.Cron,
+			AppliesToAll:  sched.AppliesToAll,
+			Enabled:       sched.Enabled,
+			Presets:       cronspec.Presets,
+			Connections:   conns,
+			SelectedConns: selected,
+		})
+	}
+	return newForm, editForms
+}
+
 // ScheduleFormPageHandler serves GET /settings/sync/schedules/new and
 // /settings/sync/schedules/{shortID}/edit.
 func ScheduleFormPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -133,6 +133,13 @@ const (
 	// drafts against (e.g. "canalesb93/breadbox"). Defaults to
 	// DevModeDefaultRepo when unset.
 	KeyDevModeGithubRepo = "devmode.github_repo"
+
+	// KeyInstanceTimezone is the IANA timezone (e.g. "America/Los_Angeles")
+	// every cron schedule — sync schedules AND agent/workflow schedules — is
+	// evaluated in, and that schedule previews are rendered in. Unset or
+	// invalid falls back to the server process's local zone (time.Local).
+	// This is the single source of truth for "what clock the cron means".
+	KeyInstanceTimezone = "instance.timezone"
 )
 
 // DevModeDefaultRepo is the repository Developer Mode files against when

--- a/internal/cronspec/cronspec.go
+++ b/internal/cronspec/cronspec.go
@@ -6,6 +6,7 @@ package cronspec
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -83,14 +84,28 @@ func ResolveCron(presetKey, customCron string) (expr string, preset string, err 
 	return customCron, CustomKey, nil
 }
 
+// Parse parses a standard 5-field cron expression evaluated in the named IANA
+// timezone (e.g. "America/Los_Angeles"). An empty tzName parses in the server's
+// local zone (robfig's default). The returned Schedule's Next() honors the
+// timezone regardless of the reference time's location, via robfig's
+// `CRON_TZ=` prefix — so this is the single place tz-anchoring is applied, and
+// stored cron strings stay clean (no embedded prefix).
+func Parse(expr, tzName string) (cron.Schedule, error) {
+	expr = strings.TrimSpace(expr)
+	if tzName != "" {
+		return cron.ParseStandard("CRON_TZ=" + tzName + " " + expr)
+	}
+	return cron.ParseStandard(expr)
+}
+
 // NextRun returns the earliest upcoming fire time across the given cron
-// expressions (strictly after `from`), and whether any valid expression was
-// found. Invalid expressions are skipped.
-func NextRun(exprs []string, from time.Time) (time.Time, bool) {
+// expressions (strictly after `from`), evaluated in tzName, and whether any
+// valid expression was found. Invalid expressions are skipped.
+func NextRun(exprs []string, tzName string, from time.Time) (time.Time, bool) {
 	var earliest time.Time
 	found := false
 	for _, e := range exprs {
-		sc, err := cron.ParseStandard(e)
+		sc, err := Parse(e, tzName)
 		if err != nil {
 			continue
 		}
@@ -103,12 +118,42 @@ func NextRun(exprs []string, from time.Time) (time.Time, bool) {
 	return earliest, found
 }
 
-// DuePassed reports whether any of the cron expressions has a fire time in the
-// half-open window (since, now] — i.e. a scheduled run was missed since `since`.
-// Used to render "due now" without re-deriving the scheduler's logic.
-func DuePassed(exprs []string, since, now time.Time) bool {
+// NextRuns returns the next n fire times of a single expression evaluated in
+// tzName, each in tzName's location (for display). Empty if the expression is
+// invalid or n <= 0.
+func NextRuns(expr, tzName string, from time.Time, n int) []time.Time {
+	if n <= 0 {
+		return nil
+	}
+	sc, err := Parse(expr, tzName)
+	if err != nil {
+		return nil
+	}
+	loc := from.Location()
+	if tzName != "" {
+		if l, lerr := time.LoadLocation(tzName); lerr == nil {
+			loc = l
+		}
+	}
+	out := make([]time.Time, 0, n)
+	t := from
+	for i := 0; i < n; i++ {
+		t = sc.Next(t)
+		if t.IsZero() {
+			break
+		}
+		out = append(out, t.In(loc))
+	}
+	return out
+}
+
+// DuePassed reports whether any of the cron expressions (evaluated in tzName)
+// has a fire time in the half-open window (since, now] — i.e. a scheduled run
+// was missed since `since`. Used to render "due now" without re-deriving the
+// scheduler's logic.
+func DuePassed(exprs []string, tzName string, since, now time.Time) bool {
 	for _, e := range exprs {
-		sc, err := cron.ParseStandard(e)
+		sc, err := Parse(e, tzName)
 		if err != nil {
 			continue
 		}

--- a/internal/cronspec/cronspec_test.go
+++ b/internal/cronspec/cronspec_test.go
@@ -75,6 +75,42 @@ func TestDuePassed(t *testing.T) {
 	}
 }
 
+func TestNextRuns(t *testing.T) {
+	from := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+	runs := NextRuns("0 12 * * *", "", from, 3)
+	if len(runs) != 3 {
+		t.Fatalf("want 3 runs, got %d", len(runs))
+	}
+	if want := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC); !runs[0].Equal(want) {
+		t.Errorf("first run = %v, want %v", runs[0], want)
+	}
+	if len(NextRuns("nonsense", "", from, 3)) != 0 {
+		t.Error("invalid expr should give no runs")
+	}
+	if NextRuns("0 12 * * *", "", from, 0) != nil {
+		t.Error("n=0 should give nil")
+	}
+}
+
+func TestParseTimezoneAnchoring(t *testing.T) {
+	// "0 6 * * *" in America/Los_Angeles fires at 06:00 PDT = 13:00 UTC (summer,
+	// UTC-7). Anchoring via the tzName must produce that instant regardless of
+	// the reference time's location.
+	from := time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC)
+	runs := NextRuns("0 6 * * *", "America/Los_Angeles", from, 1)
+	if len(runs) != 1 {
+		t.Fatalf("want 1 run, got %d", len(runs))
+	}
+	if h := runs[0].UTC().Hour(); h != 13 {
+		t.Errorf("expected fire at 13:00 UTC (06:00 PDT), got %02d:00 UTC", h)
+	}
+	// Same expression without a tz anchors to UTC → fires at 06:00 UTC.
+	utcRuns := NextRuns("0 6 * * *", "", from, 1)
+	if len(utcRuns) != 1 || utcRuns[0].UTC().Hour() != 6 {
+		t.Errorf("expected UTC fire at 06:00, got %v", utcRuns)
+	}
+}
+
 func TestValidate(t *testing.T) {
 	if err := Validate("0 6,18 * * *"); err != nil {
 		t.Errorf("valid cron rejected: %v", err)

--- a/internal/cronspec/cronspec_test.go
+++ b/internal/cronspec/cronspec_test.go
@@ -47,7 +47,7 @@ func TestHumanize(t *testing.T) {
 func TestNextRun(t *testing.T) {
 	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
 	// Earliest across two exprs: 12:00 beats 18:00.
-	next, ok := NextRun([]string{"0 18 * * *", "0 12 * * *"}, now)
+	next, ok := NextRun([]string{"0 18 * * *", "0 12 * * *"}, "", now)
 	if !ok {
 		t.Fatal("expected a next run")
 	}
@@ -55,10 +55,10 @@ func TestNextRun(t *testing.T) {
 		t.Errorf("NextRun = %v, want %v", next, want)
 	}
 	// All invalid → not found.
-	if _, ok := NextRun([]string{"bad"}, now); ok {
+	if _, ok := NextRun([]string{"bad"}, "", now); ok {
 		t.Error("expected no next run for invalid expr")
 	}
-	if _, ok := NextRun(nil, now); ok {
+	if _, ok := NextRun(nil, "", now); ok {
 		t.Error("expected no next run for empty exprs")
 	}
 }
@@ -66,11 +66,11 @@ func TestNextRun(t *testing.T) {
 func TestDuePassed(t *testing.T) {
 	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
 	// Nightly 03:00 fired between 02:00 and 09:00 → due.
-	if !DuePassed([]string{"0 3 * * *"}, time.Date(2026, 6, 4, 2, 0, 0, 0, time.UTC), now) {
+	if !DuePassed([]string{"0 3 * * *"}, "", time.Date(2026, 6, 4, 2, 0, 0, 0, time.UTC), now) {
 		t.Error("expected due (03:00 fire passed since 02:00)")
 	}
 	// Synced 04:00, nightly's next fire is tomorrow 03:00 > now → not due.
-	if DuePassed([]string{"0 3 * * *"}, time.Date(2026, 6, 4, 4, 0, 0, 0, time.UTC), now) {
+	if DuePassed([]string{"0 3 * * *"}, "", time.Date(2026, 6, 4, 4, 0, 0, 0, time.UTC), now) {
 		t.Error("expected not due (next fire is tomorrow)")
 	}
 }

--- a/internal/service/cron_describe.go
+++ b/internal/service/cron_describe.go
@@ -3,13 +3,68 @@
 package service
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
 
+	"breadbox/internal/appconfig"
+	"breadbox/internal/cronspec"
+
 	lcron "github.com/lnquy/cron"
 	rcron "github.com/robfig/cron/v3"
 )
+
+// InstanceTimezone returns the configured instance IANA timezone (e.g.
+// "America/Los_Angeles"), or "" when unset or invalid. Callers treat "" as the
+// server process's local zone. This is the single clock every cron schedule is
+// evaluated and previewed in.
+func (s *Service) InstanceTimezone(ctx context.Context) string {
+	tz := strings.TrimSpace(appconfig.String(ctx, s.Queries, appconfig.KeyInstanceTimezone, ""))
+	if tz == "" {
+		return ""
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return ""
+	}
+	return tz
+}
+
+// InstanceTimezoneLabel is a human display label for the instance zone — the
+// IANA name when configured, else the server zone's abbreviation (e.g. "UTC").
+func (s *Service) InstanceTimezoneLabel(ctx context.Context) string {
+	if tz := s.InstanceTimezone(ctx); tz != "" {
+		return tz
+	}
+	z, _ := time.Now().Zone()
+	return z
+}
+
+// CronPreviewResult is the JSON shape returned to the cron-field component: the
+// validity, the English description, the next N fire times (formatted in the
+// instance timezone), and the zone label they're shown in.
+type CronPreviewResult struct {
+	Valid       bool     `json:"valid"`
+	Description string   `json:"description"`
+	NextRuns    []string `json:"next_runs"`
+	TZLabel     string   `json:"tz_label"`
+}
+
+// CronPreview validates + describes a cron expression and computes its next n
+// fire times, all in the instance timezone. Powers the shared cron-field
+// live preview for sync schedules and workflows alike.
+func (s *Service) CronPreview(ctx context.Context, expr string, n int) CronPreviewResult {
+	tz := s.InstanceTimezone(ctx)
+	valid, desc := s.DescribeCron(expr)
+	res := CronPreviewResult{Valid: valid, Description: desc, TZLabel: s.InstanceTimezoneLabel(ctx)}
+	if !valid {
+		return res
+	}
+	for _, f := range cronspec.NextRuns(strings.TrimSpace(expr), tz, time.Now(), n) {
+		res.NextRuns = append(res.NextRuns, f.Format("Mon Jan 2 · 3:04 PM"))
+	}
+	return res
+}
 
 // cronDescriptor renders a cron expression as an English sentence. Built
 // once at package init (stateless + concurrency-safe). English-only keeps

--- a/internal/service/sync_schedules.go
+++ b/internal/service/sync_schedules.go
@@ -223,12 +223,14 @@ func (s *Service) DeleteSyncSchedule(ctx context.Context, idOrShort string) erro
 	return nil
 }
 
-// ScheduleRef is a lightweight (name, cron) pair used to describe the schedules
-// that apply to a connection — for rendering "next sync" / "syncs on" without
-// loading full schedule rows per connection.
+// ScheduleRef is a lightweight (name, cron, human) triple used to describe the
+// schedules that apply to a connection — for rendering "next sync" / "syncs on"
+// without loading full schedule rows per connection. Human is the English
+// cadence (e.g. "Every 15 minutes") so the UI can show name + readable schedule.
 type ScheduleRef struct {
-	Name string `json:"name"`
-	Cron string `json:"cron"`
+	Name  string `json:"name"`
+	Cron  string `json:"cron"`
+	Human string `json:"human"`
 }
 
 // SyncScheduleResolution loads the enabled schedules once and returns the
@@ -249,7 +251,8 @@ func (s *Service) SyncScheduleResolution(ctx context.Context) (all []ScheduleRef
 	byID := make(map[[16]byte]ScheduleRef, len(rows))
 	appliesAll := make(map[[16]byte]bool, len(rows))
 	for _, row := range rows {
-		ref := ScheduleRef{Name: row.Name, Cron: row.Cron}
+		_, human := s.DescribeCron(row.Cron)
+		ref := ScheduleRef{Name: row.Name, Cron: row.Cron, Human: human}
 		byID[row.ID.Bytes] = ref
 		appliesAll[row.ID.Bytes] = row.AppliesToAll
 		if row.AppliesToAll {

--- a/internal/sync/schedule.go
+++ b/internal/sync/schedule.go
@@ -8,6 +8,9 @@ import (
 	"hash/fnv"
 	"time"
 
+	"breadbox/internal/appconfig"
+	"breadbox/internal/cronspec"
+
 	"github.com/robfig/cron/v3"
 )
 
@@ -59,12 +62,16 @@ func (s *Scheduler) loadScheduleResolver(ctx context.Context, fallbackIntervalMi
 		return nil, fmt.Errorf("list sync schedule connection pairs: %w", err)
 	}
 
+	// Cron is evaluated in the configured instance timezone (the single source
+	// of truth for "what clock the cron means"); unset → server local.
+	tzName := appconfig.String(ctx, s.queries, appconfig.KeyInstanceTimezone, "")
+
 	r := &scheduleResolver{perConn: make(map[[16]byte][]cron.Schedule)}
 	parsed := make(map[[16]byte]cron.Schedule, len(rows))
 	appliesToAll := make(map[[16]byte]bool, len(rows))
 
 	for _, row := range rows {
-		sc, err := cron.ParseStandard(row.Cron)
+		sc, err := cronspec.Parse(row.Cron, tzName)
 		if err != nil {
 			s.logger.Warn("skipping sync schedule with invalid cron", "cron", row.Cron, "error", err)
 			continue

--- a/internal/templates/components/cron_field.go
+++ b/internal/templates/components/cron_field.go
@@ -1,0 +1,60 @@
+//go:build !headless && !lite
+
+package components
+
+import (
+	"encoding/json"
+
+	"breadbox/internal/cronspec"
+)
+
+// CronFieldProps configures the shared cron-input component: timezone-aware
+// preset chips, a custom expression input, and a live preview (English
+// description + next fire times) rendered against the instance timezone.
+//
+// The component derives the active preset from the cron VALUE (not a stored
+// preset key), so an expression with no matching preset shows "Custom" with the
+// raw cron — never a misleading preset label.
+type CronFieldProps struct {
+	// Name is the form field the resolved cron expression is submitted as
+	// (required). A hidden input bound to the live value carries it.
+	Name string
+	// PresetName, when set, submits the active preset key as a second hidden
+	// field (for storing which preset was chosen, "custom" otherwise).
+	PresetName string
+	// Value is the initial cron expression.
+	Value string
+	// Presets is the catalog of preset chips (cronspec.Presets).
+	Presets []cronspec.Preset
+	// PreviewURL is the GET endpoint for the live preview. Defaults to
+	// /-/cron/preview when empty.
+	PreviewURL string
+}
+
+func (p CronFieldProps) previewURL() string {
+	if p.PreviewURL != "" {
+		return p.PreviewURL
+	}
+	return "/-/cron/preview"
+}
+
+// cronFieldConfigJSON serializes the config the Alpine factory reads from the
+// component root's data-config attribute.
+func cronFieldConfigJSON(p CronFieldProps) string {
+	type preset struct {
+		Key   string `json:"key"`
+		Label string `json:"label"`
+		Cron  string `json:"cron"`
+	}
+	ps := make([]preset, 0, len(p.Presets))
+	for _, x := range p.Presets {
+		ps = append(ps, preset{Key: x.Key, Label: x.Label, Cron: x.Cron})
+	}
+	b, _ := json.Marshal(map[string]any{
+		"value":      p.Value,
+		"presets":    ps,
+		"previewUrl": p.previewURL(),
+		"customKey":  cronspec.CustomKey,
+	})
+	return string(b)
+}

--- a/internal/templates/components/cron_field.templ
+++ b/internal/templates/components/cron_field.templ
@@ -1,0 +1,72 @@
+package components
+
+// CronField is the shared cron-input component: preset chips + a custom
+// expression input + a live preview (English description and next fire times,
+// in the instance timezone). Used by sync schedules and workflows.
+//
+// Submits the resolved cron expression as `Name` (hidden, bound to the live
+// value) and — when PresetName is set — the active preset key. The active
+// preset is derived from the cron VALUE, so an unmatched expression always
+// shows "Custom" with the raw cron rather than a wrong preset label.
+//
+// The Alpine factory lives in static/js/admin/components/cron_field.js; the
+// live preview is fetched from PreviewURL (default /-/cron/preview).
+templ CronField(p CronFieldProps) {
+	<script src="/static/js/admin/components/cron_field.js"></script>
+	<div x-data="cronField" data-config={ cronFieldConfigJSON(p) } class="space-y-2.5">
+		<!-- Preset chips -->
+		<div class="flex flex-wrap gap-1.5">
+			<template x-for="preset in presets" :key="preset.key">
+				<button
+					type="button"
+					class="btn btn-xs"
+					:class="active === preset.key ? 'btn-primary' : 'btn-ghost'"
+					@click="applyPreset(preset)"
+					x-text="preset.label"
+				></button>
+			</template>
+		</div>
+		<!-- Custom expression input — shown only when the custom chip is active -->
+		<div x-show="active === customKey" x-cloak class="space-y-1">
+			<input
+				type="text"
+				x-model="cron"
+				@input="onInput()"
+				placeholder="0 6,18 * * *"
+				class="bb-form-input input input-sm w-full font-mono"
+				aria-label="Custom cron expression"
+			/>
+			<p class="text-[0.7rem] text-base-content/45 leading-snug">
+				Standard 5-field cron — minute hour day month weekday.
+			</p>
+		</div>
+		<!-- Resolved values submitted with the form -->
+		<input type="hidden" name={ p.Name } :value="cron"/>
+		if p.PresetName != "" {
+			<input type="hidden" name={ p.PresetName } :value="active"/>
+		}
+		<!-- Live preview -->
+		<div x-show="cron.trim().length > 0" x-cloak class="rounded-xl border border-base-300/70 bg-base-200/40 p-3 text-xs">
+			<template x-if="preview.valid">
+				<div class="space-y-1.5">
+					<p class="font-medium text-base-content/80" x-text="preview.description"></p>
+					<div class="flex items-baseline justify-between gap-2">
+						<p class="text-base-content/50">Next runs</p>
+						<p class="text-base-content/40 truncate" x-text="preview.tz ? '· ' + preview.tz : ''"></p>
+					</div>
+					<ul class="space-y-0.5 text-base-content/70 tabular-nums">
+						<template x-for="run in preview.runs" :key="run">
+							<li x-text="run"></li>
+						</template>
+					</ul>
+				</div>
+			</template>
+			<template x-if="!preview.valid">
+				<div class="flex items-center gap-2 text-error">
+					@LucideIcon("alert-circle", "w-3.5 h-3.5")
+					<span x-text="preview.description || 'Not a valid cron expression'"></span>
+				</div>
+			</template>
+		</div>
+	</div>
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -3,6 +3,7 @@ package pages
 import (
 	"time"
 
+	"breadbox/internal/cronspec"
 	"breadbox/internal/templates/components"
 )
 
@@ -474,6 +475,38 @@ templ SectionFormControls() {
 					<input type="radio" name="ds-radio-1" class="radio"/>
 					<span class="label-text">Weekly</span>
 				</label>
+			</div>
+		}
+	</div>
+}
+
+// ─── Cron field ────────────────────────────────────────────────────────
+templ SectionCronField() {
+	<div class="flex flex-col gap-6">
+		@designExample("Default (preset chips + custom + live preview)", "components.CronField — timezone-aware preset chips, a custom 5-field expression, and a live preview (English description + next runs in the instance timezone, fetched from /-/cron/preview). The active preset is derived from the cron value, so an unmatched expression shows Custom with the raw cron — never a wrong preset label.") {
+			<div class="max-w-md">
+				@components.CronField(components.CronFieldProps{
+					Name:    "ds_cron_a",
+					Value:   "0 6,18 * * *",
+					Presets: cronspec.Presets,
+				})
+			</div>
+		}
+		@designExample("Custom expression (no matching preset)", "An expression with no catalog match opens on the Custom chip with the raw cron visible — the case that previously mis-rendered as 'Every 15 minutes'.") {
+			<div class="max-w-md">
+				@components.CronField(components.CronFieldProps{
+					Name:    "ds_cron_b",
+					Value:   "0 */12 * * *",
+					Presets: cronspec.Presets,
+				})
+			</div>
+		}
+		@designExample("Empty (new schedule)", "No initial value — chips only, no preview until a cadence is chosen or typed.") {
+			<div class="max-w-md">
+				@components.CronField(components.CronFieldProps{
+					Name:    "ds_cron_c",
+					Presets: cronspec.Presets,
+				})
 			</div>
 		}
 	</div>

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -16,14 +16,14 @@ import (
 // DesignGalleryProps is the prop bag for the /design page — the full
 // component gallery rendered on one scrollable page with section anchors.
 type DesignGalleryProps struct {
-	Sections    []DesignSection
+	Sections []DesignSection
 }
 
 // DesignComponentProps is the prop bag for /design/c/{slug} — a single
 // component rendered in isolation so agents (and humans) can focus
 // screenshots on one piece at a time.
 type DesignComponentProps struct {
-	Section     DesignSection
+	Section DesignSection
 }
 
 // DesignSection describes one entry in the design system gallery.
@@ -225,6 +225,13 @@ func DesignSections() []DesignSection {
 			Description: "Inputs, selects, textareas, checkboxes, toggles, file inputs.",
 			Group:       "forms",
 			Render:      func() templ.Component { return SectionFormControls() },
+		},
+		{
+			Slug:        "cron-field",
+			Title:       "Cron field",
+			Description: "components.CronField — the shared cron input: timezone-aware preset chips, a custom 5-field expression, and a live preview (English description + next runs in the instance timezone). The active preset is derived from the cron value, so unmatched expressions show Custom rather than a wrong preset. Powers sync schedules and workflows.",
+			Group:       "forms",
+			Render:      func() templ.Component { return SectionCronField() },
 		},
 		{
 			Slug:        "radio-card",

--- a/internal/templates/components/pages/schedule_form.templ
+++ b/internal/templates/components/pages/schedule_form.templ
@@ -2,8 +2,40 @@ package pages
 
 import "breadbox/internal/templates/components"
 
-// ScheduleForm is the standalone create/edit page for a sync schedule.
-// Reached from Settings → Sync schedules → "New schedule" / edit.
+// ScheduleDrawer is the create/edit sync-schedule form rendered inside the
+// shared right-side Drawer, opened from Settings → Sync (keeps the settings
+// page itself clean). One drawer per schedule (id "schedule-<shortID>") plus a
+// create drawer ("schedule-new") is rendered server-side, so the nested
+// CronField hydrates with the right values without any fetch dance.
+templ ScheduleDrawer(p ScheduleFormProps) {
+	@components.Drawer(components.DrawerProps{ID: p.DrawerID(), Title: scheduleFormTitle(p), Size: "lg"}) {
+		<form
+			method="POST"
+			action={ templ.SafeURL(p.FormAction()) }
+			class="flex flex-col h-full"
+			x-data={ scheduleFormState(p) }
+		>
+			<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+			@components.DrawerHeader(components.DrawerHeaderProps{Icon: "refresh-cw", Title: scheduleFormTitle(p)})
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				@scheduleFormFields(p)
+			</div>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm">
+					if p.IsEdit {
+						Save changes
+					} else {
+						Create schedule
+					}
+				</button>
+			}
+		</form>
+	}
+}
+
+// ScheduleForm is the standalone create/edit page — kept as a no-JS fallback
+// for direct URLs (the primary surface is the drawer above).
 templ ScheduleForm(p ScheduleFormProps) {
 	<div class="max-w-2xl mx-auto px-4 py-6" x-data={ scheduleFormState(p) }>
 		@components.PageHeader(components.PageHeaderProps{
@@ -17,64 +49,7 @@ templ ScheduleForm(p ScheduleFormProps) {
 		}
 		<form method="POST" action={ templ.SafeURL(p.FormAction()) } class="bb-card p-5 space-y-5">
 			<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
-			<!-- Name -->
-			<div class="space-y-1.5">
-				<label for="name" class="bb-settings-row__label">Name</label>
-				<input
-					id="name"
-					name="name"
-					type="text"
-					value={ p.Name }
-					placeholder="e.g. Nightly refresh"
-					class="bb-form-input input input-sm w-full"
-					required
-				/>
-			</div>
-			<!-- Cadence — shared cron component (presets + custom + live preview) -->
-			<div class="space-y-1.5">
-				<label class="bb-settings-row__label">Cadence</label>
-				@components.CronField(components.CronFieldProps{
-					Name:       "cron",
-					PresetName: "preset",
-					Value:      p.Cron,
-					Presets:    p.Presets,
-				})
-			</div>
-			<!-- Targets -->
-			<div class="space-y-2">
-				<label class="bb-settings-row__label">Applies to</label>
-				<label class="flex items-center gap-2 text-sm cursor-pointer">
-					<input type="checkbox" name="applies_to_all" class="checkbox checkbox-sm" x-model="all"/>
-					<span>All connections <span class="text-base-content/45">(including ones added later)</span></span>
-				</label>
-				<div class="mt-2 space-y-1.5 transition-opacity" :class="all ? 'opacity-40 pointer-events-none' : ''">
-					if len(p.Connections) == 0 {
-						<p class="text-sm text-base-content/55">No connections yet.</p>
-					}
-					for _, conn := range p.Connections {
-						<label class="flex items-center gap-2 text-sm cursor-pointer">
-							if p.SelectedConns[conn.ShortID] {
-								<input type="checkbox" name="connection_ids" value={ conn.ShortID } class="checkbox checkbox-sm" checked/>
-							} else {
-								<input type="checkbox" name="connection_ids" value={ conn.ShortID } class="checkbox checkbox-sm"/>
-							}
-							<span>{ connectionLabel(conn) }</span>
-						</label>
-					}
-				</div>
-			</div>
-			<!-- Enabled -->
-			<div class="space-y-1.5">
-				<label class="flex items-center gap-2 text-sm cursor-pointer">
-					if p.Enabled {
-						<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" checked/>
-					} else {
-						<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary"/>
-					}
-					<span>Enabled</span>
-				</label>
-			</div>
-			<!-- Actions -->
+			@scheduleFormFields(p)
 			<div class="flex items-center justify-end gap-2 pt-2 border-t border-base-200">
 				<a href="/settings/general#sync" class="btn btn-ghost btn-sm">Cancel</a>
 				<button type="submit" class="btn btn-primary btn-sm">
@@ -86,6 +61,69 @@ templ ScheduleForm(p ScheduleFormProps) {
 				</button>
 			</div>
 		</form>
+	</div>
+}
+
+// scheduleFormFields renders the shared field set (name, cadence, targets,
+// enabled) used by both the drawer and the standalone page. The surrounding
+// <form>, CSRF token, and action buttons are the caller's.
+templ scheduleFormFields(p ScheduleFormProps) {
+	<!-- Name -->
+	<div class="space-y-1.5">
+		<label for={ "name-" + p.DrawerID() } class="bb-settings-row__label">Name</label>
+		<input
+			id={ "name-" + p.DrawerID() }
+			name="name"
+			type="text"
+			value={ p.Name }
+			placeholder="e.g. Nightly refresh"
+			class="bb-form-input input input-sm w-full"
+			required
+		/>
+	</div>
+	<!-- Cadence — shared cron component (presets + custom + live preview) -->
+	<div class="space-y-1.5">
+		<label class="bb-settings-row__label">Cadence</label>
+		@components.CronField(components.CronFieldProps{
+			Name:       "cron",
+			PresetName: "preset",
+			Value:      p.Cron,
+			Presets:    p.Presets,
+		})
+	</div>
+	<!-- Targets -->
+	<div class="space-y-2">
+		<label class="bb-settings-row__label">Applies to</label>
+		<label class="flex items-center gap-2 text-sm cursor-pointer">
+			<input type="checkbox" name="applies_to_all" class="checkbox checkbox-sm" x-model="all"/>
+			<span>All connections <span class="text-base-content/45">(including ones added later)</span></span>
+		</label>
+		<div class="mt-2 space-y-1.5 transition-opacity" :class="all ? 'opacity-40 pointer-events-none' : ''">
+			if len(p.Connections) == 0 {
+				<p class="text-sm text-base-content/55">No connections yet.</p>
+			}
+			for _, conn := range p.Connections {
+				<label class="flex items-center gap-2 text-sm cursor-pointer">
+					if p.SelectedConns[conn.ShortID] {
+						<input type="checkbox" name="connection_ids" value={ conn.ShortID } class="checkbox checkbox-sm" checked/>
+					} else {
+						<input type="checkbox" name="connection_ids" value={ conn.ShortID } class="checkbox checkbox-sm"/>
+					}
+					<span>{ connectionLabel(conn) }</span>
+				</label>
+			}
+		</div>
+	</div>
+	<!-- Enabled -->
+	<div class="space-y-1.5">
+		<label class="flex items-center gap-2 text-sm cursor-pointer">
+			if p.Enabled {
+				<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" checked/>
+			} else {
+				<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary"/>
+			}
+			<span>Enabled</span>
+		</label>
 	</div>
 }
 

--- a/internal/templates/components/pages/schedule_form.templ
+++ b/internal/templates/components/pages/schedule_form.templ
@@ -30,33 +30,15 @@ templ ScheduleForm(p ScheduleFormProps) {
 					required
 				/>
 			</div>
-			<!-- Cadence preset -->
+			<!-- Cadence — shared cron component (presets + custom + live preview) -->
 			<div class="space-y-1.5">
-				<label for="preset" class="bb-settings-row__label">Cadence</label>
-				<select id="preset" name="preset" class="bb-form-select select select-sm w-full bg-base-200" x-model="preset">
-					for _, preset := range p.Presets {
-						if preset.Key == p.PresetKey {
-							<option value={ preset.Key } selected>{ preset.Label }</option>
-						} else {
-							<option value={ preset.Key }>{ preset.Label }</option>
-						}
-					}
-				</select>
-			</div>
-			<!-- Custom cron (only when preset == custom) -->
-			<div class="space-y-1.5" x-show="preset === 'custom'" x-cloak>
-				<label for="cron" class="bb-settings-row__label">Custom cron expression</label>
-				<input
-					id="cron"
-					name="cron"
-					type="text"
-					value={ p.Cron }
-					placeholder="0 6,18 * * *"
-					class="bb-form-input input input-sm w-full font-mono"
-				/>
-				<p class="text-xs text-base-content/45 leading-snug">
-					Standard 5-field cron (minute hour day month weekday), evaluated in the server's local timezone.
-				</p>
+				<label class="bb-settings-row__label">Cadence</label>
+				@components.CronField(components.CronFieldProps{
+					Name:       "cron",
+					PresetName: "preset",
+					Value:      p.Cron,
+					Presets:    p.Presets,
+				})
 			</div>
 			<!-- Targets -->
 			<div class="space-y-2">
@@ -114,17 +96,13 @@ func scheduleFormTitle(p ScheduleFormProps) string {
 	return "New sync schedule"
 }
 
-// scheduleFormState is the inline Alpine x-data: tracks the selected preset
-// (to reveal the custom-cron field) and the applies-to-all flag (to dim the
-// connection picker). Short enough to stay inline per the UI rules.
+// scheduleFormState is the inline Alpine x-data: tracks the applies-to-all flag
+// (to dim the connection picker). The cron/preset state is owned by the nested
+// CronField component. Short enough to stay inline per the UI rules.
 func scheduleFormState(p ScheduleFormProps) string {
-	preset := p.PresetKey
-	if preset == "" {
-		preset = "twice_daily"
-	}
 	all := "false"
 	if p.AppliesToAll {
 		all = "true"
 	}
-	return "{ preset: '" + preset + "', all: " + all + " }"
+	return "{ all: " + all + " }"
 }

--- a/internal/templates/components/pages/schedule_form_types.go
+++ b/internal/templates/components/pages/schedule_form_types.go
@@ -51,6 +51,15 @@ func (p ScheduleFormProps) FormAction() string {
 	return "/settings/sync/schedules"
 }
 
+// DrawerID is the $store.drawers key for this form's drawer: "schedule-new" for
+// create, "schedule-<shortID>" for edit. Buttons open the matching drawer.
+func (p ScheduleFormProps) DrawerID() string {
+	if p.IsEdit {
+		return "schedule-" + p.ShortID
+	}
+	return "schedule-new"
+}
+
 // connectionLabel renders a connection's display name for the target picker.
 func connectionLabel(c service.ConnectionResponse) string {
 	name := ""

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -137,16 +137,20 @@ templ settingsSyncSection(p SettingsProps) {
 				}
 			}
 		}
+		<!-- Create + per-schedule edit drawers (slide-over from the right) -->
+		@ScheduleDrawer(p.NewScheduleForm)
+		for _, f := range p.EditScheduleForms {
+			@ScheduleDrawer(f)
+		}
 	</div>
 }
 
-// newScheduleButton is the section's primary action — links to the
-// dedicated schedule form page.
+// newScheduleButton is the section's primary action — opens the create drawer.
 templ newScheduleButton() {
-	<a href="/settings/sync/schedules/new" class="btn btn-primary btn-sm gap-2">
+	<button type="button" @click="$store.drawers.open('schedule-new')" class="btn btn-primary btn-sm gap-2">
 		@components.LucideIcon("plus", "w-4 h-4")
 		New schedule
-	</a>
+	</button>
 }
 
 // settingsScheduleRow renders one schedule: its name + human cadence and
@@ -168,9 +172,9 @@ templ settingsScheduleRow(p SettingsProps, sched service.SyncScheduleView) {
 					<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" aria-label="Enabled"/>
 				}
 			}
-			<a href={ scheduleEditURL(sched.ShortID) } class="btn btn-ghost btn-sm btn-square" aria-label="Edit schedule">
+			<button type="button" @click={ "$store.drawers.open('schedule-" + sched.ShortID + "')" } class="btn btn-ghost btn-sm btn-square" aria-label="Edit schedule">
 				@components.LucideIcon("pencil", "w-4 h-4")
-			</a>
+			</button>
 			<form method="POST" action={ scheduleDeleteURL(sched.ShortID) } onsubmit="return confirm('Delete this schedule?')">
 				<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
 				<button type="submit" class="btn btn-ghost btn-sm btn-square text-error" aria-label="Delete schedule">

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -99,6 +99,27 @@ templ settingsSyncSection(p SettingsProps) {
 			Caption: settingsSyncCaption(p),
 			Right:   newScheduleButton(),
 		}) {
+			@components.SettingsRow(components.SettingsRowProps{
+				Label:   "Timezone",
+				Caption: "Schedules are evaluated in this zone",
+				For:     "instance_timezone",
+			}) {
+				@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
+					Action:    "/settings/timezone",
+					CSRFToken: p.CSRFToken,
+					Label:     "Timezone saved",
+				}) {
+					<select id="instance_timezone" name="instance_timezone" class="select select-sm bg-base-200">
+						@tzOption("", p.InstanceTimezone, "Server default")
+						for _, tz := range commonTimezones() {
+							@tzOption(tz, p.InstanceTimezone, tz)
+						}
+						if p.InstanceTimezone != "" && !isCommonTimezone(p.InstanceTimezone) {
+							@tzOption(p.InstanceTimezone, p.InstanceTimezone, p.InstanceTimezone)
+						}
+					</select>
+				}
+			}
 			if len(p.SyncSchedules) == 0 {
 				@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 					<p class="text-sm text-base-content/55 leading-snug">
@@ -449,6 +470,44 @@ templ settingsDeveloperSection() {
 // ---------------------------------------------------------------------
 // Helpers reused by handlers + by other settings tabs
 // ---------------------------------------------------------------------
+templ tzOption(value, current, label string) {
+	if value == current {
+		<option value={ value } selected>{ label }</option>
+	} else {
+		<option value={ value }>{ label }</option>
+	}
+}
+
+// commonTimezones is a curated shortlist for the instance-timezone picker —
+// enough to cover most self-hosters without shipping the full IANA database in
+// a select. A configured zone outside this list is appended as its own option.
+func commonTimezones() []string {
+	return []string{
+		"UTC",
+		"America/Los_Angeles",
+		"America/Denver",
+		"America/Chicago",
+		"America/New_York",
+		"America/Sao_Paulo",
+		"Europe/London",
+		"Europe/Paris",
+		"Europe/Berlin",
+		"Europe/Madrid",
+		"Asia/Kolkata",
+		"Asia/Singapore",
+		"Asia/Tokyo",
+		"Australia/Sydney",
+	}
+}
+
+func isCommonTimezone(tz string) bool {
+	for _, t := range commonTimezones() {
+		if t == tz {
+			return true
+		}
+	}
+	return false
+}
 
 templ retentionOption(value, current int, label string) {
 	if value == current {

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -59,6 +59,9 @@ type SettingsProps struct {
 	// drawer), so the nested CronField hydrates with correct values.
 	NewScheduleForm   ScheduleFormProps
 	EditScheduleForms []ScheduleFormProps
+	// InstanceTimezone is the configured IANA zone cron is evaluated in
+	// (empty = server local). Surfaced as the Sync-section timezone picker.
+	InstanceTimezone string
 	// ConfigSources maps config keys to their source: "env", "db", or "default".
 	ConfigSources map[string]string
 

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -54,6 +54,11 @@ type SettingsProps struct {
 	// replacement for the single global interval). Rendered as a list in
 	// the General → Sync section.
 	SyncSchedules []service.SyncScheduleView
+	// NewScheduleForm + EditScheduleForms drive the create/edit drawers
+	// rendered server-side in the Sync section (one per schedule + a create
+	// drawer), so the nested CronField hydrates with correct values.
+	NewScheduleForm   ScheduleFormProps
+	EditScheduleForms []ScheduleFormProps
 	// ConfigSources maps config keys to their source: "env", "db", or "default".
 	ConfigSources map[string]string
 

--- a/static/js/admin/components/cron_field.js
+++ b/static/js/admin/components/cron_field.js
@@ -1,0 +1,95 @@
+// cronField — Alpine factory for the shared CronField templ component.
+//
+// Reads its config (initial cron value, preset catalog, preview endpoint, the
+// custom-preset key) from the root element's data-config JSON. Renders preset
+// chips, a custom-expression input, and a debounced live preview fetched from
+// the server (description + next fire times, in the instance timezone).
+//
+// The active preset is derived from the cron VALUE on init (presetFromCron), so
+// an expression with no matching preset shows "Custom" with the raw cron — the
+// fix for the old form preselecting a wrong preset (e.g. "Every 15 minutes" for
+// "0 */12 * * *").
+document.addEventListener('alpine:init', function () {
+  Alpine.data('cronField', function () {
+    return {
+      presets: [],
+      cron: '',
+      active: 'custom',
+      customKey: 'custom',
+      previewUrl: '/-/cron/preview',
+      preview: { valid: false, description: '', runs: [], tz: '' },
+      _debounce: null,
+
+      init: function () {
+        var cfg = {};
+        try { cfg = JSON.parse(this.$el.dataset.config || '{}'); } catch (e) { cfg = {}; }
+        this.presets = cfg.presets || [];
+        this.previewUrl = cfg.previewUrl || '/-/cron/preview';
+        this.customKey = cfg.customKey || 'custom';
+        this.cron = (cfg.value || '').trim();
+        this.active = this.presetFromCron(this.cron);
+        if (this.cron) this.fetchPreview();
+      },
+
+      // presetFromCron returns the preset key whose cron matches the expression
+      // exactly, or the custom key when none match.
+      presetFromCron: function (expr) {
+        expr = (expr || '').trim();
+        if (!expr) return this.customKey;
+        for (var i = 0; i < this.presets.length; i++) {
+          if (this.presets[i].cron && this.presets[i].cron === expr) {
+            return this.presets[i].key;
+          }
+        }
+        return this.customKey;
+      },
+
+      applyPreset: function (preset) {
+        if (preset.key === this.customKey) {
+          this.active = this.customKey;
+          this.refresh();
+          return;
+        }
+        this.cron = preset.cron;
+        this.active = preset.key;
+        this.refresh();
+      },
+
+      onInput: function () {
+        this.active = this.customKey;
+        this.refresh();
+      },
+
+      refresh: function () {
+        var self = this;
+        if (this._debounce) clearTimeout(this._debounce);
+        this._debounce = setTimeout(function () { self.fetchPreview(); }, 250);
+      },
+
+      fetchPreview: function () {
+        var self = this;
+        var expr = (this.cron || '').trim();
+        if (!expr) {
+          self.preview = { valid: false, description: '', runs: [], tz: '' };
+          return;
+        }
+        fetch(this.previewUrl + '?cron=' + encodeURIComponent(expr), {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+          .then(function (res) { return res.json(); })
+          .then(function (data) {
+            self.preview = {
+              valid: !!(data && data.valid),
+              description: (data && data.description) || '',
+              runs: (data && data.next_runs) || [],
+              tz: (data && data.tz_label) || '',
+            };
+          })
+          .catch(function () {
+            self.preview = { valid: false, description: 'Preview unavailable', runs: [], tz: '' };
+          });
+      },
+    };
+  });
+});


### PR DESCRIPTION
## Shared cron component + timezone-aware schedules + drawer

Follow-up to #1748 (cron-anchored sync schedules). Consolidates cron input into one design-system component, fixes a preset-display bug, makes cron timezone-aware, and moves schedule create/edit into a side drawer.

### Fix: edit form preselected the wrong preset
Editing a schedule with no matching preset (e.g. `0 */12 * * *`) showed **"Every 15 minutes"** selected — the old `<select>` fell back to its first option because the stored preset key (`interval-migrated`) wasn't in the catalog. The new component derives the active preset from the **cron value**, so an unmatched expression shows **Custom** with the raw cron.

### components.CronField — the shared cron input
Timezone-aware preset chips + a custom 5-field expression + a **live preview** (English description via `lnquy/cron` + the next runs, in the instance timezone), backed by `GET /-/cron/preview`. The active preset is derived from the value. Used by sync schedules; ready for workflows next.

<img src="https://i.img402.dev/7da3p9d20x.jpg" width="800" alt="CronField in the design sandbox — default, custom, empty">

### Instance timezone
The clock cron is evaluated in is now a setting (`app_config instance.timezone`, IANA), threaded through the sync scheduler (via robfig's `CRON_TZ=` anchor) and the preview. Unset = server-local (behavior-preserving). Settings → Sync gains a Timezone picker.

<img src="https://i.img402.dev/6ggrskjdrp.jpg" width="800" alt="Settings → Sync: Timezone picker + schedule list">

### Create/edit in a side drawer
The form moved off a standalone page into the shared `components.Drawer` (like Providers/Workflows), keeping the settings page clean. One drawer per schedule is rendered server-side so the nested CronField hydrates correctly; submit is a normal POST.

<img src="https://i.img402.dev/r6ckzybmyo.jpg" width="800" alt="Schedule edit drawer with CronField + live preview">

### Connections
Schedule display now shows **name + readable cadence** ("Default schedule — every 30 minutes"), not just an opaque name.

### Sandbox + tests
- Sandboxed at `/design/c/cron-field` (default / custom / empty variants).
- `cronspec` tests: `NextRuns` + timezone anchoring (`0 6 * * *` in America/Los_Angeles fires 13:00 UTC; unanchored fires 06:00 UTC).
- Build/vet/unit green; `headless` + `lite` compile; validated in-browser (sandbox, drawer save, TZ picker).

### Follow-up (not in this PR)
Repoint the **Workflows** cron input + agent scheduler to this component/instance-TZ (the agents form uses an inline JS parser — higher blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
