### PR TITLE
polish(transactions): taller collapsible headers + hover/focus states; codify interaction-states rule

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -37,7 +37,7 @@ this skill and the running app as a bug in one of them — reconcile, don't igno
 
 ---
 
-## The seven principles
+## The eight principles
 
 The DNA. Each is a small, reusable decision; together they're why our best
 surfaces feel calm.
@@ -70,6 +70,20 @@ surfaces feel calm.
 
 7. **Identity via avatar.** People and workflows get a stable DiceBear avatar
    (`UserAvatar`). Any feed of "who did this" reads the same on every surface.
+
+8. **Every interactive element has interaction states.** Anything clickable — a
+   button, a row that toggles, a custom control, a card that acts as a link —
+   must show a visible **hover** state *and* a **focus-visible** state for
+   keyboard users. Hover is a subtle background/opacity shift, never a jarring
+   one; pair it with `transition-colors` so it eases, and `cursor-pointer` so
+   the affordance reads. Keyboard focus gets a ring — the project idiom is
+   `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40` (use
+   `focus-visible:`, not `:focus`, so the ring only shows for keyboard nav). The
+   mechanics: `hover:bg-base-200/60` (or `hover:bg-base-content/5` on darker
+   rows), `transition-colors`, `cursor-pointer`, the focus-visible ring. **Don't
+   re-roll press feedback for `.btn`** — `input.css` already ships the Nova
+   `:active` translate; a real daisy button is covered. This rule is app-wide:
+   a control with no hover and no focus state is a bug, not a style choice.
 
 ---
 

--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -225,6 +225,11 @@ CollapsibleSectionProps{
   with `x-show="!open"` surfaces only when collapsed (the "active filter hidden
   here" cue). Nest the component inside an ancestor `x-data` to let the
   indicator read reactive state (e.g. the Tags section reads `selectedSlugs`).
+- The header is a real `<button>` with a comfortable `py-3` touch target and
+  full interaction states (per the *Interaction states* principle in
+  [`SKILL.md`](SKILL.md)): `hover:bg-base-200/60` with `transition-colors`,
+  `cursor-pointer`, and a keyboard `focus-visible:ring-2 focus-visible:ring-primary/40`
+  ring. The chevron rotates smoothly (`transition-transform duration-200`).
 - Backs the `/transactions` filter drawer's When / Where / What / Tags / Search
   sections: each defaults open when it holds an active filter (computed in
   `TransactionsProps.*SectionOpen`) and collapses with a count/dot indicator

--- a/internal/templates/components/collapsible_section.templ
+++ b/internal/templates/components/collapsible_section.templ
@@ -43,7 +43,7 @@ templ CollapsibleSection(p CollapsibleSectionProps) {
 	<section x-data={ collapsibleSectionData(p.DefaultOpen) } class={ "space-y-2 " + p.Class }>
 		<button
 			type="button"
-			class="group flex items-center gap-2 w-full text-left"
+			class="group flex items-center gap-2 w-full text-left -mx-2 px-2 py-3 rounded-lg cursor-pointer transition-colors hover:bg-base-200/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
 			@click="open = !open"
 			:aria-expanded="open ? 'true' : 'false'"
 		>


### PR DESCRIPTION
Polish + a new design-system rule, following up on the collapsible filter sections (Ricardo's feedback: the headers felt too small and lacked interaction affordances).

## Changes
- **Taller `CollapsibleSection` headers** — `py-3` (a comfortable ~36px touch target) instead of the cramped default, with a `-mx-2 px-2 rounded-lg` bleed so the hover/focus background reads as a clean rounded row without indenting the label.
- **Interaction states on the header button:** `hover:bg-base-200/60` + `transition-colors` + `cursor-pointer`, and a keyboard `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40` (focus-visible so the ring only shows for keyboard nav). Chevron rotation was already smooth.
- **New 8th principle in the skill** — *"Every interactive element has interaction states."* Codifies Ricardo's guidance app-wide: anything clickable must show a visible hover **and** a focus-visible state; a control with neither is a bug, not a style choice. Mechanics included; notes that `.btn` already ships press feedback so don't re-roll it. Added to `SKILL.md` (renamed "seven"→"eight principles") + a bullet on the `CollapsibleSection` entry in `components.md`.

`go build` / `go vet` / `go test ./...` green.

## Evidence
The "WHERE" header shows the hover state; all headers are taller/roomier.

<img src="https://bb-artifacts.exe.xyz/f/aa38fbc985688016.jpeg" width="800" alt="Collapsible filter headers — taller, with hover state on WHERE">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
