### PR TITLE
design-system sprint: codify the surface language as a skill + first surface (/accounts)

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: design-system
+description: >
+  Breadbox's surface design language — the conventions for building and
+  redesigning admin UI surfaces so every page reads as one calm, legible
+  product. Codifies the principles, the canonical page anatomy, the component
+  vocabulary, and the redesign method (IA-first, not a re-skin). Invoke when
+  building a new admin surface or bringing an existing one up to standard.
+  Triggers: "redesign this page", "apply our design system", "apply the surface
+  language", "make this follow our conventions", "polish this surface", "bring
+  /accounts (etc.) up to the design system", "what's our pattern for X".
+  Pair with the `daisyui` skill (primitive classes) and `validate-ui` (browser
+  evidence). NOT for low-level CSS questions — those are `.claude/rules/daisyui.md`.
+metadata:
+  version: 0.1.0
+  status: living
+---
+
+# Breadbox Design System
+
+This is the **surface design language** for the admin app: the small set of
+decisions that make `/workflows`, `/workflows/runs`, and their drawers the
+cleanest surfaces we have, generalized so every page can read the same way —
+simple, easy on the eyes, space used well on desktop *and* mobile, with a flow
+that makes sense.
+
+It is **living**. When we refine a convention, update this skill in the same PR
+so it never drifts from what we actually ship. Treat a contradiction between
+this skill and the running app as a bug in one of them — reconcile, don't ignore.
+
+> **Scope.** This skill is about *composition* — how primitives assemble into a
+> coherent surface, and how to approach a redesign. For the primitive classes
+> themselves (which daisy class, which `bb-*` extension) defer to
+> [`.claude/rules/daisyui.md`](../../rules/daisyui.md) and `docs/design-system.md`.
+> For Settings tabs specifically, [`.claude/rules/settings.md`](../../rules/settings.md)
+> is the local dialect of this same language.
+
+---
+
+## The seven principles
+
+The DNA. Each is a small, reusable decision; together they're why our best
+surfaces feel calm.
+
+1. **One consistent chrome.** Every surface opens with the same `PageHeader`
+   (title + subtitle) and, when it has sections, a `TabBar`. Switching tabs
+   should feel like moving through one surface — not landing on
+   differently-shaped pages.
+
+2. **Status lives in one tile.** A single color-coded icon tile on the left
+   carries a row's state (success / error / running / reauth). No parallel
+   "Success" text badge next to it. Less ink, faster scan. Loading/running
+   states are *never* a daisy badge — badges are terminal/categorical only.
+
+3. **One body line, by priority.** A row says at most one thing. Pick the
+   highest-priority line (error → headline → note → silence) and let the title
+   carry the quiet rows. Don't stack three muted sublines.
+
+4. **Minimal icon clusters.** Secondary actions are bare icons with tooltips —
+   run toggle, gear, overflow kebab — not text buttons crowding the row. The
+   primary action can be a real button; everything else recedes.
+
+5. **Edit in a slide-over.** Create / configure / reconfigure happen in a
+   right-side `Drawer` (header · scrollable body · sticky footer). Context stays
+   put — no full-page detour, no cramped centered modal. Use `$store.drawers`.
+
+6. **Generous, honest spacing.** The daisy `list-row` grid inside a `bb-card`,
+   hairline dividers, real breathing room. One layout that stacks cleanly on
+   mobile — not a desktop table plus a separate mobile card list.
+
+7. **Identity via avatar.** People and workflows get a stable DiceBear avatar
+   (`UserAvatar`). Any feed of "who did this" reads the same on every surface.
+
+---
+
+## Canonical page anatomy
+
+A standard surface, top to bottom:
+
+```
+PageHeader{ Title, Subtitle, Right? }          ← chrome (principle 1)
+  TabBar{ Variant:"border", Items }            ← only if the surface has sections
+[ filter row ]                                  ← TabBar Variant:"box" w/ Counts + a quiet <select>
+[ summary strip ]                               ← StatTileRow, only when numbers lead the page
+group label line  ───────────  subtotal        ← quiet text, not a boxed card-header
+  <ul class="list ..."> in a bb-card            ← list-row grid (principle 6)
+    list-row: [status tile] [name + 1 body line] [value] [overflow]
+  ...
+EmptyState{…}                                   ← when the group / page is empty
+```
+
+Rules of thumb:
+
+- **Group, don't tab, when the axis is data.** `/accounts` groups rows by
+  *connection* with a quiet label line (institution · count … subtotal) over a
+  `bb-card` of list-rows — the `/transactions` day-group idiom. A boxed
+  card-header per group is too heavy; a label line is enough.
+- **A `box` `TabBar` is a filter, not navigation.** Give each item a `Count`.
+  Never let it stretch full-width — it scrolls horizontally on mobile
+  (`tabs` already does this on main as of #1803). Pair it with a `<select>` for
+  the secondary axis instead of a second row of tabs.
+- **Summary tiles only when numbers are the headline** (Net Worth / Assets /
+  Liabilities on `/accounts`, Backups stats). Don't tile a page whose job is a
+  list.
+- **Money is private by default.** `Amount` marks values `data-private` unless
+  `Public: true`; institution/account names get `data-private="institution|account"`.
+  See `internal/templates/components/private.templ` + the privacy engine.
+
+---
+
+## Component vocabulary
+
+Reach for these before authoring anything new. Full prop catalog:
+[`components.md`](components.md).
+
+| Intent | Component | File |
+| --- | --- | --- |
+| Page title + actions | `PageHeader` | `page_header.templ` |
+| Section / filter tabs | `TabBar` (`border` nav, `box` filter) | `tab_bar.templ` |
+| Section title + count + action | `SectionHeader` | `section_header.templ` |
+| A row's status | color-coded `IconTile` | `icon_tile.templ` |
+| Slide-over edit/create | `Drawer` + `DrawerHeader` + `DrawerFooter` | `drawer.templ` |
+| Choice cards in a drawer | `RadioCard` | `radio_card.templ` |
+| Per-row actions | `OverflowMenu` (Size `"sm"`) | `overflow_menu.templ` |
+| Identity | `UserAvatar` (`XS`/`SM`) | `user_avatar.templ` |
+| Money | `Amount` | `amount.templ` |
+| Summary numbers | `StatTile` / `StatTileRow` | `stat_tile.templ` |
+| Empty list / zero state | `EmptyState` | `empty_state.templ` |
+| Loading | daisy `skeleton` mirroring the real shape | `*_skeleton.templ` |
+| Settings tab body | `SettingsSection` + `SettingsRow` | `settings_*.templ` |
+
+A run/feed row reference implementation lives in `agent_run_row.templ`
+(`AgentRunRowList` + `AgentRunRow`) — the cleanest example of principles 2–7 in
+one component.
+
+---
+
+## The redesign method — IA first, not a re-skin
+
+When asked to bring a surface up to the design system, **do not** just swap
+classes. Improve the information architecture:
+
+1. **Name the surface's one job.** What is the user here to do? (`/accounts`:
+   see balances grouped by where the money lives, and manage a connection.)
+   Everything that doesn't serve that job is a candidate for removal.
+
+2. **Audit what's there.** List every control, column, badge, and filter.
+   For each: does it earn its pixels? Filters nobody uses, columns that repeat
+   the row title, sort headers on a 12-item list — cut them. (We removed the
+   type tabs + search box from `/accounts` because the list is short.)
+
+3. **Find the right grouping.** A flat list of N things usually wants a
+   grouping axis — connection, day, category, status. Group with a quiet label
+   line, order groups by something meaningful (subtotal desc, recency), and sink
+   the orphan/empty bucket last.
+
+4. **Collapse to the anatomy above.** Map the content onto PageHeader → optional
+   tabs → optional summary → grouped list-rows → drawer for edits. Move
+   multi-input edit flows into a `Drawer`.
+
+5. **Make the grouping testable.** Pure grouping/ordering logic goes in a
+   `*_types.go` helper with a unit test (see `GroupAccountsByConnection` +
+   `accounts_list_test.go`), so the IA decision is pinned, not vibes.
+
+6. **Keep scope honest.** Server-side filtering must re-scope subtotals; respect
+   soft-deletes, attribution (`COALESCE(attributed_user_id, …)`), currency
+   (never sum across `iso_currency_code`), and liability sign/color.
+
+It is expected — and wanted — that you make a real leap on what a surface's
+redesign *is*. Propose the IA change, show it in the sandbox or a screenshot,
+then implement on the live page.
+
+---
+
+## Build & validate loop
+
+1. Edit `.templ` → `templ generate` (or rely on `make dev-watch`). Commit both
+   the `.templ` and its generated `_templ.go` sibling.
+2. Prototype risky IA in the **`/design` sandbox** first — add a section in
+   `internal/templates/components/pages/design_*.templ` + register it in
+   `design_types.go`. Share `/design/c/{slug}?embed=1` for review.
+3. Run the server with `make dev-bg`; screenshot with `make dev-shot` or the
+   `validate-ui` skill. Attach the screenshot to the PR (upload via
+   `github-image-hosting` → bb-artifacts.exe.xyz).
+4. `go build ./... && go vet ./... && go test ./...` green before pushing.
+
+---
+
+## When NOT to use this
+
+- Low-level "which daisy class" → `.claude/rules/daisyui.md`.
+- Settings tab structure → `.claude/rules/settings.md` (a dialect of this).
+- The marketing site / onboarding wizard — different patterns (`bb-wizard-*`,
+  the Astro site repo).
+- The settings modal shell, sidebar, topbar — global chrome, not a surface.

