### PR TITLE
fix(recurring): Active tab no longer blanks on a stale subscriptions.js

### DIFF
--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -276,8 +276,15 @@ templ seriesChargeRow(tx service.AdminTransactionRow) {
 // list-rows in their own card, mirroring the /accounts connection-group idiom.
 // The whole group hides when the active member/type/search filters leave it
 // with no visible rows, so a header never dangles over an empty card.
+//
+// The x-show is written so the group is ALWAYS visible when no filter is
+// active (the default view): the `groupVisible($el)` DOM scan is only reached
+// once a member/type/search filter is engaged. This is deliberate robustness —
+// short-circuiting before the custom Alpine method means a stale/cached
+// subscriptions.js missing `groupVisible` (newer than the row markup) can never
+// blank the default Active ledger. Regression guard (#1816 follow-up).
 templ subscriptionsStatusGroup(g SubscriptionStatusGroup) {
-	<div x-show="groupVisible($el)" class="flex flex-col gap-2">
+	<div x-show="(filterUser === 'all' && filterType === 'all' && !filter) || groupVisible($el)" class="flex flex-col gap-2">
 		<div class="flex items-center gap-2 px-1 min-w-0">
 			<span class="text-sm font-medium text-base-content shrink-0">{ g.Label }</span>
 			<span class="text-xs text-base-content/40 shrink-0">{ subscriptionsGroupCount(g) }</span>


### PR DESCRIPTION
Fixes the `/recurring` Active-tab regression you flagged.

## Root cause
The status-group wrapper rendered `x-show="groupVisible()"` — `groupVisible` is an Alpine method **added in #1816**, newer than the row markup around it. The admin JS bundle isn't cache-busted, so a browser holding a **cached `subscriptions.js` without `groupVisible`** evaluated an undefined method → Alpine eval error → every status group hidden → the default **Active** tab rendered **blank** even though rows were present (the tab count still showed "Active N"). A hard-refresh masked it, which is why it looked intermittent.

## Fix
Rewrote the group `x-show` to short-circuit on the unfiltered default view:
```
x-show="(filterUser === 'all' && filterType === 'all' && !filter) || groupVisible($el)"
```
`groupVisible` is now only reached once a member/type/search filter is engaged. The default Active ledger is **always visible** regardless of JS staleness.

**Verified:** with `groupVisible` forced to throw (simulating the stale/missing method), the unfiltered Active view still renders all rows.

> Systemic note: the underlying cause is that `/static/js/admin/*` isn't cache-busted, so any new Alpine method referenced from server HTML can desync from a cached bundle. Worth a follow-up (a content-hash/query-version on the admin JS) — flagging separately; this PR just makes `/recurring` robust.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/bccfcaef9a6b7894.jpeg" width="800" alt="/recurring Active tab rendering correctly">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
