### PR TITLE
fix(agents): render init metadata instead of an empty System row

### DIFF
--- a/internal/admin/agent_runs_classify_test.go
+++ b/internal/admin/agent_runs_classify_test.go
@@ -1,0 +1,67 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The SDK's first transcript line is a type:"system" / subtype:"init"
+// event that carries session metadata but no human "message". It used
+// to render as an empty "System" row; classifyTranscriptEvent now
+// summarizes the metadata instead.
+func TestClassifySystemInitEvent(t *testing.T) {
+	raw := `{"type":"system","ts":1717000000000,"data":{` +
+		`"type":"system","subtype":"init","model":"claude-opus-4-8",` +
+		`"tools":["Read","Bash","Grep"],` +
+		`"mcp_servers":[{"name":"breadbox","status":"connected"}],` +
+		`"cwd":"/app","permissionMode":"dontAsk"}}`
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ev := classifyTranscriptEvent(obj, raw)
+	if ev.Type != "system" {
+		t.Fatalf("Type = %q, want system", ev.Type)
+	}
+	if ev.Text == "" {
+		t.Fatal("init event rendered an empty System body (the bug)")
+	}
+	for _, want := range []string{"claude-opus-4-8", "3 tools", "breadbox (connected)"} {
+		if !strings.Contains(ev.Text, want) {
+			t.Errorf("summary %q missing %q", ev.Text, want)
+		}
+	}
+}
+
+// A cost_cap_hit event carries a real message; it must still win over
+// the init branch.
+func TestClassifySystemMessageEvent(t *testing.T) {
+	raw := `{"type":"cost_cap_hit","data":{"message":"Budget exceeded"}}`
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ev := classifyTranscriptEvent(obj, raw)
+	if ev.Type != "system" || ev.Text != "Budget exceeded" {
+		t.Fatalf("got Type=%q Text=%q, want system / Budget exceeded", ev.Type, ev.Text)
+	}
+}
+
+// An init event with no recognisable metadata still gets a non-empty
+// fallback label rather than a blank row.
+func TestClassifySystemInitFallback(t *testing.T) {
+	raw := `{"type":"system","data":{"subtype":"init"}}`
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ev := classifyTranscriptEvent(obj, raw)
+	if ev.Text != "Session initialized" {
+		t.Fatalf("fallback Text = %q, want Session initialized", ev.Text)
+	}
+}

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -6,9 +6,11 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"breadbox/internal/agent"
@@ -326,14 +328,77 @@ func classifyTranscriptEvent(obj map[string]any, raw string) pages.TranscriptEve
 	case "cost_cap_hit", "system":
 		ev.Type = "system"
 		if data, ok := obj["data"].(map[string]any); ok {
-			if msg, ok := data["message"].(string); ok {
+			// cost_cap_hit carries a human "message"; the SDK "init"
+			// event does not — it ships session metadata (model, tools,
+			// MCP wiring). Without the init branch the first transcript
+			// row renders blank.
+			if msg, ok := data["message"].(string); ok && msg != "" {
 				ev.Text = msg
+			} else if subtype, _ := data["subtype"].(string); subtype == "init" {
+				ev.Text = summarizeSystemInit(data)
 			}
 		}
 	default:
 		ev.Type = "raw"
 	}
 	return ev
+}
+
+// summarizeSystemInit builds a one-line summary of the SDK "init" system
+// event. That event opens every transcript but carries session metadata
+// (model, available tools, MCP server wiring) rather than a human
+// message, so the generic data.message path leaves it blank. Surfacing
+// the metadata turns the first row into a useful "session initialized"
+// header instead of an empty System line.
+func summarizeSystemInit(data map[string]any) string {
+	var parts []string
+	if model, _ := data["model"].(string); model != "" {
+		parts = append(parts, "Model "+model)
+	}
+	if tools, ok := data["tools"].([]any); ok && len(tools) > 0 {
+		noun := "tools"
+		if len(tools) == 1 {
+			noun = "tool"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", len(tools), noun))
+	}
+	if servers := mcpServerSummary(data); servers != "" {
+		parts = append(parts, "MCP: "+servers)
+	}
+	if len(parts) == 0 {
+		return "Session initialized"
+	}
+	return strings.Join(parts, " · ")
+}
+
+// mcpServerSummary renders the init event's mcp_servers array as
+// "name (status), name (status)". The SDK has shipped both snake_case
+// and camelCase for this key, so accept either.
+func mcpServerSummary(data map[string]any) string {
+	raw, ok := data["mcp_servers"].([]any)
+	if !ok {
+		raw, ok = data["mcpServers"].([]any)
+	}
+	if !ok || len(raw) == 0 {
+		return ""
+	}
+	var names []string
+	for _, s := range raw {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := sm["name"].(string)
+		if name == "" {
+			continue
+		}
+		if status, _ := sm["status"].(string); status != "" {
+			names = append(names, fmt.Sprintf("%s (%s)", name, status))
+		} else {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
 }
 
 // extractMessageText walks data.message.content[] for blocks of type


### PR DESCRIPTION
## Problem

On an agent/workflow run-detail page, the **first "System" event is always rendered empty**.

That first event is the Claude Agent SDK's `init` message (`type:"system"`, `subtype:"init"`). It carries session metadata — model, available tools, MCP server wiring, cwd — but **no human `message` field**. The classifier (`classifyTranscriptEvent`) only knew how to pull a body out of `data.message` (which exists on the *other* `type:"system"` producer, `cost_cap_hit`), so for the init event `ev.Text` stayed empty and the run-detail templ's `if ev.Text != ""` guard hid the body — leaving a bare "System" label with nothing under it.

## Fix

When the system event is the init event, summarize its metadata into the body instead:

> **System** — `Model claude-opus-4-8 · 3 tools · MCP: breadbox (connected)`

- Falls back to `"Session initialized"` when metadata is absent.
- A real `cost_cap_hit` `message` still takes precedence (checked first).
- No templ or type changes — reuses the existing `ev.Text` path, so both the static server render and the `/-/agents/runs/{id}/live` poll endpoint pick it up automatically (they share `classifyTranscriptEvent`).

The init event is genuinely the most informative line in the transcript — it's the only place that records which model ran, which tools were available, and whether the breadbox MCP connected — so surfacing it is higher-value than just hiding the empty row.

## Test

New `internal/admin/agent_runs_classify_test.go`:
- init event → non-empty summary containing model / tool count / MCP name+status
- `cost_cap_hit` message still wins over the init branch
- metadata-less init → `"Session initialized"` fallback (never blank)

`go build ./...`, `go vet ./internal/admin/ ./internal/templates/...`, and the `internal/admin` + `pages` suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
