### PR TITLE
polish(settings): move DiceBear link inline into the Avatars subtitle

### DIFF
--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -262,10 +262,9 @@ func settingsSyncCaption(p SettingsProps) string {
 // ---------------------------------------------------------------------
 templ settingsAvatarsSection(p SettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
-		Icon:    "user-circle",
-		Title:   "Avatars",
-		Caption: "DiceBear styles for auto-generated identicons — uploaded avatars are unaffected",
-		Right:   settingsAvatarStylesLink(),
+		Icon:           "user-circle",
+		Title:          "Avatars",
+		CaptionContent: settingsAvatarsCaption(),
 	}) {
 		@components.SettingsRow(components.SettingsRowProps{Stack: true}) {
 			<div class="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
@@ -282,19 +281,17 @@ templ settingsAvatarsSection(p SettingsProps) {
 	}
 }
 
-// settingsAvatarStylesLink is the section-header affordance pointing at
-// DiceBear's full style gallery, so operators can browse every available
-// style at the source before picking one in the selects below.
-templ settingsAvatarStylesLink() {
+// settingsAvatarsCaption is the section subtitle for Avatars, with an
+// inline link to DiceBear's full style gallery so operators can browse
+// every available style at the source before picking one below.
+templ settingsAvatarsCaption() {
+	DiceBear styles for auto-generated identicons — uploaded avatars are unaffected.
 	<a
 		href="https://www.dicebear.com/styles/"
 		target="_blank"
 		rel="noopener noreferrer"
-		class="btn btn-ghost btn-xs gap-1.5"
-	>
-		Browse styles
-		@components.LucideIcon("external-link", "w-3.5 h-3.5")
-	</a>
+		class="link"
+	>Browse all styles</a>.
 }
 
 // settingsAvatarPicker renders one actor-bucket picker (User or Agent)

--- a/internal/templates/components/settings_section.templ
+++ b/internal/templates/components/settings_section.templ
@@ -24,8 +24,12 @@ type SettingsSectionProps struct {
 	BrandIcon string
 	Title     string
 	Caption   string
-	Right     templ.Component
-	Variant   string
+	// CaptionContent, when set, renders in place of the plain-string
+	// Caption in the left gutter — use it when the subtitle needs inline
+	// markup (a link, emphasis). Falls back to Caption when nil.
+	CaptionContent templ.Component
+	Right          templ.Component
+	Variant        string
 	// FullWidth drops the left gutter so the content spans the whole
 	// width (overview cards, stats grids, page-level alerts). When set,
 	// the content is NOT auto-carded — the caller supplies its own
@@ -143,7 +147,11 @@ templ settingsSectionMeta(p SettingsSectionProps) {
 				}
 				<h2 class="bb-settings-section__title">{ p.Title }</h2>
 			</div>
-			if p.Caption != "" {
+			if p.CaptionContent != nil {
+				<p class="bb-settings-section__caption">
+					@p.CaptionContent
+				</p>
+			} else if p.Caption != "" {
 				<p class="bb-settings-section__caption">{ p.Caption }</p>
 			}
 		}


### PR DESCRIPTION
Moves the DiceBear gallery link from the Avatars section-header button into the section subtitle as an inline link, so it reads as part of the explanatory copy instead of a competing header action. Follow-up to #1774.

## Changes

- New `CaptionContent templ.Component` slot on `SettingsSection` — renders in place of the plain-string `Caption` when a subtitle needs inline markup (falls back to `Caption` when nil).
- Avatars section now uses `CaptionContent` with an inline underlined link ("Browse all styles") pointing at `https://www.dicebear.com/styles/`.
- Removed the header `Right`-slot "Browse styles" button helper.

<img src="https://bb-artifacts.exe.xyz/f/2c4e1dd8699aae62.jpg" width="800" alt="/settings/general — Avatars subtitle with inline Browse all styles link">

## Test plan

- [ ] Open `/settings/general` → Avatars section subtitle ends with an underlined "Browse all styles" link.
- [ ] Clicking it opens `https://www.dicebear.com/styles/` in a new tab.
- [ ] No "Browse styles" button remains in the section header.
- [ ] Other settings sections (string captions) render unchanged.
