### PR TITLE
ui: stamp cron previews with the anchor zone + reveal server-default tz

### DIFF
--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -32,6 +32,29 @@ func formatNextSync(nextRun time.Time) string {
 	return "in " + formatUptime(d)
 }
 
+// serverZoneLabel describes the server process's local zone for the
+// "Server default" timezone option, so a self-hoster who hasn't set an
+// instance zone can still see what cron evaluates in. Format: the zone
+// abbreviation plus its current UTC offset (e.g. "PDT · UTC-07:00"), or just
+// the offset when the runtime only knows a numeric zone (e.g. "UTC+05:30").
+// Read at the current instant, so it reflects the active DST offset.
+func serverZoneLabel() string {
+	name, offsetSec := time.Now().Zone()
+	sign := "+"
+	if offsetSec < 0 {
+		sign = "-"
+		offsetSec = -offsetSec
+	}
+	off := fmt.Sprintf("UTC%s%02d:%02d", sign, offsetSec/3600, (offsetSec%3600)/60)
+	name = strings.TrimSpace(name)
+	// A nameless zone surfaces as a numeric abbreviation like "+0530"; don't
+	// pair that with the offset (redundant). Show the offset alone.
+	if name == "" || strings.HasPrefix(name, "+") || strings.HasPrefix(name, "-") {
+		return off
+	}
+	return name + " · " + off
+}
+
 // buildSettingsProps assembles the typed SettingsProps shared by every
 // /settings/* General-family tab (General, System, Help). Each
 // tab handler builds full props (cheap — a few DB lookups + version
@@ -85,6 +108,7 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		NewScheduleForm:      newScheduleForm,
 		EditScheduleForms:    editScheduleForms,
 		InstanceTimezone:     appconfig.String(ctx, a.Queries, appconfig.KeyInstanceTimezone, ""),
