### PR TITLE
polish(workflows): use EditableAvatar in the custom-workflow drawer

### DIFF
--- a/internal/admin/workflows_custom_handler.go
+++ b/internal/admin/workflows_custom_handler.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"breadbox/internal/avatar"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -33,6 +34,7 @@ type customWorkflowInput struct {
 	maxTurns      int      // 0 = unset (leave default / untouched)
 	maxBudget     *float64 // nil = unset
 	enabled       bool     // create only — edit manages run-state via the card toggle
+	avatarSeed    string   // empty = slug-seeded default
 }
 
 // readCustomWorkflowInput pulls the drawer fields out of the form, validating
@@ -46,12 +48,16 @@ func readCustomWorkflowInput(r *http.Request) (customWorkflowInput, error) {
 		triggerOnSync: r.FormValue("trigger_on_sync") == "true",
 		scheduleCron:  strings.TrimSpace(r.FormValue("schedule_cron")),
 		enabled:       r.FormValue("enabled") == "true" || r.FormValue("enabled") == "on",
+		avatarSeed:    strings.TrimSpace(r.FormValue("avatar_seed")),
 	}
 	if in.name == "" {
 		return in, fmt.Errorf("name is required")
 	}
 	if in.prompt == "" {
 		return in, fmt.Errorf("prompt is required")
+	}
+	if in.avatarSeed != "" && !avatar.IsValidSeed(in.avatarSeed) {
+		return in, fmt.Errorf("invalid avatar seed")
 	}
 	if v := strings.TrimSpace(r.FormValue("max_turns")); v != "" {
 		n, err := strconv.Atoi(v)
@@ -117,6 +123,13 @@ func CreateCustomWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
 			writeError(w, http.StatusUnprocessableEntity, "WORKFLOW_CREATE_FAILED", err.Error())
 			return
 		}
+		// CreateAgentDefinitionParams carries no avatar seed, so persist a
+		// chosen one in a follow-up update (best-effort: a failure here just
+		// leaves the workflow slug-seeded, which is a valid default).
+		if in.avatarSeed != "" {
+			seed := in.avatarSeed
+			_, _ = svc.UpdateAgentDefinition(r.Context(), def.Slug, service.UpdateAgentDefinitionParams{AvatarSeed: &seed})
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"slug": def.Slug})
 	}
 }
