### PR TITLE
chore: gitignore .claude/port-locks/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ transcripts/
 # Claude Code worktrees and task locks
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.claude/port-locks/
 
 # MCP config (contains API key)
 .mcp.json


### PR DESCRIPTION
Dev port-reservation markers under `.claude/port-locks/` are ephemeral — written per running local dev server — and were never meant to be tracked. One (`8085`) got accidentally staged in a local working tree. This ignores the directory so it can't be committed again.

No code impact; `.gitignore`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)