### PR TITLE
fix(a11y): keyboard focus ring on list-row links (one scoped CSS rule)

### DIFF
--- a/input.css
+++ b/input.css
@@ -449,6 +449,31 @@
     border-color: var(--color-base-300);
   }
 
+  /* ── List-row keyboard focus ──
+   * The redesigned list surfaces (/reports, /rules, /recurring,
+   * /accounts, /tags, /categories, /connections, /household, agent-run
+   * rows) wrap each row's whole-row link in an `<a class="contents">`.
+   * `display:contents` produces no box, so `:focus-visible` on the
+   * anchor has nothing to paint — keyboard users tabbing through rows
+   * got no visible focus indicator (the `hover:bg-base-200/40` mouse
+   * state already worked). Promote the keyboard-focus ring onto the
+   * `.list-row` <li> itself.
+   *   - `:has(> a.contents:focus-visible)` scopes it to rows whose
+   *     DIRECT child row-link is focused. An inner control (the
+   *     overflow kebab) is NOT a `> a.contents`, so focusing the kebab
+   *     keeps its own focus ring and never double-rings the whole row.
+   *   - `:focus-visible` keeps it keyboard-only — a mouse click on the
+   *     row doesn't trigger the ring.
+   *   - Inset `box-shadow` (not outline) so the ring never shifts
+   *     layout, never overlaps the hairline divider, and never clips
+   *     against the bb-card's rounded first/last-row corners.
+   *   `--color-primary` at 0.4 alpha matches the app's `ring-primary/40`
+   *   focus idiom (principle #8 / StatTile, CollapsibleSection). */
+  .list-row:has(> a.contents:focus-visible) {
+    box-shadow: inset 0 0 0 2px oklch(from var(--color-primary) l c h / 0.4);
+    border-radius: inherit;
+  }
+
   /* ── Form card primitives ── */
   /* Icon-header: colored tile + title + optional subtitle.
      Used at the top of sectioned form cards (bb-card p-0 overflow-hidden). */


### PR DESCRIPTION
A11y fix: the redesigned list-row surfaces had no visible **keyboard** focus indicator on the row link, because each row link is a `display:contents` anchor (`<a class="contents">`) which has no box to paint `:focus-visible` on. One scoped CSS rule fixes every surface at once.

## The rule (`input.css`)
```css
.list-row:has(> a.contents:focus-visible) {
  box-shadow: inset 0 0 0 2px oklch(from var(--color-primary) l c h / 0.4);
  border-radius: inherit;
}
```
Covers `/reports`, `/rules`, `/recurring`, `/accounts`, `/tags`, `/categories`, `/connections`, `/household`, and agent-run rows — **no per-surface markup edits**.

## Scoping
- **Keyboard-only:** `:focus-visible` (not `:focus`) — a mouse click on a row never rings; hover (`hover:bg-base-200/40`) is unchanged.
- **Row-link-only (no kebab double-ring):** `:has(> a.contents:focus-visible)` matches only when the row's *direct-child* row-link is focused. The overflow kebab is a sibling `<button>`, so focusing it keeps its own ring and the row does not double-ring.
- **No layout shift / clean card edges:** `inset` box-shadow stays inside the row box (an outline-with-offset would clip the rounded first/last row). `--color-primary` @ 0.4 matches the `ring-primary/40` idiom (principle #8). Documented in the `input.css` spec'd-overrides family per `.claude/rules/daisyui.md`.

Verified the rule is in the compiled bundle; `go build`/`vet`/`test ./...` green. (A `:focus-visible` ring only paints on real keyboard nav — tab to a row to see it — so no programmatic screenshot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
