### PR TITLE
feat(onboarding): 'Finish setting up' banner on the home feed

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -193,8 +193,13 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
+		// "Finish setting up" banner: surfaces incomplete onboarding at the
+		// top of the home feed (nil once setup is complete or dismissed).
+		onboarding := onboardingBannerProps(computeOnboardingProgress(r.Context(), a), GetCSRFToken(r))
+
 		body := pages.Feed(pages.FeedProps{
 			CSRFToken:        GetCSRFToken(r),
+			Onboarding:       onboarding,
 			Hero:             hero,
 			ConnectionAlerts: alerts,
 			Days:             days,

--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -3,11 +3,9 @@
 package admin
 
 import (
-	"fmt"
 	"net/http"
 
 	"breadbox/internal/app"
-	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/templates/components/pages"
@@ -18,106 +16,30 @@ import (
 // GettingStartedHandler serves GET /getting-started — the setup walkthrough page.
 func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		// Step completion checks.
-		// Step 1: Configure a bank provider (Plaid, Teller, or SimpleFIN).
-		// This is the first real action — admin setup already seeds the
-		// household with one member, so connecting your money is what moves
-		// onboarding forward.
-		hasProvider := a.Config.PlaidClientID != "" || a.Config.TellerAppID != "" || a.Config.SimpleFINEnabled
-
-		// Step 2 (optional): Add a household member. Admin creation already
-		// links a first member, so this is auto-complete and carries an
-		// Optional badge — it only matters when finances are shared.
-		userCount, err := a.Queries.CountUsers(ctx)
-		if err != nil {
-			a.Logger.Error("getting started: count users", "error", err)
-		}
-		hasMember := userCount > 0
-
-		// Step 3: Connect a bank.
-		connCount, err := a.Queries.CountConnections(ctx)
-		if err != nil {
-			a.Logger.Error("getting started: count connections", "error", err)
-		}
-		hasConnection := connCount > 0
-
-		// Step 4: First successful sync.
-		successfulSyncs, err := a.Queries.CountSuccessfulSyncs(ctx)
-		if err != nil {
-			a.Logger.Error("getting started: count successful syncs", "error", err)
-		}
-		hasSync := successfulSyncs > 0
-
-		// Step 5: Configure agents (at least one API key).
-		activeAPIKeys, err := a.Queries.CountActiveApiKeys(ctx)
-		if err != nil {
-			a.Logger.Error("getting started: count active api keys", "error", err)
-		}
-		hasAPIKey := activeAPIKeys > 0
-
-		// Progress metrics.
-		accountCount, err := a.Queries.CountAccounts(ctx)
-		if err != nil {
-			a.Logger.Error("getting started: count accounts", "error", err)
-		}
-
-		txCount, err := a.Queries.CountTransactions(ctx)
-		if err != nil {
-			a.Logger.Error("getting started: count transactions", "error", err)
-		}
-
-		// Resolve the active step (first incomplete), completion count, and a
-		// rough time-to-finish estimate for the hero. Step order + per-step
-		// minutes are paired so the estimate sums only the steps still
-		// outstanding.
-		// Order MUST match the Number/State wiring in getting_started.templ:
-		// 1 provider, 2 household member (optional), 3 connection, 4 sync,
-		// 5 agents. activeStep is a 1-based index into this slice.
-		stepsDone := []bool{hasProvider, hasMember, hasConnection, hasSync, hasAPIKey}
-		stepMinutes := []int{2, 1, 2, 1, 3}
-		completedSteps := 0
-		activeStep := 0
-		minutesLeft := 0
-		for i, done := range stepsDone {
-			if done {
-				completedSteps++
-				continue
-			}
-			if activeStep == 0 {
-				activeStep = i + 1 // 1-based
-			}
-			minutesLeft += stepMinutes[i]
-		}
-		allComplete := completedSteps == len(stepsDone)
-		timeRemaining := ""
-		if !allComplete && minutesLeft > 0 {
-			timeRemaining = fmt.Sprintf("~%d min left", minutesLeft)
-		}
-
-		// Check if onboarding is dismissed (for the nav badge display).
-		dismissed := appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false)
+		// Step completion + progress is computed by the shared helper so the
+		// /getting-started walkthrough and the home-feed "Finish setting up"
+		// banner never disagree about which step is next.
+		p := computeOnboardingProgress(r.Context(), a)
 
 		data := BaseTemplateData(r, sm, "getting-started", "Getting Started")
 		props := pages.GettingStartedProps{
-			HasMember:           hasMember,
-			HasProvider:         hasProvider,
-			HasConnection:       hasConnection,
-			HasSync:             hasSync,
-			HasAPIKey:           hasAPIKey,
-			CompletedSteps:      completedSteps,
-			TotalSteps:          len(stepsDone),
-			AllComplete:         allComplete,
-			ActiveStep:          activeStep,
-			TimeRemaining:       timeRemaining,
-			MemberCount:         userCount,
-			ConnectionCount:     connCount,
-			AccountCount:        accountCount,
-			TransactionCount:    txCount,
-			SuccessfulSyncs:     successfulSyncs,
-			ApiKeyCount:         activeAPIKeys,
-			OnboardingDismissed: dismissed,
+			HasMember:           p.HasMember,
+			HasProvider:         p.HasProvider,
+			HasConnection:       p.HasConnection,
+			HasSync:             p.HasSync,
+			HasAPIKey:           p.HasAPIKey,
+			CompletedSteps:      p.CompletedSteps,
+			TotalSteps:          p.TotalSteps,
+			AllComplete:         p.AllComplete,
+			ActiveStep:          p.ActiveStep,
+			TimeRemaining:       p.TimeRemaining,
+			MemberCount:         p.MemberCount,
+			ConnectionCount:     p.ConnectionCount,
+			AccountCount:        p.AccountCount,
+			TransactionCount:    p.TransactionCount,
+			SuccessfulSyncs:     p.SuccessfulSyncs,
+			ApiKeyCount:         p.ApiKeyCount,
+			OnboardingDismissed: p.Dismissed,
 			CSRFToken:           GetCSRFToken(r),
 		}
 		renderGettingStarted(w, r, tr, data, props)

--- a/internal/admin/onboarding_progress.go
+++ b/internal/admin/onboarding_progress.go
@@ -1,0 +1,160 @@
+//go:build !headless && !lite
+
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
+	"breadbox/internal/templates/components"
+)
+
+// OnboardingProgress is the shared, DB-derived view of how far setup has
+// gotten. Both the dedicated /getting-started walkthrough and the home-feed
+// "Finish setting up" banner read from this single source so the two never
+// disagree about which step is next.
+//
+// Step order is fixed (1 provider, 2 household member [optional], 3
+// connection, 4 sync, 5 agents); ActiveStep is the 1-based index of the first
+// incomplete step (0 when AllComplete).
+type OnboardingProgress struct {
+	HasProvider   bool
+	HasMember     bool
+	HasConnection bool
+	HasSync       bool
+	HasAPIKey     bool
+
+	CompletedSteps int
+	TotalSteps     int
+	ActiveStep     int
+	AllComplete    bool
+	TimeRemaining  string
+
+	Dismissed bool
+
+	MemberCount      int64
+	ConnectionCount  int64
+	AccountCount     int64
+	TransactionCount int64
+	SuccessfulSyncs  int64
+	ApiKeyCount      int64
+}
+
+// computeOnboardingProgress runs the step-completion checks against the live
+// database. Query errors are logged and treated as "not done" so a transient
+// failure never falsely marks setup complete.
+func computeOnboardingProgress(ctx context.Context, a *app.App) OnboardingProgress {
+	logErr := func(what string, err error) {
+		if err != nil {
+			a.Logger.Error("onboarding progress: "+what, "error", err)
+		}
+	}
+
+	// Step 1: a bank provider is configured (Plaid, Teller, or SimpleFIN).
+	hasProvider := a.Config.PlaidClientID != "" || a.Config.TellerAppID != "" || a.Config.SimpleFINEnabled
+
+	// Step 2 (optional): household has a member. Admin creation seeds one, so
+	// this is effectively auto-complete.
+	userCount, err := a.Queries.CountUsers(ctx)
+	logErr("count users", err)
+
+	// Step 3: at least one bank connection.
+	connCount, err := a.Queries.CountConnections(ctx)
+	logErr("count connections", err)
+
+	// Step 4: first successful sync.
+	successfulSyncs, err := a.Queries.CountSuccessfulSyncs(ctx)
+	logErr("count successful syncs", err)
+
+	// Step 5: at least one active API key (agents).
+	activeAPIKeys, err := a.Queries.CountActiveApiKeys(ctx)
+	logErr("count active api keys", err)
+
+	accountCount, err := a.Queries.CountAccounts(ctx)
+	logErr("count accounts", err)
+
+	txCount, err := a.Queries.CountTransactions(ctx)
+	logErr("count transactions", err)
+
+	// Resolve active step + a rough time-to-finish estimate. Per-step minutes
+	// are paired with the step order so the estimate sums only outstanding
+	// steps.
+	stepsDone := []bool{hasProvider, userCount > 0, connCount > 0, successfulSyncs > 0, activeAPIKeys > 0}
+	stepMinutes := []int{2, 1, 2, 1, 3}
+	completed := 0
+	activeStep := 0
+	minutesLeft := 0
+	for i, done := range stepsDone {
+		if done {
+			completed++
+			continue
+		}
+		if activeStep == 0 {
+			activeStep = i + 1 // 1-based
+		}
+		minutesLeft += stepMinutes[i]
+	}
+	allComplete := completed == len(stepsDone)
+	timeRemaining := ""
+	if !allComplete && minutesLeft > 0 {
+		timeRemaining = fmt.Sprintf("~%d min left", minutesLeft)
+	}
+
+	return OnboardingProgress{
+		HasProvider:      hasProvider,
+		HasMember:        userCount > 0,
+		HasConnection:    connCount > 0,
+		HasSync:          successfulSyncs > 0,
+		HasAPIKey:        activeAPIKeys > 0,
+		CompletedSteps:   completed,
+		TotalSteps:       len(stepsDone),
+		ActiveStep:       activeStep,
+		AllComplete:      allComplete,
+		TimeRemaining:    timeRemaining,
+		Dismissed:        appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false),
+		MemberCount:      userCount,
+		ConnectionCount:  connCount,
+		AccountCount:     accountCount,
+		TransactionCount: txCount,
+		SuccessfulSyncs:  successfulSyncs,
+		ApiKeyCount:      activeAPIKeys,
+	}
+}
+
+// onboardingBannerProps builds the home-feed "Finish setting up" banner from
+// the progress, or returns nil when the banner should not show — setup is
+// complete or the guide was dismissed. Keeping the show/hide decision here
+// means callers just assign the result to FeedProps.Onboarding.
+func onboardingBannerProps(p OnboardingProgress, csrfToken string) *components.OnboardingBannerProps {
+	if p.AllComplete || p.Dismissed {
+		return nil
+	}
+	return &components.OnboardingBannerProps{
+		CompletedSteps: p.CompletedSteps,
+		TotalSteps:     p.TotalSteps,
+		NextStepLabel:  onboardingStepLabel(p.ActiveStep),
+		TimeRemaining:  p.TimeRemaining,
+		CSRFToken:      csrfToken,
+	}
+}
+
+// onboardingStepLabel maps a 1-based step index to the short, action-first
+// label the banner shows as "Next: …". Index 0 (all complete) returns "".
+func onboardingStepLabel(step int) string {
+	switch step {
+	case 1:
+		return "Configure a bank provider"
+	case 2:
+		return "Add a household member"
+	case 3:
+		return "Connect your bank"
+	case 4:
+		return "Run your first sync"
+	case 5:
+		return "Set up an automation"
+	default:
+		return ""
+	}
+}

--- a/internal/templates/components/onboarding_banner.templ
+++ b/internal/templates/components/onboarding_banner.templ
@@ -1,0 +1,89 @@
+package components
+
+import "strconv"
+
+// OnboardingBannerProps drives the home-feed "Finish setting up" banner — a
+// compact, dismissible progress strip that surfaces incomplete onboarding in
+// context instead of behind a separate page. The handler computes it from the
+// shared onboarding progress and only renders the banner while setup is
+// incomplete and the guide hasn't been dismissed.
+type OnboardingBannerProps struct {
+	// CompletedSteps / TotalSteps drive the segmented progress bar and the
+	// "N of M" count.
+	CompletedSteps int
+	TotalSteps     int
+
+	// NextStepLabel is the short, action-first label for the first incomplete
+	// step (e.g. "Connect your bank"), shown as the headline action.
+	NextStepLabel string
+
+	// TimeRemaining is the rough estimate ("~5 min left"); empty hides it.
+	TimeRemaining string
+
+	// ContinueHref is where the primary CTA points (defaults to
+	// /getting-started when empty).
+	ContinueHref string
+
+	// CSRFToken authorizes the inline dismiss form (POST /getting-started/dismiss).
+	CSRFToken string
+}
+
+// OnboardingBanner renders the "Finish setting up" banner. Restrained,
+// Mintlify-clean chrome: a hairline card, a quiet segmented progress bar, the
+// next action as the headline, and a primary "Continue setup" CTA plus a
+// dismiss. No hero tile, no tone fills.
+templ OnboardingBanner(p OnboardingBannerProps) {
+	<div class="bb-card p-4 mb-6 flex items-center gap-4">
+		<div class="min-w-0 flex-1">
+			<div class="flex items-center gap-2 flex-wrap">
+				<span class="text-sm font-semibold text-base-content">Finish setting up</span>
+				<span class="text-xs text-base-content/45 tabular-nums">
+					{ strconv.Itoa(p.CompletedSteps) } of { strconv.Itoa(p.TotalSteps) }
+					if p.TimeRemaining != "" {
+						{ " · " + p.TimeRemaining }
+					}
+				</span>
+			</div>
+			if p.NextStepLabel != "" {
+				<div class="mt-0.5 text-xs text-base-content/55">
+					Next: <span class="text-base-content/80 font-medium">{ p.NextStepLabel }</span>
+				</div>
+			}
+			<!-- Segmented progress: one filled bar per completed step. -->
+			<div class="mt-2 flex items-center gap-1" aria-hidden="true">
+				for i := 0; i < p.TotalSteps; i++ {
+					<span class={ "h-1 flex-1 rounded-full", onboardingSegmentClass(i < p.CompletedSteps) }></span>
+				}
+			</div>
+		</div>
+		<div class="flex items-center gap-1.5 shrink-0">
+			<a href={ onboardingContinueHref(p.ContinueHref) } class="btn btn-primary btn-sm gap-1.5">
+				Continue setup
+				@LucideIcon("arrow-right", "w-4 h-4")
+			</a>
+			<form method="POST" action="/getting-started/dismiss" class="contents">
+				<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+				<button type="submit" class="btn btn-ghost btn-sm btn-square" aria-label="Dismiss setup guide" title="Dismiss — re-open from Settings">
+					@LucideIcon("x", "w-4 h-4")
+				</button>
+			</form>
+		</div>
+	</div>
+}
+
+// onboardingSegmentClass tints a progress segment: filled segments take the
+// primary ink, the rest a quiet track.
+func onboardingSegmentClass(filled bool) string {
+	if filled {
+		return "bg-primary"
+	}
+	return "bg-base-300"
+}
+
+// onboardingContinueHref defaults the CTA target to the walkthrough page.
+func onboardingContinueHref(href string) templ.SafeURL {
+	if href == "" {
+		return templ.SafeURL("/getting-started")
+	}
+	return templ.SafeURL(href)
+}

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -27,6 +27,9 @@ templ Feed(p FeedProps) {
 	     transaction ref). The /feed view stays a glance surface — no
 	     markdown rendering cost on every visit. -->
 	<div x-data x-init="$store.shortcuts.setScope('feed')" x-destroy="$store.shortcuts.setScope('global')"></div>
+	if p.Onboarding != nil {
+		@components.OnboardingBanner(*p.Onboarding)
+	}
 	@feedHero(p)
 	if len(p.ConnectionAlerts) > 0 {
 		@feedAlerts(p)

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -2,7 +2,11 @@
 
 package pages
 
-import "time"
+import (
+	"time"
+
+	"breadbox/internal/templates/components"
+)
 
 // FeedProps is the full view model for the home Feed page. The page
 // surfaces sync runs, agent reports, MCP agent sessions, bulk-action
@@ -15,6 +19,12 @@ import "time"
 // the templ never has to import the service package.
 type FeedProps struct {
 	CSRFToken string
+
+	// Onboarding, when non-nil, renders the "Finish setting up" banner above
+	// the hero. The handler sets it only while setup is incomplete and the
+	// guide hasn't been dismissed; nil means setup is done (or dismissed) and
+	// the banner is omitted entirely.
+	Onboarding *components.OnboardingBannerProps
 
 	// Hero is the at-a-glance band rendered above the rail.
 	Hero FeedHero


### PR DESCRIPTION
Surfaces incomplete onboarding **in context** — a compact, dismissible Mintlify-style "Finish setting up" banner at the top of the home feed — instead of relying on the dedicated Getting Started page alone.

<img src="https://bb-artifacts.exe.xyz/f/b0f3f3e7b8e3241f.jpg" width="820" alt="Finish setting up banner on the home feed">

### What it does

- Shows progress (**N of M · ~time left**), the **next action** ("Next: Connect your bank"), and a quiet segmented progress bar.
- Primary **Continue setup →** CTA (to the walkthrough) + a **dismiss** (reuses the existing `POST /getting-started/dismiss`).
- **Auto-hides** once setup is complete or the guide is dismissed — verified both states (the screenshot uses a demo override since this dev env is fully set up).

### Shape

- New `computeOnboardingProgress` helper is the single source of truth — both the `/getting-started` walkthrough and this banner read from it (`getting_started.go` refactored onto it, no behavior change — page still renders 5/5 "You're all set").
- New restrained `OnboardingBanner` component (hairline card, no hero tile / tone fill).
- `FeedProps.Onboarding` (nil = omit).

### Open IA question (your call)

This ships the banner as a **complement** to the Getting Started page. You floated it as onboarding *instead* of the page — if you want, the follow-up is to **demote/retire the "Getting Started" nav item** and let this banner be the only onboarding entry point. Left that out of this PR so the banner can land low-risk first.
