### PR TITLE
fix(static): revalidate /static/* assets (kill the stale-cache desync class)

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -28,9 +28,12 @@ func NewRouter(a *app.App, version string) http.Handler {
 	r.Use(mw.Logging(a.Logger))
 	r.Use(middleware.Recoverer)
 
-	// Static files (CSS, favicon) — embedded, no auth needed.
+	// Static files (CSS, JS, fonts, favicon) — embedded, no auth needed.
+	// NewStaticHandler stamps Cache-Control: no-cache so browsers revalidate
+	// instead of serving a heuristically-stale bundle (the desync that broke
+	// /recurring), and supplies content-hash ETags so revalidation 304s.
 	staticFS, _ := fs.Sub(static.FS, ".")
-	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+	r.Handle("/static/*", NewStaticHandler(staticFS, static.DevReload))
 
 	r.Get("/health", HealthLiveHandler(version))
 	r.Get("/health/live", HealthLiveHandler(version))

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -1,0 +1,94 @@
+//go:build !lite
+
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"net/http"
+	"strings"
+)
+
+// staticCacheControl is sent on every /static/* response. "no-cache" does NOT
+// mean "don't cache" — it means the browser MAY cache the asset but MUST
+// revalidate with the server before reusing it. Paired with a validator
+// (ETag or Last-Modified) the server answers an unchanged asset with a cheap
+// 304 Not Modified, and a changed asset (new deploy) with a fresh 200. This is
+// what makes a cached admin JS/CSS bundle impossible to silently desync from
+// newer server-rendered HTML — the regression class behind the /recurring
+// "subscriptions.js missing method" bug, where a heuristically-cached bundle
+// served stale against HTML that referenced a newer method.
+//
+// We deliberately avoid "no-store" (which kills caching outright and forces a
+// full re-download on every navigation) and avoid a long max-age (which is the
+// stale-cache trap itself, absent content-hashed filenames).
+const staticCacheControl = "no-cache"
+
+// NewStaticHandler builds the handler mounted at /static/*. It wraps the
+// standard http.FileServer with two additions:
+//
+//  1. A Cache-Control: no-cache header on every response, forcing browsers to
+//     revalidate cached assets instead of serving them heuristically-stale.
+//
+//  2. Content-hash ETags for the embedded FS. http.FileServer derives a
+//     Last-Modified validator from the file's modtime and will answer
+//     conditional requests with 304 — but embed.FS files all report a zero
+//     modtime, so http.ServeContent emits no Last-Modified and cannot 304.
+//     Without a validator, "no-cache" would still be correct (never stale) but
+//     would re-transfer the full asset on every request. We precompute a
+//     sha256-based ETag per embedded file at startup and set it on the
+//     response so http.ServeContent can satisfy If-None-Match with a 304.
+//
+// In dev-reload mode (BREADBOX_DEV_RELOAD=1) files are read from disk and carry
+// real, edit-updated modtimes, so http.FileServer's own Last-Modified handling
+// already revalidates correctly. We skip the precomputed ETags there — they
+// would go stale on the next edit and reintroduce the very bug we're fixing.
+func NewStaticHandler(staticFS fs.FS, devReload bool) http.Handler {
+	fileServer := http.StripPrefix("/static/", http.FileServer(http.FS(staticFS)))
+
+	var etags map[string]string
+	if !devReload {
+		etags = buildETags(staticFS)
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", staticCacheControl)
+		if etags != nil {
+			rel := strings.TrimPrefix(r.URL.Path, "/static/")
+			if tag, ok := etags[rel]; ok {
+				// http.ServeContent reads this header to honour If-None-Match
+				// and emits the 304 itself; we just supply the validator.
+				w.Header().Set("Etag", tag)
+			}
+		}
+		fileServer.ServeHTTP(w, r)
+	})
+}
+
+// buildETags walks the embedded asset FS once and returns a map of
+// relative-path → strong ETag (a quoted sha256 prefix of the file contents).
+// Content-hashing means the validator changes exactly when the asset changes
+// (i.e. on a new build/deploy), so stale 304s are impossible.
+func buildETags(staticFS fs.FS) map[string]string {
+	etags := make(map[string]string)
+	_ = fs.WalkDir(staticFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		f, err := staticFS.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer f.Close()
+		h := sha256.New()
+		if _, err := io.Copy(h, f); err != nil {
+			return nil
+		}
+		// 16 hex chars (64 bits) is ample to distinguish asset versions.
+		etags[path] = `"` + hex.EncodeToString(h.Sum(nil))[:16] + `"`
+		return nil
+	})
+	return etags
+}

--- a/internal/api/static_test.go
+++ b/internal/api/static_test.go
@@ -1,0 +1,95 @@
+//go:build !lite
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+// embeddedFS mimics the production embed.FS: files report a zero modtime, so
+// http.ServeContent cannot derive a Last-Modified validator from them — the
+// reason NewStaticHandler supplies content-hash ETags in embedded mode.
+func embeddedFS() fstest.MapFS {
+	return fstest.MapFS{
+		"css/styles.css":            {Data: []byte("body{color:red}")},
+		"js/admin/subscriptions.js": {Data: []byte("export function f(){}")},
+		"favicon.svg":               {Data: []byte("<svg/>")},
+	}
+}
+
+// Cache-Control: no-cache is the load-bearing header — it forces browsers to
+// revalidate cached bundles instead of serving them heuristically-stale, which
+// is the desync that broke /recurring (a cached subscriptions.js missing a
+// method newer server HTML referenced).
+func TestStaticHandler_SetsNoCache(t *testing.T) {
+	h := NewStaticHandler(embeddedFS(), false)
+	for _, path := range []string{"/static/css/styles.css", "/static/js/admin/subscriptions.js", "/static/favicon.svg"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200", path, rec.Code)
+		}
+		if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+			t.Errorf("%s: Cache-Control = %q, want %q", path, got, "no-cache")
+		}
+	}
+}
+
+// In embedded mode the handler must emit an ETag so that no-cache revalidation
+// can return a cheap 304 (embed.FS files have no Last-Modified to validate
+// against).
+func TestStaticHandler_EmbeddedEmitsETagAnd304(t *testing.T) {
+	h := NewStaticHandler(embeddedFS(), false)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/static/css/styles.css", nil))
+	etag := rec.Header().Get("Etag")
+	if etag == "" {
+		t.Fatal("embedded mode: expected an ETag, got none")
+	}
+
+	// A conditional request carrying the same validator must 304.
+	req := httptest.NewRequest(http.MethodGet, "/static/css/styles.css", nil)
+	req.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("conditional GET: status = %d, want 304", rec2.Code)
+	}
+	if got := rec2.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("304 response: Cache-Control = %q, want no-cache", got)
+	}
+}
+
+// Different content must yield a different ETag so a new deploy never serves a
+// stale 304.
+func TestStaticHandler_ETagIsContentAddressed(t *testing.T) {
+	tagFor := func(body string) string {
+		fsys := fstest.MapFS{"css/styles.css": {Data: []byte(body)}}
+		rec := httptest.NewRecorder()
+		NewStaticHandler(fsys, false).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/static/css/styles.css", nil))
+		return rec.Header().Get("Etag")
+	}
+	if tagFor("body{color:red}") == tagFor("body{color:blue}") {
+		t.Error("ETag did not change when asset content changed")
+	}
+}
+
+// In dev-reload mode we rely on http.FileServer's own (disk-modtime)
+// Last-Modified validators, which update on every edit. The handler still sets
+// no-cache but must NOT precompute its own ETags (they'd go stale on the next
+// edit and reintroduce the bug).
+func TestStaticHandler_DevReloadNoPrecomputedETag(t *testing.T) {
+	h := NewStaticHandler(embeddedFS(), true)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/static/css/styles.css", nil))
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got)
+	}
+	if got := rec.Header().Get("Etag"); got != "" {
+		t.Errorf("dev-reload mode: unexpected precomputed ETag %q", got)
+	}
+}

--- a/static/embed.go
+++ b/static/embed.go
@@ -17,8 +17,15 @@ var embedded embed.FS
 // BREADBOX_STATIC_DIR, or "static" if unset.
 var FS fs.FS = embedded
 
+// DevReload reports whether static assets are being served from disk
+// (BREADBOX_DEV_RELOAD=1) rather than the embedded FS. The static handler uses
+// this to decide its revalidation strategy: disk files carry real modtimes
+// (Last-Modified validators that update on edit), whereas embedded files have a
+// zero modtime and need content-hash ETags instead. See internal/api/static.go.
+var DevReload = os.Getenv("BREADBOX_DEV_RELOAD") == "1"
+
 func init() {
-	if os.Getenv("BREADBOX_DEV_RELOAD") != "1" {
+	if !DevReload {
 		return
 	}
 	dir := os.Getenv("BREADBOX_STATIC_DIR")


### PR DESCRIPTION
Hardening: prevents the **stale-cache desync** class of bug — the root cause of the `/recurring` Active-tab regression (#1823), where a browser-cached `subscriptions.js` referenced a method the newer server HTML expected but the cached bundle lacked, blanking the page.

## Root cause
`/static/*` was a bare `http.FileServer` (`internal/api/router.go`) with **no `Cache-Control`** — so browsers heuristically cached admin JS/CSS and could serve a stale bundle against fresh HTML after a deploy.

## Fix (one place)
New `internal/api/static.go` → `NewStaticHandler` wrapping the FileServer:
- Stamps **`Cache-Control: no-cache`** on every `/static/*` response — still cacheable, but the browser **must revalidate** every time, so a cached bundle can never be silently stale (chose `no-cache` over `no-store` to keep caching benefits).
- **Embedded/prod FS has zero modtime** (so Go emits no `Last-Modified`/ETag → `no-cache` alone would re-transfer, never `304`). So the handler precomputes a **sha256 content-hash `ETag`** per embedded asset at startup → conditional GETs return a cheap `304` when unchanged, fresh `200` when content changed on deploy (hash changes ⇒ no stale `304` possible).
- **Dev-reload path** (`BREADBOX_DEV_RELOAD=1`) keeps the FileServer's disk-modtime `Last-Modified` validators and skips the precomputed ETags (so an edited file can't pin to a stale hash); still gets `no-cache`. Verified live: `no-cache` + `Last-Modified`, `If-Modified-Since` → `304`.

## Test
`internal/api/static_test.go` (4 cases): `no-cache` on css/js/favicon; embedded mode emits an ETag + conditional GET → `304`; ETag is content-addressed; dev-reload sets `no-cache` with no precomputed ETag.

`go build` / `go vet` / `go test ./...` green (`TestStaticHandler_*` 4/4). Files: `internal/api/static.go` (new), `static_test.go` (new), `router.go`, `static/embed.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
