### PR TITLE
feat(onboarding): redesign 'Finish setting up' banner to match Mintlify

### DIFF
--- a/internal/admin/onboarding_progress.go
+++ b/internal/admin/onboarding_progress.go
@@ -123,38 +123,54 @@ func computeOnboardingProgress(ctx context.Context, a *app.App) OnboardingProgre
 	}
 }
 
-// onboardingBannerProps builds the home-feed "Finish setting up" banner from
-// the progress, or returns nil when the banner should not show — setup is
-// complete or the guide was dismissed. Keeping the show/hide decision here
-// means callers just assign the result to FeedProps.Onboarding.
+// onboardingStepDef is the static definition of one onboarding step — its
+// label and the direct action the banner links to. CTA targets mirror the
+// /getting-started walkthrough so the banner stays a faithful, self-sufficient
+// stand-in once that page is retired.
+type onboardingStepDef struct {
+	title    string
+	desc     string
+	ctaLabel string
+	ctaHref  string
+	optional bool
+}
+
+// onboardingStepDefs is the fixed step order (matches OnboardingProgress's
+// 1-based ActiveStep and the per-step done flags resolved below).
+var onboardingStepDefs = []onboardingStepDef{
+	{title: "Configure a bank provider", desc: "Set up Plaid, Teller, or SimpleFIN to link accounts — or import a CSV.", ctaLabel: "Configure", ctaHref: "/settings/providers"},
+	{title: "Add a household member", desc: "Add the people whose accounts you track. Optional unless you share finances.", ctaLabel: "Add member", ctaHref: "/household/new", optional: true},
+	{title: "Connect your bank", desc: "Link a bank account to start syncing accounts and transactions.", ctaLabel: "Connect bank", ctaHref: "/connections/new"},
+	{title: "Run your first sync", desc: "Your first sync runs automatically — check the logs if it doesn't start.", ctaLabel: "View logs", ctaHref: "/logs"},
+	{title: "Set up AI agents", desc: "Create an API key so AI agents can query your finances via MCP.", ctaLabel: "Set up", ctaHref: "/workflows"},
+}
+
+// onboardingBannerProps builds the home-feed "Finish setting up" checklist
+// card from the progress, or returns nil when the banner should not show —
+// setup is complete or the guide was dismissed. Keeping the show/hide decision
+// here means callers just assign the result to FeedProps.Onboarding.
 func onboardingBannerProps(p OnboardingProgress, csrfToken string) *components.OnboardingBannerProps {
 	if p.AllComplete || p.Dismissed {
 		return nil
 	}
+	done := []bool{p.HasProvider, p.HasMember, p.HasConnection, p.HasSync, p.HasAPIKey}
+	steps := make([]components.OnboardingStep, 0, len(onboardingStepDefs))
+	for i, def := range onboardingStepDefs {
+		steps = append(steps, components.OnboardingStep{
+			Title:    def.title,
+			Desc:     def.desc,
+			CTALabel: def.ctaLabel,
+			CTAHref:  def.ctaHref,
+			Done:     done[i],
+			Active:   p.ActiveStep == i+1, // ActiveStep is 1-based
+			Optional: def.optional,
+		})
+	}
 	return &components.OnboardingBannerProps{
 		CompletedSteps: p.CompletedSteps,
 		TotalSteps:     p.TotalSteps,
-		NextStepLabel:  onboardingStepLabel(p.ActiveStep),
 		TimeRemaining:  p.TimeRemaining,
+		Steps:          steps,
 		CSRFToken:      csrfToken,
-	}
-}
-
-// onboardingStepLabel maps a 1-based step index to the short, action-first
-// label the banner shows as "Next: …". Index 0 (all complete) returns "".
-func onboardingStepLabel(step int) string {
-	switch step {
-	case 1:
-		return "Configure a bank provider"
-	case 2:
-		return "Add a household member"
-	case 3:
-		return "Connect your bank"
-	case 4:
-		return "Run your first sync"
-	case 5:
-		return "Set up an automation"
-	default:
-		return ""
 	}
 }

