### PR TITLE
fix(ui): improve tool component responsiveness on mobile

### DIFF
--- a/input.css
+++ b/input.css
@@ -3969,6 +3969,7 @@
   padding: 0.5rem 0.625rem 0.625rem 0.625rem;
   border-top: 1px solid color-mix(in oklch, var(--color-base-300) 50%, transparent);
   background: var(--color-base-100);
+  overflow-x: auto;
 }
 
 /* Final result + empty-state */
@@ -4086,6 +4087,22 @@
   /* Hide the scrollbar gutter to avoid a phantom scroll-track on
    * sidebars that fit in the viewport. */
   scrollbar-gutter: stable;
+}
+/* On narrow viewports the grid is single-column: the aside stacks
+ * below the transcript, so sticky positioning is jarring and useless. */
+@media (max-width: 1023px) {
+  .bb-run-aside {
+    position: static;
+    max-height: none;
+    overflow-y: visible;
+    scrollbar-gutter: auto;
+  }
+}
+/* On very small screens, hide the type label ("TOOL") and timestamps
+ * from tool-call summary rows so the tool name has room to breathe. */
+@media (max-width: 639px) {
+  .bb-tool__label { display: none; }
+  .bb-tool__time  { display: none; }
 }
 
 /* Tool call + result combined row. The body now contains two sections


### PR DESCRIPTION
Fixes #1802 — tool component rows were cramped on narrow mobile viewports (402px).

## Changes

Three CSS-only changes to `input.css`:

**1. Hide type label + timestamps on small screens (< 640px)**
`.bb-tool__label` ("TOOL" / "TOOL CALL · PENDING") and `.bb-tool__time` (start/end timestamps) are hidden below the `sm` breakpoint. The row on mobile becomes `[icon] [tool name] [chevron]` — clean and scannable. Desktop retains the full label + dual timestamps.

**2. Disable sticky aside on narrow viewports (< 1024px)**
`.bb-run-aside` switches from `position: sticky` to `position: static` below the `lg` breakpoint. At that width the grid is single-column and the aside stacks *below* the transcript, so sticky positioning is jarring rather than helpful.

**3. Allow horizontal scroll in expanded tool body**
`.bb-tool__body` gains `overflow-x: auto` so expanded JSON payloads can scroll horizontally rather than being silently clipped by the parent `overflow: hidden`.

## Screenshots

**Before** (from issue, 402×754 iPhone):

``&lt;img src="https://bb-artifacts.exe.xyz/f/2d9c227485557527.jpg" width="320" alt="before — mobile tool rows cramped"&gt;``

**After:**

<table>
  <tr><th>Mobile (402px)</th><th>Desktop (1280px)</th></tr>
  <tr>
    <td>``&lt;img src="https://bb-artifacts.exe.xyz/f/ce84b7dba92c07d8.jpg" width="320" alt="after — mobile tool rows clean"&gt;``</td>
    <td>``&lt;img src="https://bb-artifacts.exe.xyz/f/1725ed8cadc14e2c.jpg" width="640" alt="after — desktop tool rows unchanged"&gt;``</td>
  </tr>
</table>

Desktop retains the "TOOL CALL · PENDING" label and timestamps. Mobile drops them so the tool name has room.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSNi6Y5Ben8UrCckoLrr1N)_