### PR TITLE
fix(onboarding): banner Hide + Settings 'Show setup guide' work (CSRF _csrf field)

### DIFF
--- a/internal/templates/components/onboarding_banner.templ
+++ b/internal/templates/components/onboarding_banner.templ
@@ -75,7 +75,7 @@ templ OnboardingBanner(p OnboardingBannerProps) {
 				</div>
 			</div>
 			<form method="POST" action="/getting-started/dismiss" class="contents" @click.stop>
-				<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 				<button type="submit" class="btn btn-secondary btn-sm shrink-0" title="Hide — re-open from Settings">Hide</button>
 			</form>
 			<button

--- a/internal/templates/components/pages/schedule_form.templ
+++ b/internal/templates/components/pages/schedule_form.templ
@@ -15,7 +15,7 @@ templ ScheduleDrawer(p ScheduleFormProps) {
 			class="flex flex-col h-full"
 			x-data={ scheduleFormState(p) }
 		>
-			<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 			@components.DrawerHeader(components.DrawerHeaderProps{Icon: "refresh-cw", Title: scheduleFormTitle(p)})
 			<div class="flex-1 overflow-y-auto p-5 space-y-5">
 				@scheduleFormFields(p)
@@ -48,7 +48,7 @@ templ ScheduleForm(p ScheduleFormProps) {
 			</div>
 		}
 		<form method="POST" action={ templ.SafeURL(p.FormAction()) } class="bb-card p-5 space-y-5">
-			<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 			@scheduleFormFields(p)
 			<div class="flex items-center justify-end gap-2 pt-2 border-t border-base-200">
 				<a href="/settings/general#sync" class="btn btn-ghost btn-sm">Cancel</a>

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -208,7 +208,7 @@ templ settingsScheduleRow(p SettingsProps, sched service.SyncScheduleView) {
 				@components.LucideIcon("pencil", "w-4 h-4")
 			</button>
 			<form method="POST" action={ scheduleDeleteURL(sched.ShortID) } onsubmit="return confirm('Delete this schedule?')">
-				<input type="hidden" name="csrf_token" value={ p.CSRFToken }/>
+				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 				<button type="submit" class="btn btn-ghost btn-sm btn-square text-error" aria-label="Delete schedule">
 					@components.LucideIcon("trash-2", "w-4 h-4")
 				</button>
@@ -463,30 +463,38 @@ templ settingsResourcesSection(p SettingsProps) {
 	}
 }
 
-// Setup guide doesn't fit SettingsRowLink because the trailing
-// affordance is either a button or a link (re-open vs. open), so the
-// row is composed by hand. The leading compass icon mirrors the
-// sibling Documentation row's leading book-open icon — this Resources
-// section is an action list where the leading icon is the affordance.
-// The dedicated walkthrough page is retired: the "Finish setting up"
-// banner on the home feed is now the onboarding surface, so re-opening
-// un-dismisses the banner and lands on `/`.
+// Setup guide row. The dedicated walkthrough page is retired: the "Finish
+// setting up" banner on the home feed is now the onboarding surface, and its
+// "Hide" button dismisses it. This row is the inverse — a single "un-hide"
+// action that clears the dismissed flag and lands on `/` so the banner
+// reappears (when setup is still incomplete). The caption flips to reflect
+// whether the banner is currently hidden. The leading compass icon mirrors
+// the sibling Documentation row — this Resources section is an action list
+// where the leading icon is the affordance.
 templ settingsGettingStartedRow(p SettingsProps) {
 	<div class="bb-settings-row">
 		@components.LucideIcon("compass", "w-4 h-4 text-base-content opacity-50 shrink-0")
 		<div class="bb-settings-row__main">
 			<div class="bb-settings-row__label">Setup guide</div>
-			<p class="bb-settings-row__caption">Onboarding checklist on your home feed</p>
+			<p class="bb-settings-row__caption">
+				if p.OnboardingDismissed {
+					Hidden — show the onboarding checklist on your home feed again
+				} else {
+					Onboarding checklist on your home feed
+				}
+			</p>
 		</div>
 		<div class="bb-settings-row__control">
-			if p.OnboardingDismissed {
-				<form method="POST" action="/getting-started/reopen">
-					<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
-					<button type="submit" class="btn btn-ghost btn-sm">Re-open setup guide</button>
-				</form>
-			} else {
-				<a href="/" class="btn btn-ghost btn-sm">Open</a>
-			}
+			<form method="POST" action="/getting-started/reopen">
+				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
+				<button type="submit" class="btn btn-ghost btn-sm">
+					if p.OnboardingDismissed {
+						Show setup guide
+					} else {
+						Show on home feed
+					}
+				</button>
+			</form>
 		</div>
 	</div>
 }

--- a/internal/templates/components/user_menu.templ
+++ b/internal/templates/components/user_menu.templ
@@ -121,7 +121,7 @@ templ privacyControlButton(value, icon, label string) {
 templ userMenuLogoutForm(logoutFormID, csrfToken string) {
 	<form id={ logoutFormID } method="POST" action="/logout" class="hidden">
 		if csrfToken != "" {
-			<input type="hidden" name="csrf_token" value={ csrfToken }/>
+			<input type="hidden" name="_csrf" value={ csrfToken }/>
 		}
 	</form>
 }


### PR DESCRIPTION
The Settings → Help **Setup guide** control now works with the new onboarding banner — and fixes the bug that made it (and the banner's own Hide) silently fail.

### Root cause
The CSRF middleware reads the **`_csrf`** form field, but several forms sent `csrf_token` → they 403'd and did nothing:
- the onboarding banner's **Hide** never dismissed;
- the sync-schedule **create / edit / delete** forms (toggle / timezone / retention kept working because they use the autosave form's `_csrf`).

Normalized every form field to `_csrf`. (Logout's was already harmless — its route isn't CSRF-guarded — normalized for consistency.)

### Settings row reworked as the banner's inverse
A single **Show setup guide / Show on home feed** action that clears the dismissed flag and lands on `/` so the banner reappears; the caption flips to note when it's hidden.

<img src="https://bb-artifacts.exe.xyz/f/1a0d4ce0f9f3f557.jpg" width="820" alt="Settings → Help: Setup guide shows 'Hidden — show...' + Show setup guide button">

**Verified end-to-end:** banner Hide → `onboarding_dismissed=true` → Settings "Show setup guide" → `onboarding_dismissed=false`. build / vet / test green.
