### PR TITLE
feat(settings): link to DiceBear style gallery from Avatars section

### DIFF
--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -265,6 +265,7 @@ templ settingsAvatarsSection(p SettingsProps) {
 		Icon:    "user-circle",
 		Title:   "Avatars",
 		Caption: "DiceBear styles for auto-generated identicons — uploaded avatars are unaffected",
+		Right:   settingsAvatarStylesLink(),
 	}) {
 		@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 			<div class="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
@@ -279,6 +280,21 @@ templ settingsAvatarsSection(p SettingsProps) {
 			</p>
 		}
 	}
+}
+
+// settingsAvatarStylesLink is the section-header affordance pointing at
+// DiceBear's full style gallery, so operators can browse every available
+// style at the source before picking one in the selects below.
+templ settingsAvatarStylesLink() {
+	<a
+		href="https://www.dicebear.com/styles/"
+		target="_blank"
+		rel="noopener noreferrer"
+		class="btn btn-ghost btn-xs gap-1.5"
+	>
+		Browse styles
+		@components.LucideIcon("external-link", "w-3.5 h-3.5")
+	</a>
 }
 
 // settingsAvatarPicker renders one actor-bucket picker (User or Agent)


### PR DESCRIPTION
Adds a "Browse styles" external link in the Avatars section header on `/settings/general` so operators can view every DiceBear style at the source before picking one.

## Changes

- New `settingsAvatarStylesLink` templ helper rendering a `btn-ghost btn-xs` link with an `external-link` icon.
- Wired into the Avatars `SettingsSection` header `Right` slot, pointing at `https://www.dicebear.com/styles/` (opens in a new tab, `rel="noopener noreferrer"`).

<img src="https://bb-artifacts.exe.xyz/f/81d1bec82408fea2.jpg" width="800" alt="/settings/general — Avatars section with Browse styles link">

## Test plan

- [ ] Open `/settings/general` → Avatars section header shows a "Browse styles ↗" link top-right.
- [ ] Clicking it opens `https://www.dicebear.com/styles/` in a new tab.
- [ ] Existing avatar pickers/auto-save behavior unchanged.
