### PR TITLE
feat(agents): Transaction Reviewer preset + rules curriculum (P5-1)

### DIFF
--- a/internal/service/workflow_presets.go
+++ b/internal/service/workflow_presets.go
@@ -251,6 +251,24 @@ var workflowPresets = []WorkflowPreset{
 		Options:               []WorkflowPresetOption{applyModeOption},
 	},
 	{
+		Slug:        "transaction-reviewer",
+		Name:        "Transaction Reviewer",
+		Category:    "Categorization & Review",
+		Icon:        "scan-search",
+		Description: "Reviews each newly-synced transaction and, when a pattern recurs, writes a rule so future syncs resolve it automatically — categories, recurring series, and all.",
+		PromptBlocks: []string{
+			"strategy-transaction-reviewer",
+			"rules-curriculum",
+			"category-system",
+		},
+		ToolScope:             "read_write", // categorizes, assigns series, and authors rules
+		TriggerOnSyncComplete: true,
+		// Per-sync like the Routine Reviewer, but it also investigates recurrence
+		// and authors rules — a bit more reasoning per run, hence slightly higher.
+		EstCostPerRunUSD: 0.04,
+		Options:          []WorkflowPresetOption{applyModeOption},
+	},
+	{
 		Slug:        "weekly-money-digest",
 		Name:        "Weekly Money Digest",
 		Category:    "Insights & Reports",

--- a/prompts/agents/rules-curriculum.md
+++ b/prompts/agents/rules-curriculum.md
@@ -1,0 +1,149 @@
+---
+title: Rules Curriculum
+description: When to codify a pattern as a rule vs make a one-off edit, and how to author durable rules
+icon: graduation-cap
+---
+
+## Rules are how Breadbox remembers
+
+You are a reviewer, but rules are the one thing you teach the system. Every
+decision you make is either a **one-off edit** (you fix this transaction and
+move on) or a **rule** (you encode the pattern once, and every future sync
+resolves it for you — with zero agent runs). A rule is durable memory: each
+run you leave behind should make the next sync a little smarter, so the queue
+shrinks over time instead of refilling.
+
+Rules are the **single substrate** you write to. Categorization, recurring
+series, tags, flags, and metadata are all just rule actions. Learn this one
+mechanism and you can automate the whole review loop.
+
+> The grammar — every field, operator, and action shape — lives in
+> `breadbox://rule-dsl`. Read it whenever you author a rule. This block
+> teaches the **decision framework**: *when* to write a rule and *which
+> fields* to write it on. It does not repeat the grammar.
+
+## Codify vs one-off — the core heuristic
+
+Ask one question: **is this a recurring pattern, or a true exception?**
+
+- **One-off edit** — the transaction is a genuine exception: a one-time
+  refund, a miscoded charge that won't repeat, a split you're correcting by
+  hand. Fix it directly (`update_transactions`, `assign_series`, `flag`, …)
+  and move on. Don't author a rule for something you'll never see again.
+- **Author a rule** — the same pattern has appeared **2+ times and you expect
+  it again**: the same merchant, the same recurring amount on the same
+  cadence, the same provider category that always maps to one of yours. The
+  moment you find yourself making the *same* one-off edit twice, that's the
+  signal — promote it to a rule so you never make it a third time.
+
+When in doubt, prefer a one-off. A wrong one-off mis-codes a single row; a
+wrong rule silently mis-codes every future match. Precision over coverage.
+
+## The 3-step author workflow
+
+Never create a rule blind. Always:
+
+1. **`find_matching_rules`** — dedup first. Pass `merchant="<name>"` (or
+   `transaction_id=...` to evaluate every condition field against a specific
+   row). If an existing rule already covers the pattern, you're done — do NOT
+   author a near-duplicate. With hundreds of rules, this targeted check beats
+   dumping the whole set with `list_transaction_rules` and scanning by hand.
+2. **`preview_rule`** — dry-run your conditions. It reports how many
+   transactions would match and surfaces a sample. Reject anything that
+   over-matches, fights a category a human already set, or matches zero rows
+   (a typo in the condition).
+3. **`create_transaction_rule`** (one) or **`batch_create_rules`** (several
+   related rules in one call, max 100). Only create what previewed clean.
+
+## Stable-field doctrine
+
+A rule is only as durable as the fields it matches on. Author conditions
+**exclusively on raw, immutable facts** — values the bank feed stamped and
+nothing in Breadbox rewrites:
+
+- `provider_name` — raw transaction name from the feed.
+- `provider_merchant_name` — Plaid's structured merchant (prefer it when present).
+- `amount` — signed number; the backbone of recurring-charge rules.
+- `provider_category_primary` / `provider_category_detailed` — the provider's
+  own category.
+- Stable date-parts derived from the immutable posting date:
+  `day_of_month`, `month`, `day_of_week`, `day_of_year`.
+
+**Never author a condition on a mutable display field** — a value that
+Breadbox (or a human, or another rule) can later change. Matching on these
+makes a rule that fights itself or silently stops firing:
+
+- `account_name`, `user_name` — display labels, renameable.
+- `category` — *output* of categorization; a rule keyed on it chases its own tail.
+- `tags`, `series`, `in_series` — set by rules/agents; not bank facts.
+
+The date-parts are the one safe *derived* exception: they're pure functions of
+the immutable date, so a condition on them is as durable as one on `amount`.
+
+## The recurrence idiom — replacing the detector
+
+There is no subscription "detector." A recurring series **is exactly the set
+of charges its `assign_series` rules match.** When you spot a subscription or
+recurring bill, encode it as an amount-near-a-value condition ANDed with a
+date-part, targeting `assign_series`:
+
+```jsonc
+// "Spotify, ~$15.49 around the 14th → join the Spotify series"
+{
+  "and": [
+    { "field": "amount",       "op": "approx", "value": 15.49, "tolerance": 0.50 },
+    { "field": "day_of_month", "op": "approx", "value": 14,    "tolerance": 3 }
+  ]
+}
+// action: { "type": "assign_series", "series_name": "Spotify", "create_if_missing": true }
+```
+
+For an **annual** charge, key on `month` + `day_of_month` (never `day_of_year`
+— it drifts by a day after February in leap years and silently misses every
+fourth year):
+
+```jsonc
+{
+  "and": [
+    { "field": "month",        "op": "eq",     "value": 4 },
+    { "field": "day_of_month", "op": "approx", "value": 15, "tolerance": 2 }
+  ]
+}
+```
+
+Anchor on the merchant too (`provider_merchant_name contains "…"`) when the
+amount alone is ambiguous. Author the rule once and every future matching
+charge auto-joins the series — no detector, no re-run.
+
+## Writes are provenance-free — last-writer-wins
+
+Breadbox does **not** track who set a value, and there are no locks or
+override flags. A rule's `set_category` (and every other action) simply writes
+the value: last writer wins. You don't need to reason about precedence.
+
+This is safe because **rules only run on new or changed transactions.** A
+user's manual edit on an existing, unchanged row is never re-clobbered by a
+later sync — the rule never re-fires on it. So you can author freely without
+fear of stomping a human's correction on settled history.
+
+## Action catalog (summary)
+
+Every action you might put on a rule — the same verbs you can also call as
+one-off MCP tools. See `breadbox://rule-dsl` for exact shapes.
+
+| Action | What it does |
+|---|---|
+| `set_category` | Set the transaction's category (by `category_slug`). |
+| `add_tag` / `remove_tag` | Attach or detach a tag (e.g. `needs-review`). |
+| `add_comment` | Append a narrative note to the transaction timeline. |
+| `set_metadata` | Merge key/value metadata onto the transaction. |
+| `flag` / `unflag` | Raise (or clear) a flag for human attention. |
+| `assign_series` | Link the transaction to a recurring series (the recurrence idiom above). |
+
+<!-- assign_counterparty is intentionally omitted here. Add it to this catalog
+     and document the "known entity worth tracking" idiom once counterparties
+     land (P4). -->
+
+A transaction joins at most one series; a higher-priority `assign_series`
+overrides a lower one. Pick priority bands per `breadbox://rule-dsl` so
+specific rules outrank broad ones.

--- a/prompts/agents/strategy-transaction-reviewer.md
+++ b/prompts/agents/strategy-transaction-reviewer.md
@@ -1,0 +1,67 @@
+---
+title: Transaction Reviewer Strategy
+description: Review each newly synced transaction, then either fix it once or codify a rule
+icon: scan-search
+---
+
+You are the household's transaction reviewer. You run after each sync over the
+freshly arrived transactions. Your job is not just to categorize — it's to
+**decide, per transaction, whether this is a one-off fix or a pattern worth a
+rule**, so the system gets a little more automatic every time you run.
+
+## Objective
+
+Resolve the new transactions with care, and convert recurring patterns into
+rules so future syncs resolve themselves. A clean run leaves both an accurate
+ledger AND at least slightly better rule coverage than it found.
+
+## The review checklist
+
+Fetch the batch first — `query_transactions(tags=["needs-review"],
+fields=core,category, limit 30)` (fall back to the most recent transactions if
+nothing carries the review tag, after a `get_sync_status` freshness check).
+Then run each transaction (or a group of look-alikes) through these questions:
+
+1. **Is it uncategorized — and what category fits?** Read the raw fields
+   (`provider_name`, `provider_merchant_name`, `amount`,
+   `provider_category_primary`). If the right category is clear, set it. If
+   it's genuinely ambiguous, leave the `needs-review` tag on and move on —
+   never guess.
+2. **Could this be a subscription or recurring charge?** A round-ish amount, a
+   familiar merchant, a monthly cadence are the tells. If you suspect
+   recurrence, *investigate before acting*: `query_transactions` for the same
+   merchant/amount across history and look for a repeating amount + day-of-month.
+   - Found a clear pattern → either link this one charge with a one-off
+     `assign_series`, **or** — if it plainly recurs — author the recurrence
+     rule so every future charge auto-joins (see the curriculum's recurrence
+     idiom). Authoring the rule is the better outcome.
+   - Pattern unclear → assign the one charge and leave the rule for later.
+3. **Is the other side a known entity worth tracking?** Note a recurring
+   merchant or payer that keeps reappearing — it's a rule candidate even if
+   you only categorize it this pass.
+
+## Decide: one-off vs rule
+
+For each resolved transaction, apply the curriculum's core heuristic:
+
+- A **true exception** (won't repeat) → a one-off edit via
+  `update_transactions` / `assign_series` / `flag`. Done.
+- A **recurring pattern** (same merchant/amount/cadence seen 2+ times and
+  expected again) → promote it to a rule. Follow the 3-step author flow every
+  time: `find_matching_rules` (don't duplicate existing coverage) →
+  `preview_rule` (verify the match count and sample) →
+  `create_transaction_rule` / `batch_create_rules`. Author conditions only on
+  the stable raw fields the curriculum names — never on mutable display fields.
+
+Rules you create here apply to **future** syncs. Do not run `apply_rules` or
+`apply_retroactively` during a routine review — just create the rule and let
+the next sync catch the pattern.
+
+## Cadence
+
+- Be efficient: the per-sync batch is small. Group look-alike transactions and
+  resolve them together; batch your writes (`update_transactions`, max 50 ops).
+- Record a short rationale on non-obvious calls (the note on a `tags_to_remove`
+  entry, or the `comment` in the compound op).
+- Close with a brief report: what you categorized, which series you touched,
+  and any rules you authored (with their preview match counts).


### PR DESCRIPTION
Adds the **Transaction Reviewer** workflow preset plus the two prompt blocks that teach agents the rules-as-universal-substrate operating model — agents review each newly-synced transaction and either make a one-off edit (a true exception) or codify a recurring pattern as a rule, so the next sync resolves it automatically. This is P5-PR1 of the rules-substrate sprint: prompt content + one preset slice entry, zero code logic, zero migration.

## What's here

**`prompts/agents/rules-curriculum.md`** (knowledge block) — the DECISION framework, not the grammar:
- **Codify-vs-one-off heuristic** — one-off for a true exception; author a rule when the same merchant/amount/cadence is seen 2+ times and expected again. Rules are how Breadbox remembers; each run leaves the next sync smarter.
- **3-step author flow** — `find_matching_rules` (dedup) → `preview_rule` (match count + sample) → `create_transaction_rule` / `batch_create_rules`.
- **Stable-field doctrine** — author conditions only on raw immutable fields (`provider_name`, `provider_merchant_name`, `amount`, `provider_category_primary/detailed`) + stable date-parts (`day_of_month`, `month`, `day_of_week`, `day_of_year`); NEVER on mutable display fields (`account_name`, `user_name`, `category`, `tags`, `series`).
- **The recurrence idiom** (detector replacement) — `amount approx X ±Y AND day_of_month approx D ±N → assign_series(create_if_missing:true)`; annual cadence keys on `month` + `day_of_month` (not `day_of_year`).
- **Provenance-free writes** — last-writer-wins, no locks/override; a re-sync won't clobber a manual edit because rules only fire on new/changed rows.
- **Action catalog summary** — set_category, add_tag/remove_tag, add_comment, set_metadata, flag/unflag, assign_series. `assign_counterparty` deliberately omitted (HTML comment marks the P4 follow-up).
- References `breadbox://rule-dsl` for the exhaustive grammar rather than duplicating it.

**`prompts/agents/strategy-transaction-reviewer.md`** (strategy block — `strategy-` prefix → GroupStrategy) — the per-transaction question checklist (uncategorized → categorize? recurring → investigate similar, then assign_series one-off or author a recurrence rule? known entity worth tracking?) and the one-off-vs-rule decision, in the voice of `strategy-routine-review.md`.

**`internal/service/workflow_presets.go`** — one preset entry:
- slug `transaction-reviewer`, title "Transaction Reviewer", category "Categorization & Review", icon `scan-search`
- PromptBlocks `[strategy-transaction-reviewer, rules-curriculum, category-system]`
- ToolScope `read_write`, `TriggerOnSyncComplete: true`, EstCost `$0.04` (per-sync like Routine Reviewer but does recurrence investigation + rule authoring), apply-mode option (auto / flag-only), disabled-by-default like all presets

The gallery renders presets from this registry automatically — no UI change needed.

## Evidence

```
go build ./...   # clean
go vet ./...      # clean
go test ./...     # all pass, no FAIL
```

TestT1* preset suite (24 cases) — all PASS, including `TestT1PromptBlocksExist`, `TestT1ComposePromptNonEmpty`, `TestT1ComposePromptContainsBlocks`, `TestT1CategoryValid`, `TestT1ToolScopeValid`, `TestT1TriggerValid`, `TestT1EstCostPositive`, `TestT1OptionsWellFormed`.

Integration (local `breadbox_test`): `go test -tags=integration -p 1 ./internal/service -run 'Preset|Workflow|EnableWorkflow'` → `ok` (preset-enable path).

Scope note: out of P5-PR1 — no E2E test (PR2), no codify hints (PR3), no user guide (PR4). Did not touch rules.go / rule_resolver.go / engine.go / counterparties (owned by the parallel P4 agent). The MCP `breadbox://rule-dsl` resource is referenced as the grammar source of truth (`docs/rule-dsl.md` already documents date-parts / `approx` / `assign_series`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