@@ -160,6 +173,8 @@ func UpdateCustomWorkflowAdminHandler(svc *service.Service) http.HandlerFunc {
 			ToolScope:             &scope,
 			TriggerOnSyncComplete: &trigger,
 			ScheduleCron:          &cron,
+			// Empty seed clears back to slug-seeded (service emptyToNil).
+			AvatarSeed: &in.avatarSeed,
 		}
 		if in.maxTurns > 0 {
 			mt := in.maxTurns
@@ -207,6 +222,10 @@ func CustomWorkflowConfigAdminHandler(svc *service.Service) http.HandlerFunc {
 		if def.MaxBudgetUSD != nil {
 			budget = *def.MaxBudgetUSD
 		}
+		var avatarSeed string
+		if def.AvatarSeed != nil {
+			avatarSeed = *def.AvatarSeed
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"name":            def.Name,
 			"prompt":          def.Prompt,
@@ -216,6 +235,7 @@ func CustomWorkflowConfigAdminHandler(svc *service.Service) http.HandlerFunc {
 			"schedule_cron":   cron,
 			"max_turns":       def.MaxTurns,
 			"max_budget_usd":  budget,
+			"avatar_seed":     avatarSeed,
 			"enabled":         def.Enabled,
 		})
 	}

--- a/internal/admin/workflows_custom_handler_integration_test.go
+++ b/internal/admin/workflows_custom_handler_integration_test.go
@@ -52,6 +52,7 @@ func TestCustomWorkflowCreateConfigUpdate(t *testing.T) {
 		"model":           {"claude-sonnet-4-6"},
 		"tool_scope":      {"read_only"},
 		"max_budget_usd":  {"3.00"},
+		"avatar_seed":     {"abc123seed"},
 		"enabled":         {"true"},
 	})
 	if w.Code != http.StatusOK {
@@ -80,6 +81,9 @@ func TestCustomWorkflowCreateConfigUpdate(t *testing.T) {
 	}
 	if def.ScheduleCron == nil || *def.ScheduleCron != "0 8 * * *" {
 		t.Errorf("schedule_cron = %v, want 0 8 * * *", def.ScheduleCron)
+	}
+	if def.AvatarSeed == nil || *def.AvatarSeed != "abc123seed" {
+		t.Errorf("avatar_seed = %v, want abc123seed", def.AvatarSeed)
 	}
 
 	// --- Config (edit prefill) ---

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -816,10 +816,28 @@ templ workflowCustomDrawer() {
 		Title: "Custom workflow",
 	}) {
 		<form class="flex flex-col h-full" @submit.prevent="submitCustom($event.target)">
+			<!-- Identity header mirrors the reconfigure drawer: an editable
+			     DiceBear avatar (shuffle to reseed) + the name as an inline
+			     field. The name posts as `name`, the seed as the hidden
+			     `avatar_seed`. -->
 			<div class="flex items-center justify-between gap-4 p-5 border-b border-base-300 shrink-0">
-				<div class="flex items-center gap-3 min-w-0 flex-1">
-					@components.LucideIcon("wand-sparkles", "w-5 h-5 text-base-content/60 shrink-0")
-					<div class="text-lg font-semibold leading-tight" x-text="custom.isEdit ? 'Edit workflow' : 'New custom workflow'"></div>
+				<div class="flex items-center gap-3.5 min-w-0 flex-1">
+					@components.EditableAvatar(components.EditableAvatarProps{
+						SrcExpr:   "customAvatarSrc()",
+						OnShuffle: "shuffleCustomAvatar()",
+						Alt:       "Workflow avatar",
+						SizeClass: "w-12 h-12",
+					})
+					<input
+						type="text"
+						name="name"
+						x-model="custom.name"
+						maxlength="80"
+						required
+						placeholder="Workflow name"
+						aria-label="Workflow name"
+						class="input input-ghost !text-lg font-semibold leading-tight flex-1 min-w-0 h-auto py-1.5 px-1.5 -ml-1.5 rounded-lg transition-colors hover:bg-base-200/70"
+					/>
 				</div>
 				<div class="flex items-center gap-2 shrink-0">
 					<!-- Activate toggle (create only): set up + activate in one gesture.
@@ -832,24 +850,13 @@ templ workflowCustomDrawer() {
 						@components.LucideIcon("x", "w-4 h-4")
 					</button>
 				</div>
+				<input type="hidden" name="avatar_seed" x-model="custom.avatarSeed"/>
 			</div>
 			<div x-show="custom.loading" class="flex items-center gap-2 text-sm text-base-content/60 p-5">
 				<span class="loading loading-spinner loading-sm"></span>
 				Loading…
 			</div>
 			<div x-show="!custom.loading" x-cloak class="flex-1 overflow-y-auto p-5 space-y-5">
-				<div>
-					<div class="text-sm font-medium mb-1.5">Name</div>
-					<input
-						type="text"
-						name="name"
-						x-model="custom.name"
-						maxlength="80"
-						required
-						placeholder="e.g. Weekly anomaly sweep"
-						class="input input-sm w-full"
-					/>
-				</div>
 				<div>
 					<div class="text-sm font-medium mb-1.5">Prompt</div>
 					<textarea

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -75,6 +75,9 @@ document.addEventListener('alpine:init', function () {
         slug: '',
         name: '',
         prompt: '',
+        // avatarSeed drives the header EditableAvatar preview + posts as the
+        // hidden avatar_seed field. Empty = slug-seeded (the default).
+        avatarSeed: '',
         triggerOnSync: 'false',
         scheduleCron: '',
         model: 'claude-sonnet-4-6',
@@ -576,6 +579,7 @@ document.addEventListener('alpine:init', function () {
         self.custom.slug = slug || '';
         self.custom.name = '';
         self.custom.prompt = '';
+        self.custom.avatarSeed = '';
         self.custom.triggerOnSync = 'false';
         self.custom.scheduleCron = '';
         self.custom.model = 'claude-sonnet-4-6';
@@ -603,6 +607,7 @@ document.addEventListener('alpine:init', function () {
             self.custom.toolScope = data.tool_scope || 'read_write';
             self.custom.maxTurns = data.max_turns ? String(data.max_turns) : '';
             self.custom.maxBudget = data.max_budget_usd ? String(data.max_budget_usd) : '';
+            self.custom.avatarSeed = data.avatar_seed || '';
             self.custom.enabled = !!data.enabled;
           })
           .catch(function (e) {
@@ -639,6 +644,30 @@ document.addEventListener('alpine:init', function () {
             if (btn) btn.disabled = false;
             self.restorePageState();
           });
+      },
+
+      // customAvatarSrc builds the header avatar URL for the custom drawer,
+      // preferring the chosen seed and falling back to the slug (on edit) or a
+      // generic seed (on create, before a slug exists). Mirrors
+      // reconfigureAvatarSrc.
+      customAvatarSrc: function () {
+        var seed = this.custom.avatarSeed || this.custom.slug || 'workflow';
+        return '/avatars/' + encodeURIComponent(seed) + '?type=agent&size=88';
+      },
+
+      // shuffleCustomAvatar mints a fresh random seed so the operator can cycle
+      // to a different DiceBear mark; the preview updates reactively and the
+      // seed posts as avatar_seed on save. Mirrors shuffleAvatar.
+      shuffleCustomAvatar: function () {
+        var bytes = new Uint8Array(8);
+        if (window.crypto && window.crypto.getRandomValues) {
+          window.crypto.getRandomValues(bytes);
+        } else {
+          for (var i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+        }
+        var hex = '';
+        for (var j = 0; j < bytes.length; j++) hex += ('0' + bytes[j].toString(16)).slice(-2);
+        this.custom.avatarSeed = hex;
       },
 
       // Remove a configured workflow — deletes its agent_definition, resetting


### PR DESCRIPTION
Small polish on top of the now-merged custom-workflow drawer (#1771): the create/edit drawer uses the **same avatar-editing component** as the preset reconfigure drawer.

## What

The custom-workflow drawer's header is now an identity header — the shuffleable DiceBear avatar (`components.EditableAvatar`) + the name as an inline field — replacing the static lucide icon and the separate "Name" body field. This matches the reconfigure drawer's `workflowReconfigureIdentityHeader`.

- **templ**: `EditableAvatar` (`SrcExpr: customAvatarSrc()`, `OnShuffle: shuffleCustomAvatar()`) + inline name input + hidden `avatar_seed`; the create-only Activate toggle stays.
- **JS**: `custom.avatarSeed` state + `customAvatarSrc` / `shuffleCustomAvatar` (mirroring the reconfigure helpers), hydrated from `/config` on edit.
- **Handler**: read + validate `avatar_seed` (`avatar.IsValidSeed`); persist on create (a follow-up update, since `CreateAgentDefinitionParams` carries no seed field) and on update; return it from `GET /-/custom-workflows/{slug}`.

## Verification

`go build`, `go vet`, `go test ./...` green; `make test-integration` (admin) green — the custom-workflow integration test now also asserts the avatar seed round-trips.

<img src="https://bb-artifacts.exe.xyz/f/404e5a170beca9a8.jpg" width="900" alt="Custom workflow drawer with the shuffleable DiceBear avatar + inline name in the header">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
