### PR TITLE
fix(workflows): stop password managers autofilling the workflow name field

### DIFF
--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -274,6 +274,10 @@ templ workflowReconfigureIdentityHeader() {
 				maxlength="80"
 				placeholder="Workflow name"
 				aria-label="Workflow name"
+				autocomplete="off"
+				data-1p-ignore
+				data-lpignore="true"
+				data-form-type="other"
 				class="input input-ghost !text-lg font-semibold leading-tight flex-1 min-w-0 h-auto py-1.5 px-1.5 -ml-1.5 rounded-lg transition-colors hover:bg-base-200/70"
 			/>
 		</div>
@@ -836,6 +840,10 @@ templ workflowCustomDrawer() {
 						required
 						placeholder="Workflow name"
 						aria-label="Workflow name"
+						autocomplete="off"
+						data-1p-ignore
+						data-lpignore="true"
+						data-form-type="other"
 						class="input input-ghost !text-lg font-semibold leading-tight flex-1 min-w-0 h-auto py-1.5 px-1.5 -ml-1.5 rounded-lg transition-colors hover:bg-base-200/70"
 					/>
 				</div>


### PR DESCRIPTION
## Why it happens

The drawer's name field is `<input type="text" name="name">`. Password managers (1Password, LastPass) run heuristics over text inputs and classify a field literally named `name` as an identity/username field — so they attach their autofill affordance to it. Critically, they **ignore plain `autocomplete="off"`** for fields they flag this way, which is why it leaks through.

## Fix

Add the managers' explicit per-field opt-out attributes on both workflow name inputs (the custom-workflow drawer and the reconfigure drawer share the same field):

- `data-1p-ignore` — 1Password's documented "don't offer to fill this" attribute.
- `data-lpignore="true"` — LastPass equivalent.
- `data-form-type="other"` — Dashlane/1Password hint that this isn't a login form.
- `autocomplete="off"` — kept for completeness.

No behavior change otherwise; build / vet / templ render tests green.
