### PR TITLE
feat(rules-ui): metadata conditions + actions in the rule form editor

### DIFF
--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -193,7 +193,15 @@ templ RuleForm(p RuleFormProps) {
 										<option value="user_name">Family member</option>
 										<option value="provider">Provider</option>
 									</optgroup>
+									<optgroup label="Metadata">
+										<option value="metadata">Metadata field</option>
+									</optgroup>
 								</select>
+								<!-- Metadata key — only for the metadata field. The dotted
+								     field metadata.<key> is assembled at submit time. Fixed width
+								     + shrink-0 (matching the numeric/bool controls) so it doesn't
+								     eat the row; flex-wrap drops operator+value to row 2 on mobile. -->
+								<input type="text" x-model="cond.key" x-show="cond.field === 'metadata'" @input="syncToJson()" class="input input-xs bg-base-100 w-32 shrink-0" placeholder="key"/>
 								<!-- Flex-wrap break: on mobile, forces Operator + value + remove
 								     onto a second row so Field can use the full width. Hidden on
 								     sm+ so the row stays single-line at larger widths.
@@ -204,7 +212,7 @@ templ RuleForm(p RuleFormProps) {
 								     rendered inline (not x-for) so x-model syncs correctly on
 								     first paint when editing an existing rule. Each option value
 								     appears exactly once; labels shift per fieldType via x-text. -->
-								<select x-model="cond.op" @change="syncToJson()" :disabled="!cond.field" class="select select-xs bg-base-100 w-28 shrink-0 disabled:bg-base-200 disabled:opacity-70">
+								<select x-model="cond.op" @change="syncToJson()" :disabled="!cond.field" x-show="fieldType(cond.field) !== 'metadata'" class="select select-xs bg-base-100 w-28 shrink-0 disabled:bg-base-200 disabled:opacity-70">
 									<option value="" x-show="!cond.field">Operator...</option>
 									<option value="contains" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'tags')" x-text="fieldType(cond.field) === 'tags' ? 'has' : 'contains'"></option>
 									<option value="not_contains" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'tags')" x-text="fieldType(cond.field) === 'tags' ? 'does not have' : 'not contains'"></option>
