### PR TITLE
fix(ui): StatTile linked variant gets a focus-visible ring (principle #8)

### DIFF
--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -190,6 +190,9 @@ StatTileProps{
 ```
 
 Set `ValuePrivateKind: "amount"` on money tiles so they obfuscate with privacy mode.
+When `Href` is set the tile is an `<a>` and carries both `bb-card--interactive`
+hover and a keyboard `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40`
+ring (principle #8 — every interactive element has visible hover + focus states).
 
 ## EmptyState — `empty_state.templ`
 

--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -20,7 +20,8 @@ package components
 //   - Tone:        "neutral" (default), "primary", "success", "warning",
 //                  "error", "info". Drives icon-tile bg + icon color only.
 //   - Href:        optional. When set, the tile becomes an <a> with
-//                  bb-card--interactive hover.
+//                  bb-card--interactive hover + a keyboard focus-visible
+//                  primary ring (principle #8 — interaction states).
 
 type StatTileTone string
 
@@ -85,7 +86,7 @@ func statTileIcon(t StatTileTone) string {
 
 templ StatTile(p StatTileProps) {
 	if p.Href != "" {
-		<a href={ p.Href } class="bb-card bb-card--interactive p-4 no-underline block">
+		<a href={ p.Href } class="bb-card bb-card--interactive p-4 no-underline block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
 			@statTileBody(p)
 		</a>
 	} else {


### PR DESCRIPTION
Principle-#8 (interaction states) sweep of the **shared** design-system components — fixes the one real gap at the source so every caller benefits.

## Fixed
- **`StatTile`** — when `Href` is set the tile renders as an `<a class="bb-card bb-card--interactive">` with hover but **no visible keyboard focus ring**. Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40` to the linked variant only (the non-link `<div>` variant is untouched; hover was already covered by `bb-card--interactive`, so no redundant override). Idiom matches `collapsible_section`. Doc-comment + `components.md` entry noted.

## Audited, already correct (no changes)
`collapsible_section` (button, ring present) · `radio_card` (`peer-focus-visible:ring`) · `tab_bar` (daisy `.tab` ships focus-visible) · `overflow_menu` (real `.btn` trigger + daisy `.menu` items) · `empty_state` (real `.btn` CTAs) · `icon_tile`/`user_avatar` (non-interactive).

No render/golden test asserts StatTile HTML, so no test updates. `go build` / `go vet` / `go test ./...` green. (Focus-visible rings only paint on real keyboard nav, so no meaningful screenshot — verified the class is applied + focusable.)

## Follow-up flagged (separate PR)
The list-row row links use `<a class="contents">`, so keyboard focus paints no visible box on `/reports`, `/rules`, agent-run rows, etc. — needs a `focus-within` ring on the `<li>` across the list-row surfaces. Queuing that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
