### PR TITLE
fix(ui): close DS gaps on detail pages (EntityHeader, family table, EmptyState, badge tones)

### DIFF
--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -74,12 +74,13 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 		if len(p.Accounts) > 0 {
 			@connDetailAccounts(p)
 		} else {
-			<div class="bb-card mb-6">
-				<div class="flex flex-col items-center justify-center py-12 text-base-content/30">
-					@components.LucideIcon("wallet", "w-10 h-10 mb-3 opacity-50")
-					<p class="text-sm">No accounts found for this connection</p>
-					<p class="text-xs mt-1">Accounts will appear after the first sync</p>
-				</div>
+			<div class="mb-6">
+				@components.EmptyState(components.EmptyStateProps{
+					Icon:    "wallet",
+					Title:   "No accounts yet — they appear after the first sync",
+					Compact: true,
+					InCard:  true,
+				})
 			</div>
 		}
 		<!-- Sync History -->

--- a/internal/templates/components/pages/report_detail.templ
+++ b/internal/templates/components/pages/report_detail.templ
@@ -33,35 +33,18 @@ templ ReportDetail(p ReportDetailProps) {
 					<span x-text="toast"></span>
 				</div>
 			</div>
-			<!-- Report header -->
-			<div class="flex items-start justify-between gap-4 mb-5">
-				<div class="min-w-0">
-					<div class="flex items-center gap-2 mb-2 flex-wrap">
-						@components.ReportPriorityBadge(p.Report.Priority)
-						<span x-show="!isRead" x-cloak class="badge badge-soft badge-info badge-sm">Unread</span>
-					</div>
-					<h1 class="text-xl sm:text-2xl font-semibold leading-snug break-words text-base-content">{ p.Report.Title }</h1>
-					<div class="mt-2.5 flex items-center gap-1.5 text-xs text-base-content/50">
-						@components.LucideIcon("bot", "w-3.5 h-3.5 text-base-content/40")
-						<span class="font-medium text-base-content/70">{ p.Report.DisplayAuthor }</span>
-						<span class="text-base-content/25">·</span>
-						<span title={ p.Report.CreatedAt }>{ p.Report.CreatedAtRel }</span>
-					</div>
-				</div>
-				<div class="flex items-center gap-2 shrink-0">
-					<button type="button" @click="toggleRead()" class="btn btn-ghost btn-sm gap-2">
-						<i :data-lucide="isRead ? 'rotate-ccw' : 'check'" class="w-4 h-4"></i>
-						<span class="hidden sm:inline" x-text="isRead ? 'Mark unread' : 'Mark read'"></span>
-					</button>
-					@components.OverflowMenu(components.OverflowMenuProps{
-						AriaLabel: "Report actions",
-						Items: []components.OverflowMenuItem{
-							{Label: "Copy link", Icon: "link", OnClick: "copyLink()"},
-							{Label: "Manage report format", Icon: "sliders-horizontal", Href: "/settings/mcp#report-format"},
-						},
-					})
-				</div>
-			</div>
+			<!-- Report header — the canonical EntityHeader (PageHeader's
+			     detail sibling). The priority chip stays the header's
+			     status affordance (the /reports index encodes priority in
+			     its leading status tile instead), so the header is
+			     intentionally icon-less. -->
+			@components.EntityHeader(components.EntityHeaderProps{
+				Title:      p.Report.Title,
+				TitleClass: "break-words",
+				Badges:     reportDetailBadges(p),
+				Meta:       reportDetailMeta(p),
+				Action:     reportDetailActions(),
+			})
 			<!-- Body card — Markdown rendered server-side into .bb-prose -->
 			<div class="bb-card">
 				<div class="px-5 sm:px-7 py-5 sm:py-6">
@@ -69,6 +52,46 @@ templ ReportDetail(p ReportDetailProps) {
 				</div>
 			</div>
 		</div>
+	</div>
+}
+
+// reportDetailBadges renders the EntityHeader badge row: the priority
+// chip plus the reactive Unread badge (Alpine x-show, info-vivid). Both
+// hide < sm per the EntityHeader contract — the mark-read action stays
+// reachable on mobile.
+templ reportDetailBadges(p ReportDetailProps) {
+	@components.ReportPriorityBadge(p.Report.Priority)
+	<span x-show="!isRead" x-cloak class="badge badge-soft badge-info badge-sm">Unread</span>
+}
+
+// reportDetailMeta is the bullet-separated subtitle row: agent author ·
+// relative submit time. Rendered inside EntityHeader's meta slot.
+templ reportDetailMeta(p ReportDetailProps) {
+	<span class="flex items-center gap-1">
+		@components.LucideIcon("bot", "w-3.5 h-3.5")
+		<span class="font-medium text-base-content/70">{ p.Report.DisplayAuthor }</span>
+	</span>
+	<span class="text-base-content/20">·</span>
+	<span title={ p.Report.CreatedAt }>{ p.Report.CreatedAtRel }</span>
+}
+
+// reportDetailActions is the EntityHeader trailing cluster: the
+// mark-read/unread toggle (reactive label, icon-only < sm) and the
+// overflow menu (copy link, manage format). Rendered inside the x-data
+// scope so the Alpine bindings stay live.
+templ reportDetailActions() {
+	<div class="flex items-center gap-2">
+		<button type="button" @click="toggleRead()" class="btn btn-ghost btn-sm gap-2">
+			<i :data-lucide="isRead ? 'rotate-ccw' : 'check'" class="w-4 h-4"></i>
+			<span class="hidden sm:inline" x-text="isRead ? 'Mark unread' : 'Mark read'"></span>
+		</button>
+		@components.OverflowMenu(components.OverflowMenuProps{
+			AriaLabel: "Report actions",
+			Items: []components.OverflowMenuItem{
+				{Label: "Copy link", Icon: "link", OnClick: "copyLink()"},
+				{Label: "Manage report format", Icon: "sliders-horizontal", Href: "/settings/mcp#report-format"},
+			},
+		})
 	</div>
 }
 

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -380,16 +380,16 @@ templ ruleDetailPendingMatches(p RuleDetailProps) {
 							<table class="table table-sm">
 								<thead>
 									<tr>
-										<th class="text-xs">Name</th>
-										<th class="text-xs text-right">Amount</th>
-										<th class="text-xs">Date</th>
+										<th class="text-xs font-medium uppercase tracking-wide text-base-content/50">Name</th>
+										<th class="text-xs font-medium uppercase tracking-wide text-base-content/50 text-right">Amount</th>
+										<th class="text-xs font-medium uppercase tracking-wide text-base-content/50">Date</th>
 									</tr>
 								</thead>
 								<tbody>
 									for _, m := range p.Preview.SampleMatches {
-										<tr>
-											<td class="text-sm">{ m.ProviderName }</td>
-											<td class="text-sm text-right">
+										<tr class="hover:bg-base-200/40 transition-colors">
+											<td class="text-sm" data-private="merchant">{ m.ProviderName }</td>
+											<td class="text-sm text-right tabular-nums">
 												<!-- Rule preview shows the raw amounts the rule would
 												     match; AmountBalance keeps the stored sign visible
 												     without the success-green income tint that would
@@ -400,7 +400,7 @@ templ ruleDetailPendingMatches(p RuleDetailProps) {
 													Class:  "text-sm",
 												})
 											</td>
-											<td class="text-sm text-base-content/60">{ m.Date }</td>
+											<td class="text-sm text-base-content/60 tabular-nums">{ m.Date }</td>
 										</tr>
 									}
 								</tbody>

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -302,7 +302,7 @@ templ seriesFieldLabel(label string) {
 
 // seriesDetailBadges is the EntityHeader badge row: status + type + (candidate) confidence.
 templ seriesDetailBadges(s SubscriptionRow) {
-	<span class={ "badge badge-soft badge-sm", "badge-" + s.StatusTone }>{ s.StatusLabel }</span>
+	<span class={ seriesStatusBadgeClass(s.StatusTone) }>{ s.StatusLabel }</span>
 	@components.SeriesTypeChip(s.TypeLabel, "sm")
 	if s.Status == "candidate" {
 		@components.SeriesConfidenceChip(s.ConfidenceBand, s.BandTone)
@@ -405,6 +405,17 @@ func seriesTypeIcon(t string) string {
 	default:
 		return "repeat"
 	}
+}
+
+// seriesStatusBadgeClass renders the header status chip. The neutral tone
+// (cancelled / unknown) maps to badge-ghost rather than badge-soft
+// badge-neutral — a soft neutral badge reads as invisible gray-on-gray on
+// the dark theme (per the vivid-only badge rule). Vivid tones stay soft.
+func seriesStatusBadgeClass(tone string) string {
+	if tone == "neutral" || tone == "" {
+		return "badge badge-ghost badge-sm"
+	}
+	return "badge badge-soft badge-sm badge-" + tone
 }
 
 func seriesStatusIconTone(status string) components.IconTone {

--- a/internal/templates/components/pages/sync_log_detail.templ
+++ b/internal/templates/components/pages/sync_log_detail.templ
@@ -168,15 +168,12 @@ templ SyncLogDetail(p SyncLogDetailProps) {
 			</div>
 		</div>
 	} else {
-		<div class="bb-card p-8 text-center">
-			<div class="flex flex-col items-center">
-				<div class="w-12 h-12 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
-					@components.LucideIcon("layers", "w-6 h-6 text-base-content opacity-25")
-				</div>
-				<h3 class="text-sm font-semibold mb-1">No account breakdown</h3>
-				<p class="text-xs text-base-content/40">Per-account details are tracked for new syncs only.</p>
-			</div>
-		</div>
+		@components.EmptyState(components.EmptyStateProps{
+			Icon:    "layers",
+			Title:   "No account breakdown — tracked for new syncs only",
+			Compact: true,
+			InCard:  true,
+		})
 	}
 }
 


### PR DESCRIPTION
Design-system drift sweep of the admin **detail pages** — surgical chrome/badge/empty-state fixes only.

## Per page
- **`account_detail`** — already clean (EntityHeader + EmptyState + vivid badges). Untouched.
- **`transaction_detail`** — already clean (EntityHeader hero + blessed activity timeline + info-grid). Untouched.
- **`report_detail`** — hand-rolled `<div><h1>` header → `components.EntityHeader` (priority + reactive Unread badges → Badges; agent·time → Meta; mark-read toggle + OverflowMenu → Action; Alpine bindings preserved).
- **`subscription_detail`** — cancelled/unknown series badge `badge-soft badge-neutral` (invisible on dark) → `badge-ghost` via `seriesStatusBadgeClass` (vivid tones stay soft).
- **`rule_detail`** — sample-matches embedded table given the **family-table** skin (uppercase muted `th`, `hover:bg-base-200/40`, `tabular-nums` on Amount/Date, `data-private` name). Kept as a 3-col table (correct).
- **`connection_detail`** + **`sync_log_detail`** — hand-rolled empty blocks → `components.EmptyState` (compact, in-card), matching the EmptyStates already on those pages.

Excluded (already handled): `agent_run_detail` (keeps richer `bb-run-header`), `session_detail` + `account_link_detail` (done earlier this sprint).

Deferred (intentional, no churn): `sync_log_detail`'s header tile + `SyncBadge` pairing carries an explicit in-file justification from this sprint; the `seriesEditDrawer` form is out of scope.

`go build` / `go vet` / `go test ./...` green. (Detail routes need a live entity id to screenshot; changes are surgical chrome/badge/empty-state, verified by build + the pages/components test suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