+		ServerZoneLabel:      serverZoneLabel(),
 		ConfigSources:        a.Config.ConfigSources,
 		AvatarUserStyle:      userAvatarStyle,
 		AvatarAgentStyle:     agentAvatarStyle,

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -3,6 +3,7 @@ package pages
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -110,7 +111,7 @@ templ settingsSyncSection(p SettingsProps) {
 					Label:     "Timezone saved",
 				}) {
 					<select id="instance_timezone" name="instance_timezone" class="select select-sm bg-base-200">
-						@tzOption("", p.InstanceTimezone, "Server default")
+						@tzOption("", p.InstanceTimezone, serverDefaultTZLabel(p.ServerZoneLabel))
 						for _, tz := range commonTimezones() {
 							@tzOption(tz, p.InstanceTimezone, tz)
 						}
@@ -481,6 +482,17 @@ templ tzOption(value, current, label string) {
 	} else {
 		<option value={ value }>{ label }</option>
 	}
+}
+
+// serverDefaultTZLabel labels the empty "Server default" option with the
+// resolved server zone (e.g. "Server default (PDT · UTC-07:00)") so the
+// picker reveals what cron evaluates in when no instance zone is set. Falls
+// back to the bare label if the handler couldn't resolve a zone.
+func serverDefaultTZLabel(serverZone string) string {
+	if strings.TrimSpace(serverZone) == "" {
+		return "Server default"
+	}
+	return "Server default (" + serverZone + ")"
 }
 
 // commonTimezones is a curated shortlist for the instance-timezone picker —

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -62,6 +62,10 @@ type SettingsProps struct {
 	// InstanceTimezone is the configured IANA zone cron is evaluated in
 	// (empty = server local). Surfaced as the Sync-section timezone picker.
 	InstanceTimezone string
+	// ServerZoneLabel describes the server process's local zone (abbreviation +
+	// UTC offset, e.g. "PDT · UTC-07:00"), so the "Server default" picker option
+	// reveals what cron actually evaluates in when no instance zone is set.
+	ServerZoneLabel string
 	// ConfigSources maps config keys to their source: "env", "db", or "default".
 	ConfigSources map[string]string
 

--- a/static/js/admin/components/cron_field.js
+++ b/static/js/admin/components/cron_field.js
@@ -80,7 +80,10 @@ document.addEventListener('alpine:init', function () {
       // server's UTC offset in minutes east of UTC (0 = no shift).
       localizePresets: false,
       serverUtcOffsetMin: 0,
-      preview: { invalid: false, description: '', loading: false },
+      // tzLabel is the zone the times are anchored to (instance timezone for the
+      // sync endpoint; absent on the workflow endpoint, which bakes "(your time)"
+      // into the description instead).
+      preview: { invalid: false, description: '', loading: false, tzLabel: '' },
       _debounce: null,
 
       init: function () {
@@ -149,7 +152,15 @@ document.addEventListener('alpine:init', function () {
       previewText: function () {
         if (!String(this.cron || '').trim()) return 'Enter a schedule';
         if (this.preview.invalid) return this.preview.description || 'Not a valid cron expression';
-        return this.preview.description || '…';
+        var desc = this.preview.description || '…';
+        // Stamp the anchor zone when the endpoint provides one AND the schedule
+        // has a wall-clock time (AM/PM) — answers "whose 3 AM?" without noising
+        // up pure intervals ("Every 15 minutes") or the workflow path, which
+        // sends no label and already says "(your time)".
+        if (this.preview.tzLabel && /\b(AM|PM)\b/.test(desc)) {
+          desc += ' · ' + this.preview.tzLabel;
+        }
+        return desc;
       },
 
       refresh: function () {
@@ -162,7 +173,7 @@ document.addEventListener('alpine:init', function () {
         var self = this;
         var expr = (this.cron || '').trim();
         if (!expr) {
-          self.preview = { invalid: false, description: '', loading: false };
+          self.preview = { invalid: false, description: '', loading: false, tzLabel: '' };
           return;
         }
         self.preview.loading = true;
@@ -179,11 +190,12 @@ document.addEventListener('alpine:init', function () {
             self.preview = {
               invalid: !(data && data.valid),
               description: (data && data.description) || '',
+              tzLabel: (data && data.tz_label) || '',
               loading: false,
             };
           })
           .catch(function () {
-            self.preview = { invalid: false, description: 'Preview unavailable', loading: false };
+            self.preview = { invalid: false, description: 'Preview unavailable', loading: false, tzLabel: '' };
           });
       },
     };


### PR DESCRIPTION
Follow-up to #1763 (merged). Two small clarity fixes for the timezone-aware cron UI, prompted by review: the sync preview didn't say *whose* clock its times were in, and "Server default" gave no hint what the server zone actually is.

## What changed

**1. Cron preview stamps the anchor zone.** The shared `CronField` live preview now appends the zone label (e.g. `At 03:00 AM · PDT`) when the endpoint returns one **and** the schedule has a wall-clock time. Sync schedules are evaluated in the instance timezone, so a bare "At 3:00 AM" was ambiguous. Guard rails:
- Pure intervals (`Every 15 minutes`) get no label — there's no "whose 3 AM?" to answer.
- The workflow drawer is untouched: its endpoint sends no `tz_label` and already says `(your time)`, so the guard short-circuits.

**2. "Server default" reveals the resolved zone.** The Settings → Sync timezone picker's default option now reads `Server default (PDT · UTC-07:00)` instead of a bare "Server default", so a self-hoster who hasn't set an instance zone can see what cron actually evaluates in.

## Screenshots

<table>
<tr>
<td><b>Timezone picker — resolved server zone</b></td>
<td><b>Sync drawer — preview stamped with zone</b></td>
</tr>
<tr>
<td><img src="https://bb-artifacts.exe.xyz/f/beec8d6a1941a969.jpg" width="420" alt="Server default (PDT · UTC-07:00)"></td>
<td><img src="https://bb-artifacts.exe.xyz/f/8958cc904768debb.jpg" width="420" alt="At 03:00 AM · PDT"></td>
</tr>
</table>

## Notes

- JS-only + Go-only; no schema, no new routes. `/-/cron/preview` already returned `tz_label` (instance-tz anchor) — this just surfaces it.
- `go build ./...`, `go vet ./internal/admin/... ./internal/templates/...`, and `go test ./internal/templates/...` all green. Validated in a real browser (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
