### PR TITLE
fix(ui): expand settings content to full width

### DIFF
--- a/input.css
+++ b/input.css
@@ -669,7 +669,7 @@
     @apply opacity-100;
   }
   .bb-settings-content {
-    @apply flex-1 min-w-0 lg:max-w-5xl;
+    @apply flex-1 min-w-0;
   }
 
   /* lg+: the rail is a sticky, full-height column — the in-flow peer of the


### PR DESCRIPTION
Removes the `lg:max-w-5xl` cap on the settings content column so every settings tab fills the available canvas, matching the settings design language ("all settings tabs fill the available modal body width").

## Changes

- `input.css` → `.bb-settings-content`: drop `lg:max-w-5xl`, leaving `flex-1 min-w-0` so the content expands to fill the space between the rail and the page edge.

## Test plan

- [x] `make css` rebuilds cleanly
- [x] `/settings` renders full-width at 1440px (sections extend to the page edge, no ~1024px cap)
- [x] Rail + two-column rows still read correctly at the wider width
- [ ] Spot-check Providers / Backups / Account tabs for layout regressions

After (General tab @ 1440px):

<img src="https://bb-artifacts.exe.xyz/f/2d6c0027e34d8f53.jpg" width="800" alt="settings — full width after">
