### PR TITLE
design(sandbox): Workflows DNA tab + /accounts redesign prototype

### DIFF
--- a/internal/templates/components/pages/design_accounts_redesign.templ
+++ b/internal/templates/components/pages/design_accounts_redesign.templ
@@ -12,7 +12,7 @@ templ SectionAccountsRedesign() {
 		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
 			<p class="font-semibold text-base-content/80 mb-1">Prototype — the DNA applied to /accounts</p>
 			<ul class="space-y-1 list-disc pl-4">
-				<li>Today's <code>/accounts</code> is a 5-column sortable table. This reimagines it as the workflows list-row surface, <strong>grouped by connection</strong> — each institution is a card whose header carries the connection health (one status per connection) and a balance subtotal.</li>
+				<li>Today's <code>/accounts</code> is a 5-column sortable table. This reimagines it as the workflows list-row surface, <strong>grouped by connection</strong> — each institution is a quiet labelled group (name · count · subtotal, the /transactions day-group idiom) carrying the connection health (one status per connection) above its account rows.</li>
 				<li>Rows stay minimal: a type tile, the account name (+ owner avatar), a quiet <code>••••mask · Type</code> line, and the balance. No per-row search or filter tabs — with a household's handful of accounts, grouping is enough.</li>
 				<li>A row opens a quick-manage <code>Drawer</code> (try it) instead of a full-page detour; the full account page stays for transaction history.</li>
 			</ul>
@@ -37,7 +37,7 @@ templ SectionAccountsRedesign() {
 					</select>
 				</div>
 				@designAccountsStatStrip()
-				<div class="flex flex-col gap-3">
+				<div class="flex flex-col gap-5">
 					for _, c := range designAcctConns() {
 						@designAccountConnGroup(c)
 					}
@@ -59,38 +59,31 @@ templ designAccountsStatStrip() {
 	}
 }
 
-// designAccountConnGroup renders one connection as a card: a header naming
-// the institution + account count, its health (badge + reauth/reconnect
-// action when not active), and a balance subtotal on the right — then the
-// account list-rows beneath.
+// designAccountConnGroup renders one connection as a quiet labelled group
+// (the /transactions day-group idiom, not a boxed card header): a light line
+// naming the institution + account count, its health (badge + reauth action
+// when not active), and a balance subtotal on the right — then the account
+// list-rows in their own card beneath.
 templ designAccountConnGroup(c designAcctConn) {
-	<div class="bb-card overflow-hidden">
-		<div class="flex items-center gap-3 px-4 py-3 border-b border-base-200">
-			<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0 text-sm font-semibold text-base-content/70">
-				{ designAcctMonogram(c.Institution) }
-			</div>
-			<div class="min-w-0">
-				<div class="flex items-center gap-2 min-w-0">
-					<span class="font-medium text-sm truncate">{ c.Institution }</span>
-					@designAccountConnStatus(c.Status)
-				</div>
-				<div class="text-xs text-base-content/50">{ designAcctConnCount(c) }</div>
-			</div>
-			<div class="ml-auto text-right shrink-0">
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1 min-w-0">
+			<span class="text-sm font-medium text-base-content shrink-0">{ c.Institution }</span>
+			<span class="text-xs text-base-content/40 shrink-0">{ designAcctConnCount(c) }</span>
+			@designAccountConnStatus(c.Status)
+			<span class="ml-auto shrink-0">
 				@components.Amount(components.AmountProps{
 					Value:  designAcctConnSubtotal(c),
 					Intent: components.AmountBalance,
 					Public: true,
-					Class:  "text-sm font-semibold",
+					Class:  "text-sm font-semibold tabular-nums",
 				})
-				<div class="text-xs text-base-content/50">balance</div>
-			</div>
+			</span>
 		</div>
-		<ul class="list">
+		@components.AgentRunRowList() {
 			for _, a := range c.Accounts {
 				@designAccountRow(a)
 			}
-		</ul>
+		}
 	</div>
 }
 

--- a/internal/templates/components/pages/design_accounts_redesign.templ
+++ b/internal/templates/components/pages/design_accounts_redesign.templ
@@ -3,96 +3,119 @@ package pages
 import "breadbox/internal/templates/components"
 
 // SectionAccountsRedesign is the Workflows-DNA-applied prototype of the
-// /accounts page: the dense sortable table reimagined as the list-row
-// surface the workflows pages use. It demonstrates the three big moves —
-// status in one leading tile (with a corner health dot), one body line by
-// priority, and a quick-manage slide-over Drawer — against real components
-// and sample data. Demo only; nothing here is wired to live accounts.
+// /accounts page: the dense sortable table reimagined as the workflows
+// list-row surface, now grouped by connection. Connection health lives on
+// the group header (one status per connection); each account is a clean
+// list-row; a row opens a quick-manage slide-over Drawer. Demo only.
 templ SectionAccountsRedesign() {
-	<div x-data="{ filter: '' }" class="flex flex-col gap-6">
+	<div class="flex flex-col gap-6">
 		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
 			<p class="font-semibold text-base-content/80 mb-1">Prototype — the DNA applied to /accounts</p>
 			<ul class="space-y-1 list-disc pl-4">
-				<li>Today's <code>/accounts</code> is a 5-column sortable table. This reimagines it as the workflows list-row surface: a leading <strong>type tile that carries connection health</strong> (corner dot — amber reauth, red disconnected), <strong>one body line by priority</strong> (a connection problem replaces the normal <code>Institution · ••••mask · Type</code> meta), and a trailing balance.</li>
-				<li>The filter row mirrors <code>/workflows/runs</code>: a box <code>TabBar</code> segmented by type with counts, a member dropdown, a sort dropdown, and search.</li>
-				<li>A row opens a quick-manage <code>Drawer</code> (try it) instead of a full-page detour — the full account page stays for the transaction history.</li>
+				<li>Today's <code>/accounts</code> is a 5-column sortable table. This reimagines it as the workflows list-row surface, <strong>grouped by connection</strong> — each institution is a card whose header carries the connection health (one status per connection) and a balance subtotal.</li>
+				<li>Rows stay minimal: a type tile, the account name (+ owner avatar), a quiet <code>••••mask · Type</code> line, and the balance. No per-row search or filter tabs — with a household's handful of accounts, grouping is enough.</li>
+				<li>A row opens a quick-manage <code>Drawer</code> (try it) instead of a full-page detour; the full account page stays for transaction history.</li>
 			</ul>
 		</div>
-		@designExample("The redesigned surface", "Header → type filter (box TabBar + counts) + member/sort dropdowns + search → net-worth stat strip → the account list. Click any row to open the manage drawer.") {
+		@designExample("The redesigned surface", "Header → a slim Group-by / member control (dropdowns, never full-width tabs) → net-worth stat strip → connection groups. Click any row to open the manage drawer.") {
 			<div class="flex flex-col gap-4">
 				@components.PageHeader(components.PageHeaderProps{
 					Title:                "Accounts",
 					Subtitle:             "Every account across your connections, in one view.",
 					SubtitleHideOnMobile: true,
 				})
-				<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-					@components.TabBar(components.TabBarProps{
-						Variant:   "box",
-						AriaLabel: "Filter accounts by type (demo)",
-						Items: []components.TabBarItem{
-							{Label: "All", Href: "#", Active: true, Count: components.SectionHeaderIntPtr(6)},
-							{Label: "Cash", Href: "#", Count: components.SectionHeaderIntPtr(3)},
-							{Label: "Credit", Href: "#", Count: components.SectionHeaderIntPtr(1)},
-							{Label: "Investments", Href: "#", Count: components.SectionHeaderIntPtr(1)},
-							{Label: "Loans", Href: "#", Count: components.SectionHeaderIntPtr(1)},
-						},
-					})
-					<div class="flex items-center gap-2">
-						<select class="select select-sm w-36" aria-label="Filter by member (demo)">
-							<option>All members</option>
-							<option>Alice</option>
-							<option>Bob</option>
-						</select>
-						<select class="select select-sm w-40" aria-label="Sort accounts (demo)">
-							<option>Sort: Balance</option>
-							<option>Sort: Name</option>
-							<option>Sort: Institution</option>
-						</select>
-					</div>
+				<div class="flex items-center justify-between gap-2">
+					<select class="select select-sm w-52" aria-label="Group accounts (demo)">
+						<option>Group by: Connection</option>
+						<option>Group by: Type</option>
+						<option>No grouping</option>
+					</select>
+					<select class="select select-sm w-36" aria-label="Filter by member (demo)">
+						<option>All members</option>
+						<option>Alice</option>
+						<option>Bob</option>
+					</select>
 				</div>
-				@components.FilterSearchInput(components.FilterSearchInputProps{
-					Placeholder: "Filter accounts…",
-					XModel:      "filter",
-				})
 				@designAccountsStatStrip()
-				@components.AgentRunRowList() {
-					for _, d := range designAcctRows() {
-						@designAccountRow(d)
+				<div class="flex flex-col gap-3">
+					for _, c := range designAcctConns() {
+						@designAccountConnGroup(c)
 					}
-				}
+				</div>
 			</div>
 			@designAccountsManageDrawer()
 		}
 	</div>
 }
 
-// designAccountsStatStrip is the net-worth / assets / liabilities summary —
-// kept as data-viz (StatTileRow), calmed to match the surface. Figures are
-// the sum of the sample rows and rendered Public so privacy mode leaves the
-// demo visible.
+// designAccountsStatStrip is the net-worth / assets / liabilities summary,
+// kept as data-viz (StatTileRow). Figures are the sum of the sample rows,
+// Public so privacy mode leaves the demo visible.
 templ designAccountsStatStrip() {
 	@components.StatTileRow() {
-		@components.StatTile(components.StatTileProps{Label: "Net worth", Value: "$48,010.55", Tone: components.StatTonePrimary})
+		@components.StatTile(components.StatTileProps{Label: "Net worth", Value: "$47,168.25", Tone: components.StatTonePrimary})
 		@components.StatTile(components.StatTileProps{Label: "Assets", Value: "$52,577.10", Tone: components.StatToneSuccess})
-		@components.StatTile(components.StatTileProps{Label: "Liabilities", Value: "−$4,566.55", Tone: components.StatToneError})
+		@components.StatTile(components.StatTileProps{Label: "Liabilities", Value: "−$5,408.85", Tone: components.StatToneError})
+	}
+}
+
+// designAccountConnGroup renders one connection as a card: a header naming
+// the institution + account count, its health (badge + reauth/reconnect
+// action when not active), and a balance subtotal on the right — then the
+// account list-rows beneath.
+templ designAccountConnGroup(c designAcctConn) {
+	<div class="bb-card overflow-hidden">
+		<div class="flex items-center gap-3 px-4 py-3 border-b border-base-200">
+			<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0 text-sm font-semibold text-base-content/70">
+				{ designAcctMonogram(c.Institution) }
+			</div>
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="font-medium text-sm truncate">{ c.Institution }</span>
+					@designAccountConnStatus(c.Status)
+				</div>
+				<div class="text-xs text-base-content/50">{ designAcctConnCount(c) }</div>
+			</div>
+			<div class="ml-auto text-right shrink-0">
+				@components.Amount(components.AmountProps{
+					Value:  designAcctConnSubtotal(c),
+					Intent: components.AmountBalance,
+					Public: true,
+					Class:  "text-sm font-semibold",
+				})
+				<div class="text-xs text-base-content/50">balance</div>
+			</div>
+		</div>
+		<ul class="list">
+			for _, a := range c.Accounts {
+				@designAccountRow(a)
+			}
+		</ul>
+	</div>
+}
+
+// designAccountConnStatus surfaces connection health on the group header —
+// a soft badge + an inline recovery action, only when not active.
+templ designAccountConnStatus(status string) {
+	if status == "pending_reauth" {
+		<span class="badge badge-soft badge-warning badge-xs shrink-0">Reauth needed</span>
+		<button type="button" class="text-xs text-warning hover:underline shrink-0" @click="$store.drawers.open('acct-manage')">Reauthenticate</button>
+	} else if status == "disconnected" {
+		<span class="badge badge-soft badge-error badge-xs shrink-0">Disconnected</span>
+		<button type="button" class="text-xs text-error hover:underline shrink-0">Reconnect</button>
 	}
 }
 
 // designAccountRow renders one account as a list-row modelled on AgentRunRow:
-// a leading type tile with a connection-health corner dot, a title row (name
-// + badge + owner avatar), one priority-ordered body line, a trailing
-// balance, and an overflow menu outside the row's click target.
+// a leading type tile, a title row (name + badge + owner avatar), a quiet
+// mask·type line, a trailing balance, and an overflow menu outside the row's
+// click target. Connection health is NOT repeated here — it lives on the
+// group header.
 templ designAccountRow(d designAcctRow) {
 	<li class="list-row transition-colors hover:bg-base-200/40 items-center">
 		<div class="contents cursor-pointer" @click="$store.drawers.open('acct-manage')">
-			<div class="relative w-10 h-10 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+			<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
 				@components.LucideIcon(d.Icon, "w-4 h-4 text-base-content/70")
-				if d.Status != "" {
-					<span
-						class={ "absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ring-2 ring-base-100", designAcctDotClass(d.Status) }
-						title={ "Connection: " + d.Status }
-					></span>
-				}
 			</div>
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 min-w-0">
@@ -112,7 +135,9 @@ templ designAccountRow(d designAcctRow) {
 						})
 					}
 				</div>
-				@designAccountRowBody(d)
+				<div class="mt-0.5 text-xs text-base-content/60 min-w-0">
+					<span class="line-clamp-1">{ designAcctMeta(d) }</span>
+				</div>
 			</div>
 			<div class="shrink-0 self-center text-right">
 				if d.HasBalance {
@@ -141,43 +166,24 @@ templ designAccountRow(d designAcctRow) {
 	</li>
 }
 
-// designAccountRowBody is the single body line, priority-ordered: a
-// connection problem shouts (amber reauth / red disconnected); otherwise the
-// quiet Institution · ••••mask · Type meta. Mirrors AgentRunRow's body stack.
-templ designAccountRowBody(d designAcctRow) {
-	if d.Status == "pending_reauth" {
-		<div class="mt-0.5 text-xs text-warning/90 min-w-0">
-			<span class="line-clamp-1">Reauthentication needed</span>
-		</div>
-	} else if d.Status == "disconnected" {
-		<div class="mt-0.5 text-xs text-error/90 min-w-0">
-			<span class="line-clamp-1">Disconnected — reconnect to resume syncing</span>
-		</div>
-	} else {
-		<div class="mt-0.5 text-xs text-base-content/60 min-w-0">
-			<span class="line-clamp-1">{ designAcctMeta(d) }</span>
-		</div>
-	}
-}
-
 // designAccountsManageDrawer is the quick-manage slide-over a row opens — the
 // workflows configure/reconfigure pattern applied: header with an Exclude
 // toggle in the Right slot, a balance summary + a reauth callout + quick
 // fields, and a footer that links out to the full transaction page.
 templ designAccountsManageDrawer() {
-	@components.Drawer(components.DrawerProps{ID: "acct-manage", Title: "Manage Sapphire Card"}) {
+	@components.Drawer(components.DrawerProps{ID: "acct-manage", Title: "Manage Platinum Card"}) {
 		<form class="flex flex-col h-full" @submit.prevent="$store.drawers.close()">
 			@components.DrawerHeader(components.DrawerHeaderProps{
 				Icon:     "credit-card",
-				Title:    "Sapphire Card",
-				Subtitle: "Chase · Credit card",
+				Title:    "Platinum Card",
+				Subtitle: "American Express · Credit card",
 				Right:    designAcctExcludeToggle(),
 			})
 			<div class="flex-1 overflow-y-auto p-5 space-y-5">
 				<div class="grid grid-cols-3 gap-3">
-					@designAcctStatlet("Current", "−$1,204.55", "text-error")
-					@designAcctStatlet("Available", "$3,795.45", "")
-					@designAcctStatlet("Limit", "$5,000.00", "")
+					@designAcctStatlet("Current", "−$842.30", "text-error")
+					@designAcctStatlet("Available", "$24,157.70", "")
+					@designAcctStatlet("Limit", "$25,000.00", "")
 				</div>
 				<div class="rounded-xl border border-warning/30 bg-warning/5 px-4 py-3 flex items-center justify-between gap-3">
 					<div class="flex items-center gap-2 text-sm text-warning min-w-0">
@@ -188,13 +194,13 @@ templ designAccountsManageDrawer() {
 				</div>
 				<div>
 					<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="acct-name">Display name</label>
-					<input id="acct-name" type="text" class="input w-full" value="Sapphire Card"/>
+					<input id="acct-name" type="text" class="input w-full" value="Platinum Card"/>
 				</div>
 				<div>
 					<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="acct-owner">Owner</label>
 					<select id="acct-owner" class="select w-full">
-						<option selected>Bob</option>
-						<option>Alice</option>
+						<option selected>Alice</option>
+						<option>Bob</option>
 						<option>No owner</option>
 					</select>
 				</div>

--- a/internal/templates/components/pages/design_accounts_redesign.templ
+++ b/internal/templates/components/pages/design_accounts_redesign.templ
@@ -1,0 +1,232 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// SectionAccountsRedesign is the Workflows-DNA-applied prototype of the
+// /accounts page: the dense sortable table reimagined as the list-row
+// surface the workflows pages use. It demonstrates the three big moves —
+// status in one leading tile (with a corner health dot), one body line by
+// priority, and a quick-manage slide-over Drawer — against real components
+// and sample data. Demo only; nothing here is wired to live accounts.
+templ SectionAccountsRedesign() {
+	<div x-data="{ filter: '' }" class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">Prototype — the DNA applied to /accounts</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>Today's <code>/accounts</code> is a 5-column sortable table. This reimagines it as the workflows list-row surface: a leading <strong>type tile that carries connection health</strong> (corner dot — amber reauth, red disconnected), <strong>one body line by priority</strong> (a connection problem replaces the normal <code>Institution · ••••mask · Type</code> meta), and a trailing balance.</li>
+				<li>The filter row mirrors <code>/workflows/runs</code>: a box <code>TabBar</code> segmented by type with counts, a member dropdown, a sort dropdown, and search.</li>
+				<li>A row opens a quick-manage <code>Drawer</code> (try it) instead of a full-page detour — the full account page stays for the transaction history.</li>
+			</ul>
+		</div>
+		@designExample("The redesigned surface", "Header → type filter (box TabBar + counts) + member/sort dropdowns + search → net-worth stat strip → the account list. Click any row to open the manage drawer.") {
+			<div class="flex flex-col gap-4">
+				@components.PageHeader(components.PageHeaderProps{
+					Title:                "Accounts",
+					Subtitle:             "Every account across your connections, in one view.",
+					SubtitleHideOnMobile: true,
+				})
+				<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+					@components.TabBar(components.TabBarProps{
+						Variant:   "box",
+						AriaLabel: "Filter accounts by type (demo)",
+						Items: []components.TabBarItem{
+							{Label: "All", Href: "#", Active: true, Count: components.SectionHeaderIntPtr(6)},
+							{Label: "Cash", Href: "#", Count: components.SectionHeaderIntPtr(3)},
+							{Label: "Credit", Href: "#", Count: components.SectionHeaderIntPtr(1)},
+							{Label: "Investments", Href: "#", Count: components.SectionHeaderIntPtr(1)},
+							{Label: "Loans", Href: "#", Count: components.SectionHeaderIntPtr(1)},
+						},
+					})
+					<div class="flex items-center gap-2">
+						<select class="select select-sm w-36" aria-label="Filter by member (demo)">
+							<option>All members</option>
+							<option>Alice</option>
+							<option>Bob</option>
+						</select>
+						<select class="select select-sm w-40" aria-label="Sort accounts (demo)">
+							<option>Sort: Balance</option>
+							<option>Sort: Name</option>
+							<option>Sort: Institution</option>
+						</select>
+					</div>
+				</div>
+				@components.FilterSearchInput(components.FilterSearchInputProps{
+					Placeholder: "Filter accounts…",
+					XModel:      "filter",
+				})
+				@designAccountsStatStrip()
+				@components.AgentRunRowList() {
+					for _, d := range designAcctRows() {
+						@designAccountRow(d)
+					}
+				}
+			</div>
+			@designAccountsManageDrawer()
+		}
+	</div>
+}
+
+// designAccountsStatStrip is the net-worth / assets / liabilities summary —
+// kept as data-viz (StatTileRow), calmed to match the surface. Figures are
+// the sum of the sample rows and rendered Public so privacy mode leaves the
+// demo visible.
+templ designAccountsStatStrip() {
+	@components.StatTileRow() {
+		@components.StatTile(components.StatTileProps{Label: "Net worth", Value: "$48,010.55", Tone: components.StatTonePrimary})
+		@components.StatTile(components.StatTileProps{Label: "Assets", Value: "$52,577.10", Tone: components.StatToneSuccess})
+		@components.StatTile(components.StatTileProps{Label: "Liabilities", Value: "−$4,566.55", Tone: components.StatToneError})
+	}
+}
+
+// designAccountRow renders one account as a list-row modelled on AgentRunRow:
+// a leading type tile with a connection-health corner dot, a title row (name
+// + badge + owner avatar), one priority-ordered body line, a trailing
+// balance, and an overflow menu outside the row's click target.
+templ designAccountRow(d designAcctRow) {
+	<li class="list-row transition-colors hover:bg-base-200/40 items-center">
+		<div class="contents cursor-pointer" @click="$store.drawers.open('acct-manage')">
+			<div class="relative w-10 h-10 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+				@components.LucideIcon(d.Icon, "w-4 h-4 text-base-content/70")
+				if d.Status != "" {
+					<span
+						class={ "absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ring-2 ring-base-100", designAcctDotClass(d.Status) }
+						title={ "Connection: " + d.Status }
+					></span>
+				}
+			</div>
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="font-medium text-sm text-base-content truncate">{ d.Name }</span>
+					if d.Badge != "" {
+						<span class={ "badge badge-soft badge-xs shrink-0", designAcctBadgeTone(d.Badge) }>{ d.Badge }</span>
+					}
+					if d.OwnerName != "" {
+						@components.UserAvatar(components.UserAvatarProps{
+							ID:         d.OwnerID,
+							Name:       d.OwnerName,
+							Version:    designAcctOwnerVersion(d),
+							Size:       components.UserAvatarXS,
+							Decorative: true,
+							Lazy:       true,
+							Class:      "shrink-0",
+						})
+					}
+				</div>
+				@designAccountRowBody(d)
+			</div>
+			<div class="shrink-0 self-center text-right">
+				if d.HasBalance {
+					@components.Amount(components.AmountProps{
+						Value:  d.Balance,
+						Intent: components.AmountBalance,
+						Public: true,
+						Class:  designAcctAmountClass(d.IsLiability),
+					})
+				} else {
+					<span class="text-sm text-base-content/30">—</span>
+				}
+			</div>
+		</div>
+		<div class="shrink-0 self-center">
+			@components.OverflowMenu(components.OverflowMenuProps{
+				AriaLabel: d.Name + " actions",
+				Size:      "sm",
+				Items: []components.OverflowMenuItem{
+					{Label: "Manage account", Icon: "settings-2", OnClick: "$store.drawers.open('acct-manage')"},
+					{Label: "View all transactions", Icon: "external-link", Href: "#"},
+					{Label: "Exclude from totals", Icon: "eye-off", OnClick: ""},
+				},
+			})
+		</div>
+	</li>
+}
+
+// designAccountRowBody is the single body line, priority-ordered: a
+// connection problem shouts (amber reauth / red disconnected); otherwise the
+// quiet Institution · ••••mask · Type meta. Mirrors AgentRunRow's body stack.
+templ designAccountRowBody(d designAcctRow) {
+	if d.Status == "pending_reauth" {
+		<div class="mt-0.5 text-xs text-warning/90 min-w-0">
+			<span class="line-clamp-1">Reauthentication needed</span>
+		</div>
+	} else if d.Status == "disconnected" {
+		<div class="mt-0.5 text-xs text-error/90 min-w-0">
+			<span class="line-clamp-1">Disconnected — reconnect to resume syncing</span>
+		</div>
+	} else {
+		<div class="mt-0.5 text-xs text-base-content/60 min-w-0">
+			<span class="line-clamp-1">{ designAcctMeta(d) }</span>
+		</div>
+	}
+}
+
+// designAccountsManageDrawer is the quick-manage slide-over a row opens — the
+// workflows configure/reconfigure pattern applied: header with an Exclude
+// toggle in the Right slot, a balance summary + a reauth callout + quick
+// fields, and a footer that links out to the full transaction page.
+templ designAccountsManageDrawer() {
+	@components.Drawer(components.DrawerProps{ID: "acct-manage", Title: "Manage Sapphire Card"}) {
+		<form class="flex flex-col h-full" @submit.prevent="$store.drawers.close()">
+			@components.DrawerHeader(components.DrawerHeaderProps{
+				Icon:     "credit-card",
+				Title:    "Sapphire Card",
+				Subtitle: "Chase · Credit card",
+				Right:    designAcctExcludeToggle(),
+			})
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
+				<div class="grid grid-cols-3 gap-3">
+					@designAcctStatlet("Current", "−$1,204.55", "text-error")
+					@designAcctStatlet("Available", "$3,795.45", "")
+					@designAcctStatlet("Limit", "$5,000.00", "")
+				</div>
+				<div class="rounded-xl border border-warning/30 bg-warning/5 px-4 py-3 flex items-center justify-between gap-3">
+					<div class="flex items-center gap-2 text-sm text-warning min-w-0">
+						@components.LucideIcon("triangle-alert", "w-4 h-4 shrink-0")
+						<span class="truncate">Reauthentication needed</span>
+					</div>
+					<button type="button" class="btn btn-warning btn-sm shrink-0">Reauthenticate</button>
+				</div>
+				<div>
+					<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="acct-name">Display name</label>
+					<input id="acct-name" type="text" class="input w-full" value="Sapphire Card"/>
+				</div>
+				<div>
+					<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="acct-owner">Owner</label>
+					<select id="acct-owner" class="select w-full">
+						<option selected>Bob</option>
+						<option>Alice</option>
+						<option>No owner</option>
+					</select>
+				</div>
+			</div>
+			@components.DrawerFooter() {
+				<a href="#" class="btn btn-ghost btn-sm gap-1.5 mr-auto">
+					@components.LucideIcon("external-link", "w-4 h-4")
+					View all transactions
+				</a>
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+				<button type="submit" class="btn btn-primary btn-sm gap-1.5">
+					@components.LucideIcon("save", "w-4 h-4")
+					Save
+				</button>
+			}
+		</form>
+	}
+}
+
+// designAcctStatlet is one cell in the drawer's balance summary.
+templ designAcctStatlet(label, value, valueClass string) {
+	<div class="rounded-lg bg-base-200/60 px-3 py-2">
+		<div class="text-[0.65rem] uppercase tracking-wide text-base-content/50">{ label }</div>
+		<div class={ "text-sm font-semibold tabular-nums mt-0.5", valueClass }>{ value }</div>
+	</div>
+}
+
+// designAcctExcludeToggle is the exclude-from-totals control in the manage
+// drawer's header Right slot.
+templ designAcctExcludeToggle() {
+	<label class="flex items-center gap-2 text-xs text-base-content/60 cursor-pointer">
+		<span>Exclude</span>
+		<input type="checkbox" class="toggle toggle-sm" aria-label="Exclude from totals (demo)"/>
+	</label>
+}

--- a/internal/templates/components/pages/design_accounts_redesign_helpers.go
+++ b/internal/templates/components/pages/design_accounts_redesign_helpers.go
@@ -91,14 +91,6 @@ func designAcctConnCount(c designAcctConn) string {
 	return fmt.Sprintf("%d accounts", len(c.Accounts))
 }
 
-// designAcctMonogram is the connection tile's letter fallback.
-func designAcctMonogram(institution string) string {
-	if institution == "" {
-		return "?"
-	}
-	return strings.ToUpper(institution[:1])
-}
-
 // designAcctBadgeTone maps an inline row badge to its daisy soft tone.
 func designAcctBadgeTone(badge string) string {
 	switch badge {

--- a/internal/templates/components/pages/design_accounts_redesign_helpers.go
+++ b/internal/templates/components/pages/design_accounts_redesign_helpers.go
@@ -1,0 +1,86 @@
+//go:build !headless && !lite
+
+package pages
+
+import "fmt"
+
+// design_accounts_redesign_helpers.go holds the sample data + small class
+// helpers for SectionAccountsRedesign — the Workflows-DNA-applied prototype
+// of the /accounts page. Demo only; figures are illustrative (rendered
+// Public so privacy mode leaves them visible in the sandbox).
+
+// designAcctRow is one sample account in the redesign prototype.
+type designAcctRow struct {
+	Icon        string  // lucide type icon (wallet / credit-card / trending-up / landmark)
+	Name        string  // display name
+	Institution string  // bank
+	Mask        string  // last-4, "" when none
+	TypeLabel   string  // human type ("Checking", "Credit card", …)
+	OwnerName   string  // "" when no linked member
+	OwnerID     string  // avatar seed
+	Balance     float64 // sign reflects asset(+)/liability(−)
+	HasBalance  bool
+	IsLiability bool
+	Status      string // "" healthy | "pending_reauth" | "disconnected"
+	Badge       string // "" | "Linked" | "Excluded"
+}
+
+// designAcctRows is the fixed sample set: a mix of types, owners, balances,
+// and connection-health states so every row variant is visible.
+func designAcctRows() []designAcctRow {
+	return []designAcctRow{
+		{Icon: "wallet", Name: "Everyday Checking", Institution: "Chase", Mask: "1234", TypeLabel: "Checking", OwnerName: "Alice", OwnerID: "alice", Balance: 12340.18, HasBalance: true},
+		{Icon: "credit-card", Name: "Sapphire Card", Institution: "Chase", Mask: "8021", TypeLabel: "Credit card", OwnerName: "Bob", OwnerID: "bob", Balance: -1204.55, HasBalance: true, IsLiability: true, Status: "pending_reauth"},
+		{Icon: "trending-up", Name: "Brokerage", Institution: "Fidelity", TypeLabel: "Investment", Balance: 34120.00, HasBalance: true},
+		{Icon: "landmark", Name: "Auto Loan", Institution: "Ally", Mask: "5567", TypeLabel: "Loan", OwnerName: "Alice", OwnerID: "alice", Balance: -3362.00, HasBalance: true, IsLiability: true},
+		{Icon: "wallet", Name: "High-Yield Savings", Institution: "Ally", Mask: "9930", TypeLabel: "Savings", OwnerName: "Alice", OwnerID: "alice", Balance: 6116.92, HasBalance: true, Badge: "Linked"},
+		{Icon: "wallet", Name: "Old Savings", Institution: "Ally", Mask: "2231", TypeLabel: "Savings", HasBalance: false, Status: "disconnected"},
+	}
+}
+
+// designAcctMeta is the healthy-state body line: "Institution · ••••mask · Type".
+func designAcctMeta(d designAcctRow) string {
+	s := d.Institution
+	if d.Mask != "" {
+		s += " · ••••" + d.Mask
+	}
+	if d.TypeLabel != "" {
+		s += " · " + d.TypeLabel
+	}
+	return s
+}
+
+// designAcctDotClass maps connection health to the leading-tile corner dot.
+func designAcctDotClass(status string) string {
+	switch status {
+	case "pending_reauth":
+		return "bg-warning"
+	case "disconnected", "error":
+		return "bg-error"
+	default:
+		return "bg-base-300"
+	}
+}
+
+// designAcctBadgeTone maps an inline row badge to its daisy soft tone.
+func designAcctBadgeTone(badge string) string {
+	switch badge {
+	case "Excluded":
+		return "badge-warning"
+	default: // Linked
+		return "badge-info"
+	}
+}
+
+// designAcctAmountClass tints liabilities red; assets keep the default ink.
+func designAcctAmountClass(isLiability bool) string {
+	if isLiability {
+		return "text-sm font-semibold text-error"
+	}
+	return "text-sm font-semibold"
+}
+
+// designAcctOwnerVersion is a stable cache-bust stub for sample avatars.
+func designAcctOwnerVersion(d designAcctRow) string {
+	return fmt.Sprintf("demo-%s", d.OwnerID)
+}

--- a/internal/templates/components/pages/design_accounts_redesign_helpers.go
+++ b/internal/templates/components/pages/design_accounts_redesign_helpers.go
@@ -2,18 +2,20 @@
 
 package pages
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // design_accounts_redesign_helpers.go holds the sample data + small class
 // helpers for SectionAccountsRedesign — the Workflows-DNA-applied prototype
 // of the /accounts page. Demo only; figures are illustrative (rendered
 // Public so privacy mode leaves them visible in the sandbox).
 
-// designAcctRow is one sample account in the redesign prototype.
+// designAcctRow is one sample account within a connection group.
 type designAcctRow struct {
 	Icon        string  // lucide type icon (wallet / credit-card / trending-up / landmark)
 	Name        string  // display name
-	Institution string  // bank
 	Mask        string  // last-4, "" when none
 	TypeLabel   string  // human type ("Checking", "Credit card", …)
 	OwnerName   string  // "" when no linked member
@@ -21,45 +23,80 @@ type designAcctRow struct {
 	Balance     float64 // sign reflects asset(+)/liability(−)
 	HasBalance  bool
 	IsLiability bool
-	Status      string // "" healthy | "pending_reauth" | "disconnected"
 	Badge       string // "" | "Linked" | "Excluded"
 }
 
-// designAcctRows is the fixed sample set: a mix of types, owners, balances,
-// and connection-health states so every row variant is visible.
-func designAcctRows() []designAcctRow {
-	return []designAcctRow{
-		{Icon: "wallet", Name: "Everyday Checking", Institution: "Chase", Mask: "1234", TypeLabel: "Checking", OwnerName: "Alice", OwnerID: "alice", Balance: 12340.18, HasBalance: true},
-		{Icon: "credit-card", Name: "Sapphire Card", Institution: "Chase", Mask: "8021", TypeLabel: "Credit card", OwnerName: "Bob", OwnerID: "bob", Balance: -1204.55, HasBalance: true, IsLiability: true, Status: "pending_reauth"},
-		{Icon: "trending-up", Name: "Brokerage", Institution: "Fidelity", TypeLabel: "Investment", Balance: 34120.00, HasBalance: true},
-		{Icon: "landmark", Name: "Auto Loan", Institution: "Ally", Mask: "5567", TypeLabel: "Loan", OwnerName: "Alice", OwnerID: "alice", Balance: -3362.00, HasBalance: true, IsLiability: true},
-		{Icon: "wallet", Name: "High-Yield Savings", Institution: "Ally", Mask: "9930", TypeLabel: "Savings", OwnerName: "Alice", OwnerID: "alice", Balance: 6116.92, HasBalance: true, Badge: "Linked"},
-		{Icon: "wallet", Name: "Old Savings", Institution: "Ally", Mask: "2231", TypeLabel: "Savings", HasBalance: false, Status: "disconnected"},
+// designAcctConn is one connection (institution) — the grouping unit.
+// Connection health lives here (one status per connection), so individual
+// rows don't repeat it.
+type designAcctConn struct {
+	Institution string
+	Status      string // "active" | "pending_reauth" | "disconnected"
+	Accounts    []designAcctRow
+}
+
+// designAcctConns is the fixed sample set, grouped by connection: a mix of
+// sizes, owners, balances, and connection-health states.
+func designAcctConns() []designAcctConn {
+	return []designAcctConn{
+		{Institution: "Chase", Status: "active", Accounts: []designAcctRow{
+			{Icon: "wallet", Name: "Everyday Checking", Mask: "1234", TypeLabel: "Checking", OwnerName: "Alice", OwnerID: "alice", Balance: 12340.18, HasBalance: true},
+			{Icon: "credit-card", Name: "Sapphire Card", Mask: "8021", TypeLabel: "Credit card", OwnerName: "Bob", OwnerID: "bob", Balance: -1204.55, HasBalance: true, IsLiability: true},
+		}},
+		{Institution: "American Express", Status: "pending_reauth", Accounts: []designAcctRow{
+			{Icon: "credit-card", Name: "Platinum Card", Mask: "3007", TypeLabel: "Credit card", OwnerName: "Alice", OwnerID: "alice", Balance: -842.30, HasBalance: true, IsLiability: true},
+		}},
+		{Institution: "Fidelity", Status: "active", Accounts: []designAcctRow{
+			{Icon: "trending-up", Name: "Brokerage", TypeLabel: "Investment", Balance: 34120.00, HasBalance: true},
+		}},
+		{Institution: "Ally", Status: "active", Accounts: []designAcctRow{
+			{Icon: "wallet", Name: "High-Yield Savings", Mask: "9930", TypeLabel: "Savings", OwnerName: "Alice", OwnerID: "alice", Balance: 6116.92, HasBalance: true, Badge: "Linked"},
+			{Icon: "landmark", Name: "Auto Loan", Mask: "5567", TypeLabel: "Loan", OwnerName: "Alice", OwnerID: "alice", Balance: -3362.00, HasBalance: true, IsLiability: true},
+		}},
+		{Institution: "Old National", Status: "disconnected", Accounts: []designAcctRow{
+			{Icon: "wallet", Name: "Legacy Savings", Mask: "2231", TypeLabel: "Savings", HasBalance: false},
+		}},
 	}
 }
 
-// designAcctMeta is the healthy-state body line: "Institution · ••••mask · Type".
+// designAcctMeta is the per-row body line — "••••mask · Type". Institution
+// is omitted: the connection group header already names it.
 func designAcctMeta(d designAcctRow) string {
-	s := d.Institution
+	parts := make([]string, 0, 2)
 	if d.Mask != "" {
-		s += " · ••••" + d.Mask
+		parts = append(parts, "••••"+d.Mask)
 	}
 	if d.TypeLabel != "" {
-		s += " · " + d.TypeLabel
+		parts = append(parts, d.TypeLabel)
 	}
-	return s
+	return strings.Join(parts, " · ")
 }
 
-// designAcctDotClass maps connection health to the leading-tile corner dot.
-func designAcctDotClass(status string) string {
-	switch status {
-	case "pending_reauth":
-		return "bg-warning"
-	case "disconnected", "error":
-		return "bg-error"
-	default:
-		return "bg-base-300"
+// designAcctConnSubtotal sums the balances of a connection's accounts.
+func designAcctConnSubtotal(c designAcctConn) float64 {
+	var t float64
+	for _, a := range c.Accounts {
+		if a.HasBalance {
+			t += a.Balance
+		}
 	}
+	return t
+}
+
+// designAcctConnCount is the dimmed "N accounts" label under the institution.
+func designAcctConnCount(c designAcctConn) string {
+	if len(c.Accounts) == 1 {
+		return "1 account"
+	}
+	return fmt.Sprintf("%d accounts", len(c.Accounts))
+}
+
+// designAcctMonogram is the connection tile's letter fallback.
+func designAcctMonogram(institution string) string {
+	if institution == "" {
+		return "?"
+	}
+	return strings.ToUpper(institution[:1])
 }
 
 // designAcctBadgeTone maps an inline row badge to its daisy soft tone.
@@ -82,5 +119,5 @@ func designAcctAmountClass(isLiability bool) string {
 
 // designAcctOwnerVersion is a stable cache-bust stub for sample avatars.
 func designAcctOwnerVersion(d designAcctRow) string {
-	return fmt.Sprintf("demo-%s", d.OwnerID)
+	return "demo-" + d.OwnerID
 }

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -539,7 +539,7 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "wf-dna-accounts",
 			Title:       "Applied — /accounts redesign (prototype)",
-			Description: "The DNA reapplied to a real page: /accounts' dense sortable table reimagined as the workflows list-row surface, grouped by connection. Each institution is a card whose header carries the connection health + a balance subtotal; rows stay minimal; a quick-manage slide-over Drawer replaces the full-page detour. No search/filter-tabs — grouping is enough for a household's handful of accounts. Prototype with sample data; not wired to live accounts.",
+			Description: "The DNA reapplied to a real page: /accounts' dense sortable table reimagined as the workflows list-row surface, grouped by connection. Each institution is a quiet labelled group (name · count · subtotal — the /transactions day-group idiom) carrying connection health above its account rows; a quick-manage slide-over Drawer replaces the full-page detour. No search/filter-tabs — grouping is enough for a household's handful of accounts. Prototype with sample data; not wired to live accounts.",
 			Group:       "workflows-dna",
 			Render:      func() templ.Component { return SectionAccountsRedesign() },
 		},

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -536,6 +536,13 @@ func DesignSections() []DesignSection {
 			Group:       "workflows-dna",
 			Render:      func() templ.Component { return SectionWFDNADrawer() },
 		},
+		{
+			Slug:        "wf-dna-accounts",
+			Title:       "Applied — /accounts redesign (prototype)",
+			Description: "The DNA reapplied to a real page: /accounts' dense sortable table reimagined as the workflows list-row surface — status in one leading tile (corner health dot), one body line by priority, a type-segment filter row, and a quick-manage slide-over Drawer. Prototype with sample data; not wired to live accounts.",
+			Group:       "workflows-dna",
+			Render:      func() templ.Component { return SectionAccountsRedesign() },
+		},
 	}
 }
 

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -539,7 +539,7 @@ func DesignSections() []DesignSection {
 		{
 			Slug:        "wf-dna-accounts",
 			Title:       "Applied — /accounts redesign (prototype)",
-			Description: "The DNA reapplied to a real page: /accounts' dense sortable table reimagined as the workflows list-row surface — status in one leading tile (corner health dot), one body line by priority, a type-segment filter row, and a quick-manage slide-over Drawer. Prototype with sample data; not wired to live accounts.",
+			Description: "The DNA reapplied to a real page: /accounts' dense sortable table reimagined as the workflows list-row surface, grouped by connection. Each institution is a card whose header carries the connection health + a balance subtotal; rows stay minimal; a quick-manage slide-over Drawer replaces the full-page detour. No search/filter-tabs — grouping is enough for a household's handful of accounts. Prototype with sample data; not wired to live accounts.",
 			Group:       "workflows-dna",
 			Render:      func() templ.Component { return SectionAccountsRedesign() },
 		},

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -63,6 +63,7 @@ func DesignSectionGroups() []DesignSectionGroup {
 		{Slug: "feedback", Label: "Feedback"},
 		{Slug: "patterns", Label: "Patterns"},
 		{Slug: "onboarding", Label: "Onboarding"},
+		{Slug: "workflows-dna", Label: "Workflows DNA"},
 	}
 }
 
@@ -492,6 +493,48 @@ func DesignSections() []DesignSection {
 			Description: "Calm CSV-import alternative + documentation resources aside, shown while setup is in progress. Copy adapts to whether a provider is configured. Use components.OnboardingAltPath.",
 			Group:       "onboarding",
 			Render:      func() templ.Component { return SectionOnboardingAltPath() },
+		},
+
+		// ── Workflows DNA ───────────────────────────────────────────
+		// The north-star tab (sits last): the top-level patterns that
+		// make the /workflows + /workflows/runs surfaces (and their
+		// drawers) our cleanest, extracted for reuse on other pages.
+		// Some sections re-render components that also appear under
+		// Data display.
+		{
+			Slug:        "wf-dna-principles",
+			Title:       "The DNA — design principles",
+			Description: "Why these surfaces feel calm and legible: the seven reusable decisions behind the /workflows and /workflows/runs pages. Start here, then see each principle made concrete below.",
+			Group:       "workflows-dna",
+			Render:      func() templ.Component { return SectionWFDNAPrinciples() },
+		},
+		{
+			Slug:        "wf-dna-scaffold",
+			Title:       "Page scaffold — header + tabs",
+			Description: "The shared chrome both tabs wear: PageHeader (title + subtitle) over a TabBar, plus the box-variant status filter with count badges and a workflow dropdown. This is what makes switching tabs feel like one surface.",
+			Group:       "workflows-dna",
+			Render:      func() templ.Component { return SectionWFDNAScaffold() },
+		},
+		{
+			Slug:        "wf-dna-gallery-card",
+			Title:       "Gallery card",
+			Description: "The /workflows row (workflowPresetCard): a single clean line — leading status tile, name + clamped description, and a minimal icon cluster (run toggle + settings gear). Flows in a 2-up grid. (Also under Data display.)",
+			Group:       "workflows-dna",
+			Render:      func() templ.Component { return SectionWorkflowPresetCard() },
+		},
+		{
+			Slug:        "wf-dna-run-row",
+			Title:       "Run list row",
+			Description: "The /workflows/runs row (AgentRunRow + AgentRunRowList): status carried by one icon tile, an avatar-led title with a dimmed time, a single priority-ordered body line, trailing cost, and an overflow action. (Also under Data display.)",
+			Group:       "workflows-dna",
+			Render:      func() templ.Component { return SectionAgentRunRows() },
+		},
+		{
+			Slug:        "wf-dna-drawer",
+			Title:       "Side drawer (slide-over)",
+			Description: "The configure / reconfigure flow as a right-side Drawer — header (with a control in the Right slot) · scrollable body of RadioCard choices + fields · sticky Cancel/Save footer. Edit without leaving the page.",
+			Group:       "workflows-dna",
+			Render:      func() templ.Component { return SectionWFDNADrawer() },
 		},
 	}
 }

--- a/internal/templates/components/pages/design_workflows_dna.templ
+++ b/internal/templates/components/pages/design_workflows_dna.templ
@@ -1,0 +1,191 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// design_workflows_dna.templ holds the "Workflows DNA" sandbox group — a
+// curated north-star tab that extracts the handful of top-level patterns
+// that make the /workflows and /workflows/runs surfaces (and their side
+// drawers) the cleanest in the app. The goal is reuse: these are the
+// shapes to reach for when polishing other pages toward the same feel.
+//
+// Some sections here intentionally re-render components that also appear
+// under "Data display" (the preset card, the run row) — clustering them
+// next to the principles + page chrome tells the whole story in one place.
+// New, page-anatomy-only sections (the manifesto, the page scaffold, the
+// workflows-flavored drawer) live in this file.
+
+// SectionWFDNAPrinciples states the design DNA in words — the operating
+// principles a reviewer should internalize before reusing these shapes.
+templ SectionWFDNAPrinciples() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">What this tab is</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>The <code>/workflows</code> gallery, the <code>/workflows/runs</code> list, and their side drawers are the reference for the style we want everywhere — simple, easy on the eyes, space used well on desktop and mobile, and a flow that makes sense.</li>
+				<li>This group extracts the <em>top-level</em> patterns that give those surfaces their soul, so they can be reapplied to other pages. It deliberately skips low-level primitives (those live in Foundations / Data display).</li>
+			</ul>
+		</div>
+		@designExample("The seven principles", "The DNA. Each is a small, reusable decision — together they're why these surfaces feel calm and legible.") {
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+				@wfdnaPrinciple("layout-grid", "One consistent chrome", "Every surface opens with the same PageHeader (title + subtitle) and a TabBar. Switching tabs feels like moving through one surface — not landing on differently-shaped pages.")
+				@wfdnaPrinciple("circle-check-big", "Status lives in one tile", "A single color-coded icon tile on the left carries the row's state — success, error, running. No parallel \"Success\" text badge. Less ink, faster scan.")
+				@wfdnaPrinciple("text-quote", "One body line, by priority", "A row says at most one thing: error → top report → note → silence. Success rows stay quiet and let the title carry them.")
+				@wfdnaPrinciple("ellipsis", "Minimal icon clusters", "Actions are bare icons with tooltips — run toggle, settings gear, overflow kebab. No button text crowding the row.")
+				@wfdnaPrinciple("panel-right", "Edit in a slide-over", "Create / configure / reconfigure happen in a right-side Drawer (header · scrollable body · sticky footer). Context stays put — no full-page detour, no cramped modal.")
+				@wfdnaPrinciple("scan", "Generous, honest spacing", "The daisy list-row grid inside a bb-card, hairline dividers, real breathing room. Calm on desktop; it stacks cleanly on mobile without a second layout.")
+				@wfdnaPrinciple("bot", "Identity via avatar", "Workflows and people get a stable DiceBear avatar (UserAvatar). The feed always reads as \"who did this,\" the same way on every surface.")
+			</div>
+		}
+	</div>
+}
+
+// wfdnaPrinciple is one card in the principles grid: a quiet icon tile, a
+// title, and a one-line rationale.
+templ wfdnaPrinciple(icon, title, body string) {
+	<div class="bb-card p-4 flex items-start gap-3 h-full">
+		<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0 text-base-content/70">
+			@components.LucideIcon(icon, "w-4 h-4")
+		</div>
+		<div class="min-w-0">
+			<div class="font-medium text-sm leading-tight">{ title }</div>
+			<p class="text-xs text-base-content/60 mt-1 leading-relaxed">{ body }</p>
+		</div>
+	</div>
+}
+
+// SectionWFDNAScaffold shows the shared page chrome both workflows tabs
+// wear: a PageHeader, the top-level TabBar (border) for Gallery/Runs, and
+// the box-variant TabBar with count badges + a workflow dropdown used as
+// the runs filter row.
+templ SectionWFDNAScaffold() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>Open every multi-tab section with <code>PageHeader</code> (title + subtitle, subtitle hidden on mobile) followed by a <code>TabBar</code>. This is the chrome that makes tabs feel like one surface.</li>
+				<li>For in-page filtering, drop to the <code>box</code> TabBar variant with a <code>Count</code> on each item, paired with a quiet dropdown for the secondary axis (here: which workflow).</li>
+			</ul>
+		</div>
+		@designExample("Page header + section tabs", "PageHeader (title · subtitle) + TabBar Variant=\"border\". The same two-line header and Gallery/Runs tabs render on both /workflows and /workflows/runs, so the tabs read as one surface.") {
+			<div class="space-y-4">
+				@components.PageHeader(components.PageHeaderProps{
+					Title:                "Workflows",
+					Subtitle:             "One-click AI automations that run on your Breadbox.",
+					SubtitleHideOnMobile: true,
+				})
+				@components.TabBar(components.TabBarProps{
+					Variant:   "border",
+					AriaLabel: "Workflows sections (demo)",
+					Items: []components.TabBarItem{
+						{Label: "Gallery", Href: "#", Icon: "layout-grid", Active: true},
+						{Label: "Runs", Href: "#", Icon: "history"},
+					},
+				})
+			</div>
+		}
+		@designExample("Status filter + workflow dropdown", "The /workflows/runs filter row: a box TabBar with live Count badges per status, and a quiet select for the workflow axis. Counts respect the workflow filter; the active status drives the rows below.") {
+			<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+				@components.TabBar(components.TabBarProps{
+					Variant:   "box",
+					AriaLabel: "Filter runs by status (demo)",
+					Items: []components.TabBarItem{
+						{Label: "All", Href: "#", Active: true, Count: components.SectionHeaderIntPtr(66)},
+						{Label: "Success", Href: "#", Count: components.SectionHeaderIntPtr(29)},
+						{Label: "Error", Href: "#", Count: components.SectionHeaderIntPtr(37)},
+						{Label: "In progress", Href: "#"},
+						{Label: "Skipped", Href: "#"},
+					},
+				})
+				<select class="select select-sm w-full sm:w-52" aria-label="Filter by workflow (demo)">
+					<option>All workflows</option>
+					<option>Manual Review</option>
+					<option>Routine Reviewer</option>
+				</select>
+			</div>
+		}
+	</div>
+}
+
+// SectionWFDNADrawer renders the workflows-flavored slide-over: a setup
+// drawer whose header carries an enable toggle (DrawerHeader.Right), a body
+// of RadioCard trigger choices + a model select + a free-form note, and a
+// sticky Cancel/Save footer. Drawer ids are namespaced `wfdna-*` so they
+// never collide with the generic "drawers" section on the same page.
+templ SectionWFDNADrawer() {
+	<div x-data class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>Configure / reconfigure flows that would otherwise be a full page or a cramped modal. The right-side <code>Drawer</code> keeps the gallery visible behind it — opened via <code>$store.drawers.open('&lt;id&gt;')</code>, closed by Escape or a backdrop click.</li>
+				<li>Anatomy: <code>DrawerHeader</code> (icon · title · subtitle, with an optional control in the <code>Right</code> slot) → a scrollable body → a sticky <code>DrawerFooter</code> with the action pair. Keep the primary action on the right.</li>
+			</ul>
+		</div>
+		@designExample("Set up workflow — slide-over", "The real shape of the workflows setup drawer. Header puts the enable toggle in the Right slot; the body is RadioCard trigger choices + a model select + a note; the footer pins Cancel / Save. Open it to see the slide + backdrop.") {
+			<button type="button" class="btn btn-primary btn-sm gap-1.5" @click="$store.drawers.open('wfdna-setup')">
+				@components.LucideIcon("settings-2", "w-4 h-4")
+				Set up workflow
+			</button>
+			@components.Drawer(components.DrawerProps{ID: "wfdna-setup", Title: "Set up Large Charge Sentinel"}) {
+				<form class="flex flex-col h-full" @submit.prevent="$store.drawers.close()">
+					@components.DrawerHeader(components.DrawerHeaderProps{
+						Icon:     "shield-alert",
+						Title:    "Large Charge Sentinel",
+						Subtitle: "Flags unusually large charges right after they land.",
+						Right:    wfdnaDrawerToggle(),
+					})
+					<div class="flex-1 overflow-y-auto p-5 space-y-5">
+						<div>
+							<p class="text-xs font-medium text-base-content/50 mb-2">Trigger</p>
+							<div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+								@components.RadioCard(components.RadioCardProps{
+									Name:     "wfdna-trigger",
+									Value:    "cron",
+									Icon:     "calendar-clock",
+									Title:    "On a schedule",
+									Subtitle: "Runs on a cron you choose",
+									Checked:  true,
+								})
+								@components.RadioCard(components.RadioCardProps{
+									Name:     "wfdna-trigger",
+									Value:    "sync",
+									Icon:     "refresh-cw",
+									Title:    "After each sync",
+									Subtitle: "Runs when new data lands",
+								})
+							</div>
+						</div>
+						<div>
+							<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="wfdna-model">Model</label>
+							<select id="wfdna-model" class="select w-full">
+								<option>Claude Opus 4.8</option>
+								<option selected>Claude Sonnet 4.6</option>
+								<option>Claude Haiku 4.5</option>
+							</select>
+						</div>
+						<div>
+							<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="wfdna-note">Additional instructions</label>
+							<textarea id="wfdna-note" class="textarea w-full" rows="3" placeholder="Optional — extra guidance layered on the base prompt…"></textarea>
+						</div>
+					</div>
+					@components.DrawerFooter() {
+						<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
+						<button type="submit" class="btn btn-primary btn-sm gap-1.5">
+							@components.LucideIcon("save", "w-4 h-4")
+							Save
+						</button>
+					}
+				</form>
+			}
+		}
+	</div>
+}
+
+// wfdnaDrawerToggle is the enable control rendered in the setup drawer's
+// header Right slot — a labelled toggle, mirroring the live workflow setup
+// "Activate" affordance.
+templ wfdnaDrawerToggle() {
+	<label class="flex items-center gap-2 text-xs text-base-content/60 cursor-pointer">
+		<span>Enabled</span>
+		<input type="checkbox" class="toggle toggle-sm toggle-primary" checked aria-label="Enable workflow (demo)"/>
+	</label>
+}

--- a/static/js/admin/components/design_gallery.js
+++ b/static/js/admin/components/design_gallery.js
@@ -30,6 +30,7 @@ document.addEventListener('alpine:init', function () {
       // DesignSectionGroups() (design_types.go). Initialized to all open
       // so the catalog is fully visible on first load.
       open: {
+        'workflows-dna': true,
         foundations: true,
         layout: true,
         navigation: true,
@@ -37,6 +38,7 @@ document.addEventListener('alpine:init', function () {
         data: true,
         feedback: true,
         patterns: true,
+        onboarding: true,
       },
 
       init: function () {


### PR DESCRIPTION
Adds a **Workflows DNA** group to the `/design` sandbox (bottom of the rail) that extracts the top-level patterns making `/workflows` + `/workflows/runs` (and their drawers) our cleanest surfaces, so they can be reapplied elsewhere — plus a worked `/accounts` redesign prototype applying them.

## Sections
- **The DNA** — a seven-principle manifesto (consistent chrome, status-in-one-tile, one body line by priority, minimal icon clusters, edit-in-a-slide-over, generous spacing, identity via avatar).
- **Page scaffold** — PageHeader + TabBar + box-variant status filter.
- **Gallery card** / **Run list row** — reuse the live `SectionWorkflowPresetCard` / `SectionAgentRunRows`.
- **Side drawer** — a workflows-flavored slide-over.
- **Applied — /accounts redesign (prototype)** — the table reimagined as the list-row surface, grouped by connection with light group headers and a quick-manage drawer. Sample data only; not wired to live accounts.

## Notes
- New group registered in `DesignSections()` / `DesignSectionGroups()`; also fixed a latent gap where `onboarding` was missing from `design_gallery.js`'s open-state map.
- Sandbox-only; no production surface changes.

<img src="https://bb-artifacts.exe.xyz/f/849780f3ddfb2ca3.jpg" width="800" alt="/accounts redesign prototype in the sandbox">

## Test plan
- [x] `go build ./...`, `go test ./internal/templates/...`
- [x] Rendered at `/design` (desktop + mobile); drawer opens via `$store.drawers`
