### PR TITLE
feat(workflows): custom-workflow create/edit drawer on /workflows

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -389,4 +389,3 @@ func AgentCleanupAdminHandler(a *app.App, svc *service.Service) http.HandlerFunc
 		writeJSON(w, http.StatusOK, result)
 	}
 }
-

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -539,6 +539,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			// because a reconfigure re-authorizes recurring AI spend behavior.
 			r.With(RequireAdmin(sm)).Get("/workflows/{slug}/config", WorkflowConfigAdminHandler(svc))
 			r.With(RequireAdmin(sm)).Post("/workflows/{slug}/reconfigure", ReconfigureWorkflowAdminHandler(svc))
+			// Custom (hand-authored, source_template IS NULL) workflows: the
+			// drawer authors the whole prompt. Distinct /-/custom-workflows
+			// prefix so it never overlaps the /-/workflows/{slug} param space.
+			// Admin-only, like preset enable/reconfigure.
+			r.With(RequireAdmin(sm)).Post("/custom-workflows", CreateCustomWorkflowAdminHandler(svc))
+			r.With(RequireAdmin(sm)).Get("/custom-workflows/{slug}", CustomWorkflowConfigAdminHandler(svc))
+			r.With(RequireAdmin(sm)).Post("/custom-workflows/{slug}", UpdateCustomWorkflowAdminHandler(svc))
 			// Remove an instantiated workflow, resetting the preset card back to
 			// "Set up". Admin-only — deleting de-authorizes the recurring spend the
 			// enable gesture authorized, mirroring the enable/reconfigure guard.

--- a/internal/admin/workflows_custom_handler.go
+++ b/internal/admin/workflows_custom_handler.go
@@ -1,0 +1,275 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Custom workflows are hand-authored agent definitions (source_template IS
+// NULL): the operator writes the entire prompt themselves, rather than
+// instantiating a code-defined preset. They're created and edited from the
+// shared custom-workflow drawer on /workflows, which speaks the same field
+// vocabulary as the preset drawers (trigger_on_sync, schedule_cron, model,
+// max_turns, max_budget_usd) plus the custom-only `prompt` and `tool_scope`.
+
+// customWorkflowInput is the parsed drawer payload, shared by create + edit.
+type customWorkflowInput struct {
+	name          string
+	prompt        string
+	model         string
+	toolScope     string
+	triggerOnSync bool
+	scheduleCron  string   // empty = manual (no automatic trigger)
+	maxTurns      int      // 0 = unset (leave default / untouched)
+	maxBudget     *float64 // nil = unset
+	enabled       bool     // create only — edit manages run-state via the card toggle
+}
+
+// readCustomWorkflowInput pulls the drawer fields out of the form, validating
+// the two required fields (name, prompt) and the numeric caps.
+func readCustomWorkflowInput(r *http.Request) (customWorkflowInput, error) {
+	in := customWorkflowInput{
+		name:          strings.TrimSpace(r.FormValue("name")),
+		prompt:        strings.TrimSpace(r.FormValue("prompt")),
+		model:         strings.TrimSpace(r.FormValue("model")),
+		toolScope:     strings.TrimSpace(r.FormValue("tool_scope")),
+		triggerOnSync: r.FormValue("trigger_on_sync") == "true",
+		scheduleCron:  strings.TrimSpace(r.FormValue("schedule_cron")),
+		enabled:       r.FormValue("enabled") == "true" || r.FormValue("enabled") == "on",
+	}
+	if in.name == "" {
+		return in, fmt.Errorf("name is required")
+	}
+	if in.prompt == "" {
+		return in, fmt.Errorf("prompt is required")
+	}
+	if v := strings.TrimSpace(r.FormValue("max_turns")); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 || n > 1000 {
+			return in, fmt.Errorf("max_turns must be a whole number between 0 and 1000")
+		}
+		in.maxTurns = n
+	}
+	if v := strings.TrimSpace(r.FormValue("max_budget_usd")); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil || f < 0 {
+			return in, fmt.Errorf("max_budget_usd must be a non-negative number")
+		}
+		in.maxBudget = &f
+	}
+	if in.toolScope != "read_only" {
+		in.toolScope = "read_write"
+	}
+	return in, nil
+}
+
+// CreateCustomWorkflowAdminHandler handles POST /-/custom-workflows. It derives
+// a unique slug from the name, then creates a hand-authored agent definition
+// (source_template = NULL). Admin-only — creating a workflow authorizes
+// recurring AI spend over household data, mirroring the preset-enable guard.
+// Returns JSON {slug} for the gallery's async submit (which reloads on success).
+func CreateCustomWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		in, err := readCustomWorkflowInput(r)
+		if err != nil {
+			writeError(w, http.StatusUnprocessableEntity, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		slug, err := uniqueCustomWorkflowSlug(r.Context(), svc, slugifyWorkflowName(in.name))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "WORKFLOW_CREATE_FAILED", err.Error())
+			return
+		}
+		params := service.CreateAgentDefinitionParams{
+			Name:         in.name,
+			Slug:         slug,
+			Prompt:       in.prompt,
+			Model:        in.model,
+			ToolScope:    in.toolScope,
+			MaxTurns:     in.maxTurns,
+			MaxBudgetUSD: in.maxBudget,
+			Enabled:      in.enabled,
+			// SourceTemplate stays nil — this is a hand-authored workflow.
+		}
+		if in.triggerOnSync {
+			params.TriggerOnSyncComplete = true
+		} else if in.scheduleCron != "" {
+			c := in.scheduleCron
+			params.ScheduleCron = &c
+		}
+		def, err := svc.CreateAgentDefinition(r.Context(), params)
+		if err != nil {
+			if errors.Is(err, service.ErrInvalidParameter) {
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_CREATE_FAILED", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"slug": def.Slug})
+	}
+}
+
+// UpdateCustomWorkflowAdminHandler handles POST /-/custom-workflows/{slug}. It
+// rewrites a hand-authored workflow's prompt, trigger, model, tool scope, and
+// caps. Run-state (enabled) is untouched — that's the card toggle's job.
+// Admin-only, mirroring the create + reconfigure guards.
+func UpdateCustomWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		def, err := svc.GetAgentDefinition(r.Context(), slug)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
+			return
+		}
+		if def.SourceTemplate != nil {
+			// A preset-backed workflow is edited via the reconfigure drawer, not
+			// this endpoint — refuse so the two paths can't cross-write.
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "Not a custom workflow")
+			return
+		}
+		_ = r.ParseForm()
+		in, err := readCustomWorkflowInput(r)
+		if err != nil {
+			writeError(w, http.StatusUnprocessableEntity, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		name, prompt, model, scope := in.name, in.prompt, in.model, in.toolScope
+		trigger := in.triggerOnSync
+		// schedule_cron is always sent (a pointer to "" clears it → manual or
+		// post-sync). The service nils an empty cron at the DB boundary.
+		cron := ""
+		if !trigger {
+			cron = in.scheduleCron
+		}
+		params := service.UpdateAgentDefinitionParams{
+			Name:                  &name,
+			Prompt:                &prompt,
+			Model:                 &model,
+			ToolScope:             &scope,
+			TriggerOnSyncComplete: &trigger,
+			ScheduleCron:          &cron,
+		}
+		if in.maxTurns > 0 {
+			mt := in.maxTurns
+			params.MaxTurns = &mt
+		}
+		if in.maxBudget != nil {
+			params.MaxBudgetUSD = in.maxBudget
+		}
+		updated, err := svc.UpdateAgentDefinition(r.Context(), slug, params)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound):
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
+			case errors.Is(err, service.ErrInvalidParameter):
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			default:
+				writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_UPDATE_FAILED", err.Error())
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"slug": updated.Slug})
+	}
+}
+
+// CustomWorkflowConfigAdminHandler handles GET /-/custom-workflows/{slug}. It
+// returns a custom workflow's live config so the drawer can open prefilled for
+// an edit. 404s for an unknown slug or a preset-backed workflow.
+func CustomWorkflowConfigAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "slug")
+		def, err := svc.GetAgentDefinition(r.Context(), slug)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
+			return
+		}
+		if def.SourceTemplate != nil {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "Not a custom workflow")
+			return
+		}
+		cron := ""
+		if def.ScheduleCron != nil {
+			cron = *def.ScheduleCron
+		}
+		var budget float64
+		if def.MaxBudgetUSD != nil {
+			budget = *def.MaxBudgetUSD
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"name":            def.Name,
+			"prompt":          def.Prompt,
+			"tool_scope":      def.ToolScope,
+			"model":           def.Model,
+			"trigger_on_sync": def.TriggerOnSyncComplete,
+			"schedule_cron":   cron,
+			"max_turns":       def.MaxTurns,
+			"max_budget_usd":  budget,
+			"enabled":         def.Enabled,
+		})
+	}
+}
+
+// slugifyWorkflowName turns a display name into a URL/route-safe base slug:
+// lowercased, non-alphanumerics collapsed to single dashes, trimmed, and
+// capped to leave room for a de-collision suffix. Matches the
+// service.validAgentSlug shape (^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$).
+func slugifyWorkflowName(name string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if b.Len() > 0 && !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	s := strings.Trim(b.String(), "-")
+	if len(s) > 56 {
+		s = strings.Trim(s[:56], "-")
+	}
+	if s == "" {
+		s = "workflow"
+	}
+	return s
+}
+
+// uniqueCustomWorkflowSlug returns base, or base-2 / base-3 / … if base is
+// already taken by an existing definition. The slug column is unique, so this
+// avoids a create failure on a duplicate name.
+func uniqueCustomWorkflowSlug(ctx context.Context, svc *service.Service, base string) (string, error) {
+	defs, err := svc.ListAgentDefinitions(ctx)
+	if err != nil {
+		return "", err
+	}
+	taken := make(map[string]bool, len(defs))
+	for _, d := range defs {
+		taken[d.Slug] = true
+	}
+	if !taken[base] {
+		return base, nil
+	}
+	for i := 2; i < 1000; i++ {
+		cand := fmt.Sprintf("%s-%d", base, i)
+		if !taken[cand] {
+			return cand, nil
+		}
+	}
+	return "", fmt.Errorf("could not allocate a unique slug for %q", base)
+}

