### PR TITLE
feat(connections): app-wide connect-bank drawer + configure-provider deep link

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -476,6 +476,42 @@ func renderConnectionNew(
 	tr.RenderWithTempl(w, r, data, pages.ConnectionNew(props))
 }
 
+// newConnectDrawerResolver builds the render-time resolver for the app-wide
+// connect-bank drawer (rendered once globally in layout/base.html). It runs
+// on every authenticated full-page render, so it stays cheap: a few in-memory
+// provider-map lookups plus the small, indexed ListUsers query the wizard's
+// member-select needs. Unauthenticated requests (no session account) return
+// ok=false so the drawer is skipped — base.html only renders it in the
+// authenticated main-layout shell anyway.
+func newConnectDrawerResolver(a *app.App, sm *scs.SessionManager) func(*http.Request) (pages.ConnectionNewProps, bool) {
+	return func(r *http.Request) (pages.ConnectionNewProps, bool) {
+		if sm == nil || sm.GetString(r.Context(), sessionKeyAccountID) == "" {
+			return pages.ConnectionNewProps{}, false
+		}
+		props := pages.ConnectionNewProps{
+			CSRFToken:    GetCSRFToken(r),
+			HasPlaid:     a.Providers["plaid"] != nil,
+			HasTeller:    a.Providers["teller"] != nil,
+			HasSimpleFin: a.Providers["simplefin"] != nil,
+			TellerEnv:    a.Config.TellerEnv,
+		}
+		users, err := a.Queries.ListUsers(r.Context())
+		if err != nil {
+			// Non-fatal: render the drawer without the member list rather than
+			// failing the whole page. The wizard still works for a single-member
+			// household (the common case) and degrades gracefully otherwise.
+			a.Logger.Error("connect-bank drawer: list users", "error", err)
+		}
+		for _, u := range users {
+			props.Users = append(props.Users, pages.ConnectionNewUser{
+				ID:   pgconv.FormatUUID(u.ID),
+				Name: u.Name,
+			})
+		}
+		return props, true
+	}
+}
+
 // linkTokenRequest is the JSON body for POST /admin/api/link-token.
 type linkTokenRequest struct {
 	UserID   string `json:"user_id"`

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -20,6 +20,11 @@ import (
 func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service, mcpServer *breadboxmcp.MCPServer) chi.Router {
 	r := chi.NewRouter()
 
+	// Resolve the app-wide connect-bank drawer props at render time. Rendered
+	// once globally in layout/base.html so every "Connect a bank" entry point
+	// opens the same slide-over instead of navigating to /connections/new.
+	tr.SetConnectDrawerResolver(newConnectDrawerResolver(a, sm))
+
 	// Stamp Secure on the session cookie per request — must wrap the writer
 	// scs sets the cookie on, so it goes before LoadAndSave.
 	r.Use(mw.SecureSessionCookie(a.Config.SecureCookies, sm.Cookie.Name))
@@ -351,7 +356,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Workflow runtime settings — Claude Agent SDK auth, sidecar, and run
 		// ceilings. Admin-only because tokens are sensitive and runs cost.
 		r.Get("/settings/workflows", AgentSDKSettingsPageHandler(a, svc, sm, tr))
-			r.Get("/settings/connectors", ConnectorsSettingsPageHandler(a, svc, sm, tr))
+		r.Get("/settings/connectors", ConnectorsSettingsPageHandler(a, svc, sm, tr))
 		// Back-compat: the tab used to live at /settings/agents.
 		r.Get("/settings/agents", redirectGET("/settings/workflows"))
 		r.Get("/agents-settings", redirectGET("/settings/mcp"))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -100,6 +100,17 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.TopbarUserMenu(topbarUserMenuPropsFromData(m)), nil
 	},
+	// ConnectBankDrawer is the app-wide connect-a-bank slide-over rendered
+	// once in layout/base.html. Its props (provider availability + household
+	// members) are resolved at render time by the connectDrawer resolver and
+	// injected into the data map under "ConnectBankDrawer".
+	"ConnectBankDrawer": func(data any) (templ.Component, error) {
+		p, ok := data.(pages.ConnectionNewProps)
+		if !ok {
+			return nil, fmt.Errorf("ConnectBankDrawer: want pages.ConnectionNewProps, got %T", data)
+		}
+		return pages.ConnectBankDrawer(p), nil
+	},
 }
 
 // topbarUserMenuPropsFromData builds the identity props the topbar
