### PR TITLE
fix(connections): repair mobile row layout on /connections

### DIFF
--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -143,7 +143,7 @@ templ connectionsHealthGroup(g ConnectionsStatusGroup, canManage bool) {
 // left-accent rail.
 templ connectionsRow(c ConnectionsRow, canManage bool) {
 	<li
-		class="list-row transition-colors hover:bg-base-200/40 focus-within:bg-base-200/40 items-center"
+		class="list-row gap-3 sm:gap-4 p-3 sm:p-4 transition-colors hover:bg-base-200/40 focus-within:bg-base-200/40 items-center"
 		data-connection-row
 		data-open-url={ "/connections/" + c.ID }
 		data-conn-id={ c.ID }
@@ -196,7 +196,7 @@ templ connectionsRow(c ConnectionsRow, canManage bool) {
 templ connectionsStatusPill(c ConnectionsRow) {
 	if connectionsShowStatusPill(c) {
 		<span
-			class={ "badge badge-xs gap-1 shrink-0", connectionStatusBadgeClass(c) }
+			class={ "badge badge-xs gap-1 shrink-0 whitespace-nowrap", connectionStatusBadgeClass(c) }
 			title={ connectionsRowReason(c) }
 		>
 			@components.LucideIcon(connectionStatusIcon(c), "w-3 h-3")
@@ -245,10 +245,13 @@ templ connectionsRecovery(c ConnectionsRow) {
 	if c.Status == "pending_reauth" || c.Status == "error" {
 		<a
 			href={ templ.SafeURL(connectionsReauthURL(c)) }
-			class="btn btn-warning btn-xs shrink-0"
+			class="btn btn-warning btn-xs shrink-0 gap-1.5"
+			title="Reconnect"
+			aria-label="Reconnect"
 			@click.stop
 		>
-			Reconnect
+			@components.LucideIcon("rotate-cw", "w-3.5 h-3.5")
+			<span class="hidden sm:inline">Reconnect</span>
 		</a>
 	}
 }


### PR DESCRIPTION
Fixes #1860.

## Problem

On narrow viewports (the report was filed at 402×714) the `/connections` rows over-packed their trailing cluster — per-connection **balance + Reconnect button + overflow menu** — against the daisy `list-row` grid (`grid-template-columns: minmax(0,auto) 1fr` then fixed `auto` columns). Those fixed columns don't shrink, so the `1fr` institution-name column collapsed to near-zero. Two visible failures resulted:

1. The `shrink-0` **status pill shattered character-by-character** under `.list-row`'s `word-break: break-word` ("Reaut / h / neede / d") and rendered *on top of* the institution name.
2. The `N accounts · synced Nh ago` metadata line clipped to a useless stub.

## Fix

A small, self-contained change to `connections.templ` — desktop layout is unchanged:

- **Pin the status pill to one line** (`whitespace-nowrap`) so it can no longer wrap into a vertical stack that overlaps the name.
- **Collapse the Reconnect recovery affordance to an icon-only button on mobile** (`rotate-cw` glyph; the "Reconnect" label returns at `sm:`), reclaiming horizontal space exactly where it is tightest. `title`/`aria-label` preserve the accessible name.
- **Tighten the `list-row` gap/padding on mobile** (`gap-3 p-3`, restoring `sm:gap-4 sm:p-4`) so the name and metadata columns get room.

## Validation

Reproduced the exact bug from the issue locally (seeded a `pending_reauth` connection with a balance + four active connections), captured at the reported 402px width before and after.

<table>
  <tr><th>Before (#1860)</th><th>After</th></tr>
  <tr>
    <td>``&lt;img src="https://bb-artifacts.exe.xyz/f/356463ce4de81dfc.jpg" width="380" alt="connections mobile — before, badge overlapping name"&gt;``</td>
    <td>``&lt;img src="https://bb-artifacts.exe.xyz/f/bcdf1ca51c5f9911.jpg" width="380" alt="connections mobile — after, clean layout"&gt;``</td>
  </tr>
</table>

Desktop (1280px) is unaffected — the full "Reconnect" label returns and names/metadata render in full:

``&lt;img src="https://bb-artifacts.exe.xyz/f/f5974ccf471dbd78.jpg" width="800" alt="connections desktop — unchanged"&gt;``

`go vet` and `go test ./internal/templates/...` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTtM2NnopBN5sQV2HWx8su)_