### PR TITLE
fix(design): sync theme into embedded component iframe on /design/c

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -279,6 +279,19 @@
         init: function() {
           var self = this;
           mq.addEventListener('change', function(e) { self.systemDark = e.matches; });
+          // Cross-document sync: the `storage` event fires in every OTHER
+          // same-origin document (other tabs, and — load-bearing here — the
+          // embedded component iframe on /design/c/{slug}?embed=1) when one of
+          // them writes localStorage. Without this, toggling the theme on the
+          // standalone component page updates the parent but leaves the iframe
+          // stuck on its load-time theme. e.key is null on clear(); re-read
+          // through read() either way so we stay in sync with the source.
+          window.addEventListener('storage', function(e) {
+            if (e.key !== null && e.key !== KEY) return;
+            var pref = read();
+            self.preference = pref;
+            apply(pref);
+          });
         },
       });
     });


### PR DESCRIPTION
Toggling the theme on a standalone component page (`/design/c/{slug}`) now also switches the embedded component preview, which previously stayed on its load-time theme.

## Changes

- The standalone component viewer hosts the demo inside a same-origin iframe (`?embed=1`). The theme toggle wrote `localStorage('bb-theme')` and applied `data-theme` to the **parent** document only — the iframe was never notified, so it stayed light while the chrome went dark (or vice versa).
- Add a `storage` event listener in the `$store.theme` `init()` (`internal/templates/layout/base.html`). The `storage` event fires in every *other* same-origin document when one of them writes `localStorage`, so the iframe (and any other open tab) now re-reads and re-applies the theme.
- `e.key` is `null` on `clear()`; the listener re-reads through the existing `read()` helper either way, keeping the Alpine store's `preference` reactive (toggle glyph updates too).

## Verification

Drove the parent's theme store through `light → system → dark` on `/design/c/buttons` and confirmed the iframe's `documentElement.dataset.theme` and its own `$store.theme.preference` track the parent for all three — including `system`, where `data-theme` is removed entirely.

<img src="https://bb-artifacts.exe.xyz/f/2ce50bacbb0425c5.jpeg" width="800" alt="/design/c/buttons in dark theme — both the chrome and the embedded button demos are dark">

## Test plan

- [x] Toggle theme on `/design/c/{slug}` → embedded preview switches with the chrome
- [x] `system` preference unsets `data-theme` in the iframe too (no stuck override)
- [x] Existing parent-page theme toggling unaffected