--- a/.claude/skills/design-system/audit.md
+++ b/.claude/skills/design-system/audit.md
@@ -1,0 +1,108 @@
+# Primitive audit — flag list
+
+Goal-2 output of the design-system sprint: bless the canonical shape for each
+primitive (that lives in `SKILL.md` + `components.md`) and **flag** the
+divergent / duplicate / bespoke instances for retirement. This is the flag half
+— a worklist for the surface loop, **not** a refactor that's already happened.
+
+**Calibration.** Verified against the `design/system-sprint` tree on
+2026-06-13. `/accounts` is already migrated and is a reference, not a target.
+Line numbers are leads — re-grep before editing (generated `_templ.go` siblings
+move them). Priorities: **P1** clear DNA violation, fix soon · **P2** migrate
+when the surface is next touched · **P3** cosmetic / low-value.
+
+---
+
+## Already canonical (references, don't touch)
+
+- **list-row idiom:** `pages/accounts_list.templ`, `components/agent_run_row.templ`
+  (`AgentRunRow` + `AgentRunRowList`) — the reference for status-tile · one body
+  line · value · overflow.
+- **TabBar:** `reports.templ`, `workflows_runs.templ`, `subscriptions_list.templ`,
+  `workflows_shell.templ` use it correctly (border=nav, box=filter).
+- **Drawer:** connect-bank, provider-config, workflow create/edit, cron-field.
+- **Filters (all three blessed, see `components.md`):** `FilterSearchInput`
+  (client text — tags/categories/subscriptions), server-filter-toolbar
+  (`rules.templ`), box-`TabBar` (workflow-runs status).
+
+---
+
+## P1 — clear DNA violations
+
+### Bespoke tabs → `TabBar`
+- `pages/mcp_guide.templ:89` — hand-rolled `<div role="tablist">` + `role="tab"`
+  buttons with Alpine state. → `components.TabBar(Variant:"border", Items:…)`.
+
+### Low-contrast soft badges (invisible on the dark theme)
+Per `reference_theme_vivid_tones`: only info/success/warning/error are vivid;
+primary/secondary/accent/neutral soft badges read as gray-on-gray. Swap
+`primary→info`, `neutral→ghost` (or a vivid tone that fits the meaning).
+- `pages/report_detail.templ:41` — `badge-soft badge-primary` "Unread" → `badge-info`.
+- `pages/access.templ:436` — `badge-soft badge-primary` "Full access" → `badge-success`.
+- `pages/mcp_guide.templ:121,168,197` — `badge-soft badge-primary` "OAuth" → `badge-info`.
+- `pages/notifications_settings.templ:130` — `badge-soft badge-neutral` "Disabled" → `badge-ghost`.
+- `pages/developer_settings.templ:112,114,116` — `badge-soft badge-neutral/primary` "bug"/"task"/"filed-via-bug" → `badge-ghost`.
+
+### Loading state rendered as a badge
+- `components/helpers.go:246` — the status helper renders `in_progress` as
+  `badge badge-soft badge-warning badge-sm`. A live/running state must not be a
+  badge (`feedback_no_badge_for_loading`). → spinner + text, or a non-badge
+  running affordance. Audit every caller of this helper before changing it
+  (sync logs, run rows) so terminal statuses keep their badge.
+
+### Hand-rolled empty state → `EmptyState`
+- `pages/connection_detail.templ:503` — centered "No sync history yet" block →
+  `components.EmptyState(Compact:true, …)`.
+
+---
+
+## P2 — tables to migrate to grouped list-rows
+
+KEEP (justified dense/sortable/wizard matrices): `backups.templ:198`,
+`csv_import.templ:225`, `rule_detail.templ:380` (small embedded 3-col).
+
+MIGRATE — these are entity lists that read better as list-rows (status tile ·
+name · one body line · value · overflow), grouped where there's a natural axis:
+- `pages/rules.templ:74` — rules list (Enabled/Rule/Action/Stage/Hits/Last hit).
+  Group by stage or status; toggle + name + action summary, metrics in overflow.
+- `pages/subscriptions_list.templ:276` — recurring charges. Group by status
+  (active/paused); status tile + name + cadence line + amount.
+- `pages/account_link_detail.templ:36` — matched txn pairs. Already carries a
+  mobile card fallback → unify to one list-row layout (confidence as the tile).
+- `components/report_table.templ:36` — reports. Has a desktop-table +
+  mobile-card split → collapse to a single list-row list.
+
+> These overlap with the goal-3 surface loop (e.g. `/rules`, `/subscriptions`).
+> Prefer doing the table→list-row migration *as part of* that surface's redesign
+> rather than as an isolated swap.
+
+---
+
+## P3 — chrome & legacy cosmetics
+
+### PageHeader adoption
+~12 pages still open with hand-rolled `bb-page-header`/`bb-page-title`. Adopt
+`components.PageHeader` as each is touched. Straightforward (detail pages):
+`account_link_detail`, `agent_run_detail`, `session_detail`, `logs`. Lower
+priority (forms/wizards that may keep bespoke chrome): `category_form`,
+`rule_form`, `tag_form`, `user_form`, `connection_new`, `connection_reauth`,
+`csv_import`, `create_login`.
+
+### Legacy 40×40 icon-header tiles inside section bodies
+`category_form`, `rule_form`, `tag_form`, `users`, `create_login` — `bb-icon-header__tile`
+inside form section headers (legacy pre-PageHeader pattern). Retire when those
+forms adopt PageHeader; harmless until then.
+
+---
+
+## Not violations (checked, leaving alone)
+
+- `users.templ:148` "setup pending" badge — a persistent categorical state, not
+  a loading spinner. Fine as a badge.
+- `rule_detail.templ:343,348` "N pending" / "0 pending" — a *count* of pending
+  matches, not a running state. Fine.
+- `subscriptions_list.templ` User/Type `join-item` toggles, `transactions.templ`
+  Grouped/List view toggle, `mcp_guide` Guide/Config toggle — low-cardinality
+  local view toggles, not navigation or data filters. Acceptable as `join`.
+- Collapsible multi-field filter panels (`transactions`, `logs`) — complex
+  multi-type filtering (dates, pickers); keep, just hold them to one shape.