--- a/internal/templates/components/onboarding_banner.templ
+++ b/internal/templates/components/onboarding_banner.templ
@@ -1,89 +1,197 @@
 package components
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
-// OnboardingBannerProps drives the home-feed "Finish setting up" banner — a
-// compact, dismissible progress strip that surfaces incomplete onboarding in
-// context instead of behind a separate page. The handler computes it from the
-// shared onboarding progress and only renders the banner while setup is
-// incomplete and the guide hasn't been dismissed.
+// OnboardingStep is one row of the "Finish setting up" checklist. The banner
+// is self-sufficient — every step links to its own action — so onboarding
+// works without the dedicated Getting Started page.
+type OnboardingStep struct {
+	Title    string
+	Desc     string
+	CTALabel string
+	CTAHref  string
+	Done     bool
+	Active   bool // the first incomplete step — carries the highlighted CTA
+	Optional bool
+}
+
+// OnboardingBannerProps drives the home-feed "Finish setting up" card — a
+// dismissible, collapsible Mintlify-style checklist that surfaces incomplete
+// onboarding in context. The handler computes it from the shared onboarding
+// progress and only renders the card while setup is incomplete and the guide
+// hasn't been dismissed.
 type OnboardingBannerProps struct {
-	// CompletedSteps / TotalSteps drive the segmented progress bar and the
-	// "N of M" count.
 	CompletedSteps int
 	TotalSteps     int
 
-	// NextStepLabel is the short, action-first label for the first incomplete
-	// step (e.g. "Connect your bank"), shown as the headline action.
-	NextStepLabel string
-
-	// TimeRemaining is the rough estimate ("~5 min left"); empty hides it.
+	// TimeRemaining is the rough estimate ("~5 min left"); empty hides the
+	// subtitle's time clause.
 	TimeRemaining string
 
-	// ContinueHref is where the primary CTA points (defaults to
-	// /getting-started when empty).
-	ContinueHref string
+	// Steps is the full checklist (done + pending), rendered in order.
+	Steps []OnboardingStep
 
-	// CSRFToken authorizes the inline dismiss form (POST /getting-started/dismiss).
+	// CSRFToken authorizes the inline dismiss ("Hide") form.
 	CSRFToken string
 }
 