@@ -216,6 +224,22 @@ templ RuleForm(p RuleFormProps) {
 									<option value="lte" x-show="cond.field && fieldType(cond.field) === 'numeric'">≤</option>
 									<option value="gt" x-show="cond.field && fieldType(cond.field) === 'numeric'">&gt;</option>
 									<option value="lt" x-show="cond.field && fieldType(cond.field) === 'numeric'">&lt;</option>
+								</select>
+								<!-- Metadata operator — own select (the inline-option select above
+								     can't cleanly host the exists/not_exists presence ops). -->
+								<select x-model="cond.op" x-show="cond.field === 'metadata'" @change="syncToJson()" class="select select-xs bg-base-100 w-28 shrink-0">
+									<option value="eq">equals</option>
+									<option value="neq">not equals</option>
+									<option value="contains">contains</option>
+									<option value="not_contains">not contains</option>
+									<option value="matches">regex</option>
+									<option value="in">in list</option>
+									<option value="gt">&gt;</option>
+									<option value="gte">≥</option>
+									<option value="lt">&lt;</option>
+									<option value="lte">≤</option>
+									<option value="exists">exists</option>
+									<option value="not_exists">does not exist</option>
 								</select>
 								<!-- Value — disabled placeholder when no field picked -->
 								<input type="text" disabled x-show="!cond.field" class="input input-xs bg-base-200 opacity-70 flex-1 min-w-0" placeholder="value..."/>
@@ -241,6 +265,9 @@ templ RuleForm(p RuleFormProps) {
 								</select>
 								<input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'string' && !(cond.field === 'category' && (cond.op === 'eq' || cond.op === 'neq'))" @input="syncToJson()" class="input input-xs bg-base-100 flex-1 min-w-0" placeholder="value..."/>
 								<input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-xs bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'"/>
+								<!-- Metadata value — free text; hidden for presence ops
+								     (exists / does not exist), which need no value. -->
+								<input type="text" x-model="cond.value" x-show="cond.field === 'metadata' && cond.op !== 'exists' && cond.op !== 'not_exists'" @input="syncToJson()" class="input input-xs bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'value1, value2, ...' : 'value...'"/>
 								<!-- Remove -->
 								<button type="button" class="btn btn-ghost btn-xs btn-square shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
 									@components.LucideIcon("x", "w-3.5 h-3.5 text-base-content opacity-40")
@@ -286,6 +313,8 @@ templ RuleForm(p RuleFormProps) {
 									<option value="tag" :disabled="action.field !== 'tag'        && isActionUsed('tag')">Add tag</option>
 									<option value="tag_remove" :disabled="action.field !== 'tag_remove' && isActionUsed('tag_remove')">Remove tag</option>
 									<option value="comment" :disabled="action.field !== 'comment'    && isActionUsed('comment')">Add comment</option>
+									<option value="metadata_set">Set metadata</option>
+									<option value="metadata_remove">Remove metadata</option>
 								</select>
 								<!-- Remove — pinned to the right of the Action select on mobile,
 								     moves to the far right of the row on sm+. Rendered here (not at
@@ -333,6 +362,34 @@ templ RuleForm(p RuleFormProps) {
 									<div class="w-full sm:w-auto sm:flex-1 min-w-0 order-4 sm:order-none">
 										<textarea x-model="action.value" rows="2" class="textarea textarea-xs bg-base-100 w-full text-xs" placeholder="Comment to attach to matching transactions..."></textarea>
 										<p class="text-[0.65rem] text-base-content/40 mt-1">Plain text. The comment is attributed to this rule.</p>
+									</div>
+								</template>
+								<!-- Value: set metadata (key + typed value) -->
+								<template x-if="action.field === 'metadata_set'">
+									<div class="w-full sm:w-auto sm:flex-1 min-w-0 order-4 sm:order-none">
+										<div class="flex flex-wrap items-center gap-2">
+											<input type="text" x-model="action.key" class="input input-xs bg-base-100 w-full sm:w-40 mt-px" placeholder="key (e.g. tax_deductible)"/>
+											<select x-model="action.valueType" @change="onMetadataValueTypeChange(idx)" class="select select-xs bg-base-100 w-full sm:w-24 mt-px">
+												<option value="text">text</option>
+												<option value="number">number</option>
+												<option value="boolean">true/false</option>
+											</select>
+											<input type="text" x-model="action.value" x-show="action.valueType === 'text'" class="input input-xs bg-base-100 w-full sm:flex-1 sm:min-w-0 mt-px" placeholder="value"/>
+											<input type="number" step="any" x-model="action.value" x-show="action.valueType === 'number'" class="input input-xs bg-base-100 w-full sm:flex-1 sm:min-w-0 mt-px" placeholder="0"/>
+											<select x-model="action.value" x-show="action.valueType === 'boolean'" class="select select-xs bg-base-100 w-full sm:w-24 mt-px">
+												<option value="true">true</option>
+												<option value="false">false</option>
+											</select>
+										</div>
+										<p x-show="action.error" x-cloak class="text-[0.65rem] text-error mt-1" x-text="action.error"></p>
+										<p x-show="!action.error" class="text-[0.65rem] text-base-content/40 mt-1">Upserts one metadata key (value stored with the chosen type). Other keys are untouched.</p>
+									</div>
+								</template>
+								<!-- Value: remove metadata (key only) -->
+								<template x-if="action.field === 'metadata_remove'">
+									<div class="w-full sm:w-auto sm:flex-1 min-w-0 order-4 sm:order-none">
+										<input type="text" x-model="action.key" class="input input-xs bg-base-100 w-full mt-px" placeholder="key to remove"/>
+										<p class="text-[0.65rem] text-base-content/40 mt-1">Deletes one metadata key from matching transactions.</p>
 									</div>
 								</template>
 							</div>

--- a/static/js/admin/components/rule_form.js
+++ b/static/js/admin/components/rule_form.js
@@ -22,8 +22,17 @@ document.addEventListener('alpine:init', function () {
       account_id: 'string', account_name: 'string',
       user_id: 'string', user_name: 'string',
       tags: 'tags',
+      // "metadata" is the visual-builder field for a metadata.<key> leaf. The
+      // dotted field is assembled at submit time from cond.field + cond.key.
+      metadata: 'metadata',
     };
-    var defaultOps = { string: 'contains', numeric: 'gte', bool: 'eq', tags: 'contains' };
+    var defaultOps = { string: 'contains', numeric: 'gte', bool: 'eq', tags: 'contains', metadata: 'eq' };
+
+    // metadataFieldPrefix mirrors service.metadataFieldPrefix. A leaf with
+    // field "metadata.<key>" reads that key from the transaction's metadata blob.
+    var metadataFieldPrefix = 'metadata.';
+    // Operators that take no value (presence test) — the value input is hidden.
+    var metadataPresenceOps = { exists: true, not_exists: true };
     // Operator option sets keyed by fieldType. Kept as labels (not HTML glyphs)
     // because the visual builder renders via x-text now.
     var operatorOptionsByType = {
@@ -52,24 +61,43 @@ document.addEventListener('alpine:init', function () {
         { value: 'not_contains', label: 'does not have' },
         { value: 'in',           label: 'has any of' },
       ],
+      metadata: [
+        { value: 'eq',           label: 'equals' },
+        { value: 'neq',          label: 'not equals' },
+        { value: 'contains',     label: 'contains' },
+        { value: 'not_contains', label: 'not contains' },
+        { value: 'matches',      label: 'regex' },
+        { value: 'in',           label: 'in list' },
+        { value: 'gt',           label: '>' },
+        { value: 'gte',          label: '≥' },
+        { value: 'lt',           label: '<' },
+        { value: 'lte',          label: '≤' },
+        { value: 'exists',       label: 'exists' },
+        { value: 'not_exists',   label: 'does not exist' },
+      ],
     };
     // The initial condition row renders empty so the user must pick a field
     // explicitly — the operator + value inputs then snap to sensible defaults
     // via onFieldChange().
-    function emptyCondition() { return { field: '', op: '', value: '' }; }
+    // `key` carries the metadata key for a metadata.<key> leaf (unused by every
+    // other field type).
+    function emptyCondition() { return { field: '', op: '', value: '', key: '' }; }
     // New action rows start as unpicked drafts so "Action..." is the default
-    // and the value input stays disabled until a type is chosen.
-    function emptyAction() { return { field: '', value: '', error: '' }; }
+    // and the value input stays disabled until a type is chosen. `key` /
+    // `valueType` are only used by the metadata actions.
+    function emptyAction() { return { field: '', value: '', key: '', valueType: 'text', error: '' }; }
 
     // Action type registry — first-class typed actions match the API's
     // supported action.type values (set_category | add_tag | remove_tag |
-    // add_comment). The internal "field" name is a UI alias; we map back
-    // at submit time.
+    // add_comment | set_metadata | remove_metadata). The internal "field" name
+    // is a UI alias; we map back at submit time.
     var actionTypes = [
-      { value: 'category',   label: 'Set category' },
-      { value: 'tag',        label: 'Add tag' },
-      { value: 'tag_remove', label: 'Remove tag' },
-      { value: 'comment',    label: 'Add comment' },
+      { value: 'category',         label: 'Set category' },
+      { value: 'tag',             label: 'Add tag' },
+      { value: 'tag_remove',      label: 'Remove tag' },
+      { value: 'comment',         label: 'Add comment' },
+      { value: 'metadata_set',    label: 'Set metadata' },
+      { value: 'metadata_remove', label: 'Remove metadata' },
     ];
 
     // Tag slug regex must match the server-side validator in
@@ -90,8 +118,36 @@ document.addEventListener('alpine:init', function () {
       if (a.type === 'add_comment') {
         return { field: 'comment', value: a.content || '', error: '' };
       }
+      if (a.type === 'set_metadata') {
+        // Recover the value's type so the editor renders the right control and
+        // re-submits the same JSON type.
+        var vt = 'text', val = a.metadata_value;
+        if (typeof val === 'boolean') { vt = 'boolean'; val = val ? 'true' : 'false'; }
+        else if (typeof val === 'number') { vt = 'number'; val = String(val); }
+        else if (val == null) { val = ''; }
+        else if (typeof val !== 'string') { val = JSON.stringify(val); }
+        return { field: 'metadata_set', key: a.metadata_key || '', value: String(val), valueType: vt, error: '' };
+      }
+      if (a.type === 'remove_metadata') {
+        return { field: 'metadata_remove', key: a.metadata_key || '', value: '', valueType: 'text', error: '' };
+      }
       // Tolerate unknown types so the form still loads — validation happens at submit.
       return { field: a.type || a.field || '', value: a.category_slug || a.tag_slug || a.content || a.value || '', error: '' };
+    }
+
+    // loadCondition maps a stored condition leaf into the visual-builder shape,
+    // splitting a "metadata.<key>" field back into field="metadata" + key. Array
+    // values (the `in` operator) render as a comma-joined string.
+    function loadCondition(sub) {
+      var field = sub.field || '';
+      var key = '';
+      if (field.indexOf(metadataFieldPrefix) === 0) {
+        key = field.slice(metadataFieldPrefix.length);
+        field = 'metadata';
+      }
+      var value = sub.value;
+      if (Array.isArray(value)) value = value.join(', ');
+      return { field: field, op: sub.op || 'contains', value: String(value == null ? '' : value), key: key };
     }
 
     // Initialize form from existing rule or defaults
@@ -113,13 +169,13 @@ document.addEventListener('alpine:init', function () {
       var conditions = [], logic = 'and';
       var c = existingRule.conditions;
       if (c && c.and) {
-        conditions = c.and.map(function (sub) { return { field: sub.field || '', op: sub.op || 'contains', value: String(sub.value == null ? '' : sub.value) }; });
+        conditions = c.and.map(loadCondition);
         logic = 'and';
       } else if (c && c.or) {
-        conditions = c.or.map(function (sub) { return { field: sub.field || '', op: sub.op || 'contains', value: String(sub.value == null ? '' : sub.value) }; });
+        conditions = c.or.map(loadCondition);
         logic = 'or';
       } else if (c && c.field) {
-        conditions = [{ field: c.field, op: c.op || 'contains', value: String(c.value == null ? '' : c.value) }];
+        conditions = [loadCondition(c)];
       }
       // else: NULL or empty {} → conditions stays [] (match-all)
 
@@ -229,6 +285,9 @@ document.addEventListener('alpine:init', function () {
         else cond.op = defaultOps[this.fieldType(cond.field)] || 'contains';
         if (this.fieldType(cond.field) === 'bool') cond.value = 'true';
         else cond.value = '';
+        // Reset the metadata key when leaving/entering the metadata field so a
+        // stale key doesn't ride along on a non-metadata leaf.
+        if (cond.field !== 'metadata') cond.key = '';
         this.syncToJson();
       },
       addCondition: function () {
@@ -265,8 +324,18 @@ document.addEventListener('alpine:init', function () {
         this.form.actions.splice(idx, 1);
       },
       onActionTypeChange: function (idx) {
-        this.form.actions[idx].value = '';
-        this.form.actions[idx].error = '';
+        var a = this.form.actions[idx];
+        a.value = '';
+        a.error = '';
+        a.key = '';
+        a.valueType = 'text';
+      },
+      // When the metadata value-type switches, reset the value so a stale
+      // string doesn't carry into a boolean/number control.
+      onMetadataValueTypeChange: function (idx) {
+        var a = this.form.actions[idx];
+        a.value = a.valueType === 'boolean' ? 'true' : '';
+        a.error = '';
       },
       // Validate tag slug inline so the error renders before submit
       validateTagSlug: function (idx) {
@@ -291,6 +360,15 @@ document.addEventListener('alpine:init', function () {
             }
           }
         }
+        var setMeta = this.form.actions.filter(function (a) { return a.field === 'metadata_set' && a.key; });
+        var rmMeta = this.form.actions.filter(function (a) { return a.field === 'metadata_remove' && a.key; });
+        for (var m = 0; m < setMeta.length; m++) {
+          for (var n = 0; n < rmMeta.length; n++) {
+            if (setMeta[m].key.trim() === rmMeta[n].key.trim()) {
+              warnings.push('Metadata key "' + setMeta[m].key.trim() + '" is being set and removed — these cancel out.');
+            }
+          }
+        }
         return warnings;
       },
 
@@ -304,12 +382,12 @@ document.addEventListener('alpine:init', function () {
           var parsed = JSON.parse(this.form.conditions_json);
           if (parsed.and) {
             this.form.logic = 'and';
-            this.form.conditions = parsed.and.map(function (sub) { return { field: sub.field || '', op: sub.op || 'contains', value: String(sub.value == null ? '' : sub.value) }; });
+            this.form.conditions = parsed.and.map(loadCondition);
           } else if (parsed.or) {
             this.form.logic = 'or';
-            this.form.conditions = parsed.or.map(function (sub) { return { field: sub.field || '', op: sub.op || 'contains', value: String(sub.value == null ? '' : sub.value) }; });
+            this.form.conditions = parsed.or.map(loadCondition);
           } else if (parsed.field) {
-            this.form.conditions = [{ field: parsed.field, op: parsed.op || 'contains', value: String(parsed.value == null ? '' : parsed.value) }];
+            this.form.conditions = [loadCondition(parsed)];
           }
         } catch (e) { /* let them type freely */ }
       },
@@ -319,11 +397,32 @@ document.addEventListener('alpine:init', function () {
       // body sends `conditions: null` and the server stores NULL.
       buildConditionsJSON: function () {
         var self = this;
-        var conds = this.form.conditions.filter(function (c) { return c.field && c.value !== ''; });
+        var conds = this.form.conditions.filter(function (c) {
+          if (!c.field) return false;
+          if (self.fieldType(c.field) === 'metadata') {
+            // A metadata leaf needs a key; presence ops (exists/not_exists)
+            // need no value, every other op does.
+            if (!c.key || !c.key.trim()) return false;
+            if (metadataPresenceOps[c.op]) return true;
+            return c.value !== '';
+          }
+          return c.value !== '';
+        });
         if (conds.length === 0) return null;
         var mapped = conds.map(function (c) {
           var val = c.value;
           var type = self.fieldType(c.field);
+          if (type === 'metadata') {
+            // Assemble the dotted field; presence ops drop the value entirely.
+            // `in` collects a comma-separated list into an array. Other ops keep
+            // the value as a string — the server's metadata eval coerces by
+            // operator (numeric ops parse it; eq/neq stringify-compare).
+            var field = metadataFieldPrefix + c.key.trim();
+            if (metadataPresenceOps[c.op]) return { field: field, op: c.op };
+            var mval = val;
+            if (c.op === 'in') mval = String(val).split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+            return { field: field, op: c.op, value: mval };
+          }
           if (type === 'numeric') val = parseFloat(val) || 0;
           else if (type === 'bool') val = val === 'true';
           else if (type === 'tags' && c.op === 'in') {
@@ -368,6 +467,12 @@ document.addEventListener('alpine:init', function () {
             a.error = 'Lowercase letters, numbers, hyphens, or colons (e.g. needs-review)';
             actionError = actionError || 'Fix the tag slug before saving.';
           }
+          // A number-typed metadata value must parse — otherwise it would be
+          // silently stored as a string, contradicting the chosen type.
+          if (a.field === 'metadata_set' && a.valueType === 'number' && a.value !== '' && isNaN(parseFloat(a.value))) {
+            a.error = 'Enter a number, or switch the type to Text.';
+            actionError = actionError || 'Fix the numeric metadata value before saving.';
+          }
         });
         if (actionError) {
           this.formError = actionError;
@@ -377,13 +482,28 @@ document.addEventListener('alpine:init', function () {
         }
 
         // Build typed actions array for the API. Drop incomplete drafts.
+        // Metadata actions are kept on a non-empty key (remove_metadata needs no
+        // value; set_metadata may legitimately store an empty string).
         var actions = this.form.actions
-          .filter(function (a) { return a.field && (a.value !== undefined && a.value !== ''); })
+          .filter(function (a) {
+            if (!a.field) return false;
+            if (a.field === 'metadata_set' || a.field === 'metadata_remove') return !!(a.key && a.key.trim());
+            return a.value !== undefined && a.value !== '';
+          })
           .map(function (a) {
             if (a.field === 'category') return { type: 'set_category', category_slug: a.value };
             if (a.field === 'tag') return { type: 'add_tag', tag_slug: a.value };
             if (a.field === 'tag_remove') return { type: 'remove_tag', tag_slug: a.value };
             if (a.field === 'comment') return { type: 'add_comment', content: a.value };
+            if (a.field === 'metadata_set') {
+              // Coerce the value to its declared JSON type so the stored blob is
+              // typed (boolean true, number 100) rather than always a string.
+              var v = a.value;
+              if (a.valueType === 'number') { var n = parseFloat(a.value); v = isNaN(n) ? a.value : n; }
+              else if (a.valueType === 'boolean') { v = a.value === 'true'; }
+              return { type: 'set_metadata', metadata_key: a.key.trim(), metadata_value: v };
+            }
+            if (a.field === 'metadata_remove') return { type: 'remove_metadata', metadata_key: a.key.trim() };
             return { type: a.field, category_slug: a.value };
           });
         if (actions.length === 0) {


### PR DESCRIPTION
Stacked on #1874 (backend). The visual rule builder gains first-class **metadata** support so humans can author the new `metadata.<key>` conditions and `set_metadata` / `remove_metadata` actions in the form — no dropping to the JSON editor (and no longer API/MCP-only).

<img src="https://bb-artifacts.exe.xyz/f/85814c55da2b9b64.jpg" width="820" alt="Rule form with metadata conditions and actions">

## Conditions
- New **"Metadata field"** option in the field dropdown reveals a **key** input and a dedicated **operator** select: `equals` `not equals` `contains` `not contains` `regex` `in list` `> ≥ < ≤` `exists` `does not exist`.
- The value input **hides for the presence ops** (`exists` / `does not exist`) and comma-splits for `in list`.
- The dotted `metadata.<key>` field is assembled at submit time and split back into field + key when loading a rule for **edit**.

## Actions
- **Set metadata** — key + a `text` / `number` / `true/false` **type selector** + value. The value is coerced to the chosen JSON type on submit (`"2026"` → `2026`, `"true"` → `true`), so the stored blob is correctly typed.
- **Remove metadata** — key only.
- Both repeat freely; a same-key set+remove raises the existing combination warning.

## Why a special case
The builder's `{field, op, value}` condition and `{field, value}` action models have no slot for a dynamic **key** or a **typed value** — metadata rows carry extra `key` / `valueType` fields, with dedicated serialize/parse paths.

## Validation (real browser)
- Forward serialization captured from `submitRule()`: `metadata.tax_deductible eq "true"`, `metadata.project_code exists` (no value), `metadata.tags_csv in ["a","b","c"]`; actions with typed values (string / number `2026` / boolean `true`) + `remove_metadata`.
- Create → reload `/rules/{id}/edit` → state re-populates correctly (`field=metadata` + key + op + value; action `valueType` recovered as number/boolean/text) → delete. Backend accepted the POST (201) and DELETE (204).
- `go build`, `go vet`, and the pages/scripts-lint tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
