### PR TITLE
feat(ui): point update banner at the docs update guide

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -118,14 +118,23 @@ templ Nav(p NavProps) {
 			<p class="bb-update-card__title">Version { p.NavLatestVersion }</p>
 			<p class="bb-update-card__desc">A new release of Breadbox is available.</p>
 			<a
-				href={ templ.SafeURL(p.NavLatestURL) }
+				href="https://docs.breadbox.sh/installation/updating"
 				target="_blank"
 				rel="noopener noreferrer"
 				class="bb-update-card__action"
+				title="How to update Breadbox"
+			>
+				How to update
+				@LucideIcon("arrow-right", "")
+			</a>
+			<a
+				href={ templ.SafeURL(p.NavLatestURL) }
+				target="_blank"
+				rel="noopener noreferrer"
+				class="inline-flex items-center gap-1 text-xs text-base-content/50 no-underline hover:underline"
 				title={ "Release notes for " + p.NavLatestVersion }
 			>
-				Release notes
-				@LucideIcon("arrow-right", "")
+				View changelog
 			</a>
 		</div>
 	}


### PR DESCRIPTION
## What

The sidebar "update available" card now leads with a **How to update** link to the new docs guide, and demotes the GitHub link to a muted **View changelog** sublink.

<img src="https://i.img402.dev/nlw9850fb8.jpg" width="320" alt="Update banner — How to update + View changelog">

## Why

Real production testing surfaced two gaps in the update banner:

1. It offered **no way to act** — only a "Release notes" link. A self-hoster seeing "a new release is available" had no in-product guidance on *how* to update.
2. (Separately) the docs told users to run a `./update.sh --bump=...` script that the installer never writes.

This PR fixes #1 by linking the banner to a maintainable docs page rather than stuffing shell snippets into a sidebar card. The docs page (and the `update.sh` fix) ship in **canalesb93/breadbox-docs#55**.

## Change

`internal/templates/components/nav.templ` — the update card's primary action is now `How to update →` pointing at `https://docs.breadbox.sh/installation/updating`; the existing `NavLatestURL` (GitHub release) becomes a secondary muted "View changelog" link so "what changed" stays one click away.

- Secondary link uses inline Tailwind utilities (one-off glue, per `.claude/rules/daisyui.md`) — no new `bb-*` class.
- `go build ./...`, `go vet ./...`, and `go test ./internal/templates/...` all pass.
- Screenshot above captured against the running dashboard (card injected into the real sidebar with live CSS, since `version=dev` suppresses the banner locally).

## Not in scope (the original finding #1: banner only appeared after a restart)

That symptom is almost certainly a **release-tagging issue**, not a code bug: the version checker disables itself when the running binary's `version` is `dev` or non-semver (`internal/version/checker.go`). Worth confirming what the prod box reports under **Settings → System** / `breadbox version`. Happy to follow up if it's actually running a non-semver tag.