### PR TITLE
feat(household): redesign /household to UserAvatar-led list-rows

### DIFF
--- a/internal/templates/components/household_skeleton.templ
+++ b/internal/templates/components/household_skeleton.templ
@@ -1,0 +1,41 @@
+package components
+
+// HouseholdSkeleton mirrors the /household members list: two quiet
+// label-line groups, each over a daisy `list` of member rows. Exposed in
+// /design#loading and embedded in a <template> on the live page for any
+// future client-side refresh. The live page is full-SSR today.
+templ HouseholdSkeleton() {
+	<div aria-hidden="true" class="flex flex-col gap-5">
+		@householdSkeletonGroup(2)
+		@householdSkeletonGroup(2)
+	</div>
+}
+
+// householdSkeletonGroup mirrors one member group: a label line over a
+// rounded list of member rows.
+templ householdSkeletonGroup(rows int) {
+	<div class="flex flex-col gap-2">
+		<div class="flex items-center gap-2 px-1">
+			<div class="skeleton h-3 w-24"></div>
+			<div class="skeleton h-3 w-4"></div>
+		</div>
+		<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+			for j := 0; j < rows; j++ {
+				@householdSkeletonRow()
+			}
+		</ul>
+	</div>
+}
+
+// householdSkeletonRow mirrors householdMemberRow: a round leading avatar,
+// name + body line, and a trailing kebab slot.
+templ householdSkeletonRow() {
+	<li class="list-row items-center">
+		<div class="skeleton w-10 h-10 rounded-full shrink-0"></div>
+		<div class="min-w-0 space-y-1.5">
+			<div class="skeleton h-4 w-32 sm:w-40"></div>
+			<div class="skeleton h-2.5 w-48"></div>
+		</div>
+		<div class="skeleton w-8 h-8 rounded-lg shrink-0 ml-auto"></div>
+	</li>
+}

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1069,6 +1069,11 @@ templ SectionLoading() {
 				@components.ConnectionsSkeleton()
 			</div>
 		}
+		@designExample("Household list skeleton", "Placeholder mirroring /household — member groups (a quiet label line over a card of member list-rows: round leading avatar, name + body line, trailing kebab). Primitive is exposed here for future AJAX swaps; /household is full-SSR today.") {
+			<div class="max-w-4xl">
+				@components.HouseholdSkeleton()
+			</div>
+		}
 		@designExample("Tags list skeleton", "Placeholder mirroring /tags — filter input, helper line, and a divided card of tag rows (chip preview, slug + optional description, usage count, overflow menu). Primitive is exposed here for future AJAX swaps and adjacent tag-centric panels (e.g. tag picker / tag-attach autocomplete); /tags is full-SSR today.") {
 			<div class="max-w-3xl">
 				@components.TagsSkeleton()

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -15,30 +15,41 @@ templ Users(p UsersProps) {
 		   n (registered below) to the Add Member link, and so the ? help modal
 		   surfaces it under "This page". Reset on Alpine teardown. */
 	}}
-	<div x-data x-init="$store.shortcuts.setScope('users')" x-destroy="$store.shortcuts.setScope('global')"></div>
-	@components.PageHeader(components.PageHeaderProps{
-		Title:    "Household",
-		Subtitle: "Manage who has bank connections in Breadbox",
-		Action:   usersAddMemberAction(),
-	})
-	if p.Created {
-		<div role="alert" class="alert alert-success mb-6">
-			@components.LucideIcon("check-circle", "w-5 h-5")
-			<span>Member created. <button type="button" x-data @click="$store.drawers.open('connect-bank')" class="link font-medium">Connect a bank for them</button></span>
-		</div>
-	}
-	if p.IsUnlinked {
-		@usersUnlinkedPrompt(p)
-	}
-	if len(p.EnrichedUsers) > 0 {
-		<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-			for _, u := range p.EnrichedUsers {
-				@usersMemberCard(u)
-			}
-		</div>
-	} else {
-		@usersEmpty()
-	}
+	<!-- Root Alpine scope: sets the keyboard-shortcut scope AND establishes a
+	     data scope so $store magics (drawers) bind inside the member rows'
+	     overflow-menu @click handlers. -->
+	<div x-data x-init="$store.shortcuts.setScope('users')" x-destroy="$store.shortcuts.setScope('global')">
+		@components.PageHeader(components.PageHeaderProps{
+			Title:                "Household",
+			Subtitle:             "Everyone in your household — their sign-in access and connected accounts.",
+			SubtitleHideOnMobile: true,
+			Action:               usersAddMemberAction(),
+		})
+		if p.Created {
+			<div role="alert" class="alert alert-success mb-6">
+				@components.LucideIcon("check-circle", "w-5 h-5")
+				<span>Member created. <button type="button" @click="$store.drawers.open('connect-bank')" class="link font-medium">Connect a bank for them</button></span>
+			</div>
+		}
+		if p.IsUnlinked {
+			@usersUnlinkedPrompt(p)
+		}
+		if len(p.EnrichedUsers) > 0 {
+			{{ groups := groupHouseholdMembers(p.EnrichedUsers) }}
+			<div class="flex flex-col gap-5">
+				for _, g := range groups {
+					@householdMemberGroup(g, len(groups) > 1)
+				}
+			</div>
+		} else {
+			@usersEmpty()
+		}
+		<!-- Loading skeleton, mirroring the SSR list above. Exposed in
+		     /design#loading for any future client-side refresh. -->
+		<template id="bb-household-skeleton-template">
+			@components.HouseholdSkeleton()
+		</template>
+	</div>
 }
 
 // usersUnlinkedPrompt renders the warning panel shown when the current