@@ -364,6 +375,11 @@ type TemplateRenderer struct {
 	version        string
 	versionChecker *version.Checker
 	appcfg         appconfig.Reader
+	// connectDrawer resolves the props for the app-wide connect-bank drawer
+	// at render time (provider availability + household members). Returns
+	// ok=false to skip rendering (e.g. unauthenticated requests). Wired in
+	// NewAdminRouter; nil leaves the drawer unrendered.
+	connectDrawer func(r *http.Request) (pages.ConnectionNewProps, bool)
 }
 
 // NewTemplateRenderer parses all embedded templates and returns a renderer.
@@ -595,6 +611,18 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 				m["SessionUserName"] = tr.sm.GetString(r.Context(), sessionKeyUserName)
 			}
 		}
+		// Resolve the app-wide connect-bank drawer props (provider availability
+		// + household members). Rendered once globally in layout/base.html so
+		// every "Connect a bank" entry point opens the same slide-over. The
+		// resolver returns ok=false for unauthenticated requests; base.html
+		// only renders the drawer in the authenticated main-layout shell.
+		if tr.connectDrawer != nil {
+			if _, exists := m["ConnectBankDrawer"]; !exists {
+				if props, ok := tr.connectDrawer(r); ok {
+					m["ConnectBankDrawer"] = props
+				}
+			}
+		}
 		// Cache assembled NavProps so navPropsFromData can type-assert it
 		// directly rather than re-extracting each string key.
 		m["_NavProps"] = buildNavProps(m)
