### PR TITLE
feat(categories): rebuild /categories on the list-row language (hierarchy-aware)

### DIFF
--- a/internal/templates/components/categories_skeleton.templ
+++ b/internal/templates/components/categories_skeleton.templ
@@ -2,15 +2,16 @@ package components
 
 // CategoriesSkeleton renders a placeholder mirroring the layout of the
 // /categories page — a filter search input, the "N top-level categories"
-// helper line, and a divided card with parent rows plus a few expanded
-// subcategory groups underneath. Sized to match the real component so a
-// future swap-in (AJAX refresh, picker preview, adjacent panel) doesn't
-// shift layout.
+// helper line, and a stack of per-group cards. Each group card is a daisy
+// `list` of list-rows: an emphasized parent row (color tile + name/descriptor
+// stack + overflow slot) followed by indented subcategory rows. Sized to
+// match the real component so a future swap-in (AJAX refresh, picker preview,
+// adjacent panel) doesn't shift layout.
 //
 // /categories is a full-SSR page today; this primitive is exposed in
-// /design#loading so it's ready for the eventual AJAX swap and
-// discoverable to anyone wiring loading states for adjacent
-// category-centric panels (e.g. the category picker).
+// /design#loading so it's ready for the eventual AJAX swap and discoverable
+// to anyone wiring loading states for adjacent category-centric panels (e.g.
+// the category picker).
 //
 // Uses the daisy `skeleton` primitive (per .claude/rules/daisyui.md, the
 // hand-rolled `bb-skeleton*` family is being retired).
@@ -22,66 +23,38 @@ templ CategoriesSkeleton() {
 		<div class="px-1">
 			<div class="skeleton h-2.5 w-32"></div>
 		</div>
-		<!-- Categories list card -->
-		<div class="bb-card overflow-hidden">
-			<div class="divide-y divide-base-300/40">
-				@categoriesSkeletonParent(true, 3)
-				@categoriesSkeletonParent(false, 0)
-				@categoriesSkeletonParent(true, 2)
-				@categoriesSkeletonParent(false, 0)
-				@categoriesSkeletonParent(false, 0)
-			</div>
+		<!-- Per-group cards: a parent lead row over indented subcategory rows -->
+		<div class="flex flex-col gap-3">
+			@categoriesSkeletonGroup(3)
+			@categoriesSkeletonGroup(0)
+			@categoriesSkeletonGroup(2)
 		</div>
 	</div>
 }
 
