### PR TITLE
bold(transactions): sticky day-group headers + refined ledger rows + category flash

### DIFF
--- a/input.css
+++ b/input.css
@@ -1947,10 +1947,17 @@
    */
   .bb-tx-row {
     --bb-row-bg: var(--color-base-100);
+    /* Spine + bg + amount nudge are the only animated props — kept tight so
+       50 rows compositing on scroll/hover stays cheap. The spine is drawn as
+       an inset box-shadow that fades from transparent → primary on hover. */
+    position: relative;
+    box-shadow: inset 2px 0 0 transparent;
+    transition: background-color 0.12s ease, box-shadow 0.16s ease;
   }
   .bb-tx-row[data-tx-selected] {
     @apply bg-primary/5;
     --bb-row-bg: color-mix(in oklab, var(--color-primary) 5%, var(--color-base-100));
+    box-shadow: inset 2px 0 0 color-mix(in oklab, var(--color-primary) 55%, transparent);
   }
 
   /*
@@ -1995,6 +2002,36 @@
   .bb-tx-row:hover {
     @apply bg-base-200/40;
     --bb-row-bg: color-mix(in oklab, var(--color-base-200) 40%, var(--color-base-100));
+    box-shadow: inset 2px 0 0 color-mix(in oklab, var(--color-primary) 30%, transparent);
+  }
+
+  /* On hover the amount leans into full base-content weight and the avatar
+     gains a faint ring — small tactile cues that the row is "live". The
+     income-green amounts already carry their own color so we only nudge
+     opacity, never hue. */
+  .bb-tx-row:hover .bb-tx-amount {
+    color: var(--color-base-content);
+  }
+  .bb-tx-row:hover .bb-tx-avatar {
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--avatar-color) 10%, transparent);
+  }
+
+  /* The inline category picker reads as a real "add a category" affordance
+     once the row is hovered — quiet until then so the dominant uncategorised
+     case doesn't shout on every row. */
+  .bb-tx-row:hover .bb-cat-picker .btn {
+    background-color: color-mix(in oklab, var(--color-base-content) 5%, transparent);
+  }
+
+  /* Category-change flash — a brief primary wash applied imperatively by
+     updateRowCategory() (adds .bb-tx-row--flash, self-removes). Confirms the
+     edit landed without a toast hunt. */
+  @keyframes bb-tx-flash {
+    0%   { background-color: color-mix(in oklab, var(--color-primary) 22%, transparent); }
+    100% { background-color: transparent; }
+  }
+  .bb-tx-row--flash {
+    animation: bb-tx-flash 0.7s ease-out;
   }
 
   .bb-tx-row--focused {
@@ -2287,6 +2324,54 @@
   }
   body.bb-tx-selecting .bb-tx-header-checkbox-col {
     display: block;
+  }
+
+  /* ── Grouped-view day header ──
+     A sticky, high-contrast divider so the day you're scrolling through
+     stays anchored at the top of the viewport (Mercury / Copilot style).
+     It sticks just below the app chrome: the desktop topbar (h-14, 3.5rem)
+     at lg+, the mobile navbar (~4rem) below lg. z-20 sits under both
+     (z-30) so they always win, and under the floating bulk bar (z-40).
+     The blurred base-100 wash hides rows scrolling underneath. */
+  .bb-day-header {
+    position: sticky;
+    top: 4rem;            /* mobile navbar height */
+    z-index: 20;
+    border-radius: 0.5rem;
+    -webkit-backdrop-filter: blur(6px);
+            backdrop-filter: blur(6px);
+    background: linear-gradient(
+      to bottom,
+      var(--color-base-100) 55%,
+      color-mix(in oklch, var(--color-base-100) 80%, transparent) 100%
+    );
+  }
+  @media (min-width: 1024px) {
+    .bb-day-header { top: 3.5rem; } /* desktop topbar height (h-14) */
+  }
+
+  /* Small accent tick left of the date label — a quiet rhythm marker that
+     gives each day header a visual anchor without a heavy rule/line. */
+  .bb-day-tick {
+    width: 0.25rem;
+    height: 0.85rem;
+    border-radius: 9999px;
+    flex-shrink: 0;
+    background: color-mix(in oklab, var(--color-primary) 45%, transparent);
+  }
+
+  /* Transaction-count pill — a soft chip rather than bare faint text, so
+     the count reads as metadata attached to the date, not noise. */
+  .bb-day-count {
+    @apply inline-flex items-center text-[0.65rem] font-medium leading-none px-1.5 py-0.5 rounded-full;
+    color: oklch(from var(--color-base-content) l c h / 0.45);
+    background: oklch(from var(--color-base-content) l c h / 0.05);
+  }
+
+  /* Per-day out/in totals. The directional arrow + medium weight make the
+     two numbers legible at a glance; income keeps its success tint. */
+  .bb-day-total {
+    white-space: nowrap;
   }
 
   /* ── Date visibility (hidden in grouped, shown in list) ──

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -40,15 +40,21 @@ templ TxResults(p TxResultsProps) {
 		<div class="space-y-1">
 			for _, g := range p.DateGroups {
 				<div class="bb-date-group" data-date-group={ g.Date }>
-					<!-- Date Header -->
-					<div class="flex items-center justify-between px-2 pt-4 pb-2">
-						<div class="flex items-center gap-3">
-							<h3 class="text-xs font-semibold text-base-content/50 tracking-wide">{ g.Label }</h3>
-							<span class="text-xs text-base-content/30 tabular-nums" data-txn-count={ strconv.Itoa(len(g.Transactions)) }>
+					<!-- Date Header — sticky, high-contrast day divider with a
+					     directional spend/income readout. Sticks below the app
+					     topbar (lg) / mobile navbar (<lg) so the day you're
+					     scrolling through stays anchored, Mercury/Copilot style.
+					     Keeps the data-txn-count / data-day-* hooks the
+					     quick-search JS reads. -->
+					<div class="bb-day-header flex items-center justify-between gap-3 px-2.5 pt-5 pb-2.5">
+						<div class="flex items-center gap-2.5 min-w-0">
+							<span class="bb-day-tick" aria-hidden="true"></span>
+							<h3 class="text-sm font-semibold text-base-content/80 tracking-tight whitespace-nowrap">{ g.Label }</h3>
+							<span class="bb-day-count tabular-nums" data-txn-count={ strconv.Itoa(len(g.Transactions)) }>
 								{ fmt.Sprintf("%d txn%s", len(g.Transactions), pluralS(len(g.Transactions))) }
 							</span>
 						</div>
-						<div class="flex items-center gap-3 text-xs tabular-nums">
+						<div class="flex items-center gap-2.5 tabular-nums">
 							@dayTotalBadge("data-day-spending", g.DaySpending, false)
 							@dayTotalBadge("data-day-income", g.DayIncome, true)
 						</div>
@@ -162,11 +168,18 @@ templ dayTotalBadge(attr string, value float64, income bool) {
 		}
 		data-attr={ attr }
 		data-value={ fmt.Sprintf("%.2f", value) }
+		if income {
+			class="bb-day-total bb-day-total--in inline-flex items-center gap-1"
+		} else {
+			class="bb-day-total inline-flex items-center gap-1"
+		}
 	>
 		if income {
-			@Amount(AmountProps{Value: -value, Class: "text-xs !text-success/70"})
+			@LucideIcon("arrow-down-left", "w-3 h-3 text-success/60 shrink-0")
+			@Amount(AmountProps{Value: -value, Class: "text-xs font-medium !text-success/80"})
 		} else {
-			@Amount(AmountProps{Value: value, Intent: AmountCost, Class: "text-xs text-base-content/50"})
+			@LucideIcon("arrow-up-right", "w-3 h-3 text-base-content/30 shrink-0")
+			@Amount(AmountProps{Value: value, Intent: AmountCost, Class: "text-xs font-medium text-base-content/55"})
 		}
 	</span>
 }

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -212,7 +212,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 				@Amount(AmountProps{
 					Value:   tx.Amount,
 					Pending: tx.Pending,
-					Class:   "text-sm font-semibold",
+					Class:   "bb-tx-amount text-[0.9rem] font-semibold tracking-tight",
 				})
 			</div>
 			<!-- Expand chevron. Rotation lives on the wrapper because Lucide

--- a/static/js/admin/components/tx_row_helpers.js
+++ b/static/js/admin/components/tx_row_helpers.js
@@ -111,6 +111,19 @@ function updateRowCategory(txId, slug) {
     }
     mobileLabel.replaceWith(newLabel);
   }
+
+  // 4) Brief confirmation flash on the row so the edit reads as "landed"
+  // without the user hunting for the toast. The keyframe (bb-tx-flash, in
+  // input.css) self-clears the background; we strip the class on animation
+  // end so a re-categorize can re-trigger it.
+  row.classList.remove('bb-tx-row--flash');
+  // Force a reflow so removing + re-adding the class restarts the animation.
+  void row.offsetWidth;
+  row.classList.add('bb-tx-row--flash');
+  row.addEventListener('animationend', function handler() {
+    row.classList.remove('bb-tx-row--flash');
+    row.removeEventListener('animationend', handler);
+  });
 }
 
 // Lucide icon names are slug-shaped (e.g. "trending-up"). Reject anything


### PR DESCRIPTION
**Bold improvement** — elevates the `/transactions` ledger's two highest-impact surfaces (day-group headers + row hierarchy) while keeping the core workhorse **robust**: every bulk-select / AJAX-search / pagination / keyboard JS contract is byte-preserved (CSS-driven changes only).

## What changed
- **Sticky frosted day-group headers** (`.bb-day-header`) — a sticky, blurred base-100 divider so the day you're scrolling stays anchored (Mercury/Copilot style), sitting just under the app chrome (z-20, below the bulk bar). Plus a primary **accent tick**, a bolder `text-sm` date, a soft **count pill**, and **directional out/in totals** (↗ out / ↙ in, income success-tinted).
- **Refined rows** — amount bumped to `text-[0.9rem] font-semibold tracking-tight`; a left **primary spine** that fades in on hover and locks at 55% on selection; faint avatar ring + full-strength amount on hover; the inline category picker gets a hover bg so "Uncategorized" rows invite a click.
- **Micro-feedback** — `updateRowCategory()` adds a self-removing 0.7s primary "flash" so a category edit visibly lands.

**Robustness preserved** (verified live): `.bb-tx-row` + all `data-tx-*` hooks, checkbox/bulk-select + the bulk bar, grouped↔list toggle, `.bb-cat-picker`, `#bb-tx-results` AJAX swap (sticky is pure CSS so it survives innerHTML replacement), pagination, keyboard nav, privacy marking, day-totals markup. `go build`/`vet`/`test ./...` green (scripts-lint + tx render tests pass).

## Evidence
**Desktop (light)** — day headers w/ tick + count pill + directional totals, refined rows:
<img src="https://bb-artifacts.exe.xyz/f/e6ac7e786bda79f7.jpeg" width="900" alt="Transactions bold — desktop light">

**Scrolled** — the sticky frosted "Today" header pinned at top:
<img src="https://bb-artifacts.exe.xyz/f/fd35c1d87f1df1d9.jpeg" width="900" alt="Transactions bold — sticky day header">

**Dark**:
<img src="https://bb-artifacts.exe.xyz/f/27f54f8ee2d89018.jpeg" width="900" alt="Transactions bold — dark">

**Mobile (390px)**:
<img src="https://bb-artifacts.exe.xyz/f/50f934215dfe257f.jpeg" width="380" alt="Transactions bold — mobile">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
