### PR TITLE
fix(developer-settings): remove noisy banners and fix double-border on Save button

### DIFF
--- a/internal/templates/components/pages/developer_settings.templ
+++ b/internal/templates/components/pages/developer_settings.templ
@@ -25,16 +25,6 @@ templ DeveloperSettings(p DeveloperSettingsProps) {
 				<span>{ p.FormSuccess }</span>
 			</div>
 		}
-		if p.Form.Enabled {
-			<div role="note" class="alert alert-info alert-soft mb-4 rounded-xl">
-				@components.LucideIcon("external-link", "w-4 h-4")
-				<span>No token needed — filing opens a <strong>prefilled GitHub draft</strong> (description, screenshot, and context pre-populated) that you review and submit, using your existing GitHub session.</span>
-			</div>
-			<div role="note" class="alert alert-success alert-soft mb-4 rounded-xl">
-				@components.LucideIcon("shield-check", "w-4 h-4")
-				<span>Reports redact financial data by default — amounts, names, and other values are masked in the screenshot and HTML snapshot before they're uploaded to the artifact store and linked in the issue. Redaction can be turned off per-report from the reporter.</span>
-			</div>
-		}
 		<div class="space-y-6">
 			@developerModeSection(p)
 		</div>
@@ -47,7 +37,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 	@components.SettingsSection(components.SettingsSectionProps{
 		Icon:    "bug",
 		Title:   "Developer mode",
-		Caption: "Enable the floating reporter and point it at a GitHub repo",
+		Caption: "Enable the floating reporter and point it at a GitHub repo — amounts and names are redacted before upload by default",
 		Form: &components.SettingsSectionFormProps{
 			Action:    "/settings/developer",
 			CSRFToken: p.CSRFToken,
@@ -56,7 +46,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 	}) {
 		@components.SettingsRow(components.SettingsRowProps{
 			Label:   "Enable developer mode",
-			Caption: "Renders a floating reporter on every page for filing a GitHub issue draft",
+			Caption: "Renders a floating reporter on every page — filing opens a prefilled GitHub draft you review and submit using your existing GitHub session",
 			For:     "enabled",
 		}) {
 			<input
@@ -103,10 +93,8 @@ templ developerModeSection(p DeveloperSettingsProps) {
 }
 
 templ developerSettingsFooter() {
-	<div class="bb-action-row">
-		<button type="submit" class="btn btn-primary btn-sm gap-2">
-			@components.LucideIcon("save", "w-4 h-4")
-			Save changes
-		</button>
-	</div>
+	<button type="submit" class="btn btn-primary btn-sm gap-2">
+		@components.LucideIcon("save", "w-4 h-4")
+		Save changes
+	</button>
 }


### PR DESCRIPTION
Fixes #1782

## What changed

Three issues on the `/settings/developer` tab, all in `developer_settings.templ`:

**1. Removed "No token needed" info banner**
The banner appeared whenever developer mode was enabled and explained that filing uses your existing GitHub session. As noted in the bug, this was confusing — it reads like a system status, not useful guidance. The same context ("filing opens a prefilled GitHub draft you review and submit using your existing GitHub session") is now part of the Enable row caption, which is always visible and scannable inline.

**2. Removed "Reports redact financial data" success banner**
The success-toned alert was misleading — it looked like a transient confirmation, not a persistent property of the feature. The redaction guarantee is now surfaced in the section caption ("amounts and names are redacted before upload by default"), one line, always visible alongside the section title.

**3. Fixed double-border above Save button**
`developerSettingsFooter()` was wrapping the button in `<div class="bb-action-row">`, which carries `border-t`. But the Footer slot in `SettingsSection` already renders inside `bb-settings-card__footer`, which also applies `border-t`. The nesting produced a double hairline / a grey bar above the button. Fixed by dropping the `bb-action-row` wrapper — the button now sits directly inside the card footer, which already owns the padding, border, and background.

## Screenshot

`&lt;img src="https://bb-artifacts.exe.xyz/f/358f65f7c2f2ed19.jpg" width="800" alt="Developer settings — after"&gt;`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EFyvmvUXFpMoA2vbx1R8xF)_