### PR TITLE
feat(accounts): regroup /accounts by connection (Workflows DNA)

### DIFF
--- a/internal/admin/accounts.go
+++ b/internal/admin/accounts.go
@@ -70,36 +70,68 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 			userAvatarVersionByShort[u.ShortID] = usersAvatarVersion(u.UpdatedAt)
 		}
 
-		// Build typed rows + running totals.
+		// Build typed rows.
 		var rows []pages.AccountsListRow
-		var totalAssets, totalLiabilities float64
-		var hasAnyBalance bool
-
-		appendRow := func(row pages.AccountsListRow) {
-			if row.HasBalance {
-				hasAnyBalance = true
-				if row.IsLiability {
-					totalLiabilities += math.Abs(row.BalanceFloat)
-				} else {
-					totalAssets += row.BalanceFloat
-				}
-			}
-			rows = append(rows, row)
-		}
-
 		if useUser {
 			for _, r := range userRows {
-				appendRow(accountRowFromListByUser(r, userNameByShort, userAvatarVersionByShort))
+				rows = append(rows, accountRowFromListByUser(r, userNameByShort, userAvatarVersionByShort))
 			}
 		} else {
 			for _, r := range allRows {
-				appendRow(accountRowFromListAll(r, userNameByShort, userAvatarVersionByShort))
+				rows = append(rows, accountRowFromListAll(r, userNameByShort, userAvatarVersionByShort))
 			}
 		}
 
-		// Default ordering: liabilities & no-balance at the bottom; biggest
-		// asset first. The Alpine factory re-sorts client-side when the user
-		// clicks a header.
+		// Per-owner account counts over the UNFILTERED set, so the member
+		// dropdown order is stable regardless of the active filter.
+		accountsPerUser := make(map[string]int)
+		for _, row := range rows {
+			if row.UserID != "" {
+				accountsPerUser[row.UserID]++
+			}
+		}
+
+		// Member filter (editors only — members are already scoped to their
+		// own accounts at the query layer). A ?user=<short_id> narrows the
+		// page to one owner and re-scopes the totals + groups server-side, so
+		// every subtotal stays accurate. An unknown short_id falls back to
+		// "all" rather than erroring (matches the admin filter convention).
+		activeUserID := ""
+		if IsEditor(sm, r) {
+			if u := r.URL.Query().Get("user"); u != "" {
+				if _, ok := userNameByShort[u]; ok {
+					activeUserID = u
+				}
+			}
+		}
+		if activeUserID != "" {
+			filtered := make([]pages.AccountsListRow, 0, len(rows))
+			for _, row := range rows {
+				if row.UserID == activeUserID {
+					filtered = append(filtered, row)
+				}
+			}
+			rows = filtered
+		}
+
+		// Totals over the (filtered) rows.
+		var totalAssets, totalLiabilities float64
+		var hasAnyBalance bool
+		for _, row := range rows {
+			if !row.HasBalance {
+				continue
+			}
+			hasAnyBalance = true
+			if row.IsLiability {
+				totalLiabilities += math.Abs(row.BalanceFloat)
+			} else {
+				totalAssets += row.BalanceFloat
+			}
+		}
+
+		// Within-group ordering: liabilities & no-balance at the bottom,
+		// biggest asset first. GroupAccountsByConnection preserves this order
+		// inside each connection.
 		sort.SliceStable(rows, func(i, j int) bool {
 			a, b := rows[i], rows[j]
 			if a.HasBalance != b.HasBalance {
@@ -107,8 +139,6 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 			}
 			return a.BalanceFloat > b.BalanceFloat
 		})
