### PR TITLE
fix(ui): j/k focus cursor follows bb-card radius on list-rows

### DIFF
--- a/input.css
+++ b/input.css
@@ -1890,6 +1890,23 @@
     box-shadow: inset 3px 0 0 var(--color-primary);
   }
 
+  /* ── Carded list-row j/k cursor ──
+   * The persistent j/k focus cursor on the redesigned card surfaces
+   * (/categories, /rules, /recurring, /accounts, …) can't reuse the
+   * flat transactions-list left bar above: those rows live inside a
+   * `bb-card`/`.list` with rounded, `overflow-hidden` first/last-row
+   * corners, and the bar's square ends poke past the card's radius.
+   * Promote the cursor onto the SAME inset ring the tab `:focus-visible`
+   * state uses (border-radius: inherit → follows the card corner), and
+   * keep the `bg-primary/5` fill above for the persistent "you are here"
+   * emphasis that distinguishes a parked j/k cursor from momentary tab
+   * focus. Scoped to `.list-row` so the real `.bb-tx-row` ledger (no
+   * `.list-row`, full-bleed) keeps its left bar. */
+  .list-row.bb-tx-row--focused {
+    box-shadow: inset 0 0 0 2px var(--color-primary);
+    border-radius: inherit;
+  }
+
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) .bb-tx-row--focused {
       @apply bg-primary/10;


### PR DESCRIPTION
Scopes the persistent **j/k keyboard cursor** to follow the card's corner radius on the redesigned list-row surfaces — fixing the square left-bar nubs that poked past the rounded `bb-card` corners on `/categories`, `/rules`, `/recurring`, `/accounts`, etc.

### The bug

The j/k cursor reused `.bb-tx-row--focused`'s flat-ledger left bar (`box-shadow: inset 3px 0 0`). That idiom is built for the full-bleed transactions list. On the carded surfaces the rows live inside a rounded, `overflow-hidden` `.list`/`bb-card`, so the bar's square top/bottom-left corners poked past the card's rounded first/last-row corners.

### The fix

`.list-row.bb-tx-row--focused` now uses the **same inset ring** the tab `:focus-visible` state already uses (`border-radius: inherit` → follows the card corner), keeping the `bg-primary/5` fill for the persistent "you are here" emphasis that distinguishes a parked j/k cursor from momentary tab focus. The full-bleed `.bb-tx-row` ledger (not a `.list-row`) keeps its left bar.

One scoped rule in `input.css`; no Go changes.

### Before → after

| Before (square nubs poke past corner) | After (ring follows radius) |
|---|---|
| <img src="https://bb-artifacts.exe.xyz/f/089e2b06f13572d7.jpeg" width="380"> | <img src="https://bb-artifacts.exe.xyz/f/1a75462a2568214a.jpeg" width="380"> |

`/rules`, last row of a group — ring closes cleanly on the bottom corners too:

<img src="https://bb-artifacts.exe.xyz/f/0f8acc684aaa387d.jpeg" width="380">
