### PR TITLE
fix(reports): keep header action inline on mobile

### DIFF
--- a/internal/templates/components/page_header.templ
+++ b/internal/templates/components/page_header.templ
@@ -25,6 +25,13 @@ package components
 //   - SubtitleHideOnMobile: when true, applies `hidden sm:block` so the
 //               subtitle disappears on small screens (used on dense
 //               list pages where the subtitle is decorative).
+//   - ActionsInline: when true, the title and trailing action(s) stay on
+//               the SAME row on mobile (title left, actions right) instead
+//               of the default behaviour of stacking the actions below the
+//               title. Use this when the trailing action collapses to a
+//               compact icon button on mobile — stacking leaves it orphaned
+//               on its own line. Pages with a wide labelled primary action
+//               (e.g. "Connect Bank") should keep the default stack.
 //
 // Conventions:
 //   - Single back-affordance rule: the breadcrumb above this header is
@@ -50,6 +57,10 @@ type PageHeaderProps struct {
 	Subtitle             string
 	Icon                 string // optional Lucide icon name
 	SubtitleHideOnMobile bool
+	// ActionsInline keeps the trailing action(s) on the title's row on
+	// mobile instead of stacking them below. Best for compact icon-only
+	// actions; leave false for wide labelled primary buttons.
+	ActionsInline bool
 	// Leading is an optional visual rendered immediately left of the
 	// title block (e.g. an identity avatar). Nil keeps the classic
 	// title-only layout.
@@ -67,7 +78,7 @@ type PageHeaderProps struct {
 }
 
 templ PageHeader(p PageHeaderProps) {
-	<div class="bb-page-header">
+	<div class={ "bb-page-header", templ.KV("flex-row items-center", p.ActionsInline) }>
 		if p.Leading != nil {
 			<div class="flex items-center gap-3 min-w-0">
 				@p.Leading

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -26,7 +26,10 @@ templ Reports(p ReportsProps) {
 		Title:                "Agent Reports",
 		Subtitle:             "Messages from your AI agents — their work, flagged items, and findings",
 		SubtitleHideOnMobile: true,
-		Action:               reportsManageFormatLink(),
+		// The trailing action collapses to a compact icon button on mobile;
+		// keep it on the title's row so it doesn't orphan onto its own line.
+		ActionsInline: true,
+		Action:        reportsManageFormatLink(),
 	})
 	<div x-data="reportsPage">
 		if line := reportsGlance(p); line != "" {


### PR DESCRIPTION
Fixes #1859.

## Problem

On `/reports` the only header action — the **Manage format** ghost link — collapses to an icon-only button on mobile (its label is `hidden sm:inline`). The shared `PageHeader` stacks trailing actions *below* the title on small screens (`bb-page-header` is `flex-col items-start` until `sm:`), so that lone sliders icon was left **orphaned on its own line**, floating under the title with dead space all around it and pushing the rest of the page down.

## Fix

Add an opt-in `ActionsInline` flag to `PageHeader`. When set, the title and trailing action(s) stay on the **same row** on mobile (title left, action right) instead of stacking. `/reports` opts in — the header now reads "Agent Reports&nbsp;&nbsp;[⚙]" on one row, reclaiming the wasted vertical space (one extra report row is now visible above the fold).

- Default behaviour is unchanged: pages with a wide labelled primary action (e.g. "Connect Bank") keep the stack.
- **Desktop is a no-op** — `bb-page-header` was already `flex-row items-center` at `sm+`, so the override only affects the mobile breakpoint.

Two small, well-scoped files:
- `internal/templates/components/page_header.templ` — new `ActionsInline` prop + `templ.KV("flex-row items-center", …)` on the root.
- `internal/templates/components/pages/reports.templ` — opts in.

## Validation

`go build ./...`, `go vet ./internal/templates/...`, and `go test ./internal/templates/...` all pass. Captured against a local server seeded with 8 agent reports (5 unread) at the issue's reported viewport (402×714, iPhone).

### Mobile — before / after (402×714)

<table>
  <tr><th>Before — icon orphaned below title</th><th>After — inline on the title row</th></tr>
  <tr>
    <td>``&lt;img src="https://bb-artifacts.exe.xyz/f/a476bd61aa2f1044.jpeg" width="360" alt="reports header before — manage-format icon orphaned on its own line"&gt;``</td>
    <td>``&lt;img src="https://bb-artifacts.exe.xyz/f/3d0078ef82bf8c06.jpeg" width="360" alt="reports header after — manage-format icon inline on the title row"&gt;``</td>
  </tr>
</table>

Desktop layout verified unchanged (title left, subtitle below, labelled "Manage format" button top-right).


---
_Generated by [Claude Code](https://claude.ai/code/session_011yYFSkgTbhSy4FnsiYsgcd)_