### PR TITLE
docs(markdown): document supported Markdown format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Canonical specs in `docs/`:
 - `mcp-tools-reference.md` — MCP tools
 - `rule-dsl.md` — **canonical transaction-rule DSL**: condition grammar, actions, triggers, pipeline-stage priority, sync-vs-retroactive, chaining
 - `design-system.md` — CSS framework, components, icons
+- `markdown.md` — supported Markdown format (callouts, tables, task lists, code highlighting, sanitization); the single server-side renderer in `internal/markdown/`
 - `activity-timeline.md` — activity-timeline component contract (rendering, dedup, soft-delete tombstones, optimistic updates, how to add a new system-event kind)
 - `plaid-integration.md`, `teller-integration.md`, `simplefin-integration.md`, `csv-import.md` — provider specifics
 - `admin-dashboard.md`, `mcp-server.md`, `rest-api.md`, `backup.md` — subsystem details

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,87 @@
+# Markdown rendering
+
+One server-side renderer ([goldmark](https://github.com/yuin/goldmark) →
+[bluemonday](https://github.com/microcosm-cc/bluemonday)) produces the HTML for
+every Markdown surface: agent transcripts, reports, transaction comments, and
+workflow prompt previews. No client-side parser. Source: `internal/markdown/`;
+output is wrapped in `.bb-prose` by the caller.
+
+Standard **CommonMark + GFM** is supported as you'd expect. This doc only covers
+the non-obvious bits.
+
+## Callouts (GitHub-style admonitions)
+
+A blockquote whose **first line, alone,** is `[!TYPE]` renders as a colored,
+icon'd box:
+
+```markdown
+> [!NOTE]
+> Body goes here. Markdown inside works.
+```
+
+Five types: `NOTE` · `TIP` · `IMPORTANT` · `WARNING` · `CAUTION`. The marker
+must be on its own line — trailing text on the marker line (`> [!NOTE] hi`)
+falls back to a plain blockquote so nothing is dropped.
+
+## Tables
+
+GFM tables, with per-column alignment via the `:` in the delimiter row:
+
+```markdown
+| Left | Center | Right |
+|:-----|:------:|------:|
+| a    | b      | c     |
+```
+
+## Task lists
+
+```markdown
+- [x] done
+- [ ] todo
+```
+
+Checkboxes are **read-only** (rendered `disabled`) — display only, not
+interactive.
+
+## Fenced code blocks
+
+Syntax-highlighted server-side ([chroma](https://github.com/alecthomas/chroma),
+class-based — themed by CSS for light/dark, no JS). Each block gets chrome: a
+language label pill and a copy button.
+
+````markdown
+```sql
+SELECT * FROM transactions;
+```
+````
+
+The language tag drives highlighting; `text`/`plaintext`/no-tag render plain
+(no language pill).
+
+## Headings
+
+Every heading gets an auto-generated `id` (slug of its text) and a `#`
+hover-anchor for deep-linking. Heading levels are **not** shifted — `#` stays
+`<h1>`; `.bb-prose` CSS keeps them visually modest.
+
+## Also on
+
+- **Strikethrough** — `~~text~~`
+- **Autolinks** — bare URLs become links
+- **Typographer** — straight quotes → curly, `--`/`---` → en/em dash, `...` → ellipsis
+- External links open in a new tab with `rel="noreferrer"`
+
+## Not supported / deliberately off
+
+- **Raw HTML is dropped.** Any `<tag>` in the source is stripped by goldmark
+  (unsafe mode off) and the output is sanitized as a second pass — untrusted
+  agent/user content can't inject markup. Allowed elements/attributes are
+  whitelisted in `sanitize.go`.
+- Footnotes, definition lists, Mermaid, math — not enabled (one extension each
+  to add later if a real need shows up).
+
+## Hard wraps
+
+Transaction comments render in hard-wrap mode (a single newline → `<br>`, like
+chat). Everywhere else uses standard CommonMark paragraph folding. Callers opt
+in with `markdown.WithHardWraps()`.


### PR DESCRIPTION
Adds a concise reference for Breadbox's supported Markdown format, focused on the non-obvious specifics rather than re-explaining CommonMark.

## Changes
- New `docs/markdown.md` — covers callouts (`> [!NOTE]` etc.), GFM tables with alignment, read-only task lists, server-side syntax-highlighted code blocks (language pill + copy chrome), heading auto-anchors, strikethrough/autolinks/typographer, the raw-HTML-dropped + bluemonday sanitization model, and hard-wrap mode for comments.
- One-line pointer added to the CLAUDE.md references list.

Verified against the actual engine config in `internal/markdown/` (`markdown.go`, `extensions.go`, `sanitize.go`).

## Test plan
- [x] Docs-only — no code changes
