### PR TITLE
bb-artifacts: authenticated uploads (GitHub identity or static token)

### DIFF
--- a/.claude/skills/github-image-hosting/SKILL.md
+++ b/.claude/skills/github-image-hosting/SKILL.md
@@ -23,6 +23,9 @@ metadata:
 Upload a screenshot, image, or HTML/text snapshot and get back a public URL —
 embed it in a PR/issue or open it directly to view a rendered debug page.
 
+**Always use bb-artifacts first.** img402 is only a fallback for when bb-artifacts
+is unreachable — never reach for it (or anything else) while bb-artifacts is up.
+
 Host: **bb-artifacts.exe.xyz** (self-hosted on exe.dev). **Reads are public**
 (GitHub's camo proxy and anyone with the link can fetch). **Uploads are
 authenticated** by either of two means:

--- a/.claude/skills/github-image-hosting/SKILL.md
+++ b/.claude/skills/github-image-hosting/SKILL.md
@@ -5,8 +5,8 @@ description: >
   embedding in PRs, issues, and comments, or for sharing a rendered debug page.
   Defaults to the self-hosted host at bb-artifacts.exe.xyz — authenticated upload
   via your GitHub token (`gh auth token`, works in local AND cloud sessions);
-  public read; ~180-day retention; 25MB cap. Falls back to img402.dev, then a
-  GitHub release-asset CDN, only if the host is unreachable.
+  public read; ~180-day retention; 25MB cap. Falls back to img402.dev only if the
+  host is unreachable.
   Triggers: "screenshot this", "attach an image", "add a screenshot to the PR",
   "upload this mockup", "host this HTML", "share a debug snapshot", or any task
   producing an image or HTML page that needs a shareable URL.
@@ -81,36 +81,15 @@ the Bearer:
     echo "ARTIFACT_URL=$URL" >> "$GITHUB_ENV"
 ```
 
-## Fallbacks
+## Fallback: img402.dev (ephemeral)
 
-Only needed if bb-artifacts is unreachable or `gh` isn't authed.
-
-### Fallback 1: img402.dev (ephemeral)
-
-Constraints: 1MB max, 7-day expiry, shared 1,000 uploads/day global cap, and
-occasional outages. Requires `img402.dev` in the sandbox allowlist — it is.
+Only if bb-artifacts is unreachable. Constraints: 1MB max, 7-day expiry, shared
+1,000 uploads/day global cap, and occasional outages. Requires `img402.dev` in the
+sandbox allowlist — it is.
 
 ```bash
 URL=$(curl -s -X POST https://img402.dev/api/free -F image=@"$FILE" | jq -r .url)
 # -> https://i.img402.dev/<id>.jpg   (images only, <1MB — re-encode if larger)
-```
-
-### Fallback 2: GitHub release asset CDN (permanent)
-
-Last resort. `gh` is sandbox-exempt, so it needs no network allowlist. GitHub-hosted
-URLs are permanent (they live in the repo's release assets) — fine as a safety net,
-but they clutter releases, so prefer the ephemeral options above.
-
-```bash
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-gh release view screenshots-cdn --repo "$REPO" >/dev/null 2>&1 || \
-  gh release create screenshots-cdn --repo "$REPO" --prerelease \
-    --title "Screenshots CDN" --notes "Auto-uploaded PR validation screenshots."
-
-FNAME="$(date +%Y%m%d-%H%M%S)-$(basename "$FILE")"
-cp "$FILE" "/tmp/$FNAME"
-gh release upload screenshots-cdn "/tmp/$FNAME" --clobber --repo "$REPO"
-IMG_URL="https://github.com/$REPO/releases/download/screenshots-cdn/$FNAME"
 ```
 
 ## Embed formats

--- a/.claude/skills/github-image-hosting/SKILL.md
+++ b/.claude/skills/github-image-hosting/SKILL.md
@@ -3,10 +3,10 @@ name: github-image-hosting
 description: >
   Upload an image or an HTML/text snapshot and get a public URL suitable for
   embedding in PRs, issues, and comments, or for sharing a rendered debug page.
-  Defaults to the self-hosted host at bb-artifacts.exe.xyz (token-gated upload,
-  public read, ~180-day retention, 25MB cap). Falls back to img402.dev (tokenless,
-  ephemeral — good for cloud sessions with no token), then to a GitHub release-asset
-  CDN (permanent) when both are unavailable.
+  Defaults to the self-hosted host at bb-artifacts.exe.xyz — authenticated upload
+  via your GitHub token (`gh auth token`, works in local AND cloud sessions);
+  public read; ~180-day retention; 25MB cap. Falls back to img402.dev, then a
+  GitHub release-asset CDN, only if the host is unreachable.
   Triggers: "screenshot this", "attach an image", "add a screenshot to the PR",
   "upload this mockup", "host this HTML", "share a debug snapshot", or any task
   producing an image or HTML page that needs a shareable URL.
@@ -23,37 +23,33 @@ metadata:
 Upload a screenshot, image, or HTML/text snapshot and get back a public URL —
 embed it in a PR/issue or open it directly to view a rendered debug page.
 
-Host: **bb-artifacts.exe.xyz** (self-hosted on exe.dev). Uploads are token-gated;
-reads are fully public (GitHub's camo proxy and anyone with the link can fetch).
+Host: **bb-artifacts.exe.xyz** (self-hosted on exe.dev). **Reads are public**
+(GitHub's camo proxy and anyone with the link can fetch). **Uploads are
+authenticated** by either of two means:
 
-## Primary: bb-artifacts.exe.xyz
+- **GitHub identity** — send your GitHub token as the Bearer; the server checks it
+  resolves to an allowed login (`canalesb93`). `gh auth token` works in **both
+  local and cloud** Claude sessions, so there's no secret to store. This is the
+  default for agents.
+- **Static upload token** — a shared secret (for CI, or any non-`gh` context). See
+  the CI section below.
 
-The upload token lives in `.local.env` as `IMGHOST_TOKEN` (gitignored — never
-commit it). Read it from there:
+## Primary: bb-artifacts.exe.xyz (GitHub-identity)
 
 ```bash
-# Load host + token from the gitignored .local.env (run from repo root)
-IMGHOST_URL=$(grep -E '^IMGHOST_URL=' .local.env | cut -d= -f2- 2>/dev/null)
-IMGHOST_URL=${IMGHOST_URL:-https://bb-artifacts.exe.xyz}
-IMGHOST_TOKEN=$(grep -E '^IMGHOST_TOKEN=' .local.env | cut -d= -f2- 2>/dev/null)
-
-if [ -n "$IMGHOST_TOKEN" ]; then
-  URL=$(curl -sf -H "Authorization: Bearer $IMGHOST_TOKEN" \
-            -F file=@/tmp/screenshot.jpg "$IMGHOST_URL/upload" \
-        | jq -r .url)
-  echo "$URL"   # -> https://bb-artifacts.exe.xyz/f/<id>.jpg
-else
-  echo "no IMGHOST_TOKEN (e.g. cloud session) — use the GitHub release fallback below"
-fi
+URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
+          -F file=@/tmp/screenshot.jpg https://bb-artifacts.exe.xyz/upload | jq -r .url)
+echo "$URL"   # -> https://bb-artifacts.exe.xyz/f/<id>.jpg
 ```
 
-No `jq`? Parse with python: `python3 -c "import sys,json;print(json.load(sys.stdin)['url'])"`.
+`gh` is sandbox-exempt and authenticated in both local and cloud sessions, so this
+is the one path that works everywhere. No `jq`? Parse with python:
+`python3 -c "import sys,json;print(json.load(sys.stdin)['url'])"`.
 
 **Accepted**: images (`png/jpg/jpeg/gif/webp/svg/bmp/ico`), `html/htm`, `txt/md/log`,
-`css`, `json`, `pdf`. **Cap**: 25MB per file. **Retention**: files auto-delete after
-~180 days (configurable on the VM), so stale PR screenshots disappear on their own.
-Requires `bb-artifacts.exe.xyz` in the sandbox network allowlist — it is, in this
-project's `.claude/settings.json`.
+`css`, `json`, `pdf`. **Limits**: 25MB/file, per-IP rate limit, total-store cap;
+files auto-delete after ~180 days. Requires `bb-artifacts.exe.xyz` in the sandbox
+network allowlist — it is, in this project's `.claude/settings.json`.
 
 If an image exceeds the cap (or you just want it smaller): re-encode with
 `cwebp -q 75` or `jpegoptim --max=85 --strip-all`. Chrome DevTools MCP
@@ -66,21 +62,33 @@ returned URL renders in a browser. Handy for capturing a rendered page, a failin
 template, or a large log to share without pasting it inline.
 
 ```bash
-URL=$(curl -sf -H "Authorization: Bearer $IMGHOST_TOKEN" \
-          -F file=@/tmp/debug-snapshot.html "$IMGHOST_URL/upload" | jq -r .url)
+URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
+          -F file=@/tmp/debug-snapshot.html https://bb-artifacts.exe.xyz/upload | jq -r .url)
 echo "$URL"   # open in a browser to view the rendered page
+```
+
+### From CI (or any non-`gh` context): static upload token
+
+In GitHub Actions the ambient token is a bot, not you, so use the static upload
+secret instead. Store it as a repo secret (`IMGHOST_UPLOAD_TOKEN`) and send it as
+the Bearer:
+
+```yaml
+- name: Upload screenshot to bb-artifacts
+  run: |
+    URL=$(curl -sf -H "Authorization: Bearer ${{ secrets.IMGHOST_UPLOAD_TOKEN }}" \
+              -F file=@artifact.png https://bb-artifacts.exe.xyz/upload | jq -r .url)
+    echo "ARTIFACT_URL=$URL" >> "$GITHUB_ENV"
 ```
 
 ## Fallbacks
 
-Try these in order when the primary host fails or its token is unavailable.
+Only needed if bb-artifacts is unreachable or `gh` isn't authed.
 
-### Fallback 1: img402.dev (tokenless, ephemeral)
+### Fallback 1: img402.dev (ephemeral)
 
-Good for cloud sessions (no `IMGHOST_TOKEN` needed) and quick ephemeral shots.
 Constraints: 1MB max, 7-day expiry, shared 1,000 uploads/day global cap, and
-occasional outages (the reason it's no longer primary). Requires `img402.dev` in the
-sandbox allowlist — it is.
+occasional outages. Requires `img402.dev` in the sandbox allowlist — it is.
 
 ```bash
 URL=$(curl -s -X POST https://img402.dev/api/free -F image=@"$FILE" | jq -r .url)
@@ -89,10 +97,9 @@ URL=$(curl -s -X POST https://img402.dev/api/free -F image=@"$FILE" | jq -r .url
 
 ### Fallback 2: GitHub release asset CDN (permanent)
 
-Last resort when both hosts are unavailable. `gh` is sandbox-exempt, so it needs no
-network allowlist. GitHub-hosted URLs are permanent (they live in the repo's release
-assets) — fine as a safety net, but they clutter releases, so prefer the ephemeral
-options above.
+Last resort. `gh` is sandbox-exempt, so it needs no network allowlist. GitHub-hosted
+URLs are permanent (they live in the repo's release assets) — fine as a safety net,
+but they clutter releases, so prefer the ephemeral options above.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
@@ -134,4 +141,4 @@ IMG_URL="https://github.com/$REPO/releases/download/screenshots-cdn/$FNAME"
 - Do NOT use `![alt](url)` — GitHub renders the native pixel size and tall captures become painful to review. Inline `<img width="…">` is the only format that renders sensibly.
 - `{width=…}` kramdown syntax and `style="…"` attributes are silently stripped by GitHub's sanitizer. Use the `width` attribute.
 - For quick local sanity checks (not PR evidence), skip uploading entirely.
-- Migrating the host off exe.dev later: the store is plain files under `~/imghost/data` on the VM — `rsync` it to any static host and repoint `IMGHOST_URL`. Server source + deploy notes live at `~/dev/bb-artifacts-host/`.
+- Auth model + ops: the host accepts your GitHub identity (`GITHUB_ALLOWED_LOGINS`) or static tokens (`IMGHOST_TOKENS=label:secret`). Server source, deploy, and migration notes live at `~/dev/bb-artifacts-host/`; the store is plain files under `~/imghost/data` on the VM (`rsync` to migrate).

--- a/.claude/skills/validate-ui/SKILL.md
+++ b/.claude/skills/validate-ui/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Validate a Breadbox admin UI change in a real browser and produce a screenshot as PR
   evidence. Prefers Chrome DevTools MCP when available; falls back to headless Chromium
   via Playwright in cloud sessions where the MCP is not loaded. Saves a JPEG under 1MB,
-  uploads to the self-hosted bb-artifacts.exe.xyz CDN (auth via `gh auth token`; `gh
-  release upload` as fallback), ready to embed in a PR.
+  uploads to the self-hosted bb-artifacts.exe.xyz CDN (auth via `gh auth token`),
+  ready to embed in a PR.
   Triggers: "validate the UI change", "screenshot this page", "capture the transactions page",
   "attach a screenshot to the PR", "show me how it looks", or any task needing a visual
   of the running app before a PR can be marked done.
@@ -201,26 +201,12 @@ URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
 echo "$URL"
 ```
 
-**Fallback: GitHub release CDN** (only if bb-artifacts is unreachable or `gh` isn't
-authed). `gh` is sandbox-exempt — no network allowlist required — and gives a
-permanent, GitHub-native URL.
+**Fallback: img402.dev** (only if bb-artifacts is unreachable). Tokenless and
+ephemeral, 1MB cap — fine for these JPEGs. Requires `img402.dev` in the sandbox
+allowlist — it is.
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-
-# Ensure screenshots-cdn prerelease exists (idempotent)
-gh release view screenshots-cdn 2>/dev/null || \
-  gh release create screenshots-cdn \
-    --prerelease \
-    --title "Screenshots CDN" \
-    --notes "Auto-uploaded PR validation screenshots. Assets may be overwritten between runs."
-
-# Upload with a timestamped filename to avoid collisions
-FNAME="$(date +%Y%m%d-%H%M%S)-app-<PAGE>.jpg"
-cp /tmp/app-<PAGE>.jpg "/tmp/$FNAME"
-gh release upload screenshots-cdn "/tmp/$FNAME" --clobber
-
-URL="https://github.com/$REPO/releases/download/screenshots-cdn/$FNAME"
+URL=$(curl -s -X POST https://img402.dev/api/free -F image=@/tmp/app-<PAGE>.jpg | jq -r .url)
 echo "$URL"
 ```
 
@@ -231,7 +217,7 @@ Use inline HTML (not `![alt](url)`) so you control the displayed width. GitHub M
 **Single screenshot:**
 
 ```html
-<img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/FNAME.jpg" width="800" alt="<page> — after">
+<img src="https://bb-artifacts.exe.xyz/f/<id>.jpg" width="800" alt="<page> — after">
 ```
 
 **Before/after — side-by-side table** (preferred for visual diffs):
@@ -243,8 +229,8 @@ Use inline HTML (not `![alt](url)`) so you control the displayed width. GitHub M
     <th>After</th>
   </tr>
   <tr>
-    <td><img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/before.jpg" width="400" alt="before"></td>
-    <td><img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/after.jpg" width="400" alt="after"></td>
+    <td><img src="https://bb-artifacts.exe.xyz/f/<id-before>.jpg" width="400" alt="before"></td>
+    <td><img src="https://bb-artifacts.exe.xyz/f/<id-after>.jpg" width="400" alt="after"></td>
   </tr>
 </table>
 ```
@@ -252,14 +238,14 @@ Use inline HTML (not `![alt](url)`) so you control the displayed width. GitHub M
 **Mobile screenshot** (narrow — embed smaller):
 
 ```html
-<img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/mobile.jpg" width="320" alt="<page> — mobile">
+<img src="https://bb-artifacts.exe.xyz/f/<id>.jpg" width="320" alt="<page> — mobile">
 ```
 
 **Tall capture you still want to include** (`fullPage: true`) — collapse it:
 
 ```html
 <details><summary><page> — full page</summary>
-<img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/fullpage.jpg" width="800" alt="<page> — full page">
+<img src="https://bb-artifacts.exe.xyz/f/<id>.jpg" width="800" alt="<page> — full page">
 </details>
 ```
 
@@ -276,6 +262,6 @@ gh pr comment <PR_NUMBER> --body "<img src=\"$URL\" width=\"800\" alt=\"<page>\"
 - **Responsive changes always get at least two captures**: desktop (1280 or 1440) + mobile (390). Tablet (768) only when the change crosses the `md` breakpoint.
 - For before/after diffs, name the files `<PAGE>-before` and `<PAGE>-after` and embed them in the table above.
 - After template / CSS / Alpine changes, restart `make dev` before capturing so Tailwind / partials rebuild.
-- The `screenshots-cdn` prerelease is permanent — URLs stay valid indefinitely. Each new upload uses a timestamped filename so old URLs remain accessible.
+- bb-artifacts URLs are immutable per upload (random id) and auto-expire after ~180 days — long enough for PR review, short enough that stale screenshots clean themselves up.
 - For quick visual checks (not PR evidence), skip the upload step — the local JPEG is enough.
 - What does NOT work on GitHub Markdown: `![alt](url){width=600}` (ignored), `style="..."` attributes (stripped). Stick to `<img width="...">`.

--- a/.claude/skills/validate-ui/SKILL.md
+++ b/.claude/skills/validate-ui/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Validate a Breadbox admin UI change in a real browser and produce a screenshot as PR
   evidence. Prefers Chrome DevTools MCP when available; falls back to headless Chromium
   via Playwright in cloud sessions where the MCP is not loaded. Saves a JPEG under 1MB,
-  uploads to GitHub's native CDN via `gh release upload`, ready to embed in a PR.
+  uploads to the self-hosted bb-artifacts.exe.xyz CDN (auth via `gh auth token`; `gh
+  release upload` as fallback), ready to embed in a PR.
   Triggers: "validate the UI change", "screenshot this page", "capture the transactions page",
   "attach a screenshot to the PR", "show me how it looks", or any task needing a visual
   of the running app before a PR can be marked done.
@@ -189,23 +190,20 @@ If over 1MB: retake at `quality: 70` or drop `fullPage`.
 
 ### 7. Upload
 
-**Preferred (local sessions): self-hosted bb-artifacts.exe.xyz.** If the upload
-token is present in `.local.env`, push there — public read, ~180-day auto-expiry,
-no release clutter. See the `github-image-hosting` skill for full details.
+**Preferred: self-hosted bb-artifacts.exe.xyz** — auth with your GitHub token via
+`gh auth token`, which is present in **both** local and cloud sessions (`gh` is
+sandbox-exempt). Public read, ~180-day auto-expiry, no release clutter. See the
+`github-image-hosting` skill for full details.
 
 ```bash
-IMGHOST_TOKEN=$(grep -E '^IMGHOST_TOKEN=' .local.env | cut -d= -f2- 2>/dev/null)
-if [ -n "$IMGHOST_TOKEN" ]; then
-  URL=$(curl -sf -H "Authorization: Bearer $IMGHOST_TOKEN" \
-            -F file=@/tmp/app-<PAGE>.jpg https://bb-artifacts.exe.xyz/upload | jq -r .url)
-  echo "$URL"
-fi
+URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
+          -F file=@/tmp/app-<PAGE>.jpg https://bb-artifacts.exe.xyz/upload | jq -r .url)
+echo "$URL"
 ```
 
-**Fallback (cloud sessions, or token absent): GitHub release CDN.** In cloud
-sessions `.local.env` isn't checked out, so `IMGHOST_TOKEN` is empty — use `gh`
-(already sandbox-exempt — no network allowlist required) to upload to a dedicated
-GitHub prerelease. This gives a permanent, GitHub-native URL.
+**Fallback: GitHub release CDN** (only if bb-artifacts is unreachable or `gh` isn't
+authed). `gh` is sandbox-exempt — no network allowlist required — and gives a
+permanent, GitHub-native URL.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)


### PR DESCRIPTION
## What

Re-adds **upload authentication** to bb-artifacts after the brief anonymous window. The host now accepts uploads via **either** mechanism:

- **GitHub identity** — send a GitHub token as the Bearer; the server resolves it via the GitHub API (cached ~5min) and allows it if the login is in `GITHUB_ALLOWED_LOGINS` (`canalesb93`). Agents send `Authorization: Bearer $(gh auth token)`, which is available in **both local and cloud** sessions — **nothing to store or inject**.
- **Static upload token** — a shared secret in `IMGHOST_TOKENS=label:secret`. For CI (a repo secret) or any non-`gh` context.

**Reads stay fully public.** All existing guards stay (per-IP rate limit, 8GB store cap, type allowlist, 25MB/file, `form-action 'none'` CSP on HTML).

## Why this shape

The three upload clients hold different credentials: local agents and **cloud** agents both have `gh auth token` (your identity), while CI has a bot token. GitHub-identity covers both agent cases with zero secret management; the static token covers CI. Best of both.

## Client usage

```bash
# Agents (local + cloud)
curl -sf -H "Authorization: Bearer $(gh auth token)" -F file=@shot.jpg https://bb-artifacts.exe.xyz/upload

# CI (GitHub Actions) — uses a repo secret
curl -sf -H "Authorization: Bearer ${{ secrets.IMGHOST_UPLOAD_TOKEN }}" -F file=@shot.png https://bb-artifacts.exe.xyz/upload
```

## Verified

gh-identity upload → 200 · CI static token → 200 · no auth → 401 · garbage bearer → 401 · public read → 200.

## Changes

- `github-image-hosting` skill — GitHub-identity primary; CI static-token section + workflow snippet. **Always bb-artifacts first; img402 is the sole fallback. The GitHub release-asset CDN is removed entirely.**
- `validate-ui` skill — step 7 uses `gh auth token` (works in cloud too); release-CDN fallback + example URLs replaced with bb-artifacts (img402 fallback).

## Security notes

- Agents send your `gh` token to your own VM over HTTPS; the server validates it against GitHub and **never logs or stores it** (only caches a hash → login for 5 min).
- The CI secret is an upload-only token, not a GitHub credential — a leak grants uploads only.
- No secrets in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

