### PR TITLE
refactor(settings): rename Workflows tab to Agents + regroup the rail

### DIFF
--- a/internal/admin/agent_api.go
+++ b/internal/admin/agent_api.go
@@ -285,7 +285,7 @@ func UpdateAgentRunNoteAdminHandler(svc *service.Service, sm *scs.SessionManager
 func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
-			FlashRedirect(w, r, sm, "error", "Invalid form data.", "/settings/workflows")
+			FlashRedirect(w, r, sm, "error", "Invalid form data.", "/settings/agents")
 			return
 		}
 
@@ -316,7 +316,7 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 		if v := strings.TrimSpace(r.FormValue("max_concurrent")); v != "" {
 			n, err := strconv.Atoi(v)
 			if err != nil || n < 1 || n > 50 {
-				FlashRedirect(w, r, sm, "error", "Max concurrent must be a whole number between 1 and 50.", "/settings/workflows")
+				FlashRedirect(w, r, sm, "error", "Max concurrent must be a whole number between 1 and 50.", "/settings/agents")
 				return
 			}
 			params.MaxConcurrent = &n
@@ -324,7 +324,7 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 		if v := strings.TrimSpace(r.FormValue("global_max_budget_usd")); v != "" {
 			f, err := strconv.ParseFloat(v, 64)
 			if err != nil || f < 0 {
-				FlashRedirect(w, r, sm, "error", "Global max budget must be a non-negative number.", "/settings/workflows")
+				FlashRedirect(w, r, sm, "error", "Global max budget must be a non-negative number.", "/settings/agents")
 				return
 			}
 			params.GlobalMaxBudgetUSD = &f
@@ -333,11 +333,11 @@ func UpdateAgentSDKSettingsAdminHandler(a *app.App, svc *service.Service, sm *sc
 			params.GlobalMaxBudgetUSD = &zero
 		}
 		if _, err := svc.UpdateAgentSettings(r.Context(), params, a.Config.EncryptionKey, a.Config.DataDir); err != nil {
-			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/workflows")
+			FlashRedirect(w, r, sm, "error", "Failed to save settings: "+err.Error(), "/settings/agents")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Agent settings saved.")
-		http.Redirect(w, r, "/settings/workflows", http.StatusSeeOther)
+		http.Redirect(w, r, "/settings/agents", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/agent_sdk_settings_page.go
+++ b/internal/admin/agent_sdk_settings_page.go
@@ -14,7 +14,7 @@ import (
 	"github.com/alexedwards/scs/v2"
 )
 
-// AgentSDKSettingsPageHandler serves GET /settings/workflows (or wherever
+// AgentSDKSettingsPageHandler serves GET /settings/agents (or wherever
 // router.go wires it) — the v1 admin "Workflows settings" tab for the
 // Claude Agent SDK runner. Distinct from the existing MCP settings page
 // at /settings/mcp (which lives in agents_settings.templ and configures
@@ -87,10 +87,10 @@ func AgentSDKSettingsPageHandler(a *app.App, svc *service.Service, sm *scs.Sessi
 			HouseholdSpend30dStr: formatHouseholdSpend(spend),
 		}
 
-		data := BaseTemplateData(r, sm, "workflows-settings", "Workflows settings")
+		data := BaseTemplateData(r, sm, "agents-settings", "Agents")
 		data["CSRFToken"] = props.CSRFToken
 		data["Flash"] = nil
-		renderSettingsTab(tr, w, r, data, pages.SettingsTabWorkflows, pages.AgentSDKSettings(props))
+		renderSettingsTab(tr, w, r, data, pages.SettingsTabAgents, pages.AgentSDKSettings(props))
 	}
 }
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -357,10 +357,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings/mcp", AgentsSettingsHandler(svc, mcpServer, sm, tr))
 		// Workflow runtime settings — Claude Agent SDK auth, sidecar, and run
 		// ceilings. Admin-only because tokens are sensitive and runs cost.
-		r.Get("/settings/workflows", AgentSDKSettingsPageHandler(a, svc, sm, tr))
+		r.Get("/settings/agents", AgentSDKSettingsPageHandler(a, svc, sm, tr))
 		r.Get("/settings/connectors", ConnectorsSettingsPageHandler(a, svc, sm, tr))
-		// Back-compat: the tab used to live at /settings/agents.
-		r.Get("/settings/agents", redirectGET("/settings/workflows"))
+		// Back-compat: the tab briefly lived at /settings/workflows.
+		r.Get("/settings/workflows", redirectGET("/settings/agents"))
 		r.Get("/agents-settings", redirectGET("/settings/mcp"))
 		r.Get("/mcp-getting-started", redirectGET("/workflows"))
 		r.Get("/agent-wizard", redirectGET("/workflows"))

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -247,7 +247,7 @@ func runAgentTest(parent context.Context) error {
 		case errors.Is(err, agent.ErrAuthNotConfigured):
 			fmt.Fprintln(os.Stdout, "  ✗ auth          not configured")
 			fmt.Fprintln(os.Stdout, "")
-			fmt.Fprintln(os.Stdout, "Open the admin Settings → Agents (/settings/workflows) and paste an Anthropic credential.")
+			fmt.Fprintln(os.Stdout, "Open the admin Settings → Agents (/settings/agents) and paste an Anthropic credential.")
 			fmt.Fprintln(os.Stdout, "For a subscription token: run `claude setup-token` on any machine, then paste the sk-ant-oat01-… into Settings.")
 			return silentlyFail(err)
 		case errors.Is(err, agent.ErrBinaryNotFound):

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -217,13 +217,13 @@ func navActive(current, page string) string {
 // tab. Each settings sub-page reports its own CurrentPage id rather than a
 // shared "settings" one (account → members.go; general/system/help →
 // settings.go; providers → providers.go; mcp → settings_agents.go;
-// workflows-settings → agent_sdk_settings_page.go; api-keys → apikeys.go;
+// agents-settings → agent_sdk_settings_page.go; api-keys → apikeys.go;
 // backups → backups.go), so a plain navActive(…, "settings") would never
 // match. Keep this set in sync with those handlers' currentPage values.
 func navSettingsActive(current string) string {
 	switch current {
 	case "account", "general", "system", "help", "providers",
-		"mcp", "workflows-settings", "api-keys", "backups":
+		"mcp", "agents-settings", "api-keys", "backups":
 		return "bb-sidebar-link--active"
 	}
 	return ""

--- a/internal/templates/components/pages/agent_sdk_settings.templ
+++ b/internal/templates/components/pages/agent_sdk_settings.templ
@@ -17,8 +17,8 @@ templ AgentSDKSettings(p AgentSDKSettingsProps) {
 	<script src="/static/js/admin/components/agent_sdk_settings.js"></script>
 	<div>
 		@settingsTabHeader(settingsTabHeaderProps{
-			Title:    "Workflows",
-			Subtitle: "Authentication, runtime, and spend controls that govern your workflow runs",
+			Title:    "Agents",
+			Subtitle: "Authentication, runtime, and spend controls that govern your agent runs",
 		})
 		if p.FormError != "" {
 			<div role="alert" class="alert alert-error alert-soft mb-4 rounded-xl">

--- a/internal/templates/components/pages/settings_page.templ
+++ b/internal/templates/components/pages/settings_page.templ
@@ -55,11 +55,13 @@ templ settingsPageRail(p SettingsPageProps) {
 				<div class="bb-settings-rail__group-label">Workspace</div>
 				@settingsRailItem(p, "general", "sliders-horizontal", "General")
 				@settingsRailItem(p, "system", "cpu", "System")
-				<div class="bb-settings-rail__group-label">Integrations</div>
-				@settingsRailItem(p, "providers", "plug", "Providers")
-				@settingsRailItem(p, "workflows", "sparkles", "Workflows")
-				@settingsRailItem(p, "connectors", "cable", "Connectors")
 				@settingsRailItem(p, "notifications", "bell", "Notifications")
+				<div class="bb-settings-rail__group-label">Data</div>
+				@settingsRailItem(p, "providers", "plug", "Providers")
+				@settingsRailItem(p, "backups", "hard-drive", "Backups")
+				<div class="bb-settings-rail__group-label">AI &amp; Agents</div>
+				@settingsRailItem(p, "agents", "bot", "Agents")
+				@settingsRailItem(p, "connectors", "cable", "Connectors")
 				@settingsRailItem(p, "mcp", "brand:model-context-protocol", "MCP")
 			}
 			if p.IsEditor {
@@ -69,8 +71,7 @@ templ settingsPageRail(p SettingsPageProps) {
 				@settingsRailItem(p, "api-keys", "key-round", "API Keys")
 			}
 			if p.IsAdmin {
-				<div class="bb-settings-rail__group-label">Maintenance</div>
-				@settingsRailItem(p, "backups", "hard-drive", "Backups")
+				<div class="bb-settings-rail__group-label">Support</div>
 				@settingsRailItem(p, "developer", "bug", "Developer")
 				@settingsRailItem(p, "help", "life-buoy", "Help")
 			}

--- a/internal/templates/components/pages/settings_tabs.go
+++ b/internal/templates/components/pages/settings_tabs.go
@@ -19,7 +19,7 @@ const (
 	SettingsTabGeneral       = components.SettingsModalTabGeneral
 	SettingsTabSystem        = components.SettingsModalTabSystem
 	SettingsTabProviders     = components.SettingsModalTabProviders
-	SettingsTabWorkflows     = components.SettingsModalTabWorkflows
+	SettingsTabAgents        = components.SettingsModalTabAgents
 	SettingsTabNotifications = components.SettingsModalTabNotifications
 	SettingsTabMCP           = components.SettingsModalTabMCP
 	SettingsTabConnectors    = components.SettingsModalTabConnectors

--- a/internal/templates/components/pages/workflows_gallery.templ
+++ b/internal/templates/components/pages/workflows_gallery.templ
@@ -32,7 +32,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 					<div class="font-semibold text-sm">Set up the agent runtime first</div>
 					<div class="text-xs opacity-80">Configure an Anthropic API key in Settings to actually run these workflows. You can still enable presets — they'll stay paused until the runtime is ready.</div>
 				</div>
-				<a href="/settings/workflows" class="btn btn-sm btn-ghost">Configure</a>
+				<a href="/settings/agents" class="btn btn-sm btn-ghost">Configure</a>
 			</div>
 		}
 		if p.Spend.Show {
@@ -43,7 +43,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 						<div class="font-semibold text-sm">Workflows paused — spend ceiling reached</div>
 						<div class="text-xs opacity-80">30-day spend { p.Spend.SpentStr } has reached your ceiling ({ p.Spend.CeilingStr }). New runs are paused until spend ages out of the window or you raise the ceiling.</div>
 					</div>
-					<a href="/settings/workflows" class="btn btn-sm btn-ghost">Adjust</a>
+					<a href="/settings/agents" class="btn btn-sm btn-ghost">Adjust</a>
 				</div>
 			} else {
 				<div role="alert" class="alert alert-soft alert-warning rounded-xl mt-4 mb-2">
@@ -52,7 +52,7 @@ templ WorkflowsGallery(p WorkflowsGalleryProps) {
 						<div class="font-semibold text-sm">Approaching spend ceiling</div>
 						<div class="text-xs opacity-80">{ p.Spend.PctStr } used — { p.Spend.SpentStr } of { p.Spend.CeilingStr } in the last 30 days.</div>
 					</div>
-					<a href="/settings/workflows" class="btn btn-sm btn-ghost">Adjust</a>
+					<a href="/settings/agents" class="btn btn-sm btn-ghost">Adjust</a>
 				</div>
 			}
 		}
@@ -181,7 +181,7 @@ templ workflowReconfigureDrawer() {
 				<div x-show="reconfigure.connectors.length > 0" x-cloak>
 					<div class="text-sm font-medium mb-1">Connectors</div>
 					<div class="text-xs text-base-content/40 mb-2">
-						Extra MCP servers this workflow can call. Manage them in <a class="link link-hover" href="/settings/workflows">Workflows settings</a>.
+						Extra MCP servers this workflow can call. Manage them in <a class="link link-hover" href="/settings/agents">Agents settings</a>.
 					</div>
 					<input type="hidden" name="connectors_present" value="1"/>
 					<div class="space-y-2">

--- a/internal/templates/components/settings_modal_types.go
+++ b/internal/templates/components/settings_modal_types.go
@@ -13,7 +13,7 @@ const (
 	SettingsModalTabGeneral       = "general"
 	SettingsModalTabSystem        = "system"
 	SettingsModalTabProviders     = "providers"
-	SettingsModalTabWorkflows     = "workflows"
+	SettingsModalTabAgents        = "agents"
 	SettingsModalTabNotifications = "notifications"
 	SettingsModalTabMCP           = "mcp"
 	SettingsModalTabConnectors    = "connectors"


### PR DESCRIPTION
Renames the **Workflows** settings tab to **Agents** and regroups the settings rail.

### Why

The `/settings/workflows` tab configures the **Claude Agent SDK runtime** — auth, sidecar binary, concurrency, spend ceilings — which is distinct from the main-nav `/workflows` gallery (the automations surface). Calling it "Agents" sharpens that distinction instead of overloading "Workflows."

### Rename

- Tab id `workflows` → `agents` (`SettingsModalTabWorkflows` → `SettingsModalTabAgents`)
- `GET /settings/agents` now serves the page; `GET /settings/workflows` 302-redirects for back-compat
- Rail label **Workflows → Agents** (`sparkles` → `bot` icon)
- Header / title / subtitle, nav active-key (`workflows-settings` → `agents-settings`), inbound links (gallery "Configure/Adjust"), agent-api flash redirects, and the `breadbox agent` CLI hint all updated

### Rail regrouping

The old 5-item **Integrations** group lumped data ingestion, the AI surface, and alerting together. Split into clearer domains:

| Group | Items |
|---|---|
| **Workspace** | General · System · Notifications |
| **Data** | Providers · Backups |
| **AI & Agents** | Agents · Connectors · MCP |
| **Access** | API Keys |
| **Support** | Developer · Help |

`Notifications` moves up to Workspace (instance-level alerting), `Backups` joins Providers under Data (the data lifecycle), and the AI triad gets its own named group. `Access`/API Keys stays its own group because it's the only tab visible to non-admin editors.

### Validation

`go build`, `go vet ./...`, and unit tests for `templates` / `admin` / `cli` all green. Rendered in a real browser:

<img src="https://bb-artifacts.exe.xyz/f/c745b7662acdc856.jpg" width="800" alt="settings/agents — renamed tab + regrouped rail">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
