### PR TITLE
fix(layout): stop pages overscrolling by the topbar height

### DIFF
--- a/input.css
+++ b/input.css
@@ -629,7 +629,14 @@
        right edge; the column-gap puts the breathing room back. It's a
        column-gap, so it only applies to the lg+ row layout — on the mobile
        flex-col stack it's the cross axis and has no effect. */
-    @apply flex flex-col lg:flex-row lg:gap-x-6 lg:min-h-[calc(100vh-3rem)];
+    /* min-h fills the viewport so the sticky rail has a full-height column and
+       short settings pages don't float the rail short. Subtract BOTH main's
+       3rem (sm:p-6 top+bottom) AND the 3.5rem in-flow sticky topbar (.bb-topbar
+       is h-14) — omitting the topbar makes main a full 100dvh that stacks below
+       the topbar and overscrolls the page by 3.5rem. The 6.5rem total mirrors
+       the rail's -6.5rem of negative margin (-(3.5rem+1.5rem) top, -1.5rem
+       bottom) so rail height (100dvh) minus its margins equals this box. */
+    @apply flex flex-col lg:flex-row lg:gap-x-6 lg:min-h-[calc(100dvh-6.5rem)];
   }
   /* Mobile default: an in-flow strip above the content. The lg+ block
      below lifts it out into the fixed sidebar-extension column. */

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -544,7 +544,7 @@
     <!-- Mintlify-style surface flip: the content column is the bright
          surface (base-100) and the sidebar is the recessed one (base-200).
          Cards sit on white and read by their border, not a fill contrast. -->
-    <div class="drawer-content bg-base-100">
+    <div class="drawer-content bg-base-100 flex flex-col min-h-dvh">
       <!-- Desktop topbar — static across every page (hidden < lg, where the
            mobile navbar below takes over). Left: breadcrumb of the current
            section/page. Right: ⌘K search, theme toggle, profile menu. -->
@@ -605,8 +605,13 @@
         {{renderComponent "TopbarBreadcrumbMobile" .}}
       </div>
       {{end}}
-      <!-- Page content -->
-      <main class="p-4 sm:p-6 min-h-screen">
+      <!-- Page content — grows to fill the column instead of demanding its
+           own full viewport height. The column (.drawer-content) is min-h-dvh,
+           so the sticky topbar + navbar + this <main> together total exactly
+           the viewport; using min-h-screen here instead would stack a full
+           100vh BELOW the in-flow sticky topbar and overscroll the page by
+           the topbar's height. -->
+      <main class="p-4 sm:p-6 flex-1">
         {{template "flash" .}}
         {{- /* TemplContent slot — set by TemplateRenderer.RenderWithTempl to
               render a templ-generated body inside the base layout without


### PR DESCRIPTION
## Problem

Every admin page was scrollable ~3.5rem past the end of its content — a small phantom scroll whose size matched the top nav bar.

**Root cause:** the in-flow sticky topbar (`.bb-topbar`, `h-14` = 3.5rem) sits *above* `<main>` inside `.drawer-content`, but `<main>` itself carried `min-h-screen` (100vh). A sticky element still occupies its space in normal flow, so the content column's minimum height was **topbar (3.5rem) + 100vh** — overshooting the viewport by exactly the topbar height.

Settings had the *same 56px overscroll from a second source*: `.bb-settings-layout`'s `lg:min-h-[calc(100vh-3rem)]` subtracted only `<main>`'s `3rem` padding, never the topbar's `3.5rem`.

## Fix

- **`base.html` (drawer layout):** size the whole content column to the viewport (`.drawer-content` → `min-h-dvh flex flex-col`) and let `<main>` fill the remainder (`flex-1`) instead of independently demanding a full 100vh.
- **`input.css` (settings layout):** `lg:min-h-[calc(100vh-3rem)]` → `lg:min-h-[calc(100dvh-6.5rem)]`. The `6.5rem` accounts for main's `3rem` padding **and** the topbar's `3.5rem`, and mirrors the settings rail's `-6.5rem` of negative margin so the rail still reaches the viewport edges in lockstep (no regression to its flush-bottom behavior).

The standalone `/design` shell was already correct (it puts `min-h-screen` on the *wrapper*, not on `<main>`), so it's untouched.

## Verification

Measured `document.scrollHeight − innerHeight` headless on a viewport taller than the content (so any remaining overflow is purely the bug):

| Page (content fits viewport) | Before | After |
|---|---|---|
| `/categories` | **56px** spurious | **0px** ✅ |
| `/settings/general` | **56px** spurious | **0px** ✅ |

Pages with genuinely tall content (`/`, `/reviews`, `/sync-logs`) still scroll their real content exactly as before — only the phantom 56px is gone.

### After — rendering intact

Settings (exercises the trickier rail-aware fix — full-height rail still flush):

<img src="https://bb-artifacts.exe.xyz/f/008c54aa256c5d8f.jpg" width="800" alt="Settings — after">

Categories (the clean 56px→0px case):

<img src="https://bb-artifacts.exe.xyz/f/6d7db4817d4fe36f.jpg" width="800" alt="Categories — after">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
