### PR TITLE
feat(reports): redesign /reports to the canonical list-row idiom

### DIFF
--- a/.claude/skills/design-system/audit.md
+++ b/.claude/skills/design-system/audit.md
@@ -16,8 +16,9 @@ when the surface is next touched · **P3** cosmetic / low-value.
 ## Already canonical (references, don't touch)
 
 - **list-row idiom:** `pages/accounts_list.templ`, `components/agent_run_row.templ`
-  (`AgentRunRow` + `AgentRunRowList`) — the reference for status-tile · one body
-  line · value · overflow.
+  (`AgentRunRow` + `AgentRunRowList`), `components/report_table.templ`
+  (`ReportRow` + `ReportRowList` + `ReportsList`) — the reference for
+  status-tile · one body line · value · overflow.
 - **TabBar:** `reports.templ`, `workflows_runs.templ`, `subscriptions_list.templ`,
   `workflows_shell.templ` use it correctly (border=nav, box=filter).
 - **Drawer:** connect-bank, provider-config, workflow create/edit, cron-field.
@@ -69,9 +70,6 @@ name · one body line · value · overflow), grouped where there's a natural axi
   (active/paused); status tile + name + cadence line + amount.
 - `pages/account_link_detail.templ:36` — matched txn pairs. Already carries a
   mobile card fallback → unify to one list-row layout (confidence as the tile).
-- `components/report_table.templ:36` — reports. Has a desktop-table +
-  mobile-card split → collapse to a single list-row list.
-
 > These overlap with the goal-3 surface loop (e.g. `/rules`, `/subscriptions`).
 > Prefer doing the table→list-row migration *as part of* that surface's redesign
 > rather than as an isolated swap.

--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -245,9 +245,34 @@ Settings tabs use a local dialect of this language. See
 
 ---
 
+## ReportRow / ReportsList — `report_table.templ`
+
+The agent-reports inbox row, a list-row sibling of `AgentRunRow` (same
+shape, so `/reports` and `/agents/runs` read as one product).
+
+```go
+ReportRowProps{
+    ID string; Title string /* summary */; Priority string /* "" | "info" | "warning" | "critical" */
+    Author string; AuthorID string /* avatar seed */; IsAgent bool
+    Time string /* pre-rendered relative */; IsRead bool
+}
+@components.ReportRowList() { for _, r := range rows { @components.ReportRow(r) } }
+@components.ReportsList(rows) // convenience: flat list in one card
+```
+
+- Leading status tile = priority → vivid `IconTile` tone (critical→error,
+  warning→warning, routine→info). No parallel priority text badge in the row.
+- Title line: `UserAvatar` (IsAgent) + agent name + an info **unread dot** + the
+  relative time; the summary is the one body line below. Read rows fade
+  (`opacity-60`) and drop the dot; unread rows keep a heavier summary.
+- `OverflowMenu` (Size `"sm"`) — mark read/unread + open — renders OUTSIDE the
+  row's `<a>` link. The `/reports` All view groups rows unread-first under quiet
+  label lines (`partitionReportsByRead`). `ReportPriorityBadge` is now
+  detail-header-only.
+
 ## Reference implementation
 
 `agent_run_row.templ` (`AgentRunRowList` + `AgentRunRow`) is the cleanest single
 example of principles 2–7: status `IconTile`, one priority body line, bare-icon
 actions, `UserAvatar` identity, list-row spacing in a `bb-card`. Read it before
-authoring a new feed/list row.
+authoring a new feed/list row. `report_table.templ` is its inbox sibling.

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -62,11 +62,17 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 				}
 			}
 			t, _ := time.Parse(time.RFC3339, rep.CreatedAt)
+			authorID := ""
+			if rep.CreatedByID != nil {
+				authorID = *rep.CreatedByID
+			}
 			reports = append(reports, components.ReportRowProps{
 				ID:       rep.ID,
 				Title:    rep.Title,
 				Priority: rep.Priority,
 				Author:   reportDisplayAuthor(rep.CreatedByName, rep.Author),
+				AuthorID: authorID,
+				IsAgent:  rep.CreatedByType == "agent",
 				Time:     relativeTime(t),
 				IsRead:   isRead,
 			})

--- a/internal/templates/components/pages/design_reports_table.templ
+++ b/internal/templates/components/pages/design_reports_table.templ
@@ -3,28 +3,28 @@ package pages
 import "breadbox/internal/templates/components"
 
 // SectionReportsTable showcases the agent-reports index primitives —
-// ReportsList and ReportPriorityBadge — that the /reports page composes.
-// Mirrors how design_agent_run_chat.templ was split into its own sibling
-// so design_sections.templ stays focused.
+// ReportsList / ReportRow and ReportPriorityBadge — that the /reports page
+// composes. Mirrors how design_agent_run_chat.templ was split into its own
+// sibling so design_sections.templ stays focused.
 //
