### PR TITLE
fix(tx-list): align Name header with transaction name text (#1808)

### DIFF
--- a/input.css
+++ b/input.css
@@ -2103,6 +2103,17 @@
            border-b border-base-300/50 bg-base-200/30;
   }
 
+  /* Matches the .bb-tx-checkbox visibility contract: hidden until bulk-select
+     mode is active so the "Name" header stays aligned with the tx name text. */
+  .bb-tx-header-checkbox-col {
+    display: none;
+    flex-shrink: 0;
+    width: 1.25rem; /* w-5 */
+  }
+  body.bb-tx-selecting .bb-tx-header-checkbox-col {
+    display: block;
+  }
+
   /* ── Date visibility (hidden in grouped, shown in list) ──
      `.bb-tx-date` is the desktop right-side date column.
      `.bb-tx-date-mobile` is the date in the mobile sub-line; we also hide

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -69,7 +69,7 @@ templ TxResults(p TxResultsProps) {
 			<div class="bb-card overflow-hidden">
 				<!-- Table Header -->
 				<div class="bb-table-header">
-					<div class="w-5"></div>
+					<div class="bb-tx-header-checkbox-col"></div>
 					<div class="w-9"></div>
 					<div class="flex-1 min-w-0">Name</div>
 					<div class="hidden xl:block shrink-0">Category</div>


### PR DESCRIPTION
Fixes #1808.

In list view, the table header reserved a `w-5` spacer for the bulk-select checkbox column even though `.bb-tx-checkbox` is `display: none` by default — the JS bulk store only shows it imperatively when selection mode is active. This left the "Name" column header offset ~32px (20px checkbox + 12px gap) to the right of where transaction names actually start.

## Root cause

```html
<!-- Header always showed this spacer: -->
<div class="w-5"></div>   <!-- ← always visible, 20px wide -->
<div class="w-9"></div>   <!-- avatar placeholder -->
<div class="flex-1">Name</div>

<!-- But rows only show the checkbox when bulk-select is active: -->
<label class="bb-tx-checkbox">...</label>  <!-- display: none by default -->
<div class="bb-tx-avatar-slot">...</div>   <!-- w-9 avatar, always visible -->
<div class="flex-1">name text</div>
```

## Fix

Replace the static `w-5` spacer with `.bb-tx-header-checkbox-col` — a new CSS class that mirrors the same show/hide contract as the per-row checkboxes:

- **Default (not selecting):** `display: none` → header aligns with name text
- **Selection mode (`body.bb-tx-selecting`):** `display: block` → header aligns with name text (both shifted right by one checkbox width)

## Evidence

**Before** (from issue #1808 — header "Name" is visibly offset right of the transaction names):

``&lt;img src="https://bb-artifacts.exe.xyz/f/41ca0038a39d78ad.jpg" width="900" alt="before — Name header misaligned"&gt;``

**After** (Name header aligns with transaction names):

``&lt;img src="https://bb-artifacts.exe.xyz/f/010b3ddef19ea33f.jpg" width="900" alt="after — Name header aligned"&gt;``


---
_Generated by [Claude Code](https://claude.ai/code/session_01NJTPA7jxEjAjT1Anvsae86)_