### PR TITLE
fix(settings): stop in-place 204 autosaves from hard-navigating to a 405

### DIFF
--- a/static/js/admin/components/settings_page.js
+++ b/static/js/admin/components/settings_page.js
@@ -131,15 +131,29 @@ document.addEventListener('alpine:init', function () {
         }).then(function (res) {
           var serverToldUs = !!res.headers.get('X-BB-Flash-Message');
           self._showFlashFromHeaders(res.headers);
+          // In-place autosave success (the schedule toggle, the timezone
+          // select, …) replies 204 No Content with no redirect: the control
+          // already shows the new value, so there's nothing to swap and
+          // nowhere to navigate. Bail before the redirect handling below —
+          // otherwise res.url is the POST-only action endpoint, which the
+          // classifier reads as "left the settings space" and hard-navigates
+          // to via GET, hitting a 405 ("this page isn't working"). See
+          // ScheduleToggleHandler / SettingsTimezonePostHandler.
+          if (res.status === 204 || res.status === 205) {
+            reenable();
+            return null;
+          }
           var finalUrl = res.url || action;
           var dest = parseSettingsRedirect(finalUrl);
-          // Redirect target outside the settings space (password change →
-          // /login, etc.) → hand off to a real navigation.
-          if (!dest.settings) {
+          // A genuine server redirect to a non-settings URL (password change
+          // → /login, etc.) hands off to a real navigation. The res.redirected
+          // guard keeps a non-redirected in-place response from ever
+          // hard-navigating to its own POST-only action endpoint.
+          if (!dest.settings && res.redirected) {
             window.location.href = finalUrl;
             return null;
           }
-          var targetTab = dest.tab || self.currentTab;
+          var targetTab = (dest.settings && dest.tab) ? dest.tab : self.currentTab;
           var sameTab = targetTab === self.currentTab;
           var swapOpts = { skipInlineScripts: sameTab, preserveScroll: sameTab };
           if (!res.ok) {


### PR DESCRIPTION
## The bug

Toggling a sync schedule on the full-page Settings surface (or changing the **Timezone** select on the same tab) navigated the browser straight to the form's POST-only action endpoint via **GET** — e.g. `/settings/sync/schedules/{id}/toggle` — which returns **405** and shows Chrome's "this page isn't working" error. Reported from prod against the only configured schedule.

## Root cause

It's in the settings fragment swapper, not the handlers. In-place autosave handlers (`ScheduleToggleHandler`, `SettingsTimezonePostHandler`) reply `204 No Content` with **no redirect**, so in `settings_page.js::_submitForm` the fetch's `res.url` stays at the action endpoint. `parseSettingsRedirect` then classifies `/settings/sync/...` (and `/settings/timezone`) as *outside* the settings space — `sync`/`timezone` aren't recognized tabs — and the code ran `window.location.href = finalUrl`, a hard GET to a POST-only route.

The **Retention** select on the same tab worked only by accident: its handler `303`-redirects to `/settings` (a real tab), so `res.url` lands on a recognized tab and the swapper re-renders instead of navigating.

## The fix

Fix the swapper once instead of special-casing every handler:

- **Short-circuit `204`/`205` responses** — an in-place autosave success means the control already reflects the new value, so stay put: nothing to swap, nowhere to navigate.
- **Guard the cross-space hard-navigation on `res.redirected`** — a non-redirected response can never hard-navigate to its own action endpoint. (A genuine cross-space redirect like password-change → `/login` still has `res.redirected === true` and is honored.)

This also fixes the **latent identical bug on the Timezone select**, which I reproduced in the same way.

## Verification

Reproduced both failures in a real browser, then confirmed the fix on a freshly-built binary:

- Schedule toggle → `POST … /toggle` **204**, page stays on `/settings/general`, DB `enabled` flips correctly (`t`→`f`→`t`). No 405.
- Timezone select → `POST /settings/timezone` **204**, stays put. No 405.

<img src="https://bb-artifacts.exe.xyz/f/7d81d4168852631d.jpeg" width="800" alt="Settings → General after fix — schedule toggle and timezone select save in place">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
