### PR TITLE
bold(accounts): net-worth hero + assets/debt proportion + per-connection share meters

### DIFF
--- a/internal/admin/accounts.go
+++ b/internal/admin/accounts.go
@@ -154,7 +154,7 @@ func AccountsListPageHandler(a *app.App, svc *service.Service, sm *scs.SessionMa
 			TotalLiabilities: totalLiabilities,
 			HasAnyBalance:    hasAnyBalance,
 			ActiveUserID:     activeUserID,
-			Groups:           pages.GroupAccountsByConnection(rows),
+			Groups:           pages.AnnotateConnGroupShares(pages.GroupAccountsByConnection(rows)),
 			TotalAccounts:    len(rows),
 		}
 

--- a/internal/templates/components/pages/accounts_list.templ
+++ b/internal/templates/components/pages/accounts_list.templ
@@ -43,40 +43,7 @@ templ AccountsList(p AccountsListProps) {
 			</div>
 		}
 		if p.HasAnyBalance {
-			<div class="bb-card p-0 overflow-hidden mb-6">
-				<div class="grid grid-cols-3 divide-x divide-base-300">
-					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
-						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Net Worth</div>
-						<div class="truncate">
-							@components.Amount(components.AmountProps{
-								Value:  p.NetWorth,
-								Intent: components.AmountBalance,
-								Class:  "text-sm sm:text-2xl font-semibold tracking-tight",
-							})
-						</div>
-					</div>
-					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
-						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Assets</div>
-						<div class="truncate">
-							@components.Amount(components.AmountProps{
-								Value:  p.TotalAssets,
-								Intent: components.AmountBalance,
-								Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-success",
-							})
-						</div>
-					</div>
-					<div class="px-3 sm:px-5 py-3 sm:py-4 min-w-0">
-						<div class="text-[0.65rem] sm:text-xs font-medium text-base-content/50 mb-0.5 sm:mb-1">Liabilities</div>
-						<div class="truncate">
-							@components.Amount(components.AmountProps{
-								Value:  p.TotalLiabilities,
-								Intent: components.AmountCost,
-								Class:  "text-sm sm:text-2xl font-semibold tracking-tight text-error",
-							})
-						</div>
-					</div>
-				</div>
-			</div>
+			@accountsListHero(p)
 		}
 		if p.TotalAccounts > 0 {
 			<div class="flex flex-col gap-5">
@@ -101,23 +68,108 @@ templ AccountsList(p AccountsListProps) {
 	</div>
 }
 
+// accountsListHero is the page's headline: net worth as the single dominant
+// figure, assets/liabilities as supporting satellites, and an assets-vs-debt
+// proportion bar computed entirely from existing totals. The bar grows from
+// zero on load (tasteful motion, respects prefers-reduced-motion via the
+// `motion-reduce:transition-none` utility). All money stays data-private.
+templ accountsListHero(p AccountsListProps) {
+	<div
+		class="bb-card p-5 sm:p-6 mb-6"
+		x-data="{ shown: false }"
+		x-init="$nextTick(() => { shown = true })"
+	>
+		<div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+			<div class="min-w-0">
+				<div class="text-[0.7rem] font-medium uppercase tracking-wide text-base-content/50 mb-1">Net Worth</div>
+				<div class="truncate">
+					@components.Amount(components.AmountProps{
+						Value:  p.NetWorth,
+						Intent: components.AmountBalance,
+						Class:  "text-3xl sm:text-5xl font-semibold tracking-tight",
+					})
+				</div>
+				<div class="mt-1.5 text-xs text-base-content/50">{ accountsSummaryCaption(p) }</div>
+			</div>
+			<div class="flex items-center gap-6 sm:gap-8 shrink-0">
+				<div class="min-w-0">
+					<div class="flex items-center gap-1.5 mb-0.5">
+						<span class="w-2 h-2 rounded-full bg-success shrink-0"></span>
+						<span class="text-[0.7rem] font-medium uppercase tracking-wide text-base-content/50">Assets</span>
+					</div>
+					@components.Amount(components.AmountProps{
+						Value:  p.TotalAssets,
+						Intent: components.AmountBalance,
+						Class:  "text-lg sm:text-xl font-semibold tracking-tight text-success",
+					})
+				</div>
+				<div class="min-w-0">
+					<div class="flex items-center gap-1.5 mb-0.5">
+						<span class="w-2 h-2 rounded-full bg-error shrink-0"></span>
+						<span class="text-[0.7rem] font-medium uppercase tracking-wide text-base-content/50">Liabilities</span>
+					</div>
+					@components.Amount(components.AmountProps{
+						Value:  p.TotalLiabilities,
+						Intent: components.AmountCost,
+						Class:  "text-lg sm:text-xl font-semibold tracking-tight text-error",
+					})
+				</div>
+			</div>
+		</div>
+		<!-- Assets-vs-debt proportion bar: segment widths are the gross-balance
+		     split (assets + liabilities = 100%), a real at-a-glance leverage
+		     read from totals that already exist. -->
+		<div class="mt-5">
+			<div class="flex h-2 w-full overflow-hidden rounded-full bg-base-200">
+				<div
+					class="h-full bg-success rounded-full transition-[width] duration-700 ease-out motion-reduce:transition-none"
+					:style={ accountsProportionStyle(accountsGrossPct(p.TotalAssets, p)) }
+				></div>
+				if p.TotalLiabilities > 0 {
+					<div
+						class="h-full bg-error rounded-full border-l-2 border-base-100 transition-[width] duration-700 ease-out motion-reduce:transition-none"
+						:style={ accountsProportionStyle(accountsGrossPct(p.TotalLiabilities, p)) }
+					></div>
+				}
+			</div>
+			<div class="mt-2 flex items-center justify-between text-[0.7rem] text-base-content/45 tabular-nums">
+				<span>{ accountsPctLabel(accountsGrossPct(p.TotalAssets, p)) } assets</span>
+				if p.TotalLiabilities > 0 {
+					<span>{ accountsPctLabel(accountsGrossPct(p.TotalLiabilities, p)) } debt</span>
+				}
+			</div>
+		</div>
+	</div>
+}
+
 // accountsListConnGroup renders one connection: a quiet label line
 // (institution · count · subtotal, with health surfaced when the connection
-// needs attention) above the account list-rows in their own card.
+// needs attention) plus a share-of-assets meter, above the account list-rows
+// in their own card.
 templ accountsListConnGroup(g AccountsListConnGroup) {
 	<div class="flex flex-col gap-2">
-		<div class="flex items-center gap-2 px-1 min-w-0">
-			<span data-private="institution" class="text-sm font-medium text-base-content shrink-0">{ accountsConnLabel(g) }</span>
-			<span class="text-xs text-base-content/40 shrink-0">{ accountsConnCountLabel(g) }</span>
-			@accountsListConnStatus(g)
-			if g.HasSubtotal {
-				<span class="ml-auto shrink-0">
-					@components.Amount(components.AmountProps{
-						Value:  g.Subtotal,
-						Intent: components.AmountBalance,
-						Class:  "text-sm font-semibold tabular-nums",
-					})
-				</span>
+		<div class="flex flex-col gap-1.5 px-1">
+			<div class="flex items-center gap-2 min-w-0">
+				<span data-private="institution" class="text-sm font-semibold text-base-content shrink-0">{ accountsConnLabel(g) }</span>
+				<span class="text-xs text-base-content/40 shrink-0">{ accountsConnCountLabel(g) }</span>
+				@accountsListConnStatus(g)
+				if g.HasSubtotal {
+					<span class="ml-auto shrink-0">
+						@components.Amount(components.AmountProps{
+							Value:  g.Subtotal,
+							Intent: components.AmountBalance,
+							Class:  accountsSubtotalClass(g.Subtotal),
+						})
+					</span>
+				}
+			</div>
+			if g.SharePct > 0 {
+				<div class="flex items-center gap-2">
+					<div class="h-1 flex-1 max-w-[16rem] overflow-hidden rounded-full bg-base-200">
+						<div class="h-full rounded-full bg-success/55" style={ accountsShareWidth(g.SharePct) }></div>
+					</div>
+					<span class="text-[0.7rem] text-base-content/40 tabular-nums shrink-0">{ accountsPctLabel(g.SharePct) } of assets</span>
+				</div>
 			}
 		</div>
 		@components.AgentRunRowList() {
@@ -148,7 +200,7 @@ templ accountsListConnStatus(g AccountsListConnGroup) {
 templ accountsListRow(a AccountsListRow) {
 	<li class="list-row transition-colors hover:bg-base-200/40 items-center" data-account-id={ a.ID }>
 		<a class="contents no-underline" href={ templ.SafeURL("/accounts/" + a.ID) }>
-			<div class="w-9 h-9 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+			<div class={ "w-9 h-9 rounded-lg flex items-center justify-center shrink-0", accountsTypeTileClass(a.Type, a.IsLiability) }>
 				@accountsListTypeIcon(a.Type)
 			</div>
 			<div class="min-w-0">
@@ -202,17 +254,82 @@ templ accountsListRow(a AccountsListRow) {
 	</li>
 }
 
+// accountsListTypeIcon picks a type glyph. Color is inherited (currentColor)
+// from the tile so accountsTypeTileClass owns the tint in one place.
 templ accountsListTypeIcon(t string) {
 	switch t {
 		case "credit":
-			@components.LucideIcon("credit-card", "w-4 h-4 text-base-content/70")
+			@components.LucideIcon("credit-card", "w-4 h-4")
 		case "loan":
-			@components.LucideIcon("landmark", "w-4 h-4 text-base-content/70")
+			@components.LucideIcon("landmark", "w-4 h-4")
 		case "investment":
-			@components.LucideIcon("trending-up", "w-4 h-4 text-base-content/70")
+			@components.LucideIcon("trending-up", "w-4 h-4")
 		default:
-			@components.LucideIcon("wallet", "w-4 h-4 text-base-content/70")
+			@components.LucideIcon("wallet", "w-4 h-4")
 	}
+}
+
+// accountsTypeTileClass tints the leading type tile by what the account IS:
+// investments read as growth (success), liabilities (credit/loan) as debt
+// (warning), everyday deposit/cash accounts stay neutral. Vivid tones so the
+// tint survives the dark theme.
+func accountsTypeTileClass(t string, isLiability bool) string {
+	switch {
+	case t == "investment":
+		return "bg-success/10 text-success"
+	case isLiability:
+		return "bg-warning/10 text-warning"
+	default:
+		return "bg-base-200 text-base-content/70"
+	}
+}
+
+// accountsSubtotalClass tints a connection's net subtotal red when the
+// connection nets to debt, default ink otherwise.
+func accountsSubtotalClass(subtotal float64) string {
+	if subtotal < 0 {
+		return "text-sm font-semibold tabular-nums text-error"
+	}
+	return "text-sm font-semibold tabular-nums"
+}
+
+// accountsSummaryCaption is the hero's "N accounts across M connections" line.
+func accountsSummaryCaption(p AccountsListProps) string {
+	acct := "accounts"
+	if p.TotalAccounts == 1 {
+		acct = "account"
+	}
+	conn := "connections"
+	if len(p.Groups) == 1 {
+		conn = "connection"
+	}
+	return fmt.Sprintf("%d %s across %d %s", p.TotalAccounts, acct, len(p.Groups), conn)
+}
+
+// accountsGrossPct returns part / (assets + liabilities) as a percentage —
+// the share of the gross balance sheet. 0 when there's nothing to divide.
+func accountsGrossPct(part float64, p AccountsListProps) float64 {
+	gross := p.TotalAssets + p.TotalLiabilities
+	if gross <= 0 {
+		return 0
+	}
+	return part / gross * 100
+}
+
+// accountsPctLabel renders a percentage as a rounded whole number, e.g. "67%".
+func accountsPctLabel(pct float64) string {
+	return fmt.Sprintf("%.0f%%", pct)
+}
+
+// accountsProportionStyle is the Alpine :style expression for a hero bar
+// segment — it grows from 0 to its target width once `shown` flips true.
+func accountsProportionStyle(pct float64) string {
+	return fmt.Sprintf("shown ? 'width:%.4f%%' : 'width:0%%'", pct)
+}
+
+// accountsShareWidth is the static width style for a connection share meter.
+func accountsShareWidth(pct float64) string {
+	return fmt.Sprintf("width:%.4f%%", pct)
 }
 
 // accountsListBalanceClass tints liabilities red; assets keep the default ink.

--- a/internal/templates/components/pages/accounts_list_test.go
+++ b/internal/templates/components/pages/accounts_list_test.go
@@ -67,6 +67,43 @@ func TestGroupAccountsByConnection(t *testing.T) {
 	}
 }
 
+func TestAnnotateConnGroupShares(t *testing.T) {
+	groups := []AccountsListConnGroup{
+		{ConnectionShortID: "fidelity", Subtotal: 30000, HasSubtotal: true}, // 75% of 40000
+		{ConnectionShortID: "chase", Subtotal: 10000, HasSubtotal: true},    // 25% of 40000
+		{ConnectionShortID: "amex", Subtotal: -842.30, HasSubtotal: true},   // net debt → 0
+		{ConnectionShortID: "", HasSubtotal: false},                         // orphan, no balance → 0
+	}
+
+	got := AnnotateConnGroupShares(groups)
+
+	// Input slice must be untouched (pure).
+	if groups[0].SharePct != 0 {
+		t.Errorf("input mutated: SharePct = %v, want 0", groups[0].SharePct)
+	}
+
+	wants := map[string]float64{"fidelity": 75, "chase": 25, "amex": 0, "": 0}
+	for _, g := range got {
+		w := wants[g.ConnectionShortID]
+		if g.SharePct < w-0.01 || g.SharePct > w+0.01 {
+			t.Errorf("group %q SharePct = %.2f, want %.2f", g.ConnectionShortID, g.SharePct, w)
+		}
+	}
+}
+
+func TestAnnotateConnGroupSharesNoAssets(t *testing.T) {
+	// All net-debt / no-balance groups → no positive sum → all shares 0.
+	groups := []AccountsListConnGroup{
+		{ConnectionShortID: "amex", Subtotal: -500, HasSubtotal: true},
+		{ConnectionShortID: "orphan", HasSubtotal: false},
+	}
+	for _, g := range AnnotateConnGroupShares(groups) {
+		if g.SharePct != 0 {
+			t.Errorf("group %q SharePct = %v, want 0", g.ConnectionShortID, g.SharePct)
+		}
+	}
+}
+
 func TestAccountsConnCountLabel(t *testing.T) {
 	one := AccountsListConnGroup{Accounts: []AccountsListRow{{}}}
 	if got := accountsConnCountLabel(one); got != "1 account" {

--- a/internal/templates/components/pages/accounts_list_types.go
+++ b/internal/templates/components/pages/accounts_list_types.go
@@ -49,6 +49,13 @@ type AccountsListConnGroup struct {
 	Subtotal          float64
 	HasSubtotal       bool
 	Accounts          []AccountsListRow
+
+	// SharePct is this connection's positive subtotal as a percentage of
+	// the summed positive subtotals across all groups — "what share of
+	// your asset balances lives here." Zero for net-liability/no-balance
+	// groups (their figure speaks for itself). Filled by
+	// AnnotateConnGroupShares; drives the header's share meter.
+	SharePct float64
 }
 
 // AccountsListRow is one account row. Fields are pre-formatted (display_name
@@ -134,6 +141,31 @@ func GroupAccountsByConnection(rows []AccountsListRow) []AccountsListConnGroup {
 		return a.Subtotal > b.Subtotal
 	})
 	return groups
+}
+
+// AnnotateConnGroupShares fills SharePct on each group: its positive
+// subtotal as a percentage of the summed positive subtotals across all
+// groups. Net-liability or no-balance groups stay at 0. Returns a copy so
+// the input slice is untouched; pure + unit-tested so the share math is
+// pinned, not vibes.
+func AnnotateConnGroupShares(groups []AccountsListConnGroup) []AccountsListConnGroup {
+	var sumPositive float64
+	for _, g := range groups {
+		if g.HasSubtotal && g.Subtotal > 0 {
+			sumPositive += g.Subtotal
+		}
+	}
+	out := make([]AccountsListConnGroup, len(groups))
+	copy(out, groups)
+	if sumPositive <= 0 {
+		return out
+	}
+	for i := range out {
+		if out[i].HasSubtotal && out[i].Subtotal > 0 {
+			out[i].SharePct = out[i].Subtotal / sumPositive * 100
+		}
+	}
+	return out
 }
 
 // accountsConnLabel is the group header's institution label, with a fallback


### PR DESCRIPTION
**Bold redesign** — `/accounts` goes from a clean grouped list to an insight-forward financial overview where the money is the hero. All from **existing data** (no invented sparklines/history).

## What changed
- **Hero net-worth panel** — Net Worth at `text-5xl`, dominating; Assets/Liabilities demoted to satellites; an **assets-vs-debt proportion bar** (green/red, summing to 100%) that **animates from zero on load** (`motion-reduce`-safe) — instant leverage insight ("99% assets / 1% debt").
- **Per-connection share-of-assets meters** — each group header shows "% of assets" + a slim bar (`AnnotateConnGroupShares`, pure + unit-tested; share = positive subtotal ÷ Σ positive subtotals; net-debt groups tint red).
- **Account-type tile theming** — investment→success, credit/loan(liability)→warning (the amber Platinum Card tile), deposit→neutral; icon inherits the tint.

Preserved exactly: `GroupAccountsByConnection` + its test, server-side member filter (re-scopes totals + bar), privacy marking, liability sign/color, all links + manage overflow, orphan-bucket-last order.

`go build`/`vet`/`test ./...` green (2 new share-helper tests; grouping test untouched).

## Evidence
**Desktop (light)** — net-worth hero + proportion bar + share meters + themed tiles:
<img src="https://bb-artifacts.exe.xyz/f/2d9878e60db245a7.jpeg" width="900" alt="Accounts bold redesign — desktop light">

**Mobile (390px)** — hero stacks, bar full-width, share meters reflow:
<img src="https://bb-artifacts.exe.xyz/f/d446bb76aa5e8427.jpeg" width="380" alt="Accounts bold redesign — mobile">

**Dark** — vivid green/red proportion bar on the dark track:
<img src="https://bb-artifacts.exe.xyz/f/604992b8bcfce650.jpeg" width="900" alt="Accounts bold redesign — dark">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
