### PR TITLE
fix(settings): fix mobile layout on developer settings page

### DIFF
--- a/internal/templates/components/pages/developer_settings.templ
+++ b/internal/templates/components/pages/developer_settings.templ
@@ -62,6 +62,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 			Label:   "GitHub repository",
 			Caption: "Where issue drafts open, in owner/repo form. Defaults to the upstream Breadbox repo — point it at a fork or your own tracker.",
 			For:     "github_repo",
+			Stack:   true,
 		}) {
 			<input
 				id="github_repo"
@@ -71,7 +72,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 				placeholder="canalesb93/breadbox"
 				autocomplete="off"
 				spellcheck="false"
-				class="bb-form-input font-mono min-w-72"
+				class="bb-form-input font-mono w-full"
 			/>
 			if p.FieldErrors["github_repo"] != "" {
 				<p class="text-xs text-error mt-1">{ p.FieldErrors["github_repo"] }</p>
@@ -81,6 +82,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 			Label:   "Artifact upload token",
 			Caption: "Bearer token the server uses to upload the screenshot + HTML snapshot to the artifact host. Stored encrypted; leave blank to keep the current value.",
 			For:     "upload_token",
+			Stack:   true,
 		}) {
 			<input
 				id="upload_token"
@@ -90,7 +92,7 @@ templ developerModeSection(p DeveloperSettingsProps) {
 				placeholder="Paste an upload token"
 				autocomplete="off"
 				spellcheck="false"
-				class="bb-form-input font-mono min-w-72"
+				class="bb-form-input font-mono w-full"
 			/>
 			if p.Form.UploadTokenMasked != "" {
 				<p class="text-xs text-base-content/50 mt-1">


### PR DESCRIPTION
Fixes #1794 — mobile layout broken on `/settings/developer`.

## Problem

The "GitHub repository" and "Artifact upload token" rows each had a `min-w-72` (288px) text input without `Stack=true`. On a 402px iPhone viewport there isn't enough horizontal space for both the label column and a 288px input, causing the rows to overflow and mislayout.

## Fix

Added `Stack: true` to both rows so the input renders full-width below the label — the same pattern already used in `my_account.templ` for the same reason. Changed `min-w-72` → `w-full` on both inputs so they fill the stacked column properly. The "Enable developer mode" toggle and "Issue labels" rows are narrow enough to stay inline and are unchanged.

## Screenshots

<table>
  <tr>
    <th>Mobile — before (402px, from issue)</th>
    <th>Mobile — after (390px)</th>
  </tr>
  <tr>
    <td>`&lt;img src="https://bb-artifacts.exe.xyz/f/bcfcae6c57ba14d1.jpg" width="320" alt="before — mobile layout broken"&gt;`</td>
    <td>`&lt;img src="https://bb-artifacts.exe.xyz/f/3adade165ada00ce.jpg" width="320" alt="after — mobile layout fixed"&gt;`</td>
  </tr>
</table>

Desktop — no regression:

`&lt;img src="https://bb-artifacts.exe.xyz/f/579d56d010441010.jpg" width="800" alt="developer settings — desktop after"&gt;`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFq3AfDZeZmm4Nbvggsa26)_