### PR TITLE
feat(workflows): custom drawer delete + run now, manual trigger, manual cards

### DIFF
--- a/internal/admin/workflows_custom_handler.go
+++ b/internal/admin/workflows_custom_handler.go
@@ -41,14 +41,22 @@ type customWorkflowInput struct {
 // the two required fields (name, prompt) and the numeric caps.
 func readCustomWorkflowInput(r *http.Request) (customWorkflowInput, error) {
 	in := customWorkflowInput{
-		name:          strings.TrimSpace(r.FormValue("name")),
-		prompt:        strings.TrimSpace(r.FormValue("prompt")),
-		model:         strings.TrimSpace(r.FormValue("model")),
-		toolScope:     strings.TrimSpace(r.FormValue("tool_scope")),
-		triggerOnSync: r.FormValue("trigger_on_sync") == "true",
-		scheduleCron:  strings.TrimSpace(r.FormValue("schedule_cron")),
-		enabled:       r.FormValue("enabled") == "true" || r.FormValue("enabled") == "on",
-		avatarSeed:    strings.TrimSpace(r.FormValue("avatar_seed")),
+		name:       strings.TrimSpace(r.FormValue("name")),
+		prompt:     strings.TrimSpace(r.FormValue("prompt")),
+		model:      strings.TrimSpace(r.FormValue("model")),
+		toolScope:  strings.TrimSpace(r.FormValue("tool_scope")),
+		enabled:    r.FormValue("enabled") == "true" || r.FormValue("enabled") == "on",
+		avatarSeed: strings.TrimSpace(r.FormValue("avatar_seed")),
+	}
+	// trigger_mode is the 3-way custom-drawer trigger: manual (no automatic
+	// trigger), schedule (a cron), or sync (after each successful sync). It
+	// resolves to the underlying trigger_on_sync + schedule_cron pair.
+	switch r.FormValue("trigger_mode") {
+	case "sync":
+		in.triggerOnSync = true
+	case "schedule":
+		in.scheduleCron = strings.TrimSpace(r.FormValue("schedule_cron"))
+	default: // "manual" (or unset) — runs only on demand
 	}
 	if in.name == "" {
 		return in, fmt.Errorf("name is required")

--- a/internal/admin/workflows_custom_handler_integration_test.go
+++ b/internal/admin/workflows_custom_handler_integration_test.go
@@ -45,15 +45,15 @@ func TestCustomWorkflowCreateConfigUpdate(t *testing.T) {
 
 	// --- Create ---
 	w := postForm(t, r, "/-/custom-workflows", url.Values{
-		"name":            {"My Anomaly Sweep"},
-		"prompt":          {"Watch for unusual charges and report them."},
-		"trigger_on_sync": {"false"},
-		"schedule_cron":   {"0 8 * * *"},
-		"model":           {"claude-sonnet-4-6"},
-		"tool_scope":      {"read_only"},
-		"max_budget_usd":  {"3.00"},
-		"avatar_seed":     {"abc123seed"},
-		"enabled":         {"true"},
+		"name":           {"My Anomaly Sweep"},
+		"prompt":         {"Watch for unusual charges and report them."},
+		"trigger_mode":   {"schedule"},
+		"schedule_cron":  {"0 8 * * *"},
+		"model":          {"claude-sonnet-4-6"},
+		"tool_scope":     {"read_only"},
+		"max_budget_usd": {"3.00"},
+		"avatar_seed":    {"abc123seed"},
+		"enabled":        {"true"},
 	})
 	if w.Code != http.StatusOK {
 		t.Fatalf("create: status %d, body %s", w.Code, w.Body.String())
@@ -107,11 +107,11 @@ func TestCustomWorkflowCreateConfigUpdate(t *testing.T) {
 
 	// --- Update: rewrite prompt + switch to post-sync ---
 	uw := postForm(t, r, "/-/custom-workflows/"+created.Slug, url.Values{
-		"name":            {"My Anomaly Sweep"},
-		"prompt":          {"Updated instructions."},
-		"trigger_on_sync": {"true"},
-		"model":           {"claude-sonnet-4-6"},
-		"tool_scope":      {"read_write"},
+		"name":         {"My Anomaly Sweep"},
+		"prompt":       {"Updated instructions."},
+		"trigger_mode": {"sync"},
+		"model":        {"claude-sonnet-4-6"},
+		"tool_scope":   {"read_write"},
 	})
 	if uw.Code != http.StatusOK {
 		t.Fatalf("update: status %d, body %s", uw.Code, uw.Body.String())

--- a/internal/admin/workflows_custom_handler_unit_test.go
+++ b/internal/admin/workflows_custom_handler_unit_test.go
@@ -73,21 +73,21 @@ func TestReadCustomWorkflowInput(t *testing.T) {
 			t.Errorf("toolScope = %q, want read_only", in.toolScope)
 		}
 	})
-	t.Run("trigger + schedule + caps parse", func(t *testing.T) {
+	t.Run("schedule mode + caps parse", func(t *testing.T) {
 		in, err := parse(url.Values{
-			"name":            {"Sweep"},
-			"prompt":          {"do"},
-			"trigger_on_sync": {"true"},
-			"schedule_cron":   {"0 8 * * *"},
-			"max_turns":       {"12"},
-			"max_budget_usd":  {"2.50"},
-			"enabled":         {"true"},
+			"name":           {"Sweep"},
+			"prompt":         {"do"},
+			"trigger_mode":   {"schedule"},
+			"schedule_cron":  {"0 8 * * *"},
+			"max_turns":      {"12"},
+			"max_budget_usd": {"2.50"},
+			"enabled":        {"true"},
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !in.triggerOnSync {
-			t.Error("triggerOnSync should be true")
+		if in.triggerOnSync {
+			t.Error("triggerOnSync should be false in schedule mode")
 		}
 		if in.scheduleCron != "0 8 * * *" {
 			t.Errorf("scheduleCron = %q", in.scheduleCron)
@@ -100,6 +100,30 @@ func TestReadCustomWorkflowInput(t *testing.T) {
 		}
 		if !in.enabled {
 			t.Error("enabled should be true")
+		}
+	})
+	t.Run("sync mode sets trigger_on_sync, ignores cron", func(t *testing.T) {
+		in, _ := parse(url.Values{
+			"name":          {"S"},
+			"prompt":        {"do"},
+			"trigger_mode":  {"sync"},
+			"schedule_cron": {"0 8 * * *"},
+		})
+		if !in.triggerOnSync {
+			t.Error("triggerOnSync should be true in sync mode")
+		}
+		if in.scheduleCron != "" {
+			t.Errorf("scheduleCron should be empty in sync mode, got %q", in.scheduleCron)
+		}
+	})
+	t.Run("manual mode = no trigger", func(t *testing.T) {
+		in, _ := parse(url.Values{
+			"name":         {"M"},
+			"prompt":       {"do"},
+			"trigger_mode": {"manual"},
+		})
+		if in.triggerOnSync || in.scheduleCron != "" {
+			t.Errorf("manual should have no trigger: onSync=%v cron=%q", in.triggerOnSync, in.scheduleCron)
 		}
 	})
 	t.Run("rejects bad budget", func(t *testing.T) {

--- a/internal/admin/workflows_gallery_page.go
+++ b/internal/admin/workflows_gallery_page.go
@@ -40,11 +40,13 @@ func buildCustomWorkflowCards(defs []service.AgentDefinitionResponse) []pages.Wo
 		if d.SourceTemplate != nil {
 			continue // preset-backed → handled by the preset gallery
 		}
+		manual := !d.TriggerOnSyncComplete && (d.ScheduleCron == nil || strings.TrimSpace(*d.ScheduleCron) == "")
 		card := pages.WorkflowCustomCardProps{
 			Slug:        d.Slug,
 			Name:        d.Name,
 			Description: firstPromptLine(d.Prompt, 120),
 			Enabled:     d.Enabled,
+			Manual:      manual,
 		}
 		if d.AvatarSeed != nil {
 			card.AvatarSeed = *d.AvatarSeed

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -743,8 +743,8 @@ templ workflowConfigDrawer(preset WorkflowPresetCardProps, consentAck bool) {
 // card, the whole row toggles run-state on click for admins (cardClick).
 templ workflowCustomCard(c WorkflowCustomCardProps, isAdmin bool) {
 	<div
-		class={ "bb-card px-4 py-3 h-full flex items-center gap-3", templ.KV("bb-card--interactive", isAdmin) }
-		if isAdmin {
+		class={ "bb-card px-4 py-3 h-full flex items-center gap-3", templ.KV("bb-card--interactive", isAdmin && !c.Manual) }
+		if isAdmin && !c.Manual {
 			@click="cardClick($event)"
 		}
 	>
@@ -764,27 +764,73 @@ templ workflowCustomCard(c WorkflowCustomCardProps, isAdmin bool) {
 			<div class="text-xs text-base-content/60 mt-0.5 line-clamp-2">{ c.Description }</div>
 		</div>
 		<div class="flex items-center gap-1 shrink-0">
-			<input
-				type="checkbox"
-				class="toggle toggle-sm"
-				if c.Enabled {
-					checked
+			if c.Manual {
+				@workflowCustomManualControls(c, isAdmin)
+			} else {
+				<input
+					type="checkbox"
+					class="toggle toggle-sm"
+					if c.Enabled {
+						checked
+					}
+					aria-label={ "Toggle " + c.Name }
+					@change={ "toggleWorkflow('" + c.Slug + "', $event.target)" }
+				/>
+				if isAdmin {
+					<button
+						type="button"
+						class="btn btn-ghost btn-sm btn-square text-base-content/55"
+						@click={ "openCustom('" + c.Slug + "')" }
+						aria-label={ "Edit " + c.Name }
+					>
+						@components.LucideIcon("settings", "w-4 h-4")
+					</button>
 				}
-				aria-label={ "Toggle " + c.Name }
-				@change={ "toggleWorkflow('" + c.Slug + "', $event.target)" }
-			/>
-			if isAdmin {
-				<button
-					type="button"
-					class="btn btn-ghost btn-sm btn-square text-base-content/55"
-					@click={ "openCustom('" + c.Slug + "')" }
-					aria-label={ "Edit " + c.Name }
-				>
-					@components.LucideIcon("settings", "w-4 h-4")
-				</button>
 			}
 		</div>
 	</div>
+}
+
+// workflowCustomManualControls is the right-side cluster for a manual-only
+// custom workflow (no schedule, no post-sync trigger) — it has no recurring
+// on/off state, so it shows copy + run + settings like a one-off preset
+// instead of a run toggle. Copy is available to everyone (read-only); run +
+// settings are admin-only. The run button holds a spinner for the whole run
+// via runningOneOff[slug] (shared with the one-off cards).
+templ workflowCustomManualControls(c WorkflowCustomCardProps, isAdmin bool) {
+	<button
+		type="button"
+		class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
+		data-tip="Copy prompt"
+		@click={ "copyCustomPrompt('" + c.Slug + "')" }
+		aria-label={ "Copy the " + c.Name + " prompt" }
+	>
+		@components.LucideIcon("copy", "w-4 h-4")
+	</button>
+	if isAdmin {
+		<button
+			type="button"
+			class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
+			data-tip="Run now"
+			@click={ "runCustomNow('" + c.Slug + "', '" + jsEscape(c.Name) + "')" }
+			x-bind:disabled={ "runningOneOff['" + c.Slug + "']" }
+			aria-label={ "Run " + c.Name + " now" }
+		>
+			<span x-show={ "!runningOneOff['" + c.Slug + "']" }>
+				@components.LucideIcon("play", "w-4 h-4")
+			</span>
+			<span class="loading loading-spinner loading-xs" x-show={ "runningOneOff['" + c.Slug + "']" } x-cloak></span>
+		</button>
+		<button
+			type="button"
+			class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
+			data-tip="Settings"
+			@click={ "openCustom('" + c.Slug + "')" }
+			aria-label={ "Edit " + c.Name }
+		>
+			@components.LucideIcon("settings", "w-4 h-4")
+		</button>
+	}
 }
 
 // workflowCustomCreateRow is the dashed "add" affordance at the tail of the
@@ -889,7 +935,46 @@ templ workflowCustomDrawer() {
 					></textarea>
 					<div class="text-xs text-base-content/40 mt-1">This is the entire workflow prompt — there's no template behind it.</div>
 				</div>
-				@workflowTriggerFields("custom.triggerOnSync", "custom.scheduleCron", "")
+				<div>
+					<div class="text-sm font-medium mb-2">When should the workflow run?</div>
+					<div class="grid grid-cols-1 gap-2">
+						@components.RadioCard(components.RadioCardProps{
+							Name:      "trigger_mode",
+							Value:     "manual",
+							Icon:      "hand",
+							Title:     "Manual only",
+							Subtitle:  "Runs only when you trigger it",
+							ModelExpr: "custom.triggerMode",
+						})
+						@components.RadioCard(components.RadioCardProps{
+							Name:      "trigger_mode",
+							Value:     "schedule",
+							Icon:      "calendar-clock",
+							Title:     "Custom schedule",
+							Subtitle:  "On a recurring cron schedule",
+							ModelExpr: "custom.triggerMode",
+						})
+						@components.RadioCard(components.RadioCardProps{
+							Name:      "trigger_mode",
+							Value:     "sync",
+							Icon:      "refresh-cw",
+							Title:     "After each sync",
+							Subtitle:  "Right after new data lands",
+							ModelExpr: "custom.triggerMode",
+						})
+					</div>
+					<div x-show="custom.triggerMode === 'schedule'" x-cloak class="mt-3 space-y-2">
+						<div class="text-xs font-medium text-base-content/70">Schedule</div>
+						@components.CronField(components.CronFieldProps{
+							Name:               "schedule_cron",
+							Presets:            cronspec.WorkflowSchedulePresets,
+							PreviewURL:         "/-/workflows/cron-preview",
+							LocalizePresets:    true,
+							ServerUTCOffsetMin: serverUTCOffsetMinInt(),
+							ModelExpr:          "custom.scheduleCron",
+						})
+					</div>
+				</div>
 				@workflowModelField("custom.model")
 				<div>
 					<div class="text-sm font-medium mb-1.5">Tool access</div>
@@ -902,6 +987,30 @@ templ workflowCustomDrawer() {
 				@workflowAdvancedFields("custom.maxTurns", "custom.maxBudget")
 			</div>
 			@components.DrawerFooter() {
+				<!-- Edit-mode actions: delete the workflow + run it now. Hidden on
+				     create (no slug yet); the mr-auto on Run now pushes Cancel/Save
+				     to the right, matching the reconfigure drawer. -->
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm btn-square text-error/70 hover:text-error tooltip tooltip-top"
+					data-tip="Delete workflow"
+					x-show="custom.isEdit"
+					@click="removeWorkflow(custom.slug, custom.name)"
+					x-bind:disabled="custom.loading"
+					aria-label="Delete workflow"
+				>
+					@components.LucideIcon("trash-2", "w-4 h-4")
+				</button>
+				<button
+					type="button"
+					class="btn btn-soft btn-sm gap-1.5 mr-auto"
+					x-show="custom.isEdit"
+					@click="runWorkflow(custom.slug); $store.drawers.close()"
+					x-bind:disabled="custom.loading"
+				>
+					@components.LucideIcon("play", "w-4 h-4")
+					Run now
+				</button>
 				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
 				<button type="submit" class="btn btn-primary btn-sm gap-1.5" x-bind:disabled="custom.loading">
 					@components.LucideIcon("save", "w-4 h-4")

--- a/internal/templates/components/pages/workflows_gallery_types.go
+++ b/internal/templates/components/pages/workflows_gallery_types.go
@@ -150,6 +150,10 @@ type WorkflowCustomCardProps struct {
 	Enabled      bool   // run-state (the card toggle flips it immediately)
 	AvatarSeed   string // DiceBear seed; empty = slug-seeded
 	LastRunError bool   // most recent run failed → red status dot
+	// Manual is true when the workflow has no automatic trigger (no schedule,
+	// no post-sync). Manual cards show copy + run controls (like one-off
+	// presets) instead of a run toggle.
+	Manual bool
 }
 
 // WorkflowSpendBanner is the gallery's spend-ceiling state: shown when a

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -78,7 +78,10 @@ document.addEventListener('alpine:init', function () {
         // avatarSeed drives the header EditableAvatar preview + posts as the
         // hidden avatar_seed field. Empty = slug-seeded (the default).
         avatarSeed: '',
-        triggerOnSync: 'false',
+        // triggerMode is the 3-way trigger: 'manual' | 'schedule' | 'sync'.
+        // Posts as trigger_mode; the schedule CronField (custom.scheduleCron)
+        // only applies when 'schedule'.
+        triggerMode: 'manual',
         scheduleCron: '',
         model: 'claude-sonnet-4-6',
         toolScope: 'read_write',
@@ -580,7 +583,7 @@ document.addEventListener('alpine:init', function () {
         self.custom.name = '';
         self.custom.prompt = '';
         self.custom.avatarSeed = '';
-        self.custom.triggerOnSync = 'false';
+        self.custom.triggerMode = 'manual';
         self.custom.scheduleCron = '';
         self.custom.model = 'claude-sonnet-4-6';
         self.custom.toolScope = 'read_write';
@@ -601,8 +604,15 @@ document.addEventListener('alpine:init', function () {
           .then(function (data) {
             self.custom.name = data.name || '';
             self.custom.prompt = data.prompt || '';
-            self.custom.triggerOnSync = data.trigger_on_sync ? 'true' : 'false';
             self.custom.scheduleCron = data.schedule_cron || '';
+            // Derive the 3-way mode from the stored trigger_on_sync + cron.
+            if (data.trigger_on_sync) {
+              self.custom.triggerMode = 'sync';
+            } else if (data.schedule_cron) {
+              self.custom.triggerMode = 'schedule';
+            } else {
+              self.custom.triggerMode = 'manual';
+            }
             self.custom.model = data.model || 'claude-sonnet-4-6';
             self.custom.toolScope = data.tool_scope || 'read_write';
             self.custom.maxTurns = data.max_turns ? String(data.max_turns) : '';
@@ -668,6 +678,90 @@ document.addEventListener('alpine:init', function () {
         var hex = '';
         for (var j = 0; j < bytes.length; j++) hex += ('0' + bytes[j].toString(16)).slice(-2);
         this.custom.avatarSeed = hex;
+      },
+
+      // copyCustomPrompt copies a custom workflow's prompt to the clipboard from
+      // its config endpoint (the preset /prompt endpoint only knows presets).
+      // Backs the copy icon on manual custom cards.
+      copyCustomPrompt: function (slug) {
+        var self = this;
+        fetch('/-/custom-workflows/' + encodeURIComponent(slug), {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+          .then(function (res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+          })
+          .then(function (data) {
+            var text = (data && data.prompt) || '';
+            if (!text) {
+              self.toast('No prompt to copy.', 'error');
+              return;
+            }
+            var done = function () { self.toast('Prompt copied to clipboard.', 'success'); };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(text).then(done).catch(function () {
+                self._copyFallback(text, done);
+              });
+            } else {
+              self._copyFallback(text, done);
+            }
+          })
+          .catch(function (e) {
+            console.error('copyCustomPrompt failed', e);
+            self.toast('Could not copy the prompt.', 'error');
+          });
+      },
+
+      // runCustomNow runs a manual custom workflow from its card's Run button,
+      // mirroring runOneOff's UX (cost-confirm gate + a spinner held for the
+      // whole run via runningOneOff[slug]). Unlike a one-off preset, the
+      // workflow already exists, so it dispatches /-/workflows/{slug}/run.
+      runCustomNow: function (slug, name) {
+        var self = this;
+        if (self.runningOneOff[slug]) return; // guard against a double-click
+        name = name || slug;
+        var go = function () { self._dispatchCustomRun(slug); };
+        if (typeof window.bbConfirm !== 'function') {
+          if (window.confirm('Run "' + name + '" now? This runs Claude over your financial data and incurs API cost.')) go();
+          return;
+        }
+        window.bbConfirm({
+          title: 'Run workflow now?',
+          message: 'Run "' + name + '" now? It runs Claude over your household’s financial data and incurs Anthropic API cost.',
+          confirmLabel: 'Run now',
+          variant: 'warning',
+        }).then(function (ok) { if (ok) go(); });
+      },
+
+      _dispatchCustomRun: function (slug) {
+        var self = this;
+        if (self.runningOneOff[slug]) return;
+        self.runningOneOff[slug] = true;
+        self._post('/-/workflows/' + encodeURIComponent(slug) + '/run')
+          .then(function (res) {
+            if (res.ok || res.status === 202) {
+              return res.json().catch(function () { return null; }).then(function (run) {
+                self.runStartedToast(run);
+                if (run && run.short_id) {
+                  self._pollOneOffRun(slug, run.short_id);
+                } else {
+                  self.runningOneOff[slug] = false;
+                }
+              });
+            }
+            return res.json().catch(function () { return null; }).then(function (body) {
+              self.runningOneOff[slug] = false;
+              self.runErrorToast(body);
+            });
+          })
+          .catch(function (e) {
+            console.error('runCustomNow failed', e);
+            self.runningOneOff[slug] = false;
+            self.toast('Network error — could not start the run.', 'error');
+            self.restorePageState();
+          });
       },
 
       // Remove a configured workflow — deletes its agent_definition, resetting


### PR DESCRIPTION
Rounds out the custom-workflow UX with the actions + trigger mode that were missing.

## Changes

**Drawer actions (edit mode).** The custom drawer footer now has a **Delete** button and a **Run now** button, mirroring the preset reconfigure drawer. They reuse the existing `removeWorkflow` / `runWorkflow` handlers (`/-/workflows/{slug}/delete` + `/run`), which already operate on any definition. Hidden on create.

**Manual trigger.** "When should the workflow run?" gains a third option — **Manual only** (run on demand). The custom drawer posts a 3-way `trigger_mode` (`manual` | `schedule` | `sync`), resolved server-side to the underlying `trigger_on_sync` + `schedule_cron` pair. The shared preset trigger fields are untouched.

**Manual cards.** A manual workflow has no recurring on/off state, so its card shows **copy + run + settings** — like a one-off preset — instead of a run toggle. Run holds a spinner for the whole run (`runCustomNow` → `/-/workflows/{slug}/run`, polled); copy pulls the prompt from the custom config endpoint (the preset `/prompt` endpoint only knows presets). Scheduled / post-sync cards keep the toggle.

## Verification

Build / vet / `go test ./...` / gofmt green; `make test-integration` green (unit covers manual/schedule/sync parsing; integration creates via schedule, updates to sync). Exercised end-to-end in a browser:

<table>
<tr><th>Create drawer — Manual option</th><th>Manual card — copy/run</th><th>Edit drawer — Delete + Run now</th></tr>
<tr>
<td><img src="https://bb-artifacts.exe.xyz/f/c99da21e14fbc55d.jpg" width="280" alt="3-way trigger with Manual only selected"></td>
<td><img src="https://bb-artifacts.exe.xyz/f/2fac8f93936e5ca0.jpg" width="280" alt="manual card shows copy/run/gear, no toggle"></td>
<td><img src="https://bb-artifacts.exe.xyz/f/566fd18adfa6cf43.jpg" width="280" alt="edit drawer footer with Delete and Run now"></td>
</tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