-// OnboardingBanner renders the "Finish setting up" banner. Restrained,
-// Mintlify-clean chrome: a hairline card, a quiet segmented progress bar, the
-// next action as the headline, and a primary "Continue setup" CTA plus a
-// dismiss. No hero tile, no tone fills.
+// OnboardingBanner renders the "Finish setting up" card, modeled on
+// Mintlify's dashboard widget: a circular progress ring, a "N/M complete"
+// badge, and a collapsible step checklist. Two distinct affordances —
+//
+//   - "Hide" permanently dismisses the guide (server-side, POST .../dismiss).
+//   - the whole header toggles the checklist open/closed; the collapse state
+//     persists in localStorage, and hovering the header highlights the
+//     chevron so the entire banner reads as the collapse control.
 templ OnboardingBanner(p OnboardingBannerProps) {
-	<div class="bb-card p-4 mb-6 flex items-center gap-4">
-		<div class="min-w-0 flex-1">
-			<div class="flex items-center gap-2 flex-wrap">
-				<span class="text-sm font-semibold text-base-content">Finish setting up</span>
-				<span class="text-xs text-base-content/45 tabular-nums">
-					{ strconv.Itoa(p.CompletedSteps) } of { strconv.Itoa(p.TotalSteps) }
+	<div
+		class="bb-card mb-6 overflow-hidden"
+		x-data="{ open: localStorage.getItem('bb-onboarding-collapsed') !== '1', toggle() { this.open = !this.open; localStorage.setItem('bb-onboarding-collapsed', this.open ? '0' : '1') } }"
+	>
+		<!-- Header — the whole row is the collapse toggle; group-hover lifts the
+		     chevron so hovering anywhere reads as hovering the control. -->
+		<div
+			@click="toggle()"
+			class="group flex items-center gap-3.5 p-4 cursor-pointer select-none"
+		>
+			@onboardingProgressRing(p.CompletedSteps, p.TotalSteps)
+			<div class="min-w-0 flex-1">
+				<div class="flex items-center gap-2 flex-wrap">
+					<span class="text-sm font-semibold text-base-content">Finish setting up</span>
+					<span class="badge badge-ghost badge-sm tabular-nums">{ strconv.Itoa(p.CompletedSteps) }/{ strconv.Itoa(p.TotalSteps) } complete</span>
+				</div>
+				<div class="text-xs text-base-content/55 mt-0.5">
+					Connect your accounts to get the most out of Breadbox
 					if p.TimeRemaining != "" {
 						{ " · " + p.TimeRemaining }
 					}
-				</span>
-			</div>
-			if p.NextStepLabel != "" {
-				<div class="mt-0.5 text-xs text-base-content/55">
-					Next: <span class="text-base-content/80 font-medium">{ p.NextStepLabel }</span>
 				</div>
-			}
-			<!-- Segmented progress: one filled bar per completed step. -->
-			<div class="mt-2 flex items-center gap-1" aria-hidden="true">
-				for i := 0; i < p.TotalSteps; i++ {
-					<span class={ "h-1 flex-1 rounded-full", onboardingSegmentClass(i < p.CompletedSteps) }></span>
-				}
 			</div>
-		</div>
-		<div class="flex items-center gap-1.5 shrink-0">
-			<a href={ onboardingContinueHref(p.ContinueHref) } class="btn btn-primary btn-sm gap-1.5">
-				Continue setup
-				@LucideIcon("arrow-right", "w-4 h-4")
-			</a>
-			<form method="POST" action="/getting-started/dismiss" class="contents">
+			<form method="POST" action="/getting-started/dismiss" class="contents" @click.stop>
 				<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
-				<button type="submit" class="btn btn-ghost btn-sm btn-square" aria-label="Dismiss setup guide" title="Dismiss — re-open from Settings">
-					@LucideIcon("x", "w-4 h-4")
-				</button>
+				<button type="submit" class="btn btn-ghost btn-sm shrink-0" title="Hide — re-open from Settings">Hide</button>
 			</form>
+			<button
+				type="button"
+				@click.stop="toggle()"
+				class="btn btn-ghost btn-sm btn-square shrink-0 text-base-content/40 group-hover:text-base-content/80"
+				:aria-label="open ? 'Collapse setup checklist' : 'Expand setup checklist'"
+				:aria-expanded="open"
+			>
+				<span class="transition-transform duration-200" :class="open ? 'rotate-180' : ''">
+					@LucideIcon("chevron-down", "w-4 h-4")
+				</span>
+			</button>
+		</div>
+		<!-- Checklist — collapses below the header. -->
+		<div x-show="open" x-collapse>
+			<ul class="px-4 pb-2 flex flex-col">
+				for _, s := range p.Steps {
+					@onboardingStepRow(s)
+				}
+			</ul>
 		</div>
 	</div>
 }
 
