### PR TITLE
bold(feed): insight-led pulse hero + count-up metrics + activity sparkbar + motion

### DIFF
--- a/input.css
+++ b/input.css
@@ -449,31 +449,6 @@
     border-color: var(--color-base-300);
   }
 
-  /* ── List-row keyboard focus ──
-   * The redesigned list surfaces (/reports, /rules, /recurring,
-   * /accounts, /tags, /categories, /connections, /household, agent-run
-   * rows) wrap each row's whole-row link in an `<a class="contents">`.
-   * `display:contents` produces no box, so `:focus-visible` on the
-   * anchor has nothing to paint — keyboard users tabbing through rows
-   * got no visible focus indicator (the `hover:bg-base-200/40` mouse
-   * state already worked). Promote the keyboard-focus ring onto the
-   * `.list-row` <li> itself.
-   *   - `:has(> a.contents:focus-visible)` scopes it to rows whose
-   *     DIRECT child row-link is focused. An inner control (the
-   *     overflow kebab) is NOT a `> a.contents`, so focusing the kebab
-   *     keeps its own focus ring and never double-rings the whole row.
-   *   - `:focus-visible` keeps it keyboard-only — a mouse click on the
-   *     row doesn't trigger the ring.
-   *   - Inset `box-shadow` (not outline) so the ring never shifts
-   *     layout, never overlaps the hairline divider, and never clips
-   *     against the bb-card's rounded first/last-row corners.
-   *   `--color-primary` at 0.4 alpha matches the app's `ring-primary/40`
-   *   focus idiom (principle #8 / StatTile, CollapsibleSection). */
-  .list-row:has(> a.contents:focus-visible) {
-    box-shadow: inset 0 0 0 2px oklch(from var(--color-primary) l c h / 0.4);
-    border-radius: inherit;
-  }
-
   /* ── Form card primitives ── */
   /* Icon-header: colored tile + title + optional subtitle.
      Used at the top of sectioned form cards (bb-card p-0 overflow-hidden). */
@@ -1408,6 +1383,181 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   }
 
