### PR TITLE
fix(ui): low-contrast badges → vivid/ghost + connection empty state (design system P1)

### DIFF
--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -433,7 +433,7 @@ templ accessScopeBadge(scope string) {
 	if scope == "read_only" {
 		<span class="badge badge-soft badge-warning badge-xs shrink-0">Read only</span>
 	} else {
-		<span class="badge badge-soft badge-primary badge-xs shrink-0">Full access</span>
+		<span class="badge badge-soft badge-success badge-xs shrink-0">Full access</span>
 	}
 }
 

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -500,10 +500,11 @@ templ connDetailSyncHistory(p ConnectionDetailProps) {
 				}
 			</div>
 			<div id="sync-history-empty" class={ "px-4 sm:px-5 pb-4", templ.KV("hidden", len(p.SyncLogs) > 0) }>
-				<div class="flex flex-col items-center justify-center py-10 text-base-content/30">
-					@components.LucideIcon("refresh-cw", "w-10 h-10 mb-3 opacity-50")
-					<p class="text-sm">No sync history yet</p>
-				</div>
+				@components.EmptyState(components.EmptyStateProps{
+					Icon:    "history",
+					Title:   "No sync history yet",
+					Compact: true,
+				})
 			</div>
 		</div>
 		<!-- /sync-history-content -->

--- a/internal/templates/components/pages/developer_settings.templ
+++ b/internal/templates/components/pages/developer_settings.templ
@@ -109,11 +109,11 @@ templ developerModeSection(p DeveloperSettingsProps) {
 			Caption: "Applied automatically — add these to the repo so GitHub keeps them.",
 		}) {
 			<div class="flex items-center gap-1.5">
-				<span class="badge badge-soft badge-neutral badge-sm font-mono">bug</span>
+				<span class="badge badge-ghost badge-sm font-mono">bug</span>
 				<span class="text-base-content/40">/</span>
-				<span class="badge badge-soft badge-neutral badge-sm font-mono">task</span>
+				<span class="badge badge-ghost badge-sm font-mono">task</span>
 				<span class="text-base-content/40">+</span>
-				<span class="badge badge-soft badge-primary badge-sm font-mono">filed-via-bug</span>
+				<span class="badge badge-ghost badge-sm font-mono">filed-via-bug</span>
 			</div>
 		}
 	}

--- a/internal/templates/components/pages/mcp_guide.templ
+++ b/internal/templates/components/pages/mcp_guide.templ
@@ -118,7 +118,7 @@ templ MCPGuide(p MCPGuideProps) {
 					<div x-show="flavor === 'guide'" class="space-y-4">
 						<div class="flex items-center gap-2 mb-1">
 							<span class="badge badge-soft badge-warning badge-xs">API Key</span>
-							<span class="badge badge-soft badge-primary badge-xs">OAuth</span>
+							<span class="badge badge-soft badge-info badge-xs">OAuth</span>
 						</div>
 						<ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside">
 							<li>Open <strong>Claude Desktop</strong> and go to <strong>Settings</strong></li>
@@ -165,7 +165,7 @@ templ MCPGuide(p MCPGuideProps) {
 					<div class="space-y-4">
 						<div class="flex items-center gap-2 mb-1">
 							<span class="badge badge-soft badge-warning badge-xs">API Key</span>
-							<span class="badge badge-soft badge-primary badge-xs">OAuth</span>
+							<span class="badge badge-soft badge-info badge-xs">OAuth</span>
 						</div>
 						<p class="text-sm text-base-content/60">Run this command:</p>
 						<div class="relative" x-data="{ copied: false }">
@@ -194,7 +194,7 @@ templ MCPGuide(p MCPGuideProps) {
 					<!-- Guide flavor -->
 					<div x-show="flavor === 'guide'" class="space-y-4">
 						<div class="flex items-center gap-2 mb-1">
-							<span class="badge badge-soft badge-primary badge-xs">OAuth required</span>
+							<span class="badge badge-soft badge-info badge-xs">OAuth required</span>
 						</div>
 						<ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside">
 							<li>Create an <a href="/oauth-clients/new" class="link link-primary">OAuth Client</a> in Breadbox if you haven't already</li>

--- a/internal/templates/components/pages/notifications_settings.templ
+++ b/internal/templates/components/pages/notifications_settings.templ
@@ -127,7 +127,7 @@ templ notificationChannelRow(c NotificationChannelView, csrf string) {
 // (error) when the last send failed, otherwise Enabled (success).
 templ notificationChannelStatusBadge(c NotificationChannelView) {
 	if !c.Enabled {
-		<span class="badge badge-soft badge-neutral badge-sm">Disabled</span>
+		<span class="badge badge-ghost badge-sm">Disabled</span>
 	} else if c.HasStatus && !c.StatusOK {
 		<span class="badge badge-soft badge-error badge-sm">Delivery failed</span>
 	} else {

--- a/internal/templates/components/pages/report_detail.templ
+++ b/internal/templates/components/pages/report_detail.templ
@@ -38,7 +38,7 @@ templ ReportDetail(p ReportDetailProps) {
 				<div class="min-w-0">
 					<div class="flex items-center gap-2 mb-2 flex-wrap">
 						@components.ReportPriorityBadge(p.Report.Priority)
-						<span x-show="!isRead" x-cloak class="badge badge-soft badge-primary badge-sm">Unread</span>
+						<span x-show="!isRead" x-cloak class="badge badge-soft badge-info badge-sm">Unread</span>
 					</div>
 					<h1 class="text-xl sm:text-2xl font-semibold leading-snug break-words text-base-content">{ p.Report.Title }</h1>
 					<div class="mt-2.5 flex items-center gap-1.5 text-xs text-base-content/50">


### PR DESCRIPTION
P1 consistency sweep from the design-system audit: low-contrast soft badges → vivid/ghost so they're legible on the dark theme (where `badge-soft` in primary/secondary/accent/neutral renders gray-on-gray and all but disappears — `reference_theme_vivid_tones`), plus one hand-rolled empty state → `EmptyState`.

## Fixes
- **report_detail** — "Unread" `badge-primary` → `badge-info`
- **access** — "Full access" `badge-primary` → `badge-success`
- **mcp_guide** — "OAuth" / "OAuth required" `badge-primary` → `badge-info` (×3)
- **notifications_settings** — "Disabled" `badge-neutral` → `badge-ghost`
- **developer_settings** — "bug" / "task" / "filed-via-bug" → `badge-ghost`
- **connection_detail** — hand-rolled "No sync history yet" block → `components.EmptyState(Compact)`

**Deferred:** `mcp_guide` bespoke `role=tablist` → `TabBar` — not a clean drop-in (the tabs are Alpine-state-coupled: `x-for`/`switchTab`/paired `x-ref` panels), so converting needs a rebuild of the client state, out of scope for a mechanical sweep. Logged for a dedicated pass.

`go build` / `go vet` / `go test ./...` green. Codifies the "Badge tone & contrast — vivid only" rule now in the skill.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/b74a4ecec76292d3.jpeg" width="800" alt="Developer settings — bug/task/filed-via-bug now ghost badges">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
