### PR TITLE
v1 DB schema hardening: dead-column drop, agent→workflow rename, retention jobs, provider_raw satellite

### DIFF
--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -73,14 +73,14 @@ CRUD mutations on agent_definitions call `svc.OnDefinitionChanged()` which the o
 
 ### Run-key attribution — the run key IS the actor
 
-Every write a run makes must be attributed to its minted run key (`agent:<slug>:<runID>`, `actor_type='agent'`, `actor_name=def.Name`, `agent_definition_id=def.ID`), NOT to the MCP `clientInfo`. The Claude Agent SDK presents a generic shared `clientInfo` ("claude-code") on every connection; if attribution falls back to it, every agent collapses onto one identity and the feed shows one session under several names + avatars.
+Every write a run makes must be attributed to its minted run key (`agent:<slug>:<runID>`, `actor_type='agent'`, `actor_name=def.Name`, `workflow_id=def.ID`), NOT to the MCP `clientInfo`. The Claude Agent SDK presents a generic shared `clientInfo` ("claude-code") on every connection; if attribution falls back to it, every agent collapses onto one identity and the feed shows one session under several names + avatars.
 
 Two load-bearing pieces enforce this:
 
 1. `AssembleJobSpec` passes the run key in `BREADBOX_API_KEY`; `runMCPStdio` (`internal/cli/mcp.go`) binds it as the actor floor via `ValidateAPIKey`. If you change how the sidecar reaches MCP, keep the run key as the bound actor.
 2. `MCPServer.rebindActorFromClientInfo` (`internal/mcp/server.go`) is gated on `service.AgentRunShortIDFromContext(ctx) == ""` — it upgrades anonymous stdio / external clients to a per-`clientInfo` key but **never** clobbers a real run key. Don't remove that guard.
 
-`api_keys.agent_definition_id` (set at mint) is the durable link; `Service.ResolveAgentSlugForActor` / `GetAgentIdentityByApiKeyID` resolve any agent actor → its definition (name + slug avatar). Render an agent's identity through these, not through the raw stamped `actor_name`.
+`api_keys.workflow_id` (set at mint) is the durable link; `Service.ResolveAgentSlugForActor` / `GetAgentIdentityByApiKeyID` resolve any agent actor → its workflow (name + slug avatar). Render an agent's identity through these, not through the raw stamped `actor_name`.
 
 ## Tests + CI
 

