### PR TITLE
feat(recurring): redesign /recurring ledger to status-grouped list-rows

### DIFF
--- a/.claude/skills/design-system/audit.md
+++ b/.claude/skills/design-system/audit.md
@@ -70,8 +70,12 @@ name · one body line · value · overflow), grouped where there's a natural axi
   (group by pipeline stage; the enabled toggle is the leading status
   control, no separate tile; action summary the one body line, hits +
   last-hit the right metadata). Sandbox: `/design/c/rules-list`.
-- `pages/subscriptions_list.templ:276` — recurring charges. Group by status
-  (active/paused); status tile + name + cadence line + amount.
+- ~~`pages/subscriptions_list.templ:276`~~ — **DONE.** Recurring charges
+  migrated to grouped list-rows (group by status: Active → Paused → Ended;
+  leading status tile, name + type/renewal/price chips, cadence·next-renewal
+  body line, amount, overflow menu; Active header carries a single-currency
+  monthly subtotal). Grouping pinned by `GroupSubscriptionsByStatus` +
+  `subscriptions_list_test.go`. Sandbox: `/design/c/recurring-ledger`.
 - `pages/account_link_detail.templ:36` — matched txn pairs. Already carries a
   mobile card fallback → unify to one list-row layout (confidence as the tile).
 > These overlap with the goal-3 surface loop (e.g. `/rules`, `/subscriptions`).

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -729,6 +729,9 @@ func subscriptionRow(s service.SeriesResponse, catName, userName map[string]stri
 	if s.LastAmount != nil {
 		row.HasAmount = true
 		row.Amount = math.Abs(*s.LastAmount)
+		// Monthly-equivalent contribution — drives the ledger group's monthly
+		// subtotal (single-currency only; never summed across currencies).
+		row.MonthlyEquiv = monthlyEquivalent(s.Cadence, row.Amount)
 	}
 	if s.CategoryID != nil {
 		row.CategoryName = catName[*s.CategoryID]

--- a/internal/templates/components/pages/design_subscriptions_ledger.templ
+++ b/internal/templates/components/pages/design_subscriptions_ledger.templ
@@ -1,0 +1,30 @@
+package pages
+
+// SectionRecurringLedger showcases the /recurring (Recurring) ledger after its
+// table → grouped-list-row migration. The live page composes these same
+// subscriptionsStatusGroup / subscriptionsListRow templs; here they're wrapped
+// in a tiny literal x-data stub that satisfies the filter bindings
+// (filterUser / filterType / matches / groupVisible) so the rows render without
+// the live subscriptionsList factory. The fixtures route through the real
+// GroupSubscriptionsByStatus, so the grouping order and single-currency monthly
+// subtotal shown here match production.
+templ SectionRecurringLedger() {
+	<div class="flex flex-col gap-6">
+		<div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-xs text-base-content/60">
+			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
+			<ul class="space-y-1 list-disc pl-4">
+				<li>Renders the recurring-charge ledger (canonical: <code>/recurring</code>) as grouped daisy <code>list-row</code>s inside <code>AgentRunRowList</code> cards — the same shape as <code>/accounts</code> and <code>/rules</code>. No desktop-table / mobile-card split.</li>
+				<li>Rows group by <strong>status</strong> under quiet label lines — <strong>Active</strong> → <strong>Paused</strong> → <strong>Ended</strong> — and the Active header carries a single-currency <strong>monthly subtotal</strong> (never summed across currencies).</li>
+				<li>Each row: a leading color-coded <strong>status tile</strong> (active → success, paused → warning, ended → muted), the <strong>name</strong> + type / renewal / price chips on the title line, a single <strong>cadence · next-renewal</strong> body line, the <strong>amount</strong>, and an <strong>OverflowMenu</strong> (View · Pause/Resume · Cancel) outside the row link.</li>
+				<li>Status lives in the tile + the group header — no parallel status badge in the row (principle #2).</li>
+			</ul>
+		</div>
+		@designExample("Recurring ledger — grouped list-rows", "Full variant matrix: active rows with due-soon / overdue renewal chips + a price-rising chip, the Active group's monthly subtotal, a paused row, and ended rows (one with a stale chip, one with no amount). The x-data stub stands in for the live filter factory.") {
+			<div x-data="{ filterUser: 'all', filterType: 'all', filter: '', matches() { return true }, groupVisible() { return true } }" class="flex flex-col gap-5">
+				for _, g := range designSubscriptionLedgerGroups() {
+					@subscriptionsStatusGroup(g)
+				}
+			</div>
+		}
+	</div>
+}

--- a/internal/templates/components/pages/design_subscriptions_ledger_helpers.go
+++ b/internal/templates/components/pages/design_subscriptions_ledger_helpers.go
@@ -1,0 +1,72 @@
+//go:build !headless && !lite
+
+package pages
+
+// design_subscriptions_ledger_helpers.go holds the fixture rows for the
+// SectionRecurringLedger sandbox entry — the /recurring (Recurring) ledger
+// migrated from a table to grouped daisy list-rows. The fixtures exercise every
+// axis of the row: the three status tiles (active/paused/ended), the renewal
+// attention chip (due-soon / overdue / stale), the price-rising chip, a
+// no-amount fallback, and the Active group's single-currency monthly subtotal.
+// Routing the fixtures through the real GroupSubscriptionsByStatus keeps the
+// sandbox honest about the grouping + subtotal IA.
+
+func designSubscriptionLedgerGroups() []SubscriptionStatusGroup {
+	rows := []SubscriptionRow{
+		{
+			ShortID: "sub_netflix", Name: "Netflix", Status: "active",
+			Type: "subscription", TypeLabel: "Subscription",
+			CadenceLabel: "Monthly", NextExpected: "Jun 28",
+			HasAmount: true, Amount: 15.99, Currency: "USD", MonthlyEquiv: 15.99,
+			RenewalLabel: "Renews in 3d", RenewalTone: "info",
+			Search: "netflix",
+		},
+		{
+			ShortID: "sub_icloud", Name: "iCloud+ Storage", Status: "active",
+			Type: "subscription", TypeLabel: "Subscription",
+			CadenceLabel: "Monthly", NextExpected: "Jun 14",
+			HasAmount: true, Amount: 2.99, Currency: "USD", MonthlyEquiv: 2.99,
+			RenewalLabel: "Due tomorrow", RenewalTone: "info",
+			Search: "icloud storage",
+		},
+		{
+			ShortID: "sub_internet", Name: "Comcast Internet", Status: "active",
+			Type: "bill", TypeLabel: "Bill",
+			CadenceLabel: "Monthly", NextExpected: "Jun 9",
+			HasAmount: true, Amount: 79.00, Currency: "USD", MonthlyEquiv: 79.00,
+			RenewalLabel: "4d overdue", RenewalTone: "warning",
+			Search: "comcast internet",
+		},
+		{
+			ShortID: "sub_nyt", Name: "NYT Digital", Status: "active",
+			Type: "subscription", TypeLabel: "Subscription",
+			CadenceLabel: "Annual", NextExpected: "Mar 2",
+			HasAmount: true, Amount: 120.00, Currency: "USD", MonthlyEquiv: 10.00,
+			PriceChanged: true,
+			Search:       "nyt digital",
+		},
+		{
+			ShortID: "sub_gym", Name: "Equinox", Status: "paused",
+			Type: "bill", TypeLabel: "Bill",
+			CadenceLabel: "Monthly",
+			HasAmount:    true, Amount: 240.00, Currency: "USD", MonthlyEquiv: 240.00,
+			Search: "equinox gym",
+		},
+		{
+			ShortID: "sub_hulu", Name: "Hulu", Status: "cancelled",
+			Type: "subscription", TypeLabel: "Subscription",
+			CadenceLabel: "Monthly",
+			HasAmount:    true, Amount: 17.99, Currency: "USD", MonthlyEquiv: 17.99,
+			RenewalLabel: "Likely cancelled", RenewalTone: "error",
+			Search: "hulu",
+		},
+		{
+			ShortID: "sub_water", Name: "City Water", Status: "cancelled",
+			Type: "bill", TypeLabel: "Bill",
+			CadenceLabel: "Quarterly",
+			HasAmount:    false,
+			Search:       "city water",
+		},
+	}
+	return GroupSubscriptionsByStatus(rows)
+}

--- a/internal/templates/components/pages/design_types.go
+++ b/internal/templates/components/pages/design_types.go
@@ -292,6 +292,13 @@ func DesignSections() []DesignSection {
 			Render:      func() templ.Component { return SectionRecurringChips() },
 		},
 		{
+			Slug:        "recurring-ledger",
+			Title:       "Recurring ledger",
+			Description: "The /recurring charge ledger after its table → grouped-list-row migration: rows grouped by status (Active → Paused → Ended) under quiet label lines, a single-currency monthly subtotal on the Active header, a leading status tile (success/warning/muted), name + type/renewal/price chips, a cadence·next-renewal body line, the amount, and an overflow menu (View · Pause/Resume · Cancel). Same list-row shape as /accounts and /rules.",
+			Group:       "data",
+			Render:      func() templ.Component { return SectionRecurringLedger() },
+		},
+		{
 			Slug:        "recurring-detail",
 			Title:       "Recurring detail panels",
 			Description: "Detection-forward panels for the recurring-series detail page: SeriesDetectionPanel (match-strength badge + plain-language summary + match-window range viz, with a no-amount variant), the standalone SeriesMatchWindow amount-axis viz, SeriesEvidenceTimeline (charge timeline with matched/prior/projected markers + price-change inset, read-only and unlinkable variants), and SeriesFactStrip (read-only derived facts). Money values carry data-private so privacy mode obfuscates them. The handler assembles the values; these are pure presentation.",

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -132,8 +132,10 @@ templ SubscriptionsList(p SubscriptionsListProps) {
 							Placeholder: "Filter recurring charges...",
 							XModel:      "filter",
 						})
-						<div class="mt-4">
-							@subscriptionsActiveTable(p)
+						<div class="mt-4 flex flex-col gap-5">
+							for _, g := range GroupSubscriptionsByStatus(p.Active) {
+								@subscriptionsStatusGroup(g)
+							}
 						</div>
 					}
 				</div>
@@ -269,88 +271,134 @@ templ seriesChargeRow(tx service.AdminTransactionRow) {
 	</div>
 }
 
-// subscriptionsActiveTable is the confirmed/live ledger.
-templ subscriptionsActiveTable(p SubscriptionsListProps) {
-	<div class="bb-card overflow-hidden">
-		<div class="overflow-x-auto">
-			<table class="table table-sm">
-				<thead class="text-xs text-base-content/60">
-					<tr>
-						<th class="min-w-[12rem]">Recurring charge</th>
-						<th class="hidden md:table-cell">Cadence</th>
-						<th class="hidden lg:table-cell">Next renewal</th>
-						<th>Status</th>
-						<th class="text-right">Amount</th>
-					</tr>
-				</thead>
-				<tbody>
-					for _, s := range p.Active {
-						@subscriptionsActiveRow(s)
-					}
-				</tbody>
-			</table>
+// subscriptionsStatusGroup renders one status bucket of the ledger: a quiet
+// label line (status · count · optional monthly subtotal) above the group's
+// list-rows in their own card, mirroring the /accounts connection-group idiom.
+// The whole group hides when the active member/type/search filters leave it
+// with no visible rows, so a header never dangles over an empty card.
+templ subscriptionsStatusGroup(g SubscriptionStatusGroup) {
+	<div x-show="groupVisible($el)" class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1 min-w-0">
+			<span class="text-sm font-medium text-base-content shrink-0">{ g.Label }</span>
+			<span class="text-xs text-base-content/40 shrink-0">{ subscriptionsGroupCount(g) }</span>
+			if g.HasSubtotal {
+				<span class="ml-auto shrink-0 inline-flex items-baseline gap-1">
+					@components.Amount(components.AmountProps{
+						Value:  g.Subtotal,
+						Intent: components.AmountCost,
+						Class:  "text-sm font-semibold tabular-nums",
+					})
+					<span class="text-xs text-base-content/40">/mo</span>
+				</span>
+			}
 		</div>
+		@components.AgentRunRowList() {
+			for _, s := range g.Rows {
+				@subscriptionsListRow(s)
+			}
+		}
 	</div>
 }
 
-templ subscriptionsActiveRow(s SubscriptionRow) {
-	<tr
+// subscriptionsListRow renders one recurring charge as a daisy list-row: a
+// leading color-coded status tile, the name + type / renewal / price chips on
+// the title line, a single cadence·next-renewal body line, the trailing amount,
+// and an overflow menu OUTSIDE the row's navigation anchor (so opening the menu
+// never triggers the row link). Status is encoded in the leading tile and the
+// group header — no parallel status badge in the row (principle #2).
+templ subscriptionsListRow(s SubscriptionRow) {
+	<li
+		class="list-row transition-colors hover:bg-base-200/40 items-center"
 		data-series-card
 		data-filter-user={ s.UserID }
 		data-type={ s.Type }
 		data-search={ s.Search }
 		x-show="(filterUser === 'all' || filterUser === $el.dataset.filterUser) && (filterType === 'all' || filterType === $el.dataset.type) && matches($el)"
-		x-cloak
-		class="hover:bg-base-200/30 transition-colors"
 	>
-		<td>
-			<a href={ templ.SafeURL("/recurring/" + s.ShortID) } class="flex items-center gap-3 no-underline">
-				<div class="w-8 h-8 rounded-md bg-base-200/60 flex items-center justify-center shrink-0">
-					@components.LucideIcon("repeat", "w-4 h-4 text-base-content opacity-40")
-				</div>
-				<div class="min-w-0">
-					<div class="flex items-center gap-2 min-w-0">
-						<span data-private="merchant" class="text-sm font-medium truncate text-base-content">{ s.Name }</span>
-						@components.SeriesTypeChip(s.TypeLabel, "xs")
-					</div>
-					if s.CategoryName != "" {
-						<div class="text-xs text-base-content/40 truncate">{ s.CategoryName }</div>
+		<a
+			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-lg"
+			href={ templ.SafeURL("/recurring/" + s.ShortID) }
+			aria-label={ "Open recurring charge " + s.Name }
+		>
+			@subscriptionsStatusTile(s.Status)
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span data-private="merchant" class="font-medium text-sm text-base-content truncate">{ s.Name }</span>
+					@components.SeriesTypeChip(s.TypeLabel, "xs")
+					@components.SeriesRenewalChip(s.RenewalLabel, s.RenewalTone)
+					if s.PriceChanged {
+						<span class="badge badge-soft badge-warning badge-xs gap-1 shrink-0" title="Price has been rising">
+							@components.LucideIcon("trending-up", "w-3 h-3")
+							Price
+						</span>
 					}
 				</div>
-			</a>
-		</td>
-		<td class="hidden md:table-cell text-sm text-base-content/70">{ s.CadenceLabel }</td>
-		<td class="hidden lg:table-cell text-sm text-base-content/70">
-			if s.NextExpected != "" {
-				{ s.NextExpected }
-			} else {
-				<span class="text-base-content/30">—</span>
-			}
-		</td>
-		<td>
-			<span class="inline-flex items-center gap-1.5 flex-wrap">
-				<span class={ "badge badge-soft badge-sm", "badge-" + s.StatusTone }>{ s.StatusLabel }</span>
-				@components.SeriesRenewalChip(s.RenewalLabel, s.RenewalTone)
-				if s.PriceChanged {
-					<span class="badge badge-soft badge-warning badge-xs gap-1" title="Price has been rising">
-						@components.LucideIcon("trending-up", "w-3 h-3")
-						Price
-					</span>
+				<div class="mt-0.5 text-xs text-base-content/55 min-w-0 line-clamp-1">
+					{ subscriptionsRowBodyLine(s) }
+				</div>
+			</div>
+			<div class="shrink-0 self-center text-right">
+				if s.HasAmount {
+					@components.Amount(components.AmountProps{
+						Value:  s.Amount,
+						Intent: components.AmountCost,
+						Class:  "text-sm font-semibold",
+					})
+				} else {
+					<span class="text-sm text-base-content/30">—</span>
 				}
-			</span>
-		</td>
-		<td class="text-right">
-			if s.HasAmount {
-				@components.Amount(components.AmountProps{
-					Value:  s.Amount,
-					Intent: components.AmountCost,
-					Class:  "text-sm font-medium",
-				})
-			} else {
-				<span class="text-xs text-base-content/30">—</span>
-			}
-		</td>
-	</tr>
+			</div>
+		</a>
+		<div class="shrink-0 self-center">
+			@components.OverflowMenu(components.OverflowMenuProps{
+				AriaLabel: "Actions for " + s.Name,
+				Size:      "sm",
+				Items:     subscriptionsRowItems(s),
+			})
+		</div>
+	</li>
+}
+
+// subscriptionsStatusTile is the leading color-coded status glyph for a ledger
+// row (principle #2). Tone + icon come from the pure helpers in the types file.
+templ subscriptionsStatusTile(status string) {
+	<div class={ "w-10 h-10 rounded-lg flex items-center justify-center shrink-0", subStatusTileBg(status) }>
+		@components.LucideIcon(subStatusTileIcon(status), "w-4 h-4 "+subStatusTileIconColor(status))
+	</div>
+}
+
+// subscriptionsRowItems builds the overflow-menu actions for one ledger row.
+// View details is always present; the verdict actions match the row's status
+// (active → Pause / Cancel, paused → Resume / Cancel, ended → Reactivate) and
+// dispatch the same `series-verdict` event the candidate cards + detail toolbar
+// use, so the subscriptionsList Alpine factory handles them in one place.
+func subscriptionsRowItems(s SubscriptionRow) []components.OverflowMenuItem {
+	items := []components.OverflowMenuItem{
+		{
+			Label:     "View details",
+			Icon:      "external-link",
+			Href:      templ.SafeURL("/recurring/" + s.ShortID),
+			AriaLabel: "Open " + s.Name,
+		},
+	}
+	verdict := func(v, label, icon string, destructive bool) components.OverflowMenuItem {
+		return components.OverflowMenuItem{
+			Label:       label,
+			Icon:        icon,
+			Destructive: destructive,
+			OnClick:     fmt.Sprintf("$dispatch('series-verdict', {id: %q, name: %q, verdict: %q}); document.activeElement && document.activeElement.blur()", s.ShortID, s.Name, v),
+			AriaLabel:   label + " " + s.Name,
+		}
+	}
+	switch s.Status {
+	case service.SeriesStatusActive:
+		items = append(items, verdict("pause", "Pause", "pause", false), verdict("cancel", "Cancel", "x", true))
+	case service.SeriesStatusPaused:
+		items = append(items, verdict("confirm", "Resume", "play", false), verdict("cancel", "Cancel", "x", true))
+	case service.SeriesStatusCancelled:
+		items = append(items, verdict("confirm", "Reactivate", "rotate-ccw", false))
+	}
+	return items
 }
 
 // subscriptionsBetaBadge marks Recurring as a v1/beta feature.

--- a/internal/templates/components/pages/subscriptions_list_test.go
+++ b/internal/templates/components/pages/subscriptions_list_test.go
@@ -1,0 +1,112 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+// TestGroupSubscriptionsByStatus pins the ledger IA: rows bucket into
+// Active → Paused → Ended in that order, unknown statuses sink last in
+// first-seen order, row order is preserved within a group, and only the
+// Active group carries a monthly subtotal — single-currency only.
+func TestGroupSubscriptionsByStatus(t *testing.T) {
+	t.Run("orders groups active → paused → ended and preserves row order", func(t *testing.T) {
+		rows := []SubscriptionRow{
+			{ShortID: "p1", Status: "paused"},
+			{ShortID: "a1", Status: "active"},
+			{ShortID: "c1", Status: "cancelled"},
+			{ShortID: "a2", Status: "active"},
+		}
+		groups := GroupSubscriptionsByStatus(rows)
+		if len(groups) != 3 {
+			t.Fatalf("want 3 groups, got %d", len(groups))
+		}
+		wantOrder := []struct{ status, label string }{
+			{"active", "Active"},
+			{"paused", "Paused"},
+			{"cancelled", "Ended"},
+		}
+		for i, w := range wantOrder {
+			if groups[i].Status != w.status || groups[i].Label != w.label {
+				t.Errorf("group %d = (%q,%q), want (%q,%q)", i, groups[i].Status, groups[i].Label, w.status, w.label)
+			}
+		}
+		// Within the active group, incoming order (a1 before a2) is preserved.
+		active := groups[0]
+		if len(active.Rows) != 2 || active.Rows[0].ShortID != "a1" || active.Rows[1].ShortID != "a2" {
+			t.Errorf("active group rows = %+v, want [a1 a2]", active.Rows)
+		}
+	})
+
+	t.Run("empty input yields no groups", func(t *testing.T) {
+		if g := GroupSubscriptionsByStatus(nil); len(g) != 0 {
+			t.Errorf("want 0 groups for nil input, got %d", len(g))
+		}
+	})
+
+	t.Run("unknown status sinks last with a title-cased label", func(t *testing.T) {
+		rows := []SubscriptionRow{
+			{Status: "weird"},
+			{Status: "active"},
+		}
+		groups := GroupSubscriptionsByStatus(rows)
+		if len(groups) != 2 {
+			t.Fatalf("want 2 groups, got %d", len(groups))
+		}
+		if groups[0].Status != "active" {
+			t.Errorf("first group = %q, want active", groups[0].Status)
+		}
+		if groups[1].Status != "weird" || groups[1].Label != "Weird" {
+			t.Errorf("last group = (%q,%q), want (weird,Weird)", groups[1].Status, groups[1].Label)
+		}
+	})
+
+	t.Run("active group sums monthly equivalent for one currency", func(t *testing.T) {
+		rows := []SubscriptionRow{
+			{Status: "active", HasAmount: true, Currency: "USD", MonthlyEquiv: 10},
+			{Status: "active", HasAmount: true, Currency: "USD", MonthlyEquiv: 5.5},
+			{Status: "active", HasAmount: false, Currency: "USD", MonthlyEquiv: 99}, // no amount, ignored
+		}
+		g := GroupSubscriptionsByStatus(rows)[0]
+		if !g.HasSubtotal {
+			t.Fatal("want HasSubtotal=true for single-currency active group")
+		}
+		if g.SubtotalCurrency != "USD" {
+			t.Errorf("subtotal currency = %q, want USD", g.SubtotalCurrency)
+		}
+		if g.Subtotal != 15.5 {
+			t.Errorf("subtotal = %v, want 15.5", g.Subtotal)
+		}
+	})
+
+	t.Run("blank currency normalizes to USD for the single-currency check", func(t *testing.T) {
+		rows := []SubscriptionRow{
+			{Status: "active", HasAmount: true, Currency: "", MonthlyEquiv: 4},
+			{Status: "active", HasAmount: true, Currency: "USD", MonthlyEquiv: 6},
+		}
+		g := GroupSubscriptionsByStatus(rows)[0]
+		if !g.HasSubtotal || g.SubtotalCurrency != "USD" || g.Subtotal != 10 {
+			t.Errorf("got (has=%v cur=%q sub=%v), want (true USD 10)", g.HasSubtotal, g.SubtotalCurrency, g.Subtotal)
+		}
+	})
+
+	t.Run("mixed currencies suppress the subtotal", func(t *testing.T) {
+		rows := []SubscriptionRow{
+			{Status: "active", HasAmount: true, Currency: "USD", MonthlyEquiv: 10},
+			{Status: "active", HasAmount: true, Currency: "EUR", MonthlyEquiv: 5},
+		}
+		g := GroupSubscriptionsByStatus(rows)[0]
+		if g.HasSubtotal {
+			t.Errorf("want no subtotal across currencies, got %v %q", g.Subtotal, g.SubtotalCurrency)
+		}
+	})
+
+	t.Run("non-active groups never carry a subtotal", func(t *testing.T) {
+		rows := []SubscriptionRow{
+			{Status: "paused", HasAmount: true, Currency: "USD", MonthlyEquiv: 12},
+		}
+		g := GroupSubscriptionsByStatus(rows)[0]
+		if g.HasSubtotal {
+			t.Errorf("paused group should have no subtotal, got %v", g.Subtotal)
+		}
+	})
+}

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -3,6 +3,8 @@
 package pages
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"breadbox/internal/service"
@@ -267,4 +269,185 @@ type SubscriptionPriceChange struct {
 	From     float64
 	To       float64
 	Currency string
+}
+
+// SubscriptionStatusGroup is one status bucket of the ledger — Active, Paused,
+// or Ended — rendered as a quiet label line (status · count · optional monthly
+// subtotal) over its list-rows, the /accounts connection-group idiom applied to
+// the recurring surface. Status lives on the group header, so the rows below it
+// don't repeat a status badge.
+type SubscriptionStatusGroup struct {
+	Status string // active | paused | cancelled | (other, last)
+	Label  string // "Active" | "Paused" | "Ended"
+	Rows   []SubscriptionRow
+
+	// Subtotal is the group's monthly-equivalent spend. Only populated
+	// (HasSubtotal=true) for the Active group when every amount-bearing row
+	// shares a single currency — paused/ended series aren't billing monthly,
+	// and we never sum across iso_currency_code. SubtotalCurrency carries that
+	// shared currency for the renderer.
+	Subtotal         float64
+	SubtotalCurrency string
+	HasSubtotal      bool
+}
+
+// subscriptionStatusOrder is the canonical group order: active charges first,
+// then paused, then ended/cancelled. Any status outside this set sorts after
+// these, in first-seen order. Pure data so the grouping stays testable.
+var subscriptionStatusOrder = []struct{ status, label string }{
+	{service.SeriesStatusActive, "Active"},
+	{service.SeriesStatusPaused, "Paused"},
+	{service.SeriesStatusCancelled, "Ended"},
+}
+
+// GroupSubscriptionsByStatus buckets the ledger rows by status into Active →
+// Paused → Ended groups (unknown statuses appended last, first-seen order),
+// preserving the incoming row order within each group (the handler pre-sorts
+// Active by renewal urgency). The Active group carries a monthly-equivalent
+// subtotal when all its amount-bearing rows share one currency; never sums
+// across currencies. Pure function — unit-tested without a DB.
+func GroupSubscriptionsByStatus(rows []SubscriptionRow) []SubscriptionStatusGroup {
+	label := make(map[string]string, len(subscriptionStatusOrder))
+	rank := make(map[string]int, len(subscriptionStatusOrder))
+	keys := make([]string, 0, len(subscriptionStatusOrder))
+	for i, o := range subscriptionStatusOrder {
+		label[o.status] = o.label
+		rank[o.status] = i
+		keys = append(keys, o.status)
+	}
+
+	byStatus := make(map[string][]SubscriptionRow)
+	for _, r := range rows {
+		if _, known := label[r.Status]; !known {
+			if _, seen := byStatus[r.Status]; !seen {
+				keys = append(keys, r.Status) // unknown status, appended last
+			}
+		}
+		byStatus[r.Status] = append(byStatus[r.Status], r)
+	}
+
+	groups := make([]SubscriptionStatusGroup, 0, len(keys))
+	for _, st := range keys {
+		rs := byStatus[st]
+		if len(rs) == 0 {
+			continue
+		}
+		lbl := label[st]
+		if lbl == "" {
+			lbl = subscriptionStatusFallbackLabel(st)
+		}
+		g := SubscriptionStatusGroup{Status: st, Label: lbl, Rows: rs}
+		if st == service.SeriesStatusActive {
+			applySubscriptionMonthlySubtotal(&g)
+		}
+		groups = append(groups, g)
+	}
+	return groups
+}
+
+// applySubscriptionMonthlySubtotal fills the Active group's monthly-equivalent
+// subtotal — but only when every amount-bearing row shares one currency and the
+// total is positive. Mixed currencies leave the group subtotal-less rather than
+// summing across them.
+func applySubscriptionMonthlySubtotal(g *SubscriptionStatusGroup) {
+	sum := 0.0
+	cur := ""
+	single := true
+	any := false
+	for _, r := range g.Rows {
+		if !r.HasAmount {
+			continue
+		}
+		rc := r.Currency
+		if rc == "" {
+			rc = "USD"
+		}
+		if !any {
+			cur, any = rc, true
+		} else if rc != cur {
+			single = false
+		}
+		sum += r.MonthlyEquiv
+	}
+	if any && single && sum > 0 {
+		g.Subtotal = sum
+		g.SubtotalCurrency = cur
+		g.HasSubtotal = true
+	}
+}
+
+// subscriptionStatusFallbackLabel title-cases an unexpected status value so an
+// unknown bucket still renders a readable header.
+func subscriptionStatusFallbackLabel(status string) string {
+	if status == "" {
+		return "Other"
+	}
+	return strings.ToUpper(status[:1]) + status[1:]
+}
+
+// subscriptionsGroupCount renders the dimmed "N active charges" suffix on a
+// group header.
+func subscriptionsGroupCount(g SubscriptionStatusGroup) string {
+	noun := "charge"
+	if len(g.Rows) != 1 {
+		noun = "charges"
+	}
+	return fmt.Sprintf("%d %s", len(g.Rows), noun)
+}
+
+// subscriptionsRowBodyLine is the row's single body line — cadence then the next
+// renewal date ("Monthly · next Jun 28"). Falls back to a dash so the line is
+// never empty.
+func subscriptionsRowBodyLine(s SubscriptionRow) string {
+	parts := make([]string, 0, 2)
+	if s.CadenceLabel != "" {
+		parts = append(parts, s.CadenceLabel)
+	}
+	if s.NextExpected != "" {
+		parts = append(parts, "next "+s.NextExpected)
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, " · ")
+}
+
+// subStatusTileBg / subStatusTileIcon / subStatusTileIconColor map a series
+// status to its leading status-tile treatment (principle #2 — status lives in
+// one color-coded tile). Active is the only vivid-success state; paused warns;
+// ended is a muted, non-error terminal state (a deliberate cancellation isn't an
+// error, so it stays neutral rather than red).
+func subStatusTileBg(status string) string {
+	switch status {
+	case service.SeriesStatusActive:
+		return "bg-success/10"
+	case service.SeriesStatusPaused:
+		return "bg-warning/10"
+	default:
+		return "bg-base-200"
+	}
+}
+
+func subStatusTileIcon(status string) string {
+	switch status {
+	case service.SeriesStatusActive:
+		return "repeat"
+	case service.SeriesStatusPaused:
+		return "pause"
+	case service.SeriesStatusCancelled:
+		return "circle-slash-2"
+	default:
+		return "repeat"
+	}
+}
+
+func subStatusTileIconColor(status string) string {
+	switch status {
+	case service.SeriesStatusActive:
+		return "text-success"
+	case service.SeriesStatusPaused:
+		return "text-warning"
+	default:
+		return "text-base-content/50"
+	}
 }

--- a/static/js/admin/components/subscriptions.js
+++ b/static/js/admin/components/subscriptions.js
@@ -92,6 +92,22 @@
           return (el.dataset.search || '').indexOf(this.filter.toLowerCase()) !== -1;
         },
 
+        // Whether a status group still has a visible row under the active
+        // member / type / search filters. Drives the group wrapper's x-show so
+        // a status header never dangles over an empty card. Reads the three
+        // filter properties so Alpine re-evaluates when any of them change; the
+        // DOM scan is over the group's static rows.
+        groupVisible: function (el) {
+          var rows = el.querySelectorAll('[data-series-card]');
+          for (var i = 0; i < rows.length; i++) {
+            var r = rows[i];
+            var userOk = this.filterUser === 'all' || this.filterUser === r.dataset.filterUser;
+            var typeOk = this.filterType === 'all' || this.filterType === r.dataset.type;
+            if (userOk && typeOk && this.matches(r)) return true;
+          }
+          return false;
+        },
+
         submitVerdict: function (seriesId, seriesName, verdict) {
           var label = {
             confirm: 'Confirmed',


### PR DESCRIPTION
Surface redesign (design-system loop): the `/recurring` ledger moves from a data table to status-grouped **list-rows**.

## What changed
- **Table → grouped list-rows** (`subscriptionsListRow` in `bb-card`s). 
- **Leading status IconTile** (vivid per the badge-tone rule): active → success (`repeat`), paused → warning (`pause`), cancelled/ended → muted (`circle-slash-2`) — a deliberate cancellation is terminal/inactive, not an error, so it stays neutral.
- Title = charge name (+ `SeriesTypeChip` + renewal chip: due-soon/overdue/stale + a price-rising chip); one body line = cadence · next-renewal; right = privacy-aware `Amount` (`AmountCost`) + `OverflowMenu` (View / Pause-Resume / Cancel) outside the row link; row → `/recurring/{id}`.
- **IA: grouped by status** (Active → Paused → Ended). The **Active** group header shows a single-currency **monthly-equivalent subtotal (`/mo`)** — suppressed when rows span >1 currency (never sums across `iso_currency_code`), never on Paused/Ended. Pure unit-tested `GroupSubscriptionsByStatus`.
- Existing member/type `join` filters + search preserved; a `groupVisible` helper hides a status header when all its rows are filtered out. Principle #8 hover/focus applied.

`go build` / `go vet` / `go test ./...` green (31 pkgs, new grouping test with 7 subtests).

Deferred: reactive per-group counts under client filters.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/8db7e22384c39ddb.jpeg" width="800" alt="/recurring redesigned as status-grouped list-rows with monthly-equivalent subtotal">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
