### PR TITLE
docs: adopt rules-as-substrate doctrine in CLAUDE.md (P0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 Self-hosted financial data aggregation for households. Syncs bank data via Plaid, Teller, and CSV; stores it in PostgreSQL; exposes it to AI agents via MCP and REST API.
 
+## Operating Model — the reconciliation flywheel (READ FIRST for any data/identity/enrichment design)
+
+> **Holy rule:** *Provider data is immutable; breadbox intelligence accrues as rules, which improve the enrichment layer on every sync.*
+
+Multiple sources (Plaid, Teller, SimpleFIN, CSV, …) describe the same entities differently. Any design that *identifies*, *standardizes*, or *enriches* synced data follows this — uniformly across counterparties, series, categories, attribution, future dimensions:
+
+1. **Identity is a stable surrogate** (`id`/`short_id`), never a derived/normalized string. The same counterparty keys differently per source (`STARBUCKS #123` vs `SQ *STARBUCKS`); never let one derived key `UNIQUE`-own an identity.
+2. **Rules are the only deterministic layer — authored, not shipped.** No built-in/system resolution tier, no shipped detectors or normalizers. Rules match **raw immutable provider fields** (`provider_name`, …) plus values stably derived from immutable ones (`amount`, `day_of_month`), so they're transparent, per-user, and drift-proof across upgrades.
+3. **Agents are the intelligence; rules are how it persists.** An agent reviews transactions against guidelines and either does a one-off edit (exceptions) or — the compounding path — authors a rule on raw fields so the next sync resolves it automatically. Both are first-class; the workflow decides which. Accepted cost: no identity without intelligence — a fresh install resolves nothing until an agent/rule runs; agent-less users keep the raw provider string as display fallback.
+4. **No shipped resolution.** Detection is the agent's job — it analyzes patterns, then encodes findings as rule conditions (e.g. `amount ≈ X ± Y AND day_of_month ≈ D ± N → assign_series`). Membership/identity is the rule's. (Precedence between user/agent/rule writes is deferred — annotations are an audit log only; no logic keys off them for now.)
+
+Full design + rollout: Obsidian `planned-features/rules-as-universal-substrate.md` + `rules-substrate-implementation-roadmap.md`.
+
 ## Stack
 
 Go 1.24+ single binary. PostgreSQL, chi/v5, pgx/v5 + sqlc, goose migrations, robfig/cron. Admin UI: `html/template` + DaisyUI 5 + Tailwind v4 + Alpine.js v3 (CDN, no Node). MCP: `github.com/modelcontextprotocol/go-sdk` v1.4.0 (Streamable HTTP at `/mcp`, stdio via `breadbox mcp-stdio`).


### PR DESCRIPTION
## P0 — Doctrine

Codifies the **rules-as-universal-substrate** doctrine in `CLAUDE.md` so every future data/identity/enrichment design follows one model.

**Holy rule:** *Provider data is immutable; breadbox intelligence accrues as rules, which improve the enrichment layer on every sync.*

Four principles: (1) surrogate identity, never a derived string; (2) rules are the only deterministic layer — authored, not shipped (no built-in detectors/normalizers); (3) agents are the intelligence, rules are how it persists (one-off edits and rule-authoring both first-class); (4) no shipped resolution — detection is the agent's job, encoded as rule conditions. Precedence/provenance deferred.

### Evidence
- Doc-only change (`CLAUDE.md`), no code/build impact.
- Full design + task roadmap: Obsidian `planned-features/rules-as-universal-substrate.md` + `rules-substrate-implementation-roadmap.md`.

Base: `feat/rules-substrate` (sprint integration branch; not main).