--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -1,0 +1,201 @@
+# Component catalog
+
+The shared surface components, their props, and the one-line rule for each.
+All live in `internal/templates/components/`. This is a reference — read the
+`.templ`/`.go` source for the full contract. Generated `_templ.go` siblings are
+committed; run `templ generate` after editing a `.templ`.
+
+> Enum values below are the source-of-truth constants. When you add a variant,
+> update both the component and this file in the same PR (this skill is living).
+
+---
+
+## PageHeader — `page_header.templ`
+
+The chrome every surface opens with. Title + optional subtitle + trailing actions.
+
+```go
+PageHeaderProps{
+    Title                string        // required
+    Subtitle             string        // optional
+    Icon                 string        // optional lucide name
+    SubtitleHideOnMobile bool          // hide subtitle < sm to save vertical space
+    Leading              templ.Component // optional avatar/visual left of the title
+    TitleBadge           templ.Component // optional inline chip (e.g. "Beta")
+    SecondaryAction      templ.Component // PageHeaderSecondaryAction(...)
+    Action               templ.Component // PageHeaderAction(...) — primary, trailing
+}
+```
+
+- One primary action max; everything else is `SecondaryAction` or recedes into the body.
+- Build the common single-action case with `PageHeaderAction(href, icon, label)`.
+
+## TabBar — `tab_bar.templ`
+
+Two jobs, one component. `border` = section navigation; `box` = in-page filter.
+
+```go
+TabBarProps{
+    Items      []TabBarItem
+    Variant    string // "border" (default, nav) | "box" (filter)
+    AriaLabel  string // REQUIRED
+    Scrollable bool   // flex-nowrap; wrap caller in overflow-x-auto for mobile
+}
+TabBarItem{ Label string; Href templ.SafeURL; Active bool; Icon string; Count *int }
+```
+
+- `border` for Gallery/Runs-style section tabs (give each an `Icon`).
+- `box` for status/type filters — give each item a `Count` (use
+  `components.SectionHeaderIntPtr(n)`). Pair with a `<select>` for a second axis;
+  don't stack two tab rows.
+- Never stretch a `box` TabBar full-width. It scrolls horizontally on mobile.
+
+## SectionHeader — `section_header.templ`
+
+A titled section divider with an optional count + trailing action.
+
+```go
+SectionHeaderProps{ Icon string; Title string; Count *int; CountLabel string /* "items" */; Action templ.Component }
+```
+
+`SectionHeaderIntPtr(n)` builds the `*int` for `Count` (and for `TabBarItem.Count`).
+
+## IconTile — `icon_tile.templ`
+
+The single color-coded status tile that leads a row (principle 2).
+
+```go
+@components.IconTile(tone, icon)  // tone drives bg + currentColor of the glyph
+```
+
+- Tone is a semantic word (`success`/`error`/`warning`/`info`/…) mapped to a
+  `bb-icon-tile--{tone}` class. The inner glyph inherits `currentColor` — don't
+  add `text-{tone}` yourself.
+- This is the *status* affordance. Do not also render a "Success" text badge.
+
+## Drawer — `drawer.templ`
+
+The slide-over for create / configure / edit (principle 5). Opened via
+`$store.drawers.open('<id>')`; closed by Escape or backdrop.
+
+```go
+DrawerProps{ ID string /* required, store key */; Title string /* aria-label */; Size string /* sm|md(default)|lg|xl */; Class string }
+DrawerHeaderProps{
+    Icon string; BrandIcon string  // BrandIcon = vendored brand SVG (brand.templ)
+    Title string; TitleExpr string // TitleExpr = Alpine x-text, overrides Title
+    Subtitle string; SubtitleExpr string
+    Right templ.Component           // optional control on the header top line (e.g. enable toggle)
+}
+@components.DrawerFooter() { /* sticky action pair — primary on the right */ }
+```
+
+Anatomy: `DrawerHeader` → scrollable body → sticky `DrawerFooter`. Namespace ids
+per surface so two drawers on one page never collide.
+
+## RadioCard — `radio_card.templ`
+
+Choice cards inside a drawer (trigger type, model, mode).
+
+```go
+RadioCardProps{
+    Name string; Value string          // required — radio group + this card's value
+    Icon string; Title string; Subtitle string
+    ModelExpr string; ChangeExpr string // Alpine x-model / @change (empty = native)
+    Checked bool; Class string
+}
+```
+
+## OverflowMenu — `overflow_menu.templ`
+
+Per-row kebab of secondary actions.
+
+```go
+OverflowMenuProps{ AriaLabel string /* required */; Items []OverflowMenuItem; Position string /* end(default)|start */; Size string /* sm(default)|xs */ }
+```
+
+- Use `Size: "sm"` on list-rows (the `xs` circle reads as too small/fiddly — see #1793).
+- Render it *outside* a row's main `<a>` link so the menu button isn't swallowed by the navigation hit area.
+
+## UserAvatar — `user_avatar.templ`
+
+Stable DiceBear identity for people and agents (principle 7).
+
+```go
+UserAvatarProps{
+    ID string; Name string /* tooltip+alt+fallback glyph */; Version string /* updated_at for ?v= */
+    Size UserAvatarSize; IsAgent bool; Ring bool; Inline bool; Decorative bool; Lazy bool; Loading bool
+    Class string; Title string; SrcOverride string
+}
+// Sizes: UserAvatarXS(16) · UserAvatarSm · UserAvatarMd · UserAvatarLg · UserAvatarXL
+```
+
+- `IsAgent: true` routes to the agent DiceBear style (or a bot-tile fallback).
+- `Decorative: true` (alt="") when an adjacent `<strong>` already names the actor.
+- Use `XS` on dense list-rows (owner badge), larger on profile/header surfaces.
+
+## Amount — `amount.templ`
+
+Every monetary value. **Private by default.**
+
+```go
+AmountProps{
+    Value float64; Intent AmountIntent; Format AmountFormat; Precision int
+    Pending bool; Class string; Public bool // Public = opt OUT of privacy (rare)
+}
+// Intent: AmountTransaction("") · AmountBalance("balance") · AmountCost("cost")
+// Format: AmountFormatStandard("") · AmountFormatAbbreviated · AmountFormatCompact
+```
+
+- Sign convention is intent-aware; pair every amount with its `iso_currency_code`
+  upstream and never sum across currencies.
+- Leave `Public` false for all real balances/totals — it stays `data-private="amount"`.
+
+## StatTile / StatTileRow — `stat_tile.templ`
+
+Summary numbers when figures lead the page (Net Worth / Assets / Liabilities).
+
+```go
+StatTileProps{
+    Icon string; Label string; Value string; Description string
+    Tone StatTileTone; Href templ.SafeURL
+    ValuePrivateKind string; DescriptionPrivateKind string // "amount" → marks data-private
+}
+// Tone: StatToneNeutral · StatTonePrimary · StatToneSuccess · StatToneWarning · StatToneError · StatToneInfo
+@components.StatTileRow() { @components.StatTile(...) ... } // the divided strip
+```
+
+Set `ValuePrivateKind: "amount"` on money tiles so they obfuscate with privacy mode.
+
+## EmptyState — `empty_state.templ`
+
+Zero state for an empty list/group/page.
+
+```go
+EmptyStateProps{
+    Icon string; Title string /* required */; Body string
+    CTAHref templ.SafeURL; CTAIcon string; CTALabel string; CustomCTA templ.Component
+    Compact bool; InCard bool // Compact = small inline; InCard wraps the compact variant
+}
+```
+
+## Skeletons — `*_skeleton.templ`
+
+Loading placeholders that mirror the real component's shape so the swap-in
+doesn't shift layout. Use the daisy `skeleton` primitive (the hand-rolled
+`bb-skeleton*` family is retired). See `accounts_list_skeleton.templ` for the
+grouped-list shape.
+
+## Settings dialect — `settings_section.templ` / `settings_row.templ` / `settings_autosave_form.templ`
+
+Settings tabs use a local dialect of this language. See
+[`.claude/rules/settings.md`](../../rules/settings.md) — `SettingsSection` +
+`SettingsRow`, auto-save single controls, no accordions, danger-zone variant.
+
+---
+
+## Reference implementation
+
+`agent_run_row.templ` (`AgentRunRowList` + `AgentRunRow`) is the cleanest single
+example of principles 2–7: status `IconTile`, one priority body line, bare-icon
+actions, `UserAvatar` identity, list-row spacing in a `bb-card`. Read it before
+authoring a new feed/list row.