@@ -713,6 +741,13 @@ func (tr *TemplateRenderer) SetVersionChecker(vc *version.Checker) {
 // dismissal is not consulted and the callout shows whenever an update exists.
 func (tr *TemplateRenderer) SetAppConfigReader(r appconfig.Reader) {
 	tr.appcfg = r
+}
+
+// SetConnectDrawerResolver wires the resolver for the app-wide connect-bank
+// drawer (rendered globally in layout/base.html). It runs at render time on
+// authenticated full-page renders; returning ok=false skips the drawer.
+func (tr *TemplateRenderer) SetConnectDrawerResolver(fn func(r *http.Request) (pages.ConnectionNewProps, bool)) {
+	tr.connectDrawer = fn
 }
 
 // ruleFieldLabel maps a rule-condition field name to its human-readable

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -88,12 +88,10 @@ templ AccountsList(p AccountsListProps) {
 				@accountsListTable(p)
 			} else {
 				@components.EmptyState(components.EmptyStateProps{
-					Icon:     "wallet",
-					Title:    "No accounts yet",
-					Body:     "Once you connect a bank, every account synced from it shows up here.",
-					CTAHref:  templ.SafeURL("/connections/new"),
-					CTAIcon:  "plus",
-					CTALabel: "Connect a Bank",
+					Icon:      "wallet",
+					Title:     "No accounts yet",
+					Body:      "Once you connect a bank, every account synced from it shows up here.",
+					CustomCTA: connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a Bank"),
 				})
 			}
 		</div>

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -78,6 +78,12 @@ templ connectWizard(p ConnectionNewProps) {
 						}
 						@connectProviderRow("csv", "", "file-spreadsheet", "CSV", "Import a statement file manually", false)
 					</div>
+					if !p.HasPlaid || !p.HasTeller || !p.HasSimpleFin {
+						<a href="/settings/providers" class="inline-flex items-center gap-1 mt-2 text-xs text-base-content/50 hover:text-primary transition-colors">
+							@components.LucideIcon("settings", "w-3 h-3")
+							Don't see your bank? Configure another provider
+						</a>
+					}
 				</div>
 				if len(p.Users) == 1 {
 					<!-- Single household member: auto-selected, field hidden for a cleaner flow. -->
@@ -183,4 +189,43 @@ templ connectProviderRow(value, brand, icon, name, desc string, checked bool) {
 			</span>
 		</div>
 	</label>
+}
+
+// ConnectBankDrawer is the app-wide "Connect a bank" slide-over. It is
+// rendered ONCE globally (layout/base.html via the renderComponent bridge,
+// keyed "ConnectBankDrawer") so every "Connect a bank" entry point across
+// the app — feed, accounts, getting-started, the household toast, the
+// connections list — opens the same drawer via $store.drawers.open('connect-bank')
+// rather than navigating to the standalone /connections/new page. The props
+// are resolved at render time (see admin.connectDrawerProps): provider
+// availability + the household members the wizard's member-select needs.
+templ ConnectBankDrawer(p ConnectionNewProps) {
+	@components.Drawer(components.DrawerProps{ID: "connect-bank", Title: "Connect a bank", Size: "md"}) {
+		@components.DrawerHeader(components.DrawerHeaderProps{
+			Icon:     "building-2",
+			Title:    "Connect a bank",
+			Subtitle: "Sync transactions automatically",
+		})
+		<div class="flex-1 overflow-y-auto p-5">
+			if !p.HasPlaid && !p.HasTeller && !p.HasSimpleFin {
+				@connectNoProviders()
+			} else {
+				@connectWizard(p)
+			}
+		</div>
+	}
+}
+
+// connectBankButton renders a button that opens the global connect-bank
+// drawer. Shared by the page-level entry points (feed header + empty state,
+// accounts empty state) so they all open the same slide-over with one
+// consistent affordance. classes is the full daisy button class string;
+// icon is an optional leading Lucide name.
+templ connectBankButton(classes, icon, label string) {
+	<button type="button" x-data @click="$store.drawers.open('connect-bank')" class={ classes }>
+		if icon != "" {
+			@components.LucideIcon(icon, "w-4 h-4")
+		}
+		{ label }
+	</button>
 }

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -167,9 +167,9 @@ templ Connections(p ConnectionsProps) {
 		<!-- /links tab -->
 		<!-- Create Account Link Modal -->
 		@connectionsCreateLinkModal(p)
-		<!-- Connect-a-bank drawer — opened from the "Connect Bank" button and
-		     the empty-state CTA. Replaces the old /connections/new page nav. -->
-		@connectBankDrawer(p)
+		<!-- The Connect-a-bank drawer is rendered globally in layout/base.html
+		     (keyed "ConnectBankDrawer"); the "Connect Bank" button and empty-
+		     state CTA on this page open it via $store.drawers.open('connect-bank'). -->
 		<!-- Loading skeleton for the connections list, available for any future
 		     client-side refresh / pagination swap. Mirrors the SSR layout
 		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
@@ -535,25 +535,10 @@ templ connectFirstBankBtn() {
 	</button>
 }
 
-// connectBankDrawer embeds the shared connectWizard partial in the standard
-// right-side Drawer. Opened via $store.drawers.open('connect-bank').
-templ connectBankDrawer(p ConnectionsProps) {
-	@components.Drawer(components.DrawerProps{ID: "connect-bank", Title: "Connect a bank", Size: "md"}) {
-		@components.DrawerHeader(components.DrawerHeaderProps{
-			Icon:     "building-2",
-			Title:    "Connect a bank",
-			Subtitle: "Sync transactions automatically",
-		})
-		<div class="flex-1 overflow-y-auto p-5">
-			if !p.HasPlaid && !p.HasTeller && !p.HasSimpleFin {
-				@connectNoProviders()
-			} else {
-				@connectWizard(p.ConnectInProps())
-			}
-		</div>
-	}
-}
-
+// The connect-bank drawer is no longer embedded per-page — it renders once
+// globally in layout/base.html (component key "ConnectBankDrawer"); see
+// pages.ConnectBankDrawer in connection_new.templ. The buttons on this page
+// open it via $store.drawers.open('connect-bank').
 templ connectionsCreateLinkModal(p ConnectionsProps) {
 	<dialog id="create-link-modal" class="modal modal-bottom sm:modal-middle">
 		<div class="modal-box w-full sm:max-w-lg [padding-bottom:calc(1.5rem+env(safe-area-inset-bottom,0px))] sm:[padding-bottom:1.5rem]">

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -54,11 +54,7 @@ templ feedHero(p FeedProps) {
 		@components.PageHeader(components.PageHeaderProps{
 			Title:    "Feed",
 			Subtitle: "Everything that happened in your breadbox · " + p.Hero.Generated,
-			Action: components.PageHeaderAction(
-				templ.SafeURL("/connections/new"),
-				"plus",
-				"Connect bank",
-			),
+			Action:   connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect bank"),
 		})
 		<div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
 			@feedHeroTile("activity", "Events today", fmt.Sprintf("%d", p.Hero.EventsToday), feedHeroSubEvents(p))
@@ -292,10 +288,7 @@ templ feedEmptyFirstRun() {
 		<p class="text-sm text-base-content/55 max-w-md mx-auto mb-5">
 			Connect your first bank to start filling your feed.
 		</p>
-		<a href="/connections/new" class="btn btn-primary btn-sm">
-			@components.LucideIcon("plus", "w-3.5 h-3.5")
-			Connect a bank
-		</a>
+		@connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a bank")
 	</div>
 }
 

--- a/internal/templates/components/pages/feed_empty_test.go
+++ b/internal/templates/components/pages/feed_empty_test.go
@@ -36,7 +36,9 @@ func TestFeedEmptyStateVariants(t *testing.T) {
 			mustContain: []string{
 				"Welcome to Breadbox",
 				"Connect your first bank to start filling your feed.",
-				`href="/connections/new"`,
+				// The CTA now opens the app-wide connect-bank drawer in place
+				// rather than navigating to the standalone /connections/new page.
+				`$store.drawers.open('connect-bank')`,
 				"btn-primary",
 			},
 			mustOmit: []string{

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -138,7 +138,11 @@ templ gsStep3(p GettingStartedProps) {
 		CTAHref:      gsStepCTAHref(p.HasConnection, "/connections", "/connections/new"),
 		CTAIcon:      gsStepCTAIcon(p.HasConnection, "plus"),
 		CTALabel:     gsStepCTALabel(p.HasConnection, "View connections", "Connect bank"),
-		CTADisabled:  gsStepPendingDisabled(p.HasConnection, 3, p.ActiveStep),
+		// Not yet connected → open the global connect-bank drawer in place
+		// rather than navigating to /connections/new. Once connected the CTA
+		// becomes a plain "View connections" link (CTAHref above).
+		CTAOnClick:  gsConnectDrawerOnClick(p.HasConnection),
+		CTADisabled: gsStepPendingDisabled(p.HasConnection, 3, p.ActiveStep),
 	})
 }
 
@@ -245,6 +249,17 @@ func gsStepCTAIcon(complete bool, todoIcon string) string {
 		return ""
 	}
 	return todoIcon
+}
+
+// gsConnectDrawerOnClick returns the Alpine @click expression that opens the
+// global connect-bank drawer for the not-yet-connected "Connect bank" CTA,
+// and "" once a connection exists (so the CTA falls back to its "View
+// connections" link).
+func gsConnectDrawerOnClick(complete bool) string {
+	if complete {
+		return ""
+	}
+	return "$store.drawers.open('connect-bank')"
 }
 
 // gsStat formats a step's inline metric value, returning "" for zero/empty so

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -24,7 +24,7 @@ templ Users(p UsersProps) {
 	if p.Created {
 		<div role="alert" class="alert alert-success mb-6">
 			@components.LucideIcon("check-circle", "w-5 h-5")
-			<span>Member created. <a href="/connections/new" class="link font-medium">Connect a bank for them</a></span>
+			<span>Member created. <button type="button" x-data @click="$store.drawers.open('connect-bank')" class="link font-medium">Connect a bank for them</button></span>
 		</div>
 	}
 	if p.IsUnlinked {
@@ -174,10 +174,10 @@ templ usersMemberCard(u UsersEnrichedRow) {
 					{ usersAccountsSummary(u.AccountCount, u.ConnectionCount) }
 				</span>
 			} else {
-				<a href="/connections/new" class="flex items-center gap-1 text-xs text-base-content/40 hover:text-primary transition-colors">
+				<button type="button" x-data @click="$store.drawers.open('connect-bank')" class="flex items-center gap-1 text-xs text-base-content/40 hover:text-primary transition-colors">
 					@components.LucideIcon("plus", "w-3.5 h-3.5")
 					Connect a bank
-				</a>
+				</button>
 			}
 			if u.HasCreatedAt {
 				<span class="text-xs text-base-content/30 shrink-0">Since { u.CreatedAtLabel }</span>

--- a/internal/templates/components/setup_step.templ
+++ b/internal/templates/components/setup_step.templ
@@ -66,6 +66,12 @@ type SetupStepProps struct {
 	CTAIcon      string
 	CTALabel     string
 	CTADisabled  bool // render as a disabled btn span (no link)
+	// CTAOnClick, when non-empty, renders the CTA as a <button> with this
+	// Alpine @click expression instead of an <a href> — e.g.
+	// "$store.drawers.open('connect-bank')" to open a global drawer rather
+	// than navigate. CTAHref is ignored when this is set. Has no effect on
+	// the disabled-pending state (which stays a non-interactive span).
+	CTAOnClick string
 
 	// Stat is an optional inline metric shown in the trailing area, left of
 	// the CTA and vertically centered with it — e.g. "3" + StatLabel
@@ -179,12 +185,7 @@ templ setupStepMetaRow(p SetupStepProps) {
 templ setupStepCTA(p SetupStepProps) {
 	switch p.State {
 		case SetupStepActive:
-			<a href={ p.CTAHref } class="btn btn-primary btn-sm gap-2">
-				if p.CTAIcon != "" {
-					@LucideIcon(p.CTAIcon, "w-4 h-4")
-				}
-				{ p.CTALabel }
-			</a>
+			@setupStepCTAControl(p, "btn btn-primary btn-sm gap-2")
 		case SetupStepPending:
 			if p.CTADisabled {
 				<span class="btn btn-sm btn-disabled gap-2" aria-disabled="true">
@@ -194,20 +195,32 @@ templ setupStepCTA(p SetupStepProps) {
 					{ p.CTALabel }
 				</span>
 			} else {
-				<a href={ p.CTAHref } class="btn btn-ghost btn-sm gap-2 text-base-content/60">
-					if p.CTAIcon != "" {
-						@LucideIcon(p.CTAIcon, "w-4 h-4")
-					}
-					{ p.CTALabel }
-				</a>
+				@setupStepCTAControl(p, "btn btn-ghost btn-sm gap-2 text-base-content/60")
 			}
 		default:
-			<a href={ p.CTAHref } class="btn btn-ghost btn-sm gap-2">
-				if p.CTAIcon != "" {
-					@LucideIcon(p.CTAIcon, "w-4 h-4")
-				}
-				{ p.CTALabel }
-			</a>
+			@setupStepCTAControl(p, "btn btn-ghost btn-sm gap-2")
+	}
+}
+
+// setupStepCTAControl renders the interactive CTA as either an Alpine
+// <button> (when CTAOnClick is set — e.g. to open a global drawer) or the
+// classic <a href> link. The class string carries the per-state styling so
+// the link/button shapes can't drift apart.
+templ setupStepCTAControl(p SetupStepProps, class string) {
+	if p.CTAOnClick != "" {
+		<button type="button" x-data @click={ p.CTAOnClick } class={ class }>
+			if p.CTAIcon != "" {
+				@LucideIcon(p.CTAIcon, "w-4 h-4")
+			}
+			{ p.CTALabel }
+		</button>
+	} else {
+		<a href={ p.CTAHref } class={ class }>
+			if p.CTAIcon != "" {
+				@LucideIcon(p.CTAIcon, "w-4 h-4")
+			}
+			{ p.CTALabel }
+		</a>
 	}
 }
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -620,6 +620,12 @@
               instead. See issue #462. */ -}}
         {{if .TemplContent}}{{.TemplContent}}{{else}}{{block "content" .}}{{end}}{{end}}
       </main>
+      {{- /* App-wide connect-bank slide-over. Rendered once here (not per
+            page) so every "Connect a bank" entry point across the app opens
+            the same drawer via $store.drawers.open('connect-bank'). Props
+            (provider availability + household members) are resolved at render
+            time by the connectDrawer resolver. */ -}}
+      {{if .ConnectBankDrawer}}{{renderComponent "ConnectBankDrawer" .ConnectBankDrawer}}{{end}}
     </div>
 
     <!-- Sidebar -->


### PR DESCRIPTION
## What

Makes the **"Connect a bank" slide-over the universal entry point**. Previously only `/connections` embedded the drawer; every other "Connect a bank" button (feed header + first-run empty state, accounts empty state, getting-started step 3, the post-member-create toast + member-card link) navigated to the standalone `/connections/new` page instead.

Also surfaces a **"Don't see your bank? Configure another provider"** deep link inside the wizard whenever *any* provider is unconfigured — previously that affordance only appeared when *zero* providers were set up.

## Why

Two asks:
1. The connect flow should hint that you can configure another provider when one isn't set up.
2. Every "Connect a bank" entry point should open the side drawer, not bounce to the standalone page. Scoped to **all entry points, app-wide**.

## How

- **Global drawer**: the connect-bank drawer renders once in `layout/base.html` via the `renderComponent` bridge (`ConnectBankDrawer`). Props (provider availability + household members) resolve at render time through a new `TemplateRenderer.connectDrawer` resolver wired in `NewAdminRouter`, keeping DB/provider access out of the templates package. The per-page embed on `/connections` is removed to avoid a duplicate drawer id.
- **Entry points** all point at `$store.drawers.open('connect-bank')` instead of `/connections/new`. Buttons carry a bare `x-data` so the Alpine `@click` binds even outside a page-level scope.
- **`SetupStep`** gains an optional `CTAOnClick` so its CTA can render as an Alpine button instead of an `<a href>` (used by getting-started step 3 when not yet connected).
- The deep link shows whenever `!HasPlaid || !HasTeller || !HasSimpleFin`.

The standalone `/connections/new` page still works as a deep link.

## Notes

- Resolver runs one indexed `ListUsers` query per authenticated full-page render — negligible for a single-household self-hosted app; gated to authenticated sessions only.
- `getting_started.templ` also evolves on `feat/onboarding-setup-polish`; expect a small overlap if both land.

## Validation

- `go build ./...`, `go vet`, touched-package unit tests green (incl. updated `feed_empty_test.go`).
- Browser-verified: feed "Connect bank" opens the drawer; SimpleFIN unconfigured → deep link shows and SimpleFIN is absent from the provider cards; the `/connections` page opens the same single global drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
