### PR TITLE
refactor(connections): restrained clean pass (neutral provider tiles; status as a quiet pill)

### DIFF
--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -44,7 +44,7 @@ templ Connections(p ConnectionsProps) {
 			Action:               connectionsAction(p),
 		})
 		<!-- Tab Switcher -->
-		<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+		<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-8 w-fit">
 			<button
 				@click="tab = 'connections'"
 				:class="tab === 'connections' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
@@ -65,7 +65,7 @@ templ Connections(p ConnectionsProps) {
 		<!-- ==================== CONNECTIONS TAB ==================== -->
 		<div x-show="tab === 'connections'">
 			if len(p.Connections) > 0 {
-				<div class="flex flex-col gap-5" id="bb-connections-list">
+				<div class="flex flex-col gap-8" id="bb-connections-list">
 					for _, g := range p.Groups() {
 						@connectionsHealthGroup(g, p.CanManage)
 					}
@@ -113,13 +113,18 @@ templ Connections(p ConnectionsProps) {
 	<!-- /alpine x-data tabs -->
 }
 
-// connectionsHealthGroup renders one health bucket: a quiet label line
-// (with a count) over the bucket's connection list-rows inside a card.
+// connectionsHealthGroup renders one health bucket: a quiet plain-ink label
+// line (with a count) over the bucket's connection list-rows inside a card.
+// The needs-attention bucket earns a small warning glyph before its label —
+// a small accent, never a tinted rail or colored header.
 templ connectionsHealthGroup(g ConnectionsStatusGroup, canManage bool) {
-	<div class="flex flex-col gap-2">
-		<div class="flex items-center gap-2 px-1 min-w-0">
-			<span class={ "text-sm font-medium shrink-0", connectionsGroupLabelClass(g.Key) }>{ g.Label }</span>
-			<span class="text-xs text-base-content/40 shrink-0">{ fmt.Sprintf("%d", len(g.Rows)) }</span>
+	<div class="flex flex-col gap-3">
+		<div class="flex items-center gap-1.5 px-0.5 min-w-0">
+			if connectionsGroupIcon(g.Key) != "" {
+				@components.LucideIcon(connectionsGroupIcon(g.Key), "w-3.5 h-3.5 text-warning shrink-0")
+			}
+			<span class="text-sm font-medium text-base-content shrink-0">{ g.Label }</span>
+			<span class="text-xs text-base-content/40 shrink-0 tabular-nums">{ fmt.Sprintf("%d", len(g.Rows)) }</span>
 		</div>
 		@components.AgentRunRowList() {
 			for _, c := range g.Rows {
@@ -129,11 +134,13 @@ templ connectionsHealthGroup(g ConnectionsStatusGroup, canManage bool) {
 	</div>
 }
 
-// connectionsRow renders one connection as a daisy list-row: a leading
-// status tile (tone tracks health), the institution name with a small
-// provider mark, one priority body line, a trailing per-connection
-// balance, and — outside the row's navigation anchor — an optional
-// recovery link plus the actions overflow.
+// connectionsRow renders one connection as a daisy list-row: a leading,
+// quiet provider tile (brand identity — not a status tint), the institution
+// name beside a small status pill (shown only when action is warranted),
+// one muted body line, a trailing per-connection balance, and — outside the
+// row's navigation anchor — an optional recovery link plus the actions
+// overflow. Health tone lives in the small pill alone; no tile wash, no
+// left-accent rail.
 templ connectionsRow(c ConnectionsRow, canManage bool) {
 	<li
 		class="list-row transition-colors hover:bg-base-200/40 focus-within:bg-base-200/40 items-center"
@@ -149,12 +156,11 @@ templ connectionsRow(c ConnectionsRow, canManage bool) {
 			href={ templ.SafeURL("/connections/" + c.ID) }
 			aria-label={ "Open " + c.InstitutionName + " connection" }
 		>
-			<div class={ "w-10 h-10 rounded-lg flex items-center justify-center shrink-0", connectionTileTone(connectionStatusTone(c)) }>
-				@components.LucideIcon(connectionStatusIcon(c), "w-4 h-4")
+			<div class="w-10 h-10 rounded-lg bg-base-200/70 flex items-center justify-center shrink-0">
+				@connectionsProviderMark(c.Provider)
 			</div>
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 min-w-0">
-					@connectionsProviderMark(c.Provider)
 					<span data-private="institution" class="font-medium text-sm text-base-content truncate">{ c.InstitutionName }</span>
 					if c.Paused {
 						<span class="badge badge-ghost badge-xs shrink-0">Paused</span>
@@ -183,38 +189,37 @@ templ connectionsRow(c ConnectionsRow, canManage bool) {
 	</li>
 }
 
-// connectionsRowBody renders ONE body line, in priority order: a
-// connection-level error (reauth) → a failed last sync → the quiet
-// "N accounts · synced 2h ago". Healthy rows still get the quiet line so
-// the row always says how many accounts and when it last synced.
-templ connectionsRowBody(c ConnectionsRow) {
-	if c.ErrorMessageValid {
-		<div class="mt-0.5 text-xs min-w-0 line-clamp-1 text-warning">
-			{ components.ErrorMessage(c.ErrorCode) }
-		</div>
-	} else if c.Status == "pending_reauth" {
-		<div class="mt-0.5 text-xs min-w-0 line-clamp-1 text-warning">Reauthentication needed</div>
-	} else if c.Status == "active" && c.LastSyncStatus == "error" {
-		<div class="mt-0.5 text-xs min-w-0 line-clamp-1 text-warning">
-			if c.LastSyncErrorMessage != "" {
-				{ "Last sync failed — " + c.LastSyncErrorMessage }
-			} else {
-				Last sync failed
-			}
-		</div>
-	} else {
-		<div class="mt-0.5 text-xs text-base-content/55 min-w-0 line-clamp-1">
-			{ connectionsAccountCountLabel(c.AccountCount) }
-			<span class="text-base-content/25">&middot;</span>
-			if c.Status == "disconnected" {
-				<span>Disconnected</span>
-			} else if c.LastSyncedAtValid {
-				<span>{ "synced " + c.LastSyncedAtRelative }</span>
-			} else {
-				<span>Never synced</span>
-			}
-		</div>
+// connectionsStatusPill is the row's single health signal: a small quiet
+// icon+label badge shown only when a connection wants attention (sync error,
+// reauth, disconnected). Healthy active rows render nothing so the calm
+// majority stays decoration-free. The full error detail rides the title attr.
+templ connectionsStatusPill(c ConnectionsRow) {
+	if connectionsShowStatusPill(c) {
+		<span
+			class={ "badge badge-xs gap-1 shrink-0", connectionStatusBadgeClass(c) }
+			title={ connectionsRowReason(c) }
+		>
+			@components.LucideIcon(connectionStatusIcon(c), "w-3 h-3")
+			{ connectionStatusLabel(c) }
+		</span>
 	}
+}
+
+// connectionsRowBody renders the row's second line: the small status pill
+// (only when action is warranted) leading a quiet, muted metadata clause of
+// the same shape on every row — "N accounts · <situation>". Keeping the pill
+// here (not beside the name) lets the institution name own the full first
+// line, so it doesn't truncate to a stub on mobile. The situation clause
+// stays in muted ink; tone lives in the pill, never washed across the line.
+templ connectionsRowBody(c ConnectionsRow) {
+	<div class="mt-0.5 flex items-center gap-1.5 min-w-0">
+		@connectionsStatusPill(c)
+		<span class="text-xs text-base-content/55 min-w-0 truncate">
+			{ connectionsAccountCountLabel(c.AccountCount) }
+			<span class="text-base-content/25 mx-1">&middot;</span>
+			{ connectionsRowReason(c) }
+		</span>
+	</div>
 }
 
 // connectionsProviderMark renders the small brand glyph next to the
@@ -277,16 +282,6 @@ func connectionsRowItems(c ConnectionsRow, canManage bool) []components.Overflow
 		})
 	}
 	return items
-}
-
-// connectionsGroupLabelClass tints the needs-attention group label so the
-// bucket that wants action reads warmer than the quiet active/disconnected
-// headers.
-func connectionsGroupLabelClass(key string) string {
-	if key == "needs_attention" {
-		return "text-warning"
-	}
-	return "text-base-content"
 }
 
 templ connectionsLinkRow(l ConnectionsLinkRow, csrfToken string) {

--- a/internal/templates/components/pages/connections_scripts.go
+++ b/internal/templates/components/pages/connections_scripts.go
@@ -16,14 +16,19 @@ func connectionsCountLabel(n int) string {
 	return fmt.Sprintf("%d banks", n)
 }
 
-// connectionsSubtitle is the count line that sits in the PageHeader
-// subtitle slot. Empty when there are no connections so the subtitle
-// row collapses.
+// connectionsSubtitle is the quiet at-a-glance line in the PageHeader
+// subtitle slot: "N banks", with "· M need attention" appended in the same
+// muted ink when any connection wants action. Plain text — never a hero or
+// summary card. Empty when there are no connections so the row collapses.
 func connectionsSubtitle(p ConnectionsProps) string {
 	if len(p.Connections) == 0 {
 		return ""
 	}
-	return connectionsCountLabel(len(p.Connections))
+	base := connectionsCountLabel(len(p.Connections))
+	if att := connectionsNeedsAttentionCount(p.Connections); att > 0 {
+		return fmt.Sprintf("%s · %d need attention", base, att)
+	}
+	return base
 }
 
 // connectionsAccountSuffix renders the trailing "account"/"accounts"

--- a/internal/templates/components/pages/connections_types.go
+++ b/internal/templates/components/pages/connections_types.go
@@ -2,7 +2,11 @@
 
 package pages
 
-import "fmt"
+import (
+	"fmt"
+
+	"breadbox/internal/templates/components"
+)
 
 // ConnectionsProps mirrors the data map the old connections.html read off
 // the layout. Kept flat so admin/connections.go can copy fields one-to-one.
@@ -172,19 +176,94 @@ func connectionStatusIcon(c ConnectionsRow) string {
 	}
 }
 
-// connectionTileTone returns the bg/text utility pair for the leading
-// status tile, mirroring the agent-run row's tone helper.
-func connectionTileTone(tone string) string {
-	switch tone {
-	case "success":
-		return "bg-success/10 text-success"
-	case "warning":
-		return "bg-warning/10 text-warning"
-	case "error":
-		return "bg-error/10 text-error"
+// connectionsShowStatusPill is true for any connection that warrants a
+// status pill — i.e. it is not a healthy active connection. Healthy rows
+// stay pill-free so the calm majority reads quietly (Mintlify-clean): the
+// quiet provider tile + "synced Nh ago" body line carry them. Attention is
+// signalled only where it is warranted.
+func connectionsShowStatusPill(c ConnectionsRow) bool {
+	return connectionHealthBucket(c) != "active"
+}
+
+// connectionStatusLabel is the short word shown in the row's status pill.
+func connectionStatusLabel(c ConnectionsRow) string {
+	switch {
+	case c.Status == "disconnected":
+		return "Disconnected"
+	case c.Status == "error":
+		return "Connection error"
+	case c.Status == "pending_reauth":
+		return "Reauth needed"
+	case c.Status == "active" && c.LastSyncStatus == "error":
+		return "Sync error"
 	default:
-		return "bg-base-200 text-base-content/50"
+		return "Connected"
 	}
+}
+
+// connectionStatusBadgeClass maps a connection's health tone to the quiet
+// daisy badge utility for its status pill. The vivid tones use badge-soft so
+// the pill stays a small accent (never a fill); disconnected falls back to
+// badge-ghost because a neutral-soft badge is invisible on the dark theme.
+func connectionStatusBadgeClass(c ConnectionsRow) string {
+	switch connectionStatusTone(c) {
+	case "warning":
+		return "badge-soft badge-warning"
+	case "error":
+		return "badge-soft badge-error"
+	case "success":
+		return "badge-soft badge-success"
+	default:
+		return "badge-ghost"
+	}
+}
+
+// connectionsRowReason is the trailing clause of the quiet body line — the
+// account count's companion. It states the connection's situation in muted
+// ink; tone lives only in the small pill, never washed across the body. It
+// doubles as the status pill's hover title so the full error detail the
+// line truncates is still reachable.
+func connectionsRowReason(c ConnectionsRow) string {
+	switch {
+	case c.ErrorMessageValid:
+		return components.ErrorMessage(c.ErrorCode)
+	case c.Status == "pending_reauth":
+		return "Reauthentication needed"
+	case c.Status == "active" && c.LastSyncStatus == "error":
+		if c.LastSyncErrorMessage != "" {
+			return "Last sync failed — " + c.LastSyncErrorMessage
+		}
+		return "Last sync failed"
+	case c.Status == "disconnected":
+		return "Disconnected"
+	case c.LastSyncedAtValid:
+		return "synced " + c.LastSyncedAtRelative
+	default:
+		return "Never synced"
+	}
+}
+
+// connectionsGroupIcon returns a small leading lucide glyph for a health
+// group header. Only the needs-attention bucket gets one (a quiet warning
+// mark, a small accent — not a tinted rail); the rest read as plain-ink
+// labels.
+func connectionsGroupIcon(key string) string {
+	if key == "needs_attention" {
+		return "alert-triangle"
+	}
+	return ""
+}
+
+// connectionsNeedsAttentionCount counts connections in the needs-attention
+// bucket, for the quiet at-a-glance subtitle line.
+func connectionsNeedsAttentionCount(rows []ConnectionsRow) int {
+	n := 0
+	for _, r := range rows {
+		if connectionHealthBucket(r) == "needs_attention" {
+			n++
+		}
+	}
+	return n
 }
 
 // connectionsAccountCountLabel renders "N accounts" for the body line,


### PR DESCRIPTION
Restrained Mintlify-clean pass on **/connections** — removes the page's color-washes.

## What changed
- **Removed the status-tinted leading tile** (amber/green 40×40 wash per row) → a quiet **neutral tile holding the provider brand mark** (identity, not tint). Dropped the now-redundant inline provider mark by the name.
- **Status = a small pill, only where action's warranted**: a `badge-xs` ("Sync error" / "Reauth needed" / "Disconnected") on the metadata line — **healthy active rows show no pill** (the calm majority stays decoration-free). Full error detail moves to the pill's hover `title`.
- **De-washed the body line**: error rows no longer sprawl orange — one uniform muted "N accounts · situation" line. Institution name owns the full first line (no more mobile truncation to a stub).
- Quieter "Needs attention" header (small glyph + plain-ink label, not tinted) + plain-text "5 banks · 3 need attention" glance line. More breathing room.

Net decoration *reduction*. Behavior preserved (`GroupConnectionsByHealth` + test, connect-bank drawer + configure deep-link, Sync/Configure/Disconnect overflow, Account-Links tab, keyboard nav). Light/dark × desktop/mobile agent-verified. `go build`/`vet`/`test ./...` green.

## Evidence
<img src="https://bb-artifacts.exe.xyz/f/794975a0310cb8e4.jpeg" width="900" alt="/connections restrained clean pass">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
