### PR TITLE
fix(timeline): contain relative-time tooltip bubble (kills feed mobile sideways scroll)

### DIFF
--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -121,7 +121,16 @@ templ timelineCard(p TimelineProps) {
 				}
 			</header>
 		}
-		<ol class="bb-timeline relative pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label={ p.AriaLabel }>
+		<!--
+			overflow-x-clip contains the daisy tooltip bubble (an absolutely
+			positioned, max-content `::before` on the relative-time pill). On a
+			narrow screen the last row's timestamp sits near the right edge, so
+			the centered bubble projects past the viewport and adds a few px of
+			sideways document scroll. Clip on the X axis only — Y stays visible
+			so the hover bubble still renders above the row. Desktop is
+			unaffected: timestamps sit well left of the wide list's right edge.
+		-->
+		<ol class="bb-timeline relative overflow-x-clip pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label={ p.AriaLabel }>
 			<!--
 				Continuous left rail. Top/bottom anchored so it threads
 				through every 24px tile (events + day separators) and the
@@ -176,7 +185,8 @@ templ timelineProminent(p TimelineProps) {
 			more contrast-y than the card-mode 1px line so it reads against
 			the page surface (not just a card surface).
 		-->
-		<ol class="bb-timeline relative pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label={ p.AriaLabel }>
+		<ol class="bb-timeline relative overflow-x-clip pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label={ p.AriaLabel }>
+			<!-- overflow-x-clip: see the card variant — contains the relative-time tooltip bubble so it can't widen the document on narrow screens. -->
 			<span class="absolute left-[29px] sm:left-[33px] top-2 bottom-14 w-[2px] bg-base-300 rounded-full" aria-hidden="true"></span>
 			{ children... }
 		</ol>


### PR DESCRIPTION
Mobile fix found in the deeper mobile-QA pass: the home **Feed** had a real ~12px horizontal scroll on narrow screens.

## Root cause (not flow-content — a tooltip bubble)
The timeline row *text* fits its cell. The overflow came from the daisyUI **`tooltip::before` bubble** on each relative-time pill: it's `position:absolute; width:max-content`, centered via `translateX(-50%)`, and renders the full datetime (~166px wide). On a narrow screen the last row's timestamp center sits at x≈434, so the centered bubble projects to **x≈513 — 13px past the 500px viewport**, inflating the document `scrollWidth` (this is the "rows overflow ~45px / tooltip span 112 vs 67" the QA measured — the invisible `opacity:0` bubble overhang, not the sentence).

## Fix (minimal, invariant-safe)
`overflow-x-clip` on the shared `.bb-timeline` `<ol>` (both `timelineCard` and `timelineProminent`).
- **X-clip only** — Y stays `visible`, so the hover bubble still renders *above* the row; tooltip behavior preserved.
- **Desktop unchanged** — at 1280px timestamps sit far from the right edge; nothing clips (verified docScrollW 1280→1280).
- **Mobile fixed** — verified live: docScrollW 512→500, `actualMaxScrollX` 11→0 at 500px.
- **Rail/tile/avatar geometry untouched** — only the list container's overflow; the blessed timeline invariants (rail centring, 24/28px tiles, `leading-6`, day-grouping, tombstones) are unmodified. Shared by `/` + `/transactions/{id}` + sync/agent logs — all benefit, none regress.

`go build` / `go vet` / `go test ./...` green (timeline render tests present + green; none assert the `<ol>` class).

Closes the only finding from the mobile-QA pass — the other 9 redesigned surfaces had zero overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
