### PR TITLE
ci/release: label container images with OCI metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,13 @@ jobs:
           tags: |
             type=raw,value=edge,enable={{is_default_branch}}
             type=sha,enable={{is_default_branch}}
+          # metadata-action auto-derives the standard OCI labels from the repo
+          # (notably org.opencontainers.image.{source,revision,version,created,
+          # licenses,title,description}). source is what links the GHCR package
+          # to this repo so it inherits the README + visibility. We add the
+          # docs URL on top; the build step below applies the merged set.
+          labels: |
+            org.opencontainers.image.documentation=https://docs.breadbox.sh
 
       - name: Determine VERSION build arg
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,12 @@ jobs:
             type=raw,value=${{ steps.ver.outputs.tag }}
             type=raw,value=${{ steps.ver.outputs.bare }}
             type=raw,value=latest
+          # Same OCI labels as ci.yml so release images carry the repo link
+          # (org.opencontainers.image.source) + version/license metadata. The
+          # build step below MUST pass steps.meta.outputs.labels, or release
+          # images ship unlabelled.
+          labels: |
+            org.opencontainers.image.documentation=https://docs.breadbox.sh
 
       - uses: docker/build-push-action@v6
         with:
@@ -135,6 +141,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.ver.outputs.tag }}
           cache-from: type=gha


### PR DESCRIPTION
## What & why

Adds [OCI image labels](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images) to our container images.

We already use `docker/metadata-action`, which **computes** the standard OCI labels from the repo — but only `ci.yml` (the `:edge`/`:sha` images) was passing them to the build. **`release.yml` never passed `labels:` to `build-push-action`, so every release image (`:latest`, `:vX.Y.Z`, `:X.Y.Z`) shipped with zero labels** — including `org.opencontainers.image.source`, the label GitHub uses to link a package to its repository (and thereby inherit the README + visibility).

## Changes

- **`release.yml`** — pass `labels: ${{ steps.meta.outputs.labels }}` to the docker build. Release images now carry the full auto-derived set:
  - `org.opencontainers.image.source` → `https://github.com/canalesb93/breadbox` (repo link)
  - `…revision` (commit), `…version` (release tag), `…created`, `…licenses` (AGPL-3.0), `…title`, `…description`
- **both workflows** — add `org.opencontainers.image.documentation=https://docs.breadbox.sh` (not auto-derived).

No Dockerfile `LABEL`s added: `metadata-action` is the existing, dynamic source of truth (it fills in per-build values like revision/created/version that a static `LABEL` can't), and build-push labels would override Dockerfile ones anyway.

## Effect

Future pushes label all images. The GHCR package page shows description/license/docs, and version-tagged release images become traceable back to their exact commit. (Existing already-pushed images aren't relabelled retroactively — they pick it up on the next edge push / next release.)

## Testing

CI-only YAML change — no Go. Indentation verified, both build steps confirmed to pass `steps.meta.outputs.labels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