--- a/agent/sidecar/spec.ts
+++ b/agent/sidecar/spec.ts
@@ -28,7 +28,7 @@ const AuthConfigSchema = z.object({
 export const JobSpecSchema = z.object({
   // Identity (forwarded for log correlation; not sent to the SDK)
   runId: z.string().optional().default(""),
-  agentDefinitionId: z.string().optional().default(""),
+  workflowId: z.string().optional().default(""),
 
   // Prompt
   prompt: z.string().min(1),

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -150,7 +150,6 @@ This document defines the complete PostgreSQL database schema for the Breadbox M
                             │ provider_category_detailed│
                             │ provider_category_confidence│
                             │ provider_payment_channel│
-                            │ provider_raw (JSONB) │
                             │ pending              │
                             │ deleted_at           │
                             │ created_at           │
@@ -418,11 +417,18 @@ Plaid `account_id` values are globally unique across all items and institutions.
 | `provider_category_detailed` | `TEXT` | Yes | `NULL` | Granular subcategory from the provider (e.g., `FOOD_AND_DRINK_RESTAURANTS`, `TRANSPORTATION_GAS_AND_FUEL` for Plaid). Can be used as a stable identifier. |
 | `provider_category_confidence` | `TEXT` | Yes | `NULL` | Provider's confidence in the category assignment. One of: `VERY_HIGH`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`. |
 | `provider_payment_channel` | `TEXT` | Yes | `NULL` | Channel used to make the payment. One of: `online`, `in store`, `other`. `NULL` if the provider does not provide this field. |
-| `provider_raw` | `JSONB` | Yes | `NULL` | Unmodified provider payload for this transaction. Populated by the Plaid, Teller, and CSV adapters during upsert. Useful for debugging, replaying enrichment, and accessing fields that Breadbox does not yet model as typed columns. Large — do not `SELECT *` it on list endpoints. |
 | `pending` | `BOOLEAN` | No | `FALSE` | Whether the transaction has settled. `TRUE` = pending (not yet cleared). `FALSE` = posted. Pending transactions may change details or be replaced entirely when they post. |
 | `deleted_at` | `TIMESTAMPTZ` | Yes | `NULL` | Soft-delete timestamp. `NULL` means the transaction is active. Set to the current time when Plaid includes this `transaction_id` in the `removed` array of a `/transactions/sync` response. Soft-deleted transactions are excluded from API responses by default but are never hard-deleted. |
 | `created_at` | `TIMESTAMPTZ` | No | `NOW()` | Timestamp when this row was first inserted into Breadbox. |
 | `updated_at` | `TIMESTAMPTZ` | No | `NOW()` | Timestamp of the last upsert (update from Plaid's `modified` array or first insert). |
+
+> **Raw provider payload moved to a satellite table.** The unmodified provider
+> payload (formerly `transactions.provider_raw JSONB`) now lives in
+> `transaction_provider_payloads` (1:1, keyed by `transaction_id`,
+> `ON DELETE CASCADE`). This keeps the heavy JSONB off the frequently-scanned
+> `transactions` row. It is write-mostly (populated by the Plaid/Teller/CSV
+> adapters during upsert) and retrieved on demand via join for debugging and
+> enrichment replay — never selected on list endpoints.
 
 #### Primary Key
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -407,8 +407,7 @@ Plaid `account_id` values are globally unique across all items and institutions.
 | `provider_transaction_id` | `TEXT` | No | — | Provider-assigned transaction identifier. For Plaid: `transaction_id`. Case-sensitive. Stable for posted transactions; pending transactions may receive a new `transaction_id` when they post. Used for upsert during sync. |
 | `provider_pending_transaction_id` | `TEXT` | Yes | `NULL` | For a posted transaction that was previously pending, this is the `transaction_id` of that original pending transaction. Plaid sets this field to link the posted record back to the pending record it replaced. The application uses this to locate and soft-delete the superseded pending row. |
 | `amount` | `NUMERIC(12,2)` | No | — | Transaction amount in the account's currency. **Sign convention (Plaid passthrough):** Positive values represent money leaving the account (debits, purchases, payments). Negative values represent money entering the account (credits, refunds, deposits). This matches Plaid's native convention exactly — Breadbox does not invert the sign. See Section 4 for full rationale. |
-| `iso_currency_code` | `TEXT` | Yes | `NULL` | ISO-4217 currency code for this transaction (e.g., `USD`). `NULL` if Plaid returns an unofficial currency code. Never silently aggregate across currencies. |
-| `unofficial_currency_code` | `TEXT` | Yes | `NULL` | Non-standard currency code (e.g., cryptocurrency). Mutually exclusive with `iso_currency_code` — Plaid guarantees at most one is non-null. |
+| `iso_currency_code` | `TEXT` | Yes | `NULL` | ISO-4217 currency code for this transaction (e.g., `USD`). Never silently aggregate across currencies. |
 | `date` | `DATE` | No | — | Transaction date. For pending transactions: the date the transaction occurred. For posted transactions: the date it posted. Format: `YYYY-MM-DD`. |
 | `authorized_date` | `DATE` | Yes | `NULL` | Date the transaction was authorized by the user (e.g., when a card was swiped). Earlier than or equal to `date` for posted transactions. Not always available. |
 | `datetime` | `TIMESTAMPTZ` | Yes | `NULL` | Full timestamp of the posted transaction, if provided by the institution. Only available for select institutions. `NULL` for most transactions. |
@@ -905,8 +904,7 @@ The Plaid `/transactions/sync` endpoint returns `TransactionBase` objects in the
 | `pending_transaction_id` | string \| null | `pending_transaction_id` | `TEXT NULL` | Links posted transaction back to the pending record it replaced. |
 | `account_id` | string | — (join) | — | Used to resolve `account_id` FK via `accounts.external_account_id`. Not stored redundantly. |
 | `amount` | number | `amount` | `NUMERIC(12,2)` | Passed through with Plaid's sign convention (positive = money out). See Section 4. |
-| `iso_currency_code` | string \| null | `iso_currency_code` | `TEXT NULL` | Null when `unofficial_currency_code` is set. |
-| `unofficial_currency_code` | string \| null | `unofficial_currency_code` | `TEXT NULL` | Cryptocurrency or non-standard currency. Null when `iso_currency_code` is set. |
+| `iso_currency_code` | string \| null | `iso_currency_code` | `TEXT NULL` | ISO-4217 currency code. |
 | `date` | string (YYYY-MM-DD) | `date` | `DATE` | Pending: occurrence date. Posted: settlement date. |
 | `authorized_date` | string \| null (YYYY-MM-DD) | `authorized_date` | `DATE NULL` | When the user authorized the transaction. |
 | `datetime` | string \| null (ISO 8601) | `datetime` | `TIMESTAMPTZ NULL` | Full timestamp of posted transaction. Select institutions only. |

--- a/docs/v1-schema-api-proposal.md
+++ b/docs/v1-schema-api-proposal.md
@@ -31,7 +31,7 @@ Seven bold strokes define this proposal:
 4. **Rename `annotations` → `transaction_events`** and treat it as the first-class, partition-ready event log it already is.
 5. **Split the surface: public `/api/v1` (token-auth, OpenAPI, stable) vs. operator `/admin` (session-auth).** Workflows, provider credentials, users/logins, and settings move to operator-only.
 6. **Uniform cursor pagination + field selection on every list.** Kill offset pagination and bare-array responses.
-7. **Defer OAuth and device-codes out of the advertised v1.** Ship API-keys as the single, coherent front door. Add the missing retention/cleanup jobs for everything we *do* ship.
+7. **Defer OAuth out of the advertised v1; ship API-keys as the single, coherent front door** (and finish device-code CLI login so headless self-hosters can mint a key). Add the missing retention/cleanup jobs for everything we ship.
 
 > ⚠️ **Scope note (verified):** `csv_import_*`, `dev_reports`, and `transactions.content_hash`
 > appear in the shared dev database but are **NOT in `main`** — they leaked from sibling
@@ -68,7 +68,8 @@ by domain. Renamed columns are shown as `old → new`. New columns marked **+**.
 
 | Table | Notable target shape | Changes |
 |---|---|---|
-| `transactions` | the core ledger | **drop** `unofficial_currency_code` (dead Plaid legacy); `provider_pending_transaction_id → replaced_pending_provider_id`; `category_override → category_source` (ENUM none/rule/agent/user); evaluate moving `provider_raw` off the hot row (see §4); + index `(attributed_user_id)` |
+| `transactions` | the core ledger | **drop** `unofficial_currency_code` (dead Plaid legacy); **move** `provider_raw` → side table `transaction_provider_payloads` (decision §4.1); `provider_pending_transaction_id → replaced_pending_provider_id`; `category_override → category_source` (ENUM none/rule/agent/user); + index `(attributed_user_id)` |
+| `transaction_provider_payloads` **(NEW)** | 1:1 raw provider payload archive, keyed by `transaction_id` | holds `provider_raw JSONB` off the hot ledger so scans/queries stay lean; full payload available on join for debugging/re-enrichment |
 | `categories` | hierarchical category tree | no change — clean |
 | `tags` | reusable labels | `lifecycle TEXT → tag_retention ENUM(persistent, ephemeral)` + document "ephemeral = removal requires a reason" |
 | `transaction_tags` | txn↔tag join w/ provenance | no change — clean |
@@ -110,15 +111,15 @@ by domain. Renamed columns are shown as `old → new`. New columns marked **+**.
 |---|---|---|
 | `app_config` | env→DB→default key/value | remove dead seeded keys `sync_interval_hours`, `setup_complete` |
 
-### 2.8 Deferred out of advertised v1 (kept dormant, unadvertised, or removed)
+### 2.8 Deferred out of advertised v1
 
 | Table(s) | Verdict | Rationale |
 |---|---|---|
 | `oauth_clients`, `oauth_access_tokens`, `oauth_refresh_tokens`, `oauth_authorization_codes` | **DEFER** — not advertised; remove from v1 docs/UI | 0 production rows; expiry-cleanup job never wired; unproven rotation/revocation under load. Ship API-keys as the single front door. Re-introduce as a post-1.0 minor with the cleanup hook. |
-| `auth_device_codes` | **FINISH or CUT** | RFC-8628 CLI login is genuinely valuable, but the service layer is not wired (orphaned queries). Either complete `breadbox auth login` for v1 or drop the table until it's real. |
+| `auth_device_codes` | **FINISH for v1** (decision §4.2) | RFC-8628 CLI login is a real self-hoster story. Wire the service layer + `breadbox auth login`, add the expiry-cleanup job, and ship it. |
 
-> Net table count: 34 today − 4 OAuth (deferred) − 1 device-codes (if cut) − 1 (`reports`
-> rename is not a drop) = **~28–30 advertised tables for v1.**
+> Net table count: 34 today + 1 (`transaction_provider_payloads`) − 4 OAuth (deferred) −
+> 0 (`reports` is a rename, device-codes now ships) = **~31 advertised tables for v1.**
 
 ---
 
@@ -198,32 +199,37 @@ needs admin rights. The split makes the public contract honest.
 
 ---
 
-## 4. Open decisions (need a call before implementation)
+## 4. Resolved decisions
 
-1. **`transactions.provider_raw` (JSONB, full provider payload per row).** Useful for
-   debugging and re-processing, but stored on the hottest table for every row — real bytes
-   at scale. **Options:** (a) keep + document as internal; (b) move to a side table
-   `transaction_provider_payloads`; (c) make it config-gated (off by default).
-   **Recommendation:** (b) or (c) — keep the hot ledger lean.
-2. **`auth_device_codes`:** finish `breadbox auth login` for v1, or cut the table?
-   **Recommendation:** cut for v1 unless CLI login is a launch story.
-3. **`transaction_events` partitioning:** ship v1 with the rename + ENUM only, and add
-   `PARTITION BY RANGE (created_at)` as a documented v1.x step — or do it now?
-   **Recommendation:** rename + ENUM now; partition when an install crosses ~1M events.
-4. **Enum migration ordering:** `TEXT → ENUM` conversions are `ALTER TYPE`-class changes
-   that the shared-dev-DB rule flags as destructive. They must be sequenced carefully and
-   run as a coordinated cutover, not additive trickle. (Affects the build plan, not the
-   target.)
+These were the four open calls; resolved 2026-06-14.
+
+1. **`transactions.provider_raw` → side table.** ✅ Move to a new 1:1
+   `transaction_provider_payloads` (keyed by `transaction_id`). Keeps the hot ledger lean
+   for scans/queries while preserving every payload for debugging and re-enrichment. The
+   sync upsert writes the lean row + the payload row in the same transaction.
+2. **`auth_device_codes` → finish for v1.** ✅ Wire the service layer + `breadbox auth login`
+   so headless self-hosters can bootstrap a key without a browser. Add the missing
+   expiry-cleanup job alongside it. Table stays.
+3. **`transaction_events` partitioning → defer.** ✅ Ship the rename + ENUM in v1; add
+   `PARTITION BY RANGE (created_at)` as a documented v1.x step once an install crosses
+   ~1M events. No over-engineering for typical household scale.
+4. **Enum conversions → do them now (v1).** ✅ Convert all 14 canonical enums from
+   `TEXT+CHECK` to real Postgres `ENUM` types as part of v1. These are `ALTER TYPE`-class
+   (destructive on the shared dev DB), so they run as a **coordinated cutover** —
+   sequenced, announced to other worktrees, applied against `breadbox_test` first — not as
+   additive trickle. This is the riskiest migration in the set and gets its own wave.
 
 ---
 
 ## 5. Changelog (concise)
 
 ### ✅ ADD
+- **`transaction_provider_payloads` table** (1:1 raw-payload archive; `provider_raw` moves here off the hot ledger).
+- **Finish `breadbox auth login`** — wire `auth_device_codes` service layer + CLI + expiry-cleanup job.
 - `users.deleted_at` (soft-delete).
 - Indexes: `bank_connections(user_id, status)`, `transactions(attributed_user_id)`.
 - `UNIQUE(bank_connections.provider, provider_connection_id)` constraint.
-- Retention/cleanup jobs: `webhook_events` (7d), `mcp_tool_calls` (30d), OAuth auth-codes (if OAuth ever ships).
+- Retention/cleanup jobs: `webhook_events` (7d), `mcp_tool_calls` (30d), `auth_device_codes` (expiry).
 - Config flag gating `mcp_tool_calls` request/response JSON persistence.
 - Public API: outbound webhooks, `Idempotency-Key`, `X-Request-ID` echo, CORS config, OpenAPI request examples.
 
@@ -245,15 +251,16 @@ needs admin rights. The split makes the public contract honest.
 - `transactions.unofficial_currency_code` (dead).
 - `app_config` seeded keys `sync_interval_hours`, `setup_complete` (dead).
 - OAuth (4 tables) **from advertised v1** — keep dormant or remove; ship API-keys only.
-- `auth_device_codes` if CLI login isn't a v1 story.
 - API: flat `/login-accounts` list, redundant `batch-categorize`/`bulk-recategorize` (→ `/transactions/update`).
 
-### ➡️ MOVE (public → operator surface)
-- `/workflows`, `/workflow-runs`, `/reports`, `/connectors`, provider credentials, users/login management, settings, sync-schedules → `/admin/*` (session-auth, out of the public spec).
+### ➡️ MOVE
+- `transactions.provider_raw` column → `transaction_provider_payloads` side table (DB).
+- Surface (public → operator): `/workflows`, `/workflow-runs`, `/reports`, `/connectors`, provider credentials, users/login management, settings, sync-schedules → `/admin/*` (session-auth, out of the public spec).
 
 ### ⏸️ DEFER (document, don't build for v1)
-- Multi-tenant OAuth 2.1 client-credentials, fine-grained scopes beyond read/write,
-  `transaction_events` partitioning, account-link MCP tools (unless linking ships).
+- OAuth 2.1 (4 tables), multi-tenant client-credentials, fine-grained scopes beyond read/write.
+- `transaction_events` partitioning (`PARTITION BY RANGE (created_at)`) — add at ~1M events.
+- Account-link MCP tools (unless linking ships).
 
 ---
 

--- a/docs/v1-schema-api-proposal.md
+++ b/docs/v1-schema-api-proposal.md
@@ -1,0 +1,266 @@
+# Breadbox v1 — Schema & API Hardening Proposal
+
+> **Status:** Proposal for review (not yet implemented).
+> **Goal:** Prepare the database and public API for the v1 open-source launch so that
+> (a) self-hosters can grow their database confidently, and (b) a third-party developer
+> would *want* to build a standalone product on top of the API.
+> **Stance:** Bold. This is the last cheap moment to make breaking changes. After v1 we
+> owe users a stability pledge, so we spend the breakage budget now.
+
+---
+
+## 1. Executive summary
+
+The schema is fundamentally healthy. Past sprints already retired the worst cruft
+(`admin_accounts`, `audit_log`, `category_mappings`, `review_queue`,
+`transaction_comments`, `member_accounts` are all dropped). What remains is **drift, not
+rot**: half-finished renames, reserved-word footguns, provider-vocabulary leakage,
+TEXT-as-enum sprawl, and two experimental subsystems (OAuth, device-codes) sitting in the
+schema with zero production rows.
+
+The API is RESTful and well-documented, but it blurs **two audiences into one surface**:
+the operator (who manages providers, users, workflows) and the integrator (who reads
+financial data). v1 should split those cleanly and make the integrator surface a
+first-class, stable, fully-paginated contract.
+
+Seven bold strokes define this proposal:
+
+1. **Finish the agent→workflow rename** down to the FK columns and query files. Stop shipping a subsystem that is half "agent", half "workflow".
+2. **`short_id` becomes *the* public ID.** The API stops leaking internal UUIDs. One ID, everywhere, base62, stable.
+3. **Promote canonical enums to real Postgres `ENUM` types.** We already document 14 canonical enums in `CLAUDE.md`; the schema should enforce them, not approximate them with `TEXT + CHECK`.
+4. **Rename `annotations` → `transaction_events`** and treat it as the first-class, partition-ready event log it already is.
+5. **Split the surface: public `/api/v1` (token-auth, OpenAPI, stable) vs. operator `/admin` (session-auth).** Workflows, provider credentials, users/logins, and settings move to operator-only.
+6. **Uniform cursor pagination + field selection on every list.** Kill offset pagination and bare-array responses.
+7. **Defer OAuth and device-codes out of the advertised v1.** Ship API-keys as the single, coherent front door. Add the missing retention/cleanup jobs for everything we *do* ship.
+
+> ⚠️ **Scope note (verified):** `csv_import_*`, `dev_reports`, and `transactions.content_hash`
+> appear in the shared dev database but are **NOT in `main`** — they leaked from sibling
+> worktree branches (`csv-import-v2`, devmode-reporter). This proposal targets the real
+> `main` schema (34 live tables). Their design feedback is captured in §6 for when those
+> branches land, but they are not part of the v1 cleanup.
+
+---
+
+## 2. Target table layout (what we should AIM for)
+
+34 tables today → **30 in the v1 target** (after renames, drops, and deferrals). Grouped
+by domain. Renamed columns are shown as `old → new`. New columns marked **+**.
+
+### 2.1 Identity & access
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `users` | household members (the *people*) | + `deleted_at` (soft-delete preserves connection history) |
+| `auth_accounts` | login credentials, FK→users | `role TEXT → role_type ENUM(admin, editor, viewer)` |
+| `api_keys` | the v1 front door | `agent_definition_id → workflow_id`; keep `scope ENUM(full_access, read_only)` |
+| `sessions` | dashboard cookies (scs-managed) | unchanged — first-party admin only, never an API token |
+
+### 2.2 Connections & accounts
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `bank_connections` | one row per provider linkage | `external_id → provider_connection_id`; + index `(user_id, status)`; promote `(provider, provider_connection_id)` partial unique index → real `UNIQUE` constraint |
+| `accounts` | financial accounts under a connection | `iso_currency_code` → `NOT NULL DEFAULT 'USD'`; document `is_dependent_linked`/`excluded` as API-visible flags |
+| `account_links` | multi-account reconciliation links | `match_strategy TEXT → match_strategy ENUM(date_amount_name)` |
+| `transaction_matches` | matched txn pairs across linked accounts | keep (feature-complete, 0 rows is expected for fresh installs) |
+
+### 2.3 Transactions & enrichment
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `transactions` | the core ledger | **drop** `unofficial_currency_code` (dead Plaid legacy); `provider_pending_transaction_id → replaced_pending_provider_id`; `category_override → category_source` (ENUM none/rule/agent/user); evaluate moving `provider_raw` off the hot row (see §4); + index `(attributed_user_id)` |
+| `categories` | hierarchical category tree | no change — clean |
+| `tags` | reusable labels | `lifecycle TEXT → tag_retention ENUM(persistent, ephemeral)` + document "ephemeral = removal requires a reason" |
+| `transaction_tags` | txn↔tag join w/ provenance | no change — clean |
+| `transaction_rules` | the rule DSL store | `trigger TEXT → rule_trigger ENUM(on_create, on_change, always)` |
+| `transaction_events` ⬅ `annotations` | **renamed.** the activity/audit event log | `kind TEXT+CHECK → event_kind ENUM`; partition-by-month plan documented for scale |
+| `recurring_series` | detected subscriptions/bills | `cadence`, `status`, `type`, `detection_source`, `confidence` → ENUM types; document `detection_signals` JSONB shape |
+| `series_tags` | series↔tag join (materialized onto txns) | no change — clean |
+
+### 2.4 Sync & ingestion
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `sync_logs` | one row per sync run | `trigger → sync_trigger` (kill reserved-word footgun); keep `duration_ms` (perf denorm) |
+| `sync_log_accounts` | per-account breakdown of a run | no change — intentional, not redundant |
+| `sync_schedules` | cron-anchored schedules | no change — recently landed, clean |
+| `sync_schedule_connections` | schedule↔connection join | no change |
+| `webhook_events` | provider webhook audit | **+ retention job** (7-day default, config-keyed); document "payload not persisted, processed transactionally" |
+| `hosted_link_sessions` | shareable bank-link surface | no change — clean |
+
+### 2.5 Workflows & agents (the rename frontier)
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `workflows` ⬅ (`agent_definitions`) | scheduled AI run definitions | table already renamed; finish query-file rename |
+| `workflow_runs` ⬅ (`agent_runs`) | run history + token/cost metrics | `agent_definition_id → workflow_id`; query-file rename |
+| `reports` ⬅ `agent_reports` | AI-authored reports | `agent_run_id → workflow_run_id`; collapse `author` + `created_by_name` → single `author` display contract |
+| `connector_library` | global custom-MCP connectors | no change — newly landed, clean |
+
+### 2.6 MCP audit
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `mcp_sessions` | one row per MCP transport session | no change |
+| `mcp_tool_calls` | per-tool-call audit | **gate** `request_json`/`response_json` persistence behind a config flag (PII); **+ retention job** (30-day default) |
+
+### 2.7 Configuration
+
+| Table | Notable target shape | Changes |
+|---|---|---|
+| `app_config` | env→DB→default key/value | remove dead seeded keys `sync_interval_hours`, `setup_complete` |
+
+### 2.8 Deferred out of advertised v1 (kept dormant, unadvertised, or removed)
+
+| Table(s) | Verdict | Rationale |
+|---|---|---|
+| `oauth_clients`, `oauth_access_tokens`, `oauth_refresh_tokens`, `oauth_authorization_codes` | **DEFER** — not advertised; remove from v1 docs/UI | 0 production rows; expiry-cleanup job never wired; unproven rotation/revocation under load. Ship API-keys as the single front door. Re-introduce as a post-1.0 minor with the cleanup hook. |
+| `auth_device_codes` | **FINISH or CUT** | RFC-8628 CLI login is genuinely valuable, but the service layer is not wired (orphaned queries). Either complete `breadbox auth login` for v1 or drop the table until it's real. |
+
+> Net table count: 34 today − 4 OAuth (deferred) − 1 device-codes (if cut) − 1 (`reports`
+> rename is not a drop) = **~28–30 advertised tables for v1.**
+
+---
+
+## 3. Target API shape (what we should AIM for)
+
+### 3.1 Two surfaces, cleanly split
+
+```
+PUBLIC INTEGRATOR API           OPERATOR / ADMIN SURFACE
+/api/v1/*                       /admin/*  (or keep /-/*)
+─────────────────────           ─────────────────────────
+auth: X-API-Key (bb_…)          auth: session cookie + CSRF
+documented in openapi.yaml       not in the public spec
+stability pledge applies         free to change
+cursor pagination everywhere     —
+
+  transactions   (+ events,        providers / credentials
+                  tags, metadata)   users / login-accounts
+  accounts                          workflows / runs / reports
+  connections (read)                connectors
+  categories                        settings / app_config
+  rules                             sync-schedules
+  series                            hosted-links (create)
+  tags
+  sync-logs (read)
+  webhooks (NEW: out-bound)
+```
+
+**Why:** today `/api/v1/workflows`, `/api/v1/settings/providers/plaid`, and
+`/api/v1/login-accounts` live under the public umbrella but are operator-only in practice.
+A third-party dev shouldn't discover an endpoint, build against it, and *then* learn it
+needs admin rights. The split makes the public contract honest.
+
+### 3.2 Conventions the public API commits to
+
+- **One ID.** Every resource exposes a single `id` = the 8-char base62 `short_id`. Internal
+  UUIDs are never returned. Path params take the public id. (Today REST returns both `id`
+  (uuid) *and* `short_id` — confusing and leaky.)
+- **Cursor pagination, uniformly.** `?limit=50&cursor=<opaque>` on every list. `limit` caps
+  at 500. Response: `{ "<resource>": [...], "next_cursor": "…"|null, "has_more": bool }`.
+  No offset, no bare arrays.
+- **Field selection, uniformly.** `?fields=core|full|all` (+ named projections) on every
+  read. Documented default per resource.
+- **Error envelope (unchanged).** `{ "error": { "code": "UPPER_SNAKE", "message": "…" } }`.
+  Codes are stable contracts.
+- **Money (unchanged, documented loudly).** `NUMERIC(12,2)`, always paired with
+  `iso_currency_code`, positive = money out. Never summed across currencies.
+- **Idempotency.** Optional `Idempotency-Key` header on all writes; replays within 24h
+  return the cached response.
+- **Traceability.** Echo `X-Request-ID` on every response (middleware already generates it).
+- **CORS.** `CORS_ALLOWED_ORIGINS` env var so self-hosters can call the API from a SPA.
+
+### 3.3 Stability pledge (published with v1)
+
+> Within `/api/v1`, fields are **additive**: never removed, never renamed, never
+> re-typed. New capabilities arrive as new fields or new `/api/v1/{resource}` paths. A
+> breaking change means a new `/api/v2` prefix; `/api/v1` keeps running. Deprecated
+> endpoints carry a `Sunset` header and live for at least 12 months.
+
+### 3.4 Net-new public capabilities for "build a product on this"
+
+| Capability | Shape |
+|---|---|
+| **Outbound webhooks** | `POST /api/v1/webhooks` registers a callback URL; Breadbox fires HMAC-signed POSTs on transaction/series/report changes. The single biggest unlock for external products (no more polling). |
+| **Bulk transaction update** | consolidate `batch-categorize` + `bulk-recategorize` into one `POST /api/v1/transactions/update` (filter- or id-based). |
+| **Request body examples in OpenAPI** | spec defines shapes but lacks example payloads for writes. |
+
+### 3.5 MCP surface tightening
+
+- Standardize `fields=` defaults across all row-returning tools (today transactions/rules
+  have it, series doesn't).
+- Consolidate the 11 series tools: fold `add_series_tag`/`remove_series_tag` into
+  `update_series`; clarify `review_series` (adjudicate) vs `assign_series` (create/backfill).
+- Add `get_transaction_rule` (single-fetch mirror; REST has it, MCP doesn't).
+- Add reconciliation tools (`list_transaction_matches`, `confirm_match`, `reject_match`) if
+  account-linking is advertised for v1.
+
+---
+
+## 4. Open decisions (need a call before implementation)
+
+1. **`transactions.provider_raw` (JSONB, full provider payload per row).** Useful for
+   debugging and re-processing, but stored on the hottest table for every row — real bytes
+   at scale. **Options:** (a) keep + document as internal; (b) move to a side table
+   `transaction_provider_payloads`; (c) make it config-gated (off by default).
+   **Recommendation:** (b) or (c) — keep the hot ledger lean.
+2. **`auth_device_codes`:** finish `breadbox auth login` for v1, or cut the table?
+   **Recommendation:** cut for v1 unless CLI login is a launch story.
+3. **`transaction_events` partitioning:** ship v1 with the rename + ENUM only, and add
+   `PARTITION BY RANGE (created_at)` as a documented v1.x step — or do it now?
+   **Recommendation:** rename + ENUM now; partition when an install crosses ~1M events.
+4. **Enum migration ordering:** `TEXT → ENUM` conversions are `ALTER TYPE`-class changes
+   that the shared-dev-DB rule flags as destructive. They must be sequenced carefully and
+   run as a coordinated cutover, not additive trickle. (Affects the build plan, not the
+   target.)
+
+---
+
+## 5. Changelog (concise)
+
+### ✅ ADD
+- `users.deleted_at` (soft-delete).
+- Indexes: `bank_connections(user_id, status)`, `transactions(attributed_user_id)`.
+- `UNIQUE(bank_connections.provider, provider_connection_id)` constraint.
+- Retention/cleanup jobs: `webhook_events` (7d), `mcp_tool_calls` (30d), OAuth auth-codes (if OAuth ever ships).
+- Config flag gating `mcp_tool_calls` request/response JSON persistence.
+- Public API: outbound webhooks, `Idempotency-Key`, `X-Request-ID` echo, CORS config, OpenAPI request examples.
+
+### ✏️ RENAME
+- **Finish agent→workflow:** `workflow_runs.agent_definition_id → workflow_id`; `api_keys.agent_definition_id → workflow_id`; `agent_reports → reports` with `agent_run_id → workflow_run_id`; query files `agent_*.sql → workflow_*.sql`.
+- `annotations → transaction_events` (+ `kind → event_kind`).
+- `sync_logs.trigger → sync_trigger` (reserved word).
+- `bank_connections.external_id → provider_connection_id`.
+- `transactions.category_override → category_source`; `provider_pending_transaction_id → replaced_pending_provider_id`.
+- `tags.lifecycle → tag_retention`.
+- **Public API IDs:** responses expose `short_id` as the single canonical `id`; drop UUID exposure.
+
+### 🔁 CONVERT (TEXT+CHECK → Postgres ENUM)
+- `auth_accounts.role`, `account_links.match_strategy`, `transaction_rules.trigger`,
+  `transactions.category_source`, `transaction_events.event_kind`,
+  `recurring_series.{cadence,status,type,detection_source,confidence}`.
+
+### ❌ REMOVE
+- `transactions.unofficial_currency_code` (dead).
+- `app_config` seeded keys `sync_interval_hours`, `setup_complete` (dead).
+- OAuth (4 tables) **from advertised v1** — keep dormant or remove; ship API-keys only.
+- `auth_device_codes` if CLI login isn't a v1 story.
+- API: flat `/login-accounts` list, redundant `batch-categorize`/`bulk-recategorize` (→ `/transactions/update`).
+
+### ➡️ MOVE (public → operator surface)
+- `/workflows`, `/workflow-runs`, `/reports`, `/connectors`, provider credentials, users/login management, settings, sync-schedules → `/admin/*` (session-auth, out of the public spec).
+
+### ⏸️ DEFER (document, don't build for v1)
+- Multi-tenant OAuth 2.1 client-credentials, fine-grained scopes beyond read/write,
+  `transaction_events` partitioning, account-link MCP tools (unless linking ships).
+
+---
+
+## 6. Notes for unmerged branches (not v1 scope, captured here)
+- **csv-import-v2** (`csv_import_sessions/rows/profiles`, `transactions.content_hash`):
+  `raw_blob BYTEA` storing whole CSVs in Postgres is an anti-pattern — externalize or
+  stream. `csv_import_rows` double-stores `raw` JSON + parsed columns — pick one.
+- **devmode-reporter** (`dev_reports`): leaked into dev DB with no `main` migration and no
+  DB-write path in the handler ("no token, no persistence"). Gate behind a dev flag or drop
+  before it reaches `main`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -156,7 +156,7 @@ When `flag_only` is chosen, a directive is appended to the prompt that explicitl
 |---|---|---|
 | `id` | `UUID` | Primary key |
 | `short_id` | `TEXT` | 8-char base62 alias |
-| `agent_definition_id` | `UUID` | FK -> `workflows.id`; `SET NULL` on delete (history preserved) |
+| `workflow_id` | `UUID` | FK -> `workflows.id`; `SET NULL` on delete (history preserved) |
 | `trigger` | `TEXT` | `manual` \| `cron` \| `webhook` |
 | `status` | `TEXT` | `in_progress` \| `success` \| `error` \| `skipped` |
 | `started_at` | `TIMESTAMPTZ` | |

--- a/internal/admin/agent_run_live.go
+++ b/internal/admin/agent_run_live.go
@@ -63,8 +63,8 @@ func AgentRunLiveHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 
 		// Enrich with agent identity so the stats panel renders the
 		// same label set as the initial server render.
-		if run.AgentDefinitionID != nil {
-			if def, derr := svc.GetAgentDefinition(ctx, *run.AgentDefinitionID); derr == nil {
+		if run.WorkflowID != nil {
+			if def, derr := svc.GetAgentDefinition(ctx, *run.WorkflowID); derr == nil {
 				row.AgentSlug = def.Slug
 				row.AgentName = def.Name
 			}

--- a/internal/admin/agent_runs_page.go
+++ b/internal/admin/agent_runs_page.go
@@ -54,8 +54,8 @@ func AgentRunDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr 
 		systemPrompt := ""
 		userPrompt := ""
 		var defSlug, defName string
-		if run.AgentDefinitionID != nil {
-			if def, derr := svc.GetAgentDefinition(ctx, *run.AgentDefinitionID); derr == nil {
+		if run.WorkflowID != nil {
+			if def, derr := svc.GetAgentDefinition(ctx, *run.WorkflowID); derr == nil {
 				defSlug = def.Slug
 				defName = def.Name
 				userPrompt = def.Prompt

--- a/internal/agent/spec.go
+++ b/internal/agent/spec.go
@@ -64,7 +64,7 @@ func (a AuthConfig) GoString() string { return a.String() }
 type JobSpec struct {
 	// Identity (passed through for log correlation)
 	RunID             string `json:"runId"`
-	AgentDefinitionID string `json:"agentDefinitionId"`
+	WorkflowID string `json:"workflowId"`
 
 	// Prompt
 	Prompt       string `json:"prompt"`

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -39,6 +39,17 @@ const (
 	// agent_runs rows. Default: 30. 0 disables cleanup.
 	KeyAgentRunRetentionDays = "agent.run_retention_days"
 
+	// KeyWebhookEventRetentionDays is the number of days to keep webhook_events
+	// audit rows. Default: 7. 0 disables cleanup. Webhook payloads are not
+	// persisted (only a hash), so this is a thin audit trail safe to prune fast.
+	KeyWebhookEventRetentionDays = "webhook_event_retention_days"
+
+	// KeyMcpToolCallRetentionDays is the number of days to keep mcp_tool_calls
+	// audit rows (and the now-empty mcp_sessions they belonged to). Default: 30.
+	// 0 disables cleanup. These rows store full tool request/response JSON, which
+	// can contain user financial data — prune them on a bounded horizon.
+	KeyMcpToolCallRetentionDays = "mcp_tool_call_retention_days"
+
 	// KeyEncryptionKeyAcknowledgedAt is the RFC3339 timestamp at which the
 	// admin clicked through the /setup/save-key reveal page. Unset (empty)
 	// means the reveal page is still offered; once set, the page redirects

--- a/internal/db/agent_queries_integration_test.go
+++ b/internal/db/agent_queries_integration_test.go
@@ -152,7 +152,7 @@ func TestCreateAndCompleteAgentRun(t *testing.T) {
 
 	d := mustCreateDefinition(t, q, "qry-run-"+t.Name(), true)
 	run, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
-		AgentDefinitionID: d.ID,
+		WorkflowID: d.ID,
 		Trigger:           "manual",
 	})
 	if err != nil {
@@ -196,11 +196,11 @@ func TestCountInProgressAgentRuns(t *testing.T) {
 	ctx := context.Background()
 
 	d := mustCreateDefinition(t, q, "qry-count-"+t.Name(), true)
-	r1, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{AgentDefinitionID: d.ID, Trigger: "manual"})
+	r1, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{WorkflowID: d.ID, Trigger: "manual"})
 	if err != nil {
 		t.Fatalf("CreateAgentRun r1: %v", err)
 	}
-	if _, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{AgentDefinitionID: d.ID, Trigger: "cron"}); err != nil {
+	if _, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{WorkflowID: d.ID, Trigger: "cron"}); err != nil {
 		t.Fatalf("CreateAgentRun r2: %v", err)
 	}
 
@@ -245,7 +245,7 @@ func TestDeleteAgentRunsOlderThan(t *testing.T) {
 	d := mustCreateDefinition(t, q, "qry-cleanup-"+t.Name(), true)
 	// Insert a deliberately-old completed run via direct SQL.
 	if _, err := pool.Exec(ctx, `
-		INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at, completed_at)
+		INSERT INTO workflow_runs (workflow_id, "trigger", status, started_at, completed_at)
 		VALUES ($1, 'manual', 'success', NOW() - INTERVAL '31 days', NOW() - INTERVAL '31 days')
 	`, d.ID); err != nil {
 		t.Fatalf("insert old run: %v", err)

--- a/internal/db/agent_tables_integration_test.go
+++ b/internal/db/agent_tables_integration_test.go
@@ -76,7 +76,7 @@ func TestAgentRunsTable_Exists(t *testing.T) {
 	ctx := context.Background()
 
 	cols := []string{
-		"id", "short_id", "agent_definition_id", "trigger", "status",
+		"id", "short_id", "workflow_id", "trigger", "status",
 		"started_at", "completed_at", "duration_ms",
 		"total_cost_usd", "input_tokens", "output_tokens",
 		"cache_read_tokens", "cache_creation_tokens",
@@ -128,7 +128,7 @@ func TestAgentRunsFK_SetNullOnDefinitionDelete(t *testing.T) {
 
 	var runID pgtype.UUID
 	if err := pool.QueryRow(ctx, `
-		INSERT INTO workflow_runs (agent_definition_id, "trigger", status)
+		INSERT INTO workflow_runs (workflow_id, "trigger", status)
 		VALUES ($1, 'manual', 'success')
 		RETURNING id
 	`, defID).Scan(&runID); err != nil {
@@ -141,12 +141,12 @@ func TestAgentRunsFK_SetNullOnDefinitionDelete(t *testing.T) {
 
 	var orphanedDefID pgtype.UUID
 	if err := pool.QueryRow(ctx, `
-		SELECT agent_definition_id FROM workflow_runs WHERE id = $1
+		SELECT workflow_id FROM workflow_runs WHERE id = $1
 	`, runID).Scan(&orphanedDefID); err != nil {
 		t.Fatalf("re-fetch run: %v", err)
 	}
 	if orphanedDefID.Valid {
-		t.Errorf("expected agent_definition_id to be NULL after definition delete, got %v", orphanedDefID)
+		t.Errorf("expected workflow_id to be NULL after definition delete, got %v", orphanedDefID)
 	}
 }
 

--- a/internal/db/migrations/20260614052943_drop_transactions_unofficial_currency_code.sql
+++ b/internal/db/migrations/20260614052943_drop_transactions_unofficial_currency_code.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- Drop the dead unofficial_currency_code column. It was a Plaid-era dual-currency
+-- field (cryptocurrency / non-standard currency) that has never been written by any
+-- provider in Breadbox and is never read. Removing it for the v1 schema cleanup.
+ALTER TABLE transactions DROP COLUMN IF EXISTS unofficial_currency_code;
+
+-- +goose Down
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS unofficial_currency_code TEXT NULL;

--- a/internal/db/migrations/20260614053719_rename_agent_fk_columns_to_workflow.sql
+++ b/internal/db/migrations/20260614053719_rename_agent_fk_columns_to_workflow.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- Finish the agent_definitions->workflows / agent_runs->workflow_runs rename
+-- (migration 20260531120000) by renaming the FK columns that were "intentionally
+-- left as-is to bound the change". After this the subsystem speaks one vocabulary.
+-- Index + constraint names are renamed alongside their columns for consistency.
+
+-- workflow_runs.agent_definition_id -> workflow_id
+ALTER TABLE workflow_runs RENAME COLUMN agent_definition_id TO workflow_id;
+ALTER INDEX agent_runs_definition_started_at_idx RENAME TO workflow_runs_workflow_started_at_idx;
+ALTER TABLE workflow_runs RENAME CONSTRAINT agent_runs_agent_definition_id_fkey TO workflow_runs_workflow_id_fkey;
+
+-- api_keys.agent_definition_id -> workflow_id  (durable agent-identity link; see .claude/rules/agents.md)
+ALTER TABLE api_keys RENAME COLUMN agent_definition_id TO workflow_id;
+ALTER INDEX idx_api_keys_agent_definition_id RENAME TO idx_api_keys_workflow_id;
+ALTER TABLE api_keys RENAME CONSTRAINT api_keys_agent_definition_id_fkey TO api_keys_workflow_id_fkey;
+
+-- agent_reports.agent_run_id -> workflow_run_id
+ALTER TABLE agent_reports RENAME COLUMN agent_run_id TO workflow_run_id;
+ALTER INDEX idx_agent_reports_agent_run_id RENAME TO idx_agent_reports_workflow_run_id;
+ALTER TABLE agent_reports RENAME CONSTRAINT agent_reports_agent_run_id_fkey TO agent_reports_workflow_run_id_fkey;
+
+-- +goose Down
+ALTER TABLE agent_reports RENAME CONSTRAINT agent_reports_workflow_run_id_fkey TO agent_reports_agent_run_id_fkey;
+ALTER INDEX idx_agent_reports_workflow_run_id RENAME TO idx_agent_reports_agent_run_id;
+ALTER TABLE agent_reports RENAME COLUMN workflow_run_id TO agent_run_id;
+
+ALTER TABLE api_keys RENAME CONSTRAINT api_keys_workflow_id_fkey TO api_keys_agent_definition_id_fkey;
+ALTER INDEX idx_api_keys_workflow_id RENAME TO idx_api_keys_agent_definition_id;
+ALTER TABLE api_keys RENAME COLUMN workflow_id TO agent_definition_id;
+
+ALTER TABLE workflow_runs RENAME CONSTRAINT workflow_runs_workflow_id_fkey TO agent_runs_agent_definition_id_fkey;
+ALTER INDEX workflow_runs_workflow_started_at_idx RENAME TO agent_runs_definition_started_at_idx;
+ALTER TABLE workflow_runs RENAME COLUMN workflow_id TO agent_definition_id;

--- a/internal/db/migrations/20260614055107_transaction_provider_payloads.sql
+++ b/internal/db/migrations/20260614055107_transaction_provider_payloads.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Move transactions.provider_raw (full raw provider payload, write-only / never
+-- read) off the hot ledger into a 1:1 satellite table. Keeps row scans on the
+-- frequently-queried transactions table lean while preserving every payload for
+-- debugging and future re-enrichment (available on join, keyed by transaction_id).
+CREATE TABLE transaction_provider_payloads (
+    transaction_id uuid PRIMARY KEY REFERENCES transactions(id) ON DELETE CASCADE,
+    provider_raw   jsonb       NOT NULL,
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO transaction_provider_payloads (transaction_id, provider_raw)
+SELECT id, provider_raw FROM transactions WHERE provider_raw IS NOT NULL;
+
+ALTER TABLE transactions DROP COLUMN provider_raw;
+
+-- +goose Down
+ALTER TABLE transactions ADD COLUMN provider_raw jsonb;
+UPDATE transactions t
+   SET provider_raw = p.provider_raw
+  FROM transaction_provider_payloads p
+ WHERE p.transaction_id = t.id;
+DROP TABLE transaction_provider_payloads;

--- a/internal/db/queries/agent_reports.sql
+++ b/internal/db/queries/agent_reports.sql
@@ -1,5 +1,5 @@
 -- name: CreateAgentReport :one
-INSERT INTO agent_reports (title, body, created_by_type, created_by_id, created_by_name, priority, tags, author, session_id, agent_run_id)
+INSERT INTO agent_reports (title, body, created_by_type, created_by_id, created_by_name, priority, tags, author, session_id, workflow_run_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING *;
 
@@ -35,12 +35,12 @@ DELETE FROM agent_reports WHERE id = $1;
 -- Powers the AgentRunRow chip on the runs landing — operators see
 -- "this run produced these reports" at a glance.
 SELECT
-    agent_run_id,
+    workflow_run_id,
     id,
     short_id,
     title,
     priority,
     created_at
 FROM agent_reports
-WHERE agent_run_id = ANY($1::uuid[])
+WHERE workflow_run_id = ANY($1::uuid[])
 ORDER BY created_at ASC;

--- a/internal/db/queries/agent_runs.sql
+++ b/internal/db/queries/agent_runs.sql
@@ -1,5 +1,5 @@
 -- name: CreateAgentRun :one
-INSERT INTO workflow_runs (agent_definition_id, "trigger", model, status, started_at)
+INSERT INTO workflow_runs (workflow_id, "trigger", model, status, started_at)
 VALUES ($1, $2, $3, 'in_progress', NOW())
 RETURNING *;
 
@@ -11,13 +11,13 @@ SELECT * FROM workflow_runs WHERE short_id = $1;
 
 -- name: GetLatestAgentRun :one
 SELECT * FROM workflow_runs
-WHERE agent_definition_id = $1
+WHERE workflow_id = $1
 ORDER BY started_at DESC
 LIMIT 1;
 
 -- name: ListAgentRuns :many
 SELECT * FROM workflow_runs
-WHERE agent_definition_id = $1
+WHERE workflow_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3;
 
@@ -69,21 +69,21 @@ WHERE id = $1;
 -- the operator knows to raise max_turns / max_budget_usd or split the
 -- prompt.
 WITH ranked AS (
-    SELECT agent_definition_id, hit_cap,
+    SELECT workflow_id, hit_cap,
            ROW_NUMBER() OVER (
-               PARTITION BY agent_definition_id
+               PARTITION BY workflow_id
                ORDER BY started_at DESC
            ) AS rn
     FROM workflow_runs
-    WHERE agent_definition_id IS NOT NULL
+    WHERE workflow_id IS NOT NULL
       AND status != 'skipped'
 )
-SELECT agent_definition_id,
+SELECT workflow_id,
        COUNT(*) FILTER (WHERE hit_cap IS NOT NULL)::int AS cap_count,
        COUNT(*)::int                                     AS run_count
 FROM ranked
 WHERE rn <= 5
-GROUP BY agent_definition_id;
+GROUP BY workflow_id;
 
 -- name: GetAgentRecentErrorStats :many
 -- Per-definition "is this agent broken right now?" signal: error count
@@ -91,21 +91,21 @@ GROUP BY agent_definition_id;
 -- lock) are excluded — they aren't agent failures. The admin list
 -- renders a warning pill when error_count >= 3.
 WITH ranked AS (
-    SELECT agent_definition_id, status,
+    SELECT workflow_id, status,
            ROW_NUMBER() OVER (
-               PARTITION BY agent_definition_id
+               PARTITION BY workflow_id
                ORDER BY started_at DESC
            ) AS rn
     FROM workflow_runs
-    WHERE agent_definition_id IS NOT NULL
+    WHERE workflow_id IS NOT NULL
       AND status != 'skipped'
 )
-SELECT agent_definition_id,
+SELECT workflow_id,
        COUNT(*) FILTER (WHERE status = 'error')::int AS error_count,
        COUNT(*)::int                                  AS run_count
 FROM ranked
 WHERE rn <= 5
-GROUP BY agent_definition_id;
+GROUP BY workflow_id;
 
 -- name: CountWorkflowsWithFailedLastRun :one
 -- Sidebar failure badge: how many preset-instantiated workflows have a most
@@ -114,15 +114,15 @@ GROUP BY agent_definition_id;
 -- to gallery workflows (excludes hand-authored agent definitions). Not gated on
 -- enabled — a paused-but-failing workflow still shows its dot on the card.
 WITH last_run AS (
-    SELECT DISTINCT ON (agent_definition_id)
-           agent_definition_id, status
+    SELECT DISTINCT ON (workflow_id)
+           workflow_id, status
     FROM workflow_runs
-    WHERE agent_definition_id IS NOT NULL
-    ORDER BY agent_definition_id, started_at DESC
+    WHERE workflow_id IS NOT NULL
+    ORDER BY workflow_id, started_at DESC
 )
 SELECT COUNT(*)::bigint
 FROM workflows w
-JOIN last_run lr ON lr.agent_definition_id = w.id
+JOIN last_run lr ON lr.workflow_id = w.id
 WHERE w.source_template IS NOT NULL
   AND lr.status = 'error';
 
@@ -132,14 +132,14 @@ WHERE w.source_template IS NOT NULL
 -- (no real cost incurred) but includes errored runs (often DO incur
 -- partial cost).
 SELECT
-    agent_definition_id,
+    workflow_id,
     COUNT(*)::int                                        AS run_count,
     COALESCE(SUM(total_cost_usd), 0)::numeric(10,4)      AS total_cost_usd
 FROM workflow_runs
-WHERE agent_definition_id IS NOT NULL
+WHERE workflow_id IS NOT NULL
   AND started_at >= NOW() - INTERVAL '30 days'
   AND status != 'skipped'
-GROUP BY agent_definition_id;
+GROUP BY workflow_id;
 
 -- name: SetAgentRunNote :one
 UPDATE workflow_runs
@@ -161,7 +161,7 @@ SELECT r.short_id      AS run_short_id,
        d.slug          AS agent_slug,
        d.name          AS agent_name
 FROM workflow_runs r
-JOIN workflows d ON d.id = r.agent_definition_id
+JOIN workflows d ON d.id = r.workflow_id
 WHERE r.status = 'error'
   AND r.started_at >= NOW() - ($1::int * INTERVAL '1 hour')
 ORDER BY r.started_at DESC
@@ -191,13 +191,13 @@ RETURNING *;
 -- rows don't shadow earlier prefixes — only runs that actually carried a
 -- prefix are eligible. Used by the admin "Use last prefix" button on the
 -- Run now dialog to pre-fill the operator's prior context.
-SELECT DISTINCT ON (agent_definition_id)
-       agent_definition_id, prompt_prefix
+SELECT DISTINCT ON (workflow_id)
+       workflow_id, prompt_prefix
 FROM workflow_runs
-WHERE agent_definition_id IS NOT NULL
+WHERE workflow_id IS NOT NULL
   AND prompt_prefix IS NOT NULL
   AND prompt_prefix <> ''
-ORDER BY agent_definition_id, started_at DESC;
+ORDER BY workflow_id, started_at DESC;
 
 -- name: CleanupOrphanedAgentRuns :execresult
 UPDATE workflow_runs
@@ -248,7 +248,7 @@ SELECT
         WHERE status != 'skipped' AND duration_ms IS NOT NULL
     ), 0)::float8 / 1000.0)::float8                        AS avg_duration_seconds
 FROM workflow_runs
-WHERE agent_definition_id = $1;
+WHERE workflow_id = $1;
 
 -- GetHouseholdCostSince sums total_cost_usd across ALL agent definitions
 -- for runs started at/after the given instant, excluding skipped rows.
@@ -265,7 +265,7 @@ WHERE started_at >= sqlc.arg(since)
 -- name: ExistsRecentRunForDefinition :one
 SELECT EXISTS(
     SELECT 1 FROM workflow_runs
-    WHERE agent_definition_id = sqlc.arg(definition_id)
+    WHERE workflow_id = sqlc.arg(definition_id)
       AND started_at >= sqlc.arg(since)
       AND status <> 'skipped'
 ) AS run_exists;

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -1,5 +1,5 @@
 -- name: CreateApiKey :one
-INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type, actor_name, agent_definition_id)
+INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type, actor_name, workflow_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
 RETURNING *;
 
@@ -11,11 +11,11 @@ SELECT * FROM api_keys WHERE key_hash = $1;
 -- the api_keys row at mint (per-run keys). Lets every surface render an
 -- agent's activity under one name + slug-seeded avatar instead of the
 -- MCP clientInfo the SDK presents. Returns no rows for non-agent keys
--- or run keys minted before agent_definition_id existed (callers fall
+-- or run keys minted before workflow_id existed (callers fall
 -- back to parsing the slug from the key name).
 SELECT ad.id, ad.short_id, ad.name, ad.slug
 FROM api_keys ak
-JOIN workflows ad ON ad.id = ak.agent_definition_id
+JOIN workflows ad ON ad.id = ak.workflow_id
 WHERE ak.id = $1;
 
 -- name: GetApiKeyByPrefix :one

--- a/internal/db/queries/mcp_sessions.sql
+++ b/internal/db/queries/mcp_sessions.sql
@@ -58,3 +58,14 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
 SELECT * FROM mcp_tool_calls
 WHERE session_id = $1
 ORDER BY created_at ASC;
+
+-- name: DeleteMcpToolCallsOlderThan :execresult
+DELETE FROM mcp_tool_calls
+WHERE created_at < $1;
+
+-- name: DeleteMcpSessionsOlderThan :execresult
+DELETE FROM mcp_sessions
+WHERE mcp_sessions.created_at < $1
+  AND NOT EXISTS (
+    SELECT 1 FROM mcp_tool_calls WHERE session_id = mcp_sessions.id
+  );

--- a/internal/db/queries/transaction_provider_payloads.sql
+++ b/internal/db/queries/transaction_provider_payloads.sql
@@ -1,0 +1,12 @@
+-- name: UpsertTransactionProviderPayload :exec
+-- Stores the raw provider payload for a transaction in the 1:1 satellite table,
+-- keeping the heavy JSONB off the hot transactions row. Called right after the
+-- transaction upsert, only when a non-empty payload is available.
+INSERT INTO transaction_provider_payloads (transaction_id, provider_raw, updated_at)
+VALUES ($1, $2, now())
+ON CONFLICT (transaction_id) DO UPDATE SET
+  provider_raw = EXCLUDED.provider_raw,
+  updated_at = now();
+
+-- name: GetTransactionProviderPayload :one
+SELECT provider_raw FROM transaction_provider_payloads WHERE transaction_id = $1;

--- a/internal/db/queries/transactions.sql
+++ b/internal/db/queries/transactions.sql
@@ -7,9 +7,9 @@ INSERT INTO transactions (
   amount, iso_currency_code, date, authorized_date,
   datetime, authorized_datetime, provider_name, provider_merchant_name,
   provider_category_primary, provider_category_detailed, provider_category_confidence,
-  provider_payment_channel, pending, category_id, provider_raw, merchant_key
+  provider_payment_channel, pending, category_id, merchant_key
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
 )
 ON CONFLICT (provider_transaction_id) DO UPDATE SET
   account_id = EXCLUDED.account_id,
@@ -28,7 +28,6 @@ ON CONFLICT (provider_transaction_id) DO UPDATE SET
   provider_category_confidence = EXCLUDED.provider_category_confidence,
   provider_payment_channel = EXCLUDED.provider_payment_channel,
   pending = EXCLUDED.pending,
-  provider_raw = COALESCE(EXCLUDED.provider_raw, transactions.provider_raw),
   category_id = CASE
     WHEN transactions.category_override <> 'none' THEN transactions.category_id
     WHEN EXCLUDED.category_id IS NOT NULL THEN EXCLUDED.category_id

--- a/internal/db/queries/webhook_events.sql
+++ b/internal/db/queries/webhook_events.sql
@@ -8,3 +8,7 @@ UPDATE webhook_events SET status = $2, error_message = $3 WHERE id = $1;
 
 -- name: CountWebhookEvents :one
 SELECT COUNT(*) FROM webhook_events;
+
+-- name: DeleteWebhookEventsOlderThan :execresult
+DELETE FROM webhook_events
+WHERE created_at < $1;

--- a/internal/service/agent_cleanup_now_test.go
+++ b/internal/service/agent_cleanup_now_test.go
@@ -48,7 +48,7 @@ func TestRunCleanupNow(t *testing.T) {
 	mustInsertCompletedRun(t, q, defUUID, "0.01")
 	if _, err := pool.Exec(ctx,
 		`UPDATE workflow_runs SET started_at = $1, completed_at = $1
-		 WHERE agent_definition_id = $2`,
+		 WHERE workflow_id = $2`,
 		time.Now().AddDate(0, 0, -40), defUUID); err != nil {
 		t.Fatalf("backdate first row: %v", err)
 	}

--- a/internal/service/agent_identity_test.go
+++ b/internal/service/agent_identity_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestMintRunAPIKey_CarriesDefinitionIdentity is the core of the
 // identity-convergence fix: a minted per-run key must carry the agent's
-// DISPLAY name (def.Name) as actor_name and a durable agent_definition_id
+// DISPLAY name (def.Name) as actor_name and a durable workflow_id
 // link, so every write the run makes resolves to one canonical identity
 // (definition name + slug-seeded avatar) instead of the SDK's clientInfo.
 func TestMintRunAPIKey_CarriesDefinitionIdentity(t *testing.T) {
@@ -33,8 +33,8 @@ func TestMintRunAPIKey_CarriesDefinitionIdentity(t *testing.T) {
 	if !key.ActorName.Valid || key.ActorName.String != def.Name {
 		t.Errorf("actor_name = %q, want def.Name %q", key.ActorName.String, def.Name)
 	}
-	if !key.AgentDefinitionID.Valid {
-		t.Fatalf("agent_definition_id not set on minted run key")
+	if !key.WorkflowID.Valid {
+		t.Fatalf("workflow_id not set on minted run key")
 	}
 
 	// The key resolves to the definition's slug — the avatar seed shared
@@ -73,7 +73,7 @@ func TestResolveAgentSlugForActor_NonAgentKey(t *testing.T) {
 }
 
 // TestResolveAgentSlugForActor_FallbackFromKeyName covers the
-// slug-from-name fallback: an agent key with NO agent_definition_id link
+// slug-from-name fallback: an agent key with NO workflow_id link
 // (definition deleted via ON DELETE SET NULL, or a run key minted before
 // the FK existed) still resolves to its slug from the immutable key name,
 // so the agent's avatar keeps rendering instead of falling to the bot tile.
@@ -85,7 +85,7 @@ func TestResolveAgentSlugForActor_FallbackFromKeyName(t *testing.T) {
 		Name:      "agent:orphan-slug:Run99",
 		Scope:     "full_access",
 		ActorType: "agent",
-		// deliberately no AgentDefinitionID — simulates a deleted/pre-FK link
+		// deliberately no WorkflowID — simulates a deleted/pre-FK link
 	})
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -630,7 +630,7 @@ func TestHouseholdCostSince(t *testing.T) {
 
 	ins := func(status string, cost string, age string) {
 		_, err := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status,total_cost_usd,started_at)
 			 VALUES ($1,'cron',$2,$3, NOW() - $4::interval)`,
 			def.ID, status, cost, age)
 		if err != nil {
@@ -664,7 +664,7 @@ func TestRunOrSkip_HouseholdCeiling(t *testing.T) {
 	}
 	for _, c := range []string{"0.07", "0.06"} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status,total_cost_usd,started_at)
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status,total_cost_usd,started_at)
 			 VALUES ($1,'cron','success',$2, NOW())`, def.ID, c); err != nil {
 			t.Fatalf("insert run: %v", err)
 		}

--- a/internal/service/agent_recent_cap_test.go
+++ b/internal/service/agent_recent_cap_test.go
@@ -32,7 +32,7 @@ func TestListAgentDefinitions_PopulatesRecentCapStats(t *testing.T) {
 
 	// Mark the two most-recent rows as capped.
 	rows, err := q.ListAgentRuns(ctx, db.ListAgentRunsParams{
-		AgentDefinitionID: defUUID,
+		WorkflowID: defUUID,
 		Limit:             5,
 		Offset:            0,
 	})

--- a/internal/service/agent_recent_errors_test.go
+++ b/internal/service/agent_recent_errors_test.go
@@ -29,7 +29,7 @@ func TestListRecentErroredAgentRuns_OnlyRecentErrors(t *testing.T) {
 	mkRun := func(status string, startedAt time.Time, errMsg string) {
 		t.Helper()
 		row, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
-			AgentDefinitionID: defUUID,
+			WorkflowID: defUUID,
 			Trigger:           "manual",
 		})
 		if err != nil {

--- a/internal/service/agent_webhook_trigger_test.go
+++ b/internal/service/agent_webhook_trigger_test.go
@@ -30,7 +30,7 @@ func TestFireSyncCompleteAgents_OnlyFiresEligible(t *testing.T) {
 
 	fired := make(chan string, 4)
 	runner := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
-		fired <- spec.AgentDefinitionID
+		fired <- spec.WorkflowID
 		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
 	})
 	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
@@ -118,7 +118,7 @@ func TestFireSyncCompleteAgents_DebouncesRecentRun(t *testing.T) {
 
 	// A recent non-skipped run anchors the debounce window.
 	if _, err := pool.Exec(context.Background(),
-		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status,started_at)
+		`INSERT INTO workflow_runs (workflow_id,"trigger",status,started_at)
 		 VALUES ($1,'webhook','success', NOW())`, def.ID); err != nil {
 		t.Fatalf("seed recent run: %v", err)
 	}

--- a/internal/service/agents.go
+++ b/internal/service/agents.go
@@ -176,7 +176,7 @@ type AgentRunSummary struct {
 type AgentRunResponse struct {
 	ID                  string   `json:"id"`
 	ShortID             string   `json:"short_id"`
-	AgentDefinitionID   *string  `json:"agent_definition_id,omitempty"`
+	WorkflowID   *string  `json:"workflow_id,omitempty"`
 	Trigger             string   `json:"trigger"`
 	Status              string   `json:"status"`
 	StartedAt           string   `json:"started_at"`
@@ -365,7 +365,7 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 	statsByID := make(map[string]AgentCostStats, len(statsRows))
 	for _, r := range statsRows {
 		cost, _ := pgconv.NumericToFloat(r.TotalCostUsd)
-		statsByID[pgconv.FormatUUID(r.AgentDefinitionID)] = AgentCostStats{
+		statsByID[pgconv.FormatUUID(r.WorkflowID)] = AgentCostStats{
 			RunCount:     int(r.RunCount),
 			TotalCostUSD: cost,
 		}
@@ -379,7 +379,7 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 	}
 	errStatsByID := make(map[string]AgentRecentErrorStats, len(errStatsRows))
 	for _, r := range errStatsRows {
-		errStatsByID[pgconv.FormatUUID(r.AgentDefinitionID)] = AgentRecentErrorStats{
+		errStatsByID[pgconv.FormatUUID(r.WorkflowID)] = AgentRecentErrorStats{
 			ErrorCount: int(r.ErrorCount),
 			RunCount:   int(r.RunCount),
 		}
@@ -394,7 +394,7 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 	}
 	capStatsByID := make(map[string]AgentRecentCapStats, len(capStatsRows))
 	for _, r := range capStatsRows {
-		capStatsByID[pgconv.FormatUUID(r.AgentDefinitionID)] = AgentRecentCapStats{
+		capStatsByID[pgconv.FormatUUID(r.WorkflowID)] = AgentRecentCapStats{
 			CapCount: int(r.CapCount),
 			RunCount: int(r.RunCount),
 		}
@@ -411,7 +411,7 @@ func (s *Service) ListAgentDefinitions(ctx context.Context) ([]AgentDefinitionRe
 	prefixByID := make(map[string]string, len(prefixRows))
 	for _, r := range prefixRows {
 		if r.PromptPrefix.Valid && r.PromptPrefix.String != "" {
-			prefixByID[pgconv.FormatUUID(r.AgentDefinitionID)] = r.PromptPrefix.String
+			prefixByID[pgconv.FormatUUID(r.WorkflowID)] = r.PromptPrefix.String
 		}
 	}
 
@@ -704,7 +704,7 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 	}
 
 	args := []any{def.ID}
-	where := []string{"agent_definition_id = $1"}
+	where := []string{"workflow_id = $1"}
 	idx := 2
 	if p.Status != "" {
 		where = append(where, fmt.Sprintf("status = $%d", idx))
@@ -740,7 +740,7 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 	// Peek for has_more by asking for limit+1.
 	args = append(args, limit+1, offset)
 	query := fmt.Sprintf(`
-		SELECT id, short_id, agent_definition_id, "trigger", status, started_at, completed_at,
+		SELECT id, short_id, workflow_id, "trigger", status, started_at, completed_at,
 		       duration_ms, total_cost_usd, input_tokens, output_tokens, cache_read_tokens,
 		       cache_creation_tokens, turn_count, max_turns_used, num_tool_calls,
 		       error_message, transcript_path, session_id,
@@ -761,7 +761,7 @@ func (s *Service) ListAgentRuns(ctx context.Context, agentSlugOrID string, p Age
 	for rows.Next() {
 		var r db.WorkflowRun
 		if scanErr := rows.Scan(
-			&r.ID, &r.ShortID, &r.AgentDefinitionID, &r.Trigger, &r.Status,
+			&r.ID, &r.ShortID, &r.WorkflowID, &r.Trigger, &r.Status,
 			&r.StartedAt, &r.CompletedAt, &r.DurationMs, &r.TotalCostUsd,
 			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens,
 			&r.CacheCreationTokens, &r.TurnCount, &r.MaxTurnsUsed,
@@ -895,7 +895,7 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 		if err != nil {
 			return nil, err
 		}
-		where = append(where, fmt.Sprintf("r.agent_definition_id = $%d", idx))
+		where = append(where, fmt.Sprintf("r.workflow_id = $%d", idx))
 		args = append(args, def.ID)
 		idx++
 	}
@@ -943,14 +943,14 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 	// Peek for has_more by asking for limit+1.
 	args = append(args, limit+1, offset)
 	query := fmt.Sprintf(`
-		SELECT r.id, r.short_id, r.agent_definition_id, r."trigger", r.status, r.started_at, r.completed_at,
+		SELECT r.id, r.short_id, r.workflow_id, r."trigger", r.status, r.started_at, r.completed_at,
 		       r.duration_ms, r.total_cost_usd, r.input_tokens, r.output_tokens, r.cache_read_tokens,
 		       r.cache_creation_tokens, r.turn_count, r.max_turns_used, r.num_tool_calls,
 		       r.error_message, r.transcript_path, r.session_id,
 		       r.operator_note, r.prompt_prefix, r.hit_cap, r.model,
 		       d.slug, d.name
 		FROM workflow_runs r
-		JOIN workflows d ON d.id = r.agent_definition_id
+		JOIN workflows d ON d.id = r.workflow_id
 		%s
 		ORDER BY r.started_at DESC
 		LIMIT $%d OFFSET $%d`,
@@ -967,7 +967,7 @@ func (s *Service) ListAllAgentRuns(ctx context.Context, p AllAgentRunListParams)
 		var r db.WorkflowRun
 		var slug, name string
 		if scanErr := rows.Scan(
-			&r.ID, &r.ShortID, &r.AgentDefinitionID, &r.Trigger, &r.Status,
+			&r.ID, &r.ShortID, &r.WorkflowID, &r.Trigger, &r.Status,
 			&r.StartedAt, &r.CompletedAt, &r.DurationMs, &r.TotalCostUsd,
 			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens,
 			&r.CacheCreationTokens, &r.TurnCount, &r.MaxTurnsUsed,
@@ -1019,11 +1019,11 @@ func (s *Service) WorkflowRunStatusCounts(ctx context.Context, workflowSlugOrID 
 			// bad workflow filter rather than erroring).
 			return map[string]int{}, nil
 		}
-		where = append(where, "r.agent_definition_id = $1")
+		where = append(where, "r.workflow_id = $1")
 		args = append(args, def.ID)
 	}
 	query := "SELECT r.status, COUNT(*) FROM workflow_runs r " +
-		"JOIN workflows d ON d.id = r.agent_definition_id"
+		"JOIN workflows d ON d.id = r.workflow_id"
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")
 	}
@@ -1100,7 +1100,7 @@ func (s *Service) notifyDefinitionChanged() {
 // add_model_to_workflow_runs migration.
 func (s *Service) CreateAgentRunDB(ctx context.Context, defID pgtype.UUID, trigger, model string) (db.WorkflowRun, error) {
 	return s.Queries.CreateAgentRun(ctx, db.CreateAgentRunParams{
-		AgentDefinitionID: defID,
+		WorkflowID: defID,
 		Trigger:           trigger,
 		Model:             model,
 	})
@@ -1216,7 +1216,7 @@ func (s *Service) MintRunAPIKey(ctx context.Context, def *AgentDefinitionRespons
 	// ActorName is the agent's DISPLAY name (def.Name) — every write the
 	// run makes stamps this, so the feed reads "Routine Review" rather
 	// than the slug or the SDK's generic "claude-code" clientInfo.
-	// AgentDefinitionID is the durable link that lets any of the run's
+	// WorkflowID is the durable link that lets any of the run's
 	// activity resolve back to this one definition (name + slug avatar).
 	// The slug still lives in the key Name for the avatar seed.
 	return s.CreateAPIKey(ctx, CreateAPIKeyParams{
@@ -1224,7 +1224,7 @@ func (s *Service) MintRunAPIKey(ctx context.Context, def *AgentDefinitionRespons
 		Scope:             scope,
 		ActorType:         "agent",
 		ActorName:         def.Name,
-		AgentDefinitionID: def.ID,
+		WorkflowID: def.ID,
 	})
 }
 
@@ -1344,7 +1344,7 @@ func (s *Service) AssembleJobSpec(ctx context.Context, def *AgentDefinitionRespo
 
 	spec := &agent.JobSpec{
 		RunID:             run.ID,
-		AgentDefinitionID: def.ID,
+		WorkflowID: def.ID,
 		Prompt:            def.Prompt,
 		SystemPrompt:      systemPrompt,
 		Model:             def.Model,
@@ -1549,14 +1549,14 @@ func agentDefinitionFromRow(row db.Workflow, lastRun *AgentRunSummary) AgentDefi
 
 func agentRunFromRow(row db.WorkflowRun) AgentRunResponse {
 	var defID *string
-	if row.AgentDefinitionID.Valid {
-		s := pgconv.FormatUUID(row.AgentDefinitionID)
+	if row.WorkflowID.Valid {
+		s := pgconv.FormatUUID(row.WorkflowID)
 		defID = &s
 	}
 	return AgentRunResponse{
 		ID:                  pgconv.FormatUUID(row.ID),
 		ShortID:             row.ShortID,
-		AgentDefinitionID:   defID,
+		WorkflowID:   defID,
 		Trigger:             row.Trigger,
 		Status:              row.Status,
 		StartedAt:           pgconv.TimestampStr(row.StartedAt),

--- a/internal/service/agents_test.go
+++ b/internal/service/agents_test.go
@@ -374,7 +374,7 @@ func TestListAgentDefinitions_PopulatesCostStats30d(t *testing.T) {
 func mustInsertCompletedRun(t *testing.T, q *db.Queries, defID pgtype.UUID, costStr string) {
 	t.Helper()
 	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
-		AgentDefinitionID: defID,
+		WorkflowID: defID,
 		Trigger:           "manual",
 	})
 	if err != nil {
@@ -406,7 +406,7 @@ func mustInsertCompletedRun(t *testing.T, q *db.Queries, defID pgtype.UUID, cost
 func mustInsertSkippedRun(t *testing.T, q *db.Queries, defID pgtype.UUID) {
 	t.Helper()
 	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
-		AgentDefinitionID: defID,
+		WorkflowID: defID,
 		Trigger:           "cron",
 	})
 	if err != nil {
@@ -502,7 +502,7 @@ func TestListAgentDefinitions_NoPrefixedRuns_LeavesLastPromptPrefixNil(t *testin
 func mustInsertRunWithPrefix(t *testing.T, q *db.Queries, defID pgtype.UUID, prefix string) {
 	t.Helper()
 	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
-		AgentDefinitionID: defID,
+		WorkflowID: defID,
 		Trigger:           "manual",
 	})
 	if err != nil {

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -32,11 +32,11 @@ type CreateAPIKeyParams struct {
 	Scope     string
 	ActorType string // "user" | "agent" | "system"; defaults to "user"
 	ActorName string // optional display name, falls back to Name
-	// AgentDefinitionID links a per-run agent key back to the
+	// WorkflowID links a per-run agent key back to the
 	// agent_definition it runs for (UUID string; empty for non-agent
 	// keys). Set by MintRunAPIKey so all of an agent's activity resolves
 	// to one canonical identity. See GetAgentIdentityByApiKeyID.
-	AgentDefinitionID string
+	WorkflowID string
 }
 
 // CreateAPIKey mints a new API key and returns the full record plus the
@@ -90,10 +90,10 @@ func (s *Service) CreateAPIKey(ctx context.Context, p CreateAPIKeyParams) (*Crea
 		actorName = pgtype.Text{String: p.ActorName, Valid: true}
 	}
 	var agentDefID pgtype.UUID
-	if p.AgentDefinitionID != "" {
+	if p.WorkflowID != "" {
 		var err error
-		if agentDefID, err = pgconv.ParseUUID(p.AgentDefinitionID); err != nil {
-			return nil, fmt.Errorf("invalid agent_definition_id: %w", err)
+		if agentDefID, err = pgconv.ParseUUID(p.WorkflowID); err != nil {
+			return nil, fmt.Errorf("invalid workflow_id: %w", err)
 		}
 	}
 	apiKey, err := s.Queries.CreateApiKey(ctx, db.CreateApiKeyParams{
@@ -103,7 +103,7 @@ func (s *Service) CreateAPIKey(ctx context.Context, p CreateAPIKeyParams) (*Crea
 		Scope:             scope,
 		ActorType:         actorType,
 		ActorName:         actorName,
-		AgentDefinitionID: agentDefID,
+		WorkflowID: agentDefID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create api key: %w", err)
@@ -196,7 +196,7 @@ func (s *Service) ValidateAPIKey(ctx context.Context, key string) (*db.ApiKey, e
 
 // ResolveAgentSlugForActor returns the agent_definition slug an actor
 // (an api_keys UUID) runs for, when that key is a per-run agent key
-// linked to a definition (set at mint via agent_definition_id). The slug
+// linked to a definition (set at mint via workflow_id). The slug
 // is the avatar seed, so an agent's robot is identical everywhere its
 // activity surfaces. ok=false for non-agent actors, external mcp-client
 // identities, and keys with no definition link.
@@ -211,7 +211,7 @@ func (s *Service) ResolveAgentSlugForActor(ctx context.Context, actorID string) 
 	if row, rerr := s.Queries.GetAgentIdentityByApiKeyID(ctx, uid); rerr == nil {
 		return row.Slug, true
 	}
-	// No live definition link — the key's agent_definition_id is NULL
+	// No live definition link — the key's workflow_id is NULL
 	// because the definition was deleted (ON DELETE SET NULL) or the run
 	// key predates the column. Recover the slug from the immutable key
 	// name ("agent:<slug>:<runID>") so the agent's avatar still renders.

--- a/internal/service/csv_import.go
+++ b/internal/service/csv_import.go
@@ -245,12 +245,20 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 			ProviderPaymentChannel:  pgconv.Text("other"),
 			Pending:                 false,
 			CategoryID:              categoryID,
-			ProviderRaw:             providerRaw,
 		})
 		if err != nil {
 			result.SkippedCount++
 			result.SkipReasons = append(result.SkipReasons, fmt.Sprintf("row %d: database error: %s", rowNum, err.Error()))
 			continue
+		}
+		// Raw CSV row payload lives in the 1:1 satellite table (off the hot ledger).
+		if len(providerRaw) > 0 {
+			if err := s.Queries.UpsertTransactionProviderPayload(ctx, db.UpsertTransactionProviderPayloadParams{
+				TransactionID: txn.ID,
+				ProviderRaw:   providerRaw,
+			}); err != nil {
+				s.Logger.Warn("csv import: failed to store provider payload", "txn", txn.ShortID, "error", err)
+			}
 		}
 
 		// Determine if this was an insert or update by comparing timestamps.

--- a/internal/service/post_sync_debounce_integration_test.go
+++ b/internal/service/post_sync_debounce_integration_test.go
@@ -39,7 +39,7 @@ func TestT11_FireSyncCompleteAgents_DebounceWindow(t *testing.T) {
 	// Seed a recent non-skipped run for the within-window agent.
 	// started_at = NOW() places it squarely inside PostSyncDebounceWindow.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, started_at)
 		 VALUES ($1, 'webhook', 'success', NOW())`,
 		defInWindow.ID,
 	); err != nil {
@@ -51,7 +51,7 @@ func TestT11_FireSyncCompleteAgents_DebounceWindow(t *testing.T) {
 	// even under slow test-execution clock drift.
 	oldAge := 2 * service.PostSyncDebounceWindow
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, started_at)
 		 VALUES ($1, 'webhook', 'success', NOW() - $2::interval)`,
 		defOutWindow.ID, oldAge.String(),
 	); err != nil {
@@ -61,7 +61,7 @@ func TestT11_FireSyncCompleteAgents_DebounceWindow(t *testing.T) {
 	// Channel buffered to 4 to catch unexpected extra fires without blocking.
 	fired := make(chan string, 4)
 	runner := agent.RunnerFunc(func(_ context.Context, spec agent.JobSpec, _ agent.EventHandler) (agent.RunResult, error) {
-		fired <- spec.AgentDefinitionID
+		fired <- spec.WorkflowID
 		return agent.RunResult{Status: agent.StatusSuccess, DurationMs: 1}, nil
 	})
 	orch := service.NewOrchestrator(svc, runner, 3, encKey, slog.Default())
@@ -107,7 +107,7 @@ func TestT11_FireSyncCompleteAgents_SkippedRunDoesNotDebounce(t *testing.T) {
 	// Seed a skipped run inside the debounce window.
 	// A skipped status must NOT suppress the next sync-complete dispatch.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, started_at)
 		 VALUES ($1, 'webhook', 'skipped', NOW())`,
 		def.ID,
 	); err != nil {

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -132,7 +132,7 @@ func (s *Service) CreateAgentReport(ctx context.Context, title, body string, act
 		Tags:          tags,
 		Author:        pgconv.TextIfNotEmpty(author),
 		SessionID:     sessUUID,
-		AgentRunID:    runUUID,
+		WorkflowRunID:    runUUID,
 	})
 	if err != nil {
 		return AgentReportResponse{}, fmt.Errorf("create agent report: %w", err)
@@ -201,10 +201,10 @@ func (s *Service) ListReportSummariesForRunIDs(ctx context.Context, runIDs []str
 		return nil, fmt.Errorf("list report summaries for runs: %w", err)
 	}
 	for _, r := range rows {
-		if !r.AgentRunID.Valid {
+		if !r.WorkflowRunID.Valid {
 			continue
 		}
-		runID := pgconv.FormatUUID(r.AgentRunID)
+		runID := pgconv.FormatUUID(r.WorkflowRunID)
 		out[runID] = append(out[runID], AgentRunReportSummary{
 			ShortID:  r.ShortID,
 			Title:    r.Title,

--- a/internal/service/spend_ceiling_enforcement_integration_test.go
+++ b/internal/service/spend_ceiling_enforcement_integration_test.go
@@ -53,7 +53,7 @@ func TestT10_SpendCeilingEnforcement_ManualRunReturnsError(t *testing.T) {
 	// Seed two completed runs whose costs sum to $0.13 — over the ceiling.
 	for _, cost := range []string{"0.07", "0.06"} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+			`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 			 VALUES ($1, 'cron', 'success', $2, NOW())`,
 			def.ID, cost,
 		); err != nil {
@@ -98,7 +98,7 @@ func TestT10_SpendCeilingEnforcement_CronPathLeavesSkippedRow(t *testing.T) {
 	// Seed a run at exactly the ceiling amount. The gate condition is spent >= ceiling,
 	// so $0.05 spent against a $0.05 ceiling must block the next run.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 		 VALUES ($1, 'cron', 'success', $2, NOW())`,
 		def.ID, "0.05",
 	); err != nil {
@@ -152,7 +152,7 @@ func TestT10_SpendCeilingEnforcement_UnsetCeilingNoCap(t *testing.T) {
 	// Seed a large spend. If checkHouseholdCeiling correctly returns nil for
 	// an unset key, this spend must not block the run.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 		 VALUES ($1, 'cron', 'success', $2, NOW())`,
 		def.ID, "999.99",
 	); err != nil {
@@ -191,7 +191,7 @@ func TestT10_SpendCeilingEnforcement_ZeroCeilingNoCap(t *testing.T) {
 
 	// Seed spend that would block a naive zero-ceiling implementation.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 		 VALUES ($1, 'cron', 'success', $2, NOW())`,
 		def.ID, "50.00",
 	); err != nil {
@@ -227,7 +227,7 @@ func TestT10_SpendCeilingEnforcement_SpendUnderCeilingAllowsRun(t *testing.T) {
 
 	// Seed $0.10 worth of runs — well under the $1.00 ceiling.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 		 VALUES ($1, 'cron', 'success', $2, NOW())`,
 		def.ID, "0.10",
 	); err != nil {
@@ -267,7 +267,7 @@ func TestT10_SpendCeilingEnforcement_SkippedRunsExcludedFromSpend(t *testing.T) 
 	// Insert a skipped run with an inflated cost value. In practice skipped
 	// rows carry no real cost, but this explicitly guards the exclusion logic.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 		 VALUES ($1, 'cron', 'skipped', $2, NOW())`,
 		def.ID, "5.00",
 	); err != nil {
@@ -276,7 +276,7 @@ func TestT10_SpendCeilingEnforcement_SkippedRunsExcludedFromSpend(t *testing.T) 
 
 	// Also insert a small real-cost run well under the ceiling.
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status, total_cost_usd, started_at)
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status, total_cost_usd, started_at)
 		 VALUES ($1, 'cron', 'success', $2, NOW())`,
 		def.ID, "0.02",
 	); err != nil {

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -211,7 +211,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	argN := 1
 
 	buf.WriteString("SELECT t.id, t.short_id, t.provider_transaction_id, t.provider_pending_transaction_id, " +
-		"t.amount, t.iso_currency_code, t.unofficial_currency_code, t.date, t.authorized_date, " +
+		"t.amount, t.iso_currency_code, t.date, t.authorized_date, " +
 		"t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name, " +
 		"t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence, " +
 		"t.provider_payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
@@ -436,7 +436,6 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			pendingTransactionID   pgtype.Text
 			amount                 pgtype.Numeric
 			isoCurrencyCode        pgtype.Text
-			unofficialCurrencyCode pgtype.Text
 			date                   pgtype.Date
 			authorizedDate         pgtype.Date
 			datetime               pgtype.Timestamptz
@@ -471,7 +470,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 
 		if err := rows.Scan(
 			&id, &shortID, &externalTransactionID, &pendingTransactionID,
-			&amount, &isoCurrencyCode, &unofficialCurrencyCode,
+			&amount, &isoCurrencyCode,
 			&date, &authorizedDate, &datetime, &authorizedDatetime,
 			&name, &merchantName, &categoryPrimary, &categoryDetailed,
 			&categoryConfidence, &paymentChannel, &pending,

--- a/internal/service/transactions_bench_test.go
+++ b/internal/service/transactions_bench_test.go
@@ -24,7 +24,7 @@ func benchBuildListTransactionsQuery(params benchListParams) (string, []any) {
 	argN := 1
 
 	buf.WriteString("SELECT t.id, t.short_id, t.account_id, t.external_transaction_id, t.pending_transaction_id, " +
-		"t.amount, t.iso_currency_code, t.unofficial_currency_code, t.date, t.authorized_date, " +
+		"t.amount, t.iso_currency_code, t.date, t.authorized_date, " +
 		"t.datetime, t.authorized_datetime, t.name, t.merchant_name, " +
 		"t.category_primary, t.category_detailed, t.category_confidence, " +
 		"t.payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +

--- a/internal/service/workflow_actions_integration_test.go
+++ b/internal/service/workflow_actions_integration_test.go
@@ -19,7 +19,7 @@ import (
 func f1MustInsertCompletedRun(t *testing.T, q *db.Queries, defID pgtype.UUID) {
 	t.Helper()
 	run, err := q.CreateAgentRun(context.Background(), db.CreateAgentRunParams{
-		AgentDefinitionID: defID,
+		WorkflowID: defID,
 		Trigger:           "manual",
 	})
 	if err != nil {

--- a/internal/service/workflow_presets_integration_test.go
+++ b/internal/service/workflow_presets_integration_test.go
@@ -137,7 +137,7 @@ func TestListAllAgentRuns_WorkflowsOnly(t *testing.T) {
 	// One run apiece. short_id/id/started_at are DB-defaulted.
 	for _, defID := range []string{wf.ID, plain.ID} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			`INSERT INTO workflow_runs (workflow_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
 			defID); err != nil {
 			t.Fatalf("insert run for %s: %v", defID, err)
 		}
@@ -205,7 +205,7 @@ func TestWorkflowRunStatusCounts(t *testing.T) {
 
 	ins := func(defID, status string) {
 		if _, e := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron',$2)`,
 			defID, status); e != nil {
 			t.Fatalf("insert run: %v", e)
 		}

--- a/internal/service/workflow_run_report_summary_integration_test.go
+++ b/internal/service/workflow_run_report_summary_integration_test.go
@@ -47,7 +47,7 @@ func T22_mustCreateRunWithReports(
 
 	// Insert a run row.
 	run, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
-		AgentDefinitionID: defUUID,
+		WorkflowID: defUUID,
 		Trigger:           "manual",
 	})
 	if err != nil {
@@ -150,7 +150,7 @@ func T22TestListReportSummariesForRunIDs_RunWithNoReports(t *testing.T) {
 		t.Fatalf("T22: parse def UUID: %v", err)
 	}
 	run, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
-		AgentDefinitionID: defUUID,
+		WorkflowID: defUUID,
 		Trigger:           "manual",
 	})
 	if err != nil {
@@ -195,7 +195,7 @@ func T22TestListReportSummariesForRunIDs_MixedBatch(t *testing.T) {
 		t.Fatalf("T22: parse defB UUID: %v", err)
 	}
 	runB, err := q.CreateAgentRun(ctx, db.CreateAgentRunParams{
-		AgentDefinitionID: defBUUID,
+		WorkflowID: defBUUID,
 		Trigger:           "cron",
 	})
 	if err != nil {

--- a/internal/service/workflow_run_status_counts_integration_test.go
+++ b/internal/service/workflow_run_status_counts_integration_test.go
@@ -41,7 +41,7 @@ func TestT7WorkflowRunStatusCounts_CustomWorkflowIncluded(t *testing.T) {
 
 	// Insert a run for the custom workflow (no preset backing).
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'manual','success')`,
+		`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'manual','success')`,
 		custom.ID); err != nil {
 		t.Fatalf("insert custom run: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestT7WorkflowRunStatusCounts_SinglePreset(t *testing.T) {
 	ins := func(status string) {
 		t.Helper()
 		if _, e := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron',$2)`,
 			wf.ID, status); e != nil {
 			t.Fatalf("insert run (status=%s): %v", status, e)
 		}
@@ -121,7 +121,7 @@ func TestT7WorkflowRunStatusCounts_AllStatuses(t *testing.T) {
 
 	for _, status := range []string{"in_progress", "success", "error", "timeout", "skipped"} {
 		if _, e := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron',$2)`,
 			wf.ID, status); e != nil {
 			t.Fatalf("insert run (status=%s): %v", status, e)
 		}
@@ -157,7 +157,7 @@ func TestT7WorkflowRunStatusCounts_ScopedBySlug(t *testing.T) {
 	ins := func(defID, status string) {
 		t.Helper()
 		if _, e := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron',$2)`,
 			defID, status); e != nil {
 			t.Fatalf("insert run: %v", e)
 		}
@@ -210,7 +210,7 @@ func TestT7WorkflowRunStatusCounts_ScopedByShortID(t *testing.T) {
 	}
 
 	if _, e := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron','success')`,
+		`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron','success')`,
 		wf.ID); e != nil {
 		t.Fatalf("insert run: %v", e)
 	}
@@ -241,7 +241,7 @@ func TestT7WorkflowRunStatusCounts_UnknownFilter(t *testing.T) {
 	}
 
 	if _, e := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron','success')`,
+		`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron','success')`,
 		wf.ID); e != nil {
 		t.Fatalf("insert run: %v", e)
 	}
@@ -277,7 +277,7 @@ func TestT7WorkflowRunStatusCounts_MultiPreset(t *testing.T) {
 	ins := func(defID, status string) {
 		t.Helper()
 		if _, e := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id,"trigger",status) VALUES ($1,'cron',$2)`,
+			`INSERT INTO workflow_runs (workflow_id,"trigger",status) VALUES ($1,'cron',$2)`,
 			defID, status); e != nil {
 			t.Fatalf("insert run: %v", e)
 		}

--- a/internal/service/workflow_runs_only_filter_integration_test.go
+++ b/internal/service/workflow_runs_only_filter_integration_test.go
@@ -21,7 +21,7 @@ func TestT8_WorkflowsOnly_PresetRunIncluded(t *testing.T) {
 		t.Fatalf("EnableWorkflowFromPreset: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
 		wf.ID); err != nil {
 		t.Fatalf("insert preset run: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestT8_WorkflowsOnly_NonPresetRunExcluded(t *testing.T) {
 
 	plain := mustCreateAgentDefinition(t, svc, "t8-plain-agent", true)
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+		`INSERT INTO workflow_runs (workflow_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
 		plain.ID); err != nil {
 		t.Fatalf("insert plain run: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestT8_WorkflowsOnly_UnfilteredIncludesBoth(t *testing.T) {
 
 	for _, defID := range []string{wf.ID, plain.ID} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			`INSERT INTO workflow_runs (workflow_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
 			defID); err != nil {
 			t.Fatalf("insert run for def %s: %v", defID, err)
 		}
@@ -116,7 +116,7 @@ func TestT8_WorkflowsOnly_OnlyPresetRunsReturnedAmongMixed(t *testing.T) {
 
 	for _, defID := range []string{wf.ID, plain.ID} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO workflow_runs (agent_definition_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
+			`INSERT INTO workflow_runs (workflow_id, "trigger", status) VALUES ($1, 'manual', 'success')`,
 			defID); err != nil {
 			t.Fatalf("insert run for def %s: %v", defID, err)
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -643,14 +643,27 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 		ProviderCategoryConfidence:   pgconv.TextPtrIfNotEmpty(txn.CategoryConfidence),
 		ProviderPaymentChannel:       pgconv.TextIfNotEmpty(txn.PaymentChannel),
 		Pending:                      txn.Pending,
-		ProviderRaw:                  txn.Raw,
 		// merchant_key: the normalized recurring-series detection anchor, set at
 		// sync time so going-forward rows are immediately groupable. NULL when no
 		// usable merchant signal (excluded from auto-detection). See merchantkey.go.
 		MerchantKey: pgconv.TextIfNotEmpty(MerchantKey(merchantName, txn.Name)),
 	}
 
-	return q.UpsertTransaction(ctx, params)
+	row, err := q.UpsertTransaction(ctx, params)
+	if err != nil {
+		return db.Transaction{}, err
+	}
+	// Raw provider payload lives in a 1:1 satellite table to keep the hot ledger
+	// lean. Written in the same sync tx, only when a payload is present.
+	if len(txn.Raw) > 0 {
+		if err := q.UpsertTransactionProviderPayload(ctx, db.UpsertTransactionProviderPayloadParams{
+			TransactionID: row.ID,
+			ProviderRaw:   txn.Raw,
+		}); err != nil {
+			return db.Transaction{}, fmt.Errorf("upsert provider payload for %s: %w", txn.ExternalID, err)
+		}
+	}
+	return row, nil
 }
 
 // applyRulesToTransaction evaluates rules against a transaction and applies

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -51,13 +51,15 @@ func (s *Scheduler) Start(fallbackIntervalMinutes int) {
 		return
 	}
 
-	// Daily sync log cleanup at 3:00 AM.
+	// Daily audit-log cleanup at 3:00 AM (sync logs, webhook events, MCP tool calls).
 	_, err = s.cron.AddFunc("0 3 * * *", func() {
 		ctx := context.Background()
 		s.cleanupSyncLogs(ctx)
+		s.cleanupWebhookEvents(ctx)
+		s.cleanupMcpAuditLog(ctx)
 	})
 	if err != nil {
-		s.logger.Error("failed to add sync log cleanup job", "error", err)
+		s.logger.Error("failed to add audit-log cleanup job", "error", err)
 	}
 
 	s.cron.Start()
@@ -267,5 +269,69 @@ func (s *Scheduler) cleanupSyncLogs(ctx context.Context) {
 		s.logger.Info("sync log cleanup completed", "deleted", deleted, "retention_days", retentionDays)
 	} else {
 		s.logger.Debug("sync log cleanup completed, no old logs to delete", "retention_days", retentionDays)
+	}
+}
+
+// defaultWebhookEventRetentionDays is used when webhook_event_retention_days is
+// not configured. Webhook payloads aren't persisted, so this audit trail is thin
+// and safe to prune quickly.
+const defaultWebhookEventRetentionDays = 7
+
+// defaultMcpToolCallRetentionDays is used when mcp_tool_call_retention_days is not
+// configured. These rows store full tool request/response JSON (possible PII), so
+// keep the horizon bounded.
+const defaultMcpToolCallRetentionDays = 30
+
+// cleanupWebhookEvents deletes webhook_events older than the configured retention
+// period (webhook_event_retention_days, default 7). A value of 0 disables cleanup.
+func (s *Scheduler) cleanupWebhookEvents(ctx context.Context) {
+	retentionDays := appconfig.Int(ctx, s.queries, appconfig.KeyWebhookEventRetentionDays, defaultWebhookEventRetentionDays)
+	if retentionDays < 0 {
+		retentionDays = defaultWebhookEventRetentionDays
+	}
+	if retentionDays == 0 {
+		s.logger.Debug("webhook event cleanup disabled (retention_days=0)")
+		return
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	result, err := s.queries.DeleteWebhookEventsOlderThan(ctx, pgtype.Timestamptz{Time: cutoff, Valid: true})
+	if err != nil {
+		s.logger.Error("webhook event cleanup failed", "error", err)
+		return
+	}
+	if deleted := result.RowsAffected(); deleted > 0 {
+		s.logger.Info("webhook event cleanup completed", "deleted", deleted, "retention_days", retentionDays)
+	}
+}
+
+// cleanupMcpAuditLog deletes mcp_tool_calls older than the configured retention
+// period (mcp_tool_call_retention_days, default 30), then prunes any mcp_sessions
+// older than the cutoff that no longer have child tool calls. A value of 0
+// disables cleanup. Tool-call rows hold full request/response JSON (possible PII).
+func (s *Scheduler) cleanupMcpAuditLog(ctx context.Context) {
+	retentionDays := appconfig.Int(ctx, s.queries, appconfig.KeyMcpToolCallRetentionDays, defaultMcpToolCallRetentionDays)
+	if retentionDays < 0 {
+		retentionDays = defaultMcpToolCallRetentionDays
+	}
+	if retentionDays == 0 {
+		s.logger.Debug("mcp audit cleanup disabled (retention_days=0)")
+		return
+	}
+
+	cutoff := pgtype.Timestamptz{Time: time.Now().AddDate(0, 0, -retentionDays), Valid: true}
+	callRes, err := s.queries.DeleteMcpToolCallsOlderThan(ctx, cutoff)
+	if err != nil {
+		s.logger.Error("mcp tool-call cleanup failed", "error", err)
+		return
+	}
+	sessRes, err := s.queries.DeleteMcpSessionsOlderThan(ctx, cutoff)
+	if err != nil {
+		s.logger.Error("mcp session cleanup failed", "error", err)
+		return
+	}
+	calls, sessions := callRes.RowsAffected(), sessRes.RowsAffected()
+	if calls > 0 || sessions > 0 {
+		s.logger.Info("mcp audit cleanup completed", "tool_calls_deleted", calls, "sessions_deleted", sessions, "retention_days", retentionDays)
 	}
 }


### PR DESCRIPTION
## v1 DB schema hardening — wave 1 (schema cleanup)

First PR of the v1 schema/API prep sprint. Audit + proposal in
`docs/v1-schema-api-proposal.md` (included here). This PR is the **schema-cleanup
half**; the (partial) enum cutover lands as a follow-up.

Every commit independently builds, vets, and passes its affected integration
tests against an **isolated scratch DB** (`breadbox_v1audit`) — no destructive
migration ever touched the shared `breadbox` / `breadbox_test` dev databases.

### What's in this PR

| Commit | Change |
|---|---|
| drop dead column | Removes `transactions.unofficial_currency_code` — a Plaid-era dual-currency field, never written by any provider and never read. |
| **agent→workflow rename** | Finishes migration `20260531120000` (which renamed the tables but left the FK columns "as-is to bound the change"): `workflow_runs.agent_definition_id → workflow_id`, `api_keys.agent_definition_id → workflow_id`, `agent_reports.agent_run_id → workflow_run_id` (+ indexes/constraints, sqlc columns, all Go call sites, the JobSpec/sidecar zod protocol field, and the service JSON tag). The subsystem now speaks one vocabulary. |
| retention jobs | Adds daily cleanup for `webhook_events` (default 7d) and `mcp_tool_calls` (default 30d, also prunes emptied `mcp_sessions`). Both grew unbounded before; tool-call rows hold full request/response JSON (possible user financial data). Mirrors the existing sync-log cleanup; `0` disables. |
| provider_raw → satellite | Moves `transactions.provider_raw` (write-only, never read) off the hot ledger into a 1:1 `transaction_provider_payloads` table, keeping row scans lean while preserving payloads for debugging/re-enrichment. |

### Deliberately NOT done (curated out of the original audit)

Code archaeology found several audit-flagged renames conflict with **deliberate
prior decisions**, so they're skipped (ratified during the sprint):

- **`category_override`** — team explicitly chose to "keep the name" in #1616/#1618; baked into shipped agent prompts + OpenAPI.
- **`bank_connections.external_id`** — deliberate Phase-8 generic rename from `plaid_item_id`, documented contract with a unique index.
- **`sync_logs.trigger → sync_trigger`** — low ROI; the column exists on two tables and "trigger" is heavily overloaded.
- **`annotations → transaction_events`** — ~386 refs + the MCP `list_annotations` tool is a public contract; the name reads fine for an activity log.

Also found already-handled: the "dead" `app_config` keys were removed by `00016`, the `attributed_user_id` index already exists, and the device-code CLI login (`breadbox auth login`) is already fully built — the audit was wrong that it's "half-wired".

### Follow-up (separate PR)

- **Partial enum cutover** (TEXT+CHECK → Postgres ENUM) for the low-cascade columns only. The high-cascade ones (e.g. `category_override`, ~136 refs) are skipped because their CHECK constraints already enforce the same value sets at the DB layer.

### Verification

- `go build ./...`, `go vet ./...` green.
- Affected integration suites (db, service, api, mcp, sync) pass on the scratch DB.
- All four schema migrations round-trip (up → down → up) cleanly.
- TS sidecar: the renamed zod field typechecks; pre-existing unrelated typecheck errors in `events.ts`/`index.ts` are noted, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
