### PR TITLE
fix(settings): auto-save controls silently no-op (missing settings.js in full-page shell)

### DIFF
--- a/internal/templates/components/pages/settings_page.templ
+++ b/internal/templates/components/pages/settings_page.templ
@@ -17,6 +17,12 @@ import (
 // body swap; without it they fall back to ordinary navigations that
 // re-render the page.
 templ SettingsPage(p SettingsPageProps) {
+	// settings.js registers the `settingsAutoSave` Alpine factory (and the
+	// bbSettingsScrollToHash helper settings_page.js calls). It MUST load
+	// before settings_page.js and before Alpine's deferred init fires, or
+	// every auto-save control on every tab silently no-ops — `x-data="settingsAutoSave"`
+	// resolves to an empty component and the change→submit listener never attaches.
+	<script src="/static/js/admin/components/settings.js"></script>
 	<script src="/static/js/admin/components/settings_page.js"></script>
 	<div
 		x-data="settingsPage"


### PR DESCRIPTION
## Problem

On the live full-page Settings surface, changing any **auto-save** control (backup schedule/retention, sync interval, log retention, timezone, …) did nothing — no toast, nothing persisted. Reported against backups retention on `breadbox.exe.xyz`.

## Root cause

The full-page shell `SettingsPage` (`settings_page.templ`) loaded **only** `settings_page.js`. But every auto-save control depends on `settings.js`, which registers the `settingsAutoSave` Alpine factory. With that script absent:

- `x-data="settingsAutoSave"` resolved to an **empty component** (`init()` never ran),
- the `change → requestSubmit()` listener was never attached,
- so changing a dropdown sent **no request at all**.

The server side was always fine — `BackupScheduleHandler` → `SetAppConfig` persists correctly when the POST actually arrives (confirmed via direct `curl` and by inspecting the prod `app_config` row, last written 2026‑05‑25). The defect was purely client-side: the POST was never fired.

Corroborating signal: `settings_page.js` calls `bbSettingsScrollToHash()`, a function **defined in `settings.js`** — the two were always meant to load together. The include was dropped in the modal → full-page migration (#1601). The now-dead legacy `Settings` shell in `settings.templ` still carries the correct `settings.js` include.

## Fix

Load `settings.js` before `settings_page.js` in the `SettingsPage` shell (one line + comment). This restores `settingsAutoSave` for **every** settings tab, not just backups.

## Verification (real browser, against prod data)

- Diagnosed on `breadbox.exe.xyz`: many `GET /settings/backups`, **zero** `POST /-/backups/schedule` in the logs while the user changed the dropdown.
- After the fix, locally: changing retention fires `POST /-/backups/schedule [303]` → AJAX reload shows the new value → **full hard reload** renders it selected → `app_config.backup_retention_days` updates with a fresh `updated_at`.
- `go build ./...`, `go vet`, and `go test ./internal/templates/...` (incl. the scripts-lint test) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