--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -50,6 +50,31 @@ TabBarItem{ Label string; Href templ.SafeURL; Active bool; Icon string; Count *i
   don't stack two tab rows.
 - Never stretch a `box` TabBar full-width. It scrolls horizontally on mobile.
 
+## Filter controls — three blessed shapes, not duplicates
+
+There are three filter primitives. They are **not** redundant — pick by the
+filtering model, don't invent a fourth:
+
+| Use | Shape | Example |
+| --- | --- | --- |
+| Single-axis **client-side text** filter on a short list | `FilterSearchInput` (`filter_search_input.templ`) | `/tags`, `/categories`, `/subscriptions` |
+| **Multi-axis server-side** filter (search + status + category + creator) | server filter toolbar (sandbox slug `server-filter-toolbar`) | `/rules` |
+| **Status segments** with live counts | box-variant `TabBar` + a `<select>` for the secondary axis | `/workflows/runs` |
+
+Complex multi-field panels (date ranges + pickers, e.g. `/transactions`,
+`/logs`) are a collapsible panel — fine, but hold them to one shape. A
+low-cardinality *view* toggle (Grouped/List) is a daisy `join`, not a filter.
+
+## Badge tone & contrast — vivid only
+
+Badges are **terminal/categorical** state only — never a loading/running/
+in-progress state (that's a spinner + text). And on the dark theme only
+`info`/`success`/`warning`/`error` are vivid; `primary`/`secondary`/`accent`/
+`neutral` soft badges read as gray-on-gray and all but disappear
+(`reference_theme_vivid_tones`). Map meaning to a vivid tone, or use
+`badge-ghost` for a deliberately quiet neutral. Standard shape:
+`badge badge-soft badge-{vivid-tone} badge-sm`.
+
 ## SectionHeader — `section_header.templ`
 
 A titled section divider with an optional count + trailing action.

--- a/internal/admin/accounts.go
+++ b/internal/admin/accounts.go
@@ -70,36 +70,68 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 			userAvatarVersionByShort[u.ShortID] = usersAvatarVersion(u.UpdatedAt)
 		}
 
-		// Build typed rows + running totals.
+		// Build typed rows.
 		var rows []pages.AccountsListRow
-		var totalAssets, totalLiabilities float64
-		var hasAnyBalance bool
-
-		appendRow := func(row pages.AccountsListRow) {
-			if row.HasBalance {
-				hasAnyBalance = true
-				if row.IsLiability {
-					totalLiabilities += math.Abs(row.BalanceFloat)
-				} else {
-					totalAssets += row.BalanceFloat
-				}
-			}
-			rows = append(rows, row)
-		}
-
 		if useUser {
 			for _, r := range userRows {
-				appendRow(accountRowFromListByUser(r, userNameByShort, userAvatarVersionByShort))
+				rows = append(rows, accountRowFromListByUser(r, userNameByShort, userAvatarVersionByShort))
 			}
 		} else {
 			for _, r := range allRows {
-				appendRow(accountRowFromListAll(r, userNameByShort, userAvatarVersionByShort))
+				rows = append(rows, accountRowFromListAll(r, userNameByShort, userAvatarVersionByShort))
 			}
 		}
 
-		// Default ordering: liabilities & no-balance at the bottom; biggest
-		// asset first. The Alpine factory re-sorts client-side when the user
-		// clicks a header.
+		// Per-owner account counts over the UNFILTERED set, so the member
+		// dropdown order is stable regardless of the active filter.
+		accountsPerUser := make(map[string]int)
+		for _, row := range rows {
+			if row.UserID != "" {
+				accountsPerUser[row.UserID]++
+			}
+		}
+
+		// Member filter (editors only — members are already scoped to their
+		// own accounts at the query layer). A ?user=<short_id> narrows the
+		// page to one owner and re-scopes the totals + groups server-side, so
+		// every subtotal stays accurate. An unknown short_id falls back to
+		// "all" rather than erroring (matches the admin filter convention).
+		activeUserID := ""
+		if IsEditor(sm, r) {
+			if u := r.URL.Query().Get("user"); u != "" {
+				if _, ok := userNameByShort[u]; ok {
+					activeUserID = u
+				}
+			}
+		}
+		if activeUserID != "" {
+			filtered := make([]pages.AccountsListRow, 0, len(rows))
+			for _, row := range rows {
+				if row.UserID == activeUserID {
+					filtered = append(filtered, row)
+				}
+			}
+			rows = filtered
+		}
+
+		// Totals over the (filtered) rows.
+		var totalAssets, totalLiabilities float64
+		var hasAnyBalance bool
+		for _, row := range rows {
+			if !row.HasBalance {
+				continue
+			}
+			hasAnyBalance = true
+			if row.IsLiability {
+				totalLiabilities += math.Abs(row.BalanceFloat)
+			} else {
+				totalAssets += row.BalanceFloat
+			}
+		}
+
+		// Within-group ordering: liabilities & no-balance at the bottom,
+		// biggest asset first. GroupAccountsByConnection preserves this order
+		// inside each connection.
 		sort.SliceStable(rows, func(i, j int) bool {
 			a, b := rows[i], rows[j]
 			if a.HasBalance != b.HasBalance {
@@ -107,8 +139,6 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 			}
 			return a.BalanceFloat > b.BalanceFloat
 		})
-
-		netWorth := totalAssets - totalLiabilities
 
 		data := map[string]any{
 			"PageTitle":   "Accounts",
@@ -119,24 +149,20 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 
 		props := pages.AccountsListProps{
 			CSRFToken:        GetCSRFToken(r),
-			NetWorth:         netWorth,
+			NetWorth:         totalAssets - totalLiabilities,
 			TotalAssets:      totalAssets,
 			TotalLiabilities: totalLiabilities,
 			HasAnyBalance:    hasAnyBalance,
-			Accounts:         rows,
+			ActiveUserID:     activeUserID,
+			Groups:           pages.GroupAccountsByConnection(rows),
+			TotalAccounts:    len(rows),
 		}
 
-		// Only editors/admins see the household filter (members are already
-		// scoped to themselves at the query layer).
+		// Only editors/admins see the household filter dropdown (members are
+		// already scoped to themselves at the query layer).
 		if IsEditor(sm, r) {
 			// Sort users by number of accounts (descending) so the most active
 			// household member surfaces first, like the connections page.
-			accountsPerUser := make(map[string]int)
-			for _, row := range rows {
-				if row.UserID != "" {
-					accountsPerUser[row.UserID]++
-				}
-			}
 			usersCopy := make([]db.User, len(users))
 			copy(usersCopy, users)
 			sort.Slice(usersCopy, func(i, j int) bool {

--- a/internal/templates/components/accounts_list_skeleton.templ
+++ b/internal/templates/components/accounts_list_skeleton.templ
@@ -2,13 +2,14 @@ package components
 
 // AccountsListSkeleton renders a placeholder mirroring the layout of the
 // /accounts page — the three-stat summary card (Net Worth / Assets /
-// Liabilities) plus the sortable account table. Sized to match the
-// real component so a swap-in (current or future) doesn't shift layout.
+// Liabilities) plus a couple of connection groups (a quiet label line over a
+// card of account list-rows). Sized to match the real component so a swap-in
+// (current or future) doesn't shift layout.
 //
 // /accounts is a full-SSR page today; this primitive is exposed in
-// /design#loading so it's ready for the eventual AJAX/paginated swap
-// and discoverable to anyone wiring loading states for adjacent
-// account-centric panels.
+// /design#loading so it's ready for the eventual AJAX/paginated swap and
+// discoverable to anyone wiring loading states for adjacent account-centric
+// panels.
 //
 // Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
 // hand-rolled `bb-skeleton*` family is being retired).
@@ -25,71 +26,41 @@ templ AccountsListSkeleton() {
 				}
 			</div>
 		</div>
-		<!-- Filter search input -->
-		<div class="skeleton h-10 w-full sm:max-w-sm rounded-xl mb-4"></div>
-		<!-- Accounts table -->
-		<div class="bb-card overflow-hidden">
-			<div class="overflow-x-auto">
-				<table class="table table-sm">
-					<thead class="text-xs text-base-content/60">
-						<tr>
-							<th class="min-w-[12rem]"><div class="skeleton h-3 w-16"></div></th>
-							<th class="hidden md:table-cell"><div class="skeleton h-3 w-20"></div></th>
-							<th class="hidden lg:table-cell"><div class="skeleton h-3 w-12"></div></th>
-							<th class="hidden lg:table-cell"><div class="skeleton h-3 w-14"></div></th>
-							<th class="text-right"><div class="skeleton h-3 w-16 ml-auto"></div></th>
-							<th class="w-8"></th>
-						</tr>
-					</thead>
-					<tbody>
-						for i := 0; i < 6; i++ {
-							@accountsListSkeletonRow()
-						}
-					</tbody>
-				</table>
-			</div>
+		<!-- Connection groups: a label line over a card of account rows -->
+		<div class="flex flex-col gap-5">
+			@accountsListSkeletonGroup(2)
+			@accountsListSkeletonGroup(1)
 		</div>
 	</div>
 }
 
-// accountsListSkeletonRow mirrors one accountsListRow: icon tile + name/meta
-// stack, optional desktop-only institution/type/owner cells, right-aligned
-// balance, overflow-menu slot. Widths line up with real-row content so the
-// swap-in doesn't shift the page.
-templ accountsListSkeletonRow() {
-	<tr>
-		<!-- Account name + icon -->
-		<td>
-			<div class="flex items-center gap-3">
-				<div class="skeleton w-8 h-8 rounded-md shrink-0"></div>
-				<div class="min-w-0 space-y-1.5">
-					<div class="skeleton h-3 w-32"></div>
-					<div class="skeleton h-2.5 w-20 md:hidden"></div>
-				</div>
-			</div>
-		</td>
-		<!-- Institution (md+) -->
-		<td class="hidden md:table-cell">
-			<div class="skeleton h-3 w-28"></div>
-		</td>
-		<!-- Type (lg+) -->
-		<td class="hidden lg:table-cell">
-			<div class="skeleton h-3 w-16"></div>
-		</td>
-		<!-- Owner (lg+) -->
-		<td class="hidden lg:table-cell">
-			<div class="flex items-center gap-1.5">
-				<div class="skeleton w-5 h-5 rounded-full shrink-0"></div>
-				<div class="skeleton h-3 w-14"></div>
-			</div>
-		</td>
-		<!-- Balance -->
-		<td class="text-right">
+// accountsListSkeletonGroup mirrors one connection group — the quiet header
+// line (institution · count … subtotal) and `rows` account list-rows.
+templ accountsListSkeletonGroup(rows int) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1">
+			<div class="skeleton h-3 w-24"></div>
+			<div class="skeleton h-2.5 w-14"></div>
 			<div class="skeleton h-3.5 w-20 ml-auto"></div>
-		</td>
-		<!-- Overflow menu slot -->
-		<td class="text-right">
-			<div class="skeleton h-6 w-6 ml-auto"></div>
-		</td>
-	</tr>
+		</div>
+		<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+			for i := 0; i < rows; i++ {
+				@accountsListSkeletonRow()
+			}
+		</ul>
+	</div>
+}
+
+// accountsListSkeletonRow mirrors one accountsListRow: type tile + name/meta
+// stack, right-aligned balance, overflow-menu slot.
+templ accountsListSkeletonRow() {
+	<li class="list-row items-center">
+		<div class="skeleton w-9 h-9 rounded-lg shrink-0"></div>
+		<div class="min-w-0 space-y-1.5">
+			<div class="skeleton h-3 w-32"></div>
+			<div class="skeleton h-2.5 w-20"></div>
+		</div>
+		<div class="skeleton h-3.5 w-20 ml-auto self-center"></div>
+		<div class="skeleton h-6 w-6 self-center"></div>
+	</li>
 }

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -7,44 +7,43 @@ import (
 	"breadbox/internal/templates/components"
 )
 
-// AccountsList renders the flat /accounts admin page — a single sortable,
-// filterable table of every account the viewer is allowed to see. The
+// AccountsList renders the /accounts admin page — every account the viewer is
+// allowed to see, grouped by connection. Each institution is a quiet labelled
+// group (name · count · subtotal, carrying the connection health) above its
+// account list-rows, following the Workflows-DNA surface language. The
 // per-connection list view still lives on /connections; this page is the
-// account-centric counterpart so the user doesn't have to crack open each
-// connection to find a single account.
+// account-centric counterpart.
 //
-// Alpine factory `accountsList` (filter + sort) lives in
-// static/js/admin/components/accounts.js. Loaded synchronously (no defer)
-// per the convention in docs/design-system.md → "Alpine page components".
+// Alpine factory `accountsList` (the exclude/include action) lives in
+// static/js/admin/components/accounts.js. Loaded synchronously (no defer) per
+// the convention in docs/design-system.md → "Alpine page components".
 templ AccountsList(p AccountsListProps) {
 	<script src="/static/js/admin/components/accounts.js"></script>
 	<div x-data x-init="$store.shortcuts.setScope('accounts')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div x-data="accountsList">
 		@components.PageHeader(components.PageHeaderProps{
 			Title:                "Accounts",
-			Subtitle:             "Every account across all your connections, in one sortable view.",
+			Subtitle:             "Every account across your connections, grouped by where it lives.",
 			SubtitleHideOnMobile: true,
 		})
-		<!-- Family-member filter strip (only when 2+ household members) -->
+		<!-- Household-member filter — editors only, 2+ members. Server-side so
+		     every group subtotal re-scopes to the selected member. -->
 		if len(p.Users) > 1 {
-			<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto overflow-y-hidden">
-				<button
-					@click="filterUser = 'all'"
-					:class="filterUser === 'all' ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'"
-					class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
+			<div class="flex justify-end mb-4">
+				<select
+					class="select select-sm w-44"
+					aria-label="Filter by household member"
+					@change="window.location.href = $event.target.value ? '/accounts?user=' + encodeURIComponent($event.target.value) : '/accounts'"
 				>
-					<span class="w-5 h-5 rounded-full bg-base-300/60 flex items-center justify-center text-[0.6rem] font-semibold text-base-content/50 shrink-0">
-						@components.LucideIcon("users", "w-3 h-3")
-					</span>
-					All
-				</button>
-				for _, u := range p.Users {
-					@accountsListUserFilterBtn(u)
-				}
+					<option value="" selected?={ p.ActiveUserID == "" }>All members</option>
+					for _, u := range p.Users {
+						<option value={ u.ID } selected?={ u.ID == p.ActiveUserID }>{ u.Name }</option>
+					}
+				</select>
 			</div>
 		}
 		if p.HasAnyBalance {
-			<div class="bb-card p-0 overflow-hidden mb-6" x-show="filterUser === 'all'">
+			<div class="bb-card p-0 overflow-hidden mb-6">
 				<div class="grid grid-cols-3 divide-x divide-base-300">
 					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
 						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Net Worth</div>
@@ -79,210 +78,149 @@ templ AccountsList(p AccountsListProps) {
 				</div>
 			</div>
 		}
-		@components.FilterSearchInput(components.FilterSearchInputProps{
-			Placeholder: "Filter accounts...",
-			XModel:      "filter",
-		})
-		<div class="mt-4">
-			if len(p.Accounts) > 0 {
-				@accountsListTable(p)
-			} else {
-				@components.EmptyState(components.EmptyStateProps{
-					Icon:      "wallet",
-					Title:     "No accounts yet",
-					Body:      "Once you connect a bank, every account synced from it shows up here.",
-					CustomCTA: connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a Bank"),
-				})
-			}
-		</div>
-		<!-- Loading skeleton for the accounts list, available for any future
-		     client-side refresh / pagination swap. Mirrors the SSR layout
-		     above so swap-in doesn't shift the page. Exposed in /design#loading. -->
+		if p.TotalAccounts > 0 {
+			<div class="flex flex-col gap-5">
+				for _, g := range p.Groups {
+					@accountsListConnGroup(g)
+				}
+			</div>
+		} else {
+			@components.EmptyState(components.EmptyStateProps{
+				Icon:      "wallet",
+				Title:     "No accounts yet",
+				Body:      "Once you connect a bank, every account synced from it shows up here.",
+				CustomCTA: connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a Bank"),
+			})
+		}
+		<!-- Loading skeleton, available for any future client-side refresh /
+		     pagination swap. Mirrors the SSR layout above. Exposed in
+		     /design#loading. -->
 		<template id="bb-accounts-list-skeleton-template">
 			@components.AccountsListSkeleton()
 		</template>
 	</div>
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			lucide.createIcons();
-		});
-	</script>
 }
 
-templ accountsListUserFilterBtn(u AccountsListUserFilter) {
-	<button
-		@click={ fmt.Sprintf("filterUser = %q", u.ID) }
-		:class={ fmt.Sprintf("filterUser === %q ? 'text-base-content border-primary' : 'text-base-content/40 border-transparent hover:text-base-content/60 hover:border-base-300'", u.ID) }
-		class="flex items-center gap-2 px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-all duration-150 bg-transparent cursor-pointer whitespace-nowrap"
-	>
-		@components.UserAvatar(components.UserAvatarProps{
-			ID:         u.ID,
-			Name:       u.Name,
-			Version:    u.AvatarVersion,
-			Size:       components.UserAvatarSm,
-			Decorative: true,
-		})
-		{ u.Name }
-	</button>
-}
-
-// accountsListTable wraps the data table in a bb-card. Header is clickable to
-// drive client-side sort via the accountsList Alpine factory.
-templ accountsListTable(p AccountsListProps) {
-	<div class="bb-card overflow-hidden">
-		<div class="overflow-x-auto">
-			<table class="table table-sm">
-				<thead class="text-xs text-base-content/60">
-					<tr>
-						@accountsListSortHeader("name", "Account", "min-w-[12rem]")
-						@accountsListSortHeader("institution", "Institution", "hidden md:table-cell")
-						@accountsListSortHeader("type", "Type", "hidden lg:table-cell")
-						@accountsListSortHeader("owner", "Owner", "hidden lg:table-cell")
-						@accountsListSortHeader("balance", "Balance", "text-right")
-						<th class="w-8"></th>
-					</tr>
-				</thead>
-				<tbody>
-					for _, a := range p.Accounts {
-						@accountsListRow(a, p.CSRFToken)
-					}
-				</tbody>
-			</table>
+// accountsListConnGroup renders one connection: a quiet label line
+// (institution · count · subtotal, with health surfaced when the connection
+// needs attention) above the account list-rows in their own card.
+templ accountsListConnGroup(g AccountsListConnGroup) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1 min-w-0">
+			<span data-private="institution" class="text-sm font-medium text-base-content shrink-0">{ accountsConnLabel(g) }</span>
+			<span class="text-xs text-base-content/40 shrink-0">{ accountsConnCountLabel(g) }</span>
+			@accountsListConnStatus(g)
+			if g.HasSubtotal {
+				<span class="ml-auto shrink-0">
+					@components.Amount(components.AmountProps{
+						Value:  g.Subtotal,
+						Intent: components.AmountBalance,
+						Class:  "text-sm font-semibold tabular-nums",
+					})
+				</span>
+			}
 		</div>
+		@components.AgentRunRowList() {
+			for _, a := range g.Accounts {
+				@accountsListRow(a)
+			}
+		}
 	</div>
 }
 
-// accountsListSortHeader emits one clickable column header. The chevron icon
-// rotates based on the active sort direction.
-templ accountsListSortHeader(key, label, extraClass string) {
-	<th class={ "cursor-pointer select-none whitespace-nowrap", extraClass } @click={ fmt.Sprintf("setSort(%q)", key) }>
-		<span class="inline-flex items-center gap-1">
-			{ label }
-			<span x-show={ fmt.Sprintf("sortKey === %q", key) } x-cloak>
-				<i data-lucide="chevron-down" class="w-3 h-3" :class="sortDir === 'desc' ? '' : 'rotate-180'"></i>
-			</span>
-		</span>
-	</th>
+// accountsListConnStatus surfaces connection health on the group header — a
+// soft badge + a recovery link to /connections, only when not active.
+templ accountsListConnStatus(g AccountsListConnGroup) {
+	if g.Status == "error" || g.Status == "pending_reauth" {
+		<span class="badge badge-soft badge-warning badge-xs shrink-0">Reauth needed</span>
+		<a href="/connections" class="text-xs text-warning hover:underline shrink-0">Reauthenticate</a>
+	} else if g.Status == "disconnected" {
+		<span class="badge badge-soft badge-error badge-xs shrink-0">Disconnected</span>
+		<a href="/connections" class="text-xs text-error hover:underline shrink-0">Reconnect</a>
+	}
 }
 
-templ accountsListRow(a AccountsListRow, csrfToken string) {
-	<tr
-		data-account-row
-		data-account-id={ a.ID }
-		data-name={ strings.ToLower(a.DisplayName) }
-		data-institution={ strings.ToLower(a.InstitutionName) }
-		data-type={ a.Type }
-		data-owner={ strings.ToLower(a.OwnerName) }
-		data-balance={ fmt.Sprintf("%f", a.BalanceFloat) }
-		data-has-balance={ accountsListBool(a.HasBalance) }
-		data-search={ accountsListSearchIndex(a) }
-		data-filter-user={ a.UserID }
-		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && matches($el)"
-		x-cloak
-		class="hover:bg-base-200/30 transition-colors"
-	>
-		<!-- Account name + icon -->
-		<td>
-			<a href={ templ.SafeURL("/accounts/" + a.ID) } class="flex items-center gap-3 no-underline">
-				<div class="w-8 h-8 rounded-md bg-base-200/60 flex items-center justify-center shrink-0">
-					@accountsListTypeIcon(a.Type)
-				</div>
-				<div class="min-w-0">
-					<div class="flex items-center gap-1.5 flex-wrap">
-						<span data-private="account" class="text-sm font-medium truncate text-base-content">{ a.DisplayName }</span>
-						if a.IsDependentLinked {
-							<span class="badge badge-soft badge-info badge-xs" title="Dependent-linked: balance attributed to a linked user">Linked</span>
-						}
-						if a.Excluded {
-							<span class="badge badge-soft badge-warning badge-xs" title="Excluded from totals and sync">Excluded</span>
-						}
-					</div>
-					<div class="text-xs text-base-content/40 md:hidden">
-						@components.Private("institution", a.InstitutionName)
-						if a.MaskValid {
-							<span class="text-base-content/25">&middot;</span>
-							@components.Private("mask", " ····"+a.Mask)
-						}
-					</div>
-				</div>
-			</a>
-		</td>
-		<!-- Institution (md+) -->
-		<td class="hidden md:table-cell text-sm text-base-content/70">
-			<div class="flex items-center gap-2 min-w-0">
-				<span data-private="institution" class="truncate">{ a.InstitutionName }</span>
-				if a.MaskValid {
-					<span data-private="mask" class="text-xs text-base-content/40">&middot; ····{ a.Mask }</span>
-				}
-				if a.ConnectionStatus == "error" || a.ConnectionStatus == "pending_reauth" {
-					<span class="badge badge-soft badge-warning badge-xs" title="Connection needs attention">Reauth</span>
-				} else if a.ConnectionStatus == "disconnected" {
-					<span class="badge badge-soft badge-error badge-xs">Disconnected</span>
-				}
+// accountsListRow renders one account as a list-row: a leading type tile, a
+// title row (name + Linked/Excluded badges + owner avatar), a quiet
+// ····mask · Type line, a trailing balance, and an overflow menu outside the
+// row's navigation anchor. Connection health is NOT repeated here — it lives
+// on the group header.
+templ accountsListRow(a AccountsListRow) {
+	<li class="list-row transition-colors hover:bg-base-200/40 items-center" data-account-id={ a.ID }>
+		<a class="contents no-underline" href={ templ.SafeURL("/accounts/" + a.ID) }>
+			<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+				@accountsListTypeIcon(a.Type)
 			</div>
-		</td>
-		<!-- Type (lg+) -->
-		<td class="hidden lg:table-cell text-sm text-base-content/70 capitalize">
-			{ accountsListTypeLabel(a.Type, a.Subtype, a.SubtypeValid) }
-		</td>
-		<!-- Owner (lg+) -->
-		<td class="hidden lg:table-cell text-sm text-base-content/70">
-			if a.OwnerName != "" {
-				<span class="inline-flex items-center gap-1.5">
-					@components.UserAvatar(components.UserAvatarProps{
-						ID:         a.UserID,
-						Name:       a.OwnerName,
-						Version:    a.OwnerAvatarVersion,
-						Size:       components.UserAvatarSm,
-						Decorative: true,
-					})
-					{ a.OwnerName }
-				</span>
-			} else {
-				<span class="text-base-content/30">—</span>
-			}
-		</td>
-		<!-- Balance -->
-		<td class="text-right">
-			if a.HasBalance {
-				if a.BalanceFloat < 0 {
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span data-private="account" class="font-medium text-sm text-base-content truncate">{ a.DisplayName }</span>
+					if a.IsDependentLinked {
+						<span class="badge badge-soft badge-info badge-xs shrink-0" title="Dependent-linked: balance attributed to a linked user">Linked</span>
+					}
+					if a.Excluded {
+						<span class="badge badge-soft badge-warning badge-xs shrink-0" title="Excluded from totals and sync">Excluded</span>
+					}
+					if a.OwnerName != "" {
+						@components.UserAvatar(components.UserAvatarProps{
+							ID:         a.UserID,
+							Name:       a.OwnerName,
+							Version:    a.OwnerAvatarVersion,
+							Size:       components.UserAvatarXS,
+							Decorative: true,
+							Lazy:       true,
+							Class:      "shrink-0",
+						})
+					}
+				</div>
+				<div class="mt-0.5 text-xs text-base-content/60 min-w-0 line-clamp-1">
+					if a.MaskValid {
+						@components.Private("mask", "····"+a.Mask)
+						<span class="text-base-content/30">&middot;</span>
+					}
+					<span class="capitalize">{ accountsListTypeLabel(a.Type, a.Subtype, a.SubtypeValid) }</span>
+				</div>
+			</div>
+			<div class="shrink-0 self-center text-right">
+				if a.HasBalance {
 					@components.Amount(components.AmountProps{
 						Value:  a.BalanceFloat,
 						Intent: components.AmountBalance,
-						Class:  "text-sm font-medium text-error",
+						Class:  accountsListBalanceClass(a.IsLiability),
 					})
 				} else {
-					@components.Amount(components.AmountProps{
-						Value:  a.BalanceFloat,
-						Intent: components.AmountBalance,
-						Class:  "text-sm font-medium",
-					})
+					<span class="text-sm text-base-content/30">—</span>
 				}
-			} else {
-				<span class="text-xs text-base-content/30">—</span>
-			}
-		</td>
-		<td class="text-right">
+			</div>
+		</a>
+		<div class="shrink-0 self-center">
 			@components.OverflowMenu(components.OverflowMenuProps{
 				AriaLabel: fmt.Sprintf("Actions for %s", a.DisplayName),
-				Size:      "xs",
+				Size:      "sm",
 				Items:     accountsListRowItems(a),
 			})
-		</td>
-	</tr>
+		</div>
+	</li>
 }
 
 templ accountsListTypeIcon(t string) {
 	switch t {
 		case "credit":
-			@components.LucideIcon("credit-card", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("credit-card", "w-4 h-4 text-base-content/70")
 		case "loan":
-			@components.LucideIcon("landmark", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("landmark", "w-4 h-4 text-base-content/70")
 		case "investment":
-			@components.LucideIcon("trending-up", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("trending-up", "w-4 h-4 text-base-content/70")
 		default:
-			@components.LucideIcon("wallet", "w-4 h-4 text-base-content opacity-40")
+			@components.LucideIcon("wallet", "w-4 h-4 text-base-content/70")
 	}
+}
+
+// accountsListBalanceClass tints liabilities red; assets keep the default ink.
+func accountsListBalanceClass(isLiability bool) string {
+	if isLiability {
+		return "text-sm font-semibold text-error"
+	}
+	return "text-sm font-semibold"
 }
 
 // accountsListRowItems builds the overflow-menu items for one row.
@@ -313,31 +251,11 @@ func accountsListRowItems(a AccountsListRow) []components.OverflowMenuItem {
 	return items
 }
 
-// accountsListTypeLabel composes the type column text. Falls back to the
-// primary type when subtype is empty.
+// accountsListTypeLabel composes the type label. Falls back to the primary
+// type when subtype is empty.
 func accountsListTypeLabel(t, subtype string, subtypeValid bool) string {
 	if subtypeValid && subtype != "" {
 		return strings.ReplaceAll(subtype, "_", " ")
 	}
 	return t
-}
-
-// accountsListSearchIndex builds the lowercase haystack used by the filter
-// search input.
-func accountsListSearchIndex(a AccountsListRow) string {
-	parts := []string{a.DisplayName, a.InstitutionName, a.Type, a.OwnerName}
-	if a.SubtypeValid {
-		parts = append(parts, a.Subtype)
-	}
-	if a.MaskValid {
-		parts = append(parts, a.Mask)
-	}
-	return strings.ToLower(strings.Join(parts, " "))
-}
-
-func accountsListBool(b bool) string {
-	if b {
-		return "1"
-	}
-	return "0"
 }

--- a/internal/templates/components/pages/accounts_list_test.go
+++ b/internal/templates/components/pages/accounts_list_test.go
@@ -1,0 +1,79 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+func TestGroupAccountsByConnection(t *testing.T) {
+	rows := []AccountsListRow{
+		// Chase: an asset + a liability → subtotal 11135.63.
+		{ID: "a1", ConnectionShortID: "chase", InstitutionName: "Chase", ConnectionStatus: "active", HasBalance: true, BalanceFloat: 12340.18},
+		{ID: "a2", ConnectionShortID: "chase", InstitutionName: "Chase", ConnectionStatus: "active", HasBalance: true, BalanceFloat: -1204.55, IsLiability: true},
+		// Fidelity: a single big asset → should rank first.
+		{ID: "a3", ConnectionShortID: "fidelity", InstitutionName: "Fidelity", ConnectionStatus: "active", HasBalance: true, BalanceFloat: 34120.00},
+		// Amex: reauth, one liability.
+		{ID: "a4", ConnectionShortID: "amex", InstitutionName: "American Express", ConnectionStatus: "pending_reauth", HasBalance: true, BalanceFloat: -842.30, IsLiability: true},
+		// Orphan (connection deleted → SET NULL): no balance. Sinks last.
+		{ID: "a5", ConnectionShortID: "", InstitutionName: "", HasBalance: false},
+	}
+
+	groups := GroupAccountsByConnection(rows)
+	if len(groups) != 4 {
+		t.Fatalf("got %d groups, want 4", len(groups))
+	}
+
+	// Order: Fidelity (34120) > Chase (11135.63) > Amex (-842.30) > orphan (last).
+	wantOrder := []string{"fidelity", "chase", "amex", ""}
+	for i, want := range wantOrder {
+		if groups[i].ConnectionShortID != want {
+			t.Errorf("group[%d] = %q, want %q", i, groups[i].ConnectionShortID, want)
+		}
+	}
+
+	// Chase subtotal = 12340.18 - 1204.55 = 11135.63.
+	var chase AccountsListConnGroup
+	for _, g := range groups {
+		if g.ConnectionShortID == "chase" {
+			chase = g
+		}
+	}
+	if !chase.HasSubtotal {
+		t.Fatal("chase group should have a subtotal")
+	}
+	if got := chase.Subtotal; got < 11135.62 || got > 11135.64 {
+		t.Errorf("chase subtotal = %.2f, want 11135.63", got)
+	}
+	if len(chase.Accounts) != 2 {
+		t.Errorf("chase has %d accounts, want 2", len(chase.Accounts))
+	}
+	if chase.InstitutionName != "Chase" {
+		t.Errorf("chase institution = %q, want Chase", chase.InstitutionName)
+	}
+
+	// Amex carries the connection status onto the group header.
+	for _, g := range groups {
+		if g.ConnectionShortID == "amex" && g.Status != "pending_reauth" {
+			t.Errorf("amex status = %q, want pending_reauth", g.Status)
+		}
+	}
+
+	// Orphan group: no connection, no subtotal, lands last.
+	last := groups[len(groups)-1]
+	if last.ConnectionShortID != "" || last.HasSubtotal {
+		t.Errorf("last group = %+v, want orphan with no subtotal", last)
+	}
+	if got := accountsConnLabel(last); got != "Unlinked accounts" {
+		t.Errorf("orphan label = %q, want \"Unlinked accounts\"", got)
+	}
+}
+
+func TestAccountsConnCountLabel(t *testing.T) {
+	one := AccountsListConnGroup{Accounts: []AccountsListRow{{}}}
+	if got := accountsConnCountLabel(one); got != "1 account" {
+		t.Errorf("got %q, want \"1 account\"", got)
+	}
+	three := AccountsListConnGroup{Accounts: []AccountsListRow{{}, {}, {}}}
+	if got := accountsConnCountLabel(three); got != "3 accounts" {
+		t.Errorf("got %q, want \"3 accounts\"", got)
+	}
+}

--- a/internal/templates/components/pages/accounts_list_types.go
+++ b/internal/templates/components/pages/accounts_list_types.go
@@ -2,60 +2,153 @@
 
 package pages
 
+import (
+	"fmt"
+	"sort"
+)
+
 // AccountsListProps is the typed input for the /accounts admin page.
 type AccountsListProps struct {
 	CSRFToken string
 
-	// Net totals across all displayed accounts (computed per-viewer).
-	// HasAnyBalance is the gate the templ uses to render the summary row.
+	// Net totals across all displayed accounts (computed per-viewer, and
+	// re-scoped server-side when a member filter is active).
 	NetWorth         float64
 	TotalAssets      float64
 	TotalLiabilities float64
 	HasAnyBalance    bool
 
-	// Household-member filter strip. Only rendered when len > 1.
-	Users []AccountsListUserFilter
+	// Household-member filter. Options are only populated for editors;
+	// ActiveUserID is the currently-selected member ("" = all).
+	Users        []AccountsListUserFilter
+	ActiveUserID string
 
-	// One row per account.
-	Accounts []AccountsListRow
+	// Accounts grouped by connection (institution). TotalAccounts is the
+	// flat count, used for the empty-state gate.
+	Groups        []AccountsListConnGroup
+	TotalAccounts int
 }
 
-// AccountsListUserFilter mirrors ConnectionsUserFilter — one chip in the
-// "filter by household member" strip.
+// AccountsListUserFilter is one option in the "filter by household member"
+// dropdown.
 type AccountsListUserFilter struct {
-	ID            string // short_id — drives the x-show filter value
+	ID            string // short_id — the ?user= filter value
 	Name          string
 	First         string // first letter for the avatar circle fallback
 	AvatarVersion string // user updated_at unix timestamp for cache-busting
 }
 
-// AccountsListRow is one table row. Fields are pre-formatted (display_name
+// AccountsListConnGroup is one connection's accounts plus the header data:
+// the institution name, the shared connection health, and a balance
+// subtotal. Connection health lives here (one status per connection) so the
+// individual rows don't repeat it.
+type AccountsListConnGroup struct {
+	ConnectionShortID string
+	InstitutionName   string
+	Status            string // "active" | "error" | "pending_reauth" | "disconnected" | ""
+	Subtotal          float64
+	HasSubtotal       bool
+	Accounts          []AccountsListRow
+}
+
+// AccountsListRow is one account row. Fields are pre-formatted (display_name
 // applied, balance sign adjusted for liabilities, currency carried alongside).
 type AccountsListRow struct {
-	ID          string // formatted UUID
-	UserID      string // short_id — used by the x-show filter and avatar URL
-	DisplayName string // display_name with fallback to name
-	Type        string // canonical account type ("depository", "credit", ...)
+	ID           string // formatted UUID
+	UserID       string // short_id — owner; drives the member filter + avatar URL
+	DisplayName  string // display_name with fallback to name
+	Type         string // canonical account type ("depository", "credit", ...)
 	SubtypeValid bool
-	Subtype     string
-	MaskValid   bool
-	Mask        string
+	Subtype      string
+	MaskValid    bool
+	Mask         string
+
 	OwnerName          string // empty when no linked household member
 	OwnerFirst         string // first letter for the avatar dot fallback
 	OwnerAvatarVersion string // user updated_at unix timestamp for cache-busting
+
 	InstitutionName string
 
-	// Connection context — lets the row pill out reauth/disconnected state
-	// without fetching connection rows again.
+	// Connection context — used to group rows and (on the group header)
+	// surface reauth/disconnected state.
 	ConnectionShortID string
-	ConnectionStatus  string // "active" | "error" | "pending_reauth" | "disconnected" | ""
+	ConnectionStatus  string
 
 	IsDependentLinked bool
 	Excluded          bool
 
-	HasBalance   bool
-	BalanceFloat float64 // sign-adjusted (negative for liabilities)
+	HasBalance      bool
+	BalanceFloat    float64 // sign-adjusted (negative for liabilities)
 	IsoCurrencyCode string
 
 	IsLiability bool
+}
+
+// GroupAccountsByConnection buckets pre-sorted account rows by connection,
+// preserving row order within each group. Groups are ordered by subtotal
+// (largest first); groups without any balance sink below those with one, and
+// the orphan bucket (accounts whose connection was deleted — SET NULL)
+// sinks last. Pure function so the grouping is unit-testable without a DB.
+func GroupAccountsByConnection(rows []AccountsListRow) []AccountsListConnGroup {
+	order := make([]string, 0)
+	byKey := make(map[string]*AccountsListConnGroup)
+	for _, r := range rows {
+		key := r.ConnectionShortID
+		g, ok := byKey[key]
+		if !ok {
+			g = &AccountsListConnGroup{
+				ConnectionShortID: key,
+				InstitutionName:   r.InstitutionName,
+				Status:            r.ConnectionStatus,
+			}
+			byKey[key] = g
+			order = append(order, key)
+		}
+		if g.InstitutionName == "" && r.InstitutionName != "" {
+			g.InstitutionName = r.InstitutionName
+		}
+		if g.Status == "" && r.ConnectionStatus != "" {
+			g.Status = r.ConnectionStatus
+		}
+		if r.HasBalance {
+			g.Subtotal += r.BalanceFloat
+			g.HasSubtotal = true
+		}
+		g.Accounts = append(g.Accounts, r)
+	}
+	groups := make([]AccountsListConnGroup, 0, len(order))
+	for _, k := range order {
+		groups = append(groups, *byKey[k])
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		a, b := groups[i], groups[j]
+		// Orphan accounts (no connection) always sink last.
+		ao, bo := a.ConnectionShortID == "", b.ConnectionShortID == ""
+		if ao != bo {
+			return !ao
+		}
+		// Groups carrying a balance rank above balance-less ones.
+		if a.HasSubtotal != b.HasSubtotal {
+			return a.HasSubtotal
+		}
+		return a.Subtotal > b.Subtotal
+	})
+	return groups
+}
+
+// accountsConnLabel is the group header's institution label, with a fallback
+// for orphan accounts whose connection was removed.
+func accountsConnLabel(g AccountsListConnGroup) string {
+	if g.InstitutionName != "" {
+		return g.InstitutionName
+	}
+	return "Unlinked accounts"
+}
+
+// accountsConnCountLabel renders the dimmed "N accounts" suffix.
+func accountsConnCountLabel(g AccountsListConnGroup) string {
+	if len(g.Accounts) == 1 {
+		return "1 account"
+	}
+	return fmt.Sprintf("%d accounts", len(g.Accounts))
 }

--- a/static/js/admin/components/accounts.js
+++ b/static/js/admin/components/accounts.js
@@ -1,8 +1,9 @@
 // Accounts list page Alpine component for /accounts.
 //
 // Convention reference: docs/design-system.md → "Alpine page components".
-// Owns the client-side filter (search input + family-member chip strip)
-// and sort state for the flat accounts table.
+// The page groups accounts by connection server-side and the member filter is
+// a server-side dropdown, so the only client behaviour left is the
+// exclude/include action dispatched from a row's overflow menu.
 (function () {
   function restorePageState() {
     if (window.bbProgress && window.bbProgress.finish) window.bbProgress.finish();
@@ -21,63 +22,12 @@
   document.addEventListener('alpine:init', function () {
     Alpine.data('accountsList', function () {
       return {
-        filter: '',
-        filterUser: 'all',
-        sortKey: 'balance',
-        sortDir: 'desc',
-
         init: function () {
           var self = this;
           // Listen for excluded-toggle dispatches from the row overflow menu.
           window.addEventListener('account-set-excluded', function (e) {
             self.setExcluded(e.detail.id, e.detail.excluded);
           });
-          // Initial sort on mount so SSR-ordered rows respect the default key.
-          this.applySort();
-        },
-
-        matches: function (el) {
-          if (!this.filter) return true;
-          return (el.dataset.search || '').includes(this.filter.toLowerCase());
-        },
-
-        setSort: function (key) {
-          if (this.sortKey === key) {
-            this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
-          } else {
-            this.sortKey = key;
-            // Balance defaults to descending (largest first); text columns ascending.
-            this.sortDir = key === 'balance' ? 'desc' : 'asc';
-          }
-          this.applySort();
-        },
-
-        applySort: function () {
-          var tbody = document.querySelector('[data-account-row]');
-          if (!tbody) return;
-          tbody = tbody.parentElement;
-          if (!tbody) return;
-          var rows = Array.prototype.slice.call(tbody.querySelectorAll('[data-account-row]'));
-          var key = this.sortKey;
-          var dir = this.sortDir === 'asc' ? 1 : -1;
-          rows.sort(function (a, b) {
-            var av, bv;
-            if (key === 'balance') {
-              // Rows without a balance sink to the bottom regardless of direction.
-              var aHas = a.dataset.hasBalance === '1';
-              var bHas = b.dataset.hasBalance === '1';
-              if (aHas !== bHas) return aHas ? -1 : 1;
-              av = parseFloat(a.dataset.balance) || 0;
-              bv = parseFloat(b.dataset.balance) || 0;
-              return (av - bv) * dir;
-            }
-            av = (a.dataset[key] || '');
-            bv = (b.dataset[key] || '');
-            if (av < bv) return -1 * dir;
-            if (av > bv) return 1 * dir;
-            return 0;
-          });
-          for (var i = 0; i < rows.length; i++) tbody.appendChild(rows[i]);
         },
 
         setExcluded: function (accountId, excluded) {


### PR DESCRIPTION
## Design system sprint — kickoff

This opens a dedicated sprint to bring the whole admin app onto one coherent
surface design language — the one our `/workflows`, `/workflows/runs`, and
drawer surfaces already speak. Two pieces land here:

### 1. The `design-system` skill (the system itself)

`.claude/skills/design-system/` codifies the language so any session can apply
it consistently — replacing the throwaway "Workflows DNA" sandbox tab we were
prototyping with (that tab is dropped; the workflow components stay
sandboxified under `/design`).

- **SKILL.md** — the seven principles, the canonical page anatomy, and the
  **IA-first redesign method**: a surface pass must improve information
  architecture, not just swap classes.
- **components.md** — the shared component catalog (PageHeader, TabBar, Drawer,
  IconTile, OverflowMenu, UserAvatar, Amount, StatTile, EmptyState…) with props
  and the one-line rule for each.

It's marked **living**: when we refine a convention, we update the skill in the
same PR so it never drifts from what ships.

### 2. First surface — `/accounts` (the worked example)

The approved `/accounts` redesign, applied to the live page: rows regrouped by
**connection** (quiet label line · count … subtotal over a `bb-card` of
list-rows), the unused type tabs + search removed, privacy-aware amounts,
liability sign/color, server-side member filter that re-scopes subtotals, and a
unit-tested pure grouping function (`GroupAccountsByConnection`).

### Where this goes next

This branch is the sprint's integration point. After kickoff:
1. **Primitive audit** — tabs, tables, filter menus, list-rows, badges, etc.:
   confirm each has one canonical shape and is sandboxified.
2. **Surface-by-surface loop** — one page at a time, IA-first, each with a
   screenshot and (where logic warrants) a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
