### PR TITLE
refactor(stat-tile): Mintlify-clean stat cards (drop icon tile + tone fill; optional delta)

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -66,6 +66,12 @@ Concretely:
 - **Decoration earns its place or it's cut.** Gradients, glows, motion,
   accent washes, oversized numerals — each must justify itself against "would
   Mintlify do this?". Usually the answer is no.
+- **Stat cards are quiet.** A metric tile is a hairline box · small muted label
+  on top · big plain number (default ink, *not* a tone color) · an optional tiny
+  delta line (small arrow + "↓ 45.7% vs previous" in a quiet semantic color).
+  **No icon tile, no tone fill, no tint, no left-accent.** Use the shared
+  `StatTile` (`stat_tile.templ`); the full pattern is in `components.md` →
+  "Stat cards — the Mintlify-clean pattern".
 
 This section overrides any temptation toward "bold = bigger/louder." Bold here
 means **confidently restrained**. Keep referencing Mintlify; fold new learnings

--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -177,22 +177,42 @@ AmountProps{
 
 ## StatTile / StatTileRow — `stat_tile.templ`
 
-Summary numbers when figures lead the page (Net Worth / Assets / Liabilities).
+Quiet summary numbers in the **Mintlify-clean** style (see "Stat cards" below).
+A plain hairline box, small muted label on top, big plain number, optional tiny
+delta + description. **No icon, no tone fill, no tint.**
 
 ```go
 StatTileProps{
-    Icon string; Label string; Value string; Description string
-    Tone StatTileTone; Href templ.SafeURL
+    Label string; Value string; Description string // label on top, big number, muted subline
+    Delta string; DeltaDir StatTileDeltaDir         // optional tiny "↓ 45.7% vs previous" trend line
+    Href templ.SafeURL
     ValuePrivateKind string; DescriptionPrivateKind string // "amount" → marks data-private
+    Icon string; Tone StatTileTone // RETAINED for caller compat but NO-OPS (not rendered)
 }
-// Tone: StatToneNeutral · StatTonePrimary · StatToneSuccess · StatToneWarning · StatToneError · StatToneInfo
-@components.StatTileRow() { @components.StatTile(...) ... } // the divided strip
+// DeltaDir: StatDeltaUp (success-ish ↑) · StatDeltaDown (error-ish ↓) · StatDeltaNeutral (muted, default)
+@components.StatTileRow() { @components.StatTile(...) ... } // the 2-up / 4-up grid
 ```
 
-Set `ValuePrivateKind: "amount"` on money tiles so they obfuscate with privacy mode.
-When `Href` is set the tile is an `<a>` and carries both `bb-card--interactive`
-hover and a keyboard `focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40`
-ring (principle #8 — every interactive element has visible hover + focus states).
+The number renders in **default ink** — never a tone color. `Icon`/`Tone` are
+kept only so existing callers compile; the clean tile shows neither. Set
+`Delta` (with `DeltaDir`) for a small semantic trend line under the value.
+Set `ValuePrivateKind: "amount"` on money tiles so they obfuscate with privacy
+mode. When `Href` is set the tile is an `<a>` and carries both
+`bb-card--interactive` hover and a keyboard
+`focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40` ring
+(principle #8 — every interactive element has visible hover + focus states).
+
+### Stat cards — the Mintlify-clean pattern
+
+The canonical stat treatment, going forward, for **every** surface that shows a
+metric: a **hairline-bordered box** · a **small muted label on top** · a **big
+plain number** below (`text-2xl`/`text-3xl`, `font-semibold`, `tabular-nums`,
+default ink — *not* a tone color) · an **optional tiny delta** beneath (small
+arrow + text in a quiet semantic color) · airy padding. **No icon tile, no tone
+background fill, no tint, no left-accent.** The number speaks; status stays
+quiet. Don't reintroduce the old colored-icon-square-on-the-left tile — that was
+the decorated shape this pattern replaced. Reach for `StatTile`; if you're
+hand-rolling a metric box, match this shape.
 
 ## EmptyState — `empty_state.templ`
 

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -1336,40 +1336,60 @@ templ SectionEmptyStates() {
 // ─── Stat tiles ────────────────────────────────────────────────────────
 templ SectionStatTiles() {
 	<div class="flex flex-col gap-6">
-		@designExample("4-up tile row (canonical dashboard pattern)", "StatTileRow lays out the 2-up / 4-up grid. Tones drive the icon-tile color.") {
+		@designExample("4-up tile row (Mintlify-clean dashboard pattern)", "Hairline box · small muted label on top · big plain number (default ink) · optional muted description. No icon, no tone fill, no tint — the number speaks.") {
 			@components.StatTileRow() {
 				@components.StatTile(components.StatTileProps{
-					Icon:  "target",
 					Label: "Times matched",
 					Value: "1,284",
-					Tone:  components.StatTonePrimary,
 				})
 				@components.StatTile(components.StatTileProps{
-					Icon:  "layers",
 					Label: "Transactions",
 					Value: "342",
-					Tone:  components.StatToneInfo,
 				})
 				@components.StatTile(components.StatTileProps{
-					Icon:        "alert-circle",
 					Label:       "Pending",
 					Value:       "12",
-					Tone:        components.StatToneWarning,
 					Description: "review needed",
 				})
 				@components.StatTile(components.StatTileProps{
-					Icon:  "clock",
 					Label: "Last active",
 					Value: "2h ago",
 					Href:  "#",
 				})
 			}
 		}
-		@designExample("Without icon (label-only)", "Omit Icon when there's no meaningful glyph.") {
+		@designExample("With delta (↓/↑ vs previous)", "Set Delta + DeltaDir for a tiny semantic trend line under the value — down=error-ish, up=success-ish, neutral=muted. Mirrors Mintlify's \"↓ 45.7% vs previous\".") {
+			@components.StatTileRow() {
+				@components.StatTile(components.StatTileProps{
+					Label:    "Visitors",
+					Value:    "22",
+					Delta:    "45.7% vs previous",
+					DeltaDir: components.StatDeltaDown,
+				})
+				@components.StatTile(components.StatTileProps{
+					Label:    "Views",
+					Value:    "37",
+					Delta:    "12.4% vs previous",
+					DeltaDir: components.StatDeltaUp,
+				})
+				@components.StatTile(components.StatTileProps{
+					Label:    "Searches",
+					Value:    "0",
+					Delta:    "no change",
+					DeltaDir: components.StatDeltaNeutral,
+				})
+				@components.StatTile(components.StatTileProps{
+					Label: "Feedback",
+					Value: "0",
+				})
+			}
+		}
+		@designExample("Single tile", "Drop a StatTile anywhere — it fills its container.") {
 			<div class="max-w-sm">
 				@components.StatTile(components.StatTileProps{
-					Label: "Total volume (USD)",
-					Value: "$48,201.55",
+					Label:            "Total volume (USD)",
+					Value:            "$48,201.55",
+					ValuePrivateKind: "amount",
 				})
 			</div>
 		}

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -88,35 +88,32 @@ templ feedHero(p FeedProps) {
 	</header>
 }
 
-// feedHeroSyncTile mirrors components.StatTile's icon-tile-left geometry so
-// it sits flush in the StatTileRow, but stays bespoke: the icon tile is
-// status-toned (carrying the health signal a plain StatTile can't), and a
-// second muted "Next sync" line points users at the upcoming cron fire.
+// feedHeroSyncTile mirrors components.StatTile's Mintlify-clean geometry so
+// it sits flush in the StatTileRow: small label on top, big plain number,
+// muted sublines. It stays bespoke only to carry the sync health signal as a
+// small status-colored icon inline with the subline (a quiet accent, not a
+// tinted tile) plus a second muted "Next sync" line pointing at the upcoming
+// cron fire.
 templ feedHeroSyncTile(p FeedProps) {
-	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline block group focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40" aria-label="Last sync — view sync logs">
-		<div class="flex items-center gap-2.5 sm:gap-3">
-			<div class={ "w-8 h-8 sm:w-9 sm:h-9 rounded-lg flex items-center justify-center shrink-0", feedSyncTileBg(p.Hero.LastSyncStatus) }>
-				@components.LucideIcon("refresh-cw", "w-4 h-4 "+feedSyncTileText(p.Hero.LastSyncStatus))
-			</div>
-			<div class="min-w-0 flex-1">
-				if p.Hero.LastSyncRel != "" {
-					<div class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate">{ p.Hero.LastSyncRel }</div>
-					<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">Last sync</div>
-					<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate">
-						{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
+	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-5 no-underline block group focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40" aria-label="Last sync — view sync logs">
+		<div class="min-w-0">
+			<div class="text-xs font-medium text-base-content/50 truncate">Last sync</div>
+			if p.Hero.LastSyncRel != "" {
+				<div class="text-2xl sm:text-3xl font-semibold tabular-nums text-base-content leading-tight mt-1.5 truncate">{ p.Hero.LastSyncRel }</div>
+				<div class="text-xs text-base-content/45 mt-1 truncate flex items-center gap-1">
+					@components.LucideIcon(feedSyncIcon(p.Hero.LastSyncStatus), "w-3 h-3 shrink-0 "+feedSyncTileText(p.Hero.LastSyncStatus))
+					<span class="truncate">{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }</span>
+				</div>
+				if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
+					<div class="text-xs text-base-content/45 mt-1 truncate flex items-center gap-1">
+						@components.LucideIcon("clock", "w-3 h-3 shrink-0")
+						<span>Next sync { p.Hero.NextSyncRel }</span>
 					</div>
-					if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
-						<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate flex items-center gap-1">
-							@components.LucideIcon("clock", "w-3 h-3 shrink-0")
-							<span>Next sync { p.Hero.NextSyncRel }</span>
-						</div>
-					}
-				} else {
-					<div class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate text-base-content/30">—</div>
-					<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">Last sync</div>
-					<div class="text-[0.65rem] text-base-content/45 mt-0.5">No syncs yet</div>
 				}
-			</div>
+			} else {
+				<div class="text-2xl sm:text-3xl font-semibold tabular-nums text-base-content/30 leading-tight mt-1.5 truncate">—</div>
+				<div class="text-xs text-base-content/45 mt-1">No syncs yet</div>
+			}
 		</div>
 	</a>
 }

--- a/internal/templates/components/stat_tile.templ
+++ b/internal/templates/components/stat_tile.templ
@@ -1,27 +1,34 @@
 package components
 
-// StatTile is the canonical 4-up dashboard metric tile: a tinted icon
-// square on the left, big tabular-nums value + small label on the right,
-// optional secondary description line. Replaces the hand-rolled
-// `bb-card p-4 + flex items-center gap-3 + w-9 h-9 rounded-lg bg-{tone}/10`
-// block currently duplicated across rule_detail / logs / feed /
-// connection_detail / getting_started (see audit #17).
+// StatTile is the canonical dashboard metric tile, in the Mintlify-clean
+// style: a plain hairline-bordered box, airy padding, a small muted label
+// on top, a big plain number below (default ink — never a tone color),
+// and an optional tiny delta line + secondary description under it.
 //
-// Custom shell rather than daisy `stat` — daisy enforces value-below-label
-// typography and `place-self: end` for `stat-figure`, both of which
-// fight the icon-tile-on-left shape we already ship. See the agent
-// rationale in PR description.
+// This is deliberately RESTRAINED — no icon tile, no tone fill, no tint,
+// no left-accent. The number speaks; status is quiet. See the
+// "House style — restraint over decoration (Mintlify-clean)" section of
+// the design-system skill and the "Stat cards" note in
+// docs/components.md.
+//
+// The Icon and Tone props are kept for caller source-compatibility but are
+// intentional NO-OPS in the rendering — the clean tile shows neither. New
+// callers should leave them unset.
 //
 // Props:
-//   - Icon:        Lucide name. Optional — omit for label-only tiles.
-//   - Label:       required. Rendered as small uppercase metadata.
-//   - Value:       required. Caller formats (CommaInt, fmt.Sprintf, etc).
-//   - Description: optional secondary line below the value.
-//   - Tone:        "neutral" (default), "primary", "success", "warning",
-//                  "error", "info". Drives icon-tile bg + icon color only.
+//   - Label:       required. Small muted label, rendered on top.
+//   - Value:       required. The big plain number. Caller formats it
+//                  (CommaInt, fmt.Sprintf, money helpers, …).
+//   - Description: optional secondary muted line under the value.
+//   - Delta:       optional tiny delta line (e.g. "45.7% vs previous"),
+//                  rendered with a small directional arrow under the value.
+//   - DeltaDir:    "up" (success-ish) / "down" (error-ish) /
+//                  "neutral" (muted, default). Drives the delta arrow +
+//                  color. Only meaningful when Delta is set.
 //   - Href:        optional. When set, the tile becomes an <a> with
 //                  bb-card--interactive hover + a keyboard focus-visible
 //                  primary ring (principle #8 — interaction states).
+//   - Icon / Tone: NO-OPS. Retained for caller compatibility only.
 
 type StatTileTone string
 
@@ -34,13 +41,28 @@ const (
 	StatToneInfo    StatTileTone = "info"
 )
 
+// StatTileDeltaDir drives the optional delta line's arrow + semantic color.
+type StatTileDeltaDir string
+
+const (
+	StatDeltaUp      StatTileDeltaDir = "up"      // success-ish
+	StatDeltaDown    StatTileDeltaDir = "down"    // error-ish
+	StatDeltaNeutral StatTileDeltaDir = "neutral" // muted (default)
+)
+
 type StatTileProps struct {
+	// Icon and Tone are retained for caller compatibility but are no-ops
+	// in the Mintlify-clean rendering (no icon tile, no tone fill).
 	Icon        string
+	Tone        StatTileTone
 	Label       string
 	Value       string
 	Description string
-	Tone        StatTileTone
-	Href        templ.SafeURL // optional; if set, tile becomes a link
+	// Delta / DeltaDir render an optional tiny "↓ 45.7% vs previous"-style
+	// line under the value. Leave Delta empty to render nothing.
+	Delta    string
+	DeltaDir StatTileDeltaDir
+	Href     templ.SafeURL // optional; if set, tile becomes a link
 	// ValuePrivateKind / DescriptionPrivateKind opt the tile into the
 	// client-side privacy mode: when non-empty, the value / description is
 	// marked with `data-private="<kind>"` (typically "amount" for money
@@ -50,76 +72,63 @@ type StatTileProps struct {
 	DescriptionPrivateKind string
 }
 
-func statTileBg(t StatTileTone) string {
-	switch t {
-	case StatTonePrimary:
-		return "bg-primary/10"
-	case StatToneSuccess:
-		return "bg-success/10"
-	case StatToneWarning:
-		return "bg-warning/10"
-	case StatToneError:
-		return "bg-error/10"
-	case StatToneInfo:
-		return "bg-info/10"
+func statTileDeltaIcon(d StatTileDeltaDir) string {
+	switch d {
+	case StatDeltaUp:
+		return "arrow-up"
+	case StatDeltaDown:
+		return "arrow-down"
 	default:
-		return "bg-base-200/60"
+		return "minus"
 	}
 }
 
-func statTileIcon(t StatTileTone) string {
-	switch t {
-	case StatTonePrimary:
-		return "text-primary"
-	case StatToneSuccess:
+func statTileDeltaColor(d StatTileDeltaDir) string {
+	switch d {
+	case StatDeltaUp:
 		return "text-success"
-	case StatToneWarning:
-		return "text-warning"
-	case StatToneError:
+	case StatDeltaDown:
 		return "text-error"
-	case StatToneInfo:
-		return "text-info"
 	default:
-		return "text-base-content opacity-40"
+		return "text-base-content/40"
 	}
 }
 
 templ StatTile(p StatTileProps) {
 	if p.Href != "" {
-		<a href={ p.Href } class="bb-card bb-card--interactive p-4 no-underline block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
+		<a href={ p.Href } class="bb-card bb-card--interactive p-5 no-underline block focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
 			@statTileBody(p)
 		</a>
 	} else {
-		<div class="bb-card p-4">
+		<div class="bb-card p-5">
 			@statTileBody(p)
 		</div>
 	}
 }
 
 templ statTileBody(p StatTileProps) {
-	<div class="flex items-center gap-2.5 sm:gap-3">
-		if p.Icon != "" {
-			<div class={ "w-8 h-8 sm:w-9 sm:h-9 rounded-lg flex items-center justify-center shrink-0", statTileBg(p.Tone) }>
-				@LucideIcon(p.Icon, "w-4 h-4 "+statTileIcon(p.Tone))
+	<div class="min-w-0">
+		<div class="text-xs font-medium text-base-content/50 truncate">{ p.Label }</div>
+		<div
+			class="text-2xl sm:text-3xl font-semibold tabular-nums text-base-content leading-tight mt-1.5 truncate"
+			if p.ValuePrivateKind != "" {
+				data-private={ p.ValuePrivateKind }
+			}
+		>{ p.Value }</div>
+		if p.Delta != "" {
+			<div class={ "flex items-center gap-1 text-xs mt-1.5", statTileDeltaColor(p.DeltaDir) }>
+				@LucideIcon(statTileDeltaIcon(p.DeltaDir), "w-3 h-3 shrink-0")
+				<span class="truncate">{ p.Delta }</span>
 			</div>
 		}
-		<div class="min-w-0 flex-1">
+		if p.Description != "" {
 			<div
-				class="text-xl sm:text-2xl font-semibold tabular-nums leading-none truncate"
-				if p.ValuePrivateKind != "" {
-					data-private={ p.ValuePrivateKind }
+				class="text-xs text-base-content/45 mt-1 truncate"
+				if p.DescriptionPrivateKind != "" {
+					data-private={ p.DescriptionPrivateKind }
 				}
-			>{ p.Value }</div>
-			<div class="text-[0.65rem] sm:text-xs text-base-content/40 mt-1 uppercase tracking-wider truncate">{ p.Label }</div>
-			if p.Description != "" {
-				<div
-					class="text-[0.65rem] text-base-content/45 mt-0.5 truncate"
-					if p.DescriptionPrivateKind != "" {
-						data-private={ p.DescriptionPrivateKind }
-					}
-				>{ p.Description }</div>
-			}
-		</div>
+			>{ p.Description }</div>
+		}
 	</div>
 }
 


### PR DESCRIPTION
First clean-direction improvement (post hero-revert): refines the shared **StatTile** toward Mintlify's restrained stat-card style. The opposite of a bold redesign — this **removes** decoration.

## What changed
- StatTile is now a plain hairline `bb-card` box, airy `p-5`: a **muted label on top**, the **value as a big plain number** (`text-2xl/3xl` `tabular-nums`, default ink — never a tone color), and a muted description. **The colored icon tile and the tone-fill are gone** (no icon, no tint, no left-accent) — matching the Mintlify analytics stat cards.
- New optional **`Delta`** affordance (`Delta` + `DeltaDir` up/down/neutral) — a tiny arrow + quiet semantic-colored text, à la "↓ 45.7% vs previous". Not wired into callers yet; renders only when set.
- `Icon`/`Tone` props kept as **no-ops** so every caller compiles unchanged (recurring, feed, backups, sync-log/rule details, onboarding). Privacy marking + the linked-variant focus ring (#1828) preserved.
- The bespoke **feed "Last sync" tile** reshaped to match (label-on-top/big-number; sync health now a small inline status icon, not a tinted 40px tile).
- **Codified**: the "Stat cards — the Mintlify-clean pattern" in `components.md` + a "Stat cards are quiet" bullet in the skill's House-style section.

`go build`/`vet`/`test ./...` green.

## Evidence
**/recurring (light)** — quiet hairline stat cards:
<img src="https://bb-artifacts.exe.xyz/f/9e959a0288b0adf9.jpeg" width="900" alt="Clean StatTile — /recurring light">

**Home Feed (light)** — incl. the reshaped Last-sync tile:
<img src="https://bb-artifacts.exe.xyz/f/d00d1ae80e891631.jpeg" width="900" alt="Clean StatTile — feed light">

**/recurring (dark)**:
<img src="https://bb-artifacts.exe.xyz/f/2ab350c7ecf0b839.jpeg" width="900" alt="Clean StatTile — dark">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
