### PR TITLE
feat(transactions): collapsible filter-drawer sections + per-section polish

### DIFF
--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -203,6 +203,33 @@ EmptyStateProps{
 }
 ```
 
+## CollapsibleSection — `collapsible_section.templ`
+
+A quiet, reusable disclosure: a header row (lucide glyph + label + optional
+right-slot indicator) toggling its body open/closed with a rotating chevron.
+
+```go
+CollapsibleSectionProps{
+    Icon string; Label string /* required */
+    DefaultOpen bool            // data-driven open-on-render decision
+    Right templ.Component       // optional header indicator (rendered in scope)
+    Class string
+}
+```
+
+- Disclosure state is a tiny Alpine `{ open: <bool> }`; the body renders with
+  `x-show` (NOT `<details>`), so **form inputs inside a collapsed section still
+  submit** — this is the reason to use it over daisy `collapse`/`<details>`
+  inside a `<form>`.
+- The component exposes `open` in its Alpine scope. A `Right` indicator guarded
+  with `x-show="!open"` surfaces only when collapsed (the "active filter hidden
+  here" cue). Nest the component inside an ancestor `x-data` to let the
+  indicator read reactive state (e.g. the Tags section reads `selectedSlugs`).
+- Backs the `/transactions` filter drawer's When / Where / What / Tags / Search
+  sections: each defaults open when it holds an active filter (computed in
+  `TransactionsProps.*SectionOpen`) and collapses with a count/dot indicator
+  otherwise. Sandbox: `/design/c/collapsible-section`.
+
 ## Skeletons — `*_skeleton.templ`
 
 Loading placeholders that mirror the real component's shape so the swap-in

--- a/internal/templates/components/collapsible_section.templ
+++ b/internal/templates/components/collapsible_section.templ
@@ -1,0 +1,77 @@
+package components
+
+// CollapsibleSection is a quiet, reusable disclosure: a header row (lucide
+// glyph + label + an optional right-slot indicator) that toggles a body open
+// or closed with a rotating chevron. It is the shared abstraction behind the
+// /transactions filter drawer's When / Where / What / Tags / Search sections,
+// where each section defaults open when it holds an active filter and collapses
+// otherwise so the drawer stays scannable.
+//
+// Disclosure state is a tiny Alpine x-data (`{ open: <bool> }`) so the
+// default-open decision is data-driven by the caller (a Go bool) rather than a
+// CSS-only <details>. The body is rendered with `x-show` (NOT removed from the
+// DOM) so any form inputs inside a collapsed section still submit — this is the
+// load-bearing reason CollapsibleSection is used instead of daisy `collapse` /
+// `<details>` inside a <form>.
+//
+// The component exposes `open` in its Alpine scope. A caller's Right component
+// can read it — e.g. pass an indicator guarded with `x-show="!open"` so it only
+// surfaces when the section is collapsed (the "you have an active filter hidden
+// here" cue).
+//
+//	@components.CollapsibleSection(components.CollapsibleSectionProps{
+//	    Icon: "calendar", Label: "When", DefaultOpen: true,
+//	}) {
+//	    <!-- body controls -->
+//	}
+type CollapsibleSectionProps struct {
+	// Icon is a lucide glyph name shown left of the label. Optional.
+	Icon string
+	// Label is the section title. Required.
+	Label string
+	// DefaultOpen seeds the disclosure open on first render.
+	DefaultOpen bool
+	// Right is an optional templ.Component rendered in the header between the
+	// label and the chevron — typically a small active-filter indicator. It is
+	// rendered inside this component's Alpine scope, so it may reference `open`.
+	Right templ.Component
+	// Class adds extra classes to the section wrapper (rare).
+	Class string
+}
+
+templ CollapsibleSection(p CollapsibleSectionProps) {
+	<section x-data={ collapsibleSectionData(p.DefaultOpen) } class={ "space-y-2 " + p.Class }>
+		<button
+			type="button"
+			class="group flex items-center gap-2 w-full text-left"
+			@click="open = !open"
+			:aria-expanded="open ? 'true' : 'false'"
+		>
+			if p.Icon != "" {
+				@LucideIcon(p.Icon, "w-3.5 h-3.5 opacity-60 shrink-0")
+			}
+			<span class="text-xs font-medium text-base-content/50 uppercase tracking-wider">{ p.Label }</span>
+			<span class="flex-1"></span>
+			if p.Right != nil {
+				@p.Right
+			}
+			<!-- chevron — borrows the collapse-arrow rotation idiom -->
+			<span class="inline-flex transition-transform duration-200 text-base-content/40 group-hover:text-base-content/70 shrink-0" :class="open && 'rotate-180'">
+				@LucideIcon("chevron-down", "w-3.5 h-3.5")
+			</span>
+		</button>
+		<div x-show="open" x-collapse>
+			{ children... }
+		</div>
+	</section>
+}
+
+// collapsibleSectionData returns the Alpine x-data object literal seeding the
+// disclosure's open state. Kept as a Go helper so the default-open decision is
+// driven by a typed bool from the caller rather than string-built markup.
+func collapsibleSectionData(open bool) string {
+	if open {
+		return "{ open: true }"
+	}
+	return "{ open: false }"
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1225,6 +1225,53 @@ templ designEntityHeaderBadgesError() {
 }
 
 // ─── Empty states ──────────────────────────────────────────────────────
+// ─── Collapsible section ───────────────────────────────────────────────
+templ SectionCollapsibleSection() {
+	<div class="flex flex-col gap-6 max-w-md">
+		@designExample("Default open", "DefaultOpen: true — the body is visible on load and the chevron points up. Click the header to collapse.") {
+			@components.CollapsibleSection(components.CollapsibleSectionProps{
+				Icon:        "calendar",
+				Label:       "When",
+				DefaultOpen: true,
+			}) {
+				<div class="grid grid-cols-2 gap-3">
+					<label class="bb-filter-label">
+						Start date
+						<input type="date" class="input input-sm w-full"/>
+					</label>
+					<label class="bb-filter-label">
+						End date
+						<input type="date" class="input input-sm w-full"/>
+					</label>
+				</div>
+			}
+		}
+		@designExample("Collapsed with active indicator", "DefaultOpen: false plus a Right-slot indicator guarded with x-show=\"!open\" — the count chip surfaces only while collapsed, cueing a hidden active filter. Inputs stay in the DOM (x-show, not <details>) so they still submit.") {
+			@components.CollapsibleSection(components.CollapsibleSectionProps{
+				Icon:        "shapes",
+				Label:       "What",
+				DefaultOpen: false,
+				Right:       designCollapsibleIndicator(),
+			}) {
+				<label class="bb-filter-label">
+					Category
+					<select class="select select-sm w-full">
+						<option>All categories</option>
+						<option>Groceries</option>
+					</select>
+				</label>
+			}
+		}
+	</div>
+}
+
+// designCollapsibleIndicator is the sandbox stand-in for a section's active
+// indicator — mirrors the live txFilterCountBadge shape (only visible while
+// the section is collapsed).
+templ designCollapsibleIndicator() {
+	<span x-show="!open" x-cloak class="badge badge-soft badge-info badge-xs">2</span>
+}
+
 templ SectionEmptyStates() {
 	<div class="flex flex-col gap-6">
 		@designExample("Standard (no data yet)", "Card-wrapped, icon + title + description + CTA.") {

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -160,6 +160,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionCards() },
 		},
 		{
+			Slug:        "collapsible-section",
+			Title:       "Collapsible section",
+			Description: "components.CollapsibleSection — a quiet disclosure (lucide glyph + label + optional right-slot indicator) toggling its body with a rotating chevron. Alpine `{ open }` state so default-open is data-driven; the body uses x-show (kept in the DOM) so form inputs inside a collapsed section still submit. Backs the /transactions filter drawer's When/Where/What/Tags/Search sections — open when they hold an active filter, collapsed with a count/dot indicator otherwise.",
+			Group:       "layout",
+			Render:      func() templ.Component { return SectionCollapsibleSection() },
+		},
+		{
 			Slug:        "empty-states",
 			Title:       "Empty states",
 			Description: "Standard no-data and no-results patterns. Use components.EmptyState.",

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -222,24 +222,45 @@ templ txFilterDrawer(p TransactionsProps) {
 			<!-- Carries the page quick-search text into this GET submit so the
 			     quick-search box stays the only visible search input. -->
 			<input type="hidden" name="search" id="bb-tx-search-hidden" value={ p.FilterSearch }/>
-			<div class="flex-1 overflow-y-auto p-5 space-y-6">
+			<div class="flex-1 overflow-y-auto p-5 space-y-5">
 				<!-- When -->
-				<section class="space-y-2">
-					@txFilterSectionLabel("calendar", "When")
+				@components.CollapsibleSection(components.CollapsibleSectionProps{
+					Icon:        "calendar",
+					Label:       "When",
+					DefaultOpen: p.WhenSectionOpen(),
+					Right:       txFilterCountIndicator(p.WhenFilterCount()),
+				}) {
 					<div class="grid grid-cols-2 gap-3">
 						<label class="bb-filter-label">
 							Start date
-							<input type="date" name="start_date" value={ p.FilterStartDate } class="input input-sm w-full"/>
+							<input type="date" name="start_date" value={ p.FilterStartDate } class="input input-sm w-full" x-ref="startDate"/>
 						</label>
 						<label class="bb-filter-label">
 							End date
-							<input type="date" name="end_date" value={ p.FilterEndDate } class="input input-sm w-full"/>
+							<input type="date" name="end_date" value={ p.FilterEndDate } class="input input-sm w-full" x-ref="endDate"/>
 						</label>
 					</div>
-				</section>
+					<div class="flex flex-wrap gap-1.5 mt-2">
+						for _, preset := range txDatePresets() {
+							<button
+								type="button"
+								class="btn btn-ghost btn-xs"
+								data-start={ preset.Start }
+								data-end={ preset.End }
+								@click="$refs.startDate.value = $el.dataset.start; $refs.endDate.value = $el.dataset.end"
+							>
+								{ preset.Label }
+							</button>
+						}
+					</div>
+				}
 				<!-- Where -->
-				<section class="space-y-2">
-					@txFilterSectionLabel("landmark", "Where")
+				@components.CollapsibleSection(components.CollapsibleSectionProps{
+					Icon:        "landmark",
+					Label:       "Where",
+					DefaultOpen: p.WhereSectionOpen(),
+					Right:       txFilterCountIndicator(p.WhereFilterCount()),
+				}) {
 					<div class="space-y-3">
 						<label class="bb-filter-label">
 							Connection
@@ -269,10 +290,14 @@ templ txFilterDrawer(p TransactionsProps) {
 							</select>
 						</label>
 					</div>
-				</section>
+				}
 				<!-- What -->
-				<section class="space-y-2">
-					@txFilterSectionLabel("shapes", "What")
+				@components.CollapsibleSection(components.CollapsibleSectionProps{
+					Icon:        "shapes",
+					Label:       "What",
+					DefaultOpen: p.WhatSectionOpen(),
+					Right:       txFilterCountIndicator(p.WhatFilterCount()),
+				}) {
 					<div class="space-y-3">
 						<label class="bb-filter-label">
 							Category
@@ -294,90 +319,119 @@ templ txFilterDrawer(p TransactionsProps) {
 								</button>
 							</div>
 						</label>
-						<div class="grid grid-cols-2 gap-3">
-							<label class="bb-filter-label">
-								Min amount
-								<input type="number" name="min_amount" step="0.01" value={ p.FilterMinAmount } placeholder="0.00" class="input input-sm w-full"/>
-							</label>
-							<label class="bb-filter-label">
-								Max amount
-								<input type="number" name="max_amount" step="0.01" value={ p.FilterMaxAmount } placeholder="0.00" class="input input-sm w-full"/>
-							</label>
+						<div class="space-y-1.5">
+							<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider">Amount range</div>
+							<div class="grid grid-cols-2 gap-3">
+								<label class="bb-filter-label">
+									Min amount
+									<input type="number" name="min_amount" step="0.01" value={ p.FilterMinAmount } placeholder="0.00" class="input input-sm w-full"/>
+								</label>
+								<label class="bb-filter-label">
+									Max amount
+									<input type="number" name="max_amount" step="0.01" value={ p.FilterMaxAmount } placeholder="0.00" class="input input-sm w-full"/>
+								</label>
+							</div>
 						</div>
-						<div class="grid grid-cols-2 gap-3">
-							<label class="bb-filter-label">
-								Pending
-								<select name="pending" class="select select-sm w-full">
-									<option value="">All</option>
-									@txSelectOption("true", "Yes", p.FilterPending)
-									@txSelectOption("false", "No", p.FilterPending)
-								</select>
-							</label>
-							<label class="bb-filter-label">
-								Flagged
-								<select name="flagged" class="select select-sm w-full">
-									<option value="">All</option>
-									@txSelectOption("true", "Flagged only", p.FilterFlagged)
-									@txSelectOption("false", "Not flagged", p.FilterFlagged)
-								</select>
-							</label>
+						<div class="space-y-1.5">
+							<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider">Status</div>
+							<div class="grid grid-cols-2 gap-3">
+								<label class="bb-filter-label">
+									Pending
+									<select name="pending" class="select select-sm w-full">
+										<option value="">All</option>
+										@txSelectOption("true", "Yes", p.FilterPending)
+										@txSelectOption("false", "No", p.FilterPending)
+									</select>
+								</label>
+								<label class="bb-filter-label">
+									Flagged
+									<select name="flagged" class="select select-sm w-full">
+										<option value="">All</option>
+										@txSelectOption("true", "Flagged only", p.FilterFlagged)
+										@txSelectOption("false", "Not flagged", p.FilterFlagged)
+									</select>
+								</label>
+							</div>
 						</div>
 					</div>
-				</section>
-				<!-- Tags -->
-				<section class="space-y-2" x-data="tagFilter">
-					<div class="flex items-center justify-between">
-						@txFilterSectionLabel("tags", "Tags")
-						<label class="flex items-center gap-1.5 text-[0.65rem] text-base-content/50 cursor-pointer">
-							<input type="checkbox" x-model="anyMode" class="checkbox checkbox-xs"/>
-							<span x-text="anyMode ? 'Match any (OR)' : 'Match all (AND)'"></span>
-						</label>
-					</div>
-					<input type="hidden" name="tags" :value="!anyMode ? selectedSlugs.join(',') : ''"/>
-					<input type="hidden" name="any_tag" :value="anyMode ? selectedSlugs.join(',') : ''"/>
-					<div class="flex flex-wrap gap-1.5">
-						<template x-for="t in availableTags" :key="t.slug">
+				}
+				<!-- Tags — tagFilter scope wraps the section so the collapsed indicator
+				     can read selectedSlugs reactively. -->
+				<div x-data="tagFilter">
+					@components.CollapsibleSection(components.CollapsibleSectionProps{
+						Icon:        "tags",
+						Label:       "Tags",
+						DefaultOpen: p.TagsSectionOpen(),
+						Right:       txTagsIndicator(),
+					}) {
+						<div class="flex items-center justify-between mb-2">
+							<label class="flex items-center gap-1.5 text-[0.65rem] text-base-content/50 cursor-pointer">
+								<input type="checkbox" x-model="anyMode" class="checkbox checkbox-xs"/>
+								<span x-text="anyMode ? 'Match any (OR)' : 'Match all (AND)'"></span>
+							</label>
 							<button
 								type="button"
-								class="bb-tag bb-tag-interactive"
-								:class="{ 'bb-tag-ghost': !isSelected(t.slug) }"
-								:title="t.display_name && t.display_name !== t.slug ? (t.display_name + ' — ' + t.slug) : t.slug"
-								:style="t.color ? ('--tag-color:' + t.color) : ''"
-								@click="toggle(t.slug)"
+								x-show="selectedSlugs.length"
+								x-cloak
+								class="text-[0.65rem] text-base-content/40 hover:text-base-content/70 transition-colors"
+								@click="selectedSlugs = []"
 							>
-								<template x-if="t.icon"><i :data-lucide="t.icon"></i></template>
-								<span x-text="t.display_name || t.slug"></span>
+								Clear (<span x-text="selectedSlugs.length"></span>)
 							</button>
-						</template>
-						<span x-show="!availableTags.length" class="text-xs text-base-content/30 italic">No tags registered yet — go to <a href="/tags" class="link">/tags</a> to create one.</span>
-					</div>
-				</section>
-				<!-- Search options (apply to the quick-search box above) -->
-				<section class="space-y-2" x-data={ txSearchModeInit(p.FilterSearchMode) }>
-					@txFilterSectionLabel("search", "Search options")
-					<p class="text-[0.65rem] text-base-content/40 -mt-1">Applies to the search box above.</p>
-					<div class="grid grid-cols-2 gap-3">
-						<label class="bb-filter-label">
-							Search in
-							<select name="search_field" class="select select-sm w-full">
-								@txSearchFieldOption("all", "Name & Merchant", p.FilterSearchField, true)
-								@txSearchFieldOption("name", "Name only", p.FilterSearchField, false)
-								@txSearchFieldOption("merchant", "Merchant only", p.FilterSearchField, false)
-							</select>
-						</label>
-						<label class="bb-filter-label">
-							Match type
-							<select name="search_mode" class="select select-sm w-full" x-model="mode">
-								<option value="contains">Contains</option>
-								<option value="words">All words</option>
-								<option value="fuzzy">Fuzzy match</option>
-							</select>
-						</label>
-					</div>
-					<p class="text-[0.65rem] text-base-content/30" x-show="mode === 'contains'" x-cloak>Substring match — finds transactions containing the exact text</p>
-					<p class="text-[0.65rem] text-base-content/30" x-show="mode === 'words'" x-cloak>Matches each word independently — "Century Link" finds "CenturyLink"</p>
-					<p class="text-[0.65rem] text-base-content/30" x-show="mode === 'fuzzy'" x-cloak>Typo-tolerant similarity — finds close matches even with misspellings</p>
-				</section>
+						</div>
+						<input type="hidden" name="tags" :value="!anyMode ? selectedSlugs.join(',') : ''"/>
+						<input type="hidden" name="any_tag" :value="anyMode ? selectedSlugs.join(',') : ''"/>
+						<div class="flex flex-wrap gap-1.5">
+							<template x-for="t in availableTags" :key="t.slug">
+								<button
+									type="button"
+									class="bb-tag bb-tag-interactive"
+									:class="{ 'bb-tag-ghost': !isSelected(t.slug) }"
+									:title="t.display_name && t.display_name !== t.slug ? (t.display_name + ' — ' + t.slug) : t.slug"
+									:style="t.color ? ('--tag-color:' + t.color) : ''"
+									@click="toggle(t.slug)"
+								>
+									<template x-if="t.icon"><i :data-lucide="t.icon"></i></template>
+									<span x-text="t.display_name || t.slug"></span>
+								</button>
+							</template>
+							<span x-show="!availableTags.length" class="text-xs text-base-content/30 italic">No tags registered yet — go to <a href="/tags" class="link">/tags</a> to create one.</span>
+						</div>
+					}
+				</div>
+				<!-- Search options (apply to the quick-search box above). txSearchMode
+				     scope wraps the section so `mode` is in scope for the body. -->
+				<div x-data={ txSearchModeInit(p.FilterSearchMode) }>
+					@components.CollapsibleSection(components.CollapsibleSectionProps{
+						Icon:        "search",
+						Label:       "Search options",
+						DefaultOpen: p.SearchSectionOpen(),
+						Right:       txSearchIndicator(p.SearchSectionOpen()),
+					}) {
+						<p class="text-[0.65rem] text-base-content/40 mb-2">Refine how the search box at the top of the page matches.</p>
+						<div class="grid grid-cols-2 gap-3">
+							<label class="bb-filter-label">
+								Search in
+								<select name="search_field" class="select select-sm w-full">
+									@txSearchFieldOption("all", "Name & merchant", p.FilterSearchField, true)
+									@txSearchFieldOption("name", "Name only", p.FilterSearchField, false)
+									@txSearchFieldOption("merchant", "Merchant only", p.FilterSearchField, false)
+								</select>
+							</label>
+							<label class="bb-filter-label">
+								Match style
+								<select name="search_mode" class="select select-sm w-full" x-model="mode">
+									<option value="contains">Contains text</option>
+									<option value="words">All words</option>
+									<option value="fuzzy">Fuzzy / typo-tolerant</option>
+								</select>
+							</label>
+						</div>
+						<p class="text-[0.65rem] text-base-content/30 mt-1" x-show="mode === 'contains'" x-cloak>Substring match — finds transactions containing the exact text.</p>
+						<p class="text-[0.65rem] text-base-content/30 mt-1" x-show="mode === 'words'" x-cloak>Matches each word independently — "Century Link" finds "CenturyLink".</p>
+						<p class="text-[0.65rem] text-base-content/30 mt-1" x-show="mode === 'fuzzy'" x-cloak>Typo-tolerant similarity — finds close matches even with misspellings.</p>
+					}
+				</div>
 			</div>
 			@components.DrawerFooter() {
 				<a href="/transactions" class="btn btn-ghost btn-sm">Reset</a>
@@ -390,14 +444,42 @@ templ txFilterDrawer(p TransactionsProps) {
 	}
 }
 
-// txFilterSectionLabel is the quiet uppercase section divider used inside the
-// filter drawer — a small lucide glyph + label, matching the section-label
-// idiom in the design system.
-templ txFilterSectionLabel(icon, label string) {
-	<div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2">
-		@components.LucideIcon(icon, "w-3.5 h-3.5 opacity-60")
-		{ label }
-	</div>
+// txFilterCountIndicator builds the collapsed-state active-filter badge for a
+// CollapsibleSection header right slot: a small count chip that shows only when
+// the section is collapsed (`x-show="!open"`, evaluated in the section's Alpine
+// scope). Returns nil when the section holds no active filter so the slot stays
+// empty. Used by the When / Where / What filter sections.
+func txFilterCountIndicator(n int) templ.Component {
+	if n <= 0 {
+		return nil
+	}
+	return txFilterCountBadge(n)
+}
+
+templ txFilterCountBadge(n int) {
+	<span x-show="!open" x-cloak class="badge badge-soft badge-info badge-xs">{ fmt.Sprintf("%d", n) }</span>
+}
+
+// txTagsIndicator is the Tags-section collapsed indicator. Unlike the static
+// count badges it reads the live `selectedSlugs` from the ancestor `tagFilter`
+// scope so the count stays correct as chips toggle. Shown only when collapsed
+// and at least one tag is selected.
+templ txTagsIndicator() {
+	<span x-show="!open && selectedSlugs.length" x-cloak class="badge badge-soft badge-info badge-xs" x-text="selectedSlugs.length"></span>
+}
+
+// txSearchIndicator is the Search-options collapsed indicator — a small dot
+// rather than a count, since "non-default field/mode" isn't a tally. Returns
+// nil when the section is at its defaults.
+func txSearchIndicator(active bool) templ.Component {
+	if !active {
+		return nil
+	}
+	return txSearchDot()
+}
+
+templ txSearchDot() {
+	<span x-show="!open" x-cloak class="inline-block w-1.5 h-1.5 rounded-full bg-info" aria-hidden="true"></span>
 }
 
 // txFilterChips renders a row of removable badges summarising each active

--- a/internal/templates/components/pages/transactions_filter_test.go
+++ b/internal/templates/components/pages/transactions_filter_test.go
@@ -1,0 +1,108 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+// TestFilterSectionSmartDefaults pins the open-by-default + active-count logic
+// that drives the /transactions filter drawer's CollapsibleSection headers:
+// a section defaults open exactly when it holds an active filter, and the
+// collapsed-state count reflects how many of that section's filters are set.
+func TestFilterSectionSmartDefaults(t *testing.T) {
+	t.Run("empty props — every section collapsed, zero counts", func(t *testing.T) {
+		var p TransactionsProps
+		if p.WhenSectionOpen() || p.WhereSectionOpen() || p.WhatSectionOpen() ||
+			p.TagsSectionOpen() || p.SearchSectionOpen() {
+			t.Fatalf("no filters set, but a section defaulted open: when=%v where=%v what=%v tags=%v search=%v",
+				p.WhenSectionOpen(), p.WhereSectionOpen(), p.WhatSectionOpen(),
+				p.TagsSectionOpen(), p.SearchSectionOpen())
+		}
+		if got := p.WhenFilterCount() + p.WhereFilterCount() + p.WhatFilterCount(); got != 0 {
+			t.Fatalf("expected zero total active-filter count, got %d", got)
+		}
+	})
+
+	t.Run("When opens on either date bound", func(t *testing.T) {
+		start := TransactionsProps{FilterStartDate: "2026-01-01"}
+		if !start.WhenSectionOpen() || start.WhenFilterCount() != 1 {
+			t.Errorf("start-only: open=%v count=%d, want open=true count=1", start.WhenSectionOpen(), start.WhenFilterCount())
+		}
+		both := TransactionsProps{FilterStartDate: "2026-01-01", FilterEndDate: "2026-02-01"}
+		if both.WhenFilterCount() != 2 {
+			t.Errorf("both bounds: count=%d, want 2", both.WhenFilterCount())
+		}
+	})
+
+	t.Run("Where counts connection/account/member", func(t *testing.T) {
+		p := TransactionsProps{FilterConnID: "c", FilterAccountID: "a", FilterUserID: "u"}
+		if !p.WhereSectionOpen() || p.WhereFilterCount() != 3 {
+			t.Errorf("open=%v count=%d, want open=true count=3", p.WhereSectionOpen(), p.WhereFilterCount())
+		}
+	})
+
+	t.Run("What counts category/amounts/pending/flagged", func(t *testing.T) {
+		p := TransactionsProps{
+			FilterCategory:  "groceries",
+			FilterMinAmount: "5",
+			FilterMaxAmount: "50",
+			FilterPending:   "true",
+			FilterFlagged:   "false",
+		}
+		if !p.WhatSectionOpen() || p.WhatFilterCount() != 5 {
+			t.Errorf("open=%v count=%d, want open=true count=5", p.WhatSectionOpen(), p.WhatFilterCount())
+		}
+	})
+
+	t.Run("Tags opens in AND or OR mode", func(t *testing.T) {
+		and := TransactionsProps{FilterTags: []string{"x"}}
+		or := TransactionsProps{FilterAnyTag: []string{"y", "z"}}
+		if !and.TagsSectionOpen() || !or.TagsSectionOpen() {
+			t.Errorf("tags should open: and=%v or=%v", and.TagsSectionOpen(), or.TagsSectionOpen())
+		}
+	})
+
+	t.Run("Search opens only on non-default field or mode", func(t *testing.T) {
+		// Defaults (all / contains) stay collapsed.
+		defaults := []TransactionsProps{
+			{},
+			{FilterSearchField: "all"},
+			{FilterSearchMode: "contains"},
+			{FilterSearchField: "all", FilterSearchMode: "contains"},
+		}
+		for i, p := range defaults {
+			if p.SearchSectionOpen() {
+				t.Errorf("case %d: defaults should stay collapsed, got open", i)
+			}
+		}
+		nonDefault := []TransactionsProps{
+			{FilterSearchField: "merchant"},
+			{FilterSearchMode: "fuzzy"},
+		}
+		for i, p := range nonDefault {
+			if !p.SearchSectionOpen() {
+				t.Errorf("case %d: non-default search option should open the section", i)
+			}
+		}
+	})
+}
+
+// TestTxDatePresets verifies the quick date presets are well-formed: four
+// presets, each with a non-empty label and ISO YYYY-MM-DD bounds where start
+// is not after end.
+func TestTxDatePresets(t *testing.T) {
+	presets := txDatePresets()
+	if len(presets) != 4 {
+		t.Fatalf("expected 4 date presets, got %d", len(presets))
+	}
+	for _, p := range presets {
+		if p.Label == "" {
+			t.Errorf("preset has empty label: %+v", p)
+		}
+		if len(p.Start) != 10 || len(p.End) != 10 {
+			t.Errorf("preset %q has non-ISO bounds: start=%q end=%q", p.Label, p.Start, p.End)
+		}
+		if p.Start > p.End {
+			t.Errorf("preset %q start %q is after end %q", p.Label, p.Start, p.End)
+		}
+	}
+}

--- a/internal/templates/components/pages/transactions_types.go
+++ b/internal/templates/components/pages/transactions_types.go
@@ -3,9 +3,52 @@
 package pages
 
 import (
+	"time"
+
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
+
+// txDatePreset is one quick date-range chip in the "When" filter section.
+// Start/End are pre-formatted YYYY-MM-DD strings (the value= shape a native
+// <input type="date"> expects) so the Alpine click handler only assigns them
+// to the two date inputs — no client-side date math.
+type txDatePreset struct {
+	Label string
+	Start string
+	End   string
+}
+
+// txDatePresets returns the canonical quick date ranges, computed server-side
+// relative to now: This month, Last 30 days, Last 90 days, This year. Each
+// fills both date inputs in the When section on click.
+func txDatePresets() []txDatePreset {
+	const iso = "2006-01-02"
+	now := time.Now()
+	today := now.Format(iso)
+	return []txDatePreset{
+		{
+			Label: "This month",
+			Start: time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).Format(iso),
+			End:   today,
+		},
+		{
+			Label: "Last 30 days",
+			Start: now.AddDate(0, 0, -29).Format(iso),
+			End:   today,
+		},
+		{
+			Label: "Last 90 days",
+			Start: now.AddDate(0, 0, -89).Format(iso),
+			End:   today,
+		},
+		{
+			Label: "This year",
+			Start: time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location()).Format(iso),
+			End:   today,
+		},
+	}
+}
 
 // TransactionsConnectionOption represents one entry in the Connection filter dropdown.
 type TransactionsConnectionOption struct {
@@ -109,6 +152,96 @@ func (p TransactionsProps) HasActiveFilters() bool {
 // its own visible bar).
 func (p TransactionsProps) HasAnyFilter() bool {
 	return p.HasActiveFilters() || p.FilterSearch != ""
+}
+
+// ── Filter-drawer section smart-defaults ─────────────────────────────────
+//
+// Each of the five filter-drawer sections (When / Where / What / Tags /
+// Search options) defaults OPEN when it currently holds an active filter and
+// collapsed otherwise, so applied filters stay visible while the drawer stays
+// scannable. The `*SectionOpen` methods drive CollapsibleSection.DefaultOpen;
+// the `*FilterCount` methods feed the collapsed-state active indicator.
+// Pure functions of the props so transactions_filter_test.go can pin them.
+
+// WhenSectionOpen reports whether the date-range ("When") section holds a
+// filter (a start or end date) and should default open.
+func (p TransactionsProps) WhenSectionOpen() bool {
+	return p.WhenFilterCount() > 0
+}
+
+// WhenFilterCount counts the active date bounds (0–2).
+func (p TransactionsProps) WhenFilterCount() int {
+	n := 0
+	if p.FilterStartDate != "" {
+		n++
+	}
+	if p.FilterEndDate != "" {
+		n++
+	}
+	return n
+}
+
+// WhereSectionOpen reports whether the location ("Where") section holds a
+// connection / account / member filter and should default open.
+func (p TransactionsProps) WhereSectionOpen() bool {
+	return p.WhereFilterCount() > 0
+}
+
+// WhereFilterCount counts the active location filters (0–3).
+func (p TransactionsProps) WhereFilterCount() int {
+	n := 0
+	if p.FilterConnID != "" {
+		n++
+	}
+	if p.FilterAccountID != "" {
+		n++
+	}
+	if p.FilterUserID != "" {
+		n++
+	}
+	return n
+}
+
+// WhatSectionOpen reports whether the attributes ("What") section holds a
+// category / amount / pending / flagged filter and should default open.
+func (p TransactionsProps) WhatSectionOpen() bool {
+	return p.WhatFilterCount() > 0
+}
+
+// WhatFilterCount counts the active attribute filters (0–5).
+func (p TransactionsProps) WhatFilterCount() int {
+	n := 0
+	if p.FilterCategory != "" {
+		n++
+	}
+	if p.FilterMinAmount != "" {
+		n++
+	}
+	if p.FilterMaxAmount != "" {
+		n++
+	}
+	if p.FilterPending != "" {
+		n++
+	}
+	if p.FilterFlagged != "" {
+		n++
+	}
+	return n
+}
+
+// TagsSectionOpen reports whether the Tags section holds a tag filter (in
+// either AND or OR mode) and should default open.
+func (p TransactionsProps) TagsSectionOpen() bool {
+	return len(p.FilterTags) > 0 || len(p.FilterAnyTag) > 0
+}
+
+// SearchSectionOpen reports whether the Search-options section deviates from
+// its defaults (all fields / contains) and should default open. The quick
+// search text itself lives in the always-visible search bar, so only a
+// non-default field or match mode opens this section.
+func (p TransactionsProps) SearchSectionOpen() bool {
+	return (p.FilterSearchField != "" && p.FilterSearchField != "all") ||
+		(p.FilterSearchMode != "" && p.FilterSearchMode != "contains")
 }
 
 // IsReviewQueue reports whether the current page view is the review queue —


### PR DESCRIPTION
Follow-up on the /transactions filter drawer: the five filter sections are now **collapsible**, via a new reusable design-system component, with smart default-open and per-section tidy-ups.

## What changed

- **New `components.CollapsibleSection`** (`collapsible_section.templ`) — an Alpine disclosure (icon + label header, rotating chevron, `x-show`+`x-collapse` body) with props `Icon / Label / DefaultOpen / Right / Class`. The `Right` slot renders inside the component's Alpine scope so an indicator can show only while collapsed. Form-safe (`x-show`, not `<details>`) so collapsed inputs still submit. Added to the `/design` sandbox (Layout → `collapsible-section`) and documented in the skill's `components.md`.
- **Applied to all 5 filter sections** (When / Where / What / Tags / Search options). **Smart default-open:** a section opens iff it holds an active filter — applied filters stay visible, the rest stay tucked. Collapsed-but-active sections show a small count indicator. Computed in unit-tested Go helpers on `TransactionsProps`.
- **Per-section polish:**
  - **When** — quick presets (This month / Last 30 / Last 90 / This year) that fill the date inputs.
  - **What** — grouped "Amount range" / "Status" sub-captions.
  - **Tags** — inline "Clear (N)" + reactive selected-count.
  - **Search options** — clearer field/mode copy.
- New unit tests (`transactions_filter_test.go`): smart-default logic + date presets. Lint (`TestNoLargeInlineScripts`) passes.

Behavior preserved: still a server GET form, hidden synced search input, category picker, tag AND/OR, Reset/Apply — only the chrome changed.

`go build` / `go vet` / `go test ./...` all green.

## Evidence

<img src="https://bb-artifacts.exe.xyz/f/e3be42f67258bc14.jpeg" width="800" alt="Transactions filter drawer — collapsible sections, When+What auto-open from active filters, date presets">

Deferred recommendations (noted, not built): highlight the active date preset; optgroup accounts under their connection (needs a data-model/handler change); tag search when the tag set grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
