### PR TITLE
feat(rules): redesign /rules to stage-grouped list-rows

### DIFF
--- a/.claude/skills/design-system/audit.md
+++ b/.claude/skills/design-system/audit.md
@@ -17,8 +17,10 @@ when the surface is next touched · **P3** cosmetic / low-value.
 
 - **list-row idiom:** `pages/accounts_list.templ`, `components/agent_run_row.templ`
   (`AgentRunRow` + `AgentRunRowList`), `components/report_table.templ`
-  (`ReportRow` + `ReportRowList` + `ReportsList`) — the reference for
-  status-tile · one body line · value · overflow.
+  (`ReportRow` + `ReportRowList` + `ReportsList`), `pages/rules.templ`
+  (grouped by pipeline stage via `GroupRulesByStage`; toggle-as-status
+  leading control) — the reference for status-tile · one body line ·
+  value · overflow.
 - **TabBar:** `reports.templ`, `workflows_runs.templ`, `subscriptions_list.templ`,
   `workflows_shell.templ` use it correctly (border=nav, box=filter).
 - **Drawer:** connect-bank, provider-config, workflow create/edit, cron-field.
@@ -64,8 +66,10 @@ KEEP (justified dense/sortable/wizard matrices): `backups.templ:198`,
 
 MIGRATE — these are entity lists that read better as list-rows (status tile ·
 name · one body line · value · overflow), grouped where there's a natural axis:
-- `pages/rules.templ:74` — rules list (Enabled/Rule/Action/Stage/Hits/Last hit).
-  Group by stage or status; toggle + name + action summary, metrics in overflow.
+- ~~`pages/rules.templ:74`~~ — **DONE.** Migrated to grouped list-rows
+  (group by pipeline stage; the enabled toggle is the leading status
+  control, no separate tile; action summary the one body line, hits +
+  last-hit the right metadata). Sandbox: `/design/c/rules-list`.
 - `pages/subscriptions_list.templ:276` — recurring charges. Group by status
   (active/paused); status tile + name + cadence line + amount.
 - `pages/account_link_detail.templ:36` — matched txn pairs. Already carries a

