### PR TITLE
polish(nav): use lucide cable icon for Connections

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -82,7 +82,7 @@ templ Nav(p NavProps) {
 		// household/log admin tools are.
 		<div class="bb-sidebar-section">System</div>
 		if p.IsEditor {
-			@navLinkBadge("/connections", "link", "Connections", navActive(p.CurrentPage, "connections"), p.ConnectionsAttention, "bb-nav-badge--warn", fmt.Sprintf("%d connections need attention", p.ConnectionsAttention))
+			@navLinkBadge("/connections", "cable", "Connections", navActive(p.CurrentPage, "connections"), p.ConnectionsAttention, "bb-nav-badge--warn", fmt.Sprintf("%d connections need attention", p.ConnectionsAttention))
 			if p.IsAdmin {
 				@navLink("/household", "users", "Household", navActive(p.CurrentPage, "household"))
 				// Logs is intentionally hidden from the rail for now while we decide


### PR DESCRIPTION
Swaps the Connections sidebar nav icon from lucide `link` to `cable`.

## Changes
- `internal/templates/components/nav.templ`: Connections nav link icon `link` → `cable`

## Test plan
- [x] `templ generate` + `go build ./internal/templates/...` clean
- [x] Verified `cable` resolves to a real lucide-go SVG
- [x] Validated in browser — Connections item renders the cable icon

<img src="https://bb-artifacts.exe.xyz/f/e02bdad0fa9afea9.jpg" width="800" alt="Connections nav — cable icon">
