### PR TITLE
ci/release: split image tags into :latest (stable release) vs :edge (main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,10 +280,17 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/canalesb93/breadbox
+          # `:edge` is the rolling tip-of-main image — every merge to main
+          # republishes it. This is what the production dev box
+          # (breadbox.exe.xyz) tracks. The released, stable `:latest` and
+          # `:vX.Y.Z` tags are owned exclusively by release.yml (cut on a
+          # `v*` tag) — ci.yml must NOT push `:latest`, or it would clobber
+          # the last release with an arbitrary main commit. `type=sha`
+          # publishes an immutable `sha-<short>` tag per commit so a bad
+          # edge can be rolled back to a precise previous build.
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern=v{{version}}
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=sha,enable={{is_default_branch}}
 
       - name: Determine VERSION build arg
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,17 +107,26 @@ jobs:
         id: ver
         run: |
           if [ -n "${{ inputs.tag }}" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            tag="${{ inputs.tag }}"
           else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            tag="${GITHUB_REF_NAME}"
           fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          # Bare semver (no leading v) — the no-prefix variant is a common
+          # registry convention, so publish both `:v0.1.0` and `:0.1.0`.
+          echo "bare=${tag#v}" >> "$GITHUB_OUTPUT"
 
+      # Releases own the stable, human-pickable tags. `:latest` always points
+      # at the newest GitHub release (NOT tip of main — that's ci.yml's
+      # `:edge`). Self-host templates (Railway, Render, docker-compose.prod.yml)
+      # and `:latest` users get released software, never an arbitrary commit.
       - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ steps.ver.outputs.tag }}