--- a/internal/templates/components/pages/design_rules_list.templ
+++ b/internal/templates/components/pages/design_rules_list.templ
@@ -1,0 +1,32 @@
+package pages
+
+// SectionRulesList showcases the /rules surface's grouped list-row idiom —
+// the table→list-row migration. Rules group by pipeline stage (baseline →
+// override), each stage a quiet label line over a card of list-rows. The
+// leading control is the enabled toggle (enabled/disabled IS the status,
+// so there's no separate status tile); a disabled rule dims. Name is the
+// title, the action summary the one body line, hits + last-hit the compact
+// right metadata, and an OverflowMenu rides outside the row link.
+//
+// Wrapped in a tiny literal x-data stub so the toggle's @change resolves in
+// the sandbox without the live rulesPage factory (which reloads the page).
+templ SectionRulesList() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>Renders the transaction-rules index (canonical: <code>/rules</code>) as grouped daisy <code>list-row</code>s — the table is retired. Rules group by <strong>pipeline stage</strong> (the order they execute during sync) via <code>GroupRulesByStage</code>, each stage a quiet label line over an <code>AgentRunRowList</code> card.</li>
+				<li>The leading control is the <strong>enabled toggle</strong>: for a rule, enabled/disabled IS the status, so the toggle stands in for a status tile (no redundant second signal). A disabled rule dims (<code>opacity-60</code>), the same read-row treatment as <code>/reports</code>.</li>
+				<li>Each row: name (title) + <code>System</code> / <code>Expired</code> badges + an <strong>agent avatar</strong> on agent-authored rules; the <strong>action summary</strong> as the one body line; <strong>hits + last-hit</strong> as compact muted metadata on the right. The toggle and the <strong>OverflowMenu</strong> sit outside the row's <code>&lt;a&gt;</code> link.</li>
+				<li>Stage is not repeated per row — the group header names it. Within a group, rows keep the server's sort order.</li>
+			</ul>
+		</div>
+		@designExample("Rules index — grouped list-rows", "Full matrix: four pipeline stages (baseline → override), a system rule, an agent-authored rule (avatar), a disabled rule (dimmed + toggle off), and an expired rule. Hits + last-hit ride the right; the action summary is the one body line.") {
+			<div x-data="{ toggleRule() {}, deleteRule() {} }" class="flex flex-col gap-5">
+				for _, g := range designRuleGroups() {
+					@rulesStageGroup(g)
+				}
+			</div>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_rules_list_helpers.go
+++ b/internal/templates/components/pages/design_rules_list_helpers.go
@@ -1,0 +1,63 @@
+//go:build !headless && !lite
+
+package pages
+
+// design_rules_list_helpers.go holds the fixture rows for the
+// SectionRulesList sandbox entry. Kept beside the design types so the
+// templ stays focused on layout. The variants exercise every axis of the
+// /rules surface: the four pipeline stages (the grouping), enabled vs
+// disabled (the toggle / row dim), system vs agent vs user creators (the
+// System badge + agent avatar), an expired rule, and a never-hit rule.
+
+func lastHit(s string) *string { v := s; return &v }
+
+// designRuleRows returns the flat fixture matrix; the sandbox groups it
+// through GroupRulesByStage so the live grouping logic is what renders.
+func designRuleRows() []RulesRow {
+	return []RulesRow{
+		{
+			ID: "rule_base01", Name: "Income → Salary", Enabled: true,
+			Priority: 0, CreatedByType: "system", IsSystem: true,
+			HitCount: 412, LastHitAt: lastHit("x"), LastHitAtRelative: "2h ago",
+			PrimaryActionType: "set_category", ActionsSummary: "Set category Salary",
+		},
+		{
+			ID: "rule_std01", Name: "Starbucks → Coffee", Enabled: true,
+			Priority: 10, CreatedByType: "user",
+			HitCount: 96, LastHitAt: lastHit("x"), LastHitAtRelative: "1d ago",
+			PrimaryActionType: "set_category", ActionsSummary: "Set category Coffee",
+		},
+		{
+			ID: "rule_std02", Name: "Tag all Amazon orders", Enabled: false,
+			Priority: 10, CreatedByType: "user",
+			HitCount: 0, LastHitAtRelative: "",
+			PrimaryActionType: "add_tag", ActionsSummary: "Add tag shopping",
+		},
+		{
+			ID: "rule_ref01", Name: "Coffee runs → Dining tag", Enabled: true,
+			Priority: 50, CreatedByType: "agent", CreatedByID: "agent_curator",
+			CreatedByName: "Category curator",
+			HitCount: 38, LastHitAt: lastHit("x"), LastHitAtRelative: "4h ago",
+			PrimaryActionType: "add_tag", ActionsSummary: "Add tag dining",
+		},
+		{
+			ID: "rule_ref02", Name: "Flag large unknowns", Enabled: true,
+			Priority: 50, CreatedByType: "agent", CreatedByID: "agent_sentry",
+			CreatedByName: "Fraud sentry", ExpiresAt: lastHit("x"), Expired: true,
+			HitCount: 5, LastHitAt: lastHit("x"), LastHitAtRelative: "6d ago",
+			PrimaryActionType: "add_comment", ActionsSummary: "Add comment \"review me\"",
+		},
+		{
+			ID: "rule_ovr01", Name: "Manual override: rent", Enabled: true,
+			Priority: 100, CreatedByType: "user",
+			HitCount: 12, LastHitAt: lastHit("x"), LastHitAtRelative: "3d ago",
+			PrimaryActionType: "set_category", ActionsSummary: "Set category Rent",
+		},
+	}
+}
+
+// designRuleGroups runs the fixtures through the real grouping helper so
+// the sandbox renders exactly what the live page does.
+func designRuleGroups() []RulesStageGroup {
+	return GroupRulesByStage(designRuleRows())
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -362,6 +362,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionReportsTable() },
 		},
 		{
+			Slug:        "rules-list",
+			Title:       "Rules index",
+			Description: "The /rules surface as grouped list-rows (table retired). Rules group by pipeline stage (baseline → override) via GroupRulesByStage, each stage a quiet label line over an AgentRunRowList card. The leading control is the enabled toggle (enabled/disabled IS the status — no separate tile); disabled rows dim. Name (title) + System/Expired badges + agent avatar, the action summary as the one body line, hits + last-hit as right metadata, and an OverflowMenu outside the row link.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionRulesList() },
+		},
+		{
 			Slug:        "agent-run-chat",
 			Title:       "Agent run chat thread",
 			Description: "The chat-thread variants the /agents/runs/{id} detail page composes — assistant + user bubbles (daisy chat), tool_use + tool_result rows (expand to JSON viewer), final result bubble, and the soft-alert error row. Pairs with the markdown-prose + json-viewer sections.",

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -70,25 +70,14 @@ templ Rules(p RulesProps) {
 		if len(p.Rules) == 0 {
 			@rulesEmpty(p.FiltersActive)
 		} else {
-			<div class="overflow-x-auto rounded-xl bg-base-100 border border-base-300">
-				<table class="table table-sm table-zebra-soft">
-					<thead>
-						<tr class="text-xs text-base-content/50">
-							<th class="font-medium text-center w-14">Enabled</th>
-							<th class="font-medium">Rule</th>
-							<th class="font-medium hidden md:table-cell w-64">Action</th>
-							<th class="font-medium hidden lg:table-cell text-center w-16">Stage</th>
-							<th class="font-medium hidden sm:table-cell text-right w-20">Hits</th>
-							<th class="font-medium hidden md:table-cell w-28">Last hit</th>
-							<th class="w-12"></th>
-						</tr>
-					</thead>
-					<tbody>
-						for _, r := range p.Rules {
-							@rulesRow(r)
-						}
-					</tbody>
-				</table>
+			<!-- Grouped by pipeline stage (baseline → override), the order
+			     rules actually execute in during sync. Each stage is a quiet
+			     label line over a card of list-rows — the /accounts day-group
+			     idiom. Within a group, rows keep the server's sort order. -->
+			<div class="flex flex-col gap-5">
+				for _, g := range GroupRulesByStage(p.Rules) {
+					@rulesStageGroup(g)
+				}
 			</div>
 		}
 		if p.TotalPages > 1 {
@@ -245,19 +234,40 @@ templ rulesEmpty(filtered bool) {
 	}
 }
 
-// rulesRow renders one rule as a <tr> in the table. Critical signal
-// (toggle, name, condition/action summary, kebab) is always present;
-// secondary columns (category, stage, hits, last hit) collapse on
-// smaller viewports via `hidden md:table-cell` etc. Anything we hide on
-// mobile is folded into the second line under the name so no signal is
-// lost — only the column density changes.
-// rulesRow renders one rule. Clicking anywhere on the row toggles the
-// rule's enablement; the name link, toggle cell, and overflow cell stop
-// propagation so they keep their own behavior (open detail / toggle /
-// open the actions menu).
-templ rulesRow(r RulesRow) {
-	<tr
-		class={ "hover:bg-base-200/40 cursor-pointer", templ.KV("opacity-60", !r.Enabled) }
+// rulesStageGroup renders one pipeline stage: a quiet label line
+// (stage name · rule count · one-line description) above the stage's
+// list-rows in their own card. The grouping axis is the rule pipeline
+// itself — rules execute baseline → override during sync, so the page
+// reads top-to-bottom as the pipeline it drives. Mirrors the
+// /accounts connection-group idiom.
+templ rulesStageGroup(g RulesStageGroup) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1 min-w-0">
+			<span class="text-sm font-medium text-base-content shrink-0">{ g.Label }</span>
+			<span class="text-xs text-base-content/40 shrink-0">{ fmt.Sprintf("%d rule%s", len(g.Rules), components.PluralS(len(g.Rules))) }</span>
+			<span class="text-xs text-base-content/30 truncate hidden sm:inline">{ g.Description }</span>
+		</div>
+		@components.AgentRunRowList() {
+			for _, r := range g.Rules {
+				@rulesListRow(r)
+			}
+		}
+	</div>
+}
+
+// rulesListRow renders one rule as a daisy list-row. The leading control
+// is the enabled toggle — for a rule, enabled/disabled IS the status, so
+// the toggle stands in for a status tile (no redundant second signal); a
+// disabled row dims via `opacity-60`, the same read-row treatment as
+// /reports. The toggle and the overflow menu sit OUTSIDE the row's
+// navigation anchor so flipping the toggle or opening the menu never
+// triggers the row link. The row links to the rule detail; the name is
+// the title, the action summary the one body line, and hits + last-hit
+// the compact muted metadata on the right.
+templ rulesListRow(r RulesRow) {
+	<li
+		class={ "list-row transition-colors hover:bg-base-200/40 items-center",
+			templ.KV("opacity-60", !r.Enabled) }
 		data-rule-row
 		data-rule-id={ r.ID }
 		data-open-url={ "/rules/" + r.ID }
@@ -265,15 +275,13 @@ templ rulesRow(r RulesRow) {
 		if !r.IsSystem {
 			data-can-delete="true"
 		}
-		@click={ "toggleRule('" + r.ID + "')" }
 	>
-		<!-- Toggle column. Click is scoped to the cell so the row's
-		     toggle-on-click doesn't double-fire against the explicit
-		     control (which would net out to no change). -->
-		<td class="align-middle text-center" @click.stop>
+		<!-- Leading control = the enabled toggle (the row's status
+		     affordance). Outside the <a>, so toggling never navigates. -->
+		<label class="shrink-0 self-center cursor-pointer" title={ rulesToggleLabel(r) }>
 			<input
 				type="checkbox"
-				class="toggle toggle-sm"
+				class="toggle toggle-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
 				if r.Enabled {
 					checked
 				}
@@ -281,90 +289,74 @@ templ rulesRow(r RulesRow) {
 				data-toggle-enabled
 				@change={ "toggleRule('" + r.ID + "')" }
 			/>
-		</td>
-		<!-- Name + condition/action summary line. On mobile this cell
-		     carries the chips for category, stage, hits, and last hit
-		     too (the dedicated columns are hidden < md). -->
-		<td class="align-middle">
-			<div class="flex items-center gap-2 flex-wrap">
-				<a
-					href={ templ.SafeURL("/rules/" + r.ID) }
-					class="font-medium text-sm hover:underline truncate max-w-[40ch]"
-					@click.stop
-				>{ r.Name }</a>
-				if r.IsSystem {
-					<span class="badge badge-soft badge-info badge-xs gap-1" title="Built-in system rule">
-						@components.LucideIcon("shield", "w-2.5 h-2.5")
-						System
-					</span>
-				}
-				if r.Enabled && r.ExpiresAt != nil && r.Expired {
-					<span class="badge badge-warning badge-xs">Expired</span>
-				}
-			</div>
-			<div class="flex items-center gap-2 mt-0.5 text-xs text-base-content/50 whitespace-nowrap overflow-hidden">
-				<span class="inline-flex items-center gap-1 shrink-0" title={ r.ConditionSummary }>
-					if r.IsMatchAll {
-						@components.LucideIcon("infinity", "w-3 h-3")
-						<span class="italic">All transactions</span>
-					} else {
-						@components.LucideIcon("list-filter", "w-3 h-3")
-						<span class="tabular-nums">{ fmt.Sprintf("%d cond.", r.ConditionCount) }</span>
+		</label>
+		<a
+			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-lg"
+			href={ templ.SafeURL("/rules/" + r.ID) }
+			aria-label={ "Open rule " + r.Name }
+		>
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="font-medium text-sm text-base-content truncate">{ r.Name }</span>
+					if r.IsSystem {
+						<span class="badge badge-soft badge-info badge-xs gap-1 shrink-0" title="Built-in system rule">
+							@components.LucideIcon("shield", "w-2.5 h-2.5")
+							System
+						</span>
 					}
-				</span>
-				<span class="text-base-content/30 shrink-0">&middot;</span>
-				<span class="inline-flex items-center gap-1 shrink-0 tabular-nums" title={ r.ActionsSummary }>
-					@components.LucideIcon("zap", "w-3 h-3")
-					{ fmt.Sprintf("%d action%s", r.ActionsCount, components.PluralS(r.ActionsCount)) }
-				</span>
-				<!-- Mobile-only stage + hits chips. Hidden once the
-				     dedicated columns appear so we don't double-render. -->
-				<span class="sm:hidden text-base-content/30 shrink-0">&middot;</span>
-				<span class="sm:hidden inline-flex items-center gap-1 shrink-0 tabular-nums" title="Hits">
-					{ fmt.Sprintf("%d hits", r.HitCount) }
-				</span>
+					if r.Enabled && r.ExpiresAt != nil && r.Expired {
+						<span class="badge badge-soft badge-warning badge-xs shrink-0">Expired</span>
+					}
+					if rulesShowCreatorAvatar(r) {
+						@components.UserAvatar(components.UserAvatarProps{
+							ID:         rulesCreatorSeed(r),
+							Name:       r.CreatedByName,
+							IsAgent:    true,
+							Size:       components.UserAvatarXS,
+							Decorative: true,
+							Lazy:       true,
+							Class:      "shrink-0",
+						})
+					}
+				</div>
+				<div class="mt-0.5 flex items-center gap-1.5 text-xs text-base-content/55 min-w-0">
+					@components.LucideIcon(rulesActionIcon(r), "w-3 h-3 shrink-0 opacity-70")
+					<span class="truncate" title={ r.ActionsSummary }>{ rulesActionLabel(r) }</span>
+					<!-- Mobile-only hits; the right metadata column is hidden < sm. -->
+					<span class="sm:hidden text-base-content/30 shrink-0">&middot;</span>
+					<span class="sm:hidden shrink-0 tabular-nums whitespace-nowrap">{ fmt.Sprintf("%d hits", r.HitCount) }</span>
+				</div>
 			</div>
-		</td>
-		<td class="align-middle text-xs hidden md:table-cell">
-			@rulesActionChip(r)
-		</td>
-		<td class="align-middle text-xs text-center hidden lg:table-cell tabular-nums text-base-content/60">
-			{ fmt.Sprintf("%d", r.Priority) }
-		</td>
-		<td class="align-middle text-xs text-right hidden sm:table-cell tabular-nums text-base-content/60">
-			{ fmt.Sprintf("%d", r.HitCount) }
-		</td>
-		<td class="align-middle text-xs hidden md:table-cell text-base-content/60 tabular-nums">
-			if r.LastHitAt != nil {
-				{ r.LastHitAtRelative }
-			} else {
-				<span class="text-base-content/30">—</span>
-			}
-		</td>
-		<td class="align-middle text-right" @click.stop>
+			@rulesRowMetadata(r)
+		</a>
+		<div class="shrink-0 self-center">
 			@components.OverflowMenu(components.OverflowMenuProps{
 				AriaLabel: "Rule " + r.Name + " actions",
 				Size:      "sm",
 				Items:     rulesOverflowItems(r),
 			})
-		</td>
-	</tr>
+		</div>
+	</li>
 }
 
-// rulesActionChip renders the "what this rule does" column. Rules are no
-// longer category-only — they can set a category, add/remove a tag, add a
-// comment, or assign a series — so every row gets an icon that reflects
-// its action. A set_category rule keeps its colored category avatar; other
-// actions get a neutral icon in the same avatar shape so the column reads
-// as one consistent surface. The label fills the column and only truncates
-// when it has to, fixing the old cramped max-w cap.
-templ rulesActionChip(r RulesRow) {
-	<span class="inline-flex items-center gap-2 min-w-0">
-		<span class="bb-tx-avatar bb-tx-avatar-sm shrink-0" style={ rulesActionAvatarStyle(r) }>
-			@components.LucideIcon(rulesActionIcon(r), "w-3.5 h-3.5")
-		</span>
-		<span class="truncate" title={ r.ActionsSummary }>{ r.ActionsSummary }</span>
-	</span>
+// rulesRowMetadata renders the compact right-aligned metric column: hit
+// count over last-hit relative time. Hidden below `sm` (folded into the
+// body's second line on mobile). Pipeline stage is NOT repeated here — the
+// group header already names it.
+templ rulesRowMetadata(r RulesRow) {
+	<div class="shrink-0 self-center text-right hidden sm:block tabular-nums">
+		<div class="text-sm text-base-content/70">
+			{ fmt.Sprintf("%d", r.HitCount) }
+			<span class="text-xs text-base-content/35"> hits</span>
+		</div>
+		<div class="text-xs text-base-content/40">
+			if r.LastHitAt != nil {
+				{ r.LastHitAtRelative }
+			} else {
+				never
+			}
+		</div>
+	</div>
 }
 
 templ rulesPaginator(p RulesProps) {
@@ -424,22 +416,31 @@ templ rulesPerPageOption(value, current int) {
 	}
 }
 
-func rulesAvatarStyle(color *string) string {
-	if color != nil && *color != "" {
-		return "--avatar-color: " + *color
+// rulesActionLabel is the one body line — what the rule does. Falls back
+// to a neutral label when a rule has no actions so the row never renders an
+// empty line.
+func rulesActionLabel(r RulesRow) string {
+	if r.ActionsSummary == "" {
+		return "No actions"
 	}
-	return "--avatar-color: oklch(0.65 0 0)"
+	return r.ActionsSummary
 }
 
-// rulesActionAvatarStyle tints the action avatar. A set_category rule with
-// a known color uses the category color; every other action (tags,
-// comments, series, multi-action) gets the neutral gray so the icon, not
-// the color, carries the meaning.
-func rulesActionAvatarStyle(r RulesRow) string {
-	if r.PrimaryActionType == "set_category" {
-		return rulesAvatarStyle(r.CategoryColor)
+// rulesShowCreatorAvatar surfaces an identity avatar only where it adds
+// signal — agent-authored rules (principle 7). User rules don't need a
+// face, and system rules already carry their System badge.
+func rulesShowCreatorAvatar(r RulesRow) bool {
+	return r.CreatedByType == "agent" && r.CreatedByName != ""
+}
+
+// rulesCreatorSeed is the stable DiceBear seed for the creator avatar —
+// the actor id when known (so every rule from one agent shares a face),
+// falling back to the display name.
+func rulesCreatorSeed(r RulesRow) string {
+	if r.CreatedByID != "" {
+		return r.CreatedByID
 	}
-	return rulesAvatarStyle(nil)
+	return r.CreatedByName
 }
 
 // rulesActionIcon picks the lucide icon for the rule's primary action.

--- a/internal/templates/components/pages/rules_types.go
+++ b/internal/templates/components/pages/rules_types.go
@@ -3,6 +3,8 @@
 package pages
 
 import (
+	"sort"
+
 	"breadbox/internal/service"
 )
 
@@ -65,6 +67,13 @@ type RulesRow struct {
 	LastHitAt  *string // RFC3339; rendered via LastHitAtRelative
 	LastHitAtRelative string
 
+	// Creator identity — drives the agent avatar on agent-authored rows
+	// (principle 7). CreatedByType is one of user / agent / system;
+	// IsSystem is the pre-derived convenience flag for the System badge.
+	CreatedByType string
+	CreatedByID   string
+	CreatedByName string
+
 	CategoryIcon  *string
 	CategoryColor *string
 
@@ -97,6 +106,8 @@ func BuildRulesRow(r service.TransactionRuleResponse) RulesRow {
 		Name:             r.Name,
 		Enabled:          r.Enabled,
 		IsSystem:         r.CreatedByType == "system",
+		CreatedByType:    r.CreatedByType,
+		CreatedByName:    r.CreatedByName,
 		HitCount:         r.HitCount,
 		Priority:         r.Priority,
 		LastHitAt:        r.LastHitAt,
@@ -105,6 +116,9 @@ func BuildRulesRow(r service.TransactionRuleResponse) RulesRow {
 		ExpiresAt:        r.ExpiresAt,
 		ConditionSummary: service.ConditionSummary(r.Conditions),
 		ActionsCount:     len(r.Actions),
+	}
+	if r.CreatedByID != nil {
+		row.CreatedByID = *r.CreatedByID
 	}
 
 	row.IsMatchAll = r.Conditions.Field == "" && len(r.Conditions.And) == 0 && len(r.Conditions.Or) == 0 && r.Conditions.Not == nil
@@ -127,4 +141,70 @@ func BuildRulesRow(r service.TransactionRuleResponse) RulesRow {
 	}
 
 	return row
+}
+
+// RulesStageGroup is one pipeline-stage bucket of rules, the grouping axis
+// for the /rules surface. Rules execute in priority order during sync, so
+// grouping by stage makes the page read as the pipeline it drives. Order
+// is the canonical stage index (0=baseline … 3=override) — the pipeline's
+// execution order, top to bottom.
+type RulesStageGroup struct {
+	Slug        string
+	Label       string
+	Description string
+	Order       int
+	Rules       []RulesRow
+}
+
+// RuleStage maps a rule's numeric pipeline priority to its canonical stage
+// bucket (slug, label, one-line description). The DSL names four stages —
+// baseline(0) / standard(10) / refinement(50) / override(100) — but
+// `priority` is a free 0..1000 integer, so each named stage owns the
+// half-open range up to the next one. Kept in lock-step with
+// docs/rule-dsl.md → "Priority as pipeline stage".
+func RuleStage(priority int) (slug, label, desc string) {
+	switch {
+	case priority < 10:
+		return "baseline", "Baseline", "Foundation — broad, early classifications"
+	case priority < 50:
+		return "standard", "Standard", "The default rule stage"
+	case priority < 100:
+		return "refinement", "Refinement", "Reacts to baseline & standard output"
+	default:
+		return "override", "Override", "Final say — runs last"
+	}
+}
+
+// ruleStageOrder is the canonical execution order of the named stages,
+// driving both the group sort and RulesStageGroup.Order.
+var ruleStageOrder = map[string]int{
+	"baseline":   0,
+	"standard":   1,
+	"refinement": 2,
+	"override":   3,
+}
+
+// GroupRulesByStage buckets rows into their pipeline stage, preserving the
+// caller's row order within each bucket (so the active sort still governs
+// intra-stage ordering) and returning the groups in pipeline-execution
+// order (baseline → override). Empty stages are omitted. Pure and
+// order-stable so the IA decision is pinned by a unit test rather than
+// vibes (mirrors GroupAccountsByConnection).
+func GroupRulesByStage(rows []RulesRow) []RulesStageGroup {
+	bySlug := make(map[string]*RulesStageGroup)
+	for _, r := range rows {
+		slug, label, desc := RuleStage(r.Priority)
+		g, ok := bySlug[slug]
+		if !ok {
+			g = &RulesStageGroup{Slug: slug, Label: label, Description: desc, Order: ruleStageOrder[slug]}
+			bySlug[slug] = g
+		}
+		g.Rules = append(g.Rules, r)
+	}
+	out := make([]RulesStageGroup, 0, len(bySlug))
+	for _, g := range bySlug {
+		out = append(out, *g)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Order < out[j].Order })
+	return out
 }

--- a/internal/templates/components/pages/rules_types_test.go
+++ b/internal/templates/components/pages/rules_types_test.go
@@ -1,0 +1,73 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+func TestRuleStage(t *testing.T) {
+	cases := []struct {
+		priority int
+		wantSlug string
+	}{
+		{0, "baseline"},
+		{9, "baseline"},
+		{10, "standard"},
+		{49, "standard"},
+		{50, "refinement"},
+		{99, "refinement"},
+		{100, "override"},
+		{1000, "override"},
+	}
+	for _, c := range cases {
+		if slug, _, _ := RuleStage(c.priority); slug != c.wantSlug {
+			t.Errorf("RuleStage(%d) = %q, want %q", c.priority, slug, c.wantSlug)
+		}
+	}
+}
+
+func TestGroupRulesByStage(t *testing.T) {
+	// Intentionally out of stage order, and with two stages sharing rows,
+	// so we exercise both the bucketing and the canonical group ordering.
+	rows := []RulesRow{
+		{ID: "r1", Priority: 100}, // override
+		{ID: "r2", Priority: 10},  // standard
+		{ID: "r3", Priority: 0},   // baseline
+		{ID: "r4", Priority: 10},  // standard
+		{ID: "r5", Priority: 50},  // refinement
+		// no second baseline / override — empty buckets must not appear twice
+	}
+
+	groups := GroupRulesByStage(rows)
+	if len(groups) != 4 {
+		t.Fatalf("got %d groups, want 4", len(groups))
+	}
+
+	// Groups come back in pipeline-execution order regardless of input order.
+	wantOrder := []string{"baseline", "standard", "refinement", "override"}
+	for i, want := range wantOrder {
+		if groups[i].Slug != want {
+			t.Errorf("group[%d] = %q, want %q", i, groups[i].Slug, want)
+		}
+	}
+
+	// Standard holds both r2 and r4, in their original input order (so the
+	// active sort still governs intra-stage ordering).
+	std := groups[1]
+	if len(std.Rules) != 2 {
+		t.Fatalf("standard group: got %d rules, want 2", len(std.Rules))
+	}
+	if std.Rules[0].ID != "r2" || std.Rules[1].ID != "r4" {
+		t.Errorf("standard group order = [%s %s], want [r2 r4]", std.Rules[0].ID, std.Rules[1].ID)
+	}
+
+	// Single-rule stages carry exactly their one rule.
+	if len(groups[0].Rules) != 1 || groups[0].Rules[0].ID != "r3" {
+		t.Errorf("baseline group = %+v, want single r3", groups[0].Rules)
+	}
+}
+
+func TestGroupRulesByStageEmpty(t *testing.T) {
+	if groups := GroupRulesByStage(nil); len(groups) != 0 {
+		t.Errorf("GroupRulesByStage(nil) = %d groups, want 0", len(groups))
+	}
+}


### PR DESCRIPTION
Surface redesign (design-system loop): `/rules` moves from a data table to the canonical **list-row** idiom, grouped by pipeline stage.

## What changed
- **Table → grouped list-rows** (`rulesListRow` in a `bb-card` via `AgentRunRowList`). The Enabled/Rule/Action/Stage/Hits/Last-hit columns are gone.
- **The enabled toggle is the leading control** — a rule's status *is* enabled/disabled, so the toggle stands in for the status-tile slot (no redundant second signal); disabled rows dim `opacity-60`. The toggle keeps its AJAX `toggleRule` behavior and sits outside the row link so flipping it never navigates.
- Name = title (+ `System`/`Expired` badges + a `UserAvatar` on agent-authored rules); one body line = the action summary; hits + last-hit as compact muted metadata (folds into the body line on mobile); `OverflowMenu` (edit/toggle/delete) outside the link. Row links to `/rules/{id}`.
- **IA: grouped by pipeline stage** (Baseline → Standard → Refinement → Override — execution order) under quiet `/accounts`-style label lines (name · count · description). Pure, order-stable, unit-tested `GroupRulesByStage`. The per-row stage column is dropped (the group header names it). Filter toolbar / sort / pagination untouched.
- Principle #8 applied: focus-visible rings on the toggle + row link, hover on rows. New `/design/c/rules-list` sandbox section.

`go build` / `go vet` / `go test ./...` green (incl. the new grouping tests + scripts-lint + design smoke render + admin TestRulesTemplateRenders).

Deferred: keyboard `d`-to-delete is a latent no-op (pre-existing); wire it via the overflow delete item as a follow-up.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/309adbf8c5bb9100.jpeg" width="800" alt="/rules redesigned as stage-grouped list-rows with enabled toggles">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
