### PR TITLE
feat(categories): collapsible top-level groups

### DIFF
--- a/input.css
+++ b/input.css
@@ -469,7 +469,8 @@
    *     against the bb-card's rounded first/last-row corners.
    *   `--color-primary` at 0.4 alpha matches the app's `ring-primary/40`
    *   focus idiom (principle #8 / StatTile, CollapsibleSection). */
-  .list-row:has(> a.contents:focus-visible) {
+  .list-row:has(> a.contents:focus-visible),
+  .list-row:has(> button.contents:focus-visible) {
     box-shadow: inset 0 0 0 2px oklch(from var(--color-primary) l c h / 0.4);
     border-radius: inherit;
   }

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -83,8 +83,14 @@ templ Categories(p CategoriesProps) {
 // single card of list-rows. The wrapper carries the combined data-search
 // index so the Alpine filter can hide a whole group when neither the parent
 // nor any child matches.
+//
+// Each group owns a local `expanded` flag (default collapsed): the parent row
+// is a disclosure toggle, the subcategory rows show only when the group is
+// expanded OR a filter is active (so a search still surfaces matching
+// children inside a collapsed group). Groups whose parent has no children
+// render the parent as a plain edit link with no disclosure.
 templ categoryGroup(g CategoryGroup) {
-	<div data-search={ g.Parent.Search } x-show="matches($el)">
+	<div data-search={ g.Parent.Search } x-show="matches($el)" x-data="{ expanded: false }">
 		@components.AgentRunRowList() {
 			@categoryRow(g.Parent)
 			for _, ch := range g.Children {
@@ -107,33 +113,84 @@ templ categoryRow(r CategoryRowVM) {
 		data-category-id={ r.ID }
 		data-category-slug={ r.Slug }
 		data-search={ r.Search }
-		x-show="matches($el)"
+		if r.IsChild {
+			x-show="matches($el) && (expanded || filtering)"
+		} else {
+			x-show="matches($el)"
+		}
 	>
-		<a
-			class="contents no-underline focus:outline-none"
-			href={ templ.SafeURL(fmt.Sprintf("/categories/%s/edit", r.ID)) }
-		>
-			@categoryColorTile(r)
-			<div class="min-w-0">
-				<div class="flex items-center gap-2 min-w-0">
-					<span class={ categoryNameClass(r) }>{ r.DisplayName }</span>
-					if !r.IsChild && r.ChildCount > 0 {
-						<span class="badge badge-ghost badge-xs shrink-0">{ strconv.Itoa(r.ChildCount) }</span>
-					}
-					if r.IsSystem {
-						<span class="badge badge-ghost badge-xs shrink-0">System</span>
-					}
-					if r.Hidden {
-						<span class="badge badge-soft badge-warning badge-xs shrink-0">Hidden</span>
-					}
-				</div>
-				<div class="mt-0.5 text-xs text-base-content/45 truncate">{ categoryRowDescriptor(r) }</div>
-			</div>
-		</a>
+		if categoryIsExpandable(r) {
+			<button
+				type="button"
+				class="contents text-left cursor-pointer focus:outline-none"
+				@click="expanded = !expanded"
+				:aria-expanded="expanded"
+				aria-label={ fmt.Sprintf("Toggle %s subcategories", r.DisplayName) }
+			>
+				@categoryRowLead(r)
+				@categoryRowBody(r)
+			</button>
+		} else {
+			<a
+				class="contents no-underline focus:outline-none"
+				href={ templ.SafeURL(fmt.Sprintf("/categories/%s/edit", r.ID)) }
+			>
+				@categoryRowLead(r)
+				@categoryRowBody(r)
+			</a>
+		}
 		<div class="shrink-0 self-center">
 			@categoryRowActions(r)
 		</div>
 	</li>
+}
+
+// categoryRowLead renders the leading cell: the color tile, preceded by a
+// disclosure chevron (expandable parents) or an equal-width spacer
+// (childless parents — so every parent tile lines up). Child rows lead with
+// the bare tile; their nesting reads from the row's left indent instead.
+templ categoryRowLead(r CategoryRowVM) {
+	if r.IsChild {
+		@categoryColorTile(r)
+	} else {
+		<div class="flex items-center gap-1.5 shrink-0">
+			if categoryIsExpandable(r) {
+				<span class="shrink-0 text-base-content/40 transition-transform" :class="expanded ? 'rotate-90' : ''">
+					@components.LucideIcon("chevron-right", "w-4 h-4")
+				</span>
+			} else {
+				<span class="w-4 h-4 shrink-0"></span>
+			}
+			@categoryColorTile(r)
+		</div>
+	}
+}
+
+// categoryRowBody renders the title row (name + count/system/hidden badges)
+// and the muted descriptor line. Shared by the link and disclosure-button
+// row variants.
+templ categoryRowBody(r CategoryRowVM) {
+	<div class="min-w-0">
+		<div class="flex items-center gap-2 min-w-0">
+			<span class={ categoryNameClass(r) }>{ r.DisplayName }</span>
+			if !r.IsChild && r.ChildCount > 0 {
+				<span class="badge badge-ghost badge-xs shrink-0">{ strconv.Itoa(r.ChildCount) }</span>
+			}
+			if r.IsSystem {
+				<span class="badge badge-ghost badge-xs shrink-0">System</span>
+			}
+			if r.Hidden {
+				<span class="badge badge-soft badge-warning badge-xs shrink-0">Hidden</span>
+			}
+		</div>
+		<div class="mt-0.5 text-xs text-base-content/45 truncate">{ categoryRowDescriptor(r) }</div>
+	</div>
+}
+
+// categoryIsExpandable reports whether a row is a top-level category that
+// owns subcategories — the only rows that render a disclosure toggle.
+func categoryIsExpandable(r CategoryRowVM) bool {
+	return !r.IsChild && r.ChildCount > 0
 }
 
 // categoryColorTile renders the leading identity tile using the category's

--- a/static/js/admin/components/categories.js
+++ b/static/js/admin/components/categories.js
@@ -7,9 +7,11 @@
 // j/k/Enter/Space/e/n to the registered handlers when the page scope is
 // 'categories' (set by the sibling x-init scope-setter div in templ).
 //
-// The list is always fully expanded now (no accordion — the page IS the
-// disclosure): each top-level category and its subcategories render as
-// list-rows in a card, and every row links to the category's edit page.
+// Top-level categories that own subcategories are collapsible disclosure
+// rows (default collapsed). The group's `expanded` flag lives on the group
+// wrapper's x-data; subcategory rows show when `expanded || filtering`, so a
+// search still surfaces matching children inside a collapsed group. Childless
+// parents and subcategory rows remain plain edit links.
 //
 // Keyboard registrations and the document-level click listener live at
 // module scope under one alpine:init — they're global by design and
@@ -44,6 +46,12 @@
       return {
         // --- Filter state (used by inline x-show on groups + rows) ---
         filter: '',
+
+        // True while a filter is typed. Subcategory rows read this so a
+        // search reveals matching children even inside a collapsed group.
+        get filtering() {
+          return this.filter.trim() !== '';
+        },
 
         // --- Keyboard navigation state ---
         focusedIdx: -1,
@@ -98,9 +106,15 @@
           return null;
         },
 
-        // Activate the focused row: open the category's edit page. Every
-        // row (parent or child) links there, so Enter mirrors a click.
+        // Activate the focused row by triggering its primary control, so
+        // Enter mirrors a click: an expandable parent toggles its
+        // subcategories (button.contents), a leaf/child opens its edit page
+        // (a.contents). Falls back to editRow() if neither is present.
         activateRow: function () {
+          var row = this.currentRow();
+          if (!row) return;
+          var ctrl = row.querySelector('a.contents, button.contents');
+          if (ctrl) { ctrl.click(); return; }
           this.editRow();
         },
 


### PR DESCRIPTION
Makes `/categories` collapsible: top-level categories that own subcategories are now disclosure rows. The page opens as a clean, scannable list of the 18 top-level categories instead of a ~140-row flat dump; each parent expands on click (or **Enter** via j/k).

### Behavior

- **Default collapsed.** Each group owns a local `expanded` flag. *(Opinionated call — collapsed is what makes the long page scannable. Easy to flip the default to expanded if you'd rather.)*
- **Filter still finds everything.** Child rows show on `expanded || filtering`, so a search surfaces matching children even inside a collapsed group; clearing the filter re-collapses.
- **Keyboard.** j/k Enter triggers the row's primary control — parents toggle, leaves/children open their edit page. Collapsed children fall out of `visibleRows()` so j/k skips them.
- Childless parents (e.g. *V3 Test Category*) and subcategory rows stay plain edit links; a chevron-width spacer keeps every parent tile aligned.

### Notable fix

The toggle is a `<button class="contents">`. A `<button>`'s default `text-align: center` leaks through `display: contents` and centered the descriptor; `text-left` on the button restores left alignment. The chevron + color tile share one flex cell so the daisy `list-row` grid is unchanged.

### Evidence

| Collapsed (default) | Expanded | Mobile |
|---|---|---|
| <img src="https://bb-artifacts.exe.xyz/f/26b338963f70ff54.jpg" width="300"> | <img src="https://bb-artifacts.exe.xyz/f/6b0805c0aff90fef.jpeg" width="300"> | <img src="https://bb-artifacts.exe.xyz/f/b343cf73c6925ca8.jpg" width="220"> |

Filter auto-expand verified (`dividends` → Income › Dividends); j/k Enter toggles a focused parent.