@@ -55,9 +66,7 @@ templ usersUnlinkedPrompt(p UsersProps) {
 	<!-- Admin link prompt: admin account not yet linked to a household member -->
 	<div class="bb-card p-0 overflow-hidden mb-6 border-warning/30 bg-warning/[0.03]" x-data="{ mode: 'create', open: true }" x-show="open">
 		<div class="p-4 sm:p-5 flex items-start gap-3">
-			<div class="bb-icon-header__tile bb-icon-tile--warning">
-				@components.LucideIcon("user-plus", "w-5 h-5")
-			</div>
+			@components.LucideIcon("user-plus", "w-5 h-5 text-warning shrink-0 mt-0.5")
 			<div class="min-w-0 flex-1">
 				<h3 class="text-sm font-semibold">Link your admin account to a household member</h3>
 				<p class="text-xs text-base-content/60 mt-0.5">Your admin account isn't linked yet. Link it to manage bank connections and view your financial data.</p>
@@ -123,66 +132,88 @@ templ usersUnlinkedPrompt(p UsersProps) {
 	</div>
 }
 
-// usersMemberCard renders one household member's card: avatar, profile
-// info, login badge, and a compact stats footer. Account details are
-// intentionally omitted — the focus is the member profile.
-templ usersMemberCard(u UsersEnrichedRow) {
-	<div class="bb-card p-4 sm:p-5 flex flex-col gap-4">
-		<div class="flex items-start gap-4">
+// householdMemberGroup renders one IA bucket: a quiet label line (label ·
+// count) over the bucket's member list-rows inside a bb-card. The label is
+// suppressed when there's only one group — a single clean list needs no
+// header (design-system: group with quiet label lines, else a plain list).
+templ householdMemberGroup(g HouseholdMemberGroup, showLabel bool) {
+	<div class="flex flex-col gap-2">
+		if showLabel {
+			<div class="flex items-center gap-2 px-1 min-w-0">
+				<span class="text-sm font-medium text-base-content shrink-0">{ g.Label }</span>
+				<span class="text-xs text-base-content/40 shrink-0">{ fmt.Sprintf("%d", len(g.Rows)) }</span>
+			</div>
+		}
+		@components.AgentRunRowList() {
+			for _, u := range g.Rows {
+				@householdMemberRow(u)
+			}
+		}
+	</div>
+}
+
+// householdMemberRow renders one member as a list-row: the leading
+// UserAvatar IS the row's identity/status (design-system principle #7), a
+// title row (name + role + setup-pending badge), one body line (email ·
+// accounts summary), and an OverflowMenu outside the navigation anchor. The
+// row links to the member's edit page.
+templ householdMemberRow(u UsersEnrichedRow) {
+	<li class="list-row transition-colors hover:bg-base-200/40 focus-within:bg-base-200/40 items-center">
+		<a
+			class="contents no-underline"
+			href={ templ.SafeURL(fmt.Sprintf("/household/%s/edit", u.ID)) }
+			aria-label={ fmt.Sprintf("Edit %s", u.Name) }
+		>
 			@components.UserAvatar(components.UserAvatarProps{
 				ID:         u.ID,
 				Name:       u.Name,
 				Version:    u.AvatarVersion,
-				Size:       components.UserAvatar2XL,
+				Size:       components.UserAvatarXL,
 				Decorative: true,
+				Lazy:       true,
 				Class:      "shrink-0",
 			})
-			<div class="flex-1 min-w-0">
-				<div class="flex items-start justify-between gap-2">
-					<div class="min-w-0">
-						<div class="flex items-center gap-1.5 flex-wrap">
-							<h3 class="font-semibold text-base leading-snug">{ u.Name }</h3>
-							if u.HasLogin {
-								<span class={ "badge badge-xs", usersLoginRoleBadgeClass(u.LoginRole) }>{ u.LoginRole }</span>
-								if u.LoginSetupPending {
-									<span class="badge badge-xs badge-warning">setup pending</span>
-								}
-							} else {
-								<span class="badge badge-xs badge-ghost">no login</span>
-							}
-						</div>
-						if u.HasEmail {
-							<p class="text-xs text-base-content/45 mt-0.5">{ u.Email }</p>
-						} else if u.LoginUsername != "" {
-							<p class="text-xs text-base-content/45 mt-0.5">{ u.LoginUsername }</p>
-						} else {
-							<p class="text-xs text-base-content/30 italic mt-0.5">No email</p>
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="font-medium text-sm text-base-content truncate">{ u.Name }</span>
+					if u.HasLogin {
+						<span class={ "badge badge-xs shrink-0", usersLoginRoleBadgeClass(u.LoginRole) }>{ householdRoleLabel(u.LoginRole) }</span>
+						if u.LoginSetupPending {
+							<span class="badge badge-xs badge-warning shrink-0">setup pending</span>
 						}
-					</div>
-					@components.OverflowMenu(components.OverflowMenuProps{
-						AriaLabel: fmt.Sprintf("Actions for %s", u.Name),
-						Items:     usersOverflowItems(u),
-					})
+					}
 				</div>
+				@householdMemberRowBody(u)
 			</div>
+		</a>
+		<div class="shrink-0 self-center">
+			@components.OverflowMenu(components.OverflowMenuProps{
+				AriaLabel: fmt.Sprintf("Actions for %s", u.Name),
+				Size:      "sm",
+				Items:     usersOverflowItems(u),
+			})
 		</div>
-		<!-- Footer: account stats + member since -->
-		<div class="flex items-center justify-between gap-2 pt-3 border-t border-base-300/60">
-			if u.AccountCount > 0 {
-				<span class="flex items-center gap-1.5 text-xs text-base-content/50">
-					@components.LucideIcon("landmark", "w-3.5 h-3.5")
-					{ usersAccountsSummary(u.AccountCount, u.ConnectionCount) }
-				</span>
-			} else {
-				<button type="button" x-data @click="$store.drawers.open('connect-bank')" class="flex items-center gap-1 text-xs text-base-content/40 hover:text-primary transition-colors">
-					@components.LucideIcon("plus", "w-3.5 h-3.5")
-					Connect a bank
-				</button>
-			}
-			if u.HasCreatedAt {
-				<span class="text-xs text-base-content/30 shrink-0">Since { u.CreatedAtLabel }</span>
-			}
-		</div>
+	</li>
+}
+
+// householdMemberRowBody renders the single body line: the member's email
+// (or login username, or a quiet "No email"), then the accounts summary —
+// "N accounts across M connections" or a muted "No accounts yet".
+templ householdMemberRowBody(u UsersEnrichedRow) {
+	<div class="mt-0.5 text-xs text-base-content/55 min-w-0 line-clamp-1">
+		if u.HasEmail {
+			<span>{ u.Email }</span>
+		} else if u.LoginUsername != "" {
+			<span>{ u.LoginUsername }</span>
+		} else {
+			<span class="text-base-content/35 italic">No email</span>
+		}
+		<span class="text-base-content/25">&middot;</span>
+		if u.AccountCount > 0 {
+			<span>{ usersAccountsSummary(u.AccountCount, u.ConnectionCount) }</span>
+		} else {
+			<span class="text-base-content/35">No accounts yet</span>
+		}
 	</div>
 }
 
@@ -228,6 +259,12 @@ func usersOverflowItems(u UsersEnrichedRow) []components.OverflowMenuItem {
 			Label: "Transactions",
 			Icon:  "receipt",
 			Href:  templ.SafeURL(fmt.Sprintf("/transactions?user_id=%s", u.ID)),
+		})
+	} else {
+		items = append(items, components.OverflowMenuItem{
+			Label:   "Connect a bank",
+			Icon:    "plus",
+			OnClick: "$store.drawers.open('connect-bank')",
 		})
 	}
 	return items

--- a/internal/templates/components/pages/users_types.go
+++ b/internal/templates/components/pages/users_types.go
@@ -2,7 +2,11 @@
 
 package pages
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // UsersProps mirrors the data map the old users.html read off the layout.
 // Kept flat so admin/users.go can build it via a small mapper.
@@ -43,7 +47,9 @@ type UsersEnrichedRow struct {
 // usersLoginRoleBadgeClass returns the DaisyUI badge color modifier for a
 // login-account role. Mirrors the {{if eq $la.Role "admin"}}badge-primary
 // {{else if eq $la.Role "editor"}}badge-secondary{{else}}badge-ghost
-// chain in the prior html/template version.
+// chain in the prior html/template version. Solid (not soft) so the tone
+// stays visible in dark mode, where soft primary/secondary collapse to
+// invisible grays.
 func usersLoginRoleBadgeClass(role string) string {
 	switch role {
 	case "admin":
@@ -53,6 +59,85 @@ func usersLoginRoleBadgeClass(role string) string {
 	default:
 		return "badge-ghost"
 	}
+}
+
+// householdRoleLabel title-cases a login role for the row badge. Empty
+// stays empty (the row renders no badge for a profile without a login).
+func householdRoleLabel(role string) string {
+	switch role {
+	case "admin":
+		return "Admin"
+	case "editor":
+		return "Editor"
+	case "viewer":
+		return "Viewer"
+	case "":
+		return ""
+	default:
+		return strings.ToUpper(role[:1]) + role[1:]
+	}
+}
+
+// householdRoleRank orders sign-in roles from most to least privileged so
+// an admin always sorts above an editor above a viewer within the access
+// group. Unknown / empty roles sink last.
+func householdRoleRank(role string) int {
+	switch role {
+	case "admin":
+		return 0
+	case "editor":
+		return 1
+	case "viewer":
+		return 2
+	default:
+		return 3
+	}
+}
+
+// HouseholdMemberGroup is one labelled bucket on the Household page: the
+// members who can sign in (ordered by privilege) and the attribution-only
+// profiles (no login). Pinning the IA in a typed, testable helper keeps the
+// grouping decision honest rather than vibes (design-system principle #5).
+type HouseholdMemberGroup struct {
+	Key   string // "access" | "profiles"
+	Label string
+	Rows  []UsersEnrichedRow
+}
+
+// groupHouseholdMembers partitions members into the sign-in-access group
+// (HasLogin) and the profiles group (no login), drops any empty bucket, and
+// orders the access group by role rank then name, profiles by name. The
+// access group always precedes profiles. Pure + deterministic so the page's
+// information architecture is unit-pinned.
+func groupHouseholdMembers(rows []UsersEnrichedRow) []HouseholdMemberGroup {
+	var access, profiles []UsersEnrichedRow
+	for _, r := range rows {
+		if r.HasLogin {
+			access = append(access, r)
+		} else {
+			profiles = append(profiles, r)
+		}
+	}
+
+	sort.SliceStable(access, func(i, j int) bool {
+		ri, rj := householdRoleRank(access[i].LoginRole), householdRoleRank(access[j].LoginRole)
+		if ri != rj {
+			return ri < rj
+		}
+		return strings.ToLower(access[i].Name) < strings.ToLower(access[j].Name)
+	})
+	sort.SliceStable(profiles, func(i, j int) bool {
+		return strings.ToLower(profiles[i].Name) < strings.ToLower(profiles[j].Name)
+	})
+
+	var groups []HouseholdMemberGroup
+	if len(access) > 0 {
+		groups = append(groups, HouseholdMemberGroup{Key: "access", Label: "Sign-in access", Rows: access})
+	}
+	if len(profiles) > 0 {
+		groups = append(groups, HouseholdMemberGroup{Key: "profiles", Label: "Profiles", Rows: profiles})
+	}
+	return groups
 }
 
 // usersAccountsSummary renders the "<N> account(s) across <M> connection(s)"

--- a/internal/templates/components/pages/users_types_test.go
+++ b/internal/templates/components/pages/users_types_test.go
@@ -1,0 +1,96 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+func TestGroupHouseholdMembers(t *testing.T) {
+	rows := []UsersEnrichedRow{
+		{ID: "1", Name: "Zara", HasLogin: true, LoginRole: "viewer"},
+		{ID: "2", Name: "Bob", HasLogin: false},
+		{ID: "3", Name: "Alice", HasLogin: true, LoginRole: "admin"},
+		{ID: "4", Name: "Cara", HasLogin: true, LoginRole: "editor"},
+		{ID: "5", Name: "Amy", HasLogin: false},
+		{ID: "6", Name: "Adam", HasLogin: true, LoginRole: "admin"},
+	}
+
+	groups := groupHouseholdMembers(rows)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+
+	// Access group comes first, ordered admin → editor → viewer, then name.
+	if groups[0].Key != "access" {
+		t.Fatalf("expected first group key 'access', got %q", groups[0].Key)
+	}
+	wantAccess := []string{"Adam", "Alice", "Cara", "Zara"} // two admins tie-break by name
+	if got := names(groups[0].Rows); !equal(got, wantAccess) {
+		t.Errorf("access order = %v, want %v", got, wantAccess)
+	}
+
+	// Profiles group second, ordered by name.
+	if groups[1].Key != "profiles" {
+		t.Fatalf("expected second group key 'profiles', got %q", groups[1].Key)
+	}
+	wantProfiles := []string{"Amy", "Bob"}
+	if got := names(groups[1].Rows); !equal(got, wantProfiles) {
+		t.Errorf("profiles order = %v, want %v", got, wantProfiles)
+	}
+}
+
+func TestGroupHouseholdMembersDropsEmptyBuckets(t *testing.T) {
+	// Only members with logins → a single 'access' group, no empty profiles.
+	onlyAccess := groupHouseholdMembers([]UsersEnrichedRow{
+		{Name: "A", HasLogin: true, LoginRole: "admin"},
+	})
+	if len(onlyAccess) != 1 || onlyAccess[0].Key != "access" {
+		t.Fatalf("expected single access group, got %+v", onlyAccess)
+	}
+
+	// Only profiles → a single 'profiles' group.
+	onlyProfiles := groupHouseholdMembers([]UsersEnrichedRow{
+		{Name: "A", HasLogin: false},
+	})
+	if len(onlyProfiles) != 1 || onlyProfiles[0].Key != "profiles" {
+		t.Fatalf("expected single profiles group, got %+v", onlyProfiles)
+	}
+
+	if got := groupHouseholdMembers(nil); len(got) != 0 {
+		t.Fatalf("expected no groups for empty input, got %+v", got)
+	}
+}
+
+func TestHouseholdRoleLabel(t *testing.T) {
+	cases := map[string]string{
+		"admin":  "Admin",
+		"editor": "Editor",
+		"viewer": "Viewer",
+		"":       "",
+		"custom": "Custom",
+	}
+	for in, want := range cases {
+		if got := householdRoleLabel(in); got != want {
+			t.Errorf("householdRoleLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func names(rows []UsersEnrichedRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Surface redesign (design-system loop): `/household` moves from a legacy 2-up member-card grid to UserAvatar-led list-rows.

## What changed
- **List-rows** (`householdMemberRow` in `AgentRunRowList`), replacing the bespoke `bb-card` grid.
- **Leading = the member's `UserAvatar`** (XL) — identity is the status here (principle #7).
- Title = name + role badge (Admin/Editor/Viewer, solid so it stays legible on dark) + the kept categorical "setup pending" badge; one body line = email/login · "N accounts across M connections"; trailing `OverflowMenu` (Edit profile, Manage/Create login, Transactions or Connect-a-bank) outside the row link; row → `/household/{id}/edit`. Principle #8 hover/focus.
- **IA:** members partition into **Sign-in access** (has a login; ordered admin→editor→viewer) and **Profiles** (attribution-only), under quiet label lines shown only when both buckets exist. Pure unit-tested `groupHouseholdMembers`.
- Dropped the legacy `bb-icon-header__tile` from the unlinked-admin prompt; added `HouseholdSkeleton` to `/design#loading`.
- Preserved: add-member, edit, login management (create/manage = password/setup-token path), transactions deep-link, unlinked-admin prompt, success alert, `n` shortcut.

`go build` / `go vet` / `go test ./...` green (new grouping test).

Deferred: no household-level settings exist in the model (none added); per-member Remove/Reset needs backend endpoints that don't exist yet (login management covers reset today).

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/79de54bed7e0111f.jpeg" width="800" alt="/household redesigned — Sign-in access vs Profiles, UserAvatar-led list-rows">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
