### PR TITLE
refactor(reports): restrained Mintlify-clean pass (drop per-row tinted tiles; finding-forward)

### DIFF
--- a/.claude/skills/design-system/components.md
+++ b/.claude/skills/design-system/components.md
@@ -288,11 +288,14 @@ ReportRowProps{
 @components.ReportsList(rows) // convenience: flat list in one card
 ```
 
-- Leading status tile = priority → vivid `IconTile` tone (critical→error,
-  warning→warning, routine→info). No parallel priority text badge in the row.
-- Title line: `UserAvatar` (IsAgent) + agent name + an info **unread dot** + the
-  relative time; the summary is the one body line below. Read rows fade
-  (`opacity-60`) and drop the dot; unread rows keep a heavier summary.
+- Leading status = a **small bare priority glyph** (no tinted tile): vivid ink
+  only for critical (`text-error`) / warning (`text-warning`), a muted glyph for
+  routine — color is an accent, not a per-row fill. No parallel priority badge.
+- The **summary is the prominent line**; the `UserAvatar` (IsAgent) + agent name
+  + an info **unread dot** + relative time ride above it as a quiet metadata
+  line. Read rows fade (`opacity-55`) and drop the dot; unread rows keep a
+  slightly stronger summary. A quiet "N unread · M from <Agent>" at-a-glance line
+  (plain muted text, not a card) sits above the filter tabs.
 - `OverflowMenu` (Size `"sm"`) — mark read/unread + open — renders OUTSIDE the
   row's `<a>` link. The `/reports` All view groups rows unread-first under quiet
   label lines (`partitionReportsByRead`). `ReportPriorityBadge` is now

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -42,9 +42,23 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 		}
 
 		var unreadCount int
+		// Tally unread reports per author so the at-a-glance line can name
+		// the agent contributing the most ("8 unread · 3 from Review Agent").
+		unreadByAuthor := map[string]int{}
+		var topAuthor string
+		var topAuthorCount int
 		for _, rep := range all {
 			if rep.ReadAt == nil {
 				unreadCount++
+				author := reportDisplayAuthor(rep.CreatedByName, rep.Author)
+				if author == "" {
+					continue
+				}
+				unreadByAuthor[author]++
+				if unreadByAuthor[author] > topAuthorCount {
+					topAuthorCount = unreadByAuthor[author]
+					topAuthor = author
+				}
 			}
 		}
 
@@ -80,11 +94,13 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 
 		data := BaseTemplateData(r, sm, "reports", "Agent Reports")
 		props := pages.ReportsProps{
-			Reports:      reports,
-			FilterStatus: statusFilter,
-			AllCount:     len(all),
-			UnreadCount:  unreadCount,
-			ReadCount:    len(all) - unreadCount,
+			Reports:             reports,
+			FilterStatus:        statusFilter,
+			AllCount:            len(all),
+			UnreadCount:         unreadCount,
+			ReadCount:           len(all) - unreadCount,
+			TopUnreadAgent:      topAuthor,
+			TopUnreadAgentCount: topAuthorCount,
 		}
 		tr.RenderWithTempl(w, r, data, pages.Reports(props))
 	}

--- a/internal/templates/components/pages/design_reports_table.templ
+++ b/internal/templates/components/pages/design_reports_table.templ
@@ -18,8 +18,8 @@ templ SectionReportsTable() {
 			<p class="font-semibold text-base-content/80 mb-1">When to use</p>
 			<ul class="space-y-1 list-disc pl-4">
 				<li>Renders the agent-reports index (canonical: <code>/reports</code>) via <code>ReportsList</code> / <code>ReportRow</code> — a single daisy <code>list-row</code> layout inside a <code>bb-card</code>, the same shape as <code>AgentRunRow</code>. No desktop-table / mobile-card split. The full report body lives on the detail page.</li>
-				<li>Each row: a leading <strong>status tile</strong> (priority → vivid tone: error / warning / info), <strong>agent identity</strong> (UserAvatar + name), an <strong>unread dot</strong> + relative <strong>time</strong> on the title line, the <strong>summary</strong> as the one body line, and a trailing <strong>OverflowMenu</strong> (mark read/unread · open) rendered outside the row link.</li>
-				<li>Unread rows stay full-strength with a heavier summary + an info dot; read rows fade (row opacity) and drop the dot. Status lives in the tile — no parallel priority text badge in the row.</li>
+				<li>Each row leads with a <strong>small bare priority glyph</strong> (vivid ink only for critical / warning; muted for routine — no tinted tile). The <strong>summary</strong> is the prominent line; the <strong>agent identity</strong> (UserAvatar + name) + an <strong>unread dot</strong> + relative <strong>time</strong> ride above it as a quiet metadata line. A trailing <strong>OverflowMenu</strong> (mark read/unread · open) renders outside the row link.</li>
+				<li>Unread rows keep a slightly stronger summary + an info dot; read rows fade (row opacity) and drop the dot. Status is a small glyph, not a parallel priority text badge.</li>
 				<li>The whole row is a real <code>&lt;a&gt;</code> (keyboard / middle-click + the accessible name); the overflow menu sits outside it. On <code>/reports</code> the All view groups rows unread-first under quiet label lines.</li>
 				<li><code>ReportPriorityBadge</code> is the shared priority chip, reused in the detail-page header.</li>
 			</ul>

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -29,8 +29,11 @@ templ Reports(p ReportsProps) {
 		Action:               reportsManageFormatLink(),
 	})
 	<div x-data="reportsPage">
+		if line := reportsGlance(p); line != "" {
+			<p class="text-sm text-base-content/55 mb-4 -mt-1">{ line }</p>
+		}
 		<!-- Filter tabs + mark-all-read -->
-		<div class="flex items-center justify-between gap-2 mb-5 flex-wrap">
+		<div class="flex items-center justify-between gap-2 mb-6 flex-wrap">
 			@components.TabBar(components.TabBarProps{
 				Variant:   "border",
 				AriaLabel: "Filter reports by read state",
@@ -58,7 +61,7 @@ templ Reports(p ReportsProps) {
 		if len(p.Reports) > 0 {
 			if p.FilterStatus == "" {
 				{{ unread, read := partitionReportsByRead(p.Reports) }}
-				<div class="flex flex-col gap-5">
+				<div class="flex flex-col gap-7">
 					if len(unread) > 0 {
 						@reportsGroup("Unread", len(unread)) {
 							@components.ReportsList(unread)
@@ -96,10 +99,10 @@ templ Reports(p ReportsProps) {
 // inbox so the All view reads "Unread first, then Read" without a heavy
 // boxed card-header per group.
 templ reportsGroup(label string, count int) {
-	<div class="flex flex-col gap-2">
+	<div class="flex flex-col gap-3">
 		<div class="flex items-center gap-2 px-1">
-			<span class="text-sm font-medium text-base-content">{ label }</span>
-			<span class="text-xs text-base-content/40 tabular-nums">{ reportsGroupCount(count) }</span>
+			<span class="text-xs font-medium uppercase tracking-wide text-base-content/45">{ label }</span>
+			<span class="text-xs text-base-content/35 tabular-nums">{ reportsGroupCount(count) }</span>
 		</div>
 		{ children... }
 	</div>

--- a/internal/templates/components/pages/reports_types.go
+++ b/internal/templates/components/pages/reports_types.go
@@ -3,6 +3,7 @@
 package pages
 
 import (
+	"fmt"
 	"strconv"
 
 	"breadbox/internal/templates/components"
@@ -43,6 +44,28 @@ type ReportsProps struct {
 	AllCount    int
 	UnreadCount int
 	ReadCount   int
+	// At-a-glance: the agent contributing the most unread reports and how
+	// many, used to render the quiet "N unread · M from <Agent>" context
+	// line above the filter tabs. TopUnreadAgent is "" when no single agent
+	// stands out (or there are no unread reports).
+	TopUnreadAgent      string
+	TopUnreadAgentCount int
+}
+
+// reportsGlance renders the quiet at-a-glance line above the filter tabs —
+// plain muted text (not a hero/digest card), e.g. "8 unread · 3 from
+// Review Agent". Returns "" when there's nothing unread, so the line only
+// appears when it carries information. The "· M from <Agent>" clause is
+// appended only when one agent clearly leads the unread pile (>= 2).
+func reportsGlance(p ReportsProps) string {
+	if p.UnreadCount <= 0 {
+		return ""
+	}
+	line := fmt.Sprintf("%d unread", p.UnreadCount)
+	if p.TopUnreadAgentCount >= 2 && p.TopUnreadAgent != "" {
+		line += fmt.Sprintf(" · %d from %s", p.TopUnreadAgentCount, p.TopUnreadAgent)
+	}
+	return line
 }
 
 // reportsCountPtr adapts an int count to the *int TabBarItem.Count slot,

--- a/internal/templates/components/report_table.templ
+++ b/internal/templates/components/report_table.templ
@@ -53,20 +53,20 @@ templ ReportsList(rows []ReportRowProps) {
 	}
 }
 
-// ReportRow renders one report as a daisy `list-row`: a leading
-// priority-coded status tile, the agent identity (avatar + name) with an
-// unread dot and relative time as the title line, the summary as the one
-// body line below, and an overflow menu rendered OUTSIDE the row's
-// navigation anchor. Read rows fade and drop the dot; unread rows stay
-// full-strength with a heavier summary — the two restrained unread
-// channels (the leading info dot is the third). Status lives in the tile,
-// not a parallel text badge.
+// ReportRow renders one report as a daisy `list-row`. The summary (the
+// agent's finding) is the prominent line; the agent identity (avatar +
+// name) + an unread dot + relative time ride above it as a quiet metadata
+// line. A small, bare priority glyph leads the row — vivid ink only for
+// warning/critical, a muted glyph for routine — replacing the old 40×40
+// tinted tile so the inbox reads calm (Mintlify-clean: color is an accent,
+// not a per-row fill). Read rows fade and drop the dot; unread rows keep a
+// slightly stronger summary. Status is a small glyph, not a parallel badge.
 templ ReportRow(r ReportRowProps) {
 	<li
 		x-show={ fmt.Sprintf("!dismissed['%s']", r.ID) }
 		x-transition.opacity.duration.200ms
-		class={ "list-row transition-colors hover:bg-base-200/40 items-center",
-			templ.KV("opacity-60", r.IsRead) }
+		class={ "list-row py-3.5 gap-3 transition-colors hover:bg-base-200/40 items-center",
+			templ.KV("opacity-55", r.IsRead) }
 		data-report-id={ r.ID }
 	>
 		<a
@@ -74,7 +74,9 @@ templ ReportRow(r ReportRowProps) {
 			href={ templ.SafeURL("/reports/" + r.ID) }
 			aria-label={ reportRowLinkLabel(r) }
 		>
-			@IconTile(reportTileTone(r.Priority), reportTileIcon(r.Priority))
+			<div class="w-5 self-center flex items-center justify-center shrink-0">
+				@LucideIcon(reportTileIcon(r.Priority), "w-4 h-4 "+reportGlyphClass(r.Priority))
+			</div>
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 min-w-0">
 					@UserAvatar(UserAvatarProps{
@@ -86,13 +88,13 @@ templ ReportRow(r ReportRowProps) {
 						Lazy:       true,
 						Class:      "shrink-0",
 					})
-					<span class={ "text-sm truncate", reportAuthorClass(r.IsRead) }>{ reportAuthorLabel(r.Author) }</span>
+					<span class={ "text-xs truncate", reportAuthorClass(r.IsRead) }>{ reportAuthorLabel(r.Author) }</span>
 					if !r.IsRead {
 						<span class="w-1.5 h-1.5 rounded-full bg-info shrink-0" title="Unread" aria-hidden="true"></span>
 					}
-					<span class="ml-auto shrink-0 text-xs text-base-content/45 tabular-nums" title="Submitted">{ r.Time }</span>
+					<span class="ml-auto shrink-0 text-xs text-base-content/40 tabular-nums" title="Submitted">{ r.Time }</span>
 				</div>
-				<div class="mt-0.5 min-w-0">
+				<div class="mt-1 min-w-0">
 					<span class={ "block text-sm line-clamp-1 leading-snug", reportSummaryClass(r.IsRead) }>{ r.Title }</span>
 				</div>
 			</div>
@@ -134,22 +136,24 @@ func reportRowMenuItems(r ReportRowProps) []OverflowMenuItem {
 	return items
 }
 
-// reportTileTone maps a report's priority to the IconTile tone — a vivid
-// status colour per the badge-tone rule (error/warning/info). Routine
-// reports ("" / "info") use the calm info tone; read rows desaturate via
-// the row-level opacity, so the tile never shouts once the report is seen.
-func reportTileTone(priority string) string {
+// reportGlyphClass colours the small leading priority glyph. Vivid ink is
+// reserved for the priorities that actually warrant a glance — warning and
+// critical; routine reports get a quiet muted glyph so the inbox doesn't
+// repeat a loud tinted square down every row (Mintlify-clean restraint:
+// color is a small accent, not a per-row fill). Read rows desaturate
+// further via the row-level opacity.
+func reportGlyphClass(priority string) string {
 	switch priority {
 	case "critical":
-		return "error"
+		return "text-error"
 	case "warning":
-		return "warning"
+		return "text-warning"
 	default:
-		return "info"
+		return "text-base-content/35"
 	}
 }
 
-// reportTileIcon picks the glyph inside the status tile — alert shapes for
+// reportTileIcon picks the leading priority glyph — alert shapes for
 // warning/critical (matching ReportPriorityBadge), a neutral message glyph
 // for routine reports.
 func reportTileIcon(priority string) string {
@@ -173,13 +177,14 @@ func reportAvatarSeed(r ReportRowProps) string {
 	return reportAuthorLabel(r.Author)
 }
 
-// reportAuthorClass splits the agent-name weight by read state — unread
-// reports stay full-strength, read ones fade.
+// reportAuthorClass styles the agent name, which now reads as a quiet
+// metadata label above the summary — muted either way, a touch quieter
+// once the report is read. The summary carries the row's weight.
 func reportAuthorClass(isRead bool) string {
 	if isRead {
-		return "font-normal text-base-content/55"
+		return "text-base-content/45"
 	}
-	return "font-medium text-base-content"
+	return "font-medium text-base-content/70"
 }
 
 // reportAuthorLabel falls back to a neutral label when an agent didn't
@@ -191,11 +196,11 @@ func reportAuthorLabel(author string) string {
 	return author
 }
 
-// reportSummaryClass styles the summary line by read state — medium + full
-// strength when unread, lighter + muted when read.
+// reportSummaryClass styles the summary line — the row's prominent content
+// line. Medium + full-strength ink when unread; lighter + muted when read.
 func reportSummaryClass(isRead bool) string {
 	if isRead {
-		return "font-normal text-base-content/55"
+		return "font-normal text-base-content/50"
 	}
 	return "font-medium text-base-content"
 }

--- a/internal/templates/components/reports_skeleton.templ
+++ b/internal/templates/components/reports_skeleton.templ
@@ -25,8 +25,10 @@ templ ReportsSkeleton() {
 				<div class="skeleton h-8 w-32 rounded-md"></div>
 			</div>
 		</div>
+		<!-- At-a-glance line -->
+		<div class="skeleton h-4 w-44 rounded-md mb-4"></div>
 		<!-- Filter tabs + mark-all-read -->
-		<div class="flex items-center justify-between gap-2 mb-5">
+		<div class="flex items-center justify-between gap-2 mb-6">
 			<div class="flex items-center gap-4">
 				<div class="skeleton h-5 w-12"></div>
 				<div class="skeleton h-5 w-16"></div>
@@ -36,9 +38,9 @@ templ ReportsSkeleton() {
 		</div>
 		<!-- Group label line + list-row card. Summary widths vary so the
 		     skeleton reads as motion. -->
-		<div class="flex flex-col gap-2">
+		<div class="flex flex-col gap-3">
 			<div class="flex items-center gap-2 px-1">
-				<div class="skeleton h-4 w-16 rounded-md"></div>
+				<div class="skeleton h-3 w-14 rounded-md"></div>
 				<div class="skeleton h-3 w-4 rounded-md"></div>
 			</div>
 			<ul class="list rounded-xl bg-base-100 border border-base-300 overflow-hidden">
@@ -55,12 +57,12 @@ templ ReportsSkeleton() {
 // agent identity line (small avatar + name + time), a summary line, and a
 // trailing overflow kebab placeholder.
 templ reportsSkeletonRow(summaryW string) {
-	<li class="list-row items-center">
-		<div class="skeleton w-10 h-10 rounded-lg shrink-0"></div>
+	<li class="list-row py-3.5 gap-3 items-center">
+		<div class="skeleton w-4 h-4 rounded-md shrink-0"></div>
 		<div class="min-w-0 space-y-1.5">
 			<div class="flex items-center gap-2">
-				<div class="skeleton w-4 h-4 rounded-full shrink-0"></div>
-				<div class="skeleton h-3.5 w-24 rounded-md"></div>
+				<div class="skeleton w-5 h-5 rounded-full shrink-0"></div>
+				<div class="skeleton h-3 w-24 rounded-md"></div>
 				<div class="skeleton h-3 w-12 rounded-md ml-auto"></div>
 			</div>
 			<div class={ "skeleton h-4 rounded-md max-w-full", summaryW }></div>


### PR DESCRIPTION
Restrained Mintlify-clean pass on **/reports** — *removes* decoration, no hero.

## What changed
- **Removed the per-row tone-filled icon tile** (8 blue + 1 red + 1 amber tinted squares down the list) → a **small bare priority glyph** (vivid ink only for warning/critical; routine = muted).
- **The agent's finding is now the prominent line**; the agent name dropped to quiet metadata (avatar · name · unread dot · time).
- Quieter unread (small dot + weight, no wash; read rows fade), more whitespace (roomier rows, bigger group gaps, quiet uppercase group labels).
- A **plain-text glance line** — "8 unread · 3 from Review Agent" — not a digest/hero card.

No hero, no tints added — only removed. Behavior preserved (unread-first grouping + test, mark read/unread + AJAX, tabs, links, avatars). Mobile + dark agent-verified. `go build`/`vet`/`test ./...` green.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/34c28bd6bc21cbe6.jpeg" width="900" alt="/reports restrained clean pass">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
