### PR TITLE
fix(devmode): authenticate dev-reporter uploads (token configurable in Settings → Developer)

### DIFF
--- a/internal/admin/developer_settings.go
+++ b/internal/admin/developer_settings.go
@@ -36,10 +36,15 @@ func DeveloperSettingsHandler(a *app.App, svc *service.Service, sm *scs.SessionM
 			}
 		}
 
+		uploadTokenMasked := ""
+		if settings.UploadToken != nil {
+			uploadTokenMasked = *settings.UploadToken
+		}
 		props := pages.DeveloperSettingsProps{
 			Form: pages.DeveloperSettingsFormFields{
-				Enabled:    settings.Enabled,
-				GithubRepo: settings.GithubRepo,
+				Enabled:           settings.Enabled,
+				GithubRepo:        settings.GithubRepo,
+				UploadTokenMasked: uploadTokenMasked,
 			},
 			FieldErrors: map[string]string{},
 			FormError:   formError,
@@ -69,6 +74,10 @@ func DeveloperSettingsPostHandler(a *app.App, svc *service.Service, sm *scs.Sess
 		params := service.UpdateDevModeSettingsParams{
 			Enabled:    &enabled,
 			GithubRepo: &repo,
+		}
+		// Empty submit = keep the stored token; non-empty = replace it.
+		if tok := strings.TrimSpace(r.FormValue("upload_token")); tok != "" {
+			params.UploadToken = &tok
 		}
 
 		if _, err := svc.UpdateDevModeSettings(r.Context(), params); err != nil {

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -134,6 +134,12 @@ const (
 	// DevModeDefaultRepo when unset.
 	KeyDevModeGithubRepo = "devmode.github_repo"
 
+	// KeyDevModeUploadToken is the Bearer token the server uses to upload the
+	// reporter's screenshot + HTML snapshot to the artifact host
+	// (bb-artifacts.exe.xyz). Stored AES-GCM encrypted; set from
+	// Settings → Developer. The BB_ARTIFACTS_UPLOAD_TOKEN env var overrides it.
+	KeyDevModeUploadToken = "devmode.upload_token"
+
 	// KeyInstanceTimezone is the IANA timezone (e.g. "America/Los_Angeles")
 	// every cron schedule — sync schedules AND agent/workflow schedules — is
 	// evaluated in, and that schedule previews are rendered in. Unset or

--- a/internal/service/bb_artifacts.go
+++ b/internal/service/bb_artifacts.go
@@ -11,15 +11,19 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"strings"
 	"time"
+
+	"breadbox/internal/appconfig"
 )
 
 // bbArtifactsUploadURL is the upload endpoint for the self-hosted artifact
 // store (bb-artifacts.exe.xyz) — public read, ~180-day retention, 25 MB cap,
-// hosts both images and HTML. Uploads require auth: set BB_ARTIFACTS_UPLOAD_TOKEN
-// (sent as a Bearer token, kept server-side — never exposed to the browser).
-// Endpoint overridable via BB_ARTIFACTS_UPLOAD_URL for staging/self-host. The
-// URL is public; the token is a secret.
+// hosts both images and HTML. Uploads require auth — see artifactUploadToken for
+// how the Bearer token is resolved (Settings → Developer, or the
+// BB_ARTIFACTS_UPLOAD_TOKEN env override). The token is kept server-side and is
+// never exposed to the browser. Endpoint overridable via BB_ARTIFACTS_UPLOAD_URL
+// for staging/self-host. The URL is public; the token is a secret.
 const bbArtifactsUploadURL = "https://bb-artifacts.exe.xyz/upload"
 
 // bbArtifactsMaxBytes mirrors the store's per-file cap.
@@ -32,11 +36,30 @@ func bbArtifactsEndpoint() string {
 	return bbArtifactsUploadURL
 }
 
+// artifactUploadToken resolves the Bearer token for artifact uploads, with the
+// project-wide precedence env → app_config → none: the BB_ARTIFACTS_UPLOAD_TOKEN
+// env var wins (ops override), otherwise the encrypted token saved in
+// Settings → Developer. Returns "" when neither is configured (uploads then go
+// out unauthenticated and the host will 401 — best-effort, the report still files).
+func (s *Service) artifactUploadToken(ctx context.Context) string {
+	if v := strings.TrimSpace(os.Getenv("BB_ARTIFACTS_UPLOAD_TOKEN")); v != "" {
+		return v
+	}
+	if len(s.EncryptionKey) == 0 {
+		return ""
+	}
+	tok, _, err := appconfig.ReadEncrypted(ctx, s.Queries, appconfig.KeyDevModeUploadToken, s.EncryptionKey)
+	if err != nil {
+		return ""
+	}
+	return tok
+}
+
 // uploadArtifact posts a file (image or HTML) to the artifact store and returns
 // the public URL. The store keys content-type off the filename extension, so
-// pass "screenshot.jpg" / "snapshot.html". Best-effort: callers fall back to
-// omitting the artifact from the report on error.
-func uploadArtifact(ctx context.Context, data []byte, filename string) (string, error) {
+// pass "screenshot.jpg" / "snapshot.html". token is the Bearer credential (may
+// be ""). Best-effort: callers fall back to omitting the artifact on error.
+func uploadArtifact(ctx context.Context, data []byte, filename, token string) (string, error) {
 	if len(data) == 0 {
 		return "", fmt.Errorf("artifact: empty file")
 	}
@@ -63,9 +86,10 @@ func uploadArtifact(ctx context.Context, data []byte, filename string) (string, 
 	}
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	// Auth is kept server-side: the browser POSTs to /-/dev-reports (session +
-	// CSRF), and the server attaches the upload token here. Never sent to clients.
-	if tok := os.Getenv("BB_ARTIFACTS_UPLOAD_TOKEN"); tok != "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
+	// CSRF), and the server attaches the resolved upload token here. Never sent
+	// to clients.
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}

--- a/internal/service/bb_artifacts.go
+++ b/internal/service/bb_artifacts.go
@@ -15,9 +15,11 @@ import (
 )
 
 // bbArtifactsUploadURL is the upload endpoint for the self-hosted artifact
-// store (bb-artifacts.exe.xyz) — anonymous upload, public read, ~180-day
-// retention, 25 MB cap, hosts both images and HTML. Overridable via env for
-// staging/self-host. A public URL, not a secret.
+// store (bb-artifacts.exe.xyz) — public read, ~180-day retention, 25 MB cap,
+// hosts both images and HTML. Uploads require auth: set BB_ARTIFACTS_UPLOAD_TOKEN
+// (sent as a Bearer token, kept server-side — never exposed to the browser).
+// Endpoint overridable via BB_ARTIFACTS_UPLOAD_URL for staging/self-host. The
+// URL is public; the token is a secret.
 const bbArtifactsUploadURL = "https://bb-artifacts.exe.xyz/upload"
 
 // bbArtifactsMaxBytes mirrors the store's per-file cap.
@@ -60,6 +62,11 @@ func uploadArtifact(ctx context.Context, data []byte, filename string) (string, 
 		return "", err
 	}
 	req.Header.Set("Content-Type", mw.FormDataContentType())
+	// Auth is kept server-side: the browser POSTs to /-/dev-reports (session +
+	// CSRF), and the server attaches the upload token here. Never sent to clients.
+	if tok := os.Getenv("BB_ARTIFACTS_UPLOAD_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
@@ -68,6 +75,9 @@ func uploadArtifact(ctx context.Context, data []byte, filename string) (string, 
 	}
 	defer resp.Body.Close()
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", fmt.Errorf("artifact: upload unauthorized (401) — set BB_ARTIFACTS_UPLOAD_TOKEN on the server")
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", fmt.Errorf("artifact: upload returned %d", resp.StatusCode)
 	}

--- a/internal/service/devmode_reports.go
+++ b/internal/service/devmode_reports.go
@@ -44,8 +44,9 @@ type DevReportResult struct {
 
 // CreateDevReport hosts the (redacted) screenshot + HTML snapshot on the
 // artifact store and builds a prefilled GitHub "new issue" draft URL with the
-// image embedded and the snapshot linked. No token, no DB — the draft rides
-// the user's GitHub session and they review + submit it.
+// image embedded and the snapshot linked. The GitHub draft rides the user's
+// GitHub session (no token for filing); the artifact upload is authenticated
+// server-side with the token from artifactUploadToken.
 //
 // Artifacts are public-read, so the client redacts financial data before
 // upload; uploads here are best-effort (a failure just omits that artifact).
@@ -57,15 +58,16 @@ func (s *Service) CreateDevReport(ctx context.Context, in CreateDevReportInput) 
 	}
 
 	repo := appconfig.String(ctx, s.Queries, appconfig.KeyDevModeGithubRepo, appconfig.DevModeDefaultRepo)
+	uploadToken := s.artifactUploadToken(ctx)
 
 	var imageURL, htmlURL string
 	if len(in.ScreenshotData) > 0 {
-		if u, err := uploadArtifact(ctx, in.ScreenshotData, "screenshot.jpg"); err == nil {
+		if u, err := uploadArtifact(ctx, in.ScreenshotData, "screenshot.jpg", uploadToken); err == nil {
 			imageURL = u
 		}
 	}
 	if strings.TrimSpace(in.HTMLSnapshot) != "" {
-		if u, err := uploadArtifact(ctx, []byte(in.HTMLSnapshot), "snapshot.html"); err == nil {
+		if u, err := uploadArtifact(ctx, []byte(in.HTMLSnapshot), "snapshot.html", uploadToken); err == nil {
 			htmlURL = u
 		}
 	}

--- a/internal/service/devmode_settings.go
+++ b/internal/service/devmode_settings.go
@@ -12,25 +12,38 @@ import (
 )
 
 // DevModeSettingsResponse is the read shape for Settings → Developer.
+// UploadToken is masked (never plaintext) and nil when unset.
 type DevModeSettingsResponse struct {
-	Enabled    bool   `json:"enabled"`
-	GithubRepo string `json:"github_repo"`
+	Enabled     bool    `json:"enabled"`
+	GithubRepo  string  `json:"github_repo"`
+	UploadToken *string `json:"upload_token,omitempty"`
 }
 
 // UpdateDevModeSettingsParams holds the writable Developer-Mode settings.
 // Nil = leave untouched. An empty GithubRepo clears it (falls back to the
-// default).
+// default). UploadToken: nil or empty = leave the stored token alone; non-empty
+// = replace it (stored encrypted).
 type UpdateDevModeSettingsParams struct {
-	Enabled    *bool
-	GithubRepo *string
+	Enabled     *bool
+	GithubRepo  *string
+	UploadToken *string
 }
 
-// GetDevModeSettings reads the devmode.* keys from app_config.
+// GetDevModeSettings reads the devmode.* keys from app_config. The upload token
+// is decrypted then masked for display; the plaintext never leaves the server.
 func (s *Service) GetDevModeSettings(ctx context.Context) (*DevModeSettingsResponse, error) {
-	return &DevModeSettingsResponse{
+	resp := &DevModeSettingsResponse{
 		Enabled:    appconfig.Bool(ctx, s.Queries, appconfig.KeyDevModeEnabled, false),
 		GithubRepo: appconfig.String(ctx, s.Queries, appconfig.KeyDevModeGithubRepo, appconfig.DevModeDefaultRepo),
-	}, nil
+	}
+	if len(s.EncryptionKey) > 0 {
+		tok, _, err := appconfig.ReadEncrypted(ctx, s.Queries, appconfig.KeyDevModeUploadToken, s.EncryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("read devmode upload token: %w", err)
+		}
+		resp.UploadToken = maskToken(tok)
+	}
+	return resp, nil
 }
 
 // DevModeEnabled is a cheap single-key read used by the base-layout middleware
@@ -56,6 +69,16 @@ func (s *Service) UpdateDevModeSettings(ctx context.Context, p UpdateDevModeSett
 		}
 		if err := s.Queries.SetAppConfig(ctx, appconfigParam(appconfig.KeyDevModeGithubRepo, repo)); err != nil {
 			return nil, fmt.Errorf("set devmode_github_repo: %w", err)
+		}
+	}
+	if p.UploadToken != nil {
+		if tok := strings.TrimSpace(*p.UploadToken); tok != "" {
+			if len(s.EncryptionKey) == 0 {
+				return nil, fmt.Errorf("%w: ENCRYPTION_KEY must be set to store the upload token", ErrInvalidParameter)
+			}
+			if err := appconfig.WriteEncrypted(ctx, s.Queries, appconfig.KeyDevModeUploadToken, tok, s.EncryptionKey); err != nil {
+				return nil, fmt.Errorf("write devmode upload token: %w", err)
+			}
 		}
 	}
 	return s.GetDevModeSettings(ctx)

--- a/internal/templates/components/pages/developer_settings.templ
+++ b/internal/templates/components/pages/developer_settings.templ
@@ -88,6 +88,31 @@ templ developerModeSection(p DeveloperSettingsProps) {
 			}
 		}
 		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Artifact upload token",
+			Caption: "Bearer token the server uses to upload the screenshot + HTML snapshot to the artifact host. Stored encrypted; leave blank to keep the current value.",
+			For:     "upload_token",
+		}) {
+			<input
+				id="upload_token"
+				type="password"
+				name="upload_token"
+				value=""
+				placeholder="Paste an upload token"
+				autocomplete="off"
+				spellcheck="false"
+				class="bb-form-input font-mono min-w-72"
+			/>
+			if p.Form.UploadTokenMasked != "" {
+				<p class="text-xs text-base-content/50 mt-1">
+					Currently set ({ p.Form.UploadTokenMasked }). The <code>BB_ARTIFACTS_UPLOAD_TOKEN</code> env var overrides this when set.
+				</p>
+			} else {
+				<p class="text-xs text-warning mt-1">
+					Not set — the reporter can't upload artifacts until this (or the <code>BB_ARTIFACTS_UPLOAD_TOKEN</code> env var) is configured.
+				</p>
+			}
+		}
+		@components.SettingsRow(components.SettingsRowProps{
 			Label:   "Issue labels",
 			Caption: "Applied automatically — add these to the repo so GitHub keeps them.",
 		}) {

--- a/internal/templates/components/pages/developer_settings_types.go
+++ b/internal/templates/components/pages/developer_settings_types.go
@@ -14,7 +14,11 @@ type DeveloperSettingsProps struct {
 }
 
 // DeveloperSettingsFormFields holds the editable developer settings.
+// UploadTokenMasked is the masked display of the stored artifact upload token
+// (empty when none is set); the input itself is always rendered blank so a
+// resubmit never writes the mask back.
 type DeveloperSettingsFormFields struct {
-	Enabled    bool
-	GithubRepo string
+	Enabled           bool
+	GithubRepo        string
+	UploadTokenMasked string
 }


### PR DESCRIPTION
## What

Fixes the in-app **dev reporter** (floating bug/debug button → `POST /-/dev-reports`), which broke once bb-artifacts required authenticated uploads, **and** makes the upload token configurable from **Settings → Developer** instead of an env var.

## Why it broke

`service.uploadArtifact` posts the screenshot/HTML snapshot to bb-artifacts **server-side** with no Authorization header. Anonymous uploads used to be accepted; after auth was required, the host returns **401** and artifacts fail to attach.

## Fix

- **New setting** `devmode.upload_token` on the Developer tab — a password field, stored **AES-GCM encrypted**, shown **masked** (mirrors the agent-token handling). Empty submit keeps the stored value.
- **Token resolution** (`artifactUploadToken`, precedence env → app_config → none): `BB_ARTIFACTS_UPLOAD_TOKEN` still overrides for ops; otherwise the encrypted setting is used. Resolved server-side and passed to `uploadArtifact` — never exposed to the browser (the client only ever talks to `/-/dev-reports`, session + CSRF).
- Clearer 401 error; UI shows a "currently set (••••)" hint or a warning when neither the setting nor the env var is configured.

## How to use

Settings → Developer → **Artifact upload token** → paste an upload token (e.g. the `app` token on the bb-artifacts VM) → Save. No redeploy needed.

## Verification

`go build ./...`, `go vet`, and the `service` / `appconfig` / `pages` unit tests all pass. (Generated templ + sqlc are gitignored and regenerated in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
