### PR TITLE
fix(workflows): show all workflow runs on /workflows/runs + row polish

### DIFF
--- a/internal/admin/workflows_runs_page.go
+++ b/internal/admin/workflows_runs_page.go
@@ -46,12 +46,12 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		}
 
 		var (
-			presets   []service.WorkflowPresetView
+			defs      []service.AgentDefinitionResponse
 			subStatus *service.AgentSubsystemStatus
 			wg        sync.WaitGroup
 		)
 		wg.Add(2)
-		go func() { defer wg.Done(); presets, _ = svc.ListWorkflowPresets(ctx) }()
+		go func() { defer wg.Done(); defs, _ = svc.ListAgentDefinitions(ctx) }()
 		go func() { defer wg.Done(); subStatus = svc.GetAgentSubsystemStatus(ctx) }()
 		wg.Wait()
 
@@ -60,7 +60,10 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			Offset:        offset,
 			Status:        status,
 			AgentSlugOrID: workflowSlug,
-			WorkflowsOnly: true,
+			// Show runs for EVERY workflow — preset-instantiated AND custom
+			// (source_template NULL). /agents is retired and this is the only
+			// runs surface, so the legacy WorkflowsOnly gate (source_template
+			// IS NOT NULL) would wrongly hide all custom-workflow runs.
 		}
 		result, err := svc.ListAllAgentRuns(ctx, params)
 		if err != nil {
@@ -87,7 +90,7 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		props := pages.WorkflowRunsProps{
 			StatusFilter:   status,
 			WorkflowSlug:   workflowSlug,
-			Options:        workflowRunFilterOptions(presets),
+			Options:        workflowRunFilterOptions(defs),
 			Limit:          workflowRunsPageLimit,
 			Offset:         offset,
 			HasMore:        result.HasMore,
@@ -136,18 +139,20 @@ func WorkflowRunsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 	}
 }
 
