### PR TITLE
fix(ui): in_progress status → spinner (not a badge); mcp_guide tabs → daisy tabs-border

### DIFF
--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -236,6 +236,12 @@ func StatusBadge(status string) string {
 // pages via @templ.Raw so every sync-status pill on the dashboard, logs,
 // and detail pages stays aligned. Unknown statuses render the raw value
 // inside a ghost badge with HTML-escaping.
+//
+// Terminal statuses (success / error / unknown) render as a soft daisy
+// badge. The live `in_progress` state is deliberately NOT a badge — badges
+// are terminal/categorical only (design-system principle #2,
+// feedback_no_badge_for_loading) — so it renders as an inline spinner +
+// muted text that reads as "still running" rather than a finished state.
 func SyncBadge(status string) string {
 	switch status {
 	case "success":
@@ -243,7 +249,7 @@ func SyncBadge(status string) string {
 	case "error":
 		return `<span class="badge badge-soft badge-error badge-sm">error</span>`
 	case "in_progress":
-		return `<span class="badge badge-soft badge-warning badge-sm">in progress</span>`
+		return `<span class="inline-flex items-center gap-1.5 text-sm text-base-content/60"><span class="loading loading-spinner loading-xs"></span>In progress</span>`
 	default:
 		return `<span class="badge badge-ghost badge-sm">` + html.EscapeString(status) + `</span>`
 	}

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -358,7 +358,7 @@ func TestSyncBadge(t *testing.T) {
 	}{
 		{"success", `<span class="badge badge-soft badge-success badge-sm">success</span>`},
 		{"error", `<span class="badge badge-soft badge-error badge-sm">error</span>`},
-		{"in_progress", `<span class="badge badge-soft badge-warning badge-sm">in progress</span>`},
+		{"in_progress", `<span class="inline-flex items-center gap-1.5 text-sm text-base-content/60"><span class="loading loading-spinner loading-xs"></span>In progress</span>`},
 		{"", `<span class="badge badge-ghost badge-sm"></span>`},
 		{"unknown", `<span class="badge badge-ghost badge-sm">unknown</span>`},
 		{"<script>", `<span class="badge badge-ghost badge-sm">&lt;script&gt;</span>`},

--- a/internal/templates/components/pages/mcp_guide.templ
+++ b/internal/templates/components/pages/mcp_guide.templ
@@ -86,11 +86,17 @@ templ MCPGuide(p MCPGuideProps) {
 			<div class="px-4 sm:px-5 py-4">
 				<!-- Agent tabs + flavor toggle -->
 				<div class="flex flex-wrap items-center justify-between gap-3 mb-5">
-					<div class="flex flex-wrap gap-1.5" role="tablist">
+					<!-- Daisy tabs-border shape (matches components.TabBar Variant:"border").
+					     Kept as an Alpine x-for + @click strip rather than the Go-slice
+					     TabBar component because the tabs are client-reactive: switchTab
+					     carries side effects (flavor flip + per-panel lucide re-render) and
+					     the active state is driven by Alpine `tab`, which the static
+					     server-rendered TabBar can't express. -->
+					<div class="tabs tabs-border" role="tablist" aria-label="MCP client">
 						<template x-for="t in tabs" :key="t.id">
 							<button
-								class="btn btn-sm gap-2 transition-all"
-								:class="tab === t.id ? 'btn-primary' : 'btn-ghost'"
+								class="tab gap-2"
+								:class="tab === t.id && 'tab-active'"
 								@click="switchTab(t.id)"
 								role="tab"
 								:aria-selected="tab === t.id"


### PR DESCRIPTION
The last two P1 items from the design-system audit — both code-level cleanups (no live render surface for a screenshot; verified by build + unit tests).

## 1. `in_progress` status no longer a badge
`helpers.go` `SyncBadge` rendered `in_progress` as `badge badge-soft badge-warning badge-sm` — a running state must not be a badge (principle #2 / the "no loading badge" rule). Audited every caller: the only live render is `sync_log_detail` (a title-chip row where an inline spinner fits). Swapped **only** the `in_progress` arm to a `loading loading-spinner loading-xs` + muted "In progress" text (mirrors the canonical running shape in `agent_run_live.go`); **all terminal arms keep their badge** (success/error soft, unknown ghost). `helpers_test.go` expectation updated; `TestSyncBadge` green.

## 2. `mcp_guide` bespoke tabs → daisy `tabs tabs-border`
The `mcp_guide` tab strip used a `btn-primary`/`btn-ghost` toggle (a flagged anti-pattern). Restyled it to the daisy `tabs tabs-border` shape that `components.TabBar` emits — a pure class swap, panels + `switchTab` + flavor logic untouched. **Literal `components.TabBar` adoption is deferred** (sound reason): those tabs are Alpine-reactive (`x-for` over a JS array, `@click` side effects, reactive active-class), while `TabBar` iterates a static Go slice and emits `<a href>` items with no Alpine-binding slot — a literal swap would require a risky reactive-API change to the shared primitive that other surfaces depend on. The anti-pattern (button-toggle tabs) is removed either way.

`go build` / `go vet` / `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
