### PR TITLE
fix(onboarding): soften banner checklist dividers

### DIFF
--- a/internal/templates/components/onboarding_banner.templ
+++ b/internal/templates/components/onboarding_banner.templ
@@ -101,7 +101,7 @@ templ OnboardingBanner(p OnboardingBannerProps) {
 // (struck through + receded when done, emphasized when active), a short
 // description, and the highlighted CTA on the active step only.
 templ onboardingStepRow(s OnboardingStep) {
-	<li class="flex items-start gap-3 py-2.5 border-t border-base-200/70">
+	<li class="flex items-start gap-3 py-2.5 border-t" style="border-top-color: color-mix(in oklab, var(--color-base-content) 6%, transparent)">
 		<span class={ onboardingStepGlyphClass(s) }>
 			@LucideIcon(onboardingStepGlyph(s), "w-[18px] h-[18px]")
 		</span>


### PR DESCRIPTION
Softens the onboarding banner checklist dividers, which read too contrasting — especially in **dark mode**, where the daisy semantic-color border did not honor its `/opacity` modifier (same Tailwind-v4 quirk as the ring stroke) and rendered near-solid white.

Fix: inline `color-mix(in oklab, var(--color-base-content) 6%, transparent)` so the hairline is genuinely faint and symmetric in both themes.

<img src="https://bb-artifacts.exe.xyz/f/160a0ffc6d534ce1.jpeg" width="760" alt="softened dividers, dark">