+  /* ════════════════════════════════════════════════════════════════════
+   * Home Feed — bold hero + alive stream  (branch design/bold-feed)
+   * --------------------------------------------------------------------
+   * The /feed surface is the product's front door. It elevates the shared
+   * timeline with an insight-forward hero (a live sync-health "pulse" + a
+   * count-up metric cluster) and tasteful load/hover motion. Everything is
+   * scoped under `.bb-feed-*` so no other surface inherits it, and every
+   * keyframe is neutralised by the global prefers-reduced-motion reset at
+   * the top of this file (it zeroes animation-duration on *, ::before,
+   * ::after with !important).
+   * ════════════════════════════════════════════════════════════════════ */
+
+  /* Load-in rise: a soft fade + lift used on the hero tiles and the
+   * section blocks. Paired with .bb-feed-stagger for a cascade. */
+  @keyframes bb-feed-rise {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .bb-feed-rise {
+    animation: bb-feed-rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  /* Cascade direct children. Delays are capped at ~7 steps so a long list
+   * never accrues a visible "still loading" tail. */
+  .bb-feed-stagger > * { animation: bb-feed-rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) both; }
+  .bb-feed-stagger > *:nth-child(1) { animation-delay: 0.02s; }
+  .bb-feed-stagger > *:nth-child(2) { animation-delay: 0.07s; }
+  .bb-feed-stagger > *:nth-child(3) { animation-delay: 0.12s; }
+  .bb-feed-stagger > *:nth-child(4) { animation-delay: 0.17s; }
+  .bb-feed-stagger > *:nth-child(5) { animation-delay: 0.22s; }
+  .bb-feed-stagger > *:nth-child(n+6) { animation-delay: 0.27s; }
+
+  /* Hero metric tile — flat bordered card that lifts on hover/focus and
+   * carries a hairline top-accent in the metric's own tone. */
+  .bb-feed-tile {
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.18s ease, border-color 0.18s ease,
+                background-color 0.18s ease, box-shadow 0.2s ease;
+  }
+  .bb-feed-tile--link:hover,
+  .bb-feed-tile--link:focus-visible {
+    transform: translateY(-3px);
+    border-color: color-mix(in srgb, var(--bb-feed-accent, var(--color-base-content)) 38%, var(--color-base-300));
+    box-shadow: 0 8px 22px -12px color-mix(in srgb, var(--bb-feed-accent, #000) 55%, transparent);
+  }
+  /* Tonal top-edge accent — a 2px bar the width of the card, in the
+   * tile's metric colour, that brightens on hover. */
+  .bb-feed-tile::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 2px;
+    background: color-mix(in srgb, var(--bb-feed-accent, var(--color-base-content)) 45%, transparent);
+    opacity: 0.55;
+    transition: opacity 0.18s ease;
+  }
+  .bb-feed-tile--link:hover::before,
+  .bb-feed-tile--link:focus-visible::before { opacity: 1; }
+
+  /* The tinted icon chip inside a tile (and the pulse panel). */
+  .bb-feed-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.625rem;
+    color: var(--bb-feed-accent, var(--color-base-content));
+    background: color-mix(in srgb, var(--bb-feed-accent, var(--color-base-content)) 12%, transparent);
+  }
+
+  /* ── Sync-health pulse panel ──
+   * The hero's lead element. A slightly larger card whose left edge carries
+   * a 3px status-tinted accent rail and whose background is a faint vertical
+   * wash of the status tone — confident without shouting. */
+  .bb-feed-pulse {
+    position: relative;
+    overflow: hidden;
+    border-color: color-mix(in srgb, var(--bb-feed-accent, var(--color-base-300)) 30%, var(--color-base-300));
+    background:
+      linear-gradient(180deg,
+        color-mix(in srgb, var(--bb-feed-accent, transparent) 7%, var(--color-base-100)) 0%,
+        var(--color-base-100) 70%);
+    transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.2s ease;
+  }
+  .bb-feed-pulse::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: color-mix(in srgb, var(--bb-feed-accent, var(--color-base-content)) 75%, transparent);
+  }
+  .bb-feed-pulse--link:hover,
+  .bb-feed-pulse--link:focus-visible {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 26px -14px color-mix(in srgb, var(--bb-feed-accent, #000) 60%, transparent);
+  }
+
+  /* Live status dot with an expanding ping ring (healthy/syncing only). */
+  .bb-feed-dot {
+    position: relative;
+    display: inline-flex;
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: 9999px;
+    background: var(--bb-feed-accent, var(--color-base-content));
+  }
+  .bb-feed-dot--live::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 9999px;
+    background: var(--bb-feed-accent, var(--color-base-content));
+    animation: bb-feed-ping 1.9s cubic-bezier(0, 0, 0.2, 1) infinite;
+  }
+  @keyframes bb-feed-ping {
+    0%   { transform: scale(1);   opacity: 0.55; }
+    75%, 100% { transform: scale(2.6); opacity: 0; }
+  }
+
+  /* Activity sparkbars — a compact "rhythm" strip built from the per-day
+   * event counts the page already renders. Pure presentation; no new data. */
+  .bb-feed-sparkbar {
+    display: block;
+    flex: 1 1 0;
+    max-width: 1.5rem;
+    align-self: flex-end;
+    border-radius: 0.3rem;
+    background: color-mix(in srgb, var(--color-primary) 60%, transparent);
+    min-height: 4px;
+    transition: height 0.45s cubic-bezier(0.22, 1, 0.36, 1), background-color 0.15s ease;
+  }
+  .bb-feed-sparkbar:hover {
+    background: color-mix(in srgb, var(--color-primary) 90%, transparent);
+  }
+
+  /* ── Alive stream — per-row hover affordance ──
+   * Highlights the row BODY only (the column right of the rail) so the
+   * continuous timeline rail is never painted over. The negative inline
+   * margin lets the highlight breathe past the text without shifting the
+   * rail geometry. Comment-bubble rows are excluded — they own a bespoke
+   * tail treatment in the prominent-timeline overrides. */
+  .bb-feed-stream .bb-timeline > li:not([role="separator"]):not(:has(.bb-comment-bubble)) > div:last-child {
+    border-radius: 0.7rem;
+    margin-inline: -0.5rem;
+    padding-inline: 0.5rem;
+    transition: background-color 0.15s ease;
+  }
+  .bb-feed-stream .bb-timeline > li:not([role="separator"]):not(:has(.bb-comment-bubble)):hover > div:last-child {
+    background: color-mix(in srgb, var(--color-base-200) 55%, transparent);
+  }
+
+  /* First-run hero — a confident, branded welcome on an empty front door. */
+  .bb-feed-welcome {
+    position: relative;
+    overflow: hidden;
+    background:
+      radial-gradient(120% 140% at 50% -20%,
+        color-mix(in srgb, var(--color-primary) 12%, transparent) 0%,
+        transparent 60%),
+      var(--color-base-100);
+  }
+  .bb-feed-welcome__orb {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 4.5rem;
+    height: 4.5rem;
+    border-radius: 1.25rem;
+    color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 14%, var(--color-base-100));
+    border: 1px solid color-mix(in srgb, var(--color-primary) 28%, transparent);
+    box-shadow: 0 14px 40px -18px color-mix(in srgb, var(--color-primary) 70%, transparent);
+  }
+
   /* ── Comment bubble ──
    *
    * Chat-style bubble used by the transaction-detail activity timeline for
@@ -2126,6 +2276,17 @@
   .bb-table-header {
     @apply flex items-center gap-3 px-4 py-2 text-xs font-medium text-base-content/40
            border-b border-base-300/50 bg-base-200/30;
+  }
+
+  /* Matches the .bb-tx-checkbox visibility contract: hidden until bulk-select
+     mode is active so the "Name" header stays aligned with the tx name text. */
+  .bb-tx-header-checkbox-col {
+    display: none;
+    flex-shrink: 0;
+    width: 1.25rem; /* w-5 */
+  }
+  body.bb-tx-selecting .bb-tx-header-checkbox-col {
+    display: block;
   }
 
   /* ── Date visibility (hidden in grouped, shown in list) ──

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -50,75 +50,136 @@ templ feedActiveFilterBanner(p FeedProps) {
 
 // ── Hero band ─────────────────────────────────────────────────────────────
 //
-// The summary strip is the canonical StatTileRow: three plain StatTiles
-// (events / new transactions / unread reports) plus a sync tile. The sync
-// tile stays bespoke because it carries two affordances StatTile doesn't
-// model — a status-toned icon tile that doubles as the health indicator,
-// and a second "next sync" sub-line — but it mirrors StatTile's
-// icon-tile-left geometry exactly so the row reads as one uniform strip.
+// The hero leads with a single insight — sync health — rendered as a live
+// "pulse" panel, then a 2×2 cluster of count-up metrics with per-metric
+// colour identity and a sparkbar "activity rhythm" built from the same
+// per-day buckets the rail below renders. On desktop the pulse takes the
+// left 5 columns and the cluster the right 7; on mobile the pulse stacks
+// on top and the cluster falls to a 2-up grid.
 templ feedHero(p FeedProps) {
-	<header class="mb-6">
+	<header class="mb-7 bb-feed-rise">
 		@components.PageHeader(components.PageHeaderProps{
 			Title:    "Feed",
 			Subtitle: "Everything that happened in your breadbox · " + p.Hero.Generated,
 			Action:   connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect bank"),
 		})
-		@components.StatTileRow() {
-			@components.StatTile(components.StatTileProps{
-				Icon:        "activity",
-				Label:       "Events today",
-				Value:       fmt.Sprintf("%d", p.Hero.EventsToday),
-				Description: feedHeroSubEvents(p),
-			})
-			@components.StatTile(components.StatTileProps{
-				Icon:        "download-cloud",
-				Label:       "New transactions",
-				Value:       fmt.Sprintf("%d", p.Hero.NewTransactionsToday),
-				Description: "synced today",
-			})
-			@feedHeroSyncTile(p)
-			@components.StatTile(components.StatTileProps{
-				Icon:        "file-text",
-				Label:       "Unread reports",
-				Value:       fmt.Sprintf("%d", p.Hero.UnreadReports),
-				Description: feedHeroSubReports(p),
-				Tone:        feedUnreadReportsTone(p.Hero.UnreadReports),
-			})
-		}
+		<div class="grid grid-cols-1 lg:grid-cols-12 gap-3 bb-feed-stagger">
+			<div class="lg:col-span-5">
+				@feedPulsePanel(p)
+			</div>
+			<div class="lg:col-span-7 grid grid-cols-2 gap-3">
+				@feedMetricTile("activity", "Events today", p.Hero.EventsToday, feedHeroSubEvents(p), "primary", "")
+				@feedMetricTile("arrow-down-circle", "New transactions", p.Hero.NewTransactionsToday, "synced today", "success", "/transactions")
+				@feedMetricTile("file-text", "Unread reports", p.Hero.UnreadReports, feedHeroSubReports(p), feedReportsTone(p.Hero.UnreadReports), "/reports")
+				@feedSparkTile(p)
+			</div>
+		</div>
 	</header>
 }
 
-// feedHeroSyncTile mirrors components.StatTile's icon-tile-left geometry so
-// it sits flush in the StatTileRow, but stays bespoke: the icon tile is
-// status-toned (carrying the health signal a plain StatTile can't), and a
-// second muted "Next sync" line points users at the upcoming cron fire.
-templ feedHeroSyncTile(p FeedProps) {
-	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline block group focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40" aria-label="Last sync — view sync logs">
-		<div class="flex items-center gap-2.5 sm:gap-3">
-			<div class={ "w-8 h-8 sm:w-9 sm:h-9 rounded-lg flex items-center justify-center shrink-0", feedSyncTileBg(p.Hero.LastSyncStatus) }>
-				@components.LucideIcon("refresh-cw", "w-4 h-4 "+feedSyncTileText(p.Hero.LastSyncStatus))
-			</div>
-			<div class="min-w-0 flex-1">
-				if p.Hero.LastSyncRel != "" {
-					<div class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate">{ p.Hero.LastSyncRel }</div>
-					<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">Last sync</div>
-					<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate">
-						{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
+// feedPulsePanel is the hero's lead element — sync health rendered loud.
+// A status-tinted accent rail, a faint tonal wash, a live ping dot (when
+// healthy or syncing), the relative time as the headline, and the
+// institution / next-sync context below.
+templ feedPulsePanel(p FeedProps) {
+	<a
+		href="/logs?tab=syncs"
+		class="bb-card bb-feed-pulse bb-feed-pulse--link p-5 no-underline flex flex-col h-full min-h-[8.5rem]"
+		style={ feedAccentVar(feedPulseTone(p.Hero.LastSyncStatus)) }
+		aria-label="Last sync — view sync logs"
+	>
+		<div class="flex items-center gap-2">
+			<span class="bb-feed-chip">
+				@components.LucideIcon("refresh-cw", "w-3.5 h-3.5")
+			</span>
+			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/45 font-medium">Last sync</div>
+			<span class="ml-auto inline-flex items-center gap-1.5 text-[0.7rem] font-semibold" style="color: var(--bb-feed-accent)">
+				<span class={ "bb-feed-dot", templ.KV("bb-feed-dot--live", feedPulseLive(p.Hero.LastSyncStatus)) } aria-hidden="true"></span>
+				{ feedPulseStatusWord(p.Hero.LastSyncStatus) }
+			</span>
+		</div>
+		<div class="flex-1 flex flex-col justify-center mt-3">
+			if p.Hero.LastSyncRel != "" {
+				<div class="text-3xl sm:text-4xl font-bold tabular-nums tracking-tight leading-none">{ p.Hero.LastSyncRel }</div>
+				<div class="text-xs text-base-content/55 mt-2.5 truncate">
+					{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
+				</div>
+				if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
+					<div class="text-xs text-base-content/45 mt-1 truncate flex items-center gap-1">
+						@components.LucideIcon("clock", "w-3 h-3 shrink-0")
+						<span>Next sync { p.Hero.NextSyncRel }</span>
 					</div>
-					if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
-						<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate flex items-center gap-1">
-							@components.LucideIcon("clock", "w-3 h-3 shrink-0")
-							<span>Next sync { p.Hero.NextSyncRel }</span>
-						</div>
-					}
-				} else {
-					<div class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate text-base-content/30">—</div>
-					<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">Last sync</div>
-					<div class="text-[0.65rem] text-base-content/45 mt-0.5">No syncs yet</div>
 				}
-			</div>
+			} else {
+				<div class="text-3xl sm:text-4xl font-bold tabular-nums tracking-tight leading-none text-base-content/30">—</div>
+				<div class="text-xs text-base-content/45 mt-2.5">No syncs yet</div>
+			}
 		</div>
 	</a>
+}
+
+// feedMetricTile is one count-up metric in the hero cluster. The number
+// animates 0→value on load (feedCountUp, reduced-motion aware); the icon
+// chip + top-edge accent carry the metric's colour identity. When href is
+// set the whole tile is an interactive link that lifts on hover/focus.
+templ feedMetricTile(icon, label string, value int, sub, tone, href string) {
+	if href != "" {
+		<a href={ templ.SafeURL(href) } class="bb-card bb-feed-tile bb-feed-tile--link p-4 no-underline block focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2" style={ feedAccentVar(tone) }>
+			@feedMetricInner(icon, label, value, sub)
+		</a>
+	} else {
+		<div class="bb-card bb-feed-tile p-4" style={ feedAccentVar(tone) }>
+			@feedMetricInner(icon, label, value, sub)
+		</div>
+	}
+}
+
+templ feedMetricInner(icon, label string, value int, sub string) {
+	<div class="flex items-center gap-2">
+		<span class="bb-feed-chip">
+			@components.LucideIcon(icon, "w-3.5 h-3.5")
+		</span>
+		<div class="text-[0.65rem] uppercase tracking-wider text-base-content/45 font-medium truncate">{ label }</div>
+	</div>
+	<div
+		class="text-3xl font-bold tabular-nums tracking-tight mt-2"
+		x-data="feedCountUp"
+		data-count-target={ fmt.Sprintf("%d", value) }
+	>{ fmt.Sprintf("%d", value) }</div>
+	if sub != "" {
+		<div class="text-xs text-base-content/45 mt-0.5 truncate">{ sub }</div>
+	}
+}
+
+// feedSparkTile renders the "activity rhythm" cell — a row of sparkbars
+// built from the per-day event counts already in p.Days. Pure presentation
+// off existing data; bars animate up via the height transition on load.
+templ feedSparkTile(p FeedProps) {
+	<div class="bb-card bb-feed-tile p-4 flex flex-col" style={ feedAccentVar("primary") }>
+		<div class="flex items-center gap-2">
+			<span class="bb-feed-chip">
+				@components.LucideIcon("bar-chart-3", "w-3.5 h-3.5")
+			</span>
+			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/45 font-medium">Activity</div>
+		</div>
+		if bars := feedSparkBars(p.Days); len(bars) > 0 {
+			<div class="flex items-end justify-between gap-1.5 mt-auto pt-3" style="height:2.75rem">
+				for _, b := range bars {
+					<span
+						class="bb-feed-sparkbar tooltip tooltip-top"
+						style={ fmt.Sprintf("height:%d%%", b.Height) }
+						data-tip={ fmt.Sprintf("%s · %d event%s", b.Label, b.Count, pluralFeedS(b.Count)) }
+					></span>
+				}
+			</div>
+			<div class="flex items-center justify-between text-[0.6rem] text-base-content/40 mt-1.5 tabular-nums">
+				<span>{ bars[0].Label }</span>
+				<span>{ bars[len(bars)-1].Label }</span>
+			</div>
+		} else {
+			<div class="text-xs text-base-content/40 mt-auto pt-3">No activity yet</div>
+		}
+	</div>
 }
 
 // ── Pinned alerts ─────────────────────────────────────────────────────────
@@ -157,7 +218,7 @@ templ feedAlertCard(a FeedAlert) {
 
 // ── Filters ───────────────────────────────────────────────────────────────
 templ feedFilters(p FeedProps) {
-	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto [mask-image:linear-gradient(to_right,black_85%,transparent)] sm:[mask-image:none]" aria-label="Feed filters">
+	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto bb-feed-rise [mask-image:linear-gradient(to_right,black_85%,transparent)] sm:[mask-image:none]" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
 		@feedFilterChip("Syncs", "syncs", "refresh-cw", p.Filter)
 		@feedFilterChip("Reports", "reports", "file-text", p.Filter)
@@ -173,9 +234,9 @@ templ feedFilterChip(label, slug, icon, current string) {
 		if current == slug {
 			aria-current="page"
 		}
-		class={ "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors no-underline whitespace-nowrap shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2",
-			templ.KV("bg-primary/10 border-primary/40 text-primary", current == slug),
-			templ.KV("border-base-300 text-base-content/65 hover:bg-base-200/70", current != slug) }
+		class={ "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150 no-underline whitespace-nowrap shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2",
+			templ.KV("bg-primary/10 border-primary/40 text-primary shadow-sm shadow-primary/10", current == slug),
+			templ.KV("border-base-300 text-base-content/65 hover:bg-base-200/70 hover:border-base-content/20 hover:-translate-y-px", current != slug) }
 	>
 		@components.LucideIcon(icon, "w-3 h-3")
 		{ label }
@@ -193,6 +254,7 @@ templ feedTimeline(p FeedProps) {
 		     the top. data-* attrs seed the cursor + dedup anchor; the inner
 		     <a href> is the no-JS fallback. -->
 		<div
+			class="bb-feed-stream bb-feed-rise"
 			x-data="feedPagination"
 			data-feed-before={ feedPaginationCursor(p) }
 			data-feed-filter={ p.Filter }
@@ -297,16 +359,36 @@ templ feedEmptyState(p FeedProps) {
 }
 
 // feedEmptyFirstRun is shown when zero bank connections exist. The CTA is
-// the only path forward — connect a bank — so the canonical EmptyState
-// renders the primary connect-bank button (which opens the app-wide
-// connect-bank drawer) via its CustomCTA slot.
+// the only path forward — connect a bank — so we render it as a primary
+// button rather than a quiet link.
 templ feedEmptyFirstRun() {
-	@components.EmptyState(components.EmptyStateProps{
-		Icon:      "landmark",
-		Title:     "Welcome to Breadbox",
-		Body:      "Connect your first bank to start filling your feed.",
-		CustomCTA: connectBankButton("btn btn-primary btn-sm gap-2", "plus", "Connect a bank"),
-	})
+	<div class="bb-card bb-feed-welcome bb-feed-rise p-10 sm:p-14 text-center">
+		<span class="bb-feed-welcome__orb mx-auto mb-5">
+			@components.LucideIcon("landmark", "w-9 h-9")
+		</span>
+		<h2 class="text-2xl font-bold tracking-tight mb-2">Welcome to Breadbox</h2>
+		<p class="text-sm text-base-content/55 max-w-md mx-auto mb-7 leading-relaxed">
+			Connect your first bank to start filling your feed. Syncs, agent reports, and everything your household does land here as it happens.
+		</p>
+		@connectBankButton("btn btn-primary gap-2", "plus", "Connect a bank")
+		<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-10 max-w-2xl mx-auto text-left">
+			@feedWelcomeHint("refresh-cw", "success", "Automatic syncs", "Transactions stream in as your banks post them.")
+			@feedWelcomeHint("sparkles", "primary", "Agent reports", "Your workflows summarise what changed, and why.")
+			@feedWelcomeHint("message-square", "info", "Household activity", "See who tagged, categorised, or commented.")
+		</div>
+	</div>
+}
+
+// feedWelcomeHint is one "here's what you'll see" card in the first-run
+// hero — orients a brand-new user before any data exists.
+templ feedWelcomeHint(icon, tone, title, body string) {
+	<div class="rounded-xl border border-base-200 bg-base-100 p-4" style={ feedAccentVar(tone) }>
+		<span class="bb-feed-chip">
+			@components.LucideIcon(icon, "w-3.5 h-3.5")
+		</span>
+		<div class="text-sm font-semibold mt-2.5">{ title }</div>
+		<div class="text-xs text-base-content/50 mt-1 leading-relaxed">{ body }</div>
+	</div>
 }
 
 // feedEmptyFiltered is shown when a chip filter is active but produced
@@ -314,14 +396,19 @@ templ feedEmptyFirstRun() {
 // filter banner offers, repeated here so a user landing in an empty state
 // has a clear way out without scrolling back up.
 templ feedEmptyFiltered(filter string) {
-	@components.EmptyState(components.EmptyStateProps{
-		Icon:     "filter",
-		Title:    feedEmptyFilteredHeadline(filter),
-		Body:     "Nothing in this slice today.",
-		CTAHref:  templ.SafeURL("/"),
-		CTAIcon:  "x",
-		CTALabel: "Clear filter",
-	})
+	<div class="bb-card bb-feed-rise p-10 sm:p-12 text-center">
+		<span class="bb-feed-chip mx-auto mb-4" style="--bb-feed-accent: var(--color-base-content); width:3rem; height:3rem; border-radius:1rem">
+			@components.LucideIcon("filter", "w-6 h-6")
+		</span>
+		<h2 class="text-lg font-semibold mb-1">{ feedEmptyFilteredHeadline(filter) }</h2>
+		<p class="text-sm text-base-content/55 mb-5">
+			Nothing in this slice today.
+		</p>
+		<a href="/" class="btn btn-sm btn-ghost border border-base-300">
+			@components.LucideIcon("x", "w-3.5 h-3.5")
+			Clear filter
+		</a>
+	</div>
 }
 
 // feedEmptyNoRecent is the "all caught up" card for households that have
@@ -330,44 +417,45 @@ templ feedEmptyFiltered(filter string) {
 // browse-history link, since sync-all is admin-only.
 templ feedEmptyNoRecent(p FeedProps) {
 	if p.IsAdmin {
-		@components.EmptyState(components.EmptyStateProps{
-			Icon:      "moon",
-			Title:     "Quiet around here",
-			Body:      feedEmptyNoRecentSubline(p.LastSyncAt),
-			CustomCTA: feedEmptyNoRecentAdminCTA(),
-		})
+		<div class="bb-card bb-feed-rise p-10 sm:p-12 text-center" x-data="feedSyncNow">
+			<span class="bb-feed-chip mx-auto mb-4" style="--bb-feed-accent: var(--color-base-content); width:3rem; height:3rem; border-radius:1rem">
+				@components.LucideIcon("moon", "w-6 h-6")
+			</span>
+			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
+			<p class="text-sm text-base-content/55 mb-5">
+				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
+			</p>
+			<div class="flex items-center justify-center gap-2 flex-wrap">
+				<button
+					type="button"
+					class="btn btn-primary btn-sm"
+					x-bind:disabled="state !== 'idle'"
+					x-on:click="triggerSyncNow()"
+				>
+					<i data-lucide="refresh-cw" class="w-3.5 h-3.5" x-bind:class="state === 'syncing' ? 'animate-spin' : ''"></i>
+					<span x-text="state === 'syncing' ? 'Syncing…' : (state === 'done' ? 'Sync queued' : 'Sync now')"></span>
+				</button>
+				<a href="/transactions" class="btn btn-sm btn-ghost border border-base-300">
+					@components.LucideIcon("receipt", "w-3.5 h-3.5")
+					Browse transactions
+				</a>
+			</div>
+		</div>
 	} else {
-		@components.EmptyState(components.EmptyStateProps{
-			Icon:     "moon",
-			Title:    "Quiet around here",
-			Body:     feedEmptyNoRecentSubline(p.LastSyncAt),
-			CTAHref:  templ.SafeURL("/transactions"),
-			CTAIcon:  "receipt",
-			CTALabel: "Browse transactions",
-		})
+		<div class="bb-card bb-feed-rise p-10 sm:p-12 text-center">
+			<span class="bb-feed-chip mx-auto mb-4" style="--bb-feed-accent: var(--color-base-content); width:3rem; height:3rem; border-radius:1rem">
+				@components.LucideIcon("moon", "w-6 h-6")
+			</span>
+			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
+			<p class="text-sm text-base-content/55 mb-5">
+				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
+			</p>
+			<a href="/transactions" class="btn btn-sm btn-ghost border border-base-300">
+				@components.LucideIcon("receipt", "w-3.5 h-3.5")
+				Browse transactions
+			</a>
+		</div>
 	}
-}
-
-// feedEmptyNoRecentAdminCTA is the admin empty-state action pair: the
-// sync-all kickoff button (wired to the feedSyncNow Alpine factory in
-// feed.js) plus a quiet link into the transaction history. Rendered into
-// the EmptyState CustomCTA slot so the card chrome stays canonical.
-templ feedEmptyNoRecentAdminCTA() {
-	<div class="flex items-center justify-center gap-2 flex-wrap" x-data="feedSyncNow">
-		<button
-			type="button"
-			class="btn btn-primary btn-sm"
-			x-bind:disabled="state !== 'idle'"
-			x-on:click="triggerSyncNow()"
-		>
-			<i data-lucide="refresh-cw" class="w-3.5 h-3.5" x-bind:class="state === 'syncing' ? 'animate-spin' : ''"></i>
-			<span x-text="state === 'syncing' ? 'Syncing…' : (state === 'done' ? 'Sync queued' : 'Sync now')"></span>
-		</button>
-		<a href="/transactions" class="btn btn-sm btn-ghost border border-base-300">
-			@components.LucideIcon("receipt", "w-3.5 h-3.5")
-			Browse transactions
-		</a>
-	</div>
 }
 
 // feedEmptyFilteredHeadline maps a chip slug onto its empty-state
@@ -1026,14 +1114,136 @@ func feedNonEmpty(a, fallback string) string {
 	return fallback
 }
 
-// feedUnreadReportsTone draws the eye to the unread-reports stat tile only
-// when there's something to read — a primary-toned icon tile when unread > 0,
-// otherwise the quiet neutral default.
-func feedUnreadReportsTone(unread int) components.StatTileTone {
-	if unread > 0 {
-		return components.StatTonePrimary
+// feedAccentVar maps a tone name onto the `--bb-feed-accent` custom
+// property the hero CSS reads for chip tint, top-edge accent, hover glow,
+// and the pulse panel's accent rail. Returns a `style` attribute value.
+func feedAccentVar(tone string) string {
+	switch tone {
+	case "primary":
+		return "--bb-feed-accent: var(--color-primary)"
+	case "success":
+		return "--bb-feed-accent: var(--color-success)"
+	case "info":
+		return "--bb-feed-accent: var(--color-info)"
+	case "warning":
+		return "--bb-feed-accent: var(--color-warning)"
+	case "error":
+		return "--bb-feed-accent: var(--color-error)"
 	}
-	return components.StatToneNeutral
+	return "--bb-feed-accent: var(--color-base-content)"
+}
+
+// feedReportsTone tints the Unread reports tile amber when there's
+// something to read, neutral when the inbox is clear.
+func feedReportsTone(unread int) string {
+	if unread > 0 {
+		return "warning"
+	}
+	return "primary"
+}
+
+// feedPulseTone selects the hero pulse panel's accent from sync status.
+func feedPulseTone(status string) string {
+	switch status {
+	case "success":
+		return "success"
+	case "error":
+		return "error"
+	case "in_progress":
+		return "info"
+	}
+	return "primary"
+}
+
+// feedPulseLive gates the expanding ping-ring on the status dot — only a
+// healthy or actively-syncing connection "pulses". A failing one shows a
+// solid (alarming, non-animated) dot.
+func feedPulseLive(status string) bool {
+	return status == "success" || status == "in_progress"
+}
+
+// feedPulseStatusWord is the short status pill in the pulse panel corner.
+// The lowercase "healthy"/"failing" words the tests assert live in
+// feedSyncSubLine below; this is the capitalised glance word.
+func feedPulseStatusWord(status string) string {
+	switch status {
+	case "success":
+		return "Live"
+	case "error":
+		return "Failing"
+	case "in_progress":
+		return "Syncing"
+	}
+	return "Idle"
+}
+
+// feedSparkBar is one bar in the hero "activity rhythm" strip.
+type feedSparkBar struct {
+	Label  string
+	Count  int
+	Height int // 0–100, percentage of the tallest bar in the window
+}
+
+// feedSparkBars buckets the rendered day-groups into a chronological
+// (oldest→newest) sparkline of event counts. Uses only the data already
+// on the page (p.Days is newest-first) — no new query. Caps at the last 7
+// buckets so the strip stays legible; a non-zero day always gets a visible
+// minimum height so a single event never renders as an invisible sliver.
+func feedSparkBars(days []FeedDay) []feedSparkBar {
+	if len(days) == 0 {
+		return nil
+	}
+	n := len(days)
+	if n > 7 {
+		n = 7
+	}
+	window := days[:n] // newest-first slice of the most recent n days
+	maxCount := 1
+	for _, d := range window {
+		if c := len(d.Items); c > maxCount {
+			maxCount = c
+		}
+	}
+	bars := make([]feedSparkBar, 0, n)
+	for i := n - 1; i >= 0; i-- { // reverse → chronological
+		c := len(window[i].Items)
+		h := c * 100 / maxCount
+		if c > 0 && h < 14 {
+			h = 14
+		}
+		bars = append(bars, feedSparkBar{
+			Label:  feedSparkLabel(window[i].Label),
+			Count:  c,
+			Height: h,
+		})
+	}
+	return bars
+}
+
+// feedSparkLabel shortens a day-bucket label for the tiny sparkbar axis
+// ("Today"→"Now", "Yesterday"→"Yday"); other labels (e.g. "Jun 11") pass
+// through untouched.
+func feedSparkLabel(label string) string {
+	switch label {
+	case "Today":
+		return "Now"
+	case "Yesterday":
+		return "Yday"
+	}
+	return label
+}
+
+func feedSyncDotClass(status string) string {
+	switch status {
+	case "success":
+		return "bg-success"
+	case "error":
+		return "bg-error animate-pulse"
+	case "in_progress":
+		return "bg-info animate-pulse"
+	default:
+		return "bg-base-300"
+	}
 }
 
 func feedSyncSubLine(status, institution string) string {

--- a/static/js/admin/components/feed.js
+++ b/static/js/admin/components/feed.js
@@ -95,6 +95,37 @@ document.addEventListener('alpine:init', function () {
     };
   });
 
+  // feedCountUp animates a hero metric number from 0 to its target on
+  // load. The element ships with its final value as text content (no-JS
+  // fallback) plus a `data-count-target` attr; this tween overwrites it
+  // for the ~0.7s reveal, then snaps to the exact target. Honors
+  // prefers-reduced-motion by skipping straight to the final value.
+  Alpine.data('feedCountUp', function () {
+    return {
+      init: function () {
+        var el = this.$el;
+        var target = parseInt(el.getAttribute('data-count-target') || '0', 10);
+        if (!target || target < 0) return;
+        var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (reduce) { el.textContent = String(target); return; }
+        var dur = 700, start = null;
+        el.textContent = '0';
+        function step(ts) {
+          if (start === null) start = ts;
+          var p = Math.min((ts - start) / dur, 1);
+          var eased = 1 - Math.pow(1 - p, 3);
+          el.textContent = String(Math.round(eased * target));
+          if (p < 1) {
+            requestAnimationFrame(step);
+          } else {
+            el.textContent = String(target);
+          }
+        }
+        requestAnimationFrame(step);
+      },
+    };
+  });
+
   Alpine.data('feedSyncNow', function () {
     return {
       state: 'idle',


### PR DESCRIPTION
**Bold redesign** — the home **Feed** (`/`) goes from a flat 4-tile band to a confident, insight-led dashboard hero, with a restrained motion vocabulary the rest of the app can adopt. The blessed timeline rail is untouched; everything new is scoped under `.bb-feed-*`.

## What changed
- **Asymmetric insight hero (12-col):** a lead **sync-health "pulse" panel** (the one *actionable* glance — "are my banks healthy?") rendered loud: status-tinted accent rail + wash, a live ping dot (healthy/syncing only; failing shows a solid alarm dot), the relative time as a 4xl headline. Here it's **red/"Failing"** because syncs are erroring — the most important signal now leads.
- **Color-coded 2×2 metric cluster:** Events (brand) · New transactions (success→`/transactions`) · Unread reports (amber-when-unread→`/reports`), with tinted icon chips + tonal top accents; the interactive ones lift on hover.
- **"Activity rhythm" sparkbar** built purely from the per-day event buckets already in `p.Days` (no new query) — chronological mini-bars, oldest→"Now". Real insight-over-time from existing data.
- **Motion** (all `prefers-reduced-motion`-gated): staggered rise-in reveal, **count-up** numbers (`feedCountUp`, no-JS fallback = final value), tile/chip hover-lift, the ping. A confident-but-tasteful vocabulary.
- **Branded first-run welcome** (replacing the faded-icon empty card) + polished filtered/quiet empties. All test-asserted copy preserved.

Preserved: all data, links, filters, pagination, CTAs, and the timeline rail invariants. `go build`/`vet`/`test ./...` green (feed_hero/feed_empty tests pass unchanged).

## Evidence
**Desktop (light)** — pulse hero + metric cluster + activity sparkbar:
<img src="https://bb-artifacts.exe.xyz/f/c74f430c66f6da64.jpeg" width="900" alt="Feed bold redesign — desktop light">

**Mobile (390px)** — pulse stacks, cluster 2-up:
<img src="https://bb-artifacts.exe.xyz/f/223570d4b9f3fe5d.jpeg" width="380" alt="Feed bold redesign — mobile">

**Dark** — tinted pulse + tonal metric accents + sparkbars:
<img src="https://bb-artifacts.exe.xyz/f/fce98281f5f62089.jpeg" width="900" alt="Feed bold redesign — dark">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
