### PR TITLE
feat(ui): default all toggles to the green tone

### DIFF
--- a/internal/templates/components/pages/agent_form.templ
+++ b/internal/templates/components/pages/agent_form.templ
@@ -254,7 +254,7 @@ templ AgentForm(p AgentFormProps) {
 									type="checkbox"
 									name="enabled"
 									value="true"
-									class="toggle toggle-primary"
+									class="toggle"
 									x-model="agentEnabled"
 								/>
 							</label>

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -308,9 +308,9 @@ templ mcpToolsDrawer(p AgentsSettingsProps) {
 templ agentsSettingsToolRow(t AgentsSettingsTool) {
 	<label class="flex items-start gap-3 p-2 rounded-xl hover:bg-base-200/50 transition-colors cursor-pointer">
 		if t.Enabled {
-			<input type="checkbox" name="enabled_tools" value={ t.Name } class="toggle toggle-sm toggle-primary mt-0.5 flex-shrink-0" checked/>
+			<input type="checkbox" name="enabled_tools" value={ t.Name } class="toggle toggle-sm mt-0.5 flex-shrink-0" checked/>
 		} else {
-			<input type="checkbox" name="enabled_tools" value={ t.Name } class="toggle toggle-sm toggle-primary mt-0.5 flex-shrink-0"/>
+			<input type="checkbox" name="enabled_tools" value={ t.Name } class="toggle toggle-sm mt-0.5 flex-shrink-0"/>
 		}
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-2 flex-wrap">

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -464,8 +464,8 @@ templ SectionFormControls() {
 					<span class="label-text">Notifications</span>
 				</label>
 				<label class="label cursor-pointer gap-2">
-					<input type="checkbox" class="toggle toggle-primary" checked/>
-					<span class="label-text">Primary tone</span>
+					<input type="checkbox" class="toggle" checked/>
+					<span class="label-text">Green by default</span>
 				</label>
 				<label class="label cursor-pointer gap-2">
 					<input type="radio" name="ds-radio-1" class="radio" checked/>

--- a/internal/templates/components/pages/developer_settings.templ
+++ b/internal/templates/components/pages/developer_settings.templ
@@ -64,7 +64,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 				type="checkbox"
 				name="enabled"
 				value="true"
-				class="toggle toggle-primary"
+				class="toggle"
 				checked?={ p.Form.Enabled }
 			/>
 		}

--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -124,9 +124,9 @@ templ providersSimplefinDrawer(p ProvidersProps, h *service.ProviderHealthSummar
 						@providerField(providerFieldProps{Label: "Offer SimpleFIN", For: "simplefin_enabled"}) {
 							<label class="flex items-center gap-3 cursor-pointer">
 								if p.SimpleFINEnabled {
-									<input type="checkbox" id="simplefin_enabled" name="simplefin_enabled" value="on" class="toggle toggle-primary" checked/>
+									<input type="checkbox" id="simplefin_enabled" name="simplefin_enabled" value="on" class="toggle" checked/>
 								} else {
-									<input type="checkbox" id="simplefin_enabled" name="simplefin_enabled" value="on" class="toggle toggle-primary"/>
+									<input type="checkbox" id="simplefin_enabled" name="simplefin_enabled" value="on" class="toggle"/>
 								}
 								<span class="text-sm text-base-content/70">Available when adding a connection</span>
 							</label>

--- a/internal/templates/components/pages/schedule_form.templ
+++ b/internal/templates/components/pages/schedule_form.templ
@@ -118,9 +118,9 @@ templ scheduleFormFields(p ScheduleFormProps) {
 	<div class="space-y-1.5">
 		<label class="flex items-center gap-2 text-sm cursor-pointer">
 			if p.Enabled {
-				<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" checked/>
+				<input type="checkbox" name="enabled" class="toggle toggle-sm" checked/>
 			} else {
-				<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary"/>
+				<input type="checkbox" name="enabled" class="toggle toggle-sm"/>
 			}
 			<span>Enabled</span>
 		</label>

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -188,9 +188,9 @@ templ settingsScheduleRow(p SettingsProps, sched service.SyncScheduleView) {
 				Label:     "Schedule updated",
 			}) {
 				if sched.Enabled {
-					<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" checked aria-label="Enabled"/>
+					<input type="checkbox" name="enabled" class="toggle toggle-sm" checked aria-label="Enabled"/>
 				} else {
-					<input type="checkbox" name="enabled" class="toggle toggle-sm toggle-primary" aria-label="Enabled"/>
+					<input type="checkbox" name="enabled" class="toggle toggle-sm" aria-label="Enabled"/>
 				}
 			}
 			<button type="button" @click={ "$store.drawers.open('schedule-" + sched.ShortID + "')" } class="btn btn-ghost btn-sm btn-square" aria-label="Edit schedule">

--- a/internal/templates/components/pages/user_form.templ
+++ b/internal/templates/components/pages/user_form.templ
@@ -135,7 +135,7 @@ templ userFormCreate() {
 								<span class="text-sm font-medium text-base-content/70">Create login account</span>
 								<p class="text-xs text-base-content/40 mt-0.5">Allow this member to sign in to Breadbox</p>
 							</div>
-							<input type="checkbox" x-model="createLogin" class="toggle toggle-primary toggle-sm"/>
+							<input type="checkbox" x-model="createLogin" class="toggle toggle-sm"/>
 						</label>
 						<!-- Role dropdown (shown when toggle is on) -->
 						<div x-show="createLogin" x-collapse>

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -166,7 +166,7 @@ templ workflowReconfigureDrawer() {
 					<div class="space-y-2">
 						<template x-for="c in reconfigure.connectors" :key="c.name">
 							<label class="flex items-center gap-3 p-2 rounded-lg ring-1 ring-base-content/10 cursor-pointer hover:bg-base-200/50 transition-colors">
-								<input type="checkbox" name="connector" :value="c.name" x-model="c.enabled" class="toggle toggle-sm toggle-primary shrink-0"/>
+								<input type="checkbox" name="connector" :value="c.name" x-model="c.enabled" class="toggle toggle-sm shrink-0"/>
 								<div class="min-w-0 flex-1">
 									<div class="text-sm font-mono" x-text="c.name"></div>
 									<div class="text-xs text-base-content/40 truncate" x-text="c.url"></div>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -818,7 +818,7 @@
         <div class="rounded-xl border border-base-200 p-2.5 space-y-2">
           <label class="flex items-start gap-2 cursor-pointer">
             <input type="checkbox" x-model="redact" @change="onRedactChange()"
-                   class="toggle toggle-sm toggle-success mt-0.5">
+                   class="toggle toggle-sm mt-0.5">
             <span class="min-w-0">
               <span class="text-xs font-medium flex items-center gap-1">
                 {{ lucide "shield-check" "w-3.5 h-3.5 text-success" }} Redact financial data


### PR DESCRIPTION
Defaults every toggle component across the app to the green on-state instead of the primary tone, which isn't a great fit for a switch.

## Changes
- Strip explicit `toggle-primary` modifiers from all app toggles (settings, schedule form, agent form, user form, developer settings, providers, agent tools, workflows gallery) so they fall back to the base `.toggle` Apple-green (`#34c759`) default.
- Normalize the dev-reporter redact toggle from `toggle-success` (theme green) to the same bare green default for visual consistency.
- Update the `/design/c/form-controls` gallery: the "Primary tone" example becomes "Green by default".

## Test plan
- [x] `go build ./...` + `go vet ./...` pass
- [x] `templ generate` + `make css` regenerated cleanly
- [x] Visual check of `/design/c/form-controls` — toggles render green

<img src="https://bb-artifacts.exe.xyz/f/20499a8bf112aeb7.jpg" width="800" alt="Form controls — toggles green by default">