-// ReportsList is responsive: a table on sm+ and a stacked list on mobile.
-// At the sandbox width it renders the table; resize the standalone
-// /design/c/reports-table viewport below sm to see the stacked variant.
-// It's wrapped in a tiny literal x-data so the row interactions (full-row
-// navigation via rowNav, the optimistic mark-read dismiss) the live
-// reportsPage factory drives can be exercised here too.
+// ReportsList renders ONE responsive daisy list-row layout (no
+// desktop-table / mobile-card split): a priority-coded status tile, the
+// agent identity, the summary, and a trailing overflow menu. It's wrapped
+// in a tiny literal x-data so the row's optimistic mark-read / mark-unread
+// actions the live reportsPage factory drives can be exercised here too.
 templ SectionReportsTable() {
 	<div class="flex flex-col gap-6">
 		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
 			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
 			<ul class="space-y-1 list-disc pl-4">
-				<li>Renders the agent-reports index (canonical: <code>/reports</code>) via <code>ReportsList</code> — a clean daisy <code>table</code> on desktop, a stacked list on mobile, no bespoke wrapper. The full report body lives on the detail page.</li>
-				<li>Columns: <strong>Agent</strong> (name + relative time, with a leading primary dot for unread), <strong>Status</strong> (a soft priority badge for warning/critical, an em-dash otherwise), <strong>Summary</strong> (the report title), and a trailing hover-revealed mark-read action.</li>
-				<li>The whole row is a click target: the summary is a real <code>&lt;a&gt;</code> (keyboard / middle-click + the accessible name), and <code>rowNav</code> delegates clicks elsewhere on the row to it. The mark-read button stops propagation and optimistically dismisses the row.</li>
+				<li>Renders the agent-reports index (canonical: <code>/reports</code>) via <code>ReportsList</code> / <code>ReportRow</code> — a single daisy <code>list-row</code> layout inside a <code>bb-card</code>, the same shape as <code>AgentRunRow</code>. No desktop-table / mobile-card split. The full report body lives on the detail page.</li>
+				<li>Each row: a leading <strong>status tile</strong> (priority → vivid tone: error / warning / info), <strong>agent identity</strong> (UserAvatar + name), an <strong>unread dot</strong> + relative <strong>time</strong> on the title line, the <strong>summary</strong> as the one body line, and a trailing <strong>OverflowMenu</strong> (mark read/unread · open) rendered outside the row link.</li>
+				<li>Unread rows stay full-strength with a heavier summary + an info dot; read rows fade (row opacity) and drop the dot. Status lives in the tile — no parallel priority text badge in the row.</li>
+				<li>The whole row is a real <code>&lt;a&gt;</code> (keyboard / middle-click + the accessible name); the overflow menu sits outside it. On <code>/reports</code> the All view groups rows unread-first under quiet label lines.</li>
 				<li><code>ReportPriorityBadge</code> is the shared priority chip, reused in the detail-page header.</li>
 			</ul>
 		</div>
-		@designExample("Priority badge — ReportPriorityBadge", "Pure daisy soft badge, no layout. Default / info / empty renders nothing (the Status column shows an em-dash); warning and critical map to soft warning/error badges with a leading glyph.") {
+		@designExample("Priority badge — ReportPriorityBadge", "Pure daisy soft badge, no layout. Default / info / empty renders nothing; warning and critical map to soft warning/error badges with a leading glyph. Used in the report detail header (the index row encodes priority in its status tile instead).") {
 			<div class="flex flex-wrap items-center gap-2">
 				@components.ReportPriorityBadge("")
 				<span class="text-xs text-base-content/40">← empty renders nothing</span>
@@ -32,8 +32,8 @@ templ SectionReportsTable() {
 				@components.ReportPriorityBadge("critical")
 			</div>
 		}
-		@designExample("Reports index — ReportsList", "Full variant matrix: unread rows carry a primary dot + heavier text; read rows drop the dot and fade. The status column shows a badge for warning/critical and an em-dash otherwise. Long summaries clamp to two lines. Hover a row to reveal its mark-read button. Renders as a table here; collapses to a stacked list below sm.") {
-			<div x-data="{ dismissed: {}, markRead(id) { this.dismissed[id] = true }, rowNav(e, url) { if (e.target.closest('button') || e.target.closest('a')) return; window.location.href = url } }">
+		@designExample("Reports index — ReportsList", "Full variant matrix in one list-row layout: critical/warning/routine priority tiles, read vs unread (info dot + heavier summary vs faded row), and a long summary that clamps to one line. The overflow menu carries mark read/unread + open.") {
+			<div x-data="{ dismissed: {}, markRead(id) { this.dismissed[id] = true }, markUnread() {} }">
 				@components.ReportsList(designReportRows())
 			</div>
 		}

--- a/internal/templates/components/pages/design_reports_table_helpers.go
+++ b/internal/templates/components/pages/design_reports_table_helpers.go
@@ -7,8 +7,9 @@ import "breadbox/internal/templates/components"
 // design_reports_table_helpers.go holds the fixture rows for the
 // SectionReportsTable sandbox entry. Kept beside the design types so the
 // templ stays focused on layout. The variants exercise every axis of the
-// reports index: the three priority tones in the status column, read vs
-// unread (dot + weight), and a long summary that clamps to two lines.
+// reports index: the three priority tones in the status tile, read vs
+// unread (dot + weight + row fade), and a long summary that clamps to one
+// line.
 
 // designReportRows returns the full fixture matrix passed to
 // components.ReportsList in the sandbox.
@@ -19,6 +20,8 @@ func designReportRows() []components.ReportRowProps {
 			Title:    "3 duplicate subscriptions found totaling $47/mo",
 			Priority: "critical",
 			Author:   "Subscription watchdog",
+			AuthorID: "rep_crit01_agent",
+			IsAgent:  true,
 			Time:     "12m ago",
 			IsRead:   false,
 		},
@@ -27,6 +30,8 @@ func designReportRows() []components.ReportRowProps {
 			Title:    "Dining spend is 38% over your monthly target",
 			Priority: "warning",
 			Author:   "Budget coach",
+			AuthorID: "rep_warn01_agent",
+			IsAgent:  true,
 			Time:     "1h ago",
 			IsRead:   false,
 		},
@@ -35,6 +40,8 @@ func designReportRows() []components.ReportRowProps {
 			Title:    "Weekly recap: 42 transactions categorized, all matched",
 			Priority: "",
 			Author:   "Daily recap",
+			AuthorID: "rep_plain1_agent",
+			IsAgent:  true,
 			Time:     "3h ago",
 			IsRead:   false,
 		},
@@ -43,6 +50,8 @@ func designReportRows() []components.ReportRowProps {
 			Title:    "Monthly statement reconciled — no discrepancies",
 			Priority: "",
 			Author:   "Reconciler",
+			AuthorID: "rep_read01_agent",
+			IsAgent:  true,
 			Time:     "2d ago",
 			IsRead:   true,
 		},
@@ -51,6 +60,8 @@ func designReportRows() []components.ReportRowProps {
 			Title:    "Heads up: your travel-rewards card annual fee of $550 posts on the 14th, and based on this year's redemptions it may no longer pay for itself",
 			Priority: "warning",
 			Author:   "Rewards analyst",
+			AuthorID: "rep_long01_agent",
+			IsAgent:  true,
 			Time:     "5h ago",
 			IsRead:   false,
 		},
@@ -59,6 +70,8 @@ func designReportRows() []components.ReportRowProps {
 			Title:    "Unusual $1,240 charge from a new merchant",
 			Priority: "critical",
 			Author:   "Fraud sentry",
+			AuthorID: "rep_rc01_agent",
+			IsAgent:  true,
 			Time:     "3d ago",
 			IsRead:   true,
 		},

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -52,9 +52,27 @@ templ Reports(p ReportsProps) {
 				</button>
 			}
 		</div>
-		<!-- Reports index: table on desktop, stacked list on mobile -->
+		<!-- Reports index: one responsive list-row layout. The All view
+		     groups unread-first under quiet label lines; a single-status
+		     filter renders one flat list. -->
 		if len(p.Reports) > 0 {
-			@components.ReportsList(p.Reports)
+			if p.FilterStatus == "" {
+				{{ unread, read := partitionReportsByRead(p.Reports) }}
+				<div class="flex flex-col gap-5">
+					if len(unread) > 0 {
+						@reportsGroup("Unread", len(unread)) {
+							@components.ReportsList(unread)
+						}
+					}
+					if len(read) > 0 {
+						@reportsGroup("Read", len(read)) {
+							@components.ReportsList(read)
+						}
+					}
+				</div>
+			} else {
+				@components.ReportsList(p.Reports)
+			}
 		} else {
 			@components.EmptyState(components.EmptyStateProps{
 				Icon:    "inbox",
@@ -71,6 +89,20 @@ templ Reports(p ReportsProps) {
 	<template id="bb-reports-skeleton-template">
 		@components.ReportsSkeleton()
 	</template>
+}
+
+// reportsGroup renders a quiet label line (title · count) above a list of
+// report rows — the /accounts group-label idiom applied to the reports
+// inbox so the All view reads "Unread first, then Read" without a heavy
+// boxed card-header per group.
+templ reportsGroup(label string, count int) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1">
+			<span class="text-sm font-medium text-base-content">{ label }</span>
+			<span class="text-xs text-base-content/40 tabular-nums">{ reportsGroupCount(count) }</span>
+		</div>
+		{ children... }
+	</div>
 }
 
 // reportsManageFormatLink is the header's single trailing action — a

--- a/internal/templates/components/pages/reports_types.go
+++ b/internal/templates/components/pages/reports_types.go
@@ -2,7 +2,31 @@
 
 package pages
 
-import "breadbox/internal/templates/components"
+import (
+	"strconv"
+
+	"breadbox/internal/templates/components"
+)
+
+// partitionReportsByRead splits the (recency-ordered) report rows into an
+// unread slice and a read slice, preserving the input order within each.
+// The All view renders unread-first so the inbox surfaces what still needs
+// attention before what's already been seen — the IA win over a flat list.
+func partitionReportsByRead(rows []components.ReportRowProps) (unread, read []components.ReportRowProps) {
+	for _, r := range rows {
+		if r.IsRead {
+			read = append(read, r)
+		} else {
+			unread = append(unread, r)
+		}
+	}
+	return unread, read
+}
+
+// reportsGroupCount renders a group's row count for the label line.
+func reportsGroupCount(n int) string {
+	return strconv.Itoa(n)
+}
 
 // ReportsProps mirrors the field set the handler (admin/reports.go)
 // builds for the agent-reports inbox. The row view-model lives in the

--- a/internal/templates/components/pages/reports_types_test.go
+++ b/internal/templates/components/pages/reports_types_test.go
@@ -1,0 +1,41 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"testing"
+
+	"breadbox/internal/templates/components"
+)
+
+func TestPartitionReportsByRead(t *testing.T) {
+	rows := []components.ReportRowProps{
+		{ID: "a", IsRead: false},
+		{ID: "b", IsRead: true},
+		{ID: "c", IsRead: false},
+		{ID: "d", IsRead: true},
+	}
+
+	unread, read := partitionReportsByRead(rows)
+
+	if len(unread) != 2 {
+		t.Fatalf("want 2 unread, got %d", len(unread))
+	}
+	if len(read) != 2 {
+		t.Fatalf("want 2 read, got %d", len(read))
+	}
+	// Order within each partition must be preserved (recency order).
+	if unread[0].ID != "a" || unread[1].ID != "c" {
+		t.Errorf("unread order not preserved: got %s, %s", unread[0].ID, unread[1].ID)
+	}
+	if read[0].ID != "b" || read[1].ID != "d" {
+		t.Errorf("read order not preserved: got %s, %s", read[0].ID, read[1].ID)
+	}
+}
+
+func TestPartitionReportsByRead_Empty(t *testing.T) {
+	unread, read := partitionReportsByRead(nil)
+	if unread != nil || read != nil {
+		t.Errorf("want nil slices for empty input, got unread=%v read=%v", unread, read)
+	}
+}

--- a/internal/templates/components/report_table.templ
+++ b/internal/templates/components/report_table.templ
@@ -7,173 +7,174 @@ import (
 
 // ReportRowProps is the view-model for a single agent report in the
 // /reports index. Tags and the full body live on the detail page, not the
-// index — the index is a scannable surface: agent · time, status,
-// summary, and a trailing mark-read action.
+// index — the index is a scannable surface: a priority status tile, agent
+// identity, the summary, and a trailing overflow menu.
 type ReportRowProps struct {
 	ID       string // short_id / id; the row links to /reports/{ID}
 	Title    string // the summary line
-	Priority string // "" | "warning" | "critical"
-	Author   string // agent name
+	Priority string // "" | "info" | "warning" | "critical"
+	Author   string // agent display name
+	AuthorID string // stable avatar seed (created_by_id, falls back to name)
+	IsAgent  bool   // routes UserAvatar to the agent DiceBear style
 	Time     string // pre-rendered relative time, e.g. "2h ago"
 	IsRead   bool
 }
 
-// ReportsList renders the agent-reports index responsively: a clean daisy
-// "runs"-style table on sm+ (Agent, Status, Summary, action) and a
-// stacked list on mobile — a 4-column table can't fit a phone without
-// pushing the summary off-screen, so each report collapses to its summary
-// over an `agent · time · status` meta line. It takes the slice (not
-// children) so both breakpoints iterate the same data without the caller
-// duplicating the loop.
+// ReportRowList wraps a series of @ReportRow elements in the canonical
+// daisy `list` surface inside a card. Dividers come from the daisy list
+// primitive — no bespoke wrapper. Same shape as @AgentRunRowList so the
+// reports inbox and the agent-runs feed read as one product.
 //
-// The rows depend on the reportsPage Alpine factory
-// (static/js/admin/components/reports.js) for rowNav (full-row click) and
-// the optimistic mark-read dismiss, so wrap @ReportsList in an element
-// carrying x-data="reportsPage".
-templ ReportsList(rows []ReportRowProps) {
-	<!-- Desktop: table -->
-	<div class="bb-card p-0 overflow-hidden hidden sm:block">
-		<table class="table">
-			<thead>
-				<tr class="text-xs uppercase tracking-wider text-base-content/40 border-base-200">
-					<th class="font-medium">Agent</th>
-					<th class="font-medium">Status</th>
-					<th class="font-medium w-full">Summary</th>
-					<th class="font-medium"><span class="sr-only">Actions</span></th>
-				</tr>
-			</thead>
-			<tbody>
-				for _, r := range rows {
-					@reportTableRow(r)
-				}
-			</tbody>
-		</table>
-	</div>
-	<!-- Mobile: stacked list -->
-	<ul class="bb-card p-0 overflow-hidden sm:hidden divide-y divide-base-200">
-		for _, r := range rows {
-			@reportMobileRow(r)
-		}
+//	@components.ReportRowList() {
+//	  for _, r := range rows {
+//	    @components.ReportRow(r)
+//	  }
+//	}
+templ ReportRowList() {
+	<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+		{ children... }
 	</ul>
 }
 
-// reportTableRow renders one report as a clickable desktop table row. The
-// summary is a real <a> (keyboard / middle-click reachable + the
-// accessible name); rowNav delegates a click elsewhere on the row to it,
-// while the mark-read button stops propagation.
-templ reportTableRow(r ReportRowProps) {
-	<tr
-		x-show={ fmt.Sprintf("!dismissed['%s']", r.ID) }
-		x-transition.opacity.duration.200ms
-		class="group hover:bg-base-200/50 cursor-pointer transition-colors border-base-200"
-		@click={ fmt.Sprintf("rowNav($event, '/reports/%s')", r.ID) }
-	>
-		<td class="align-middle whitespace-nowrap">
-			<div class="flex items-center gap-2.5">
-				@reportUnreadDot(r.IsRead)
-				<div class="min-w-0">
-					<div class={ "text-sm truncate max-w-[12rem]", reportAuthorClass(r.IsRead) }>{ reportAuthorLabel(r.Author) }</div>
-					<div class="text-xs text-base-content/45 tabular-nums">{ r.Time }</div>
-				</div>
-			</div>
-		</td>
-		<td class="align-middle">
-			@reportStatusCell(r.Priority)
-		</td>
-		<td class="align-middle">
-			<a
-				href={ templ.SafeURL("/reports/" + r.ID) }
-				class={ "block no-underline line-clamp-2 leading-snug max-w-prose", reportSummaryClass(r.IsRead) }
-				aria-label={ reportRowLinkLabel(r) }
-			>{ r.Title }</a>
-		</td>
-		<td class="align-middle text-right">
-			if !r.IsRead {
-				@reportMarkReadButton(r.ID, true)
-			}
-		</td>
-	</tr>
+// ReportsList renders a flat list of report rows in one card. Used by the
+// single-filter (Unread / Read) views and the /design sandbox; the All
+// view groups unread-first by calling @ReportRowList directly. It takes
+// the slice (not children) so callers don't duplicate the loop.
+//
+// The rows depend on the reportsPage Alpine factory
+// (static/js/admin/components/reports.js) for the optimistic mark-read /
+// mark-unread actions, so wrap @ReportsList in an element carrying
+// x-data="reportsPage".
+templ ReportsList(rows []ReportRowProps) {
+	@ReportRowList() {
+		for _, r := range rows {
+			@ReportRow(r)
+		}
+	}
 }
 
-// reportMobileRow renders one report as a stacked list item: the summary
-// (the headline), then a quiet `agent · time · status` meta line, with a
-// trailing mark-read button. The whole row is a click target.
-templ reportMobileRow(r ReportRowProps) {
+// ReportRow renders one report as a daisy `list-row`: a leading
+// priority-coded status tile, the agent identity (avatar + name) with an
+// unread dot and relative time as the title line, the summary as the one
+// body line below, and an overflow menu rendered OUTSIDE the row's
+// navigation anchor. Read rows fade and drop the dot; unread rows stay
+// full-strength with a heavier summary — the two restrained unread
+// channels (the leading info dot is the third). Status lives in the tile,
+// not a parallel text badge.
+templ ReportRow(r ReportRowProps) {
 	<li
 		x-show={ fmt.Sprintf("!dismissed['%s']", r.ID) }
 		x-transition.opacity.duration.200ms
-		class="flex items-start gap-3 px-4 py-3.5 cursor-pointer hover:bg-base-200/50 transition-colors"
-		@click={ fmt.Sprintf("rowNav($event, '/reports/%s')", r.ID) }
+		class={ "list-row transition-colors hover:bg-base-200/40 items-center",
+			templ.KV("opacity-60", r.IsRead) }
+		data-report-id={ r.ID }
 	>
-		<div class="mt-1.5">
-			@reportUnreadDot(r.IsRead)
-		</div>
-		<div class="min-w-0 flex-1">
-			<a
-				href={ templ.SafeURL("/reports/" + r.ID) }
-				class={ "block no-underline line-clamp-2 leading-snug", reportSummaryClass(r.IsRead) }
-				aria-label={ reportRowLinkLabel(r) }
-			>{ r.Title }</a>
-			<div class="mt-1.5 flex items-center gap-1.5 text-xs text-base-content/45 flex-wrap">
-				<span class="font-medium text-base-content/65 truncate max-w-[9rem]">{ reportAuthorLabel(r.Author) }</span>
-				<span class="text-base-content/25">·</span>
-				<span class="tabular-nums">{ r.Time }</span>
-				if r.Priority == "critical" || r.Priority == "warning" {
-					@ReportPriorityBadge(r.Priority)
-				}
+		<a
+			class="contents no-underline"
+			href={ templ.SafeURL("/reports/" + r.ID) }
+			aria-label={ reportRowLinkLabel(r) }
+		>
+			@IconTile(reportTileTone(r.Priority), reportTileIcon(r.Priority))
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					@UserAvatar(UserAvatarProps{
+						ID:         reportAvatarSeed(r),
+						Name:       reportAuthorLabel(r.Author),
+						IsAgent:    r.IsAgent,
+						Size:       UserAvatarXS,
+						Decorative: true,
+						Lazy:       true,
+						Class:      "shrink-0",
+					})
+					<span class={ "text-sm truncate", reportAuthorClass(r.IsRead) }>{ reportAuthorLabel(r.Author) }</span>
+					if !r.IsRead {
+						<span class="w-1.5 h-1.5 rounded-full bg-info shrink-0" title="Unread" aria-hidden="true"></span>
+					}
+					<span class="ml-auto shrink-0 text-xs text-base-content/45 tabular-nums" title="Submitted">{ r.Time }</span>
+				</div>
+				<div class="mt-0.5 min-w-0">
+					<span class={ "block text-sm line-clamp-1 leading-snug", reportSummaryClass(r.IsRead) }>{ r.Title }</span>
+				</div>
 			</div>
+		</a>
+		<div class="shrink-0 self-center">
+			@OverflowMenu(OverflowMenuProps{
+				AriaLabel: fmt.Sprintf("Actions for report by %s", reportAuthorLabel(r.Author)),
+				Size:      "sm",
+				Items:     reportRowMenuItems(r),
+			})
 		</div>
-		if !r.IsRead {
-			<div class="shrink-0 self-center">
-				@reportMarkReadButton(r.ID, false)
-			</div>
-		}
 	</li>
 }
 
-// reportUnreadDot renders the small primary dot that marks an unread row
-// (and an equal-size spacer for read rows so the columns stay aligned).
-templ reportUnreadDot(isRead bool) {
-	if !isRead {
-		<span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0" title="Unread"></span>
+// reportRowMenuItems builds the per-row overflow actions. Unread rows get
+// "Mark as read" (the optimistic dismiss); read rows get "Mark as
+// unread". Both carry an "Open report" link so the menu is never a single
+// item, and the action is reachable from the kebab as well as the row.
+func reportRowMenuItems(r ReportRowProps) []OverflowMenuItem {
+	items := make([]OverflowMenuItem, 0, 2)
+	if r.IsRead {
+		items = append(items, OverflowMenuItem{
+			Label:   "Mark as unread",
+			Icon:    "rotate-ccw",
+			OnClick: fmt.Sprintf("markUnread('%s')", r.ID),
+		})
 	} else {
-		<span class="w-1.5 h-1.5 shrink-0"></span>
+		items = append(items, OverflowMenuItem{
+			Label:   "Mark as read",
+			Icon:    "check",
+			OnClick: fmt.Sprintf("markRead('%s')", r.ID),
+		})
 	}
+	items = append(items, OverflowMenuItem{
+		Label: "Open report",
+		Icon:  "external-link",
+		Href:  templ.SafeURL("/reports/" + r.ID),
+	})
+	return items
 }
 
-// reportMarkReadButton renders the optimistic mark-read control. On
-// desktop (hoverReveal=true) it stays hidden until row-hover/focus; on
-// the mobile list it's always visible (no hover on touch).
-templ reportMarkReadButton(id string, hoverReveal bool) {
-	<button
-		type="button"
-		@click.stop={ fmt.Sprintf("markRead('%s')", id) }
-		class={ "btn btn-ghost btn-xs btn-square text-base-content/40 hover:text-success hover:bg-success/10 transition-opacity",
-			templ.KV("sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100", hoverReveal) }
-		aria-label="Mark as read"
-		title="Mark as read"
-	>
-		@LucideIcon("check", "w-4 h-4")
-	</button>
-}
-
-// reportStatusCell renders the Status column: a soft priority badge for
-// warning/critical, and a quiet em-dash for routine ("" / "info")
-// reports so the column reads as "nothing notable" rather than blank.
-templ reportStatusCell(priority string) {
+// reportTileTone maps a report's priority to the IconTile tone — a vivid
+// status colour per the badge-tone rule (error/warning/info). Routine
+// reports ("" / "info") use the calm info tone; read rows desaturate via
+// the row-level opacity, so the tile never shouts once the report is seen.
+func reportTileTone(priority string) string {
 	switch priority {
-		case "critical":
-			@ReportPriorityBadge("critical")
-		case "warning":
-			@ReportPriorityBadge("warning")
-		default:
-			<span class="text-base-content/25" aria-hidden="true">—</span>
+	case "critical":
+		return "error"
+	case "warning":
+		return "warning"
+	default:
+		return "info"
 	}
+}
+
+// reportTileIcon picks the glyph inside the status tile — alert shapes for
+// warning/critical (matching ReportPriorityBadge), a neutral message glyph
+// for routine reports.
+func reportTileIcon(priority string) string {
+	switch priority {
+	case "critical":
+		return "alert-octagon"
+	case "warning":
+		return "alert-triangle"
+	default:
+		return "message-square-text"
+	}
+}
+
+// reportAvatarSeed returns a stable DiceBear seed for the report's author:
+// the creator's actor id when known (so every report from one agent shares
+// an avatar), falling back to the display name for operator-submitted rows.
+func reportAvatarSeed(r ReportRowProps) string {
+	if strings.TrimSpace(r.AuthorID) != "" {
+		return r.AuthorID
+	}
+	return reportAuthorLabel(r.Author)
 }
 
 // reportAuthorClass splits the agent-name weight by read state — unread
-// reports stay full-strength, read ones fade — one of the two restrained
-// unread channels (the other is the leading primary dot).
+// reports stay full-strength, read ones fade.
 func reportAuthorClass(isRead bool) string {
 	if isRead {
 		return "font-normal text-base-content/55"
@@ -182,7 +183,7 @@ func reportAuthorClass(isRead bool) string {
 }
 
 // reportAuthorLabel falls back to a neutral label when an agent didn't
-// supply a name, so the column never renders empty.
+// supply a name, so the row never renders empty.
 func reportAuthorLabel(author string) string {
 	if strings.TrimSpace(author) == "" {
 		return "Agent"
@@ -190,21 +191,20 @@ func reportAuthorLabel(author string) string {
 	return author
 }
 
-// reportSummaryClass styles the summary line by read state — bold + full
+// reportSummaryClass styles the summary line by read state — medium + full
 // strength when unread, lighter + muted when read.
 func reportSummaryClass(isRead bool) string {
 	if isRead {
-		return "font-normal text-base-content/60"
+		return "font-normal text-base-content/55"
 	}
 	return "font-medium text-base-content"
 }
 
-// reportRowLinkLabel builds the summary link's accessible name. The row's
-// visual state signals — the leading primary dot, the status badge, and
-// the summary weight — are non-textual, so the link folds them into one
-// spoken label, e.g. "Unread. Critical. <title> — <author>, <time>".
-// Routine ("" / "info") reports carry no priority word, matching
-// ReportPriorityBadge.
+// reportRowLinkLabel builds the row link's accessible name. The row's
+// visual state signals — the leading status tile, the unread dot, and the
+// summary weight — are non-textual, so the link folds them into one spoken
+// label, e.g. "Unread. Critical. <title> — <author>, <time>". Routine
+// ("" / "info") reports carry no priority word.
 func reportRowLinkLabel(r ReportRowProps) string {
 	var b strings.Builder
 	if !r.IsRead {

--- a/internal/templates/components/reports_skeleton.templ
+++ b/internal/templates/components/reports_skeleton.templ
@@ -2,9 +2,10 @@ package components
 
 // ReportsSkeleton renders a placeholder mirroring the layout of the
 // /reports page — page header, filter tabs ("All / Unread / Read" +
-// "Mark all read"), and the daisy `table` of reports. Each row mirrors
-// ReportTableRow: an agent + time cell, a status cell, a summary cell,
-// and a trailing action. Sized to match the real component so a future
+// "Mark all read"), a quiet group label line, and a card of report
+// list-rows. Each row mirrors @ReportRow: a leading status tile, an
+// agent identity line (avatar + name + time), a summary line, and a
+// trailing overflow kebab. Sized to match the real component so a future
 // swap-in (filter switch, AJAX refresh) doesn't shift layout.
 //
 // /reports is a full-SSR page today; this primitive is exposed in
@@ -33,44 +34,37 @@ templ ReportsSkeleton() {
 			</div>
 			<div class="skeleton h-8 w-28 rounded-md shrink-0"></div>
 		</div>
-		<!-- Reports table. Summary widths vary so the skeleton reads as motion. -->
-		<div class="bb-card p-0 overflow-hidden">
-			<div class="overflow-x-auto">
-				<table class="table">
-					<tbody>
-						@reportsSkeletonRow("w-72 sm:w-96", true)
-						@reportsSkeletonRow("w-56 sm:w-80", false)
-						@reportsSkeletonRow("w-80 sm:w-[28rem]", true)
-						@reportsSkeletonRow("w-64 sm:w-72", false)
-						@reportsSkeletonRow("w-72 sm:w-[26rem]", true)
-						@reportsSkeletonRow("w-52 sm:w-64", false)
-					</tbody>
-				</table>
+		<!-- Group label line + list-row card. Summary widths vary so the
+		     skeleton reads as motion. -->
+		<div class="flex flex-col gap-2">
+			<div class="flex items-center gap-2 px-1">
+				<div class="skeleton h-4 w-16 rounded-md"></div>
+				<div class="skeleton h-3 w-4 rounded-md"></div>
 			</div>
+			<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+				@reportsSkeletonRow("w-72 sm:w-96")
+				@reportsSkeletonRow("w-56 sm:w-80")
+				@reportsSkeletonRow("w-80 sm:w-[28rem]")
+				@reportsSkeletonRow("w-64 sm:w-72")
+			</ul>
 		</div>
 	</div>
 }
 
-// reportsSkeletonRow mirrors one ReportTableRow: an agent (name + time)
-// cell, a status cell, a summary cell, and a trailing action slot.
-// `unread` reserves the mark-read button placeholder.
-templ reportsSkeletonRow(summaryW string, unread bool) {
-	<tr class="border-base-200">
-		<td>
-			<div class="flex items-center gap-2.5">
-				<div class="w-1.5 h-1.5"></div>
-				<div class="space-y-1.5">
-					<div class="skeleton h-3.5 w-24 rounded-md"></div>
-					<div class="skeleton h-3 w-14 rounded-md"></div>
-				</div>
+// reportsSkeletonRow mirrors one @ReportRow: a leading status tile, an
+// agent identity line (small avatar + name + time), a summary line, and a
+// trailing overflow kebab placeholder.
+templ reportsSkeletonRow(summaryW string) {
+	<li class="list-row items-center">
+		<div class="skeleton w-10 h-10 rounded-lg shrink-0"></div>
+		<div class="min-w-0 space-y-1.5">
+			<div class="flex items-center gap-2">
+				<div class="skeleton w-4 h-4 rounded-full shrink-0"></div>
+				<div class="skeleton h-3.5 w-24 rounded-md"></div>
+				<div class="skeleton h-3 w-12 rounded-md ml-auto"></div>
 			</div>
-		</td>
-		<td><div class="skeleton h-5 w-16 rounded-full"></div></td>
-		<td><div class={ "skeleton h-4 rounded-md max-w-full", summaryW }></div></td>
-		<td class="text-right">
-			if unread {
-				<div class="skeleton h-6 w-6 rounded inline-block"></div>
-			}
-		</td>
-	</tr>
+			<div class={ "skeleton h-4 rounded-md max-w-full", summaryW }></div>
+		</div>
+		<div class="skeleton w-8 h-8 rounded-md shrink-0 self-center"></div>
+	</li>
 }

--- a/static/js/admin/components/reports.js
+++ b/static/js/admin/components/reports.js
@@ -11,14 +11,6 @@ document.addEventListener('alpine:init', function () {
 
       init: function () {},
 
-      // Full-row navigation: a click anywhere on a table row opens the
-      // report, except on the mark-read button or the summary link (which
-      // navigate on their own).
-      rowNav: function (event, url) {
-        if (event.target.closest('button') || event.target.closest('a')) return;
-        window.location.href = url;
-      },
-
       flash: function (message, type) {
         window.dispatchEvent(new CustomEvent('bb-toast', {
           detail: { message: message, type: type || 'error' }
@@ -36,6 +28,18 @@ document.addEventListener('alpine:init', function () {
         } catch (e) {
           delete this.dismissed[id];
           this.flash('Could not mark read — try again');
+        }
+      },
+
+      // Mark a read report unread again. Reload on success so the row
+      // moves back into the Unread group; toast on failure.
+      markUnread: async function (id) {
+        try {
+          var res = await fetch('/-/reports/' + id + '/unread', { method: 'POST' });
+          if (!res.ok) throw new Error(String(res.status));
+          window.location.reload();
+        } catch (e) {
+          this.flash('Could not mark unread — try again');
         }
       },
 


### PR DESCRIPTION
Surface redesign (design-system loop): `/reports` moves from a desktop-table + mobile-card split to the canonical **list-row** idiom — matching `AgentRunRow` / `/accounts`. An IA improvement, not a re-skin.

## What changed
- **One responsive list-row layout** (`report_table.templ` → `ReportRow` / `ReportRowList` / `ReportsList`) in a `bb-card`; the dual table/card markup is gone.
- **Status in one color-coded `IconTile`** (vivid per the badge-tone rule): critical → `error` (`alert-octagon`), warning → `warning` (`alert-triangle`), routine → `info` (`message-square-text`). The per-row priority text badge is dropped (status lives in the tile; `ReportPriorityBadge` is now detail-header-only).
- **Agent identity** via `UserAvatar` (IsAgent) + name; **summary** as the single body line; relative time; trailing `OverflowMenu` (Size sm) outside the row link. Whole row links to the report.
- **Unread, three restrained channels:** an info dot + heavier summary; read rows fade (`opacity-60`) and drop the dot. Mark read/unread moved into the overflow menu (added `markUnread`).
- **IA: unread-first grouping** — the All view groups rows under quiet "Unread N" / "Read N" label lines (`/accounts`-style) via `partitionReportsByRead` (pure, unit-tested). Single-status tabs render one flat list.
- Sandbox (`reports-table`) + `reports_skeleton` updated to the new shape.

`go build` / `go vet` / `go test ./...` green (incl. the new partition test + scripts-lint guard).

Deferred: server-side agent avatar via `ResolveAgentSlugForActor`; priority sub-grouping within Unread; bulk-select.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/3f088225a8f3a2a0.jpeg" width="800" alt="/reports redesigned as list-rows with unread-first grouping and status tiles">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