-// workflowRunFilterOptions builds the workflow dropdown from the enabled
-// presets — each instantiated workflow's slug + name. Disabled presets
-// (never instantiated) can't have runs, so they're omitted.
-func workflowRunFilterOptions(presets []service.WorkflowPresetView) []pages.WorkflowRunFilterOption {
-	opts := make([]pages.WorkflowRunFilterOption, 0, len(presets))
-	for _, v := range presets {
-		if !v.Enabled || v.WorkflowSlug == nil {
+// workflowRunFilterOptions builds the workflow filter dropdown from every
+// workflow definition — preset-instantiated and custom alike — so the run
+// history can be narrowed to any workflow that has runs. Disabled
+// workflows are kept too: they may be disabled now but still have past
+// runs worth filtering to.
+func workflowRunFilterOptions(defs []service.AgentDefinitionResponse) []pages.WorkflowRunFilterOption {
+	opts := make([]pages.WorkflowRunFilterOption, 0, len(defs))
+	for _, d := range defs {
+		if d.Slug == "" {
 			continue
 		}
 		opts = append(opts, pages.WorkflowRunFilterOption{
-			Slug: *v.WorkflowSlug,
-			Name: v.Name,
+			Slug: d.Slug,
+			Name: d.Name,
 		})
 	}
 	return opts

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -1003,11 +1003,14 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 }
 
 // WorkflowRunStatusCounts returns a status→count map across preset-backed
-// workflow runs (source_template IS NOT NULL), optionally narrowed to one
-// workflow. Powers the count badges on the Workflows → Runs status tabs.
-// Same hand-rolled SQL pattern as ListAllAgentRuns.
+// workflow runs, optionally narrowed to one workflow. Powers the count
+// badges on the Workflows → Runs status tabs. Every definition is a
+// workflow now (preset-instantiated AND custom/hand-authored), so this
+// counts them all — the page is the single runs surface and must not
+// hide custom-workflow runs. Same hand-rolled SQL pattern as
+// ListAllAgentRuns.
 func (s *Service) WorkflowRunStatusCounts(ctx context.Context, workflowSlugOrID string) (map[string]int, error) {
-	where := []string{"d.source_template IS NOT NULL"}
+	where := []string{}
 	args := []any{}
 	if workflowSlugOrID != "" {
 		def, err := s.resolveAgentDefinition(ctx, workflowSlugOrID)
@@ -1020,8 +1023,11 @@ func (s *Service) WorkflowRunStatusCounts(ctx context.Context, workflowSlugOrID 
 		args = append(args, def.ID)
 	}
 	query := "SELECT r.status, COUNT(*) FROM workflow_runs r " +
-		"JOIN workflows d ON d.id = r.agent_definition_id WHERE " +
-		strings.Join(where, " AND ") + " GROUP BY r.status"
+		"JOIN workflows d ON d.id = r.agent_definition_id"
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+	query += " GROUP BY r.status"
 	rows, err := s.Pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("workflow run status counts: %w", err)

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -201,7 +201,7 @@ func TestWorkflowRunStatusCounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnableWorkflowFromPreset: %v", err)
 	}
-	plain := mustCreateAgentDefinition(t, svc, "plain-counts", true)
+	custom := mustCreateAgentDefinition(t, svc, "custom-counts", true)
 
 	ins := func(defID, status string) {
 		if _, e := pool.Exec(ctx,
@@ -214,17 +214,18 @@ func TestWorkflowRunStatusCounts(t *testing.T) {
 	ins(wf.ID, "success")
 	ins(wf.ID, "error")
 	ins(wf.ID, "skipped")
-	ins(plain.ID, "success") // not a workflow → excluded
+	ins(custom.ID, "success") // custom workflow → now included
 
+	// Unscoped: preset + custom workflow runs aggregate together (3 success).
 	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
 	if err != nil {
 		t.Fatalf("WorkflowRunStatusCounts: %v", err)
 	}
-	if counts["success"] != 2 || counts["error"] != 1 || counts["skipped"] != 1 {
-		t.Fatalf("counts = %v, want success:2 error:1 skipped:1 (plain excluded)", counts)
+	if counts["success"] != 3 || counts["error"] != 1 || counts["skipped"] != 1 {
+		t.Fatalf("counts = %v, want success:3 error:1 skipped:1 (custom included)", counts)
 	}
 
-	// Filtered to the one workflow — same tally.
+	// Filtered to the one preset workflow — only its tally.
 	scoped, err := svc.WorkflowRunStatusCounts(ctx, wf.Slug)
 	if err != nil {
 		t.Fatalf("scoped counts: %v", err)

--- a/internal/service/workflow_run_status_counts_integration_test.go
+++ b/internal/service/workflow_run_status_counts_integration_test.go
@@ -27,28 +27,31 @@ func TestT7WorkflowRunStatusCounts_EmptyDB(t *testing.T) {
 	}
 }
 
-// TestT7WorkflowRunStatusCounts_PlainAgentExcluded confirms that runs belonging
-// to a hand-authored agent (source_template IS NULL) are not counted even when
-// they share the same status values as a workflow run.
-func TestT7WorkflowRunStatusCounts_PlainAgentExcluded(t *testing.T) {
+// TestT7WorkflowRunStatusCounts_CustomWorkflowIncluded confirms that runs
+// belonging to a custom/hand-authored workflow (source_template IS NULL) ARE
+// counted. /workflows/runs is the single runs surface now (/agents is
+// retired), so every workflow's runs must appear — the legacy
+// source_template IS NOT NULL gate wrongly hid custom workflows added via the
+// custom-workflow drawer.
+func TestT7WorkflowRunStatusCounts_CustomWorkflowIncluded(t *testing.T) {
 	svc, _, pool := newService(t)
 	ctx := context.Background()
 
-	plain := mustCreateAgentDefinition(t, svc, "t7-plain-excluded", true)
+	custom := mustCreateAgentDefinition(t, svc, "t7-custom-included", true)
 
-	// Insert a run for the plain agent only — no preset-backed workflow exists.
+	// Insert a run for the custom workflow (no preset backing).
 	if _, err := pool.Exec(ctx,
 		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'manual','success')`,
-		plain.ID); err != nil {
-		t.Fatalf("insert plain run: %v", err)
+		custom.ID); err != nil {
+		t.Fatalf("insert custom run: %v", err)
 	}
 
 	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
 	if err != nil {
 		t.Fatalf("WorkflowRunStatusCounts: %v", err)
 	}
-	if len(counts) != 0 {
-		t.Fatalf("expected empty counts (plain agent excluded), got %v", counts)
+	if counts["success"] != 1 {
+		t.Fatalf("expected custom workflow run counted (success=1), got %v", counts)
 	}
 }
 
@@ -286,18 +289,20 @@ func TestT7WorkflowRunStatusCounts_MultiPreset(t *testing.T) {
 	ins(wfB.ID, "skipped")
 	ins(wfC.ID, "timeout")
 
-	// Also insert a plain agent run to confirm it stays excluded.
-	plain := mustCreateAgentDefinition(t, svc, "t7-multi-plain", true)
-	ins(plain.ID, "success")
+	// Also insert a custom-workflow run (source_template NULL) to confirm it
+	// is now INCLUDED — every workflow's runs surface on /workflows/runs.
+	custom := mustCreateAgentDefinition(t, svc, "t7-multi-custom", true)
+	ins(custom.ID, "success")
 
 	counts, err := svc.WorkflowRunStatusCounts(ctx, "")
 	if err != nil {
 		t.Fatalf("WorkflowRunStatusCounts: %v", err)
 	}
 
-	// Workflow-backed: 2 success, 1 error, 1 skipped, 1 timeout. Plain excluded.
-	if counts["success"] != 2 {
-		t.Errorf("success = %d, want 2", counts["success"])
+	// Preset-backed: 2 success, 1 error, 1 skipped, 1 timeout — plus the custom
+	// workflow's 1 success = 3 success total.
+	if counts["success"] != 3 {
+		t.Errorf("success = %d, want 3 (2 preset + 1 custom)", counts["success"])
 	}
 	if counts["error"] != 1 {
 		t.Errorf("error = %d, want 1", counts["error"])
@@ -312,7 +317,7 @@ func TestT7WorkflowRunStatusCounts_MultiPreset(t *testing.T) {
 		t.Errorf("in_progress should be absent, got %d", counts["in_progress"])
 	}
 	total := counts["success"] + counts["error"] + counts["skipped"] + counts["timeout"]
-	if total != 5 {
-		t.Errorf("total workflow runs = %d, want 5 (plain excluded)", total)
+	if total != 6 {
+		t.Errorf("total workflow runs = %d, want 6 (5 preset + 1 custom)", total)
 	}
 }

--- a/internal/templates/components/agent_run_row.templ
+++ b/internal/templates/components/agent_run_row.templ
@@ -178,8 +178,7 @@ templ agentRunAccessoryIcons(p AgentRunRowProps) {
 // stay quiet — the title row alone carries them.
 templ agentRunRowBody(p AgentRunRowProps) {
 	if p.Status == "error" && (p.ErrorMessageFriendly != "" || p.ErrorMessage != "") {
-		<div class="mt-0.5 inline-flex items-center gap-1.5 text-xs text-error/90 min-w-0">
-			@LucideIcon("triangle-alert", "w-3 h-3 shrink-0")
+		<div class="mt-0.5 text-xs text-error/90 min-w-0">
 			<span class="line-clamp-1">
 				if p.ErrorMessageFriendly != "" {
 					{ p.ErrorMessageFriendly }
@@ -190,10 +189,6 @@ templ agentRunRowBody(p AgentRunRowProps) {
 		</div>
 	} else if len(p.Reports) > 0 {
 		<div class="mt-0.5 flex items-center gap-1.5 text-xs min-w-0">
-			<i
-				data-lucide={ agentRunReportIcon(p.Reports[0].Priority) }
-				class={ "w-3 h-3 shrink-0", agentRunReportIconColor(p.Reports[0].Priority) }
-			></i>
 			<span class={ "line-clamp-1 min-w-0", agentRunReportTextColor(p.Reports[0].Priority) }>
 				{ p.Reports[0].Title }
 			</span>
@@ -291,28 +286,6 @@ func agentRunTriggerIcon(trigger string) string {
 		return "play"
 	default:
 		return "circle"
-	}
-}
-
-func agentRunReportIcon(priority string) string {
-	switch priority {
-	case "critical":
-		return "alert-octagon"
-	case "warning":
-		return "alert-triangle"
-	default:
-		return "file-text"
-	}
-}
-
-func agentRunReportIconColor(priority string) string {
-	switch priority {
-	case "critical":
-		return "text-error"
-	case "warning":
-		return "text-warning"
-	default:
-		return "text-base-content/50"
 	}
 }
 

--- a/internal/templates/components/pages/workflows_runs.templ
+++ b/internal/templates/components/pages/workflows_runs.templ
@@ -87,7 +87,7 @@ templ workflowRunsFilters(p WorkflowRunsProps) {
 templ workflowRunActions(slug, shortID string, ready bool) {
 	@components.OverflowMenu(components.OverflowMenuProps{
 		AriaLabel: "Run " + shortID + " actions",
-		Size:      "xs",
+		Size:      "sm",
 		Items: []components.OverflowMenuItem{
 			{
 				Label:     "Re-run workflow",


### PR DESCRIPTION
Fixes `/workflows/runs` hiding every custom workflow's runs, and polishes the run rows.

The page filtered on `source_template IS NOT NULL` (the `WorkflowsOnly` gate), so it only showed **preset-instantiated** workflows. Now that `/agents` is retired and this is the only runs surface, custom/hand-authored workflows (`source_template = NULL`) belong here too — locally that gate was hiding **65 of 66 runs** (e.g. "Manual Review", "Manual Sweep Test").

## Changes
- **Show all runs** — handler no longer sets `WorkflowsOnly`; the list shows every workflow's runs.
- **Match the badges** — `WorkflowRunStatusCounts` drops the `source_template` gate so the status-tab counts match the rows.
- **Filterable** — the workflow filter dropdown now sources from all workflow definitions (custom included), not just presets.
- **Row polish** — bigger overflow-menu button (`xs`→`sm`), and removed the redundant leading error/report icon (the left status tile already signals state).
- Updated 3 integration tests that encoded the old "exclude plain agents" intent; the service-level `WorkflowsOnly` capability + its tests stay intact.

<img src="https://bb-artifacts.exe.xyz/f/709972a22ee523b4.jpg" width="800" alt="/workflows/runs — custom workflow runs now visible, polished rows">

## Test plan
- [x] `go build ./...`, `go vet -tags integration ./internal/service/...`
- [x] Affected integration tests green (`WorkflowRunStatusCounts`, `WorkflowsOnly`, counts suites)
- [x] Unit suite green (`go test ./...`)
- [x] Verified in a browser: run `0SWS6kjf` ("Manual Sweep Test") + "Manual Review" runs now render on `/workflows/runs`
