### PR TITLE
docs(deploy): use -f docker-compose.prod.yml in update commands

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -183,15 +183,19 @@ tag is published on GitHub — when you see it, run:
 
 ```bash
 cd /opt/breadbox       # or $HOME/.breadbox for user installs
-docker compose pull
-docker compose up -d
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
 ```
+
+The installer writes the Compose file as `docker-compose.prod.yml`, so the
+`-f` flag is required (a bare `docker compose pull` looks for
+`docker-compose.yml` and won't find it).
 
 If you installed with a domain (Caddy enabled), include the profile:
 
 ```bash
-docker compose --profile caddy pull
-docker compose --profile caddy up -d
+docker compose --profile caddy -f docker-compose.prod.yml pull
+docker compose --profile caddy -f docker-compose.prod.yml up -d
 ```
 
 ### Image tags
@@ -223,7 +227,7 @@ By default `docker-compose.prod.yml` references `ghcr.io/canalesb93/breadbox:lat
 image: ghcr.io/canalesb93/breadbox:v0.1.0
 ```
 
-Then `docker compose pull && docker compose up -d` will hold that version.
+Then `docker compose -f docker-compose.prod.yml pull && docker compose -f docker-compose.prod.yml up -d` will hold that version.
 To instead track the unreleased tip of `main`, set the tag to `:edge`.
 
 ### Unattended updates
@@ -236,7 +240,7 @@ when updates happen, which matters for a self-hosted financial app.
 Simple cron-driven equivalent:
 
 ```bash
-0 3 * * * cd /opt/breadbox && docker compose pull && docker compose up -d >> /var/log/breadbox-update.log 2>&1
+0 3 * * * cd /opt/breadbox && docker compose -f docker-compose.prod.yml pull && docker compose -f docker-compose.prod.yml up -d >> /var/log/breadbox-update.log 2>&1
 ```
 
 ## Uninstalling


### PR DESCRIPTION
Follow-up to #1752 — this single-commit fix was pushed to that PR's branch but the merge raced it and dropped the commit, so it never landed on `main`.

The installer-produced install dir keeps the Compose file as `docker-compose.prod.yml` and drives it with `-f`. A bare `docker compose pull` looks for `docker-compose.yml` and fails there, so the **Updating** section's commands (pull/up, Caddy variant, pinning line, cron example) need the `-f docker-compose.prod.yml` flag, plus a one-line note explaining why.

Manual-Setup commands are intentionally left bare — that section downloads the file *renamed* to `docker-compose.yml` (line 118), so they're already correct. Rebased onto current `main`, preserving the new `:edge` tag note.

Matches the canonical guide at docs.breadbox.sh/installation/updating.