--- a/internal/admin/workflows_custom_handler_integration_test.go
+++ b/internal/admin/workflows_custom_handler_integration_test.go
@@ -1,0 +1,165 @@
+//go:build integration && !headless && !lite
+
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// customWorkflowRouter wires the three custom-workflow handlers on a minimal
+// chi router with the {slug} param, bypassing RequireAdmin for handler-level
+// coverage.
+func customWorkflowRouter(svc *service.Service) *chi.Mux {
+	r := chi.NewRouter()
+	r.Post("/-/custom-workflows", CreateCustomWorkflowAdminHandler(svc))
+	r.Get("/-/custom-workflows/{slug}", CustomWorkflowConfigAdminHandler(svc))
+	r.Post("/-/custom-workflows/{slug}", UpdateCustomWorkflowAdminHandler(svc))
+	return r
+}
+
+func postForm(t *testing.T, r *chi.Mux, path string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestCustomWorkflowCreateConfigUpdate exercises the full custom-workflow
+// lifecycle through the admin handlers: create a hand-authored workflow, read
+// its config back, edit the prompt + trigger, and confirm the definition
+// round-trips with source_template still NULL.
+func TestCustomWorkflowCreateConfigUpdate(t *testing.T) {
+	svc := newTestSvc(t)
+	r := customWorkflowRouter(svc)
+
+	// --- Create ---
+	w := postForm(t, r, "/-/custom-workflows", url.Values{
+		"name":            {"My Anomaly Sweep"},
+		"prompt":          {"Watch for unusual charges and report them."},
+		"trigger_on_sync": {"false"},
+		"schedule_cron":   {"0 8 * * *"},
+		"model":           {"claude-sonnet-4-6"},
+		"tool_scope":      {"read_only"},
+		"max_budget_usd":  {"3.00"},
+		"enabled":         {"true"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: status %d, body %s", w.Code, w.Body.String())
+	}
+	var created struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("create: decode: %v", err)
+	}
+	if created.Slug != "my-anomaly-sweep" {
+		t.Fatalf("create: slug = %q, want my-anomaly-sweep", created.Slug)
+	}
+
+	// The created definition must be hand-authored (source_template NULL).
+	def, err := svc.GetAgentDefinition(t.Context(), created.Slug)
+	if err != nil {
+		t.Fatalf("GetAgentDefinition: %v", err)
+	}
+	if def.SourceTemplate != nil {
+		t.Fatalf("source_template = %q, want NULL (custom)", *def.SourceTemplate)
+	}
+	if def.ToolScope != "read_only" {
+		t.Errorf("tool_scope = %q, want read_only", def.ToolScope)
+	}
+	if def.ScheduleCron == nil || *def.ScheduleCron != "0 8 * * *" {
+		t.Errorf("schedule_cron = %v, want 0 8 * * *", def.ScheduleCron)
+	}
+
+	// --- Config (edit prefill) ---
+	cfgReq := httptest.NewRequest(http.MethodGet, "/-/custom-workflows/"+created.Slug, nil)
+	cfgW := httptest.NewRecorder()
+	r.ServeHTTP(cfgW, cfgReq)
+	if cfgW.Code != http.StatusOK {
+		t.Fatalf("config: status %d, body %s", cfgW.Code, cfgW.Body.String())
+	}
+	var cfg struct {
+		Name      string `json:"name"`
+		Prompt    string `json:"prompt"`
+		ToolScope string `json:"tool_scope"`
+	}
+	if err := json.Unmarshal(cfgW.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("config: decode: %v", err)
+	}
+	if cfg.Prompt != "Watch for unusual charges and report them." {
+		t.Errorf("config prompt mismatch: %q", cfg.Prompt)
+	}
+
+	// --- Update: rewrite prompt + switch to post-sync ---
+	uw := postForm(t, r, "/-/custom-workflows/"+created.Slug, url.Values{
+		"name":            {"My Anomaly Sweep"},
+		"prompt":          {"Updated instructions."},
+		"trigger_on_sync": {"true"},
+		"model":           {"claude-sonnet-4-6"},
+		"tool_scope":      {"read_write"},
+	})
+	if uw.Code != http.StatusOK {
+		t.Fatalf("update: status %d, body %s", uw.Code, uw.Body.String())
+	}
+	def2, err := svc.GetAgentDefinition(t.Context(), created.Slug)
+	if err != nil {
+		t.Fatalf("GetAgentDefinition (post-update): %v", err)
+	}
+	if def2.Prompt != "Updated instructions." {
+		t.Errorf("updated prompt = %q", def2.Prompt)
+	}
+	if !def2.TriggerOnSyncComplete {
+		t.Error("trigger_on_sync_complete should be true after update")
+	}
+	if def2.ScheduleCron != nil && *def2.ScheduleCron != "" {
+		t.Errorf("schedule_cron should be cleared when switching to post-sync, got %v", *def2.ScheduleCron)
+	}
+	if def2.ToolScope != "read_write" {
+		t.Errorf("tool_scope = %q, want read_write after update", def2.ToolScope)
+	}
+}
+
+// TestUniqueCustomWorkflowSlug confirms a duplicate name yields a de-collided
+// slug rather than a create failure.
+func TestUniqueCustomWorkflowSlug(t *testing.T) {
+	svc := newTestSvc(t)
+	r := customWorkflowRouter(svc)
+
+	mk := func() *httptest.ResponseRecorder {
+		return postForm(t, r, "/-/custom-workflows", url.Values{
+			"name":            {"Duplicate Name"},
+			"prompt":          {"do something"},
+			"trigger_on_sync": {"true"},
+		})
+	}
+	first := mk()
+	if first.Code != http.StatusOK {
+		t.Fatalf("first create: %d %s", first.Code, first.Body.String())
+	}
+	second := mk()
+	if second.Code != http.StatusOK {
+		t.Fatalf("second create: %d %s", second.Code, second.Body.String())
+	}
+	var a, b struct {
+		Slug string `json:"slug"`
+	}
+	_ = json.Unmarshal(first.Body.Bytes(), &a)
+	_ = json.Unmarshal(second.Body.Bytes(), &b)
+	if a.Slug == b.Slug {
+		t.Fatalf("expected distinct slugs, both = %q", a.Slug)
+	}
+	if a.Slug != "duplicate-name" || b.Slug != "duplicate-name-2" {
+		t.Fatalf("slugs = %q, %q; want duplicate-name, duplicate-name-2", a.Slug, b.Slug)
+	}
+}

--- a/internal/admin/workflows_custom_handler_unit_test.go
+++ b/internal/admin/workflows_custom_handler_unit_test.go
@@ -1,0 +1,110 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSlugifyWorkflowName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Daily triage", "daily-triage"},
+		{"Weekly  Anomaly   Sweep", "weekly-anomaly-sweep"},
+		{"  Leading/trailing!! ", "leading-trailing"},
+		{"Spend Report (monthly)", "spend-report-monthly"},
+		{"MixedCASE123", "mixedcase123"},
+		{"!!!", "workflow"},
+		{"", "workflow"},
+		{"-- dashes --", "dashes"},
+	}
+	for _, tc := range cases {
+		if got := slugifyWorkflowName(tc.in); got != tc.want {
+			t.Errorf("slugifyWorkflowName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSlugifyWorkflowNameLength(t *testing.T) {
+	long := strings.Repeat("a", 200)
+	got := slugifyWorkflowName(long)
+	if len(got) > 56 {
+		t.Fatalf("slug too long: %d chars (want <= 56)", len(got))
+	}
+}
+
+func TestReadCustomWorkflowInput(t *testing.T) {
+	parse := func(form url.Values) (customWorkflowInput, error) {
+		r := httptest.NewRequest("POST", "/-/custom-workflows", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		return readCustomWorkflowInput(r)
+	}
+
+	t.Run("requires name", func(t *testing.T) {
+		if _, err := parse(url.Values{"prompt": {"hi"}}); err == nil {
+			t.Fatal("expected error for missing name")
+		}
+	})
+	t.Run("requires prompt", func(t *testing.T) {
+		if _, err := parse(url.Values{"name": {"X"}}); err == nil {
+			t.Fatal("expected error for missing prompt")
+		}
+	})
+	t.Run("defaults tool scope to read_write", func(t *testing.T) {
+		in, err := parse(url.Values{"name": {"X"}, "prompt": {"do"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if in.toolScope != "read_write" {
+			t.Errorf("toolScope = %q, want read_write", in.toolScope)
+		}
+	})
+	t.Run("read_only preserved", func(t *testing.T) {
+		in, _ := parse(url.Values{"name": {"X"}, "prompt": {"do"}, "tool_scope": {"read_only"}})
+		if in.toolScope != "read_only" {
+			t.Errorf("toolScope = %q, want read_only", in.toolScope)
+		}
+	})
+	t.Run("trigger + schedule + caps parse", func(t *testing.T) {
+		in, err := parse(url.Values{
+			"name":            {"Sweep"},
+			"prompt":          {"do"},
+			"trigger_on_sync": {"true"},
+			"schedule_cron":   {"0 8 * * *"},
+			"max_turns":       {"12"},
+			"max_budget_usd":  {"2.50"},
+			"enabled":         {"true"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !in.triggerOnSync {
+			t.Error("triggerOnSync should be true")
+		}
+		if in.scheduleCron != "0 8 * * *" {
+			t.Errorf("scheduleCron = %q", in.scheduleCron)
+		}
+		if in.maxTurns != 12 {
+			t.Errorf("maxTurns = %d, want 12", in.maxTurns)
+		}
+		if in.maxBudget == nil || *in.maxBudget != 2.50 {
+			t.Errorf("maxBudget = %v, want 2.50", in.maxBudget)
+		}
+		if !in.enabled {
+			t.Error("enabled should be true")
+		}
+	})
+	t.Run("rejects bad budget", func(t *testing.T) {
+		if _, err := parse(url.Values{"name": {"X"}, "prompt": {"do"}, "max_budget_usd": {"-1"}}); err == nil {
+			t.Fatal("expected error for negative budget")
+		}
+	})
+}

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"breadbox/internal/cronspec"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
 
@@ -28,6 +29,66 @@ func buildAgentsListStatus(s *service.AgentSubsystemStatus) pages.AgentSubsystem
 		BinaryPresent:  s.BinaryPresent,
 		BinaryPath:     s.BinaryPath,
 	}
+}
+
+// buildCustomWorkflowCards maps the household's hand-authored workflows
+// (source_template IS NULL) into gallery cards for the Custom section.
+// Preset-instantiated definitions are skipped — they render in the preset
+// gallery above.
+func buildCustomWorkflowCards(defs []service.AgentDefinitionResponse) []pages.WorkflowCustomCardProps {
+	out := make([]pages.WorkflowCustomCardProps, 0, len(defs))
+	for _, d := range defs {
+		if d.SourceTemplate != nil {
+			continue // preset-backed → handled by the preset gallery
+		}
+		card := pages.WorkflowCustomCardProps{
+			Slug:         d.Slug,
+			Name:         d.Name,
+			Description:  firstPromptLine(d.Prompt, 120),
+			Enabled:      d.Enabled,
+			TriggerLabel: customWorkflowTriggerLabel(d),
+		}
+		if d.AvatarSeed != nil {
+			card.AvatarSeed = *d.AvatarSeed
+		}
+		if d.LastRun != nil && d.LastRun.Status == "error" {
+			card.LastRunError = true
+		}
+		out = append(out, card)
+	}
+	return out
+}
+
+// customWorkflowTriggerLabel renders a one-word trigger summary for a custom
+// workflow card: post-sync, scheduled, or manual.
+func customWorkflowTriggerLabel(d service.AgentDefinitionResponse) string {
+	if d.TriggerOnSyncComplete {
+		return "After each sync"
+	}
+	if d.ScheduleCron != nil && strings.TrimSpace(*d.ScheduleCron) != "" {
+		if desc := cronspec.Humanize(*d.ScheduleCron, ""); desc != "" {
+			return desc
+		}
+		return "Scheduled"
+	}
+	return "Manual"
+}
+
+// firstPromptLine returns the first non-empty line of a prompt, truncated to
+// max runes with an ellipsis. Drives the custom card's one-line description.
+func firstPromptLine(s string, max int) string {
+	for _, raw := range strings.Split(s, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		r := []rune(line)
+		if len(r) > max {
+			return string(r[:max]) + "…"
+		}
+		return line
+	}
+	return ""
 }
 
 // buildWorkflowSpendBanner derives the gallery's spend-ceiling banner from
@@ -86,9 +147,10 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			consented  bool
 			spend      service.HouseholdSpendStatus
 			lastRuns   map[string]*service.AgentRunSummary
+			defs       []service.AgentDefinitionResponse
 			wg         sync.WaitGroup
 		)
-		wg.Add(5)
+		wg.Add(6)
 		go func() { defer wg.Done(); presets, presetsErr = svc.ListWorkflowPresets(ctx) }()
 		go func() { defer wg.Done(); status = svc.GetAgentSubsystemStatus(ctx) }()
 		go func() { defer wg.Done(); consented = svc.WorkflowsConsentAcknowledged(ctx) }()
@@ -96,6 +158,9 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 		// Last-run summaries are a soft enrichment: a query hiccup drops the
 		// per-card "Last run" line but doesn't fail the gallery.
 		go func() { defer wg.Done(); lastRuns, _ = svc.GetEnabledWorkflowLastRuns(ctx) }()
+		// Definitions back the Custom section (source_template IS NULL). A
+		// failure just drops the section — the preset gallery still renders.
+		go func() { defer wg.Done(); defs, _ = svc.ListAgentDefinitions(ctx) }()
 		wg.Wait()
 
 		if presetsErr != nil {
@@ -110,6 +175,7 @@ func WorkflowsGalleryPageHandler(svc *service.Service, sm *scs.SessionManager, t
 			ConsentAcknowledged: consented,
 			Spend:               buildWorkflowSpendBanner(spend),
 			IsAdmin:             IsAdmin(sm, r),
+			Custom:              buildCustomWorkflowCards(defs),
 		}
 
 		data := BaseTemplateData(r, sm, "workflows", "Workflows")

--- a/internal/templates/components/pages/agent_runs_types.go
+++ b/internal/templates/components/pages/agent_runs_types.go
@@ -96,11 +96,11 @@ type TranscriptEvent struct {
 	ToolResultAt time.Time
 
 	// CostUSD / token counts are populated for type=="result".
-	CostUSD     float64
-	TokensIn    int64
-	TokensOut   int64
-	CacheRead   int64
-	CacheWrite  int64
+	CostUSD    float64
+	TokensIn   int64
+	TokensOut  int64
+	CacheRead  int64
+	CacheWrite int64
 
 	// RawJSON is the un-parsed original line. Always set so callers can
 	// always render something readable when the parser doesn't recognise

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -713,28 +713,33 @@ templ SectionTagPicker() {
 		@designExample("Chip states", "Each chip in the picker grid carries one of five states. Click cycles a chip through the right column.") {
 			<div class="flex flex-wrap items-center gap-2 max-w-xl">
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--absent" style="--tag-color:#0ea5e9">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
-</span>
+					<span class="bb-tagpicker-chip-glyph">
+						@components.LucideIcon("plus", "")
+					</span>
 					<span class="truncate">absent</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--present" style="--tag-color:#10b981">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("check", "")
-</span>
+					<span class="bb-tagpicker-chip-glyph">
+						@components.LucideIcon("check", "")
+					</span>
 					<span class="truncate">present</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--mixed" style="--tag-color:#f59e0b">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("minus", "")
-</span>
+					<span class="bb-tagpicker-chip-glyph">
+						@components.LucideIcon("minus", "")
+					</span>
 					<span class="truncate">mixed</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-add" style="--tag-color:#6366f1">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
-</span>
+					<span class="bb-tagpicker-chip-glyph">
+						@components.LucideIcon("plus", "")
+					</span>
 					<span class="truncate">pending-add</span>
 				</span>
 				<span class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-remove" style="--tag-color:#ef4444">
-					<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("x", "")
-</span>
+					<span class="bb-tagpicker-chip-glyph">
+						@components.LucideIcon("x", "")
+					</span>
 					<span class="truncate">pending-remove</span>
 				</span>
 			</div>
@@ -756,28 +761,33 @@ templ SectionTagPicker() {
 				<div class="bb-tagpicker-body">
 					<div class="bb-tagpicker-grid">
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--present" style="--tag-color:#10b981">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("check", "")
-</span>
+							<span class="bb-tagpicker-chip-glyph">
+								@components.LucideIcon("check", "")
+							</span>
 							<span class="truncate">recurring</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--mixed" style="--tag-color:#f59e0b">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("minus", "")
-</span>
+							<span class="bb-tagpicker-chip-glyph">
+								@components.LucideIcon("minus", "")
+							</span>
 							<span class="truncate">needs-review</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-add" style="--tag-color:#6366f1">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
-</span>
+							<span class="bb-tagpicker-chip-glyph">
+								@components.LucideIcon("plus", "")
+							</span>
 							<span class="truncate">subscription</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--absent" style="--tag-color:#0ea5e9">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("plus", "")
-</span>
+							<span class="bb-tagpicker-chip-glyph">
+								@components.LucideIcon("plus", "")
+							</span>
 							<span class="truncate">business</span>
 						</button>
 						<button type="button" class="bb-tag bb-tag-interactive bb-tagpicker-chip bb-tagpicker-chip--pending-remove" style="--tag-color:#ef4444">
-							<span class="bb-tagpicker-chip-glyph">@components.LucideIcon("x", "")
-</span>
+							<span class="bb-tagpicker-chip-glyph">
+								@components.LucideIcon("x", "")
+							</span>
 							<span class="truncate">refund</span>
 						</button>
 					</div>
@@ -888,12 +898,24 @@ templ SectionMenusDropdowns() {
 		@designExample("Menu (vertical nav list)", "menu-md / menu-sm.") {
 			<ul class="menu bg-base-100 rounded-xl border border-base-300 w-56">
 				<li class="menu-title">Settings</li>
-				<li><a class="menu-active">@components.LucideIcon("key", "w-4 h-4")
-API keys</a></li>
-				<li><a>@components.LucideIcon("users", "w-4 h-4")
-Household</a></li>
-				<li><a>@components.LucideIcon("bot", "w-4 h-4")
-MCP</a></li>
+				<li>
+					<a class="menu-active">
+						@components.LucideIcon("key", "w-4 h-4")
+						API keys
+					</a>
+				</li>
+				<li>
+					<a>
+						@components.LucideIcon("users", "w-4 h-4")
+						Household
+					</a>
+				</li>
+				<li>
+					<a>
+						@components.LucideIcon("bot", "w-4 h-4")
+						MCP
+					</a>
+				</li>
 			</ul>
 		}
 	</div>
@@ -2846,8 +2868,9 @@ templ SectionCommandPalette() {
 						<div class="bb-cmdk-group-label">Overview</div>
 						<div class="bb-cmdk-item">
 							<div class="bb-cmdk-generic">
-								<div class="bb-cmdk-item-icon">@components.LucideIcon("rss", "")
-</div>
+								<div class="bb-cmdk-item-icon">
+									@components.LucideIcon("rss", "")
+								</div>
 								<div class="bb-cmdk-item-label">
 									<div class="bb-cmdk-item-title">Feed</div>
 									<div class="bb-cmdk-item-desc">Activity feed across the household</div>
@@ -2859,8 +2882,9 @@ templ SectionCommandPalette() {
 						</div>
 						<div class="bb-cmdk-item" data-active="true">
 							<div class="bb-cmdk-generic">
-								<div class="bb-cmdk-item-icon">@components.LucideIcon("receipt", "")
-</div>
+								<div class="bb-cmdk-item-icon">
+									@components.LucideIcon("receipt", "")
+								</div>
 								<div class="bb-cmdk-item-label">
 									<div class="bb-cmdk-item-title">Transactions</div>
 									<div class="bb-cmdk-item-desc">View all transactions</div>
@@ -2904,8 +2928,9 @@ templ SectionCommandPalette() {
 			<div class="border border-base-300 rounded-xl bg-base-100 max-w-[560px] mx-auto py-2">
 				<div class="bb-cmdk-item">
 					<div class="bb-cmdk-generic">
-						<div class="bb-cmdk-item-icon">@components.LucideIcon("rss", "")
-</div>
+						<div class="bb-cmdk-item-icon">
+							@components.LucideIcon("rss", "")
+						</div>
 						<div class="bb-cmdk-item-label">
 							<div class="bb-cmdk-item-title">Feed</div>
 							<div class="bb-cmdk-item-desc">Default — neutral icon tile</div>
@@ -2917,8 +2942,9 @@ templ SectionCommandPalette() {
 				</div>
 				<div class="bb-cmdk-item" data-active="true">
 					<div class="bb-cmdk-generic">
-						<div class="bb-cmdk-item-icon">@components.LucideIcon("receipt", "")
-</div>
+						<div class="bb-cmdk-item-icon">
+							@components.LucideIcon("receipt", "")
+						</div>
 						<div class="bb-cmdk-item-label">
 							<div class="bb-cmdk-item-title">Transactions</div>
 							<div class="bb-cmdk-item-desc">Active — primary tint on tile + bg-primary/8 on row</div>
@@ -2930,8 +2956,9 @@ templ SectionCommandPalette() {
 				</div>
 				<div class="bb-cmdk-item">
 					<div class="bb-cmdk-generic">
-						<div class="bb-cmdk-item-icon">@components.LucideIcon("plus-circle", "")
-</div>
+						<div class="bb-cmdk-item-icon">
+							@components.LucideIcon("plus-circle", "")
+						</div>
 						<div class="bb-cmdk-item-label">
 							<div class="bb-cmdk-item-title">Connect a Bank</div>
 						</div>

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -73,6 +73,42 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 				</section>
 			}
 		</div>
+		// Custom workflows — hand-authored automations (source_template IS
+		// NULL). Rendered in their own section with a "Create" affordance so
+		// the operator can author a free-form prompt + schedule. Shown when
+		// any exist, or to admins (who can create the first one).
+		if len(p.Custom) > 0 || p.IsAdmin {
+			<section class="mt-8">
+				<div class="flex items-center justify-between gap-2 mb-3 px-0.5">
+					<div class="flex items-center gap-2">
+						@components.LucideIcon("wand-sparkles", "w-4 h-4 text-base-content/55")
+						<h2 class="text-sm font-semibold">Custom workflows</h2>
+					</div>
+					if p.IsAdmin {
+						<button type="button" class="btn btn-sm btn-ghost gap-1.5" @click="openCustom('')">
+							@components.LucideIcon("plus", "w-4 h-4")
+							Create custom workflow
+						</button>
+					}
+				</div>
+				if len(p.Custom) > 0 {
+					<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+						for _, c := range p.Custom {
+							@workflowCustomCard(c, p.IsAdmin)
+						}
+					</div>
+				} else {
+					<button
+						type="button"
+						class="bb-card w-full px-4 py-6 flex items-center justify-center gap-2 text-sm text-base-content/55 hover:text-base-content hover:border-base-content/20 transition-colors"
+						@click="openCustom('')"
+					>
+						@components.LucideIcon("plus", "w-4 h-4")
+						Author your own workflow — write a prompt, pick a schedule, and let it run.
+					</button>
+				}
+			</section>
+		}
 		<!-- Configure drawer: one components.Drawer slide-over per available preset. -->
 		<!-- Each Drawer renders its own backdrop + panel via the shared $store.drawers store. -->
 		// Drawers exist only for the admin who can actually submit them; a
@@ -92,6 +128,9 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 		// GET /-/workflows/{slug}/config. Admin-only (the link that opens it is).
 		if p.IsAdmin {
 			@workflowReconfigureDrawer()
+			// One shared custom-workflow drawer, used for both create (blank)
+			// and edit (hydrated by openCustom from GET /-/custom-workflows/{slug}).
+			@workflowCustomDrawer()
 		}
 	</div>
 }
@@ -690,6 +729,147 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 						{ workflowSetupCTALabel(preset.OneOff) }
 					</button>
 				}
+			}
+		</form>
+	}
+}
+
+// workflowCustomCard is one hand-authored workflow row in the Custom section.
+// It leads with the workflow's DiceBear avatar (its visual identity) and a
+// trigger summary, then the run toggle + an edit gear that opens the shared
+// custom drawer prefilled via openCustom(slug).
+templ workflowCustomCard(c WorkflowCustomCardProps, isAdmin bool) {
+	<div class="bb-card px-4 py-3 h-full flex items-center gap-3">
+		<div class="relative shrink-0">
+			<img
+				src={ customWorkflowAvatarSrc(c) }
+				alt={ c.Name + " avatar" }
+				class="w-9 h-9 rounded-lg bg-base-200"
+				loading="lazy"
+			/>
+			if c.LastRunError {
+				<span class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-error ring-2 ring-base-100" title="Last run failed"></span>
+			}
+		</div>
+		<div class="flex-1 min-w-0">
+			<div class="font-medium text-sm leading-tight truncate">{ c.Name }</div>
+			<div class="text-xs text-base-content/60 mt-0.5 line-clamp-1">{ c.Description }</div>
+			<div class="text-[11px] text-base-content/40 mt-0.5 inline-flex items-center gap-1">
+				@components.LucideIcon("clock", "w-3 h-3")
+				{ c.TriggerLabel }
+			</div>
+		</div>
+		<div class="flex items-center gap-1 shrink-0">
+			<input
+				type="checkbox"
+				class="toggle toggle-sm"
+				if c.Enabled {
+					checked
+				}
+				aria-label={ "Toggle " + c.Name }
+				@change={ "toggleWorkflow('" + c.Slug + "', $event.target)" }
+			/>
+			if isAdmin {
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm btn-square text-base-content/55"
+					@click={ "openCustom('" + c.Slug + "')" }
+					aria-label={ "Edit " + c.Name }
+				>
+					@components.LucideIcon("settings", "w-4 h-4")
+				</button>
+			}
+		</div>
+	</div>
+}
+
+// customWorkflowAvatarSrc builds the server-rendered DiceBear URL for a custom
+// workflow card, preferring the stored seed and falling back to the slug (the
+// server maps slug → stored seed too, so both resolve to the same mark).
+func customWorkflowAvatarSrc(c WorkflowCustomCardProps) string {
+	seed := c.AvatarSeed
+	if seed == "" {
+		seed = c.Slug
+	}
+	return "/avatars/" + seed + "?type=agent&size=72"
+}
+
+// workflowCustomDrawer is the single create+edit slide-over for hand-authored
+// workflows. openCustom('') opens it blank (create); openCustom(slug) hydrates
+// it from GET /-/custom-workflows/{slug} (edit). It reuses the shared trigger /
+// model / advanced field sub-templs, adding the custom-only prompt textarea and
+// tool-scope picker. Submits to POST /-/custom-workflows (create) or
+// /-/custom-workflows/{slug} (edit) via submitCustom().
+templ workflowCustomDrawer() {
+	@components.Drawer(components.DrawerProps{
+		ID:    "wf-custom",
+		Title: "Custom workflow",
+	}) {
+		<form class="flex flex-col h-full" @submit.prevent="submitCustom($event.target)">
+			<div class="flex items-center justify-between gap-4 p-5 border-b border-base-300 shrink-0">
+				<div class="flex items-center gap-3 min-w-0 flex-1">
+					@components.LucideIcon("wand-sparkles", "w-5 h-5 text-base-content/60 shrink-0")
+					<div class="text-lg font-semibold leading-tight" x-text="custom.isEdit ? 'Edit workflow' : 'New custom workflow'"></div>
+				</div>
+				<div class="flex items-center gap-2 shrink-0">
+					<!-- Activate toggle (create only): set up + activate in one gesture.
+					     On edit, run-state is the card toggle's job. -->
+					<label class="flex items-center gap-2 cursor-pointer" x-show="!custom.isEdit">
+						<span class="text-xs text-base-content/55 hidden sm:inline">Activate</span>
+						<input type="checkbox" name="enabled" value="true" x-model="custom.enabled" class="toggle toggle-sm"/>
+					</label>
+					<button type="button" class="btn btn-ghost btn-sm btn-square" @click="$store.drawers.close()" aria-label="Close">
+						@components.LucideIcon("x", "w-4 h-4")
+					</button>
+				</div>
+			</div>
+			<div x-show="custom.loading" class="flex items-center gap-2 text-sm text-base-content/60 p-5">
+				<span class="loading loading-spinner loading-sm"></span>
+				Loading…
+			</div>
+			<div x-show="!custom.loading" x-cloak class="flex-1 overflow-y-auto p-5 space-y-5">
+				<div>
+					<div class="text-sm font-medium mb-1.5">Name</div>
+					<input
+						type="text"
+						name="name"
+						x-model="custom.name"
+						maxlength="80"
+						required
+						placeholder="e.g. Weekly anomaly sweep"
+						class="input input-sm w-full"
+					/>
+				</div>
+				<div>
+					<div class="text-sm font-medium mb-1.5">Prompt</div>
+					<textarea
+						name="prompt"
+						x-model="custom.prompt"
+						rows="10"
+						required
+						class="textarea textarea-bordered w-full text-sm font-mono leading-relaxed"
+						placeholder="The full instructions sent on every run. Describe the goal, what to look at, and how to act — e.g. &#34;Review new transactions, flag anything over $200 that isn't a known merchant, and write a short report.&#34;"
+					></textarea>
+					<div class="text-xs text-base-content/40 mt-1">This is the entire workflow prompt — there's no template behind it.</div>
+				</div>
+				@workflowTriggerFields("custom.triggerOnSync", "custom.scheduleCron", "")
+				@workflowModelField("custom.model")
+				<div>
+					<div class="text-sm font-medium mb-1.5">Tool access</div>
+					<div class="join w-full rounded-lg overflow-hidden">
+						<input type="radio" name="tool_scope" value="read_write" x-model="custom.toolScope" aria-label="Read &amp; write" class="join-item btn btn-sm flex-1 checked:btn-primary"/>
+						<input type="radio" name="tool_scope" value="read_only" x-model="custom.toolScope" aria-label="Read only" class="join-item btn btn-sm flex-1 checked:btn-primary"/>
+					</div>
+					<div class="text-xs text-base-content/40 mt-1">Read &amp; write lets the workflow categorize, tag, and create rules; read-only restricts it to reporting.</div>
+				</div>
+				@workflowAdvancedFields("custom.maxTurns", "custom.maxBudget")
+			</div>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="custom.loading">
+					@components.LucideIcon("save", "w-4 h-4")
+					<span x-text="custom.isEdit ? 'Save changes' : 'Create workflow'"></span>
+				</button>
 			}
 		</form>
 	}

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -133,6 +133,24 @@ type WorkflowsGalleryProps struct {
 	// IsAdmin gates the "Set up" action: instantiating a workflow from a
 	// preset is admin-only. Non-admins see a disabled control + hint.
 	IsAdmin bool
+	// Custom holds the household's hand-authored workflows (source_template
+	// IS NULL) — rendered in their own section with a "Create custom
+	// workflow" affordance. Empty for non-admins (they can't create them).
+	Custom []WorkflowCustomCardProps
+}
+
+// WorkflowCustomCardProps is one hand-authored (non-preset) workflow card
+// in the gallery's "Custom" section. Unlike a preset card it carries no
+// template options — the operator authored the whole prompt — and is
+// edited via the shared custom-workflow drawer (openCustom).
+type WorkflowCustomCardProps struct {
+	Slug         string
+	Name         string
+	Description  string // first line of the prompt
+	Enabled      bool   // run-state (the card toggle flips it immediately)
+	AvatarSeed   string // DiceBear seed; empty = slug-seeded
+	TriggerLabel string // "After each sync" / a cron summary / "Manual"
+	LastRunError bool   // most recent run failed → red status dot
 }
 
 // WorkflowSpendBanner is the gallery's spend-ceiling state: shown when a

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -63,6 +63,28 @@ document.addEventListener('alpine:init', function () {
       },
       // -------------------------------------------------------------------
 
+      // --- Custom (hand-authored) workflow drawer ------------------------
+      // One drawer for both create (openCustom('')) and edit
+      // (openCustom(slug), hydrated from GET /-/custom-workflows/{slug}).
+      // The operator authors the whole prompt; there's no preset template.
+      // triggerOnSync is a STRING ('true' | 'false') so the trigger radios
+      // bind via x-model; the CronField two-way binds custom.scheduleCron.
+      custom: {
+        loading: false,
+        isEdit: false,
+        slug: '',
+        name: '',
+        prompt: '',
+        triggerOnSync: 'false',
+        scheduleCron: '',
+        model: 'claude-sonnet-4-6',
+        toolScope: 'read_write',
+        maxTurns: '',
+        maxBudget: '',
+        enabled: true, // create-only "Activate" toggle
+      },
+      // -------------------------------------------------------------------
+
       // runningOneOff[slug] is true while a one-off's Run-now request is in
       // flight, so each card's inline Run button can show a spinner + disable
       // itself (preventing a double-dispatch). Keyed by preset slug since two
@@ -490,6 +512,81 @@ document.addEventListener('alpine:init', function () {
           })
           .catch(function (e) {
             console.error('submitReconfigure failed', e);
+            if (btn) btn.disabled = false;
+            self.restorePageState();
+          });
+      },
+
+      // Open the shared custom-workflow drawer. With no slug it opens blank
+      // for a create; with a slug it hydrates from GET /-/custom-workflows/{slug}
+      // for an edit. Resets to create defaults first so a prior edit's values
+      // don't bleed in.
+      openCustom: function (slug) {
+        var self = this;
+        self.custom.isEdit = !!slug;
+        self.custom.slug = slug || '';
+        self.custom.name = '';
+        self.custom.prompt = '';
+        self.custom.triggerOnSync = 'false';
+        self.custom.scheduleCron = '';
+        self.custom.model = 'claude-sonnet-4-6';
+        self.custom.toolScope = 'read_write';
+        self.custom.maxTurns = '';
+        self.custom.maxBudget = '';
+        self.custom.enabled = true;
+        self.custom.loading = !!slug;
+        Alpine.store('drawers').open('wf-custom');
+        if (!slug) return;
+        fetch('/-/custom-workflows/' + encodeURIComponent(slug), {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+          })
+          .then(function (data) {
+            self.custom.name = data.name || '';
+            self.custom.prompt = data.prompt || '';
+            self.custom.triggerOnSync = data.trigger_on_sync ? 'true' : 'false';
+            self.custom.scheduleCron = data.schedule_cron || '';
+            self.custom.model = data.model || 'claude-sonnet-4-6';
+            self.custom.toolScope = data.tool_scope || 'read_write';
+            self.custom.maxTurns = data.max_turns ? String(data.max_turns) : '';
+            self.custom.maxBudget = data.max_budget_usd ? String(data.max_budget_usd) : '';
+            self.custom.enabled = !!data.enabled;
+          })
+          .catch(function (e) {
+            console.error('openCustom failed', e);
+            Alpine.store('drawers').close();
+            self.restorePageState();
+          })
+          .finally(function () {
+            self.custom.loading = false;
+          });
+      },
+
+      // Submit the custom-workflow drawer: POST to /-/custom-workflows (create)
+      // or /-/custom-workflows/{slug} (edit), then reload so the card reflects
+      // the new state.
+      submitCustom: function (form) {
+        var self = this;
+        var fd = new FormData(form);
+        // The create "Activate" checkbox is omitted by FormData when unchecked.
+        var box = form.querySelector('input[name="enabled"]');
+        if (box && !box.checked) fd.set('enabled', 'false');
+        var url = self.custom.isEdit
+          ? '/-/custom-workflows/' + encodeURIComponent(self.custom.slug)
+          : '/-/custom-workflows';
+        var btn = form.querySelector('button[type="submit"]');
+        if (btn) btn.disabled = true;
+        self._post(url, new URLSearchParams(fd).toString())
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            window.location.reload();
+          })
+          .catch(function (e) {
+            console.error('submitCustom failed', e);
             if (btn) btn.disabled = false;
             self.restorePageState();
           });


### PR DESCRIPTION
Adds a basic custom-workflow create/edit drawer to /workflows so hand-authored (non-preset) automations are first-class again. **PR 2 of 2** — stacked on #1769 (the removal). Merge #1769 first.

## What

`/workflows` is now the single home for *both* preset and custom automations.

- **Custom workflows section** — a new section in the gallery lists hand-authored definitions (`source_template IS NULL`) as cards: DiceBear avatar, prompt first line, trigger summary, a run toggle, and an edit gear. A **Create custom workflow** button (and an empty-state CTA) opens the drawer.
- **One drawer, create + edit** — opens blank for create, or hydrated from `GET /-/custom-workflows/{slug}` for edit. The operator authors the **entire prompt** (no template behind it), plus trigger (the shared `CronField`), model, tool access (read/write vs read-only), and the advanced turn/budget caps. It reuses the existing `components.Drawer` + the shared `workflowTriggerFields` / `workflowModelField` / `workflowAdvancedFields` sub-templs, so it matches the preset setup/reconfigure drawers exactly.

## How

- New handlers in `internal/admin/workflows_custom_handler.go`:
  - `POST /-/custom-workflows` — create (derives + de-collides a slug from the name).
  - `GET /-/custom-workflows/{slug}` — config JSON for the edit prefill.
  - `POST /-/custom-workflows/{slug}` — update.
  - Distinct `/-/custom-workflows` prefix so it never overlaps the `/-/workflows/{slug}` param space. Admin-only, mirroring the preset enable/reconfigure guards.
- Built on the existing `service.CreateAgentDefinition` / `UpdateAgentDefinition` (with `SourceTemplate = nil`) — **no new service methods**, and the **preset reconfigure path is untouched**.
- Run-state stays the card toggle's job (the `/-/workflows/{slug}/enable|disable` parallels); create offers an "Activate" toggle.

## Verification

- `go build`, `go vet`, `go test ./...` — green. `make test-integration` (admin + service + db) — green.
- New tests: unit coverage for slug derivation + form parsing; an integration test driving create → config → update through the handlers, asserting `source_template` stays NULL and the prompt/trigger round-trip.

<img src="https://bb-artifacts.exe.xyz/f/790ae133579f7b51.jpg" width="900" alt="Custom workflow drawer — full prompt authoring + schedule + model + tool scope; Custom workflows section behind it">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
