### PR TITLE
refactor(recurring): compact Needs-review candidates (evidence on demand)

### DIFF
--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -186,17 +186,37 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 					@components.SeriesConfidenceChip(s.ConfidenceBand, s.BandTone)
 					<span>{ s.SignalSummary }</span>
 				</div>
-				<button
-					type="button"
-					@click="why = !why"
-					class="text-xs text-base-content/40 hover:text-base-content/70 inline-flex items-center gap-1 mt-2 cursor-pointer bg-transparent"
-				>
-					<span class="transition-transform" :class="why ? 'rotate-90' : ''">
-						@components.LucideIcon("chevron-right", "w-3 h-3")
-					</span>
-					Why detected?
-				</button>
-				<div x-show="why" x-cloak class="mt-2 rounded-lg bg-base-200/50 p-3">
+			</div>
+			<div class="text-right shrink-0">
+				if s.HasAmount {
+					@components.Amount(components.AmountProps{
+						Value:  s.Amount,
+						Intent: components.AmountCost,
+						Class:  "text-sm font-semibold",
+					})
+				}
+				<div class="text-xs text-base-content/40 mt-0.5">{ s.CadenceLabel }</div>
+			</div>
+		</div>
+		<!-- One disclosure keeps the candidate compact by default: the
+		     detection signals and the charges it was detected from both live
+		     behind "Why detected?", so the Needs-review tab reads as a clean
+		     list of decisions rather than a wall of evidence. -->
+		<div class="mt-2">
+			<button
+				type="button"
+				@click="why = !why"
+				class="text-xs text-base-content/40 hover:text-base-content/70 inline-flex items-center gap-1 cursor-pointer bg-transparent"
+				:aria-expanded="why"
+			>
+				<span class="transition-transform" :class="why ? 'rotate-90' : ''">
+					@components.LucideIcon("chevron-right", "w-3 h-3")
+				</span>
+				Why detected?
+				<span class="text-base-content/30">· { subscriptionEvidenceHint(s.OccurrenceCount) }</span>
+			</button>
+			<div x-show="why" x-cloak class="mt-2 space-y-3">
+				<div class="rounded-lg bg-base-200/50 p-3">
 					if len(s.SignalFacts) > 0 {
 						<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
 							for _, f := range s.SignalFacts {
@@ -211,32 +231,21 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 						<p class="text-xs text-base-content/50">No detection signals recorded — created manually or by an agent.</p>
 					}
 				</div>
-			</div>
-			<div class="text-right shrink-0">
-				if s.HasAmount {
-					@components.Amount(components.AmountProps{
-						Value:  s.Amount,
-						Intent: components.AmountCost,
-						Class:  "text-sm font-semibold",
-					})
+				if len(s.MemberRows) > 0 {
+					<div>
+						<div class="text-[0.7rem] uppercase tracking-wider text-base-content/40 mb-1">Based on these charges</div>
+						<div>
+							for _, m := range s.MemberRows {
+								@seriesChargeRow(m)
+							}
+						</div>
+						if s.OccurrenceCount > len(s.MemberRows) {
+							<div class="text-xs text-base-content/40 mt-1.5 pl-1">+ { fmt.Sprintf("%d", s.OccurrenceCount-len(s.MemberRows)) } more</div>
+						}
+					</div>
 				}
-				<div class="text-xs text-base-content/40 mt-0.5">{ s.CadenceLabel }</div>
 			</div>
 		</div>
-		<!-- Evidence: the charges this candidate was detected from. -->
-		if len(s.MemberRows) > 0 {
-			<div class="mt-3 pt-3 border-t border-base-200">
-				<div class="text-[0.7rem] uppercase tracking-wider text-base-content/40 mb-1">Based on these charges</div>
-				<div>
-					for _, m := range s.MemberRows {
-						@seriesChargeRow(m)
-					}
-				</div>
-				if s.OccurrenceCount > len(s.MemberRows) {
-					<div class="text-xs text-base-content/40 mt-1.5 pl-1">+ { fmt.Sprintf("%d", s.OccurrenceCount-len(s.MemberRows)) } more</div>
-				}
-			</div>
-		}
 		<div class="flex items-center justify-end gap-2 mt-3 pt-3 border-t border-base-200">
 			<button
 				type="button"
@@ -256,6 +265,16 @@ templ subscriptionCandidateCard(s SubscriptionRow) {
 			</button>
 		</div>
 	</div>
+}
+
+// subscriptionEvidenceHint renders the charge-count hint on the "Why
+// detected?" toggle so reviewers know evidence sits behind it (the full
+// charge list is collapsed by default to keep each candidate compact).
+func subscriptionEvidenceHint(n int) string {
+	if n == 1 {
+		return "1 charge"
+	}
+	return fmt.Sprintf("%d charges", n)
 }
 
 // seriesChargeRow renders one linked charge as a leading date column + the


### PR DESCRIPTION
The **Needs-review** tab on `/recurring` rendered each candidate as a tall card with its full charge evidence *always expanded* — a wall of transaction rows that buried the actual decision and made the tab read nothing like the restrained Active tab.

This folds the detection signals **and** the "Based on these charges" list behind the single **"Why detected? · N charges"** disclosure. Each candidate now defaults to a compact decision card — name · type · confidence · summary · amount · Confirm/Not-recurring — so the tab reads as a clean, scannable list of decisions. Expanding reveals the signal facts + the full charge list exactly as before.

### Before → after (collapsed)

| Before — one tall card, evidence always on | After — compact decisions (3 fit where 1 did) |
|---|---|
| <img src="https://bb-artifacts.exe.xyz/f/37370bbd1f5210c4.jpeg" width="380"> | <img src="https://bb-artifacts.exe.xyz/f/4b4525ad784ca46c.jpg" width="380"> |

### Expanded — evidence on demand, unchanged

<img src="https://bb-artifacts.exe.xyz/f/1789620de4e3d79f.jpeg" width="560">

One templ function; no behavior change beyond the default-collapsed evidence.
