### PR TITLE
polish(settings): tidy the Avatars section on /settings/general

### DIFF
--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -255,11 +255,12 @@ templ settingsAvatarsSection(p SettingsProps) {
 		Title:   "Avatars",
 		Caption: "DiceBear styles for auto-generated identicons — uploaded avatars are unaffected",
 	}) {
-		@settingsAvatarPickerRow(p, "user", "Users", p.AvatarUserStyle, userPreviewSeeds())
-		@settingsAvatarPickerRow(p, "agent", "Agents", p.AvatarAgentStyle, agentPreviewSeeds())
+		@settingsAvatarPickerRow(p, "user", "Users", "Household members", p.AvatarUserStyle, userPreviewSeeds())
+		@settingsAvatarPickerRow(p, "agent", "Agents", "AI workflow runners", p.AvatarAgentStyle, agentPreviewSeeds())
 		@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
-			<p class="text-xs text-base-content/45 leading-snug">
-				Browsers cache avatars for 24h — hard-refresh after changing a style.
+			<p class="flex items-start gap-1.5 text-xs text-base-content/45 leading-snug">
+				@components.LucideIcon("info", "w-3.5 h-3.5 shrink-0 mt-px opacity-80")
+				<span>Browsers cache avatars for 24h — hard-refresh after changing a style.</span>
 			</p>
 		}
 	}
@@ -267,22 +268,35 @@ templ settingsAvatarsSection(p SettingsProps) {
 
 // settingsAvatarPickerRow renders one actor-bucket picker (User or
 // Agent). actor matches the form field the POST handler dispatches
-// on; both POSTs go to /settings/avatar-style.
-templ settingsAvatarPickerRow(p SettingsProps, actor, label, current string, seeds []string) {
+// on; both POSTs go to /settings/avatar-style. The live preview tiles
+// re-render as the <select> changes (Alpine `style` x-model), so the
+// operator sees the chosen style before the auto-save toast confirms.
+templ settingsAvatarPickerRow(p SettingsProps, actor, label, caption, current string, seeds []string) {
 	<div x-data={ "{ style: $el.dataset.style }" } data-style={ current } class="contents">
 		@components.SettingsRow(components.SettingsRowProps{
-			Label: label,
-			For:   "avatar_style_" + actor,
-			Stack: true,
+			Label:   label,
+			Caption: caption,
+			For:     "avatar_style_" + actor,
+			Stack:   true,
 		}) {
-			<div class="flex flex-wrap items-center gap-3">
+			<div class="flex flex-wrap items-center justify-between gap-3">
+				<div class="flex items-center gap-1.5">
+					for _, seed := range seeds {
+						<img
+							class="w-9 h-9 rounded-full bg-base-200 ring-1 ring-base-300/60"
+							loading="lazy"
+							alt={ "Preview " + seed }
+							:src={ avatarPreviewExpr(seed) }
+						/>
+					}
+				</div>
 				@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
 					Action:    "/settings/avatar-style",
 					CSRFToken: p.CSRFToken,
 					Label:     label + " avatar style saved",
 				}) {
 					<input type="hidden" name="actor" value={ actor }/>
-					<select id={ "avatar_style_" + actor } name="avatar_style" class="select select-sm bg-base-200" x-model="style">
+					<select id={ "avatar_style_" + actor } name="avatar_style" class="select select-sm bg-base-200 w-44" x-model="style">
 						for _, opt := range p.AvatarStyles {
 							if opt.ID == current {
 								<option value={ opt.ID } selected>{ opt.Label }</option>
@@ -292,15 +306,6 @@ templ settingsAvatarPickerRow(p SettingsProps, actor, label, current string, see
 						}
 					</select>
 				}
-				<div class="flex items-center gap-2">
-					for _, seed := range seeds {
-						<img
-							class="w-9 h-9 rounded-full bg-base-200"
-							alt={ "Preview " + seed }
-							:src={ avatarPreviewExpr(seed) }
-						/>
-					}
-				</div>
 			</div>
 		}
 	</div>


### PR DESCRIPTION
Polishes the Avatars section on `/settings/general` so the two style pickers read as part of the same `[label + caption] [control]` settings language the rest of the General tab uses (Theme, Timezone, Log retention) instead of full-width stretched selects with the preview tiles dumped in a separate row.

## Changes
- Added per-bucket captions — **Household members** / **AI workflow runners** — so the User and Agent pickers read as distinct actor categories at a glance.
- Laid the live preview tiles and a natural-width select on one line, spread `justify-between`, replacing the edge-to-edge stretched select.
- Gave the 24h-cache note an `info` icon so it reads as guidance rather than stray text.
- Kept `Stack=true` (the combined tiles+select control is too wide to share a row, per `.claude/rules/settings.md`) so the layout degrades cleanly on mobile — the select wraps below the tiles with no overlap.

## Before / after (desktop)
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://bb-artifacts.exe.xyz/f/28985ae8a50f2301.jpg" width="400" alt="avatars section before"></td>
    <td><img src="https://bb-artifacts.exe.xyz/f/47501b3ddf76b970.jpg" width="400" alt="avatars section after"></td>
  </tr>
</table>

Mobile (after) — tiles and select stack without overlapping the caption:

<img src="https://bb-artifacts.exe.xyz/f/e065906bf0f7c5dc.jpg" width="320" alt="avatars section after — mobile">

## Test plan
- [ ] `/settings/general` → Avatars section renders as captioned User/Agent rows with preview tiles + a natural-width select.
- [ ] Changing the Users or Agents style dropdown re-renders the preview tiles live and shows the auto-save toast.
- [ ] Mobile (390px): tiles and select wrap without overlapping the label/caption.
- [ ] `go build ./...`, `go vet ./...`, `go test ./internal/templates/components/...` pass (templ scripts-lint guard included).
