### PR TITLE
feat(ui): workflows — row-click toggles enablement, hover affordance

### DIFF
--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -315,7 +315,12 @@ templ workflowPromptPreviewModal() {
 // right. Set up, Run now, Reconfigure, and Preview prompt all live in the
 // drawer the gear opens, so the row itself stays uncluttered.
 templ workflowPresetCard(preset WorkflowPresetCardProps, isAdmin bool) {
-	<div class="bb-card px-4 py-3 h-full flex items-center gap-3">
+	<div
+		class={ "bb-card px-4 py-3 h-full flex items-center gap-3", templ.KV("bb-card--interactive", !preset.OneOff && isAdmin) }
+		if !preset.OneOff && isAdmin {
+			@click="cardClick($event)"
+		}
+	>
 		<div class={ presetTileClasses(preset.Enabled && !preset.OneOff) }>
 			@components.LucideIcon(preset.Icon, "w-5 h-5")
 			if preset.LastRun != nil && preset.LastRun.Status == "error" {
@@ -365,10 +370,15 @@ templ workflowCardControls(preset WorkflowPresetCardProps, isAdmin bool) {
 			</button>
 		}
 	} else if isAdmin {
+		// Not yet set up: clicking the toggle (or the row) optimistically flips
+		// it on and opens the setup drawer. Saving keeps it on; cancelling
+		// (Cancel / Esc / backdrop) reverts it via the drawer-close watcher,
+		// keyed off data-setup-slug.
 		<input
 			type="checkbox"
 			class="toggle toggle-sm"
-			@click.prevent={ workflowOpenConfigJS(preset) }
+			data-setup-slug={ preset.Slug }
+			@click={ "beginSetup('" + preset.Slug + "', $event.target)" }
 			aria-label={ "Set up " + preset.Name }
 		/>
 		<button

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -69,8 +69,57 @@ document.addEventListener('alpine:init', function () {
       runningOneOff: {},
       // -------------------------------------------------------------------
 
+      // pendingSetupSlug tracks a not-yet-set-up card whose run toggle was
+      // optimistically flipped on while its setup drawer is open. If that
+      // drawer is dismissed without saving (Cancel / Esc / backdrop), the
+      // drawer-close watcher in init() reverts the toggle. A successful save
+      // reloads the page, so the optimistic state is replaced by server truth.
+      pendingSetupSlug: '',
+      // -------------------------------------------------------------------
+
       init: function () {
         this.csrfToken = this.$el.dataset.csrf || '';
+        var self = this;
+        // Revert an optimistic setup toggle when its drawer closes unsaved.
+        // submitDrawer reloads on success (no close call), so the only way the
+        // config drawer leaves the screen with a pending toggle is a dismiss.
+        this.$watch('$store.drawers.active', function (active) {
+          if (
+            self.pendingSetupSlug &&
+            active !== 'wf-config-' + self.pendingSetupSlug
+          ) {
+            self._revertPendingSetup();
+          }
+        });
+      },
+
+      // cardClick makes the whole preset row act as its run toggle. A click
+      // that lands on an actual control (the toggle, the settings gear, a link)
+      // is left to that control; anywhere else forwards to the row's toggle via
+      // a synthesized click, so the toggle's own @change / @click handler runs
+      // (toggleWorkflow for set-up cards, beginSetup for not-yet-set-up ones).
+      // Wired only on recurring (non one-off) cards for admins.
+      cardClick: function (ev) {
+        if (ev.target.closest('button, a, input, label, [role="button"]')) return;
+        var toggle = ev.currentTarget.querySelector('input.toggle:not([disabled])');
+        if (toggle) toggle.click();
+      },
+
+      // beginSetup handles a not-yet-set-up card's toggle: optimistically show
+      // it enabled and open the setup drawer. Tracked by pendingSetupSlug so a
+      // dismissed drawer reverts it (see the init() watcher).
+      beginSetup: function (slug, el) {
+        if (el) el.checked = true;
+        this.pendingSetupSlug = slug;
+        Alpine.store('drawers').open('wf-config-' + slug);
+      },
+
+      _revertPendingSetup: function () {
+        var slug = this.pendingSetupSlug;
+        this.pendingSetupSlug = '';
+        if (!slug) return;
+        var cb = document.querySelector('input.toggle[data-setup-slug="' + slug + '"]');
+        if (cb) cb.checked = false;
       },
 
       restorePageState: function () {


### PR DESCRIPTION
Make the whole preset row clickable on recurring Workflows cards (not one-offs) so a click anywhere on the row toggles enablement, with a hover tint + pointer cursor signalling it's interactive.

## Changes

- **Hover/cursor affordance** — recurring cards (admin) get the existing `bb-card--interactive` class (`cursor-pointer` + `hover:bg-base-200/50`). One-off cards (Rule Foundation, Bulk Catch-Up) stay non-interactive.
- **Row click = toggle** — `cardClick` forwards a row click to that row's run toggle, ignoring clicks on the toggle/gear/links so they keep their own behavior.
- **First-enable flow** — a not-yet-set-up card optimistically flips its toggle on and opens the setup drawer; **Cancel/Esc/backdrop reverts** it, **Save** keeps it on (page reload reflects server truth). Tracked via `pendingSetupSlug` + an `$store.drawers.active` watcher.
- One-off cards are excluded entirely (no recurring on/off state).

<img src="https://bb-artifacts.exe.xyz/f/c5358e909046f915.jpeg" width="800" alt="Workflows — row hover state">

## Test plan

- [x] Toggle rows show pointer cursor + hover tint; one-off cards do not
- [x] Row click on a not-set-up card → toggle flips on **and** setup drawer opens
- [x] Cancel reverts the optimistic toggle to off
- [x] Save keeps the card enabled after reload
- [x] Row click on a set-up card disables it; click again re-enables — both persist across reload
- [x] `go build`, `go vet`, templates test suite (scripts-lint + workflows render) green