-// onboardingSegmentClass tints a progress segment: filled segments take the
-// primary ink, the rest a quiet track.
-func onboardingSegmentClass(filled bool) string {
-	if filled {
-		return "bg-primary"
-	}
-	return "bg-base-300"
+// onboardingStepRow renders one checklist row: a status glyph, the step title
+// (struck through + receded when done, emphasized when active), a short
+// description, and the highlighted CTA on the active step only.
+templ onboardingStepRow(s OnboardingStep) {
+	<li class="flex items-start gap-3 py-2.5 border-t border-base-200/70">
+		<span class={ onboardingStepGlyphClass(s) }>
+			@LucideIcon(onboardingStepGlyph(s), "w-[18px] h-[18px]")
+		</span>
+		<div class="min-w-0 flex-1">
+			<div class="flex items-center gap-2 flex-wrap">
+				<span class={ onboardingStepTitleClass(s) }>{ s.Title }</span>
+				if s.Optional {
+					<span class="badge badge-ghost badge-xs shrink-0">Optional</span>
+				}
+			</div>
+			if s.Desc != "" {
+				<div class="text-xs text-base-content/45 mt-0.5">{ s.Desc }</div>
+			}
+		</div>
+		if s.Active && s.CTAHref != "" {
+			<a href={ templ.SafeURL(s.CTAHref) } class="btn btn-primary btn-xs gap-1 shrink-0 self-center" @click.stop>
+				{ s.CTALabel }
+				@LucideIcon("arrow-right", "w-3.5 h-3.5")
+			</a>
+		}
+	</li>
 }
 
-// onboardingContinueHref defaults the CTA target to the walkthrough page.
-func onboardingContinueHref(href string) templ.SafeURL {
-	if href == "" {
-		return templ.SafeURL("/getting-started")
+// onboardingProgressRing renders the Mintlify-style circular progress donut:
+// a quiet track ring with a primary arc proportional to completion.
+templ onboardingProgressRing(completed, total int) {
+	<svg class="w-9 h-9 shrink-0 -rotate-90" viewBox="0 0 36 36" aria-hidden="true">
+		<circle cx="18" cy="18" r="15" fill="none" style="stroke: var(--color-base-200)" stroke-width="3"></circle>
+		<circle
+			cx="18"
+			cy="18"
+			r="15"
+			fill="none"
+			style="stroke: var(--color-primary)"
+			stroke-width="3"
+			stroke-linecap="round"
+			stroke-dasharray={ onboardingRingDash(completed, total) }
+		></circle>
+	</svg>
+}
+
+// onboardingRingDash returns the stroke-dasharray ("arc gap") that fills the
+// ring to the completion fraction. Circumference for r=15 is 2·π·15 ≈ 94.25.
+func onboardingRingDash(completed, total int) string {
+	const circumference = 94.25
+	frac := 0.0
+	if total > 0 {
+		frac = float64(completed) / float64(total)
 	}
-	return templ.SafeURL(href)
+	return fmt.Sprintf("%.2f %.2f", frac*circumference, circumference)
+}
+
+// onboardingStepGlyph picks the status icon: a filled check when done, a
+// target dot for the active step, a hollow circle for pending steps.
+func onboardingStepGlyph(s OnboardingStep) string {
+	switch {
+	case s.Done:
+		return "circle-check"
+	case s.Active:
+		return "circle-dot"
+	default:
+		return "circle"
+	}
+}
+
+// onboardingStepGlyphClass tints the status glyph: done reads success-green
+// (Mintlify's positive check), active draws the primary accent, pending is
+// faint.
+func onboardingStepGlyphClass(s OnboardingStep) string {
+	base := "shrink-0 mt-0.5 "
+	switch {
+	case s.Done:
+		return base + "text-success"
+	case s.Active:
+		return base + "text-primary"
+	default:
+		return base + "text-base-content/25"
+	}
+}
+
+// onboardingStepTitleClass styles the title: done recedes (line-through),
+// active reads strongest, pending is muted.
+func onboardingStepTitleClass(s OnboardingStep) string {
+	base := "text-sm min-w-0 truncate "
+	switch {
+	case s.Done:
+		return base + "text-base-content/40 line-through"
+	case s.Active:
+		return base + "font-medium text-base-content"
+	default:
+		return base + "text-base-content/70"
+	}
 }


### PR DESCRIPTION
Rebuilds the home-feed "Finish setting up" banner as a faithful, **self-sufficient** stand-in for the Getting Started page (which we'll retire later) — modeled directly on Mintlify's dashboard widget.

### Ours (expanded) vs Mintlify reference

| Breadbox | Mintlify |
|---|---|
| <img src="https://bb-artifacts.exe.xyz/f/a1bea55ef83d6524.jpg" width="420"> | <img src="https://bb-artifacts.exe.xyz/f/43c81d3630baa36f.jpeg" width="420"> |

### What it copies

- **Circular progress ring** + **"N/M complete"** badge + subtitle.
- **Collapsible** checklist: the whole header toggles open/closed, the state **persists in localStorage**, and hovering the header **lifts the chevron** so the entire banner reads as the collapse control.
- **Two distinct affordances** (as you asked): a **Hide** button (permanent dismiss) *and* the collapse chevron.
- Each step is a checklist row — status glyph (green check + strikethrough when done, primary dot when active, hollow when pending), a short description, and a **direct CTA on the active step** (e.g. "Connect bank →"). No dependency on the Getting Started page.

### Dark + collapsed

<img src="https://bb-artifacts.exe.xyz/f/0aaeb6198d8af7e0.jpeg" width="560">

Self-sufficient by design so the dedicated page can be dropped in a follow-up. Ring stroke uses inline `var(--color-*)` (Tailwind v4 doesn't emit `stroke-{semantic-color}` for daisy colors). Builds on the wiring from #1846.