-
-		netWorth := totalAssets - totalLiabilities
 
 		data := map[string]any{
 			"PageTitle":   "Accounts",
@@ -119,24 +149,20 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 
 		props := pages.AccountsListProps{
 			CSRFToken:        GetCSRFToken(r),
-			NetWorth:         netWorth,
+			NetWorth:         totalAssets - totalLiabilities,
 			TotalAssets:      totalAssets,
 			TotalLiabilities: totalLiabilities,
 			HasAnyBalance:    hasAnyBalance,
-			Accounts:         rows,
+			ActiveUserID:     activeUserID,
+			Groups:           pages.GroupAccountsByConnection(rows),
+			TotalAccounts:    len(rows),
 		}
 
-		// Only editors/admins see the household filter (members are already
-		// scoped to themselves at the query layer).
+		// Only editors/admins see the household filter dropdown (members are
+		// already scoped to themselves at the query layer).
 		if IsEditor(sm, r) {
 			// Sort users by number of accounts (descending) so the most active
 			// household member surfaces first, like the connections page.
-			accountsPerUser := make(map[string]int)
-			for _, row := range rows {
-				if row.UserID != "" {
-					accountsPerUser[row.UserID]++
-				}
-			}
 			usersCopy := make([]db.User, len(users))
 			copy(usersCopy, users)
 			sort.Slice(usersCopy, func(i, j int) bool {

--- a/internal/templates/components/accounts_list_skeleton.templ
+++ b/internal/templates/components/accounts_list_skeleton.templ
@@ -2,13 +2,14 @@ package components
 
 // AccountsListSkeleton renders a placeholder mirroring the layout of the
 // /accounts page — the three-stat summary card (Net Worth / Assets /
-// Liabilities) plus the sortable account table. Sized to match the
-// real component so a swap-in (current or future) doesn't shift layout.
+// Liabilities) plus a couple of connection groups (a quiet label line over a
+// card of account list-rows). Sized to match the real component so a swap-in
+// (current or future) doesn't shift layout.
 //
 // /accounts is a full-SSR page today; this primitive is exposed in
-// /design#loading so it's ready for the eventual AJAX/paginated swap
-// and discoverable to anyone wiring loading states for adjacent
-// account-centric panels.
+// /design#loading so it's ready for the eventual AJAX/paginated swap and
+// discoverable to anyone wiring loading states for adjacent account-centric
+// panels.
 //
 // Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
 // hand-rolled `bb-skeleton*` family is being retired).
@@ -25,71 +26,41 @@ templ AccountsListSkeleton() {
 				}
 			</div>
 		</div>
-		<!-- Filter search input -->
-		<div class="skeleton h-10 w-full sm:max-w-sm rounded-xl mb-4"></div>
-		<!-- Accounts table -->
-		<div class="bb-card overflow-hidden">
-			<div class="overflow-x-auto">
-				<table class="table table-sm">
-					<thead class="text-xs text-base-content/60">
-						<tr>
-							<th class="min-w-[12rem]"><div class="skeleton h-3 w-16"></div></th>
-							<th class="hidden md:table-cell"><div class="skeleton h-3 w-20"></div></th>
-							<th class="hidden lg:table-cell"><div class="skeleton h-3 w-12"></div></th>
-							<th class="hidden lg:table-cell"><div class="skeleton h-3 w-14"></div></th>
-							<th class="text-right"><div class="skeleton h-3 w-16 ml-auto"></div></th>
-							<th class="w-8"></th>
-						</tr>
-					</thead>
-					<tbody>
-						for i := 0; i < 6; i++ {
-							@accountsListSkeletonRow()
-						}
-					</tbody>
-				</table>
-			</div>
+		<!-- Connection groups: a label line over a card of account rows -->
+		<div class="flex flex-col gap-5">
+			@accountsListSkeletonGroup(2)
+			@accountsListSkeletonGroup(1)
 		</div>
 	</div>
 }
 
-// accountsListSkeletonRow mirrors one accountsListRow: icon tile + name/meta
-// stack, optional desktop-only institution/type/owner cells, right-aligned
-// balance, overflow-menu slot. Widths line up with real-row content so the
-// swap-in doesn't shift the page.
-templ accountsListSkeletonRow() {
-	<tr>
-		<!-- Account name + icon -->
-		<td>
-			<div class="flex items-center gap-3">
-				<div class="skeleton w-8 h-8 rounded-md shrink-0"></div>
-				<div class="min-w-0 space-y-1.5">
-					<div class="skeleton h-3 w-32"></div>
-					<div class="skeleton h-2.5 w-20 md:hidden"></div>
-				</div>
-			</div>
-		</td>
-		<!-- Institution (md+) -->
-		<td class="hidden md:table-cell">
-			<div class="skeleton h-3 w-28"></div>
-		</td>
-		<!-- Type (lg+) -->
-		<td class="hidden lg:table-cell">
-			<div class="skeleton h-3 w-16"></div>
-		</td>
-		<!-- Owner (lg+) -->
-		<td class="hidden lg:table-cell">
-			<div class="flex items-center gap-1.5">
-				<div class="skeleton w-5 h-5 rounded-full shrink-0"></div>
-				<div class="skeleton h-3 w-14"></div>
-			</div>
-		</td>
-		<!-- Balance -->
-		<td class="text-right">
+// accountsListSkeletonGroup mirrors one connection group — the quiet header
+// line (institution · count … subtotal) and `rows` account list-rows.
+templ accountsListSkeletonGroup(rows int) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1">
+			<div class="skeleton h-3 w-24"></div>
+			<div class="skeleton h-2.5 w-14"></div>
 			<div class="skeleton h-3.5 w-20 ml-auto"></div>
-		</td>
-		<!-- Overflow menu slot -->
-		<td class="text-right">
-			<div class="skeleton h-6 w-6 ml-auto"></div>
-		</td>
-	</tr>
+		</div>
+		<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+			for i := 0; i < rows; i++ {
+				@accountsListSkeletonRow()
+			}
+		</ul>
+	</div>
+}
+
+// accountsListSkeletonRow mirrors one accountsListRow: type tile + name/meta
+// stack, right-aligned balance, overflow-menu slot.
+templ accountsListSkeletonRow() {
+	<li class="list-row items-center">
+		<div class="skeleton w-9 h-9 rounded-lg shrink-0"></div>
+		<div class="min-w-0 space-y-1.5">
+			<div class="skeleton h-3 w-32"></div>
+			<div class="skeleton h-2.5 w-20"></div>
+		</div>
+		<div class="skeleton h-3.5 w-20 ml-auto self-center"></div>
+		<div class="skeleton h-6 w-6 self-center"></div>
+	</li>
 }

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -7,44 +7,43 @@ import (
 	"breadbox/internal/templates/components"
 )
 
-// AccountsList renders the flat /accounts admin page — a single sortable,
-// filterable table of every account the viewer is allowed to see. The
+// AccountsList renders the /accounts admin page — every account the viewer is
+// allowed to see, grouped by connection. Each institution is a quiet labelled
+// group (name · count · subtotal, carrying the connection health) above its
+// account list-rows, following the Workflows-DNA surface language. The
 // per-connection list view still lives on /connections; this page is the
-// account-centric counterpart so the user doesn't have to crack open each
-// connection to find a single account.
+// account-centric counterpart.
 //
-// Alpine factory `accountsList` (filter + sort) lives in
-// static/js/admin/components/accounts.js. Loaded synchronously (no defer)
-// per the convention in docs/design-system.md → "Alpine page components".
+// Alpine factory `accountsList` (the exclude/include action) lives in
+// static/js/admin/components/accounts.js. Loaded synchronously (no defer) per
+// the convention in docs/design-system.md → "Alpine page components".
 templ AccountsList(p AccountsListProps) {
 	<script src="/static/js/admin/components/accounts.js"></script>
 	<div x-data x-init="$store.shortcuts.setScope('accounts')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div x-data="accountsList">
 		@components.PageHeader(components.PageHeaderProps{
 			Title:                "Accounts",
-			Subtitle:             "Every account across all your connections, in one sortable view.",
+			Subtitle:             "Every account across your connections, grouped by where it lives.",
 			SubtitleHideOnMobile: true,
 		})
-		<!-- Family-member filter strip (only when 2+ household members) -->
+		<!-- Household-member filter — editors only, 2+ members. Server-side so
+		     every group subtotal re-scopes to the selected member. -->
 		if len(p.Users) > 1 {
-			<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto overflow-y-hidden">
-				<button
-					@click="filterUser = 'all'"
-					:class="filterUser === 'all' ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'"
-					class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
+			<div class="flex justify-end mb-4">
+				<select
+					class="select select-sm w-44"
+					aria-label="Filter by household member"
+					@change="window.location.href = $event.target.value ? '/accounts?user=' + encodeURIComponent($event.target.value) : '/accounts'"
 				>
-					<span class="w-5 h-5 rounded-full bg-base-300/60 flex items-center justify-center text-[0.6rem] font-semibold text-base-content/50 shrink-0">
-						@components.LucideIcon("users", "w-3 h-3")
-					</span>
-					All
-				</button>
-				for _, u := range p.Users {
-					@accountsListUserFilterBtn(u)
-				}
+					<option value="" selected?={ p.ActiveUserID == "" }>All members</option>
+					for _, u := range p.Users {
+						<option value={ u.ID } selected?={ u.ID == p.ActiveUserID }>{ u.Name }</option>
+					}
+				</select>
 			</div>
 		}
 		if p.HasAnyBalance {
-			<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterUser === 'all'">
+			<div class="bb-card p-0 overflow-hidden mb-6">
 				<div class="grid grid-cols-3 divide-x divide-base-300">
 					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Net Worth</div>
@@ -79,210 +78,149 @@ templ AccountsList(p AccountsListProps) {
 				</div>
 			</div>
 		}
-		@components.FilterSearchInput(components.FilterSearchInputProps{
-			Placeholder: "Filter accounts...",
-			XModel:      "filter",
-		})
-		<div class="mt-4">
-			if len(p.Accounts) > 0 {
-				@accountsListTable(p)
-			} else {
-				@components.EmptyState(components.EmptyStateProps{
-					Icon:      "wallet",
-					Title:     "No accounts yet",
-					Body:      "Once you connect a bank, every account synced from it shows up here.",
-					CustomCTA: connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a Bank"),
-				})
-			}
-		</div>
-		<!-- Loading skeleton for the accounts list, available for any future
-		     client-side refresh / pagination swap. Mirrors the SSR layout
-		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		if p.TotalAccounts > 0 {
+			<div class="flex flex-col gap-5">
+				for _, g := range p.Groups {
+					@accountsListConnGroup(g)
+				}
+			</div>
+		} else {
+			@components.EmptyState(components.EmptyStateProps{
+				Icon:      "wallet",
+				Title:     "No accounts yet",
+				Body:      "Once you connect a bank, every account synced from it shows up here.",
+				CustomCTA: connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a Bank"),
+			})
+		}
+		<!-- Loading skeleton, available for any future client-side refresh /
+		     pagination swap. Mirrors the SSR layout above. Exposed in
+		     /design#loading. -->
 		<template id="bb-accounts-list-skeleton-template">
 			@components.AccountsListSkeleton()
 		</template>
 	</div>
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			lucide.createIcons();
-		});
-	</script>
 }
 
-templ accountsListUserFilterBtn(u AccountsListUserFilter) {
-	<button
-		@click={ fmt.Sprintf("filterUser = %q", u.ID) }
-		:class={ fmt.Sprintf("filterUser === %q ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'", u.ID) }
-		class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
-	>
-		@components.UserAvatar(components.UserAvatarProps{
-			ID:         u.ID,
-			Name:       u.Name,
-			Version:    u.AvatarVersion,
-			Size:       components.UserAvatarSm,
-			Decorative: true,
-		})
-		{ u.Name }
-	</button>
-}
-
-// accountsListTable wraps the data table in a bb-card. Header is clickable to
-// drive client-side sort via the accountsList Alpine factory.
-templ accountsListTable(p AccountsListProps) {
-	<div class="bb-card overflow-hidden">
-		<div class="overflow-x-auto">
-			<table class="table table-sm">
-				<thead class="text-xs text-base-content/60">
-					<tr>
-						@accountsListSortHeader("name", "Account", "min-w-[12rem]")
-						@accountsListSortHeader("institution", "Institution", "hidden md:table-cell")
-						@accountsListSortHeader("type", "Type", "hidden lg:table-cell")
-						@accountsListSortHeader("owner", "Owner", "hidden lg:table-cell")
-						@accountsListSortHeader("balance", "Balance", "text-right")
-						<th class="w-8"></th>
-					</tr>
-				</thead>
-				<tbody>
-					for _, a := range p.Accounts {
-						@accountsListRow(a, p.CSRFToken)
-					}
-				</tbody>
-			</table>
+// accountsListConnGroup renders one connection: a quiet label line
+// (institution · count · subtotal, with health surfaced when the connection
+// needs attention) above the account list-rows in their own card.
+templ accountsListConnGroup(g AccountsListConnGroup) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1 min-w-0">
+			<span data-private="institution" class="text-sm font-medium text-base-content shrink-0">{ accountsConnLabel(g) }</span>
+			<span class="text-xs text-base-content/40 shrink-0">{ accountsConnCountLabel(g) }</span>
+			@accountsListConnStatus(g)
+			if g.HasSubtotal {
+				<span class="ml-auto shrink-0">
+					@components.Amount(components.AmountProps{
+						Value:  g.Subtotal,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-semibold tabular-nums",
+					})
+				</span>
+			}
 		</div>
+		@components.AgentRunRowList() {
+			for _, a := range g.Accounts {
+				@accountsListRow(a)
+			}
+		}
 	</div>
 }
 
-// accountsListSortHeader emits one clickable column header. The chevron icon
-// rotates based on the active sort direction.
-templ accountsListSortHeader(key, label, extraClass string) {
-	<th class={ "cursor-pointer select-none whitespace-nowrap", extraClass } @click={ fmt.Sprintf("setSort(%q)", key) }>
-		<span class="inline-flex items-center gap-1">
-			{ label }
-			<span x-show={ fmt.Sprintf("sortKey === %q", key) } x-cloak>
-				<i data-lucide="chevron-down" class="w-3 h-3" :class="sortDir === 'desc' ? '' : 'rotate-180'"></i>
-			</span>
-		</span>
-	</th>
+// accountsListConnStatus surfaces connection health on the group header — a
+// soft badge + a recovery link to /connections, only when not active.
+templ accountsListConnStatus(g AccountsListConnGroup) {
+	if g.Status == "error" || g.Status == "pending_reauth" {
+		<span class="badge badge-soft badge-warning badge-xs shrink-0">Reauth needed</span>
+		<a href="/connections" class="text-xs text-warning hover:underline shrink-0">Reauthenticate</a>
+	} else if g.Status == "disconnected" {
+		<span class="badge badge-soft badge-error badge-xs shrink-0">Disconnected</span>
+		<a href="/connections" class="text-xs text-error hover:underline shrink-0">Reconnect</a>
+	}
 }
 
-templ accountsListRow(a AccountsListRow, csrfToken string) {
-	<tr
-		data-account-row
-		data-account-id={ a.ID }
-		data-name={ strings.ToLower(a.DisplayName) }
-		data-institution={ strings.ToLower(a.InstitutionName) }
-		data-type={ a.Type }
-		data-owner={ strings.ToLower(a.OwnerName) }
-		data-balance={ fmt.Sprintf("%f", a.BalanceFloat) }
-		data-has-balance={ accountsListBool(a.HasBalance) }
-		data-search={ accountsListSearchIndex(a) }
-		data-filter-user={ a.UserID }
-		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && matches($el)"
-		x-cloak
-		class="hover:bg-base-200/30 transition-colors"
-	>
-		<!-- Account name + icon -->
-		<td>
-			<a href={ templ.SafeURL("/accounts/" + a.ID) } class="flex items-center gap-3 no-underline">
-				<div class="w-8 h-8 rounded-md bg-base-200/60 flex items-center justify-center shrink-0">
-					@accountsListTypeIcon(a.Type)
-				</div>
-				<div class="min-w-0">
-					<div class="flex items-center gap-1.5 flex-wrap">
-						<span data-private="account" class="text-sm font-medium truncate text-base-content">{ a.DisplayName }</span>
-						if a.IsDependentLinked {
-							<span class="badge badge-soft badge-info badge-xs" title="Dependent-linked: balance attributed to a linked user">Linked</span>
-						}
-						if a.Excluded {
-							<span class="badge badge-soft badge-warning badge-xs" title="Excluded from totals and sync">Excluded</span>
-						}
-					</div>
-					<div class="text-xs text-base-content/40 md:hidden">
-						@components.Private("institution", a.InstitutionName)
-						if a.MaskValid {
-							<span class="text-base-content/25">&middot;</span>
-							@components.Private("mask", " ····"+a.Mask)
-						}
-					</div>
-				</div>
-			</a>
-		</td>
-		<!-- Institution (md+) -->
-		<td class="hidden md:table-cell text-sm text-base-content/70">
-			<div class="flex items-center gap-2 min-w-0">
-				<span data-private="institution" class="truncate">{ a.InstitutionName }</span>
-				if a.MaskValid {
-					<span data-private="mask" class="text-xs text-base-content/40">&middot; ····{ a.Mask }</span>
-				}
-				if a.ConnectionStatus == "error" || a.ConnectionStatus == "pending_reauth" {
-					<span class="badge badge-soft badge-warning badge-xs" title="Connection needs attention">Reauth</span>
-				} else if a.ConnectionStatus == "disconnected" {
-					<span class="badge badge-soft badge-error badge-xs">Disconnected</span>
-				}
+// accountsListRow renders one account as a list-row: a leading type tile, a
+// title row (name + Linked/Excluded badges + owner avatar), a quiet
+// ····mask · Type line, a trailing balance, and an overflow menu outside the
+// row's navigation anchor. Connection health is NOT repeated here — it lives
+// on the group header.
+templ accountsListRow(a AccountsListRow) {
+	<li class="list-row transition-colors hover:bg-base-200/40 items-center" data-account-id={ a.ID }>
+		<a class="contents no-underline" href={ templ.SafeURL("/accounts/" + a.ID) }>
+			<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+				@accountsListTypeIcon(a.Type)
 			</div>
-		</td>
-		<!-- Type (lg+) -->
-		<td class="hidden lg:table-cell text-sm text-base-content/70 capitalize">
-			{ accountsListTypeLabel(a.Type, a.Subtype, a.SubtypeValid) }
-		</td>
-		<!-- Owner (lg+) -->
-		<td class="hidden lg:table-cell text-sm text-base-content/70">
-			if a.OwnerName != "" {
-				<span class="inline-flex items-center gap-1.5">
-					@components.UserAvatar(components.UserAvatarProps{
-						ID:         a.UserID,
-						Name:       a.OwnerName,
-						Version:    a.OwnerAvatarVersion,
-						Size:       components.UserAvatarSm,
-						Decorative: true,
-					})
-					{ a.OwnerName }
-				</span>
-			} else {
-				<span class="text-base-content/30">—</span>
-			}
-		</td>
-		<!-- Balance -->
-		<td class="text-right">
-			if a.HasBalance {
-				if a.BalanceFloat < 0 {
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span data-private="account" class="font-medium text-sm text-base-content truncate">{ a.DisplayName }</span>
+					if a.IsDependentLinked {
+						<span class="badge badge-soft badge-info badge-xs shrink-0" title="Dependent-linked: balance attributed to a linked user">Linked</span>
+					}
+					if a.Excluded {
+						<span class="badge badge-soft badge-warning badge-xs shrink-0" title="Excluded from totals and sync">Excluded</span>
+					}
+					if a.OwnerName != "" {
+						@components.UserAvatar(components.UserAvatarProps{
+							ID:         a.UserID,
+							Name:       a.OwnerName,
+							Version:    a.OwnerAvatarVersion,
+							Size:       components.UserAvatarXS,
+							Decorative: true,
+							Lazy:       true,
+							Class:      "shrink-0",
+						})
+					}
+				</div>
+				<div class="mt-0.5 text-xs text-base-content/60 min-w-0 line-clamp-1">
+					if a.MaskValid {
+						@components.Private("mask", "····"+a.Mask)
+						<span class="text-base-content/30">&middot;</span>
+					}
+					<span class="capitalize">{ accountsListTypeLabel(a.Type, a.Subtype, a.SubtypeValid) }</span>
+				</div>
+			</div>
+			<div class="shrink-0 self-center text-right">
+				if a.HasBalance {
 					@components.Amount(components.AmountProps{
 						Value:  a.BalanceFloat,
 						Intent: components.AmountBalance,
-						Class:  "text-sm font-medium text-error",
+						Class:  accountsListBalanceClass(a.IsLiability),
 					})
 				} else {
-					@components.Amount(components.AmountProps{
-						Value:  a.BalanceFloat,
-						Intent: components.AmountBalance,
-						Class:  "text-sm font-medium",
-					})
+					<span class="text-sm text-base-content/30">—</span>
 				}
-			} else {
-				<span class="text-xs text-base-content/30">—</span>
-			}
-		</td>
-		<td class="text-right">
+			</div>
+		</a>
+		<div class="shrink-0 self-center">
 			@components.OverflowMenu(components.OverflowMenuProps{
 				AriaLabel: fmt.Sprintf("Actions for %s", a.DisplayName),
-				Size:      "xs",
+				Size:      "sm",
 				Items:     accountsListRowItems(a),
 			})
-		</td>
-	</tr>
+		</div>
+	</li>
 }
 
 templ accountsListTypeIcon(t string) {
 	switch t {
 		case "credit":
-			@components.LucideIcon("credit-card", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("credit-card", "w-4 h-4 text-base-content/70")
 		case "loan":
-			@components.LucideIcon("landmark", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("landmark", "w-4 h-4 text-base-content/70")
 		case "investment":
-			@components.LucideIcon("trending-up", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("trending-up", "w-4 h-4 text-base-content/70")
 		default:
-			@components.LucideIcon("wallet", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("wallet", "w-4 h-4 text-base-content/70")
 	}
+}
+
+// accountsListBalanceClass tints liabilities red; assets keep the default ink.
+func accountsListBalanceClass(isLiability bool) string {
+	if isLiability {
+		return "text-sm font-semibold text-error"
+	}
+	return "text-sm font-semibold"
 }
 
 // accountsListRowItems builds the overflow-menu items for one row.
@@ -313,31 +251,11 @@ func accountsListRowItems(a AccountsListRow) []components.OverflowMenuItem {
 	return items
 }
 
-// accountsListTypeLabel composes the type column text. Falls back to the
-// primary type when subtype is empty.
+// accountsListTypeLabel composes the type label. Falls back to the primary
+// type when subtype is empty.
 func accountsListTypeLabel(t, subtype string, subtypeValid bool) string {
 	if subtypeValid && subtype != "" {
 		return strings.ReplaceAll(subtype, "_", " ")
 	}
 	return t
-}
-
-// accountsListSearchIndex builds the lowercase haystack used by the filter
-// search input.
-func accountsListSearchIndex(a AccountsListRow) string {
-	parts := []string{a.DisplayName, a.InstitutionName, a.Type, a.OwnerName}
-	if a.SubtypeValid {
-		parts = append(parts, a.Subtype)
-	}
-	if a.MaskValid {
-		parts = append(parts, a.Mask)
-	}
-	return strings.ToLower(strings.Join(parts, " "))
-}
-
-func accountsListBool(b bool) string {
-	if b {
-		return "1"
-	}
-	return "0"
 }

--- a/internal/templates/components/pages/accounts_list_test.go
+++ b/internal/templates/components/pages/accounts_list_test.go
@@ -1,0 +1,79 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+func TestGroupAccountsByConnection(t *testing.T) {
+	rows := []AccountsListRow{
+		// Chase: an asset + a liability → subtotal 11135.63.
+		{ID: "a1", ConnectionShortID: "chase", InstitutionName: "Chase", ConnectionStatus: "active", HasBalance: true, BalanceFloat: 12340.18},
+		{ID: "a2", ConnectionShortID: "chase", InstitutionName: "Chase", ConnectionStatus: "active", HasBalance: true, BalanceFloat: -1204.55, IsLiability: true},
+		// Fidelity: a single big asset → should rank first.
+		{ID: "a3", ConnectionShortID: "fidelity", InstitutionName: "Fidelity", ConnectionStatus: "active", HasBalance: true, BalanceFloat: 34120.00},
+		// Amex: reauth, one liability.
+		{ID: "a4", ConnectionShortID: "amex", InstitutionName: "American Express", ConnectionStatus: "pending_reauth", HasBalance: true, BalanceFloat: -842.30, IsLiability: true},
+		// Orphan (connection deleted → SET NULL): no balance. Sinks last.
+		{ID: "a5", ConnectionShortID: "", InstitutionName: "", HasBalance: false},
+	}
+
+	groups := GroupAccountsByConnection(rows)
+	if len(groups) != 4 {
+		t.Fatalf("got %d groups, want 4", len(groups))
+	}
+
+	// Order: Fidelity (34120) > Chase (11135.63) > Amex (-842.30) > orphan (last).
+	wantOrder := []string{"fidelity", "chase", "amex", ""}
+	for i, want := range wantOrder {
+		if groups[i].ConnectionShortID != want {
+			t.Errorf("group[%d] = %q, want %q", i, groups[i].ConnectionShortID, want)
+		}
+	}
+
+	// Chase subtotal = 12340.18 - 1204.55 = 11135.63.
+	var chase AccountsListConnGroup
+	for _, g := range groups {
+		if g.ConnectionShortID == "chase" {
+			chase = g
+		}
+	}
+	if !chase.HasSubtotal {
+		t.Fatal("chase group should have a subtotal")
+	}
+	if got := chase.Subtotal; got < 11135.62 || got > 11135.64 {
+		t.Errorf("chase subtotal = %.2f, want 11135.63", got)
+	}
+	if len(chase.Accounts) != 2 {
+		t.Errorf("chase has %d accounts, want 2", len(chase.Accounts))
+	}
+	if chase.InstitutionName != "Chase" {
+		t.Errorf("chase institution = %q, want Chase", chase.InstitutionName)
+	}
+
+	// Amex carries the connection status onto the group header.
+	for _, g := range groups {
+		if g.ConnectionShortID == "amex" && g.Status != "pending_reauth" {
+			t.Errorf("amex status = %q, want pending_reauth", g.Status)
+		}
+	}
+
+	// Orphan group: no connection, no subtotal, lands last.
+	last := groups[len(groups)-1]
+	if last.ConnectionShortID != "" || last.HasSubtotal {
+		t.Errorf("last group = %+v, want orphan with no subtotal", last)
+	}
+	if got := accountsConnLabel(last); got != "Unlinked accounts" {
+		t.Errorf("orphan label = %q, want \"Unlinked accounts\"", got)
+	}
+}
+
+func TestAccountsConnCountLabel(t *testing.T) {
+	one := AccountsListConnGroup{Accounts: []AccountsListRow{{}}}
+	if got := accountsConnCountLabel(one); got != "1 account" {
+		t.Errorf("got %q, want \"1 account\"", got)
+	}
+	three := AccountsListConnGroup{Accounts: []AccountsListRow{{}, {}, {}}}
+	if got := accountsConnCountLabel(three); got != "3 accounts" {
+		t.Errorf("got %q, want \"3 accounts\"", got)
+	}
+}

--- a/internal/templates/components/pages/accounts_list_types.go
+++ b/internal/templates/components/pages/accounts_list_types.go
@@ -2,60 +2,153 @@
 
 package pages
 
+import (
+	"fmt"
+	"sort"
+)
+
 // AccountsListProps is the typed input for the /accounts admin page.
 type AccountsListProps struct {
 	CSRFToken string
 
-	// Net totals across all displayed accounts (computed per-viewer).
-	// HasAnyBalance is the gate the templ uses to render the summary row.
+	// Net totals across all displayed accounts (computed per-viewer, and
+	// re-scoped server-side when a member filter is active).
 	NetWorth         float64
 	TotalAssets      float64
 	TotalLiabilities float64
 	HasAnyBalance    bool
 
-	// Household-member filter strip. Only rendered when len > 1.
-	Users []AccountsListUserFilter
+	// Household-member filter. Options are only populated for editors;
+	// ActiveUserID is the currently-selected member ("" = all).
+	Users        []AccountsListUserFilter
+	ActiveUserID string
 
-	// One row per account.
-	Accounts []AccountsListRow
+	// Accounts grouped by connection (institution). TotalAccounts is the
+	// flat count, used for the empty-state gate.
+	Groups        []AccountsListConnGroup
+	TotalAccounts int
 }
 
-// AccountsListUserFilter mirrors ConnectionsUserFilter — one chip in the
-// "filter by household member" strip.
+// AccountsListUserFilter is one option in the "filter by household member"
+// dropdown.
 type AccountsListUserFilter struct {
-	ID            string // short_id — drives the x-show filter value
+	ID            string // short_id — the ?user= filter value
 	Name          string
 	First         string // first letter for the avatar circle fallback
 	AvatarVersion string // user updated_at unix timestamp for cache-busting
 }
 
-// AccountsListRow is one table row. Fields are pre-formatted (display_name
+// AccountsListConnGroup is one connection's accounts plus the header data:
+// the institution name, the shared connection health, and a balance
+// subtotal. Connection health lives here (one status per connection) so the
+// individual rows don't repeat it.
+type AccountsListConnGroup struct {
+	ConnectionShortID string
+	InstitutionName   string
+	Status            string // "active" | "error" | "pending_reauth" | "disconnected" | ""
+	Subtotal          float64
+	HasSubtotal       bool
+	Accounts          []AccountsListRow
+}
+
+// AccountsListRow is one account row. Fields are pre-formatted (display_name
 // applied, balance sign adjusted for liabilities, currency carried alongside).
 type AccountsListRow struct {
-	ID          string // formatted UUID
-	UserID      string // short_id — used by the x-show filter and avatar URL
-	DisplayName string // display_name with fallback to name
-	Type        string // canonical account type ("depository", "credit", ...)
+	ID           string // formatted UUID
+	UserID       string // short_id — owner; drives the member filter + avatar URL
+	DisplayName  string // display_name with fallback to name
+	Type         string // canonical account type ("depository", "credit", ...)
 	SubtypeValid bool
-	Subtype     string
-	MaskValid   bool
-	Mask        string
+	Subtype      string
+	MaskValid    bool
+	Mask         string
+
 	OwnerName          string // empty when no linked household member
 	OwnerFirst         string // first letter for the avatar dot fallback
 	OwnerAvatarVersion string // user updated_at unix timestamp for cache-busting
+
 	InstitutionName string
 
-	// Connection context — lets the row pill out reauth/disconnected state
-	// without fetching connection rows again.
+	// Connection context — used to group rows and (on the group header)
+	// surface reauth/disconnected state.
 	ConnectionShortID string
-	ConnectionStatus  string // "active" | "error" | "pending_reauth" | "disconnected" | ""
+	ConnectionStatus  string
 
 	IsDependentLinked bool
 	Excluded          bool
 
-	HasBalance   bool
-	BalanceFloat float64 // sign-adjusted (negative for liabilities)
+	HasBalance      bool
+	BalanceFloat    float64 // sign-adjusted (negative for liabilities)
 	IsoCurrencyCode string
 
 	IsLiability bool
+}
+
+// GroupAccountsByConnection buckets pre-sorted account rows by connection,
+// preserving row order within each group. Groups are ordered by subtotal
+// (largest first); groups without any balance sink below those with one, and
+// the orphan bucket (accounts whose connection was deleted — SET NULL)
+// sinks last. Pure function so the grouping is unit-testable without a DB.
+func GroupAccountsByConnection(rows []AccountsListRow) []AccountsListConnGroup {
+	order := make([]string, 0)
+	byKey := make(map[string]*AccountsListConnGroup)
+	for _, r := range rows {
+		key := r.ConnectionShortID
+		g, ok := byKey[key]
+		if !ok {
+			g = &AccountsListConnGroup{
+				ConnectionShortID: key,
+				InstitutionName:   r.InstitutionName,
+				Status:            r.ConnectionStatus,
+			}
+			byKey[key] = g
+			order = append(order, key)
+		}
+		if g.InstitutionName == "" && r.InstitutionName != "" {
+			g.InstitutionName = r.InstitutionName
+		}
+		if g.Status == "" && r.ConnectionStatus != "" {
+			g.Status = r.ConnectionStatus
+		}
+		if r.HasBalance {
+			g.Subtotal += r.BalanceFloat
+			g.HasSubtotal = true
+		}
+		g.Accounts = append(g.Accounts, r)
+	}
+	groups := make([]AccountsListConnGroup, 0, len(order))
+	for _, k := range order {
+		groups = append(groups, *byKey[k])
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		a, b := groups[i], groups[j]
+		// Orphan accounts (no connection) always sink last.
+		ao, bo := a.ConnectionShortID == "", b.ConnectionShortID == ""
+		if ao != bo {
+			return !ao
+		}
+		// Groups carrying a balance rank above balance-less ones.
+		if a.HasSubtotal != b.HasSubtotal {
+			return a.HasSubtotal
+		}
+		return a.Subtotal > b.Subtotal
+	})
+	return groups
+}
+
+// accountsConnLabel is the group header's institution label, with a fallback
+// for orphan accounts whose connection was removed.
+func accountsConnLabel(g AccountsListConnGroup) string {
+	if g.InstitutionName != "" {
+		return g.InstitutionName
+	}
+	return "Unlinked accounts"
+}
+
+// accountsConnCountLabel renders the dimmed "N accounts" suffix.
+func accountsConnCountLabel(g AccountsListConnGroup) string {
+	if len(g.Accounts) == 1 {
+		return "1 account"
+	}
+	return fmt.Sprintf("%d accounts", len(g.Accounts))
 }

--- a/static/js/admin/components/accounts.js
+++ b/static/js/admin/components/accounts.js
@@ -1,8 +1,9 @@
 // Accounts list page Alpine component for /accounts.
 //
 // Convention reference: docs/design-system.md → "Alpine page components".
-// Owns the client-side filter (search input + family-member chip strip)
-// and sort state for the flat accounts table.
+// The page groups accounts by connection server-side and the member filter is
+// a server-side dropdown, so the only client behaviour left is the
+// exclude/include action dispatched from a row's overflow menu.
 (function () {
   function restorePageState() {
     if (window.bbProgress && window.bbProgress.finish) window.bbProgress.finish();
@@ -21,63 +22,12 @@
   document.addEventListener('alpine:init', function () {
     Alpine.data('accountsList', function () {
       return {
-        filter: '',
-        filterUser: 'all',
-        sortKey: 'balance',
-        sortDir: 'desc',
-
         init: function () {
           var self = this;
           // Listen for excluded-toggle dispatches from the row overflow menu.
           window.addEventListener('account-set-excluded', function (e) {
             self.setExcluded(e.detail.id, e.detail.excluded);
           });
-          // Initial sort on mount so SSR-ordered rows respect the default key.
-          this.applySort();
-        },
-
-        matches: function (el) {
-          if (!this.filter) return true;
-          return (el.dataset.search || '').includes(this.filter.toLowerCase());
-        },
-
-        setSort: function (key) {
-          if (this.sortKey === key) {
-            this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
-          } else {
-            this.sortKey = key;
-            // Balance defaults to descending (largest first); text columns ascending.
-            this.sortDir = key === 'balance' ? 'desc' : 'asc';
-          }
-          this.applySort();
-        },
-
-        applySort: function () {
-          var tbody = document.querySelector('[data-account-row]');
-          if (!tbody) return;
-          tbody = tbody.parentElement;
-          if (!tbody) return;
-          var rows = Array.prototype.slice.call(tbody.querySelectorAll('[data-account-row]'));
-          var key = this.sortKey;
-          var dir = this.sortDir === 'asc' ? 1 : -1;
-          rows.sort(function (a, b) {
-            var av, bv;
-            if (key === 'balance') {
-              // Rows without a balance sink to the bottom regardless of direction.
-              var aHas = a.dataset.hasBalance === '1';
-              var bHas = b.dataset.hasBalance === '1';
-              if (aHas !== bHas) return aHas ? -1 : 1;
-              av = parseFloat(a.dataset.balance) || 0;
-              bv = parseFloat(b.dataset.balance) || 0;
-              return (av - bv) * dir;
-            }
-            av = (a.dataset[key] || '');
-            bv = (b.dataset[key] || '');
-            if (av < bv) return -1 * dir;
-            if (av > bv) return 1 * dir;
-            return 0;
-          });
-          for (var i = 0; i < rows.length; i++) tbody.appendChild(rows[i]);
         },
 
         setExcluded: function (accountId, excluded) {


### PR DESCRIPTION
Applies the approved `/accounts` redesign — the dense 5-column sortable table becomes the Workflows-DNA list-row surface, **grouped by connection**.

## What changed
- **Grouped by connection.** Each institution is a quiet labelled group (name · count · subtotal — the `/transactions` day-group idiom) carrying the connection health (one status per connection: a `Reauth needed` / `Disconnected` badge + a recovery link to `/connections`) above its account list-rows. Orphan accounts (connection deleted → `SET NULL`) bucket last.
- **List-rows replace the table.** A type tile, the account name (+ `Linked`/`Excluded` badges + owner avatar), a quiet `····mask · Type` line, and the balance (red for liabilities). Status is not repeated per-row — it lives on the group header. Rows stack cleanly on mobile (no column-hiding).
- **Member filter is server-side** (`?user=<short_id>`), so every group subtotal re-scopes to the selected member. Unknown ids fall back to "all".
- **Dropped** the client-side member chip strip, the search box, and clickable-header sorting — with a household's handful of accounts, grouping carries it. `accounts.js` shrinks to just the exclude/include action.
- `GroupAccountsByConnection` is a pure, unit-tested function; the loading skeleton is updated to match.

The full `/accounts/{id}` detail page (with transactions) is unchanged and remains the click-through target. A quick-manage **drawer** is a planned follow-up (prototyped in the `/design` → Workflows DNA tab, #1798).

## After
<img src="https://bb-artifacts.exe.xyz/f/3cf93b03d8774994.jpg" width="800" alt="/accounts redesign — desktop">

Mobile:
<img src="https://bb-artifacts.exe.xyz/f/09013e0c165c3ab2.jpg" width="300" alt="/accounts redesign — mobile">

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (unit) — green
- [x] New unit test `TestGroupAccountsByConnection` (ordering, subtotals, status-on-header, orphan bucket)
- [x] Verified live with real dev data: groups + subtotals + owner avatars + liabilities render; `?user=` filter + invalid-fallback return 200; exclude/include still works
- [ ] Reviewer: confirm scoping for a non-editor member (already query-scoped) reads right