-// categoriesSkeletonParent mirrors one top-level category row: large icon
-// tile + chevron + display name + optional child-count badge + overflow
-// menu. When `childCount > 0`, a sub-list of indented child rows is
-// rendered below it to match the expanded state.
-templ categoriesSkeletonParent(expanded bool, childCount int) {
-	<div>
-		<!-- Parent row -->
-		<div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3">
-			<!-- Large icon tile -->
-			<div class="skeleton w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"></div>
-			<div class="flex items-center gap-2 min-w-0 flex-1">
-				<!-- Chevron placeholder -->
-				<div class="skeleton w-3.5 h-3.5 rounded shrink-0"></div>
-				<!-- Display name -->
+// categoriesSkeletonGroup mirrors one group card: the parent list-row plus
+// `childCount` indented subcategory list-rows.
+templ categoriesSkeletonGroup(childCount int) {
+	<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+		<!-- Parent lead row -->
+		<li class="list-row items-center">
+			<div class="skeleton w-9 h-9 rounded-xl shrink-0"></div>
+			<div class="min-w-0 space-y-1.5">
 				<div class="skeleton h-3.5 w-40 sm:w-48"></div>
-				if childCount > 0 {
-					<!-- Child-count pill -->
-					<div class="skeleton h-4 w-6 rounded-full shrink-0"></div>
-				}
+				<div class="skeleton h-2.5 w-24"></div>
 			</div>
-			<!-- Overflow menu -->
-			<div class="skeleton h-6 w-6 rounded shrink-0"></div>
-		</div>
-		if expanded && childCount > 0 {
-			<!-- Expanded subcategory list -->
-			<div class="border-t border-base-300/30 bg-base-200/20">
-				for i := 0; i < childCount; i++ {
-					@categoriesSkeletonChild()
-				}
-			</div>
+			<div class="skeleton h-6 w-6 ml-auto self-center"></div>
+		</li>
+		for i := 0; i < childCount; i++ {
+			<!-- Indented subcategory row -->
+			<li class="list-row items-center pl-12 sm:pl-14">
+				<div class="skeleton w-8 h-8 rounded-xl shrink-0"></div>
+				<div class="min-w-0 space-y-1.5">
+					<div class="skeleton h-3 w-28 sm:w-36"></div>
+					<div class="skeleton h-2.5 w-20"></div>
+				</div>
+				<div class="skeleton h-6 w-6 ml-auto self-center"></div>
+			</li>
 		}
-	</div>
-}
-
-// categoriesSkeletonChild mirrors one subcategory row: indented padding,
-// small icon tile, display name, and trailing overflow-menu slot. Width
-// of the name placeholder is narrower than the parent so the skeleton
-// reads as a real hierarchy at a glance.
-templ categoriesSkeletonChild() {
-	<div class="flex items-center gap-3 sm:gap-4 pl-10 sm:pl-14 pr-4 sm:pr-5 py-2.5">
-		<!-- Small icon tile -->
-		<div class="skeleton w-7 h-7 sm:w-8 sm:h-8 rounded-lg shrink-0"></div>
-		<div class="flex items-center gap-2 min-w-0 flex-1">
-			<!-- Subcategory name (narrower than parent) -->
-			<div class="skeleton h-3 w-28 sm:w-36"></div>
-		</div>
-		<!-- Overflow menu -->
-		<div class="skeleton h-6 w-6 rounded shrink-0"></div>
-	</div>
+	</ul>
 }

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
 
@@ -16,6 +15,15 @@ import (
 // This is a purely configuration-focused page: no period selector, no
 // spending totals, no per-category amounts. Users manage the two-level
 // taxonomy here; spending analytics live on the Insights page.
+//
+// IA (Workflows-DNA surface language): one bb-card of list-rows per
+// top-level category — the parent as the emphasized lead row, its
+// subcategories as indented rows beneath. Each row leads with the
+// category's own color/icon tile (the bb-tx-avatar data-color mechanism),
+// names the category as the title, carries a muted descriptor (subcategory
+// count for parents · slug for children), and ends with an OverflowMenu
+// (edit/delete) rendered OUTSIDE the row link. The whole row links to the
+// category's edit page.
 //
 // The categoriesPage Alpine factory + j/k/Enter/Space/e/n keyboard
 // shortcuts live in static/js/admin/components/categories.js. Loaded
@@ -46,14 +54,12 @@ templ Categories(p CategoriesProps) {
 		})
 		if len(p.Categories) > 0 {
 			<div class="text-xs text-base-content/40 px-1">
-				{ fmt.Sprintf("%d top-level categories", len(p.Categories)) }
+				{ categoriesTopLevelLabel(len(p.Categories)) }
 			</div>
-			<div class="bb-card overflow-hidden">
-				<div class="divide-y divide-base-300/40">
-					for _, parent := range p.Categories {
-						@categoryRow(parent)
-					}
-				</div>
+			<div class="flex flex-col gap-3">
+				for _, g := range BuildCategoryGroups(p.Categories) {
+					@categoryGroup(g)
+				}
 			</div>
 		} else {
 			@categoriesEmpty()
@@ -73,155 +79,115 @@ templ Categories(p CategoriesProps) {
 	</script>
 }
 
-// categoryRow renders one top-level category with its expandable child list.
-templ categoryRow(c service.CategoryResponse) {
-	<div data-search={ categorySearchIndex(c) } x-show="matches($el)">
-		<div
-			role="button"
-			tabindex="0"
-			data-category-row
-			data-category-level="primary"
-			data-category-id={ c.ID }
-			data-category-slug={ c.Slug }
-			class="group flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 hover:bg-base-200/30 transition-colors duration-150 cursor-pointer select-none"
-			@click={ fmt.Sprintf("toggle('%s')", c.ID) }
+// categoryGroup renders one top-level category and its subcategories as a
+// single card of list-rows. The wrapper carries the combined data-search
+// index so the Alpine filter can hide a whole group when neither the parent
+// nor any child matches.
+templ categoryGroup(g CategoryGroup) {
+	<div data-search={ g.Parent.Search } x-show="matches($el)">
+		@components.AgentRunRowList() {
+			@categoryRow(g.Parent)
+			for _, ch := range g.Children {
+				@categoryRow(ch)
+			}
+		}
+	</div>
+}
+
+// categoryRow renders one category — parent or child — as a daisy list-row.
+// Child rows indent so the hierarchy reads at a glance; the leading tile,
+// title, descriptor, badges, and trailing overflow menu are otherwise the
+// same shape for both levels.
+templ categoryRow(r CategoryRowVM) {
+	<li
+		class={ "list-row transition-colors hover:bg-base-200/40 items-center",
+			templ.KV("pl-12 sm:pl-14", r.IsChild) }
+		data-category-row
+		data-category-level={ categoryRowLevel(r) }
+		data-category-id={ r.ID }
+		data-category-slug={ r.Slug }
+		data-search={ r.Search }
+		x-show="matches($el)"
+	>
+		<a
+			class="contents no-underline focus:outline-none"
+			href={ templ.SafeURL(fmt.Sprintf("/categories/%s/edit", r.ID)) }
 		>
-			@categoryIconTile(c, false)
-			<div class="flex items-center gap-2 min-w-0 flex-1">
-				<i
-					data-lucide="chevron-right"
-					class="w-3.5 h-3.5 text-base-content opacity-30 transition-transform duration-200 shrink-0"
-					:class={ fmt.Sprintf("isOpen('%s') ? 'rotate-90' : ''", c.ID) }
-				></i>
-				<span class={ "font-semibold text-sm truncate", templ.KV("text-base-content/40", c.IsSystem), templ.KV("text-base-content/40 italic", c.Hidden && !c.IsSystem) }>
-					{ c.DisplayName }
-				</span>
-				if len(c.Children) > 0 {
-					<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40 shrink-0">
-						{ strconv.Itoa(len(c.Children)) }
-					</span>
-				}
-				if c.IsSystem {
-					<span class="badge badge-ghost badge-xs">System</span>
-				}
-				if c.Hidden {
-					<span class="badge badge-ghost badge-xs">Hidden</span>
-				}
-			</div>
-			<div class="flex items-center justify-end shrink-0" @click.stop>
-				@categoryRowActions(c, false)
-			</div>
-		</div>
-		if len(c.Children) > 0 {
-			<div x-show={ fmt.Sprintf("isOpen('%s')", c.ID) } x-cloak x-collapse>
-				<div class="border-t border-base-300/30 bg-base-200/20">
-					for _, child := range c.Children {
-						@categoryChildRow(child)
+			@categoryColorTile(r)
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class={ categoryNameClass(r) }>{ r.DisplayName }</span>
+					if !r.IsChild && r.ChildCount > 0 {
+						<span class="badge badge-ghost badge-xs shrink-0">{ strconv.Itoa(r.ChildCount) }</span>
+					}
+					if r.IsSystem {
+						<span class="badge badge-ghost badge-xs shrink-0">System</span>
+					}
+					if r.Hidden {
+						<span class="badge badge-soft badge-warning badge-xs shrink-0">Hidden</span>
 					}
 				</div>
+				<div class="mt-0.5 text-xs text-base-content/45 truncate">{ categoryRowDescriptor(r) }</div>
 			</div>
-		} else {
-			<div x-show={ fmt.Sprintf("expanded['%s']", c.ID) } x-cloak x-collapse>
-				<div class="border-t border-base-300/30 bg-base-200/20 py-3 pl-14 sm:pl-20 pr-5">
-					<p class="text-sm text-base-content/30 italic">No subcategories</p>
-				</div>
-			</div>
-		}
-	</div>
+		</a>
+		<div class="shrink-0 self-center">
+			@categoryRowActions(r)
+		</div>
+	</li>
 }
 
-// categoryChildRow renders one subcategory beneath its parent.
-templ categoryChildRow(c service.CategoryResponse) {
-	<div
-		data-search={ categoryChildSearchIndex(c) }
-		data-category-row
-		data-category-level="sub"
-		data-category-id={ c.ID }
-		data-category-slug={ c.Slug }
-		x-show="matches($el)"
-		class="group flex items-center gap-3 sm:gap-4 pl-10 sm:pl-14 pr-4 sm:pr-5 py-2.5 hover:bg-base-200/30 transition-colors duration-150"
-	>
-		@categoryIconTile(c, true)
-		<div class="flex items-center gap-2 min-w-0 flex-1">
-			<span class={ "text-sm truncate", templ.KV("text-base-content/40 italic", c.Hidden) }>
-				{ c.DisplayName }
-			</span>
-			if c.Hidden {
-				<span class="badge badge-ghost badge-xs">Hidden</span>
+// categoryColorTile renders the leading identity tile using the category's
+// own color + icon, via the shared bb-tx-avatar data-color mechanism
+// (`--avatar-color` drives a color-mix background + the glyph tint, with
+// per-theme tuning handled by the CSS). Colorless categories fall back to
+// the neutral `bb-tx-avatar--uncategorized` tile with a tag glyph. Child
+// rows use the smaller `--sm` variant.
+templ categoryColorTile(r CategoryRowVM) {
+	if r.Color != "" || r.Icon != "" {
+		<div class={ categoryTileClass(r.IsChild) } style={ categoryTileColorStyle(r.Color) }>
+			if r.Icon != "" {
+				@components.LucideIcon(r.Icon, categoryTileIconClass(r.IsChild))
+			} else {
+				@components.LucideIcon("folder", categoryTileIconClass(r.IsChild))
 			}
 		</div>
-		<div class="flex items-center justify-end shrink-0" @click.stop>
-			@categoryRowActions(c, true)
-		</div>
-	</div>
-}
-
-// categoryIconTile renders the colored square icon tile at the start of
-// each row. Parent rows use the larger 9–10 geometry; child rows use 7–8.
-templ categoryIconTile(c service.CategoryResponse, child bool) {
-	if child {
-		<div class="flex items-center justify-center w-7 h-7 sm:w-8 sm:h-8 rounded-lg shrink-0" style={ categoryTileBg(c.Color, true) }>
-			@categoryTileInner(c, true)
-		</div>
 	} else {
-		<div class="flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0" style={ categoryTileBg(c.Color, false) }>
-			@categoryTileInner(c, false)
+		<div class={ categoryTileClass(r.IsChild) + " bb-tx-avatar--uncategorized" }>
+			@components.LucideIcon("tag", categoryTileIconClass(r.IsChild))
 		</div>
-	}
-}
-
-templ categoryTileInner(c service.CategoryResponse, child bool) {
-	if c.Icon != nil && *c.Icon != "" {
-		if child {
-			@components.LucideIconWithStyle(*c.Icon, "w-3.5 h-3.5", categoryIconColor(c.Color))
-		} else {
-			@components.LucideIconWithStyle(*c.Icon, "w-5 h-5", categoryIconColor(c.Color))
-		}
-	} else if c.Color != nil && *c.Color != "" {
-		if child {
-			<span class="w-2 h-2 rounded-full" style={ fmt.Sprintf("background-color: %s", *c.Color) }></span>
-		} else {
-			<span class="w-3 h-3 rounded-full" style={ fmt.Sprintf("background-color: %s", *c.Color) }></span>
-		}
-	} else {
-		if child {
-			<span class="w-2 h-2 rounded-full bg-base-content/20"></span>
-		} else {
-			@components.LucideIcon("tag", "w-5 h-5 text-primary opacity-60")
-		}
 	}
 }
 
 // categoryRowActions emits the trailing edit/delete controls as a single
 // always-visible kebab menu so actions are reachable on every viewport
-// (mouse, touch, keyboard). Matches the pattern used on /tags (PR #728).
-templ categoryRowActions(c service.CategoryResponse, child bool) {
+// (mouse, touch, keyboard), rendered outside the row's navigation anchor so
+// the menu button isn't swallowed by the row link.
+templ categoryRowActions(r CategoryRowVM) {
 	@components.OverflowMenu(components.OverflowMenuProps{
-		AriaLabel: fmt.Sprintf("Category %s actions", c.DisplayName),
-		Size:      "xs",
-		Items:     categoryRowItems(c),
+		AriaLabel: fmt.Sprintf("Category %s actions", r.DisplayName),
+		Size:      "sm",
+		Items:     categoryRowItems(r),
 	})
 }
 
 // categoryRowItems builds the Edit (+ optional Delete) items for one
-// category row. System categories omit Delete entirely (same as the
-// inline version we replaced).
-func categoryRowItems(c service.CategoryResponse) []components.OverflowMenuItem {
+// category row. System categories omit Delete entirely.
+func categoryRowItems(r CategoryRowVM) []components.OverflowMenuItem {
 	items := []components.OverflowMenuItem{
 		{
 			Label:     "Edit",
 			Icon:      "pencil",
-			Href:      templ.SafeURL(fmt.Sprintf("/categories/%s/edit", c.ID)),
-			AriaLabel: fmt.Sprintf("Edit category %s", c.DisplayName),
+			Href:      templ.SafeURL(fmt.Sprintf("/categories/%s/edit", r.ID)),
+			AriaLabel: fmt.Sprintf("Edit category %s", r.DisplayName),
 		},
 	}
-	if !c.IsSystem {
+	if !r.IsSystem {
 		items = append(items, components.OverflowMenuItem{
 			Label:       "Delete",
 			Icon:        "trash-2",
-			OnClick:     fmt.Sprintf("$dispatch('delete-category', {id: '%s', name: '%s'})", jsEscape(c.ID), jsEscape(c.DisplayName)),
+			OnClick:     fmt.Sprintf("$dispatch('delete-category', {id: '%s', name: '%s'})", jsEscape(r.ID), jsEscape(r.DisplayName)),
 			Destructive: true,
-			AriaLabel:   fmt.Sprintf("Delete category %s", c.DisplayName),
+			AriaLabel:   fmt.Sprintf("Delete category %s", r.DisplayName),
 		})
 	}
 	return items
@@ -283,27 +249,56 @@ templ deleteCategoryModal() {
 	</dialog>
 }
 
-// categoryTileBg returns a background-color style string for the icon tile.
-// When a category has a color it's used at ~12% alpha; otherwise a neutral
-// default matches the old html/template rendering.
-func categoryTileBg(color *string, child bool) string {
-	if color != nil && *color != "" {
-		if child {
-			return fmt.Sprintf("background-color: %s12", *color)
-		}
-		return fmt.Sprintf("background-color: %s18", *color)
+// categoryRowLevel returns the data-category-level value the keyboard
+// navigation in categories.js reads ("primary" / "sub").
+func categoryRowLevel(r CategoryRowVM) string {
+	if r.IsChild {
+		return "sub"
 	}
-	if child {
-		return ""
-	}
-	return "background-color: oklch(48% 0.17 265 / 0.08)"
+	return "primary"
 }
 
-// categoryIconColor returns a text-color style string for a colored icon,
-// or empty when the category has no color set.
-func categoryIconColor(color *string) string {
-	if color == nil || *color == "" {
+// categoryNameClass styles the row title: parents read heavier than
+// children; system + hidden categories dim (hidden also italic) so the
+// taxonomy's inactive corners recede.
+func categoryNameClass(r CategoryRowVM) string {
+	weight := "font-medium"
+	if !r.IsChild {
+		weight = "font-semibold"
+	}
+	tone := "text-base-content"
+	switch {
+	case r.IsSystem:
+		tone = "text-base-content/55"
+	case r.Hidden:
+		tone = "text-base-content/55 italic"
+	}
+	return "truncate text-sm " + weight + " " + tone
+}
+
+// categoryTileClass returns the bb-tx-avatar tile class; child rows use the
+// smaller --sm variant.
+func categoryTileClass(child bool) string {
+	if child {
+		return "bb-tx-avatar bb-tx-avatar--sm"
+	}
+	return "bb-tx-avatar"
+}
+
+// categoryTileIconClass sizes the glyph inside the tile to match the tile.
+func categoryTileIconClass(child bool) string {
+	if child {
+		return "w-3.5 h-3.5"
+	}
+	return "w-4 h-4"
+}
+
+// categoryTileColorStyle binds the category's color to the bb-tx-avatar
+// `--avatar-color` custom property (empty when the category has no color, so
+// the CSS fallback applies).
+func categoryTileColorStyle(color string) string {
+	if color == "" {
 		return ""
 	}
-	return fmt.Sprintf("color: %s", *color)
+	return "--avatar-color: " + color
 }

--- a/internal/templates/components/pages/categories_test.go
+++ b/internal/templates/components/pages/categories_test.go
@@ -1,0 +1,135 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+func strptr(s string) *string { return &s }
+
+func TestBuildCategoryGroups(t *testing.T) {
+	cats := []service.CategoryResponse{
+		{
+			ID:          "p1",
+			Slug:        "food-dining",
+			DisplayName: "Food & Dining",
+			Color:       strptr("#22c55e"),
+			Icon:        strptr("utensils"),
+			Children: []service.CategoryResponse{
+				{ID: "c1", Slug: "groceries", DisplayName: "Groceries", Color: strptr("#16a34a")},
+				{ID: "c2", Slug: "restaurants", DisplayName: "Restaurants", Hidden: true},
+			},
+		},
+		{
+			ID:          "p2",
+			Slug:        "income",
+			DisplayName: "Income",
+			IsSystem:    true,
+			// No children — childless parent.
+		},
+	}
+
+	groups := BuildCategoryGroups(cats)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(groups))
+	}
+
+	// Order preserved from the service layer.
+	if groups[0].Parent.ID != "p1" || groups[1].Parent.ID != "p2" {
+		t.Fatalf("group order not preserved: %q, %q", groups[0].Parent.ID, groups[1].Parent.ID)
+	}
+
+	// Parent VM: flattened color/icon, child count, not-a-child.
+	p := groups[0].Parent
+	if p.IsChild {
+		t.Error("parent flagged as child")
+	}
+	if p.ChildCount != 2 {
+		t.Errorf("ChildCount = %d, want 2", p.ChildCount)
+	}
+	if p.Color != "#22c55e" || p.Icon != "utensils" {
+		t.Errorf("parent color/icon = %q/%q, want #22c55e/utensils", p.Color, p.Icon)
+	}
+
+	// Childless system parent.
+	sys := groups[1].Parent
+	if sys.ChildCount != 0 || !sys.IsSystem {
+		t.Errorf("system parent: ChildCount=%d IsSystem=%v, want 0/true", sys.ChildCount, sys.IsSystem)
+	}
+	if len(groups[1].Children) != 0 {
+		t.Errorf("childless parent has %d children, want 0", len(groups[1].Children))
+	}
+
+	// Children: flagged, carry parent name, colorless one resolves to "".
+	kids := groups[0].Children
+	if len(kids) != 2 {
+		t.Fatalf("got %d children, want 2", len(kids))
+	}
+	if !kids[0].IsChild || kids[0].ParentName != "Food & Dining" {
+		t.Errorf("child[0]: IsChild=%v ParentName=%q", kids[0].IsChild, kids[0].ParentName)
+	}
+	if kids[1].Color != "" {
+		t.Errorf("colorless child Color = %q, want empty", kids[1].Color)
+	}
+	if !kids[1].Hidden {
+		t.Error("hidden child not flagged hidden")
+	}
+
+	// Parent search index folds in every child so the header stays visible
+	// when a filter matches a subcategory.
+	for _, want := range []string{"food & dining", "food-dining", "groceries", "restaurants"} {
+		if !strings.Contains(p.Search, want) {
+			t.Errorf("parent Search missing %q: %q", want, p.Search)
+		}
+	}
+	// Child search index folds in the parent name so a parent-name filter
+	// keeps the children visible.
+	if !strings.Contains(kids[0].Search, "groceries") || !strings.Contains(kids[0].Search, "food & dining") {
+		t.Errorf("child Search missing own name or parent: %q", kids[0].Search)
+	}
+}
+
+func TestCategoryRowDescriptor(t *testing.T) {
+	tests := []struct {
+		name string
+		r    CategoryRowVM
+		want string
+	}{
+		{"child shows slug", CategoryRowVM{IsChild: true, Slug: "groceries"}, "groceries"},
+		{"parent none", CategoryRowVM{ChildCount: 0}, "No subcategories"},
+		{"parent one", CategoryRowVM{ChildCount: 1}, "1 subcategory"},
+		{"parent many", CategoryRowVM{ChildCount: 4}, "4 subcategories"},
+	}
+	for _, tc := range tests {
+		if got := categoryRowDescriptor(tc.r); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCategoriesTopLevelLabel(t *testing.T) {
+	if got := categoriesTopLevelLabel(1); got != "1 top-level category" {
+		t.Errorf("singular: got %q", got)
+	}
+	if got := categoriesTopLevelLabel(3); got != "3 top-level categories" {
+		t.Errorf("plural: got %q", got)
+	}
+}
+
+func TestCategoryNameClass(t *testing.T) {
+	// Parent reads heavier than a child.
+	if cls := categoryNameClass(CategoryRowVM{}); !strings.Contains(cls, "font-semibold") {
+		t.Errorf("parent class missing font-semibold: %q", cls)
+	}
+	if cls := categoryNameClass(CategoryRowVM{IsChild: true}); !strings.Contains(cls, "font-medium") {
+		t.Errorf("child class missing font-medium: %q", cls)
+	}
+	// Hidden dims + italicizes.
+	if cls := categoryNameClass(CategoryRowVM{Hidden: true}); !strings.Contains(cls, "italic") {
+		t.Errorf("hidden class missing italic: %q", cls)
+	}
+}

--- a/internal/templates/components/pages/categories_types.go
+++ b/internal/templates/components/pages/categories_types.go
@@ -3,33 +3,124 @@
 package pages
 
 import (
+	"fmt"
 	"strings"
 
 	"breadbox/internal/service"
 )
 
-// CategoriesProps mirrors the data map the old categories.html read. The
-// page is purely configuration-focused — no spending data or period
-// selector — so only the category tree is needed.
+// CategoriesProps mirrors the data the /categories page reads. The page is
+// purely configuration-focused — no spending data or period selector — so
+// only the category tree is needed. BuildCategoryGroups flattens it into the
+// render model the templ consumes.
 type CategoriesProps struct {
 	Categories []service.CategoryResponse
 }
 
-// categorySearchIndex returns a single space-joined lowercase string
-// containing the parent's display name / slug plus every child's display
-// name / slug. Rendered into a `data-search` attribute so the Alpine
-// filter input can match on any term with one includes() call.
-func categorySearchIndex(c service.CategoryResponse) string {
-	parts := make([]string, 0, 2+len(c.Children)*2)
-	parts = append(parts, c.DisplayName, c.Slug)
-	for _, ch := range c.Children {
-		parts = append(parts, ch.DisplayName, ch.Slug)
-	}
-	return strings.ToLower(strings.Join(parts, " "))
+// CategoryRowVM is the flattened view-model for one category list-row —
+// parent or child. Pointer fields on service.CategoryResponse are
+// dereferenced here so the templ never nil-checks per cell, and the
+// per-row `data-search` index is precomputed so the Alpine filter matches
+// with one includes() call.
+type CategoryRowVM struct {
+	ID          string
+	Slug        string
+	DisplayName string
+	Color       string // resolved color (hex/oklch), "" when none set
+	Icon        string // resolved lucide name, "" when none set
+	IsSystem    bool
+	Hidden      bool
+	IsChild     bool
+	ChildCount  int    // parents only — drives the count pill
+	ParentName  string // children only — folded into Search + reads as context
+	Search      string // lowercase data-search index for the Alpine filter
 }
 
-// categoryChildSearchIndex is the child-row analogue: just the child's own
-// display name and slug, lowercased for direct substring matching.
-func categoryChildSearchIndex(c service.CategoryResponse) string {
-	return strings.ToLower(c.DisplayName + " " + c.Slug)
+// CategoryGroup is one top-level category (the lead/parent row) plus its
+// subcategory rows. One group renders as a single bb-card of list-rows: the
+// parent as the emphasized first row, its children indented beneath.
+type CategoryGroup struct {
+	Parent   CategoryRowVM
+	Children []CategoryRowVM
+}
+
+// BuildCategoryGroups flattens the service category tree into the page's
+// render model — one group per top-level category, each carrying a parent
+// row VM and its subcategory row VMs. Order is preserved from the service
+// layer (DB sort_order). Pure, so the IA is unit-testable without a DB.
+//
+// The parent's Search index folds in every child so the parent header stays
+// visible when a filter matches one of its subcategories; each child's index
+// folds in the parent name so a parent-name filter keeps the children
+// visible too.
+func BuildCategoryGroups(cats []service.CategoryResponse) []CategoryGroup {
+	groups := make([]CategoryGroup, 0, len(cats))
+	for _, parent := range cats {
+		pv := categoryRowVM(parent, false, "")
+		pv.ChildCount = len(parent.Children)
+
+		searchParts := []string{parent.DisplayName, parent.Slug}
+		children := make([]CategoryRowVM, 0, len(parent.Children))
+		for _, ch := range parent.Children {
+			cv := categoryRowVM(ch, true, parent.DisplayName)
+			cv.Search = strings.ToLower(strings.Join(
+				[]string{ch.DisplayName, ch.Slug, parent.DisplayName}, " "))
+			children = append(children, cv)
+			searchParts = append(searchParts, ch.DisplayName, ch.Slug)
+		}
+		pv.Search = strings.ToLower(strings.Join(searchParts, " "))
+
+		groups = append(groups, CategoryGroup{Parent: pv, Children: children})
+	}
+	return groups
+}
+
+// categoryRowVM builds the shared row view-model. Search is set by the
+// caller (it needs sibling/parent context).
+func categoryRowVM(c service.CategoryResponse, child bool, parentName string) CategoryRowVM {
+	return CategoryRowVM{
+		ID:          c.ID,
+		Slug:        c.Slug,
+		DisplayName: c.DisplayName,
+		Color:       categoryDeref(c.Color),
+		Icon:        categoryDeref(c.Icon),
+		IsSystem:    c.IsSystem,
+		Hidden:      c.Hidden,
+		IsChild:     child,
+		ParentName:  parentName,
+	}
+}
+
+func categoryDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return strings.TrimSpace(*s)
+}
+
+// categoriesTopLevelLabel renders the dimmed "N top-level categories" helper
+// line above the groups.
+func categoriesTopLevelLabel(n int) string {
+	if n == 1 {
+		return "1 top-level category"
+	}
+	return fmt.Sprintf("%d top-level categories", n)
+}
+
+// categoryRowDescriptor returns the muted one-line descriptor under a row's
+// name: the subcategory count for a parent (the entity's shape at a glance),
+// the slug for a child (its stable handle, the value rules and
+// /transactions?category= reference).
+func categoryRowDescriptor(r CategoryRowVM) string {
+	if r.IsChild {
+		return r.Slug
+	}
+	switch r.ChildCount {
+	case 0:
+		return "No subcategories"
+	case 1:
+		return "1 subcategory"
+	default:
+		return fmt.Sprintf("%d subcategories", r.ChildCount)
+	}
 }

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1074,7 +1074,7 @@ templ SectionLoading() {
 				@components.TagsSkeleton()
 			</div>
 		}
-		@designExample("Categories skeleton", "Placeholder mirroring /categories — filter input, helper line, and a divided card with parent rows plus expanded subcategory groups. Primitive is exposed here for future AJAX swaps and adjacent category-centric panels (e.g. category picker); /categories is full-SSR today.") {
+		@designExample("Categories skeleton", "Placeholder mirroring /categories — filter input, helper line, and one card per top-level category (an emphasized parent list-row over indented subcategory rows). Primitive is exposed here for future AJAX swaps and adjacent category-centric panels (e.g. category picker); /categories is full-SSR today.") {
 			<div class="max-w-3xl">
 				@components.CategoriesSkeleton()
 			</div>

--- a/static/js/admin/components/categories.js
+++ b/static/js/admin/components/categories.js
@@ -2,10 +2,14 @@
 //
 // Convention reference: docs/design-system.md → "Alpine page components".
 //
-// Owns the per-instance filter / expansion state and the j/k focus ring
-// for the category tree. The shared base.html shortcuts dispatcher routes
+// Owns the per-instance filter state and the j/k focus ring for the
+// category list. The shared base.html shortcuts dispatcher routes
 // j/k/Enter/Space/e/n to the registered handlers when the page scope is
 // 'categories' (set by the sibling x-init scope-setter div in templ).
+//
+// The list is always fully expanded now (no accordion — the page IS the
+// disclosure): each top-level category and its subcategories render as
+// list-rows in a card, and every row links to the category's edit page.
 //
 // Keyboard registrations and the document-level click listener live at
 // module scope under one alpine:init — they're global by design and
@@ -13,11 +17,9 @@
 (function () {
   var FOCUSED_CLASS = 'bb-tx-row--focused'; // reuse the tx-list focus styling
 
-  // Reads the DOM for visible category rows (two levels: primary row +
-  // subcategory rows inside each expanded x-collapse). offsetParent !== null
-  // respects both the filter (x-show on parent/child wrappers) and the
-  // collapsed state (x-collapse toggles display) — collapsed children
-  // simply won't appear here.
+  // Reads the DOM for visible category rows (parent + subcategory rows).
+  // offsetParent !== null respects the filter (x-show on group + row
+  // wrappers) so filtered-out rows simply won't appear here.
   function visibleRows() {
     var all = document.querySelectorAll('[data-category-row]');
     var out = [];
@@ -40,9 +42,8 @@
   document.addEventListener('alpine:init', function () {
     Alpine.data('categoriesPage', function () {
       return {
-        // --- Filter + expansion state (used by inline x-show / x-collapse) ---
+        // --- Filter state (used by inline x-show on groups + rows) ---
         filter: '',
-        expanded: {},
 
         // --- Keyboard navigation state ---
         focusedIdx: -1,
@@ -55,15 +56,7 @@
           if (instance === this) instance = null;
         },
 
-        // --- Filter + expansion methods (called from inline x-* expressions) ---
-        toggle: function (id) {
-          this.expanded[id] = !this.expanded[id];
-        },
-
-        isOpen: function (id) {
-          return !!this.expanded[id] || !!this.filter;
-        },
-
+        // --- Filter method (called from inline x-show expressions) ---
         matches: function (el) {
           if (!this.filter) return true;
           return (el.dataset.search || '').includes(this.filter.toLowerCase());
@@ -105,21 +98,10 @@
           return null;
         },
 
-        // Activate the focused row: expand/collapse a primary via click
-        // (which fires the @click="toggle('<id>')" handler on the row);
-        // jump to the filtered transactions list for a subcategory.
+        // Activate the focused row: open the category's edit page. Every
+        // row (parent or child) links there, so Enter mirrors a click.
         activateRow: function () {
-          var row = this.currentRow();
-          if (!row) return;
-          var level = row.getAttribute('data-category-level');
-          if (level === 'primary') {
-            row.click();
-            return;
-          }
-          if (level === 'sub') {
-            var slug = row.getAttribute('data-category-slug');
-            if (slug) window.location.href = '/transactions?category=' + encodeURIComponent(slug);
-          }
+          this.editRow();
         },
 
         editRow: function () {
@@ -158,7 +140,7 @@
     reg.register({
       id: 'categories.activate',
       keys: 'Enter',
-      description: 'Expand primary / open subcategory',
+      description: 'Open focused category',
       group: 'Actions',
       scope: 'categories',
       action: function () { if (instance) instance.activateRow(); },
@@ -167,7 +149,7 @@
     reg.register({
       id: 'categories.activate.space',
       keys: ' ', // Space — e.key is a literal space
-      description: 'Expand / open (Space)',
+      description: 'Open focused category (Space)',
       group: 'Actions',
       scope: 'categories',
       visible: false, // Enter is the canonical binding shown in help
@@ -200,9 +182,10 @@
     });
   });
 
-  // When the user clicks a row (to expand/collapse a primary or select
-  // a sub), sync the j/k ring to that row so subsequent keyboard nav
-  // picks up from there — matches the tx-list convention.
+  // When the user clicks within a row, sync the j/k ring to that row so
+  // subsequent keyboard nav picks up from there — matches the tx-list
+  // convention. (Row clicks land on the inner edit link and navigate; this
+  // only matters for keyboard users who then resume j/k.)
   document.addEventListener('click', function (e) {
     var row = e.target && e.target.closest && e.target.closest('[data-category-row]');
     if (!row) return;


### PR DESCRIPTION
Surface redesign (design-system loop): `/categories` rebuilt on the list-row language with a hierarchy-aware layout.

## What changed
- **List-rows** (via `AgentRunRowList`), one `bb-card` per top-level category.
- **Leading color/icon tile** reuses the data-driven `bb-tx-avatar` mechanism — binds the category's own `Color` to `--avatar-color` (color-mix bg + glyph tint from existing CSS, no hardcoded alpha); icon = the category's lucide icon (fallback `folder`); colorless → neutral uncategorized tile. Parents use the full tile, children the `--sm` variant.
- Title = display name (parents `font-semibold` + count pill, children `font-medium`; system/hidden dim) + `System`/`Hidden` badges; muted descriptor = subcategory count (parents) / slug (children); `OverflowMenu` (edit/delete, system omits delete) outside the row link. Row → `/categories/{id}/edit`.
- **IA: hierarchy** — parent as the emphasized lead row, subcategories indented beneath. **Accordion retired** (always expanded — the page is the disclosure). Pure unit-tested `BuildCategoryGroups` with search indexes so a child match keeps its parent visible and a parent match keeps children visible.
- Preserved: `FilterSearchInput`, create flow, edit/delete + color/icon model, j/k focus + e/n/Enter shortcuts (Enter/e now open edit). Principle #8 hover + focus states.

`go build` / `go vet` / `go test ./...` green (new `TestBuildCategoryGroups` + 3 more).

Deferred: no transaction-count descriptor (page is config-only — the tree carries no counts); no preselected parent on "add subcategory".

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/c6c36a6c7f2ebb6b.jpeg" width="800" alt="/categories redesigned as hierarchy-aware list-rows with category color/icon tiles">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
