### PR TITLE
feat(design-system): tray surface pattern (.bb-tray) — prototype on the onboarding banner

### DIFF
--- a/input.css
+++ b/input.css
@@ -449,6 +449,23 @@
     border-color: var(--color-base-300);
   }
 
+  /* ── Tray — a recessed, grouped surface ──
+   * A muted base-200 "well" that holds regular-bg `.bb-card` panels floating
+   * inside it (the tray's own padding is the gray gutter around them). Models
+   * Mintlify's "Finish setting up" card: the outer surface reads gray, while
+   * the grouped rows sit on the regular base-100 fill — an inversion of the
+   * usual flat card. Reusable across the design system: wrap grouped content
+   * in `.bb-tray`, keep a header / section labels directly on the tray, and
+   * nest one or more `.bb-card` panels for the rows. The gray↔regular contrast
+   * is just the base-200/base-100 relationship, so it holds in both themes.
+   * `.bb-tray__label` is the quiet uppercase section label between panels. */
+  .bb-tray {
+    @apply rounded-2xl bg-base-200/70 border border-base-300/60 p-1.5;
+  }
+  .bb-tray__label {
+    @apply px-2.5 pt-2 pb-1 text-[0.7rem] font-medium uppercase tracking-wider text-base-content/40;
+  }
+
   /* ── List-row keyboard focus ──
    * The redesigned list surfaces (/reports, /rules, /recurring,
    * /accounts, /tags, /categories, /connections, /household, agent-run

--- a/internal/templates/components/onboarding_banner.templ
+++ b/internal/templates/components/onboarding_banner.templ
@@ -133,17 +133,19 @@ templ onboardingStepRow(s OnboardingStep) {
 }
 
 // onboardingProgressRing renders the Mintlify-style circular progress donut:
-// a quiet track ring with a primary arc proportional to completion.
+// a thicker arc over a track that keeps contrast against the gray tray. The
+// track is a base-content tint (not base-200, which now matches the tray) so
+// the incomplete portion stays legible in both themes.
 templ onboardingProgressRing(completed, total int) {
-	<svg class="w-9 h-9 shrink-0 -rotate-90" viewBox="0 0 36 36" aria-hidden="true">
-		<circle cx="18" cy="18" r="15" fill="none" style="stroke: var(--color-base-200)" stroke-width="3"></circle>
+	<svg class="w-10 h-10 shrink-0 -rotate-90" viewBox="0 0 36 36" aria-hidden="true">
+		<circle cx="18" cy="18" r="15" fill="none" style="stroke: color-mix(in oklab, var(--color-base-content) 15%, transparent)" stroke-width="4"></circle>
 		<circle
 			cx="18"
 			cy="18"
 			r="15"
 			fill="none"
 			style="stroke: var(--color-primary)"
-			stroke-width="3"
+			stroke-width="4"
 			stroke-linecap="round"
 			stroke-dasharray={ onboardingRingDash(completed, total) }
 		></circle>

--- a/internal/templates/components/onboarding_banner.templ
+++ b/internal/templates/components/onboarding_banner.templ
@@ -47,15 +47,19 @@ type OnboardingBannerProps struct {
 //     persists in localStorage, and hovering the header highlights the
 //     chevron so the entire banner reads as the collapse control.
 templ OnboardingBanner(p OnboardingBannerProps) {
+	<!-- Tray styling: the outer surface reads gray (.bb-tray), while the
+	     checklist rows sit on the regular base-100 fill inside a nested
+	     .bb-card panel — Mintlify's "Finish setting up" treatment. -->
 	<div
-		class="bb-card mb-6 overflow-hidden"
+		class="bb-tray mb-6"
 		x-data="{ open: localStorage.getItem('bb-onboarding-collapsed') !== '1', toggle() { this.open = !this.open; localStorage.setItem('bb-onboarding-collapsed', this.open ? '0' : '1') } }"
 	>
-		<!-- Header — the whole row is the collapse toggle; group-hover lifts the
-		     chevron so hovering anywhere reads as hovering the control. -->
+		<!-- Header sits directly on the gray tray. The whole row is the collapse
+		     toggle; group-hover lifts the chevron so hovering anywhere reads as
+		     hovering the control. -->
 		<div
 			@click="toggle()"
-			class="group flex items-center gap-3.5 p-4 cursor-pointer select-none transition-colors hover:bg-base-200/40"
+			class="group flex items-center gap-3.5 px-2.5 py-2 rounded-xl cursor-pointer select-none transition-colors hover:bg-base-300/40"
 		>
 			@onboardingProgressRing(p.CompletedSteps, p.TotalSteps)
 			<div class="min-w-0 flex-1">
@@ -86,13 +90,16 @@ templ OnboardingBanner(p OnboardingBannerProps) {
 				</span>
 			</button>
 		</div>
-		<!-- Checklist — collapses below the header. -->
+		<!-- Checklist — a regular-bg .bb-card panel floating on the gray tray,
+		     collapsing below the header. -->
 		<div x-show="open" x-collapse>
-			<ul class="px-4 pb-2 flex flex-col">
-				for _, s := range p.Steps {
-					@onboardingStepRow(s)
-				}
-			</ul>
+			<div class="bb-card mt-1">
+				<ul class="px-3.5 py-1 flex flex-col">
+					for _, s := range p.Steps {
+						@onboardingStepRow(s)
+					}
+				</ul>
+			</div>
 		</div>
 	</div>
 }
@@ -101,7 +108,7 @@ templ OnboardingBanner(p OnboardingBannerProps) {
 // (struck through + receded when done, emphasized when active), a short
 // description, and the highlighted CTA on the active step only.
 templ onboardingStepRow(s OnboardingStep) {
-	<li class="flex items-start gap-3 py-2.5 border-t" style="border-top-color: color-mix(in oklab, var(--color-base-content) 6%, transparent)">
+	<li class="flex items-start gap-3 py-2.5 border-t first:border-t-0" style="border-top-color: color-mix(in oklab, var(--color-base-content) 6%, transparent)">
 		<span class={ onboardingStepGlyphClass(s) }>
 			@LucideIcon(onboardingStepGlyph(s), "w-[18px] h-[18px]")
 		</span>


### PR DESCRIPTION
**Prototype** of a reusable "tray" surface styling, modeled on Mintlify's "Finish setting up" card: the outer surface reads **gray** (`base-200`) and the grouped rows float on the **regular** `base-100` fill inside a nested `.bb-card` — an inversion of the usual flat card.

Reusable bits (organized for adoption by other components later):
- **`.bb-tray`** — a recessed `base-200` "well" with a gutter; nest one or more `.bb-card` panels inside, keep header/labels directly on the tray.
- **`.bb-tray__label`** — quiet uppercase section label between panels.
- Both documented in `input.css`; the contrast is just the `base-200/base-100` relationship so it holds in both themes.

Applied to the onboarding banner as the first adopter (header on the gray, checklist in a floating panel).

| Light | Dark |
|---|---|
| <img src="https://bb-artifacts.exe.xyz/f/2473841b121e7d73.jpeg" width="440"> | <img src="https://bb-artifacts.exe.xyz/f/c90ee91ade2db4d7.jpeg" width="440"> |

build / vet / test green. Off latest main.
