### PR TITLE
feat(workflows): bold prompt editor entry for custom workflows

### DIFF
--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -1000,24 +1000,16 @@ templ workflowCustomPromptField() {
 					</button>
 				</div>
 			</div>
-			// Empty body — clean centered invitation with a real CTA button.
+			// Empty body — a quiet placeholder that reads like an empty editor
+			// field; click anywhere to compose.
 			<button
 				type="button"
 				x-show="!custom.prompt.trim()"
 				@click="editPrompt(true)"
-				class="group flex w-full cursor-pointer flex-col items-center gap-3 px-5 py-9 text-center transition-colors hover:bg-base-200/40"
+				class="flex min-h-28 w-full cursor-pointer items-start gap-2 px-4 py-3.5 text-left text-sm text-base-content/40 transition-colors hover:bg-base-200/40 hover:text-base-content/60"
 			>
-				<span class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 text-base-content/50 transition-colors group-hover:bg-primary/10 group-hover:text-primary">
-					@components.LucideIcon("sparkles", "w-5 h-5")
-				</span>
-				<span class="max-w-sm">
-					<span class="block text-sm font-semibold">Compose the prompt</span>
-					<span class="block text-xs text-base-content/55 mt-1">The full instructions sent on every run — author it in Markdown with live preview. This is the entire workflow; there's no template behind it.</span>
-				</span>
-				<span class="btn btn-primary btn-sm gap-1.5">
-					@components.LucideIcon("pencil", "w-4 h-4")
-					Open editor
-				</span>
+				@components.LucideIcon("pencil", "w-4 h-4 mt-0.5 shrink-0")
+				<span>The full instructions sent on every run. Click to compose it in Markdown, with live preview.</span>
 			</button>
 			// Filled body — clickable monospace excerpt; hover highlights it.
 			<button

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -867,18 +867,7 @@ templ workflowCustomDrawer() {
 				Loading…
 			</div>
 			<div x-show="!custom.loading" x-cloak class="flex-1 overflow-y-auto p-5 space-y-5">
-				<div>
-					<div class="text-sm font-medium mb-1.5">Prompt</div>
-					<textarea
-						name="prompt"
-						x-model="custom.prompt"
-						rows="10"
-						required
-						class="textarea textarea-bordered w-full text-sm font-mono leading-relaxed"
-						placeholder="The full instructions sent on every run. Describe the goal, what to look at, and how to act — e.g. &#34;Review new transactions, flag anything over $200 that isn't a known merchant, and write a short report.&#34;"
-					></textarea>
-					<div class="text-xs text-base-content/40 mt-1">This is the entire workflow prompt — there's no template behind it.</div>
-				</div>
+				@workflowCustomPromptField()
 				<div>
 					<div class="text-sm font-medium mb-2">When should the workflow run?</div>
 					<div class="grid grid-cols-1 gap-2">
@@ -963,4 +952,75 @@ templ workflowCustomDrawer() {
 			}
 		</form>
 	}
+}
+
+// workflowCustomPromptField is the hero of the custom drawer: the prompt IS the
+// whole workflow, so instead of a cramped inline textarea it gets a bold,
+// full-width surface that hands authoring off to the global prompt modal
+// (#bb-prompt-modal in base.html) and its Markdown Edit/Preview flow. The raw
+// value lives in custom.prompt and rides to the server in a hidden field; the
+// modal writes back through editPrompt()'s onSaved callback. Two states:
+//
+//   - empty   : an inviting dashed call-to-action that opens straight into the
+//               editor (editPrompt(true)). Tints error-red when a save was
+//               attempted with no prompt (custom.promptError).
+//   - filled  : a framed card with a faded monospace excerpt and Preview / Edit
+//               actions (editPrompt(false) / editPrompt(true)).
+templ workflowCustomPromptField() {
+	<div>
+		// Hidden carrier — keeps `prompt` in the form's FormData. Not `required`
+		// (a hidden required control can't be focused, which silently blocks
+		// submit); submitCustom() validates non-empty in JS instead.
+		<textarea name="prompt" x-model="custom.prompt" class="hidden" aria-hidden="true" tabindex="-1"></textarea>
+		// Empty state — bold invitation.
+		<button
+			type="button"
+			x-show="!custom.prompt.trim()"
+			@click="editPrompt(true)"
+			x-bind:class="custom.promptError ? 'border-error hover:border-error' : 'border-base-300 bg-base-200/30 hover:border-primary/50 hover:bg-primary/5'"
+			class="group w-full text-left rounded-xl border-2 border-dashed transition-colors p-5 flex items-center gap-4"
+		>
+			<span class="shrink-0 w-11 h-11 rounded-xl bg-primary text-primary-content flex items-center justify-center shadow-sm transition-transform group-hover:scale-105">
+				@components.LucideIcon("sparkles", "w-5 h-5")
+			</span>
+			<span class="min-w-0 flex-1">
+				<span class="block text-sm font-semibold">Compose the workflow prompt</span>
+				<span class="block text-xs text-base-content/55 mt-0.5">The full instructions sent on every run — author it in Markdown with live preview. This is the entire workflow; there's no template behind it.</span>
+			</span>
+			<span class="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
+				Open editor
+				@components.LucideIcon("arrow-right", "w-3.5 h-3.5")
+			</span>
+		</button>
+		// Filled state — framed excerpt with Preview / Edit.
+		<div x-show="custom.prompt.trim()" x-cloak class="rounded-xl border border-base-300 overflow-hidden bg-base-100">
+			<div class="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-base-300 bg-base-200/40">
+				<span class="flex items-center gap-2 text-xs font-medium text-base-content/70 min-w-0">
+					@components.LucideIcon("file-text", "w-3.5 h-3.5 shrink-0")
+					<span class="truncate">Workflow prompt</span>
+					<span class="badge badge-ghost badge-xs shrink-0">Markdown</span>
+				</span>
+				<div class="flex items-center gap-1 shrink-0">
+					<button type="button" @click="editPrompt(false)" class="btn btn-ghost btn-xs gap-1.5">
+						@components.LucideIcon("eye", "w-3.5 h-3.5")
+						Preview
+					</button>
+					<button type="button" @click="editPrompt(true)" class="btn btn-primary btn-xs gap-1.5">
+						@components.LucideIcon("pencil", "w-3.5 h-3.5")
+						Edit
+					</button>
+				</div>
+			</div>
+			<button
+				type="button"
+				@click="editPrompt(true)"
+				class="relative block w-full text-left max-h-44 overflow-hidden hover:bg-base-200/30 transition-colors"
+				aria-label="Edit workflow prompt"
+			>
+				<pre class="text-xs font-mono leading-relaxed whitespace-pre-wrap break-words px-4 py-3.5 text-base-content/80" x-text="custom.prompt"></pre>
+				<span class="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-base-100 to-transparent"></span>
+			</button>
+		</div>
+		<p x-show="custom.promptError" x-cloak class="text-xs text-error mt-1.5">A prompt is required — open the editor and add instructions.</p>
+	</div>
 }

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -1000,44 +1000,38 @@ templ workflowCustomPromptField() {
 					</button>
 				</div>
 			</div>
-			// Empty body — bold centered invitation.
+			// Empty body — clean centered invitation with a real CTA button.
 			<button
 				type="button"
 				x-show="!custom.prompt.trim()"
 				@click="editPrompt(true)"
-				class="group flex w-full flex-col items-center gap-3 px-5 py-9 text-center transition-colors hover:bg-base-200/40"
+				class="group flex w-full cursor-pointer flex-col items-center gap-3 px-5 py-9 text-center transition-colors hover:bg-base-200/40"
 			>
-				<span class="flex w-12 h-12 items-center justify-center rounded-xl bg-primary text-primary-content shadow-sm transition-transform group-hover:scale-105">
+				<span class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 text-base-content/50 transition-colors group-hover:bg-primary/10 group-hover:text-primary">
 					@components.LucideIcon("sparkles", "w-5 h-5")
 				</span>
 				<span class="max-w-sm">
 					<span class="block text-sm font-semibold">Compose the prompt</span>
 					<span class="block text-xs text-base-content/55 mt-1">The full instructions sent on every run — author it in Markdown with live preview. This is the entire workflow; there's no template behind it.</span>
 				</span>
-				<span class="inline-flex items-center gap-1.5 text-xs font-medium text-primary">
-					@components.LucideIcon("pencil", "w-3.5 h-3.5")
-					Open the editor
+				<span class="btn btn-primary btn-sm gap-1.5">
+					@components.LucideIcon("pencil", "w-4 h-4")
+					Open editor
 				</span>
 			</button>
-			// Filled body — clickable monospace excerpt with a hover hint.
+			// Filled body — clickable monospace excerpt; hover highlights it.
 			<button
 				type="button"
 				x-show="custom.prompt.trim()"
 				x-cloak
 				@click="editPrompt(true)"
-				class="group relative block w-full max-h-44 overflow-hidden text-left transition-colors hover:bg-base-200/25"
+				class="relative block w-full max-h-44 cursor-pointer overflow-hidden text-left transition-colors hover:bg-base-200/50"
 				aria-label="Edit prompt"
 			>
 				<pre class="px-4 py-3.5 text-xs font-mono leading-relaxed whitespace-pre-wrap break-words text-base-content/80" x-text="custom.prompt"></pre>
-				// Fade the bottom of the excerpt into the card, and float an
-				// "edit" hint there that lifts in on hover.
-				<span class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-base-100 via-base-100/85 to-transparent"></span>
-				<span class="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-3 opacity-0 translate-y-1 transition-all group-hover:opacity-100 group-hover:translate-y-0">
-					<span class="inline-flex items-center gap-1.5 rounded-full border border-base-300 bg-base-100 px-3 py-1 text-xs font-medium shadow-sm">
-						@components.LucideIcon("pencil", "w-3.5 h-3.5")
-						Click to edit
-					</span>
-				</span>
+				// Fade the bottom of the excerpt into the card so the clipped
+				// text doesn't end in a hard line.
+				<span class="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-base-100 via-base-100/85 to-transparent"></span>
 			</button>
 		</div>
 		<p x-show="custom.promptError" x-cloak class="text-xs text-error mt-1.5">A prompt is required — open the editor and add instructions.</p>

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -961,46 +961,35 @@ templ workflowCustomDrawer() {
 // value lives in custom.prompt and rides to the server in a hidden field; the
 // modal writes back through editPrompt()'s onSaved callback. Two states:
 //
-//   - empty   : an inviting dashed call-to-action that opens straight into the
-//               editor (editPrompt(true)). Tints error-red when a save was
-//               attempted with no prompt (custom.promptError).
+//   - empty   : the same framed card, but its body is a bold centered
+//               call-to-action that opens straight into the editor
+//               (editPrompt(true)). Tints error-red when a save was attempted
+//               with no prompt (custom.promptError).
 //   - filled  : a framed card with a faded monospace excerpt and Preview / Edit
-//               actions (editPrompt(false) / editPrompt(true)).
+//               actions (editPrompt(false) / editPrompt(true)); the excerpt
+//               itself is clickable, with a hover hint, and opens the editor.
+//
+// Both states share the same frame + "Prompt" header so the field reads as one
+// document that's either empty or full, never two different shapes.
 templ workflowCustomPromptField() {
 	<div>
 		// Hidden carrier — keeps `prompt` in the form's FormData. Not `required`
 		// (a hidden required control can't be focused, which silently blocks
 		// submit); submitCustom() validates non-empty in JS instead.
 		<textarea name="prompt" x-model="custom.prompt" class="hidden" aria-hidden="true" tabindex="-1"></textarea>
-		// Empty state — bold invitation.
-		<button
-			type="button"
-			x-show="!custom.prompt.trim()"
-			@click="editPrompt(true)"
-			x-bind:class="custom.promptError ? 'border-error hover:border-error' : 'border-base-300 bg-base-200/30 hover:border-primary/50 hover:bg-primary/5'"
-			class="group w-full text-left rounded-xl border-2 border-dashed transition-colors p-5 flex items-center gap-4"
+		<div
+			x-bind:class="custom.promptError ? 'border-error' : 'border-base-300'"
+			class="rounded-xl border overflow-hidden bg-base-100"
 		>
-			<span class="shrink-0 w-11 h-11 rounded-xl bg-primary text-primary-content flex items-center justify-center shadow-sm transition-transform group-hover:scale-105">
-				@components.LucideIcon("sparkles", "w-5 h-5")
-			</span>
-			<span class="min-w-0 flex-1">
-				<span class="block text-sm font-semibold">Compose the workflow prompt</span>
-				<span class="block text-xs text-base-content/55 mt-0.5">The full instructions sent on every run — author it in Markdown with live preview. This is the entire workflow; there's no template behind it.</span>
-			</span>
-			<span class="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
-				Open editor
-				@components.LucideIcon("arrow-right", "w-3.5 h-3.5")
-			</span>
-		</button>
-		// Filled state — framed excerpt with Preview / Edit.
-		<div x-show="custom.prompt.trim()" x-cloak class="rounded-xl border border-base-300 overflow-hidden bg-base-100">
+			// Header — identical across states; the right slot only carries the
+			// Preview / Edit actions once there's a prompt to act on.
 			<div class="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-base-300 bg-base-200/40">
 				<span class="flex items-center gap-2 text-xs font-medium text-base-content/70 min-w-0">
 					@components.LucideIcon("file-text", "w-3.5 h-3.5 shrink-0")
-					<span class="truncate">Workflow prompt</span>
+					<span class="truncate">Prompt</span>
 					<span class="badge badge-ghost badge-xs shrink-0">Markdown</span>
 				</span>
-				<div class="flex items-center gap-1 shrink-0">
+				<div x-show="custom.prompt.trim()" class="flex items-center gap-1 shrink-0">
 					<button type="button" @click="editPrompt(false)" class="btn btn-ghost btn-xs gap-1.5">
 						@components.LucideIcon("eye", "w-3.5 h-3.5")
 						Preview
@@ -1011,14 +1000,44 @@ templ workflowCustomPromptField() {
 					</button>
 				</div>
 			</div>
+			// Empty body — bold centered invitation.
 			<button
 				type="button"
+				x-show="!custom.prompt.trim()"
 				@click="editPrompt(true)"
-				class="relative block w-full text-left max-h-44 overflow-hidden hover:bg-base-200/30 transition-colors"
-				aria-label="Edit workflow prompt"
+				class="group flex w-full flex-col items-center gap-3 px-5 py-9 text-center transition-colors hover:bg-base-200/40"
 			>
-				<pre class="text-xs font-mono leading-relaxed whitespace-pre-wrap break-words px-4 py-3.5 text-base-content/80" x-text="custom.prompt"></pre>
-				<span class="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-base-100 to-transparent"></span>
+				<span class="flex w-12 h-12 items-center justify-center rounded-xl bg-primary text-primary-content shadow-sm transition-transform group-hover:scale-105">
+					@components.LucideIcon("sparkles", "w-5 h-5")
+				</span>
+				<span class="max-w-sm">
+					<span class="block text-sm font-semibold">Compose the prompt</span>
+					<span class="block text-xs text-base-content/55 mt-1">The full instructions sent on every run — author it in Markdown with live preview. This is the entire workflow; there's no template behind it.</span>
+				</span>
+				<span class="inline-flex items-center gap-1.5 text-xs font-medium text-primary">
+					@components.LucideIcon("pencil", "w-3.5 h-3.5")
+					Open the editor
+				</span>
+			</button>
+			// Filled body — clickable monospace excerpt with a hover hint.
+			<button
+				type="button"
+				x-show="custom.prompt.trim()"
+				x-cloak
+				@click="editPrompt(true)"
+				class="group relative block w-full max-h-44 overflow-hidden text-left transition-colors hover:bg-base-200/25"
+				aria-label="Edit prompt"
+			>
+				<pre class="px-4 py-3.5 text-xs font-mono leading-relaxed whitespace-pre-wrap break-words text-base-content/80" x-text="custom.prompt"></pre>
+				// Fade the bottom of the excerpt into the card, and float an
+				// "edit" hint there that lifts in on hover.
+				<span class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-base-100 via-base-100/85 to-transparent"></span>
+				<span class="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-3 opacity-0 translate-y-1 transition-all group-hover:opacity-100 group-hover:translate-y-0">
+					<span class="inline-flex items-center gap-1.5 rounded-full border border-base-300 bg-base-100 px-3 py-1 text-xs font-medium shadow-sm">
+						@components.LucideIcon("pencil", "w-3.5 h-3.5")
+						Click to edit
+					</span>
+				</span>
 			</button>
 		</div>
 		<p x-show="custom.promptError" x-cloak class="text-xs text-error mt-1.5">A prompt is required — open the editor and add instructions.</p>

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -74,6 +74,10 @@ document.addEventListener('alpine:init', function () {
         maxTurns: '',
         maxBudget: '',
         enabled: true, // create-only "Activate" toggle
+        // promptError flips true when a save is attempted with an empty prompt.
+        // The prompt entry (workflowCustomPromptField) tints error-red and a
+        // helper line appears; editPrompt() and a fresh openCustom() clear it.
+        promptError: false,
       },
       // -------------------------------------------------------------------
 
@@ -576,6 +580,7 @@ document.addEventListener('alpine:init', function () {
         self.custom.maxTurns = '';
         self.custom.maxBudget = '';
         self.custom.enabled = true;
+        self.custom.promptError = false;
         self.custom.loading = !!slug;
         Alpine.store('drawers').open('wf-custom');
         if (!slug) return;
@@ -621,6 +626,13 @@ document.addEventListener('alpine:init', function () {
       // the new state.
       submitCustom: function (form) {
         var self = this;
+        // The prompt lives behind the modal in a hidden field (no native
+        // `required`), so guard it here. Flag the entry and bail — the operator
+        // taps it to open the editor.
+        if (!self.custom.prompt || !self.custom.prompt.trim()) {
+          self.custom.promptError = true;
+          return;
+        }
         var fd = new FormData(form);
         // The create "Activate" checkbox is omitted by FormData when unchecked.
         var box = form.querySelector('input[name="enabled"]');
@@ -796,6 +808,34 @@ document.addEventListener('alpine:init', function () {
       // (value, for the Copy action) plus the server-rendered, sanitized HTML
       // (html, so the modal skips its own /-/markdown/preview round-trip).
       // This is the single prompt-preview surface — no bespoke dialog here.
+      // editPrompt hands custom-workflow prompt authoring to the global prompt
+      // modal (#bb-prompt-modal in base.html) and its Markdown Edit/Preview
+      // flow — the inline textarea is retired. The value round-trips through
+      // custom.prompt: we seed the modal with it and write edits back via
+      // onSaved. startInEdit picks the landing view (true = editor, false =
+      // rendered preview); omit it to auto-pick — editor when empty, preview
+      // when there's already something to read.
+      editPrompt: function (startInEdit) {
+        var self = this;
+        var hasPrompt = !!(self.custom.prompt && self.custom.prompt.trim());
+        var edit = startInEdit === undefined ? !hasPrompt : !!startInEdit;
+        self.custom.promptError = false;
+        window.dispatchEvent(new CustomEvent('bb-prompt-modal', {
+          detail: {
+            mode: 'editable',
+            edit: edit,
+            title: self.custom.isEdit ? 'Edit workflow prompt' : 'Workflow prompt',
+            subtitle: 'Markdown — runs verbatim on every run.',
+            value: self.custom.prompt || '',
+            saveLabel: 'Save prompt',
+            onSaved: function (v) {
+              self.custom.prompt = v;
+              self.custom.promptError = false;
+            },
+          },
+        }));
+      },
+
       previewPrompt: function (slug, name) {
         var self = this;
         fetch('/-/workflows/' + encodeURIComponent(slug) + '/prompt', {

--- a/static/js/admin/components/workflows_gallery.js
+++ b/static/js/admin/components/workflows_gallery.js
@@ -824,7 +824,7 @@ document.addEventListener('alpine:init', function () {
           detail: {
             mode: 'editable',
             edit: edit,
-            title: self.custom.isEdit ? 'Edit workflow prompt' : 'Workflow prompt',
+            title: self.custom.isEdit ? 'Edit prompt' : 'Prompt',
             subtitle: 'Markdown — runs verbatim on every run.',
             value: self.custom.prompt || '',
             saveLabel: 'Save prompt',


### PR DESCRIPTION
## What

The custom-workflow prompt **is** the whole workflow — there's no template behind it — so it deserves more than a cramped inline textarea buried in the drawer. This retires the inline `<textarea>` and hands authoring to the global prompt modal (`#bb-prompt-modal`, the one built out in `/design/c/prompt-preview`) and its Markdown **Edit / Preview** flow, fronted by a single framed "Prompt" card with two states.

**Empty** — same frame + "Prompt" header as the filled state, with a a quiet single-line placeholder that reads like an empty editor field. Opens straight into the editor. Tints error-red if you try to save without a prompt.

**Filled** — a faded monospace excerpt with **Preview** / **Edit** actions in the header. The excerpt itself is clickable (pointer cursor + hover highlight). Preview renders server-side via `/-/markdown/preview` (goldmark + bluemonday).

<table>
  <tr><th>Empty — clean invite (shares the card frame)</th><th>Filled — excerpt, hover-highlighted</th></tr>
  <tr>
    <td><img src="https://bb-artifacts.exe.xyz/f/5332a07307986502.jpg" width="400" alt="empty prompt card"></td>
    <td><img src="https://bb-artifacts.exe.xyz/f/2a08ecbf6df9e8b4.jpg" width="400" alt="filled prompt card on hover"></td>
  </tr>
</table>

The Edit/Preview modal flow it now drives:

<table>
  <tr><th>Editor</th><th>Live Markdown preview</th></tr>
  <tr>
    <td><img src="https://bb-artifacts.exe.xyz/f/985a7e49cda38bbe.jpg" width="400" alt="prompt editor"></td>
    <td><img src="https://bb-artifacts.exe.xyz/f/1aa10c0017c0fcfb.jpg" width="400" alt="prompt preview render"></td>
  </tr>
</table>

## How

- New `workflowCustomPromptField()` templ helper replaces the inline textarea in `workflowCustomDrawer()`. One framed card, two bodies via `x-show` on `custom.prompt.trim()` — shared frame + "Prompt" header so it reads as one document.
- The raw value still rides to the server in a **hidden** `prompt` field; the modal writes edits back through `editPrompt()`'s `onSaved` callback (`custom.prompt = v`).
- A hidden `required` control can't be focused (silently blocks submit), so `submitCustom()` validates the prompt is non-empty in JS and flips `custom.promptError` to tint the card + show a helper line.
- `editPrompt(startInEdit)` dispatches `bb-prompt-modal` in `editable` mode — auto-picks editor when empty, preview when there's something to read.

## Notes

- No new `bb-*` classes — single-caller layout built from daisy + inline utilities. Error state uses `border-error` (not `bg-error`) so it doesn't collide with the card status-dot render test.
- Validated end-to-end in a real browser (empty → editor → preview → save → filled). `go test ./...` green.

