### PR TITLE
fix: serve uploaded avatars when /avatars/{id} receives a short_id

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -57,12 +57,21 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 			// stable slug (/avatars/<slug>?type=agent), so resolve any
 			// per-workflow custom seed before generating — keeping the slug-
 			// keyed render and the api_keys-keyed render (below) consistent.
-			seed := idStr
 			if actor == avatar.ActorAgent {
-				seed = agentAvatarSeed(r.Context(), a.Queries, idStr)
+				seed := agentAvatarSeed(r.Context(), a.Queries, idStr)
+				serveGeneratedAvatarForActor(w, r, seed, actor, size)
+				return
 			}
-			serveGeneratedAvatarForActor(w, r, seed, actor, size)
-			return
+			// The id may be a user short_id. UserAvatar embeds short_ids
+			// (not full UUIDs) in avatar URLs, so without this lookup,
+			// uploaded profile images are never served — the handler would
+			// always fall through to a generated DiceBear avatar.
+			resolved, rerr := a.Queries.GetUserUUIDByShortID(r.Context(), idStr)
+			if rerr != nil {
+				serveGeneratedAvatarForActor(w, r, idStr, actor, size)
+				return
+			}
+			uid = resolved
 		}
 
 		row, err := a.Queries.GetUserAvatar(r.Context(), uid)


### PR DESCRIPTION
Fixes #1795 — user filter tabs on `/accounts` (and the Owner column) show generated DiceBear avatars even when the user has uploaded a profile photo.

## Root cause

`UserAvatar` embeds **short_ids** (8-char base62) in `/avatars/{id}` URLs — both the household-member filter strip and the owner column pass `u.ShortID` as the `ID` prop.

`AvatarHandler` only tried UUID parsing via `resolveUUID`. A short_id fails that parse, so the handler fell straight through to `serveGeneratedAvatarForActor` — uploaded images were never reached.

## Fix

One additional lookup in the non-UUID path of `AvatarHandler` (`internal/admin/avatars.go`):

```
resolveUUID fails
  └─ ActorAgent? → agentAvatarSeed path (unchanged)
  └─ else: GetUserUUIDByShortID
       ├─ found  → uid resolved; fall through to GetUserAvatar
       │               ├─ uploaded image → serve it  ✓
       │               └─ no upload      → DiceBear seed
       └─ not found → DiceBear seed fallback
```

Agent avatar rendering (workflow slugs) is unaffected — it exits before the new lookup.

## Validation

Manually verified the three cases with curl against the dev server:

| ID type | Has upload | Before | After |
|---|---|---|---|
| short_id (`rZx3y8I5`) | ✓ | `image/svg+xml` | **`image/png`** |
| short_id (`RyFoFKhw`) | ✗ | `image/svg+xml` | `image/svg+xml` |
| unknown string | — | `image/svg+xml` | `image/svg+xml` |

All unit tests pass (`go test ./...`).

## Screenshots — `/accounts` page (renders without errors)

<table>
  <tr>
    <th>Desktop (1280×800)</th>
    <th>Mobile (402×714 — issue viewport)</th>
  </tr>
  <tr>
    <td>`&lt;img src="https://bb-artifacts.exe.xyz/f/ca086729967b354d.jpg" width="400" alt="accounts desktop"&gt;`</td>
    <td>`&lt;img src="https://bb-artifacts.exe.xyz/f/65ef7abc4fe5b1c9.jpg" width="200" alt="accounts mobile"&gt;`</td>
  </tr>
</table>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5FruaPktJUb6uZZ4QSsu8)_