### PR TITLE
feat(tags): redesign /tags to color-tile list-rows (matches /categories)

### DIFF
--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -41,6 +41,7 @@ func TagsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateR
 				Description:      t.Description,
 				Color:            t.Color,
 				Icon:             t.Icon,
+				Lifecycle:        t.Lifecycle,
 				TransactionCount: count,
 			})
 		}

--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -11,6 +11,16 @@ import (
 // via TemplateRenderer.RenderWithTempl — tags are purely configuration,
 // no per-tag analytics beyond a usage count linking to the filtered
 // transactions view.
+//
+// IA (Workflows-DNA surface language): tags are list-rows grouped by the
+// one axis that matters for "coordinating work on transactions" — whether
+// the tag is attached to anything. The In-use bucket leads (busiest tags
+// first); the Unused bucket sinks last. Each group is a quiet label line
+// over a card of list-rows. A row leads with the tag's own color/icon tile
+// (the shared bb-tx-avatar data-color mechanism, color sourced from the
+// tag), names the tag as the title (+ slug muted when it differs), carries
+// one body line (usage count · description), and ends with an OverflowMenu
+// rendered OUTSIDE the row link. The whole row links to the tag edit page.
 templ Tags(p TagsProps) {
 	<!-- Component factory. Loaded synchronously (no defer) so the
 	     Alpine.data() registration runs before Alpine — itself deferred from
@@ -28,15 +38,10 @@ templ Tags(p TagsProps) {
 			XModel:      "filter",
 		})
 		if len(p.Tags) > 0 {
-			<div class="text-xs text-base-content/40 px-1">
-				{ fmt.Sprintf("%d tags", len(p.Tags)) }
-			</div>
-			<div class="bb-card overflow-hidden">
-				<div class="divide-y divide-base-300/40">
-					for _, t := range p.Tags {
-						@tagListRow(t)
-					}
-				</div>
+			<div class="flex flex-col gap-5">
+				for _, g := range BuildTagGroups(p.Tags) {
+					@tagGroup(g)
+				}
 			</div>
 		} else {
 			@tagsEmpty()
@@ -50,73 +55,120 @@ templ Tags(p TagsProps) {
 	</div>
 }
 
-// tagListRow renders one tag as a horizontal row: chip preview (natural
-// width), slug + optional description, usage count, then an
-// actions slot. No fixed column widths — the chip sizes to its content so
-// longer names like "Needs Enrichment" don't get truncated the way they
-// did in the old w-32 column.
-templ tagListRow(t TagRow) {
+// tagGroup renders one bucket: a quiet label line (name · count) above the
+// tag list-rows in their own card. The wrapper carries the combined search
+// index so the Alpine filter hides the whole group — label included — when
+// no member row matches.
+templ tagGroup(g TagGroup) {
 	<div
+		data-search={ g.Search }
+		x-show="!filter || ($el.dataset.search || '').includes(filter.toLowerCase())"
+		class="flex flex-col gap-2"
+	>
+		<div class="flex items-center gap-2 px-1 min-w-0">
+			<span class="text-sm font-medium text-base-content shrink-0">{ g.Label }</span>
+			<span class="text-xs text-base-content/40 shrink-0">{ g.CountLabel }</span>
+		</div>
+		@components.AgentRunRowList() {
+			for _, t := range g.Rows {
+				@tagListRow(t)
+			}
+		}
+	</div>
+}
+
+// tagListRow renders one tag as a daisy list-row: a leading color/icon tile
+// (the tag's identity), the display name as title with the slug muted when
+// it differs, a single body line (usage count · description), and a trailing
+// overflow menu rendered outside the row's navigation anchor so the kebab
+// isn't swallowed by the row link. The whole row links to the tag edit page.
+templ tagListRow(t TagRow) {
+	<li
+		class="list-row transition-colors hover:bg-base-200/40 items-center"
 		data-search={ tagSearchIndex(t) }
 		x-show="!filter || ($el.dataset.search || '').includes(filter.toLowerCase())"
-		class="group flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3"
 	>
-		<!-- Chip preview — natural width, capped so it can't monopolize the row -->
-		<div class="shrink-0 min-w-0 max-w-[10rem] sm:max-w-[14rem]">
-			@components.TagChip(components.TagChipData{
-				Slug:        t.Slug,
-				DisplayName: t.DisplayName,
-				Color:       t.Color,
-				Icon:        t.Icon,
-			})
-		</div>
-		<!-- Slug + optional description -->
-		<div class="flex-1 min-w-0">
-			<code class="font-mono text-xs text-base-content/60 bg-base-200/50 px-1.5 py-0.5 rounded">{ t.Slug }</code>
-			if t.Description != "" {
-				<p data-user-content class="text-xs text-base-content/50 mt-1 line-clamp-1">{ t.Description }</p>
-			}
-		</div>
-		<!-- Transaction count (always visible; desktop gets the "txns" label) -->
-		<div class="shrink-0 text-right tabular-nums">
-			if t.TransactionCount > 0 {
-				<a
-					href={ templ.SafeURL(fmt.Sprintf("/transactions?tags=%s", t.Slug)) }
-					class="inline-flex items-baseline gap-1 text-xs text-base-content/70 hover:text-base-content"
-					title="View transactions"
-				>
-					<span class="font-medium">{ strconv.FormatInt(t.TransactionCount, 10) }</span>
-					<span class="text-base-content/40 hidden sm:inline">{ tagCountLabel(t.TransactionCount) }</span>
-				</a>
-			} else {
-				<span class="text-xs text-base-content/25">&mdash;</span>
-			}
-		</div>
-		<!-- Actions — single always-visible kebab menu so edit/delete are
-		     reachable on every viewport (mouse, touch, keyboard). Matches
-		     the pattern used on /rules and /agents row menus. -->
-		<div class="shrink-0 flex items-center">
+		<a
+			class="contents no-underline focus:outline-none"
+			href={ templ.SafeURL(fmt.Sprintf("/tags/%s/edit", t.ID)) }
+		>
+			@tagColorTile(t)
+			<div class="min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="truncate text-sm font-medium text-base-content">{ t.DisplayName }</span>
+					if tagShowSlug(t) {
+						<code class="font-mono text-xs text-base-content/45 shrink-0">{ t.Slug }</code>
+					}
+					if t.Lifecycle == "ephemeral" {
+						<span class="badge badge-ghost badge-xs shrink-0" title="Ephemeral: a temporary work tag, not a durable label">Ephemeral</span>
+					}
+				</div>
+				<div class="mt-0.5 text-xs text-base-content/45 truncate">
+					<span>{ tagUsagePhrase(t.TransactionCount) }</span>
+					if t.Description != "" {
+						<span class="text-base-content/30"> &middot; </span>
+						<span data-user-content>{ t.Description }</span>
+					}
+				</div>
+			</div>
+		</a>
+		<div class="shrink-0 self-center">
 			@components.OverflowMenu(components.OverflowMenuProps{
 				AriaLabel: fmt.Sprintf("Tag %s actions", t.Slug),
-				Size:      "xs",
-				Items: []components.OverflowMenuItem{
-					{
-						Label:     "Edit",
-						Icon:      "pencil",
-						Href:      templ.SafeURL(fmt.Sprintf("/tags/%s/edit", t.ID)),
-						AriaLabel: fmt.Sprintf("Edit tag %s", t.Slug),
-					},
-					{
-						Label:       "Delete",
-						Icon:        "trash-2",
-						OnClick:     fmt.Sprintf("deleteTag('%s', '%s', '%s')", jsEscape(t.ID), jsEscape(t.Slug), strconv.FormatInt(t.TransactionCount, 10)),
-						Destructive: true,
-						AriaLabel:   fmt.Sprintf("Delete tag %s", t.Slug),
-					},
-				},
+				Size:      "sm",
+				Items:     tagRowItems(t),
 			})
 		</div>
-	</div>
+	</li>
+}
+
+// tagColorTile renders the leading identity tile using the tag's own color +
+// icon via the shared bb-tx-avatar data-color mechanism (`--avatar-color`
+// drives the color-mix background + glyph tint). Colorless/iconless tags fall
+// back to the neutral `bb-tx-avatar--uncategorized` tile with a tag glyph —
+// the same shape /categories uses, so the two config-taxonomy pages read
+// identically.
+templ tagColorTile(t TagRow) {
+	if t.Color != nil || t.Icon != nil {
+		<div class="bb-tx-avatar" style={ tagTileColorStyle(t.Color) }>
+			@components.LucideIcon(tagTileIcon(t), "w-4 h-4")
+		</div>
+	} else {
+		<div class="bb-tx-avatar bb-tx-avatar--uncategorized">
+			@components.LucideIcon("tag", "w-4 h-4")
+		</div>
+	}
+}
+
+// tagRowItems builds the trailing overflow-menu items for one tag row: Edit,
+// an optional "View transactions" deep-link (only when the tag is attached to
+// anything — preserves the filtered-transactions affordance the old count
+// link carried, now that the row itself navigates to edit), and Delete.
+func tagRowItems(t TagRow) []components.OverflowMenuItem {
+	items := []components.OverflowMenuItem{
+		{
+			Label:     "Edit",
+			Icon:      "pencil",
+			Href:      templ.SafeURL(fmt.Sprintf("/tags/%s/edit", t.ID)),
+			AriaLabel: fmt.Sprintf("Edit tag %s", t.Slug),
+		},
+	}
+	if t.TransactionCount > 0 {
+		items = append(items, components.OverflowMenuItem{
+			Label:     "View transactions",
+			Icon:      "receipt",
+			Href:      templ.SafeURL(fmt.Sprintf("/transactions?tags=%s", t.Slug)),
+			AriaLabel: fmt.Sprintf("View transactions tagged %s", t.Slug),
+		})
+	}
+	items = append(items, components.OverflowMenuItem{
+		Label:       "Delete",
+		Icon:        "trash-2",
+		OnClick:     fmt.Sprintf("deleteTag('%s', '%s', '%s')", jsEscape(t.ID), jsEscape(t.Slug), strconv.FormatInt(t.TransactionCount, 10)),
+		Destructive: true,
+		AriaLabel:   fmt.Sprintf("Delete tag %s", t.Slug),
+	})
+	return items
 }
 
 templ tagsEmpty() {

--- a/internal/templates/components/pages/tags_test.go
+++ b/internal/templates/components/pages/tags_test.go
@@ -1,0 +1,128 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildTagGroups(t *testing.T) {
+	tags := []TagRow{
+		{ID: "1", Slug: "zzz-rare", DisplayName: "Zzz Rare", TransactionCount: 3},
+		{ID: "2", Slug: "needs-review", DisplayName: "Needs Review", TransactionCount: 12},
+		{ID: "3", Slug: "fresh", DisplayName: "Fresh", TransactionCount: 0},
+		{ID: "4", Slug: "reconciled", DisplayName: "Reconciled", TransactionCount: 12},
+		{ID: "5", Slug: "alpha-unused", DisplayName: "Alpha Unused", TransactionCount: 0},
+	}
+
+	groups := BuildTagGroups(tags)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2 (in-use, unused)", len(groups))
+	}
+
+	// In-use bucket leads.
+	in := groups[0]
+	if in.Key != "in-use" || in.Label != "In use" {
+		t.Fatalf("group[0] = %q/%q, want in-use/In use", in.Key, in.Label)
+	}
+	if in.CountLabel != "3 tags" {
+		t.Errorf("in-use CountLabel = %q, want %q", in.CountLabel, "3 tags")
+	}
+	if len(in.Rows) != 3 {
+		t.Fatalf("in-use rows = %d, want 3", len(in.Rows))
+	}
+	// Ordered by count desc; the two count==12 tags tie-break by display name
+	// (Needs Review < Reconciled), then the count==3 tag last.
+	wantOrder := []string{"needs-review", "reconciled", "zzz-rare"}
+	for i, slug := range wantOrder {
+		if in.Rows[i].Slug != slug {
+			t.Errorf("in-use row %d = %q, want %q", i, in.Rows[i].Slug, slug)
+		}
+	}
+
+	// Unused bucket sinks last, sorted alphabetically by display name.
+	un := groups[1]
+	if un.Key != "unused" || un.Label != "Unused" {
+		t.Fatalf("group[1] = %q/%q, want unused/Unused", un.Key, un.Label)
+	}
+	if len(un.Rows) != 2 {
+		t.Fatalf("unused rows = %d, want 2", len(un.Rows))
+	}
+	if un.Rows[0].Slug != "alpha-unused" || un.Rows[1].Slug != "fresh" {
+		t.Errorf("unused order = %q,%q, want alpha-unused,fresh", un.Rows[0].Slug, un.Rows[1].Slug)
+	}
+
+	// The group search index folds in every member so a filter keeps the
+	// label line visible when any row matches.
+	if !strings.Contains(in.Search, "needs-review") || !strings.Contains(in.Search, "zzz-rare") {
+		t.Errorf("in-use Search missing a member slug: %q", in.Search)
+	}
+}
+
+func TestBuildTagGroupsOmitsEmptyBuckets(t *testing.T) {
+	// All in use → only the In-use group, no empty Unused bucket.
+	onlyUsed := BuildTagGroups([]TagRow{
+		{ID: "1", Slug: "a", DisplayName: "A", TransactionCount: 1},
+	})
+	if len(onlyUsed) != 1 || onlyUsed[0].Key != "in-use" {
+		t.Fatalf("all-used: got %d groups (%v), want 1 in-use", len(onlyUsed), groupKeys(onlyUsed))
+	}
+
+	// All unused → only the Unused group.
+	onlyUnused := BuildTagGroups([]TagRow{
+		{ID: "1", Slug: "a", DisplayName: "A", TransactionCount: 0},
+	})
+	if len(onlyUnused) != 1 || onlyUnused[0].Key != "unused" {
+		t.Fatalf("all-unused: got %d groups (%v), want 1 unused", len(onlyUnused), groupKeys(onlyUnused))
+	}
+
+	// Empty input → no groups.
+	if got := BuildTagGroups(nil); len(got) != 0 {
+		t.Fatalf("nil input: got %d groups, want 0", len(got))
+	}
+}
+
+func TestTagRowHelpers(t *testing.T) {
+	if got := tagUsagePhrase(0); got != "Not used yet" {
+		t.Errorf("tagUsagePhrase(0) = %q", got)
+	}
+	if got := tagUsagePhrase(1); got != "1 transaction" {
+		t.Errorf("tagUsagePhrase(1) = %q", got)
+	}
+	if got := tagUsagePhrase(5); got != "5 transactions" {
+		t.Errorf("tagUsagePhrase(5) = %q", got)
+	}
+
+	// Slug shown only when it differs from the display name.
+	if tagShowSlug(TagRow{DisplayName: "needs-review", Slug: "needs-review"}) {
+		t.Error("tagShowSlug should be false when name == slug")
+	}
+	if !tagShowSlug(TagRow{DisplayName: "Needs Review", Slug: "needs-review"}) {
+		t.Error("tagShowSlug should be true when name differs from slug")
+	}
+
+	// Color binds to the avatar var; icon falls back to "tag".
+	c := "#f59e0b"
+	if got := tagTileColorStyle(&c); got != "--avatar-color: #f59e0b" {
+		t.Errorf("tagTileColorStyle = %q", got)
+	}
+	if got := tagTileColorStyle(nil); got != "" {
+		t.Errorf("tagTileColorStyle(nil) = %q, want empty", got)
+	}
+	if got := tagTileIcon(TagRow{}); got != "tag" {
+		t.Errorf("tagTileIcon(empty) = %q, want tag", got)
+	}
+	ic := "bookmark"
+	if got := tagTileIcon(TagRow{Icon: &ic}); got != "bookmark" {
+		t.Errorf("tagTileIcon = %q, want bookmark", got)
+	}
+}
+
+func groupKeys(gs []TagGroup) []string {
+	out := make([]string, len(gs))
+	for i, g := range gs {
+		out[i] = g.Key
+	}
+	return out
+}

--- a/internal/templates/components/pages/tags_types.go
+++ b/internal/templates/components/pages/tags_types.go
@@ -3,6 +3,8 @@
 package pages
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -24,7 +26,76 @@ type TagRow struct {
 	Description      string
 	Color            *string
 	Icon             *string
+	Lifecycle        string // "persistent" | "ephemeral"
 	TransactionCount int64
+}
+
+// TagGroup is one quiet-labelled bucket of tag rows. The /tags IA splits
+// the flat tag list along the one axis that matters for "coordinating work
+// on transactions": whether a tag is actually attached to anything. Active
+// working tags surface first (In use, most-used first); the empty bucket
+// sinks last (Unused) — the design-system "sink the orphan/empty bucket"
+// rule. Each group renders as a label line over a card of list-rows.
+type TagGroup struct {
+	Key        string // "in-use" | "unused" — stable handle, not shown
+	Label      string // "In use" | "Unused"
+	CountLabel string // "4 tags" — quiet count beside the label
+	Search     string // concat of member search indexes, for the group's x-show
+	Rows       []TagRow
+}
+
+// BuildTagGroups partitions tags into the In-use / Unused buckets and orders
+// each meaningfully: In use by transaction count desc (busiest tags first),
+// ties broken by display name; Unused alphabetically. Empty buckets are
+// omitted so a household with no unused tags shows a single clean list. Pure,
+// so the IA decision is unit-testable without a DB.
+func BuildTagGroups(tags []TagRow) []TagGroup {
+	inUse := make([]TagRow, 0, len(tags))
+	unused := make([]TagRow, 0)
+	for _, t := range tags {
+		if t.TransactionCount > 0 {
+			inUse = append(inUse, t)
+		} else {
+			unused = append(unused, t)
+		}
+	}
+
+	sort.SliceStable(inUse, func(i, j int) bool {
+		if inUse[i].TransactionCount != inUse[j].TransactionCount {
+			return inUse[i].TransactionCount > inUse[j].TransactionCount
+		}
+		return strings.ToLower(inUse[i].DisplayName) < strings.ToLower(inUse[j].DisplayName)
+	})
+	sort.SliceStable(unused, func(i, j int) bool {
+		return strings.ToLower(unused[i].DisplayName) < strings.ToLower(unused[j].DisplayName)
+	})
+
+	groups := make([]TagGroup, 0, 2)
+	if len(inUse) > 0 {
+		groups = append(groups, newTagGroup("in-use", "In use", inUse))
+	}
+	if len(unused) > 0 {
+		groups = append(groups, newTagGroup("unused", "Unused", unused))
+	}
+	return groups
+}
+
+// newTagGroup assembles a TagGroup, precomputing the quiet count label and
+// the combined search index (every member's index folded in) so the Alpine
+// filter can hide a whole group — label line included — when no member row
+// matches the query.
+func newTagGroup(key, label string, rows []TagRow) TagGroup {
+	parts := make([]string, 0, len(rows))
+	for _, t := range rows {
+		parts = append(parts, tagSearchIndex(t))
+	}
+	return TagGroup{
+		Key:        key,
+		Label:      label,
+		CountLabel: tagGroupCountLabel(len(rows)),
+		Search:     strings.Join(parts, " "),
+		Rows:       rows,
+	}
 }
 
 // tagSearchIndex returns a single lowercase string containing slug,
@@ -34,11 +105,59 @@ func tagSearchIndex(t TagRow) string {
 	return strings.ToLower(t.Slug + " " + t.DisplayName + " " + t.Description)
 }
 
-// tagCountLabel returns "txn" / "txns" depending on count, so "1 txn" reads
-// correctly alongside "62 txns".
-func tagCountLabel(n int64) string {
+// tagGroupCountLabel renders the dimmed "N tags" count beside a group label.
+func tagGroupCountLabel(n int) string {
 	if n == 1 {
-		return "txn"
+		return "1 tag"
 	}
-	return "txns"
+	return fmt.Sprintf("%d tags", n)
+}
+
+// tagUsagePhrase is the row's single body line: the usage count carried as
+// prose. Zero-usage rows (only ever in the Unused group) read "Not used yet".
+func tagUsagePhrase(n int64) string {
+	switch {
+	case n <= 0:
+		return "Not used yet"
+	case n == 1:
+		return "1 transaction"
+	default:
+		return fmt.Sprintf("%d transactions", n)
+	}
+}
+
+// tagShowSlug reports whether the slug should be shown muted beside the
+// display name — only when it actually differs (case-insensitively) from the
+// name, so a tag whose name already IS its slug doesn't read "foo foo".
+func tagShowSlug(t TagRow) bool {
+	return t.DisplayName != "" && !strings.EqualFold(t.DisplayName, t.Slug)
+}
+
+// tagDeref unwraps an optional string field to its trimmed value.
+func tagDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return strings.TrimSpace(*s)
+}
+
+// tagTileIcon resolves the leading tile glyph: the tag's own lucide icon when
+// set, else a neutral "tag" fallback.
+func tagTileIcon(t TagRow) string {
+	if ic := tagDeref(t.Icon); ic != "" {
+		return ic
+	}
+	return "tag"
+}
+
+// tagTileColorStyle binds the tag's color to the shared bb-tx-avatar
+// `--avatar-color` custom property — the same data-color tile mechanism the
+// /categories rows use. Empty when the tag has no color, so the CSS neutral
+// fallback applies. The color is sourced from the tag, never hardcoded.
+func tagTileColorStyle(color *string) string {
+	c := tagDeref(color)
+	if c == "" {
+		return ""
+	}
+	return "--avatar-color: " + c
 }

--- a/internal/templates/components/tags_skeleton.templ
+++ b/internal/templates/components/tags_skeleton.templ
@@ -1,13 +1,11 @@
 package components
 
-// TagsSkeleton renders a placeholder mirroring the layout of the /tags
-// page — a filter search input, the "N tags" helper line, and a divided
-// card with tag rows. Each row mirrors tagListRow: a chip-shaped pill
-// preview (natural width, capped at ~10–14rem), a slug-shaped code pill
-// + optional description line, a usage-count badge, and a trailing
-// overflow-menu slot. Sized to match the real component so a future
-// swap-in (AJAX refresh, picker preview, adjacent panel) doesn't shift
-// layout.
+// TagsSkeleton renders a placeholder mirroring the redesigned /tags page —
+// a filter search input, a quiet group label line, and a daisy `list` card
+// of tag list-rows. Each row mirrors tagListRow: a square color/icon tile, a
+// title line (name + muted slug) over a body line, and a trailing
+// overflow-menu dot. Sized to match the real component so a future swap-in
+// (AJAX refresh, picker preview, adjacent panel) doesn't shift layout.
 //
 // /tags is a full-SSR page today; this primitive is exposed in
 // /design#loading so it's ready for the eventual AJAX swap and
@@ -20,42 +18,37 @@ templ TagsSkeleton() {
 	<div class="space-y-4" aria-hidden="true">
 		<!-- Filter search input -->
 		<div class="skeleton h-10 w-full sm:max-w-sm rounded-xl"></div>
-		<!-- Helper line: "N tags" -->
-		<div class="px-1">
-			<div class="skeleton h-2.5 w-20"></div>
-		</div>
-		<!-- Tag rows card. Widths vary so the skeleton reads as motion. -->
-		<div class="bb-card overflow-hidden">
-			<div class="divide-y divide-base-300/40">
-				@tagsSkeletonRow("w-24", "w-28", "w-10", true)
-				@tagsSkeletonRow("w-32", "w-20", "w-8", false)
-				@tagsSkeletonRow("w-20", "w-36", "w-12", true)
-				@tagsSkeletonRow("w-28", "w-24", "w-8", false)
-				@tagsSkeletonRow("w-16", "w-32", "w-6", false)
-				@tagsSkeletonRow("w-36", "w-16", "w-10", true)
+		<!-- One labelled group: a quiet "In use · N" line over a card of rows -->
+		<div class="flex flex-col gap-2">
+			<div class="flex items-center gap-2 px-1">
+				<div class="skeleton h-3 w-16"></div>
+				<div class="skeleton h-2.5 w-10"></div>
 			</div>
+			<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
+				@tagsSkeletonRow("w-28", "w-40", true)
+				@tagsSkeletonRow("w-20", "w-28", false)
+				@tagsSkeletonRow("w-32", "w-48", true)
+				@tagsSkeletonRow("w-24", "w-32", false)
+			</ul>
 		</div>
 	</div>
 }
 
-// tagsSkeletonRow mirrors one tag row in /tags: a colored pill chip
-// preview, slug code-pill + optional description, usage-count badge,
-// and the overflow menu. Widths come from the caller so a stack of
-// rows can be varied for motion.
-templ tagsSkeletonRow(chipW string, slugW string, countW string, withDesc bool) {
-	<div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3">
-		<!-- Chip preview (rounded-full pill, matches bb-tag shape) -->
-		<div class={ "skeleton h-5 rounded-full shrink-0", chipW }></div>
-		<!-- Slug code pill + optional description -->
-		<div class="flex-1 min-w-0 space-y-1.5">
-			<div class={ "skeleton h-3 rounded-md", slugW }></div>
-			if withDesc {
-				<div class="skeleton h-2.5 w-2/3"></div>
+// tagsSkeletonRow mirrors one tag list-row: a square color tile, a title-line
+// pill + body-line pill, and the trailing overflow dot. Widths come from the
+// caller so a stack of rows can be varied for motion.
+templ tagsSkeletonRow(titleW string, bodyW string, withBody bool) {
+	<li class="list-row items-center">
+		<!-- Leading color/icon tile (square, matches bb-tx-avatar) -->
+		<div class="skeleton w-9 h-9 rounded-lg shrink-0"></div>
+		<!-- Title + body lines -->
+		<div class="min-w-0 space-y-1.5">
+			<div class={ "skeleton h-3.5 rounded-md", titleW }></div>
+			if withBody {
+				<div class={ "skeleton h-2.5 rounded-md", bodyW }></div>
 			}
 		</div>
-		<!-- Usage count -->
-		<div class={ "skeleton h-3 shrink-0", countW }></div>
 		<!-- Overflow menu -->
-		<div class="skeleton h-6 w-6 rounded shrink-0"></div>
-	</div>
+		<div class="skeleton h-6 w-6 rounded shrink-0 self-center"></div>
+	</li>
 }


### PR DESCRIPTION
Surface redesign (design-system loop): `/tags` rebuilt as color-tile list-rows, matching `/categories` so the two config-taxonomy pages read identically.

## What changed
- **List-rows** (`AgentRunRowList`) replacing the custom flex rows.
- **Leading color/icon tile** via the shared `bb-tx-avatar` data-color mechanism — `--avatar-color` bound from the tag's own `Color` (never hardcoded), glyph = the tag's lucide icon (fallback `tag`), neutral tile when colorless. (Chose the tile over a `bb-tag` chip since the title already carries the name.)
- Title = display name + muted slug (only when it differs) + `Ephemeral` badge; one body line = usage phrase ("N transactions" / "Not used yet") · description; trailing `OverflowMenu` (Edit · View transactions [when used] · Delete) outside the row link; row → `/tags/{id}/edit`.
- **IA: split In use → Unused** (in-use most-used-first, unused alphabetical) under quiet label lines; empty buckets omitted. Pure unit-tested `BuildTagGroups`.
- Preserved: search, create, edit/delete, color/icon model, the filtered-transactions affordance (now "View transactions" in the menu). Principle #8 hover/focus.

`go build` / `go vet` / `go test ./...` green (new grouping test).

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/bbbb48095240b3bf.jpeg" width="800" alt="/tags redesigned — In use / Unused color-tile list-rows">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