+            type=raw,value=${{ steps.ver.outputs.bare }}
             type=raw,value=latest
 
       - uses: docker/build-push-action@v6

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -194,16 +194,37 @@ docker compose --profile caddy pull
 docker compose --profile caddy up -d
 ```
 
+### Image tags
+
+Breadbox publishes three kinds of tag to `ghcr.io/canalesb93/breadbox`,
+following the usual registry convention:
+
+| Tag | Points at | Updated when | Use it for |
+| --- | --- | --- | --- |
+| `:latest` | the **newest stable release** | a `vX.Y.Z` tag is cut | the default — released, tested software with automatic minor upgrades |
+| `:vX.Y.Z` (and `:X.Y.Z`) | that **exact release**, immutable | never (frozen) | full control — pin it and upgrade deliberately |
+| `:edge` | the **rolling tip of `main`** | every merge to `main` | bleeding edge — try changes before they're released |
+
+`:latest` is **not** a per-commit rolling tag — it only moves forward when
+a release is published. If you want the tip of `main`, use `:edge`. Each
+`main` commit also gets an immutable `:sha-<short>` tag for precise
+rollback.
+
+`install.sh` defaults to pinning the specific release tag it finds
+(`:vX.Y.Z`), so fresh installs are reproducible out of the box; it only
+falls back to `:edge` when no release exists yet.
+
 ### Pinning a specific version
 
 By default `docker-compose.prod.yml` references `ghcr.io/canalesb93/breadbox:latest`
-(rolling). To pin a specific release, edit the `image:` line:
+(the newest stable release). To pin a specific release, edit the `image:` line:
 
 ```yaml
 image: ghcr.io/canalesb93/breadbox:v0.1.0
 ```
 
 Then `docker compose pull && docker compose up -d` will hold that version.
+To instead track the unreleased tip of `main`, set the tag to `:edge`.
 
 ### Unattended updates
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,5 +1,12 @@
 services:
   breadbox:
+    # Image tags (see deploy/README.md → "Image tags"):
+    #   :latest   newest stable release (recommended default — what this file
+    #             ships with; managed platforms like Railway/Render pull it).
+    #   :vX.Y.Z   a specific, immutable release — pin this for full control
+    #             (install.sh rewrites the line below to the release it found).
+    #   :edge     rolling tip of main, rebuilt every merge — bleeding edge,
+    #             for testing upstream before it's released.
     image: ghcr.io/canalesb93/breadbox:latest
     restart: unless-stopped
     env_file: .env

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -631,12 +631,15 @@ else
     info "Fetching latest release..."
     TAG=$(get_latest_tag)
     if [ "$TAG" = "latest" ]; then
-        # Pre-v0.1.0 there's no GitHub Release yet, so this fires for
-        # every install. Phrase as neutral info rather than a warning
-        # — the rolling :latest image is the right behavior in this
-        # state.
-        info "No release tagged yet — using :latest image (rolling)."
-        IMAGE_TAG="latest"
+        # No GitHub Release found (API failure, or a repo with no releases
+        # yet). The rolling tip-of-main image is `:edge`, not `:latest` —
+        # `:latest` is reserved for the newest stable release and only
+        # exists once release.yml has cut one. Fall back to `:edge` so the
+        # install still works and tracks main. Deployment files come from
+        # the `main` branch (see DOWNLOAD_REF below, still keyed off the
+        # "latest" sentinel in TAG).
+        info "No release tagged yet — using :edge image (rolling, tip of main)."
+        IMAGE_TAG="edge"
     else
         success "Latest release: ${TAG}"
         IMAGE_TAG="$TAG"
@@ -754,7 +757,7 @@ fi
 
 # Record the pinned tag for traceability and for any user-side scripting
 # that wants to know which release this dir was installed against.
-# "latest" signals the user picked rolling updates.
+# "edge" signals the user is on the rolling tip-of-main image.
 printf "%s\n" "$IMAGE_TAG" > "${INSTALL_DIR}/.breadbox-version"
 
 # --- Generate .env ---

--- a/deploy/railway-deploy.md
+++ b/deploy/railway-deploy.md
@@ -43,18 +43,21 @@ Click → Railway provisions, in one flow:
 
 ## Updating
 
-The template pulls `:latest`, so Railway doesn't auto-redeploy on
-every upstream commit by design — self-hosters of a financial app
-generally want explicit control over upgrade timing.
+The template pulls `:latest`, which tracks the **newest stable
+release** (not every commit to `main`). Railway doesn't auto-redeploy
+on a new release — a manual redeploy is required, which suits a
+financial app where you want explicit control over upgrade timing.
 
 To pull a newer image, go to the breadbox service in Railway →
 **Deployments** → **Redeploy**. The admin dashboard also surfaces an
 "update available" badge in the sidebar when a newer GitHub release
 exists.
 
-To pin a specific tag, change the image source under **Service
-Settings** → **Source** to `ghcr.io/canalesb93/breadbox:v0.1.0` (or
-whatever tag).
+To pin a specific release (recommended for full reproducibility),
+change the image source under **Service Settings** → **Source** to
+`ghcr.io/canalesb93/breadbox:v0.1.0` (or whatever tag). To instead
+track the unreleased tip of `main`, use
+`ghcr.io/canalesb93/breadbox:edge`.
 
 ## Alternative: deploy without the button
 

--- a/deploy/render-deploy.md
+++ b/deploy/render-deploy.md
@@ -69,8 +69,9 @@ land on `/setup`, create your admin.
 
 ## Updating
 
-Because the service pulls a fixed image tag (`:latest`), Render does
-**not** auto-redeploy when upstream `main` advances — by design, so
+The service pulls `:latest`, which tracks the **newest stable
+release** (not every commit to `main`). Render does **not**
+auto-redeploy when a new release is published — by design, so
 self-hosters of a financial app control their own upgrade timing.
 
 To pull a newer image, click **Manual Deploy** → **Deploy latest
@@ -78,10 +79,11 @@ image** on the service in the Render dashboard. The breadbox admin
 dashboard also surfaces an "update available" badge in the sidebar
 when a newer GitHub release exists.
 
-To pin to a specific release, edit the `image.url` in your
-`render.yaml` (or your own template copy) — e.g.
-`ghcr.io/canalesb93/breadbox:v0.1.0` — and Render redeploys to that
-tag on the next sync.
+To pin to a specific release (recommended for full reproducibility),
+edit the `image.url` in your `render.yaml` (or your own template
+copy) — e.g. `ghcr.io/canalesb93/breadbox:v0.1.0` — and Render
+redeploys to that tag on the next sync. To instead track the
+unreleased tip of `main`, use `ghcr.io/canalesb93/breadbox:edge`.
 
 ## Cost notes
 

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,13 @@
 # Pulls the multi-arch image published by this repo's release CI — no
 # Dockerfile build at deploy time, no GitHub permissions required from
 # the user clicking the button. ~30 s deploys instead of ~4 min builds.
-# Trade-off: users don't get auto-redeploy on every `main` push;
+#
+# The :latest tag below tracks the newest STABLE RELEASE (cut by
+# release.yml on a vX.Y.Z tag), not the tip of main — so a one-click
+# deploy lands on released, tested software. For the bleeding edge use
+# :edge; to pin a release for full control use :vX.Y.Z. See
+# deploy/README.md → "Image tags".
+# Trade-off: users don't get auto-redeploy on every new release;
 # Render redeploys on manual trigger or when a new image tag is pulled.
 #
 # Render's `generateValue` produces base64, not hex, and Breadbox's


### PR DESCRIPTION
## What & why

Aligns our container image tags with the standard registry convention so a `:latest` pull means "newest **stable release**," not "whatever last merged to `main`."

Previously **both** `ci.yml` (every merge to `main`) and `release.yml` (on a `vX.Y.Z` tag) pushed `:latest`, so `:latest` effectively tracked the tip of `main` — i.e. it behaved like an `:edge`/nightly tag while *looking* like a stable release. A first-time self-hoster clicking the Railway/Render button could land on an unreleased mid-feature commit, which is exactly the least-surprise violation you don't want for a financial app.

## The convention now

| Tag | Points at | Pushed by | Audience |
| --- | --- | --- | --- |
| `:latest` | newest **stable release** | `release.yml` (on `v*`) | default — templates, self-host |
| `:vX.Y.Z` / `:X.Y.Z` | that exact release (immutable) | `release.yml` | pinned / reproducible / rollback |
| `:edge` | rolling tip of `main` | `ci.yml` (every merge) | bleeding edge, **our prod box** |
| `:sha-<short>` | one immutable commit | `ci.yml` | precise edge rollback |

## Changes

- **`ci.yml`** — Build & Push now publishes `:edge` (+ `:sha-<short>`) on `main` instead of `:latest`. Dropped the dead `type=semver` lines (this workflow never triggers on tags by design).
- **`release.yml`** — unchanged behavior for `:latest`/`:vX.Y.Z`; added the bare `:X.Y.Z` (no-`v`) variant and clarifying comments.
- **`install.sh`** — no-release fallback now uses `:edge` (the rolling image) instead of `:latest`. The normal path already pins the specific release tag it finds, so fresh installs stay reproducible.
- **Docs** — new canonical "Image tags" table in `deploy/README.md`; corrected the "rolling `:latest`" wording in `railway-deploy.md`, `render-deploy.md`, `render.yaml`, and `docker-compose.prod.yml` comments.

## Production (breadbox.exe.xyz)

The prod box's `docker-compose.yml` has been repointed `:latest` → `:edge` (backup kept on the box) so it keeps tracking tip-of-main. **No restart was done** — it's still serving its current image; the existing post-merge deploy job will pull the freshly-built `:edge` and complete the cutover once this PR merges.

⚠️ Merge ordering: because `:edge` doesn't exist on the registry until this PR's CI runs, the prod box (now pointed at `:edge`) won't receive a deploy from any *other* `main` push that lands before this one — that deploy's `docker compose pull` would fail (no outage; container keeps running). Merging this PR publishes `:edge` and the deploy cuts over cleanly.

## Transition note

`:latest` on the registry currently still points at the last `main` commit (the old behavior's final push). It self-corrects to the newest *release* the next time `release.yml` runs. No action needed; `install.sh` users already pin `vX.Y.Z`.

## Testing

Docs/CI/shell only — no Go changes, so `go build/vet/test` are unaffected. `sh -n deploy/install.sh` passes; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
