### PR TITLE
refactor(ui): adopt PageHeader + drop legacy icon-tiles across edit forms

### DIFF
--- a/internal/templates/components/pages/category_form.templ
+++ b/internal/templates/components/pages/category_form.templ
@@ -23,24 +23,13 @@ templ CategoryForm(p CategoryFormProps) {
 	}
 	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">
-				if p.IsEdit {
-					Edit Category
-				} else {
-					Add Category
-				}
-			</h1>
-			<p class="text-sm text-base-content/50 mt-1">
-				if p.IsEdit {
-					Update appearance and settings. System categories have limited editability.
-				} else {
-					Organize transactions with a new category in your taxonomy.
-				}
-			</p>
-		</div>
-	</div>
+	{{ title := "Add Category" }}
+	{{ subtitle := "Organize transactions with a new category in your taxonomy." }}
+	if p.IsEdit {
+		{{ title = "Edit Category" }}
+		{{ subtitle = "Update appearance and settings. System categories have limited editability." }}
+	}
+	@components.PageHeader(components.PageHeaderProps{Title: title, Subtitle: subtitle})
 	<div class="max-w-lg" x-data="categoryForm()">
 		<form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
 			<div class="p-5 sm:p-6">

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -15,12 +15,10 @@ import "breadbox/internal/templates/components"
 // (sandbox/development/production) flows in through data-teller-env on the
 // x-data root and is read once in the factory's init().
 templ ConnectionNew(p ConnectionNewProps) {
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">Connect a bank</h1>
-			<p class="text-sm text-base-content/50 mt-1">Link a bank account to start syncing transactions</p>
-		</div>
-	</div>
+	@components.PageHeader(components.PageHeaderProps{
+		Title:    "Connect a bank",
+		Subtitle: "Link a bank account to start syncing transactions",
+	})
 	if !p.HasPlaid && !p.HasTeller && !p.HasSimpleFin {
 		<div class="bb-card p-8 max-w-lg">
 			@connectNoProviders()

--- a/internal/templates/components/pages/connection_reauth.templ
+++ b/internal/templates/components/pages/connection_reauth.templ
@@ -41,12 +41,10 @@ templ ConnectionReauth(p ConnectionReauthProps) {
 		<script src="https://cdn.teller.io/connect/connect.js"></script>
 	}
 	<script src="/static/js/admin/components/connection_reauth.js"></script>
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">Re-authenticate</h1>
-			<p class="text-sm text-base-content/50 mt-1">{ p.InstitutionName } needs to be re-connected</p>
-		</div>
-	</div>
+	@components.PageHeader(components.PageHeaderProps{
+		Title:    "Re-authenticate",
+		Subtitle: p.InstitutionName + " needs to be re-connected",
+	})
 	<div class="bb-card p-8 max-w-lg">
 		<div
 			x-data="connectionReauth"

--- a/internal/templates/components/pages/create_login.templ
+++ b/internal/templates/components/pages/create_login.templ
@@ -23,12 +23,10 @@ templ CreateLogin(p CreateLoginProps) {
 }
 
 templ createLoginManage(p CreateLoginProps) {
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">Manage Login</h1>
-			<p class="text-sm text-base-content/50 mt-1">Login account for { p.UserName }</p>
-		</div>
-	</div>
+	@components.PageHeader(components.PageHeaderProps{
+		Title:    "Manage Login",
+		Subtitle: "Login account for " + p.UserName,
+	})
 	<div class="max-w-lg">
 		<div
 			class="bb-card p-0 overflow-hidden"
@@ -36,14 +34,9 @@ templ createLoginManage(p CreateLoginProps) {
 		>
 			<!-- Account info -->
 			<div class="p-5 sm:p-6">
-				<div class="bb-icon-header">
-					<div class="bb-icon-header__tile bb-icon-tile--primary">
-						@components.LucideIcon("key", "w-5 h-5")
-					</div>
-					<div class="bb-icon-header__text">
-						<h2 class="text-sm font-semibold truncate">{ p.LoginUsername }</h2>
-						<p class="text-xs text-base-content/45">Login account</p>
-					</div>
+				<div class="mb-5">
+					<h2 class="text-sm font-semibold truncate">{ p.LoginUsername }</h2>
+					<p class="text-xs text-base-content/45">Login account</p>
 				</div>
 				<div class="grid grid-cols-2 gap-4">
 					<div>
@@ -93,14 +86,9 @@ templ createLoginManage(p CreateLoginProps) {
 				class="bb-card p-5 sm:p-6 mt-4"
 				x-data={ manageLoginSetupAlpine(p) }
 			>
-				<div class="bb-icon-header">
-					<div class="bb-icon-header__tile bb-icon-tile--warning">
-						@components.LucideIcon("link", "w-5 h-5")
-					</div>
-					<div class="bb-icon-header__text">
-						<h2 class="text-sm font-semibold">Setup Link</h2>
-						<p class="text-xs text-base-content/45">Share this link with { p.UserName } so they can set their password.</p>
-					</div>
+				<div class="mb-5">
+					<h2 class="text-sm font-semibold">Setup Link</h2>
+					<p class="text-xs text-base-content/45">Share this link with { p.UserName } so they can set their password.</p>
 				</div>
 				<div class="flex items-center gap-2 mb-3">
 					<input
@@ -170,25 +158,18 @@ templ createLoginManage(p CreateLoginProps) {
 }
 
 templ createLoginNew(p CreateLoginProps) {
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">Create Login</h1>
-			<p class="text-sm text-base-content/50 mt-1">Create a sign-in account for { p.UserName }</p>
-		</div>
-	</div>
+	@components.PageHeader(components.PageHeaderProps{
+		Title:    "Create Login",
+		Subtitle: "Create a sign-in account for " + p.UserName,
+	})
 	<div class="max-w-lg" x-data={ newLoginAlpine(p) }>
 		<template x-if="!done">
 			<form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
 				<!-- Header + fields -->
 				<div class="p-5 sm:p-6">
-					<div class="bb-icon-header">
-						<div class="bb-icon-header__tile bb-icon-tile--primary">
-							@components.LucideIcon("user-plus", "w-5 h-5")
-						</div>
-						<div class="bb-icon-header__text">
-							<h2 class="text-sm font-semibold">New login account</h2>
-							<p class="text-xs text-base-content/45">They'll receive a link to set their password</p>
-						</div>
+					<div class="mb-5">
+						<h2 class="text-sm font-semibold">New login account</h2>
+						<p class="text-xs text-base-content/45">They'll receive a link to set their password</p>
 					</div>
 					<div class="space-y-4">
 						<div>
@@ -236,14 +217,9 @@ templ createLoginNew(p CreateLoginProps) {
 			<div class="bb-card p-0 overflow-hidden">
 				<!-- Header -->
 				<div class="p-5 sm:p-6">
-					<div class="bb-icon-header">
-						<div class="bb-icon-header__tile bb-icon-tile--success">
-							@components.LucideIcon("circle-check", "w-5 h-5")
-						</div>
-						<div class="bb-icon-header__text">
-							<h2 class="text-sm font-semibold">Login created</h2>
-							<p class="text-xs text-base-content/45">Share the setup link with { p.UserName }</p>
-						</div>
+					<div class="mb-5">
+						<h2 class="text-sm font-semibold">Login created</h2>
+						<p class="text-xs text-base-content/45">Share the setup link with { p.UserName }</p>
 					</div>
 					<div x-data="{ copied: false }">
 						<label class="block text-xs font-medium text-base-content/50 mb-1.5">Setup Link</label>

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -24,24 +24,21 @@ templ RuleForm(p RuleFormProps) {
 		@templ.JSONScript("rule-form-data", p.Rule)
 	}
 	<div x-data="ruleForm" data-is-edit={ ruleFormIsEditAttr(p.IsEdit) }>
-		<div class="bb-page-header">
-			<div>
-				<h1 class="bb-page-title" x-text="isEdit ? 'Edit Rule' : 'New Rule'"></h1>
-				<p class="text-sm text-base-content/50 mt-1">When transactions match the conditions, the actions are applied automatically.</p>
-			</div>
-		</div>
+		{{ title := "New Rule" }}
+		if p.IsEdit {
+			{{ title = "Edit Rule" }}
+		}
+		@components.PageHeader(components.PageHeaderProps{
+			Title:    title,
+			Subtitle: "When transactions match the conditions, the actions are applied automatically.",
+		})
 		<div class="max-w-2xl">
 			<form @submit.prevent="submitRule()" class="bb-card p-0 overflow-hidden">
 				<!-- Top section: icon header + rule name -->
 				<div class="p-5 sm:p-6">
-					<div class="bb-icon-header">
-						<div class="bb-icon-header__tile bb-icon-tile--primary">
-							@components.LucideIcon("list-filter", "w-5 h-5")
-						</div>
-						<div class="bb-icon-header__text">
-							<h2 class="text-sm font-semibold" x-text="isEdit ? 'Rule details' : 'New rule'"></h2>
-							<p class="text-xs text-base-content/45">Pick when it fires and what it does</p>
-						</div>
+					<div class="mb-5">
+						<h2 class="text-sm font-semibold" x-text="isEdit ? 'Rule details' : 'New rule'"></h2>
+						<p class="text-xs text-base-content/45">Pick when it fires and what it does</p>
 					</div>
 					<div>
 						<label class="block text-xs font-medium text-base-content/50 mb-1.5" for="rule-name">Rule name</label>

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -8,47 +8,31 @@ import "breadbox/internal/templates/components"
 // Alpine submit flow) is preserved.
 templ TagForm(p TagFormProps) {
 	<script src="/static/js/admin/slug.js"></script>
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">
-				if p.IsEdit {
-					Edit Tag
-				} else {
-					Add Tag
-				}
-			</h1>
-			<p class="text-sm text-base-content/50 mt-1">
-				if p.IsEdit {
-					Slug is immutable &mdash; other fields can be changed.
-				} else {
-					Create a new tag for coordinating transaction work.
-				}
-			</p>
-		</div>
-	</div>
+	{{ title := "Add Tag" }}
+	{{ subtitle := "Create a new tag for coordinating transaction work." }}
+	if p.IsEdit {
+		{{ title = "Edit Tag" }}
+		{{ subtitle = "Slug is immutable — other fields can be changed." }}
+	}
+	@components.PageHeader(components.PageHeaderProps{Title: title, Subtitle: subtitle})
 	<div class="max-w-lg" x-data="tagForm()">
 		<form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
 			<div class="p-5 sm:p-6">
-				<div class="bb-icon-header">
-					<div class="bb-icon-header__tile bb-icon-tile--primary">
-						@components.LucideIcon("tag", "w-5 h-5")
-					</div>
-					<div class="bb-icon-header__text">
-						<h2 class="text-sm font-semibold">
-							if p.IsEdit {
-								{ tagDisplayOr(p.Tag) }
-							} else {
-								New tag
-							}
-						</h2>
-						<p class="text-xs text-base-content/45">
-							if p.IsEdit {
-								<code class="font-mono text-xs">{ tagSlugOr(p.Tag) }</code>
-							} else {
-								Open-ended label for transactions
-							}
-						</p>
-					</div>
+				<div class="mb-5">
+					<h2 class="text-sm font-semibold">
+						if p.IsEdit {
+							{ tagDisplayOr(p.Tag) }
+						} else {
+							New tag
+						}
+					</h2>
+					<p class="text-xs text-base-content/45">
+						if p.IsEdit {
+							<code class="font-mono text-xs">{ tagSlugOr(p.Tag) }</code>
+						} else {
+							Open-ended label for transactions
+						}
+					</p>
 				</div>
 				<!-- Live preview chip -->
 				<div class="flex items-center gap-3 p-3 bg-base-200/40 rounded-xl mb-5">
@@ -209,14 +193,12 @@ templ TagForm(p TagFormProps) {
 		if p.IsEdit {
 			<div class="bb-card mt-6 border-error/30">
 				<div class="p-5 sm:p-6">
-					<div class="bb-icon-header">
-						<div class="bb-icon-header__tile bg-error/10 text-error">
-							@components.LucideIcon("alert-triangle", "w-5 h-5")
-						</div>
-						<div class="bb-icon-header__text">
-							<h2 class="text-sm font-semibold">Danger zone</h2>
-							<p class="text-xs text-base-content/45">Deleting a tag removes it from all transactions. Activity annotations are preserved.</p>
-						</div>
+					<div class="mb-5">
+						<h2 class="text-sm font-semibold flex items-center gap-2">
+							@components.LucideIcon("alert-triangle", "w-4 h-4 text-error")
+							Danger zone
+						</h2>
+						<p class="text-xs text-base-content/45">Deleting a tag removes it from all transactions. Activity annotations are preserved.</p>
 					</div>
 					<div class="mt-4">
 						<button

--- a/internal/templates/components/pages/user_form.templ
+++ b/internal/templates/components/pages/user_form.templ
@@ -12,24 +12,13 @@ templ UserForm(p UserFormProps) {
 	// listener before Alpine fires the event. See #828 for the debugging
 	// trail behind this rule.
 	<script src="/static/js/admin/components/user_form.js"></script>
-	<div class="bb-page-header">
-		<div>
-			<h1 class="bb-page-title">
-				if p.IsEdit {
-					Edit { userFormName(p.User) }
-				} else {
-					Add Member
-				}
-			</h1>
-			<p class="text-sm text-base-content/50 mt-1">
-				if p.IsEdit {
-					Update member details
-				} else {
-					Add a new person to your household
-				}
-			</p>
-		</div>
-	</div>
+	{{ title := "Add Member" }}
+	{{ subtitle := "Add a new person to your household" }}
+	if p.IsEdit {
+		{{ title = "Edit " + userFormName(p.User) }}
+		{{ subtitle = "Update member details" }}
+	}
+	@components.PageHeader(components.PageHeaderProps{Title: title, Subtitle: subtitle})
 	if p.IsEdit {
 		@userFormEdit(p)
 	} else {


### PR DESCRIPTION
Design-system **chrome sweep** of the admin edit-form pages — surgical (chrome only, no body redesigns).

## Per page
| Page | PageHeader | Legacy icon-tile removed |
|---|---|---|
| `rule_form` | ✓ (dynamic New/Edit title) | ✓ (dropped `list-filter` section tile) |
| `tag_form` | ✓ | ✓ ×2 (top + danger-zone; danger keeps an inline `text-error` glyph) |
| `user_form` | ✓ (edit: "Edit {name}") | — none present |
| `category_form` | ✓ | kept 1 — it's a **live icon/color preview** of the category being authored (reactive), not a topic tile |
| `connection_new` / `connection_reauth` | ✓ | — (brand/step marks, not legacy tiles) |
| `create_login` | ✓ (manage + new flows) | ✓ ×4 |

`csv_import` left as-is (wizard chrome). Form bodies, `bb-action-row` save footers, validation, CSRF, and Alpine wiring untouched. No low-contrast badges found; principle-#8 states are covered by daisy `btn` on the touched chrome.

`go build` / `go vet` / `go test ./...` green.

## Evidence — `/rules/new` on the canonical PageHeader + quiet section labels (no icon tiles)
<img src="https://bb-artifacts.exe.xyz/f/0aa45d70419cb554.jpeg" width="800" alt="Rule form on PageHeader chrome with quiet WHEN/MATCH/THEN labels">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
