### PR TITLE
feat(settings): edit MCP prompts via the prompt-preview modal

### DIFF
--- a/input.css
+++ b/input.css
@@ -603,7 +603,7 @@
      brackets them. Flatter than .bb-card (no shadow) so it reads as a
      quiet container, not a raised panel. */
   .bb-settings-card {
-    @apply rounded-xl border border-base-300 bg-base-100 overflow-hidden;
+    @apply rounded-xl border border-base-300 bg-base-100;
   }
   .bb-settings-card--danger {
     @apply border-error/25 bg-error/[0.025];
@@ -626,6 +626,16 @@
      reveals. */
   .bb-settings-row {
     @apply flex items-center justify-between gap-4 px-4 sm:px-5 py-3.5 min-h-[3rem];
+  }
+  /* The card no longer clips with overflow-hidden (so row tooltips can escape
+     its bounds), so round whichever child sits at the top/bottom edge — keeps a
+     `--link` row's hover background, the footer's tint, and the hairline
+     dividers flush with the card's rounded border instead of poking past it. */
+  .bb-settings-card > :first-child {
+    @apply rounded-t-xl;
+  }
+  .bb-settings-card > :last-child {
+    @apply rounded-b-xl;
   }
   .bb-settings-card > .bb-settings-row + .bb-settings-row,
   .bb-settings-card__body > .bb-settings-row + .bb-settings-row,

--- a/internal/service/mcp_config.go
+++ b/internal/service/mcp_config.go
@@ -6,10 +6,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 )
+
+// normalizeNewlines collapses CRLF (and lone CR) to LF. HTML form submission
+// normalizes textarea line endings to CRLF, so a prompt saved through the
+// settings form would otherwise be stored with \r\n and never byte-match the
+// LF-only built-in default constants — leaving every prompt stuck showing
+// "Customized" even right after a reset-to-default. Canonicalizing on write
+// keeps stored == default when the user saves the default verbatim.
+func normalizeNewlines(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
 
 // MCPConfig represents the MCP permission and instruction settings.
 type MCPConfig struct {
@@ -82,6 +93,7 @@ func (s *Service) SaveMCPDisabledTools(ctx context.Context, tools []string) erro
 
 // SaveMCPInstructions saves server instructions.
 func (s *Service) SaveMCPInstructions(ctx context.Context, instructions string) error {
+	instructions = normalizeNewlines(instructions)
 	if len(instructions) > 20000 {
 		return fmt.Errorf("instructions exceed maximum length of 20,000 characters")
 	}
@@ -93,6 +105,7 @@ func (s *Service) SaveMCPInstructions(ctx context.Context, instructions string) 
 
 // SaveMCPReviewGuidelines saves review guidelines (served via breadbox://review-guidelines).
 func (s *Service) SaveMCPReviewGuidelines(ctx context.Context, guidelines string) error {
+	guidelines = normalizeNewlines(guidelines)
 	if len(guidelines) > 30000 {
 		return fmt.Errorf("review guidelines exceed maximum length of 30,000 characters")
 	}
@@ -104,6 +117,7 @@ func (s *Service) SaveMCPReviewGuidelines(ctx context.Context, guidelines string
 
 // SaveMCPReportFormat saves report format guidelines (served via breadbox://report-format).
 func (s *Service) SaveMCPReportFormat(ctx context.Context, format string) error {
+	format = normalizeNewlines(format)
 	if len(format) > 20000 {
 		return fmt.Errorf("report format exceeds maximum length of 20,000 characters")
 	}

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -3,6 +3,7 @@ package pages
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"breadbox/internal/templates/components"
 )
@@ -26,28 +27,41 @@ templ AgentsSettings(p AgentsSettingsProps) {
 		@components.SettingsSection(components.SettingsSectionProps{
 			Icon:    "scroll-text",
 			Title:   "Agent prompts",
-			Caption: "Guidance served to agents over MCP — open a row to edit",
+			Caption: "Guidance served to agents over MCP — edit with a live Markdown preview",
 		}) {
-			@mcpRow(mcpRowData{
-				ID:    "instructions",
-				Icon:  "scroll-text",
-				Name:  "Server instructions",
-				Desc:  "Sent to agents when they connect via MCP",
-				Right: mcpCustomizedStatus(p.Instructions != p.DefaultInstructions),
+			@mcpPromptRow(mcpPromptRowData{
+				ID:        "instructions",
+				Icon:      "scroll-text",
+				Name:      "Server instructions",
+				Subtitle:  "Sent to agents when they connect via MCP",
+				Action:    "/mcp-settings/instructions",
+				Field:     "instructions",
+				Value:     p.Instructions,
+				Default:   p.DefaultInstructions,
+				Warn:      true,
+				CSRFToken: p.CSRFToken,
 			})
-			@mcpRow(mcpRowData{
-				ID:    "review-guidelines",
-				Icon:  "book-open",
-				Name:  "Review guidelines",
-				Desc:  "Served as breadbox://review-guidelines during reviews",
-				Right: mcpCustomizedStatus(p.ReviewGuidelines != p.DefaultReviewGuidelines),
+			@mcpPromptRow(mcpPromptRowData{
+				ID:        "review-guidelines",
+				Icon:      "book-open",
+				Name:      "Review guidelines",
+				Subtitle:  "Served as breadbox://review-guidelines during reviews",
+				Action:    "/mcp-settings/review-guidelines",
+				Field:     "review_guidelines",
+				Value:     p.ReviewGuidelines,
+				Default:   p.DefaultReviewGuidelines,
+				CSRFToken: p.CSRFToken,
 			})
-			@mcpRow(mcpRowData{
-				ID:    "report-format",
-				Icon:  "file-text",
-				Name:  "Report format",
-				Desc:  "Served as breadbox://report-format when submitting reports",
-				Right: mcpCustomizedStatus(p.ReportFormat != p.DefaultReportFormat),
+			@mcpPromptRow(mcpPromptRowData{
+				ID:        "report-format",
+				Icon:      "file-text",
+				Name:      "Report format",
+				Subtitle:  "Served as breadbox://report-format when submitting reports",
+				Action:    "/mcp-settings/report-format",
+				Field:     "report_format",
+				Value:     p.ReportFormat,
+				Default:   p.DefaultReportFormat,
+				CSRFToken: p.CSRFToken,
 			})
 		}
 		@components.SettingsSection(components.SettingsSectionProps{
@@ -76,44 +90,9 @@ templ AgentsSettings(p AgentsSettingsProps) {
 			})
 		}
 		// Drawers — fixed-position, rendered after the sections; only the
-		// one matching the open id (plus its scrim) shows.
-		@mcpPromptDrawer(mcpPromptDrawerData{
-			ID:        "instructions",
-			Icon:      "scroll-text",
-			Title:     "Server instructions",
-			Subtitle:  "Sent to agents when they connect via MCP",
-			Action:    "/mcp-settings/instructions",
-			Field:     "instructions",
-			Value:     p.Instructions,
-			Default:   p.DefaultInstructions,
-			MaxLength: 20000,
-			Warn:      true,
-			CSRFToken: p.CSRFToken,
-		})
-		@mcpPromptDrawer(mcpPromptDrawerData{
-			ID:        "review-guidelines",
-			Icon:      "book-open",
-			Title:     "Review guidelines",
-			Subtitle:  "Served as breadbox://review-guidelines during reviews",
-			Action:    "/mcp-settings/review-guidelines",
-			Field:     "review_guidelines",
-			Value:     p.ReviewGuidelines,
-			Default:   p.DefaultReviewGuidelines,
-			MaxLength: 30000,
-			CSRFToken: p.CSRFToken,
-		})
-		@mcpPromptDrawer(mcpPromptDrawerData{
-			ID:        "report-format",
-			Icon:      "file-text",
-			Title:     "Report format",
-			Subtitle:  "Served as breadbox://report-format when submitting reports",
-			Action:    "/mcp-settings/report-format",
-			Field:     "report_format",
-			Value:     p.ReportFormat,
-			Default:   p.DefaultReportFormat,
-			MaxLength: 20000,
-			CSRFToken: p.CSRFToken,
-		})
+		// one matching the open id (plus its scrim) shows. The three agent
+		// prompts edit inline via the global prompt modal (#bb-prompt-modal),
+		// so only tools + connection keep a drawer.
 		@mcpToolsDrawer(p)
 		@mcpConnectionDrawer()
 	</div>
@@ -163,99 +142,121 @@ templ mcpRow(d mcpRowData) {
 	</button>
 }
 
-// mcpCustomizedStatus is the right-side indicator for a prompt row: a quiet
-// "Customized" chip when the saved text diverges from the built-in default,
-// or muted "Default" text otherwise. Ghost (not a soft palette tone) so it
-// stays legible in both themes per .claude/rules/daisyui.md.
-templ mcpCustomizedStatus(customized bool) {
-	if customized {
-		<span class="badge badge-ghost badge-sm">Customized</span>
-	} else {
-		<span class="text-xs text-base-content/40 whitespace-nowrap">Default</span>
-	}
-}
-
 templ mcpToolsCountStatus(enabled, total int) {
 	<span class="text-xs text-base-content/60 whitespace-nowrap tabular-nums">{ strconv.Itoa(enabled) } of { strconv.Itoa(total) } enabled</span>
 }
 
 // ---------------------------------------------------------------------
-// Prompt drawers (Server Instructions, Review Guidelines, Report Format)
+// Prompt rows (Server Instructions, Review Guidelines, Report Format)
 // ---------------------------------------------------------------------
 
-// mcpPromptDrawerData configures one full-height prompt-editing drawer. The
-// three agent-prompt textareas share this shape; only the copy, endpoint,
-// limit, and the editing-risk warning (instructions only) differ.
-type mcpPromptDrawerData struct {
-	ID        string // drawer suffix → "mcp-<ID>"
+// mcpPromptRowData configures one agent-prompt row. The three prompts share
+// this shape; only the copy, endpoint, field, and the editing-risk note
+// (instructions only) differ. Editing happens inline through the global prompt
+// modal (#bb-prompt-modal in base.html) — opened from the row's pencil button
+// in editable mode (Edit/Preview Markdown toggle + Copy). Save writes the
+// buffer back into the row's hidden field and submits the form as a normal
+// POST (server validates length, then flash + redirect). Reset restores the
+// built-in default and saves immediately; it only shows once customized.
+type mcpPromptRowData struct {
+	ID        string // anchor id + drawer-free row key
 	Icon      string
-	Title     string
-	Subtitle  string
+	Name      string
+	Subtitle  string // row caption + modal subtitle
 	Action    string // POST endpoint
-	Field     string // textarea name
+	Field     string // hidden textarea name
 	Value     string
 	Default   string
-	MaxLength int
-	Warn      bool // show the editing-risk alert (instructions only)
+	Warn      bool // append the editing-risk note to the modal subtitle (instructions only)
 	CSRFToken string
 }
 
-templ mcpPromptDrawer(d mcpPromptDrawerData) {
-	@components.Drawer(components.DrawerProps{
-		ID:    "mcp-" + d.ID,
-		Title: d.Title,
-		Size:  "xl",
-	}) {
-		<form
-			method="POST"
-			action={ templ.SafeURL(d.Action) }
-			class="flex flex-col h-full"
-			x-data={ mcpPromptState(d.Value, d.Default) }
-			@submit="saving = true"
-		>
-			<input type="hidden" name="_csrf" value={ d.CSRFToken }/>
-			@components.DrawerHeader(components.DrawerHeaderProps{
-				Icon:     d.Icon,
-				Title:    d.Title,
-				Subtitle: d.Subtitle,
-			})
-			<div class="flex-1 flex flex-col min-h-0 p-5 gap-3">
-				if d.Warn {
-					<div role="alert" class="alert alert-warning alert-soft text-xs shrink-0">
-						@components.LucideIcon("triangle-alert", "w-4 h-4")
-						<span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
-					</div>
+templ mcpPromptRow(d mcpPromptRowData) {
+	<div id={ d.ID } class="bb-settings-row" x-data={ mcpPromptRowState(d.Default) }>
+		@components.LucideIcon(d.Icon, "w-5 h-5 text-base-content opacity-60 shrink-0")
+		<div class="bb-settings-row__main">
+			<div class="bb-settings-row__label">
+				{ d.Name }
+				if mcpPromptCustomized(d) {
+					<span class="badge badge-ghost badge-sm font-normal">Customized</span>
+				} else {
+					<span class="text-xs text-base-content/40 font-normal whitespace-nowrap">Default</span>
 				}
-				<textarea
-					name={ d.Field }
-					class="textarea font-mono text-xs leading-relaxed w-full flex-1 min-h-[16rem] resize-none"
-					maxlength={ strconv.Itoa(d.MaxLength) }
-					x-model="value"
-					placeholder="Prompt text for MCP agents…"
-				></textarea>
-				<p class="text-xs text-base-content/40 shrink-0" x-text={ fmt.Sprintf("value.length + '/%d'", d.MaxLength) }></p>
 			</div>
-			@components.DrawerFooter() {
-				<button type="button" class="btn btn-ghost btn-sm mr-auto" @click="resetToDefaults()">Reset to defaults</button>
-				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
-				<button type="submit" class="btn btn-primary btn-sm" :disabled="saving">
-					<span x-show="!saving">Save changes</span>
-					<span x-show="saving" x-cloak class="flex items-center gap-2"><span class="loading loading-spinner loading-xs"></span> Saving…</span>
+			<p class="bb-settings-row__caption">{ d.Subtitle }</p>
+		</div>
+		<div class="bb-settings-row__control gap-1">
+			// Edit / preview — opens the global prompt modal in editable mode
+			// (preview first), targeting the hidden field below.
+			<button
+				type="button"
+				class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
+				data-tip="Edit prompt"
+				@click={ mcpPromptEditJS(d) }
+				aria-label={ "Edit " + d.Name }
+			>
+				@components.LucideIcon("settings-2", "w-4 h-4")
+			</button>
+			// Reset to the built-in default — only shown once customized.
+			if mcpPromptCustomized(d) {
+				<button
+					type="button"
+					class="btn btn-ghost btn-sm btn-square text-base-content/55 tooltip tooltip-top"
+					data-tip="Reset to default"
+					@click="resetPrompt()"
+					aria-label={ "Reset " + d.Name + " to default" }
+				>
+					@components.LucideIcon("rotate-ccw", "w-4 h-4")
 				</button>
 			}
+		</div>
+		// Hidden form: the textarea is the source of truth — server-rendered with
+		// the saved value, written directly by the prompt modal (target=$refs.field)
+		// or by resetPrompt(), then submitted. settings_page.js serializes this
+		// form via FormData, so the field's DOM value is what persists — no x-model
+		// (its async data→field flush desynced against FormData's read).
+		<form method="POST" action={ templ.SafeURL(d.Action) } x-ref="form" class="hidden">
+			<input type="hidden" name="_csrf" value={ d.CSRFToken }/>
+			<textarea name={ d.Field } x-ref="field" class="hidden">{ d.Value }</textarea>
 		</form>
-	}
+	</div>
 }
 
-// mcpPromptState is the Alpine scope for a prompt drawer — the live textarea
-// value, its default (for reset), a saving flag for the Save spinner, and a
-// reset-to-defaults action gated behind a bbConfirm. Returned as an inline
-// object literal (not a factory call) so it carries the per-drawer default
-// without tripping the x-data factory-args lint.
-func mcpPromptState(value, def string) string {
+// mcpPromptCustomized reports whether the saved prompt diverges from the
+// built-in default (whitespace-insensitive). Drives the Customized/Default
+// badge and whether the reset affordance shows. Computed server-side and
+// re-evaluated on every settings body swap, so it never drifts from storage.
+func mcpPromptCustomized(d mcpPromptRowData) bool {
+	norm := func(s string) string {
+		return strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n"))
+	}
+	return norm(d.Value) != norm(d.Default)
+}
+
+// mcpPromptRowState is the Alpine scope for a prompt row — just the built-in
+// default (for reset) and the reset action. resetPrompt writes the default
+// straight into the hidden field and submits; FormData then serializes that
+// value verbatim. Returned as an inline object literal (not a factory call) so
+// it carries the per-row default without tripping the x-data factory-args lint.
+func mcpPromptRowState(def string) string {
 	return fmt.Sprintf(
-		"{ value: %s, def: %s, saving: false, async resetToDefaults() { const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current text will be replaced with the built-in default. Save to apply.',confirmLabel:'Reset',variant:'warning'}); if (ok) { this.value = this.def; } } }",
-		jsString(value), jsString(def),
+		"{ def: %s, async resetPrompt() { const ok = await bbConfirm({ title: 'Reset to default?', message: 'The built-in default prompt will replace your current text and save immediately.', confirmLabel: 'Reset', variant: 'warning' }); if (ok) { this.$refs.field.value = this.def; this.$refs.form.requestSubmit(); } } }",
+		jsString(def),
+	)
+}
+
+// mcpPromptEditJS builds the @click expression that opens the global prompt
+// modal in editable mode for this row. Save writes the buffer into $refs.field
+// (the hidden textarea) and onSaved submits the row's form. The editing-risk
+// note rides along in the subtitle for the instructions prompt.
+func mcpPromptEditJS(d mcpPromptRowData) string {
+	subtitle := d.Subtitle
+	if d.Warn {
+		subtitle += " — editing changes how agents read your data model and call tools."
+	}
+	return fmt.Sprintf(
+		"$dispatch('bb-prompt-modal', { mode: 'editable', edit: false, title: %s, subtitle: %s, value: $refs.field.value, target: $refs.field, onSaved: () => $refs.form.requestSubmit(), saveLabel: 'Save changes' })",
+		jsString(d.Name), jsString(subtitle),
 	)
 }
 


### PR DESCRIPTION
Edit the three MCP agent prompts on `/settings/mcp` through the global prompt-preview modal instead of plain-textarea drawers, and fix a pre-existing bug that kept prompts stuck on "Customized".

## Changes
- Each agent-prompt row (Server instructions / Review guidelines / Report format) now opens the global prompt-preview modal (`#bb-prompt-modal`) via a `settings-2` edit icon — preview-first, with an Edit/Preview Markdown toggle and Copy. A reset icon appears only when the prompt is customized. The per-prompt slide-over drawers are removed.
- **Fix "stuck Customized":** HTML form submission normalizes textarea newlines to CRLF, so saving the LF-only default constant never byte-matched it (this had already silently drifted review-guidelines/report-format). Normalize CRLF→LF in `SaveMCPInstructions/ReviewGuidelines/ReportFormat`, and make the badge comparison newline-insensitive.
- Drop `x-model` on the hidden field (its async data→field flush raced `settings_page.js`'s `FormData` serialization); server-render the saved value as the source of truth and compute `Customized` server-side.
- Remove `overflow-hidden` from `.bb-settings-card` so row tooltips escape the card bounds; round the first/last children instead to keep hover backgrounds, the footer tint, and hairline dividers flush with the rounded corners.

## Screenshots
<table>
  <tr><th>MCP settings rows</th><th>Prompt-preview modal</th></tr>
  <tr>
    <td><img src="https://bb-artifacts.exe.xyz/f/a4cea4b1e408890c.jpg" width="400" alt="MCP settings prompt rows"></td>
    <td><img src="https://bb-artifacts.exe.xyz/f/270e8f4bf1bf326f.jpg" width="400" alt="prompt-preview modal"></td>
  </tr>
</table>

Tooltip now escapes the card (no clipping):

<img src="https://bb-artifacts.exe.xyz/f/5e3d3c9c06595bf0.jpg" width="520" alt="Edit prompt tooltip unclipped above the icon">

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./internal/templates/...`
- [x] `go test -tags integration -p 1 -run 'MCP|Instruction|ReportFormat|ReviewGuidelines' ./internal/service/`
- [x] Edit a prompt via the modal → saves, row shows "Customized"
- [x] Reset → restores the default (stored LF, 0 CR), row shows "Default", reset icon hides
- [x] Tooltip renders above the edit icon unclipped; corners clean across General/Backups/System tabs
