### PR TITLE
bb-artifacts: read IMGHOST_UPLOAD_TOKEN env for upload auth

### DIFF
--- a/.claude/skills/github-image-hosting/SKILL.md
+++ b/.claude/skills/github-image-hosting/SKILL.md
@@ -30,23 +30,26 @@ Host: **bb-artifacts.exe.xyz** (self-hosted on exe.dev). **Reads are public**
 (GitHub's camo proxy and anyone with the link can fetch). **Uploads are
 authenticated** by either of two means:
 
-- **GitHub identity** — send your GitHub token as the Bearer; the server checks it
-  resolves to an allowed login (`canalesb93`). `gh auth token` works in **both
-  local and cloud** Claude sessions, so there's no secret to store. This is the
-  default for agents.
-- **Static upload token** — a shared secret (for CI, or any non-`gh` context). See
-  the CI section below.
+- **Static upload token** — send a secret as the Bearer. Set `IMGHOST_UPLOAD_TOKEN`
+  in the environment and it's used automatically. This is how cloud/remote sessions
+  and CI authenticate.
+- **GitHub identity** — if `IMGHOST_UPLOAD_TOKEN` isn't set, send your GitHub token
+  (`gh auth token`); the server allows it if it resolves to login `canalesb93`. This
+  is the zero-config path for local sessions.
 
-## Primary: bb-artifacts.exe.xyz (GitHub-identity)
+## Primary: bb-artifacts.exe.xyz
 
 ```bash
-URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
+# Prefer a configured upload token (cloud/remote export IMGHOST_UPLOAD_TOKEN);
+# otherwise fall back to your GitHub identity via gh (local sessions).
+AUTH="${IMGHOST_UPLOAD_TOKEN:-$(gh auth token 2>/dev/null)}"
+URL=$(curl -sf -H "Authorization: Bearer $AUTH" \
           -F file=@/tmp/screenshot.jpg https://bb-artifacts.exe.xyz/upload | jq -r .url)
 echo "$URL"   # -> https://bb-artifacts.exe.xyz/f/<id>.jpg
 ```
 
-`gh` is sandbox-exempt and authenticated in both local and cloud sessions, so this
-is the one path that works everywhere. No `jq`? Parse with python:
+Both `gh` and `IMGHOST_UPLOAD_TOKEN` are available across local and cloud sessions,
+so this path works everywhere. No `jq`? Parse with python:
 `python3 -c "import sys,json;print(json.load(sys.stdin)['url'])"`.
 
 **Accepted**: images (`png/jpg/jpeg/gif/webp/svg/bmp/ico`), `html/htm`, `txt/md/log`,
@@ -65,16 +68,18 @@ returned URL renders in a browser. Handy for capturing a rendered page, a failin
 template, or a large log to share without pasting it inline.
 
 ```bash
-URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
+AUTH="${IMGHOST_UPLOAD_TOKEN:-$(gh auth token 2>/dev/null)}"
+URL=$(curl -sf -H "Authorization: Bearer $AUTH" \
           -F file=@/tmp/debug-snapshot.html https://bb-artifacts.exe.xyz/upload | jq -r .url)
 echo "$URL"   # open in a browser to view the rendered page
 ```
 
-### From CI (or any non-`gh` context): static upload token
+### The `IMGHOST_UPLOAD_TOKEN` secret (cloud/remote sessions + CI)
 
-In GitHub Actions the ambient token is a bot, not you, so use the static upload
-secret instead. Store it as a repo secret (`IMGHOST_UPLOAD_TOKEN`) and send it as
-the Bearer:
+Cloud/remote Claude sessions export `IMGHOST_UPLOAD_TOKEN` in their environment —
+the snippets above pick it up automatically. For GitHub Actions the ambient token
+is a bot, not you, so store the same secret as a repo secret
+(`IMGHOST_UPLOAD_TOKEN`) and send it as the Bearer:
 
 ```yaml
 - name: Upload screenshot to bb-artifacts

--- a/.claude/skills/validate-ui/SKILL.md
+++ b/.claude/skills/validate-ui/SKILL.md
@@ -190,13 +190,14 @@ If over 1MB: retake at `quality: 70` or drop `fullPage`.
 
 ### 7. Upload
 
-**Preferred: self-hosted bb-artifacts.exe.xyz** — auth with your GitHub token via
-`gh auth token`, which is present in **both** local and cloud sessions (`gh` is
-sandbox-exempt). Public read, ~180-day auto-expiry, no release clutter. See the
-`github-image-hosting` skill for full details.
+**Preferred: self-hosted bb-artifacts.exe.xyz** — auth with a configured
+`IMGHOST_UPLOAD_TOKEN` (cloud/remote sessions export it) or, if unset, your GitHub
+identity via `gh auth token` (local). Public read, ~180-day auto-expiry, no release
+clutter. See the `github-image-hosting` skill for full details.
 
 ```bash
-URL=$(curl -sf -H "Authorization: Bearer $(gh auth token)" \
+AUTH="${IMGHOST_UPLOAD_TOKEN:-$(gh auth token 2>/dev/null)}"
+URL=$(curl -sf -H "Authorization: Bearer $AUTH" \
           -F file=@/tmp/app-<PAGE>.jpg https://bb-artifacts.exe.xyz/upload | jq -r .url)
 echo "$URL"
 ```


### PR DESCRIPTION
## What

Makes the image-hosting skills read **`IMGHOST_UPLOAD_TOKEN`** from the environment for upload auth, so cloud/remote Claude sessions (which can set env vars) authenticate with a static token — the same secret name already used for the CI repo secret.

```bash
# both skills now do:
AUTH="${IMGHOST_UPLOAD_TOKEN:-$(gh auth token 2>/dev/null)}"
curl -sf -H "Authorization: Bearer $AUTH" -F file=@FILE https://bb-artifacts.exe.xyz/upload
```

## Auth resolution (one consistent var everywhere)

- **Cloud / remote sessions** → export `IMGHOST_UPLOAD_TOKEN`; used automatically.
- **CI** → repo secret `IMGHOST_UPLOAD_TOKEN` (workflow snippet unchanged).
- **Local sessions** → no token set → falls back to GitHub identity via `gh auth token`.

The host already accepts that token (it's in the VM's `IMGHOST_TOKENS`). Reads stay public; all guards unchanged.

## Changes

- `github-image-hosting` skill — primary + HTML snippets use `${IMGHOST_UPLOAD_TOKEN:-$(gh auth token)}`; auth section documents the env var for cloud/remote + CI.
- `validate-ui` skill — step 7 same precedence.

Follow-up to #1753 (which is merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
