### PR TITLE
feat(counterparties): entity + assign_counterparty action + resolution (P4-A)

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -182,6 +182,9 @@ func runServe(_ context.Context, version string, noDashboardFlag bool) error {
 	// (resolve-or-mint + link). Function-pointer hook keeps the sync engine
 	// decoupled from the series service — same pattern as OnSyncComplete.
 	a.SyncEngine.AssignSeriesInTx = a.Service.AssignSeriesFromRuleTx
+	// Materialize assign_counterparty rule actions inside the sync transaction
+	// (resolve-or-create + link) — same decoupling pattern as AssignSeriesInTx.
+	a.SyncEngine.AssignCounterpartyInTx = a.Service.AssignCounterpartyFromRuleTx
 	agentSched.Start(ctx)
 	a.AgentOrchestrator = agentOrch
 	a.AgentScheduler = agentSched

--- a/internal/db/migrations/20260620040614_counterparties.sql
+++ b/internal/db/migrations/20260620040614_counterparties.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+
+-- Counterparties (rules-as-universal-substrate, P4). A counterparty is the OTHER
+-- side of a transaction — merchants AND non-merchants (Venmo recipients, people,
+-- employers / paychecks). ONE canonical, cross-provider, surrogate-identity
+-- (id/short_id) entity, agent-curated. There is NO shipped normalizer and NO
+-- auto-create: a transaction's counterparty_id is set ONLY by an
+-- `assign_counterparty` rule (on raw immutable provider fields) or a first-class
+-- one-off assign. Membership is therefore rule-defined, exactly like series.
+--
+-- Doctrine notes:
+--   * NO UNIQUE on name. Unlike recurring_series (whose name is mint-by-name
+--     intent), counterparties are assigned by short_id. A name collision is
+--     allowed; the resolve-or-create path de-dupes by name in application logic
+--     and `canonical_counterparty_id` rolls duplicates up later.
+--   * canonical_counterparty_id is a self-reference for later rollups (e.g.
+--     folding "Uber" and "Uber Eats" into one canonical entity). NULL for now.
+--   * Enrichment columns (website_url, logo_url, category_id, mcc, attrs) live on
+--     the counterparty so they're enriched once per entity and shared by every
+--     transaction that resolves to it. The async fetch job is a future hook.
+--
+-- ADDITIVE: CREATE TABLE + ADD COLUMN (nullable) + CREATE INDEX only. Safe to
+-- apply to the shared dev DB — older `breadbox serve` processes that never read
+-- or write counterparty_id keep working untouched.
+
+CREATE TABLE counterparties (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    short_id    TEXT        NOT NULL UNIQUE,
+    name        TEXT        NOT NULL,
+    website_url TEXT        NULL,
+    logo_url    TEXT        NULL,
+    category_id UUID        NULL REFERENCES categories(id) ON DELETE SET NULL,
+    mcc         TEXT        NULL,
+    attrs       JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    -- Self-reference for cross-counterparty rollups (agent-decided granularity).
+    canonical_counterparty_id UUID NULL REFERENCES counterparties(id) ON DELETE SET NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at  TIMESTAMPTZ NULL
+);
+
+CREATE TRIGGER set_short_id_counterparties
+    BEFORE INSERT ON counterparties
+    FOR EACH ROW EXECUTE FUNCTION set_short_id();
+
+-- Live-row partial index for the List/Get sweeps (soft-deleted rows excluded).
+CREATE INDEX counterparties_deleted_at_idx
+    ON counterparties (deleted_at)
+    WHERE deleted_at IS NULL;
+
+-- Partial index over the rollup self-reference so canonical rollups stay cheap
+-- once they exist (most rows have a NULL canonical pointer).
+CREATE INDEX counterparties_canonical_idx
+    ON counterparties (canonical_counterparty_id)
+    WHERE canonical_counterparty_id IS NOT NULL;
+
+-- The occurrence link. SET NULL on counterparty delete — a transaction is a real
+-- bank charge that must outlive a derived grouping (same policy as series_id).
+-- counterparty_id is rule-resolved POST-upsert (UpsertTransaction is unchanged),
+-- exactly like series_id.
+ALTER TABLE transactions
+    ADD COLUMN counterparty_id UUID NULL REFERENCES counterparties(id) ON DELETE SET NULL;
+
+CREATE INDEX transactions_counterparty_id_idx
+    ON transactions (counterparty_id)
+    WHERE counterparty_id IS NOT NULL;
+
+-- +goose Down
+
+-- Purely additive up — a faithful inverse drops the column + table. The CASCADE
+-- on the table drop is unnecessary (only transactions.counterparty_id references
+-- it, dropped first), but harmless.
+DROP INDEX IF EXISTS transactions_counterparty_id_idx;
+ALTER TABLE transactions DROP COLUMN IF EXISTS counterparty_id;
+DROP TABLE IF EXISTS counterparties CASCADE;

--- a/internal/db/migrations/20260620040615_annotations_counterparty_kinds.sql
+++ b/internal/db/migrations/20260620040615_annotations_counterparty_kinds.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+-- Extend the annotations.kind CHECK constraint to recognise counterparty
+-- membership events on the activity timeline:
+--   - counterparty_assigned: written when a transaction is linked to a
+--     counterparty (manual assign or rule materialization).
+--   - counterparty_unlinked: written when a transaction is detached from one.
+--
+-- Drop + add run in goose's per-migration transaction so the table is never
+-- without a constraint. Additive in the shared-DB sense: the new constraint only
+-- WIDENS the allowed set, so older `breadbox serve` processes (which never write
+-- the new kinds) keep working before they pick up the emitting code.
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated',
+    'transaction_deleted',
+    'transaction_restored',
+    'series_assigned',
+    'series_unlinked',
+    'counterparty_assigned',
+    'counterparty_unlinked'
+  ));
+
+-- +goose Down
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated',
+    'transaction_deleted',
+    'transaction_restored',
+    'series_assigned',
+    'series_unlinked'
+  ));

--- a/internal/db/queries/counterparties.sql
+++ b/internal/db/queries/counterparties.sql
@@ -1,0 +1,75 @@
+-- name: InsertCounterparty :one
+INSERT INTO counterparties (name, website_url, logo_url, category_id, mcc, attrs)
+VALUES ($1, $2, $3, $4, $5, COALESCE(sqlc.narg('attrs'), '{}'::jsonb))
+RETURNING *;
+
+-- name: GetCounterpartyByID :one
+SELECT * FROM counterparties WHERE id = $1 AND deleted_at IS NULL;
+
+-- name: GetCounterpartyByShortID :one
+SELECT * FROM counterparties WHERE short_id = $1 AND deleted_at IS NULL;
+
+-- name: GetCounterpartyUUIDByShortID :one
+SELECT id FROM counterparties WHERE short_id = $1;
+
+-- GetCounterpartyByName resolves a live counterparty by exact name. There is NO
+-- UNIQUE on name (counterparties are assigned by short_id, not minted-by-name),
+-- so this is the resolve half of the rule path's resolve-or-create: it picks the
+-- oldest live row with the name, and the caller creates one only when none
+-- exists. Deterministic (created_at ASC) so concurrent callers converge.
+-- name: GetCounterpartyByName :one
+SELECT * FROM counterparties
+WHERE name = $1 AND deleted_at IS NULL
+ORDER BY created_at ASC
+LIMIT 1;
+
+-- name: ListCounterparties :many
+SELECT * FROM counterparties
+WHERE deleted_at IS NULL
+ORDER BY name ASC;
+
+-- UpdateCounterparty applies the enrichment-lane edits. NULL args leave a column
+-- unchanged via COALESCE, except name which is always set (the caller passes the
+-- current value when unchanged).
+-- name: UpdateCounterparty :one
+UPDATE counterparties
+SET name        = $2,
+    website_url = COALESCE(sqlc.narg('website_url'), website_url),
+    logo_url    = COALESCE(sqlc.narg('logo_url'), logo_url),
+    category_id = COALESCE(sqlc.narg('category_id'), category_id),
+    mcc         = COALESCE(sqlc.narg('mcc'), mcc),
+    attrs       = COALESCE(sqlc.narg('attrs'), attrs),
+    updated_at  = NOW()
+WHERE id = $1 AND deleted_at IS NULL
+RETURNING *;
+
+-- name: SoftDeleteCounterparty :execrows
+UPDATE counterparties
+SET deleted_at = NOW(), updated_at = NOW()
+WHERE id = $1 AND deleted_at IS NULL;
+
+-- LinkTransactionCounterparty attaches a transaction to a counterparty, NULL-fill
+-- only — it never clobbers an existing assignment. Returns rows affected.
+-- name: LinkTransactionCounterparty :execrows
+UPDATE transactions
+SET counterparty_id = $1, updated_at = NOW()
+WHERE id = ANY(sqlc.arg('transaction_ids')::uuid[])
+  AND counterparty_id IS NULL
+  AND deleted_at IS NULL;
+
+-- UnlinkTransactionCounterparty detaches transactions from a counterparty (clears
+-- counterparty_id), guarded on counterparty_id so it can never steal a charge
+-- from another counterparty. Returns rows affected so the caller can verify every
+-- id was actually linked.
+-- name: UnlinkTransactionCounterparty :execrows
+UPDATE transactions
+SET counterparty_id = NULL, updated_at = NOW()
+WHERE id = ANY(sqlc.arg('transaction_ids')::uuid[])
+  AND counterparty_id = sqlc.arg('counterparty_id')
+  AND deleted_at IS NULL;
+
+-- CounterpartyTransactionCount returns the live charge count linked to a
+-- counterparty (the admin list / detail "N transactions" label).
+-- name: CounterpartyTransactionCount :one
+SELECT COUNT(*) FROM transactions
+WHERE counterparty_id = $1 AND deleted_at IS NULL;

--- a/internal/service/counterparties.go
+++ b/internal/service/counterparties.go
@@ -1,0 +1,502 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Annotation kinds for counterparty membership events on the transaction
+// activity timeline (see *_annotations_counterparty_kinds.sql).
+const (
+	annotationKindCounterpartyAssigned = "counterparty_assigned"
+	annotationKindCounterpartyUnlinked = "counterparty_unlinked"
+)
+
+// counterpartyAssignMaxMembers caps the per-call link batch (mirrors the
+// update_transactions / assign_series 50-op ceiling).
+const counterpartyAssignMaxMembers = 50
+
+// AssignCounterparty is the imperative create/link entry point shared by the
+// `assign_counterparty` MCP tool and REST endpoints. It binds the listed
+// transactions to an existing counterparty (CounterpartyShortID) or — surrogate-
+// first — resolves-or-creates one by name (CreateIfMissing), then links members
+// (NULL-fill only). Default is assign-existing; a counterparty is NEVER
+// auto-created unless CreateIfMissing is set.
+func (s *Service) AssignCounterparty(ctx context.Context, in AssignCounterpartyInput, actor Actor) (*CounterpartyResponse, error) {
+	if len(in.TransactionIDs) > counterpartyAssignMaxMembers {
+		return nil, fmt.Errorf("%w: at most %d transactions per call", ErrInvalidParameter, counterpartyAssignMaxMembers)
+	}
+
+	switch {
+	case in.CounterpartyShortID != nil && strings.TrimSpace(*in.CounterpartyShortID) != "":
+		return s.linkCounterpartyMembers(ctx, *in.CounterpartyShortID, in.TransactionIDs, actor)
+	case in.CreateIfMissing && strings.TrimSpace(in.Name) != "":
+		return s.createCounterpartyByName(ctx, in, actor)
+	default:
+		return nil, fmt.Errorf("%w: provide counterparty_short_id, or name with create_if_missing", ErrInvalidParameter)
+	}
+}
+
+// createCounterpartyByName resolves (or creates) a counterparty by its live name
+// and links any members in one transaction. Unlike series there is no UNIQUE on
+// name, so this is a resolve-or-create that de-dupes on the live name.
+// FailIfExists makes it a strict create.
+func (s *Service) createCounterpartyByName(ctx context.Context, in AssignCounterpartyInput, actor Actor) (*CounterpartyResponse, error) {
+	name := strings.TrimSpace(in.Name)
+	memberIDs, err := s.resolveTransactionIDs(ctx, in.TransactionIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin assign counterparty: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	row, existed, err := resolveOrCreateCounterpartyByName(ctx, qtx, name)
+	if err != nil {
+		return nil, err
+	}
+	if existed && in.FailIfExists {
+		return nil, fmt.Errorf("%w: a counterparty named %q already exists — edit it instead of creating a new one", ErrConflict, name)
+	}
+
+	if len(memberIDs) > 0 {
+		if err := linkCounterpartyAndAnnotate(ctx, tx, qtx, row, memberIDs, actor); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit assign counterparty: %w", err)
+	}
+	resp := counterpartyFromRow(row)
+	return &resp, nil
+}
+
+// AssignCounterpartyFromRuleTx materializes an `assign_counterparty` rule action
+// INSIDE the sync transaction (the engine calls this via the
+// Engine.AssignCounterpartyInTx hook, so the sync package never imports service).
+// It resolves the target counterparty by short_id, or — surrogate-first —
+// resolves-or-creates one by name (createIfMissing), then links the single
+// transaction (NULL-fill only). All on the provided tx so it commits atomically
+// with the sync. Failure to resolve is a no-op (the rule is skipped) rather than
+// a sync failure.
+func (s *Service) AssignCounterpartyFromRuleTx(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, counterpartyShortID, counterpartyName string, createIfMissing bool) error {
+	qtx := s.Queries.WithTx(tx)
+
+	var row db.Counterparty
+	switch {
+	case strings.TrimSpace(counterpartyShortID) != "":
+		r, err := qtx.GetCounterpartyByShortID(ctx, counterpartyShortID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil // rule references a missing counterparty — no-op, don't break sync
+			}
+			return fmt.Errorf("resolve counterparty %q: %w", counterpartyShortID, err)
+		}
+		row = r
+	case createIfMissing && strings.TrimSpace(counterpartyName) != "":
+		r, _, err := resolveOrCreateCounterpartyByName(ctx, qtx, strings.TrimSpace(counterpartyName))
+		if err != nil {
+			return fmt.Errorf("resolve-or-create rule counterparty: %w", err)
+		}
+		row = r
+	default:
+		return nil // nothing actionable
+	}
+
+	return linkCounterpartyAndAnnotate(ctx, tx, qtx, row, []pgtype.UUID{txnID}, SystemActor())
+}
+
+// resolveOrCreateCounterpartyByName returns the oldest live counterparty with the
+// given name, creating one when none exists. The bool reports whether an existing
+// row was found (true) versus freshly created (false). There is no UNIQUE on
+// name, so this is application-level de-dup — acceptable per the doctrine
+// (duplicates roll up later via canonical_counterparty_id).
+func resolveOrCreateCounterpartyByName(ctx context.Context, qtx *db.Queries, name string) (db.Counterparty, bool, error) {
+	existing, err := qtx.GetCounterpartyByName(ctx, name)
+	if err == nil {
+		return existing, true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return db.Counterparty{}, false, fmt.Errorf("lookup counterparty by name: %w", err)
+	}
+	created, err := qtx.InsertCounterparty(ctx, db.InsertCounterpartyParams{Name: name})
+	if err != nil {
+		return db.Counterparty{}, false, fmt.Errorf("create counterparty: %w", err)
+	}
+	return created, false, nil
+}
+
+// linkCounterpartyAndAnnotate links members to a counterparty (NULL-fill only)
+// and emits a counterparty_assigned annotation for the charges this call actually
+// linked. The caller owns the surrounding transaction.
+func linkCounterpartyAndAnnotate(ctx context.Context, tx pgx.Tx, qtx *db.Queries, cp db.Counterparty, memberIDs []pgtype.UUID, actor Actor) error {
+	if len(memberIDs) == 0 {
+		return nil
+	}
+	// Only charges currently counterparty-less get a timeline event — a re-apply
+	// NULL-fills already-linked members and must not re-emit.
+	newlyLinked, err := unlinkedCounterpartySubset(ctx, tx, memberIDs)
+	if err != nil {
+		return err
+	}
+	if _, err := qtx.LinkTransactionCounterparty(ctx, db.LinkTransactionCounterpartyParams{
+		CounterpartyID: cp.ID,
+		TransactionIds: memberIDs,
+	}); err != nil {
+		return fmt.Errorf("link counterparty members: %w", err)
+	}
+	if len(newlyLinked) > 0 {
+		if err := emitCounterpartyMembershipAnnotations(ctx, qtx, annotationKindCounterpartyAssigned, newlyLinked, cp.ShortID, cp.Name, actor); err != nil {
+			return fmt.Errorf("emit counterparty_assigned annotations: %w", err)
+		}
+	}
+	return nil
+}
+
+// linkCounterpartyMembers binds transactions to an existing counterparty
+// (NULL-fill only) in one transaction. Used by the existing-counterparty branch
+// of AssignCounterparty.
+func (s *Service) linkCounterpartyMembers(ctx context.Context, idOrShort string, memberIDsOrShorts []string, actor Actor) (*CounterpartyResponse, error) {
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	memberIDs, err := s.resolveTransactionIDs(ctx, memberIDsOrShorts)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin link counterparty members: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	row, err := qtx.GetCounterpartyByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get counterparty: %w", err)
+	}
+	if err := linkCounterpartyAndAnnotate(ctx, tx, qtx, row, memberIDs, actor); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit link counterparty members: %w", err)
+	}
+	resp := counterpartyFromRow(row)
+	return &resp, nil
+}
+
+// UnlinkCounterpartyTransactions detaches transactions from a counterparty — the
+// inverse of the link path. It clears each charge's counterparty_id and emits a
+// counterparty_unlinked timeline event. It refuses if any listed transaction
+// isn't currently bound to this counterparty.
+func (s *Service) UnlinkCounterpartyTransactions(ctx context.Context, idOrShort string, memberIDsOrShorts []string, actor Actor) (*CounterpartyResponse, error) {
+	if len(memberIDsOrShorts) == 0 {
+		return nil, fmt.Errorf("%w: at least one transaction to unlink is required", ErrInvalidParameter)
+	}
+	if len(memberIDsOrShorts) > counterpartyAssignMaxMembers {
+		return nil, fmt.Errorf("%w: at most %d transactions per call", ErrInvalidParameter, counterpartyAssignMaxMembers)
+	}
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	memberIDs, err := s.resolveTransactionIDs(ctx, memberIDsOrShorts)
+	if err != nil {
+		return nil, err
+	}
+	memberIDs = dedupeUUIDs(memberIDs)
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin unlink counterparty: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	row, err := qtx.GetCounterpartyByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get counterparty: %w", err)
+	}
+
+	detached, err := qtx.UnlinkTransactionCounterparty(ctx, db.UnlinkTransactionCounterpartyParams{
+		CounterpartyID: row.ID,
+		TransactionIds: memberIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unlink counterparty members: %w", err)
+	}
+	if int(detached) != len(memberIDs) {
+		return nil, fmt.Errorf("%w: %d of %d transactions are not bound to this counterparty",
+			ErrInvalidParameter, len(memberIDs)-int(detached), len(memberIDs))
+	}
+
+	if err := emitCounterpartyMembershipAnnotations(ctx, qtx, annotationKindCounterpartyUnlinked, memberIDs, row.ShortID, row.Name, actor); err != nil {
+		return nil, fmt.Errorf("emit counterparty_unlinked annotations: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit unlink counterparty: %w", err)
+	}
+	resp := counterpartyFromRow(row)
+	return &resp, nil
+}
+
+// GetCounterparty returns a single counterparty by short_id or uuid.
+func (s *Service) GetCounterparty(ctx context.Context, idOrShort string) (*CounterpartyResponse, error) {
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.Queries.GetCounterpartyByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get counterparty: %w", err)
+	}
+	resp := counterpartyFromRow(row)
+	return &resp, nil
+}
+
+// ListCounterparties returns all live counterparties, alphabetically by name.
+func (s *Service) ListCounterparties(ctx context.Context) ([]CounterpartyResponse, error) {
+	rows, err := s.Queries.ListCounterparties(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list counterparties: %w", err)
+	}
+	out := make([]CounterpartyResponse, len(rows))
+	for i, r := range rows {
+		out[i] = counterpartyFromRow(r)
+	}
+	return out, nil
+}
+
+// UpdateCounterparty applies an enrichment-lane edit (name + logo/url/category/
+// mcc). Only the supplied (non-nil) fields change.
+func (s *Service) UpdateCounterparty(ctx context.Context, idOrShort string, in EditCounterpartyInput, actor Actor) (*CounterpartyResponse, error) {
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	if in.Name == nil && in.WebsiteURL == nil && in.LogoURL == nil && in.CategoryID == nil && in.MCC == nil {
+		return nil, fmt.Errorf("%w: provide at least one field to update", ErrInvalidParameter)
+	}
+	if in.Name != nil && strings.TrimSpace(*in.Name) == "" {
+		return nil, fmt.Errorf("%w: name cannot be empty", ErrInvalidParameter)
+	}
+
+	row, err := s.Queries.GetCounterpartyByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get counterparty: %w", err)
+	}
+
+	name := row.Name
+	if in.Name != nil {
+		name = strings.TrimSpace(*in.Name)
+	}
+
+	var categoryID pgtype.UUID
+	if in.CategoryID != nil {
+		if strings.TrimSpace(*in.CategoryID) == "" {
+			return nil, fmt.Errorf("%w: category_id cannot be empty", ErrInvalidParameter)
+		}
+		cid, err := s.resolveCategoryID(ctx, *in.CategoryID)
+		if err != nil {
+			return nil, fmt.Errorf("%w: category %q not found", ErrInvalidParameter, *in.CategoryID)
+		}
+		categoryID = cid
+	}
+
+	updated, err := s.Queries.UpdateCounterparty(ctx, db.UpdateCounterpartyParams{
+		ID:         id,
+		Name:       name,
+		WebsiteUrl: pgconv.TextFromPtr(in.WebsiteURL),
+		LogoUrl:    pgconv.TextFromPtr(in.LogoURL),
+		CategoryID: categoryID,
+		Mcc:        pgconv.TextFromPtr(in.MCC),
+		Attrs:      nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update counterparty: %w", err)
+	}
+	resp := counterpartyFromRow(updated)
+	return &resp, nil
+}
+
+// DeleteCounterparty soft-deletes a counterparty. The ON DELETE SET NULL FK is
+// only triggered by a hard delete; a soft delete leaves linked transactions
+// pointing at the now-hidden row, which List/Get exclude — acceptable for now,
+// the read-model fallback (PR B) renders the provider string when the join misses.
+func (s *Service) DeleteCounterparty(ctx context.Context, idOrShort string) error {
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return err
+	}
+	n, err := s.Queries.SoftDeleteCounterparty(ctx, id)
+	if err != nil {
+		return fmt.Errorf("soft delete counterparty: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// CounterpartyTransactionCount returns the live charge count bound to a
+// counterparty.
+func (s *Service) CounterpartyTransactionCount(ctx context.Context, idOrShort string) (int64, error) {
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return 0, err
+	}
+	n, err := s.Queries.CounterpartyTransactionCount(ctx, id)
+	if err != nil {
+		return 0, fmt.Errorf("count counterparty transactions: %w", err)
+	}
+	return n, nil
+}
+
+// ListCounterpartyGoverningRules returns the rules whose `assign_counterparty`
+// action targets this counterparty — by its short_id (assign to existing) or by
+// its name (resolve-or-create by name). These rules ARE the counterparty's
+// durable definition (rules-as-substrate): its membership is whatever they match.
+// Mirrors ListGoverningRules for series (hand-rolled SQL + convertRuleRows).
+func (s *Service) ListCounterpartyGoverningRules(ctx context.Context, idOrShort string) ([]TransactionRuleResponse, error) {
+	id, err := s.resolveCounterpartyID(ctx, idOrShort)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.Queries.GetCounterpartyByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get counterparty: %w", err)
+	}
+
+	query := ruleSelectQuery + `
+		WHERE tr.actions @> jsonb_build_array(jsonb_build_object('type', 'assign_counterparty', 'counterparty_short_id', $1::text))
+		   OR tr.actions @> jsonb_build_array(jsonb_build_object('type', 'assign_counterparty', 'counterparty_name', $2::text))
+		ORDER BY tr.priority DESC, tr.created_at ASC`
+	rows, err := s.Pool.Query(ctx, query, row.ShortID, row.Name)
+	if err != nil {
+		return nil, fmt.Errorf("list counterparty governing rules: %w", err)
+	}
+	defer rows.Close()
+
+	var scanned []ruleRow
+	for rows.Next() {
+		var rr ruleRow
+		if err := rows.Scan(rr.scanDest()...); err != nil {
+			return nil, fmt.Errorf("scan governing rule: %w", err)
+		}
+		scanned = append(scanned, rr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate governing rules: %w", err)
+	}
+	return s.convertRuleRows(ctx, scanned), nil
+}
+
+// unlinkedCounterpartySubset returns the subset of ids whose transactions are not
+// yet bound to any counterparty (counterparty_id IS NULL). Used so
+// counterparty_assigned annotations are emitted only for charges the link
+// actually binds.
+func unlinkedCounterpartySubset(ctx context.Context, tx pgx.Tx, ids []pgtype.UUID) ([]pgtype.UUID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	rows, err := tx.Query(ctx,
+		`SELECT id FROM transactions WHERE id = ANY($1::uuid[]) AND counterparty_id IS NULL AND deleted_at IS NULL`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("query unlinked counterparty members: %w", err)
+	}
+	defer rows.Close()
+	var out []pgtype.UUID
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan unlinked counterparty member: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// emitCounterpartyMembershipAnnotations writes one counterparty_assigned /
+// counterparty_unlinked annotation per affected transaction, atomic with the
+// surrounding tx. The payload carries the counterparty short_id + name so the
+// timeline can render and deep-link the sentence.
+func emitCounterpartyMembershipAnnotations(ctx context.Context, q *db.Queries, kind string, txnIDs []pgtype.UUID, cpShortID, cpName string, actor Actor) error {
+	if len(txnIDs) == 0 {
+		return nil
+	}
+	if actor.Type == "" {
+		actor = SystemActor()
+	}
+	payload := map[string]interface{}{
+		"counterparty_id":   cpShortID,
+		"counterparty_name": cpName,
+	}
+	for _, txnID := range txnIDs {
+		if err := writeAnnotation(ctx, q, writeAnnotationParams{
+			TransactionID: txnID,
+			Kind:          kind,
+			ActorType:     normalizeAnnotationActorType(actor.Type),
+			ActorID:       actor.ID,
+			ActorName:     actor.Name,
+			Payload:       payload,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// counterpartyFromRow converts a db.Counterparty to a CounterpartyResponse.
+func counterpartyFromRow(r db.Counterparty) CounterpartyResponse {
+	resp := CounterpartyResponse{
+		ID:         formatUUID(r.ID),
+		ShortID:    r.ShortID,
+		Name:       r.Name,
+		WebsiteURL: textPtr(r.WebsiteUrl),
+		LogoURL:    textPtr(r.LogoUrl),
+		MCC:        textPtr(r.Mcc),
+		CreatedAt:  pgconv.TimestampStr(r.CreatedAt),
+		UpdatedAt:  pgconv.TimestampStr(r.UpdatedAt),
+	}
+	if r.CategoryID.Valid {
+		s := formatUUID(r.CategoryID)
+		resp.CategoryID = &s
+	}
+	if r.CanonicalCounterpartyID.Valid {
+		s := formatUUID(r.CanonicalCounterpartyID)
+		resp.CanonicalCounterpartyID = &s
+	}
+	return resp
+}

--- a/internal/service/counterparties_integration_test.go
+++ b/internal/service/counterparties_integration_test.go
@@ -1,0 +1,464 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func cpStrptr(s string) *string { return &s }
+
+// seedCounterpartyCharges creates a user→connection→account and N charges with a
+// shared provider_name, returning the account ID and the member db.Transaction
+// rows.
+func seedCounterpartyCharges(t *testing.T, queries *db.Queries, name string, dates []string) (pgtype.UUID, []db.Transaction) {
+	t.Helper()
+	acctID := seedTxnFixture(t, queries)
+	rows := make([]db.Transaction, 0, len(dates))
+	for _, d := range dates {
+		rows = append(rows, testutil.MustCreateTransaction(t, queries, acctID, name+"_"+d, name, 999, d))
+	}
+	return acctID, rows
+}
+
+func shortIDs(rows []db.Transaction) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.ShortID
+	}
+	return out
+}
+
+func countLinkedCounterparty(t *testing.T, pool *pgxpool.Pool, cpID string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM transactions WHERE counterparty_id = $1`, cpID).Scan(&n); err != nil {
+		t.Fatalf("count linked counterparty members: %v", err)
+	}
+	return n
+}
+
+// TestAssignCounterparty_CreateByName resolves-or-creates a counterparty by name,
+// links members, and de-dupes — a second create-by-name resolves the SAME row
+// (no UNIQUE on name, application-level de-dup).
+func TestAssignCounterparty_CreateByName(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	_, members := seedCounterpartyCharges(t, queries, "VENMO", []string{"2026-02-15", "2026-03-15", "2026-04-15"})
+	actor := service.Actor{Type: "user", ID: "u1", Name: "Tester"}
+
+	resp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name:            "Venmo",
+		CreateIfMissing: true,
+		TransactionIDs:  shortIDs(members),
+	}, actor)
+	if err != nil {
+		t.Fatalf("AssignCounterparty create: %v", err)
+	}
+	if resp.Name != "Venmo" {
+		t.Errorf("got name=%q, want Venmo", resp.Name)
+	}
+	if n := countLinkedCounterparty(t, pool, resp.ID); n != 3 {
+		t.Errorf("linked members = %d, want 3", n)
+	}
+
+	// Resolve-or-create de-dupes: same name → same surrogate, no duplicate row.
+	again, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Venmo", CreateIfMissing: true,
+	}, actor)
+	if err != nil {
+		t.Fatalf("AssignCounterparty re-resolve: %v", err)
+	}
+	if again.ID != resp.ID {
+		t.Errorf("re-resolve by name created a new counterparty: %s != %s", again.ID, resp.ID)
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM counterparties WHERE name = 'Venmo' AND deleted_at IS NULL`).Scan(&count); err != nil {
+		t.Fatalf("count counterparties: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 'Venmo' counterparty, got %d", count)
+	}
+}
+
+// TestAssignCounterparty_FailIfExists makes the by-name path a strict create.
+func TestAssignCounterparty_FailIfExists(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	if _, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Uber", CreateIfMissing: true,
+	}, actor); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	_, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Uber", CreateIfMissing: true, FailIfExists: true,
+	}, actor)
+	if err == nil {
+		t.Fatal("expected ErrConflict, got nil")
+	}
+}
+
+// TestAssignCounterparty_NoAutoCreate confirms a counterparty is NOT created
+// unless create_if_missing is set.
+func TestAssignCounterparty_NoAutoCreate(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+	actor := service.Actor{Type: "user", Name: "Tester"}
+	if _, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{Name: "Stripe"}, actor); err == nil {
+		t.Fatal("expected error when create_if_missing is false and no counterparty_short_id, got nil")
+	}
+}
+
+// TestAssignCounterparty_LinkExisting binds a stray charge to an existing
+// counterparty by short_id.
+func TestAssignCounterparty_LinkExisting(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID, members := seedCounterpartyCharges(t, queries, "SPOTIFY", []string{"2026-02-15", "2026-03-15"})
+	actor := service.Actor{Type: "user", ID: "u1", Name: "Tester"}
+
+	created, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Spotify", CreateIfMissing: true, TransactionIDs: shortIDs(members),
+	}, actor)
+	if err != nil {
+		t.Fatalf("seed counterparty: %v", err)
+	}
+
+	extra := testutil.MustCreateTransaction(t, queries, acctID, "SPOTIFY_extra", "SPOTIFY", 999, "2026-05-15")
+	resp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		CounterpartyShortID: cpStrptr(created.ShortID),
+		TransactionIDs:      []string{extra.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("AssignCounterparty link existing: %v", err)
+	}
+	if resp.ShortID != created.ShortID {
+		t.Errorf("linked to wrong counterparty: %s != %s", resp.ShortID, created.ShortID)
+	}
+	if n := countLinkedCounterparty(t, pool, resp.ID); n != 3 {
+		t.Errorf("linked members = %d, want 3", n)
+	}
+}
+
+// TestApplyRuleRetroactively_AssignCounterpartyByShortID covers the rule path
+// (single-rule retroactive) binding by short_id.
+func TestApplyRuleRetroactively_AssignCounterpartyByShortID(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "UBER TRIP 1", "Uber", 1599, "2026-03-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "UBER TRIP 2", "Uber", 1599, "2026-04-15")
+	other := testutil.MustCreateTransaction(t, queries, acctID, "STARBUCKS", "Starbucks", 599, "2026-04-16")
+	actor := service.Actor{Type: "user", ID: "u1", Name: "Tester"}
+
+	cp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{Name: "Uber", CreateIfMissing: true}, actor)
+	if err != nil {
+		t.Fatalf("create counterparty: %v", err)
+	}
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Uber → counterparty",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "Uber"},
+		Actions:    []service.RuleAction{{Type: "assign_counterparty", CounterpartyShortID: cp.ShortID}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	n, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("matched = %d, want 2", n)
+	}
+	if got := countLinkedCounterparty(t, pool, cp.ID); got != 2 {
+		t.Errorf("linked members = %d, want 2", got)
+	}
+	// The non-matching charge stays unbound.
+	var cpID pgtype.UUID
+	if err := pool.QueryRow(ctx, `SELECT counterparty_id FROM transactions WHERE id=$1`, other.ID).Scan(&cpID); err != nil {
+		t.Fatalf("query other txn: %v", err)
+	}
+	if cpID.Valid {
+		t.Error("non-matching transaction was wrongly bound to a counterparty")
+	}
+}
+
+// TestApplyRuleRetroactively_AssignCounterpartyByName covers resolve-or-create by
+// name on the single-rule retroactive path.
+func TestApplyRuleRetroactively_AssignCounterpartyByName(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM 1", "Netflix", 1599, "2026-03-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX.COM 2", "Netflix", 1599, "2026-04-15")
+	actor := service.Actor{Type: "user", ID: "u1", Name: "Tester"}
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Netflix → counterparty",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "Netflix"},
+		Actions:    []service.RuleAction{{Type: "assign_counterparty", CounterpartyName: "Netflix", CreateIfMissing: true}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+	if _, err := svc.ApplyRuleRetroactively(ctx, rule.ID); err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+
+	cp := findCounterpartyByName(t, svc, "Netflix")
+	if cp == nil {
+		t.Fatal("retroactive assign_counterparty did not create a Netflix counterparty")
+	}
+	if got := countLinkedCounterparty(t, pool, cp.ID); got != 2 {
+		t.Errorf("linked members = %d, want 2", got)
+	}
+}
+
+// TestApplyAllRulesRetroactively_AssignCounterparty covers the BULK retroactive
+// path (the one that historically dropped assign_series) materializing
+// assign_counterparty.
+func TestApplyAllRulesRetroactively_AssignCounterparty(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "DOORDASH 1", "DoorDash", 2599, "2026-03-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "DOORDASH 2", "DoorDash", 1899, "2026-04-15")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	if _, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "DoorDash → counterparty",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "DoorDash"},
+		Actions:    []service.RuleAction{{Type: "assign_counterparty", CounterpartyName: "DoorDash", CreateIfMissing: true}},
+		Actor:      actor,
+	}); err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	if _, err := svc.ApplyAllRulesRetroactively(ctx); err != nil {
+		t.Fatalf("ApplyAllRulesRetroactively: %v", err)
+	}
+	cp := findCounterpartyByName(t, svc, "DoorDash")
+	if cp == nil {
+		t.Fatal("bulk retroactive assign_counterparty did not create a DoorDash counterparty")
+	}
+	if got := countLinkedCounterparty(t, pool, cp.ID); got != 2 {
+		t.Errorf("bulk path linked members = %d, want 2", got)
+	}
+}
+
+// TestListCounterpartyGoverningRules returns the assign_counterparty rules whose
+// target is this counterparty — by short_id or by name.
+func TestListCounterpartyGoverningRules(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	cp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{Name: "Venmo", CreateIfMissing: true}, actor)
+	if err != nil {
+		t.Fatalf("create counterparty: %v", err)
+	}
+
+	byID, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "By short id",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "VENMO"},
+		Actions:    []service.RuleAction{{Type: "assign_counterparty", CounterpartyShortID: cp.ShortID}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create rule A: %v", err)
+	}
+	byName, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "By name",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "VENMO PAY"},
+		Actions:    []service.RuleAction{{Type: "assign_counterparty", CounterpartyName: "Venmo", CreateIfMissing: true}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create rule B: %v", err)
+	}
+	if _, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Unrelated",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "Spotify"},
+		Actions:    []service.RuleAction{{Type: "assign_counterparty", CounterpartyName: "Spotify", CreateIfMissing: true}},
+		Actor:      actor,
+	}); err != nil {
+		t.Fatalf("create unrelated rule: %v", err)
+	}
+
+	governing, err := svc.ListCounterpartyGoverningRules(ctx, cp.ShortID)
+	if err != nil {
+		t.Fatalf("ListCounterpartyGoverningRules: %v", err)
+	}
+	got := map[string]bool{}
+	for _, r := range governing {
+		got[r.ID] = true
+	}
+	if !got[byID.ID] || !got[byName.ID] {
+		t.Errorf("governing rules missing expected entries: %+v", got)
+	}
+	if len(governing) != 2 {
+		t.Errorf("governing rules = %d, want 2 (unrelated excluded)", len(governing))
+	}
+}
+
+// TestCounterpartyCascadeDelete_NullsCounterpartyID confirms a hard delete nulls
+// members' counterparty_id (ON DELETE SET NULL).
+func TestCounterpartyCascadeDelete_NullsCounterpartyID(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	_, members := seedCounterpartyCharges(t, queries, "VENMO", []string{"2026-02-15", "2026-03-15"})
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	cp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Venmo", CreateIfMissing: true, TransactionIDs: shortIDs(members),
+	}, actor)
+	if err != nil {
+		t.Fatalf("create counterparty: %v", err)
+	}
+	if n := countLinkedCounterparty(t, pool, cp.ID); n != 2 {
+		t.Fatalf("precondition: linked = %d, want 2", n)
+	}
+
+	if _, err := pool.Exec(ctx, `DELETE FROM counterparties WHERE id = $1`, cp.ID); err != nil {
+		t.Fatalf("delete counterparty: %v", err)
+	}
+	var nulled int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM transactions WHERE counterparty_id IS NULL AND short_id = ANY($1)`,
+		shortIDs(members)).Scan(&nulled); err != nil {
+		t.Fatalf("count nulled: %v", err)
+	}
+	if nulled != 2 {
+		t.Errorf("expected both members' counterparty_id nulled, got %d", nulled)
+	}
+}
+
+// TestRuleConditions_CounterpartyAndHasCounterparty exercises the condition
+// read-half: rules conditioned on has_counterparty / a specific counterparty
+// match only the bound transactions when applied retroactively.
+func TestRuleConditions_CounterpartyAndHasCounterparty(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	testutil.MustCreateTag(t, queries, "is-bound", "Is bound")
+	testutil.MustCreateTag(t, queries, "is-venmo", "Is Venmo")
+	acctID := seedTxnFixture(t, queries)
+	v1 := testutil.MustCreateTransaction(t, queries, acctID, "VENMO 1", "Venmo", 1599, "2026-03-15")
+	v2 := testutil.MustCreateTransaction(t, queries, acctID, "VENMO 2", "Venmo", 1599, "2026-04-15")
+	loose := testutil.MustCreateTransaction(t, queries, acctID, "STARBUCKS", "Starbucks", 599, "2026-04-16")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	cp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Venmo", CreateIfMissing: true, TransactionIDs: []string{v1.ShortID, v2.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("assign counterparty: %v", err)
+	}
+
+	hasRule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Bound get a tag",
+		Conditions: service.Condition{Field: "has_counterparty", Op: "eq", Value: true},
+		Actions:    []service.RuleAction{{Type: "add_tag", TagSlug: "is-bound"}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create has_counterparty rule: %v", err)
+	}
+	matched, err := svc.ApplyRuleRetroactively(ctx, hasRule.ID)
+	if err != nil {
+		t.Fatalf("apply has_counterparty rule: %v", err)
+	}
+	if matched != 2 {
+		t.Errorf("has_counterparty matched = %d, want 2", matched)
+	}
+	if !txnHasTag(t, pool, v1.ID, "is-bound") || !txnHasTag(t, pool, v2.ID, "is-bound") {
+		t.Error("expected both bound charges to receive is-bound")
+	}
+	if txnHasTag(t, pool, loose.ID, "is-bound") {
+		t.Error("unbound transaction was wrongly tagged by a has_counterparty rule")
+	}
+
+	cpRule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Venmo counterparty tag",
+		Conditions: service.Condition{Field: "counterparty", Op: "eq", Value: cp.ShortID},
+		Actions:    []service.RuleAction{{Type: "add_tag", TagSlug: "is-venmo"}},
+		Actor:      actor,
+	})
+	if err != nil {
+		t.Fatalf("create counterparty rule: %v", err)
+	}
+	matched, err = svc.ApplyRuleRetroactively(ctx, cpRule.ID)
+	if err != nil {
+		t.Fatalf("apply counterparty rule: %v", err)
+	}
+	if matched != 2 {
+		t.Errorf("counterparty eq matched = %d, want 2", matched)
+	}
+	if !txnHasTag(t, pool, v1.ID, "is-venmo") {
+		t.Error("expected bound charge to receive is-venmo")
+	}
+	if txnHasTag(t, pool, loose.ID, "is-venmo") {
+		t.Error("unbound transaction was wrongly tagged by a counterparty eq rule")
+	}
+}
+
+// TestValidateActions_AssignCounterparty validates the write-time action checks.
+func TestValidateActions_AssignCounterparty(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	if err := svc.ValidateActions(ctx, []service.RuleAction{
+		{Type: "assign_counterparty", CounterpartyName: "Venmo"},
+	}); err == nil {
+		t.Error("expected error for counterparty_name without create_if_missing")
+	}
+	if err := svc.ValidateActions(ctx, []service.RuleAction{
+		{Type: "assign_counterparty", CounterpartyShortID: "cp123abc", CounterpartyName: "Venmo", CreateIfMissing: true},
+	}); err == nil {
+		t.Error("expected error when both counterparty_short_id and counterparty_name set")
+	}
+	if err := svc.ValidateActions(ctx, []service.RuleAction{
+		{Type: "assign_counterparty"},
+	}); err == nil {
+		t.Error("expected error when neither counterparty_short_id nor counterparty_name set")
+	}
+	if err := svc.ValidateActions(ctx, []service.RuleAction{
+		{Type: "assign_counterparty", CounterpartyShortID: "nope0000"},
+	}); err == nil {
+		t.Error("expected error for unknown counterparty_short_id")
+	}
+	if err := svc.ValidateActions(ctx, []service.RuleAction{
+		{Type: "assign_counterparty", CounterpartyName: "Venmo", CreateIfMissing: true},
+	}); err != nil {
+		t.Errorf("expected valid name+create_if_missing action, got %v", err)
+	}
+}
+
+// findCounterpartyByName returns the live counterparty with the given name, or nil.
+func findCounterpartyByName(t *testing.T, svc *service.Service, name string) *service.CounterpartyResponse {
+	t.Helper()
+	all, err := svc.ListCounterparties(context.Background())
+	if err != nil {
+		t.Fatalf("list counterparties: %v", err)
+	}
+	for i := range all {
+		if all[i].Name == name {
+			return &all[i]
+		}
+	}
+	return nil
+}

--- a/internal/service/resolve.go
+++ b/internal/service/resolve.go
@@ -86,6 +86,11 @@ func (s *Service) resolveSeriesID(ctx context.Context, idOrShort string) (pgtype
 	return s.resolveID(ctx, idOrShort, s.Queries.GetRecurringSeriesUUIDByShortID, ErrNotFound)
 }
 
+// resolveCounterpartyID accepts either a UUID string or a short ID for a counterparty.
+func (s *Service) resolveCounterpartyID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+	return s.resolveID(ctx, idOrShort, s.Queries.GetCounterpartyUUIDByShortID, ErrNotFound)
+}
+
 // resolveAgentReportID accepts either a UUID string or a short ID for an agent report.
 func (s *Service) resolveAgentReportID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
 	return s.resolveID(ctx, idOrShort, s.Queries.GetAgentReportUUIDByShortID, ErrNotFound)

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -44,6 +44,8 @@ var validConditionFields = map[string]string{
 	"tags":                       "tags",
 	"series":                     "string", // recurring-series short_id the txn belongs to
 	"in_series":                  "bool",   // whether the txn belongs to any recurring series
+	"counterparty":               "string", // counterparty short_id the txn is bound to
+	"has_counterparty":           "bool",   // whether the txn is bound to any counterparty
 
 	// Date-part fields — numeric values derived from the tz-naive `date`
 	// column (no timezone math; provider-localized). day_of_week uses Go's
@@ -479,6 +481,10 @@ func evaluateLeaf(c *CompiledCondition, tctx TransactionContext) bool {
 		return evalString(c, tctx.SeriesShortID)
 	case "in_series":
 		return evalBool(c, tctx.InSeries)
+	case "counterparty":
+		return evalString(c, tctx.CounterpartyShortID)
+	case "has_counterparty":
+		return evalBool(c, tctx.HasCounterparty)
 	case "day_of_month":
 		if tctx.Date.IsZero() {
 			return false
@@ -847,15 +853,16 @@ func toStringSlice(v interface{}) ([]string, bool) {
 // Unknown types are rejected by ValidateActions. Read-time tolerates unknown
 // types by skipping them with a logged warning (see sync/rule_resolver).
 var validActionTypes = map[string]bool{
-	"set_category":    true,
-	"add_tag":         true,
-	"remove_tag":      true,
-	"add_comment":     true,
-	"assign_series":   true,
-	"set_metadata":    true,
-	"remove_metadata": true,
-	"flag":            true,
-	"unflag":          true,
+	"set_category":        true,
+	"add_tag":             true,
+	"remove_tag":          true,
+	"add_comment":         true,
+	"assign_series":       true,
+	"assign_counterparty": true,
+	"set_metadata":        true,
+	"remove_metadata":     true,
+	"flag":                true,
+	"unflag":              true,
 }
 
 // tagSlugPattern enforces the tag slug format: lowercase alphanumerics with
@@ -874,7 +881,7 @@ func (s *Service) ValidateActions(ctx context.Context, actions []RuleAction) err
 	seenCategory := false
 	for _, a := range actions {
 		if !validActionTypes[a.Type] {
-			return fmt.Errorf("%w: unknown action type %q (expected set_category|add_tag|remove_tag|add_comment|assign_series|set_metadata|remove_metadata|flag|unflag)", ErrInvalidParameter, a.Type)
+			return fmt.Errorf("%w: unknown action type %q (expected set_category|add_tag|remove_tag|add_comment|assign_series|assign_counterparty|set_metadata|remove_metadata|flag|unflag)", ErrInvalidParameter, a.Type)
 		}
 		switch a.Type {
 		case "set_category":
@@ -911,6 +918,20 @@ func (s *Service) ValidateActions(ctx context.Context, actions []RuleAction) err
 			if hasSeries {
 				if _, err := s.resolveSeriesID(ctx, a.SeriesShortID); err != nil {
 					return fmt.Errorf("%w: assign_series series_short_id %q not found", ErrInvalidParameter, a.SeriesShortID)
+				}
+			}
+		case "assign_counterparty":
+			hasCP := strings.TrimSpace(a.CounterpartyShortID) != ""
+			hasName := strings.TrimSpace(a.CounterpartyName) != ""
+			if hasCP == hasName {
+				return fmt.Errorf("%w: assign_counterparty requires exactly one of counterparty_short_id or counterparty_name", ErrInvalidParameter)
+			}
+			if hasName && !a.CreateIfMissing {
+				return fmt.Errorf("%w: assign_counterparty with counterparty_name requires create_if_missing=true", ErrInvalidParameter)
+			}
+			if hasCP {
+				if _, err := s.resolveCounterpartyID(ctx, a.CounterpartyShortID); err != nil {
+					return fmt.Errorf("%w: assign_counterparty counterparty_short_id %q not found", ErrInvalidParameter, a.CounterpartyShortID)
 				}
 			}
 		case "set_metadata":
@@ -1597,7 +1618,8 @@ const transactionContextQuery = `SELECT t.id, t.provider_name, COALESCE(t.provid
 	COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 	t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
 	COALESCE(array_agg(DISTINCT tag.slug) FILTER (WHERE tag.slug IS NOT NULL), ARRAY[]::text[]),
-	COALESCE(rs.short_id, ''), (t.series_id IS NOT NULL), t.metadata, t.date
+	COALESCE(rs.short_id, ''), (t.series_id IS NOT NULL), t.metadata, t.date,
+	COALESCE(cp.short_id, ''), (t.counterparty_id IS NOT NULL)
 	FROM transactions t
 	JOIN accounts a ON t.account_id = a.id
 	JOIN bank_connections bc ON a.connection_id = bc.id
@@ -1605,16 +1627,17 @@ const transactionContextQuery = `SELECT t.id, t.provider_name, COALESCE(t.provid
 	LEFT JOIN transaction_tags tt ON tt.transaction_id = t.id
 	LEFT JOIN tags tag ON tag.id = tt.tag_id
 	LEFT JOIN recurring_series rs ON rs.id = t.series_id
+	LEFT JOIN counterparties cp ON cp.id = t.counterparty_id
 	WHERE t.deleted_at IS NULL
 	AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
 
 // transactionContextGroupBy is the GROUP BY clause matching transactionContextQuery.
-const transactionContextGroupBy = ` GROUP BY t.id, t.provider_name, t.provider_merchant_name, t.amount, t.provider_category_primary, t.provider_category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name, rs.short_id, t.series_id, t.metadata, t.date`
+const transactionContextGroupBy = ` GROUP BY t.id, t.provider_name, t.provider_merchant_name, t.amount, t.provider_category_primary, t.provider_category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name, rs.short_id, t.series_id, t.metadata, t.date, cp.short_id, t.counterparty_id`
 
 // transactionContextColumns is the number of columns selected by
 // transactionContextQuery (and bound by scanTransactionContextRow). Callers size
 // their scan-dest slice with this so adding a column is a single-line change.
-const transactionContextColumns = 16
+const transactionContextColumns = 18
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
@@ -1642,6 +1665,8 @@ func scanTransactionContextRow(dest []any) *transactionContextRow {
 	dest[13] = &r.tctx.InSeries
 	dest[14] = &r.metadataRaw
 	dest[15] = &r.dateRaw
+	dest[16] = &r.tctx.CounterpartyShortID
+	dest[17] = &r.tctx.HasCounterparty
 	return r
 }
 
@@ -1694,6 +1719,10 @@ type retroTxnIntent struct {
 	// assign_series — last-writer-wins; nil means no assignment.
 	series     *RuleAction
 	seriesRule ruleapply.Rule
+
+	// assign_counterparty — last-writer-wins; nil means no assignment.
+	counterparty     *RuleAction
+	counterpartyRule ruleapply.Rule
 
 	// set_metadata / remove_metadata — net-diffed, disjoint by construction.
 	metadataSet    map[string]any
@@ -1756,6 +1785,13 @@ func (s *Service) applyRetroTxnIntent(ctx context.Context, tx pgx.Tx, it *retroT
 	if it.series != nil {
 		if err := s.AssignSeriesFromRuleTx(ctx, tx, it.txnID, it.series.SeriesShortID, it.series.SeriesName, it.series.CreateIfMissing); err != nil {
 			return fmt.Errorf("apply assign_series retroactively: %w", err)
+		}
+	}
+
+	// assign_counterparty — same resolve-or-create + link the sync path uses.
+	if it.counterparty != nil {
+		if err := s.AssignCounterpartyFromRuleTx(ctx, tx, it.txnID, it.counterparty.CounterpartyShortID, it.counterparty.CounterpartyName, it.counterparty.CreateIfMissing); err != nil {
+			return fmt.Errorf("apply assign_counterparty retroactively: %w", err)
 		}
 	}
 
@@ -1833,6 +1869,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 	var tagAdds []string
 	var tagRemoves []string
 	var seriesAssign *RuleAction
+	var counterpartyAssign *RuleAction
 	metadataSet := map[string]any{}
 	var metadataRemove []string
 	var flagIntent string
@@ -1855,6 +1892,9 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		case "assign_series":
 			aCopy := a
 			seriesAssign = &aCopy
+		case "assign_counterparty":
+			aCopy := a
+			counterpartyAssign = &aCopy
 		case "set_metadata":
 			if a.MetadataKey == "" {
 				continue
@@ -1881,7 +1921,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		}
 	}
 	hasWriteAction := categorySetCatID.Valid || len(tagAdds) > 0 || len(tagRemoves) > 0 || seriesAssign != nil ||
-		len(metadataSet) > 0 || len(metadataRemove) > 0 || flagIntent != ""
+		counterpartyAssign != nil || len(metadataSet) > 0 || len(metadataRemove) > 0 || flagIntent != ""
 	if !hasWriteAction {
 		return 0, fmt.Errorf("%w: rule has no applicable actions", ErrInvalidParameter)
 	}
@@ -1966,18 +2006,20 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 
 		for _, txnID := range matchIDs {
 			it := retroTxnIntent{
-				txnID:          txnID,
-				catID:          categorySetCatID,
-				catSlug:        categorySetSlug,
-				catRule:        appliedRule,
-				tagAdds:        make(map[string]ruleapply.Rule, len(tagAdds)),
-				tagRemoves:     make(map[string]ruleapply.Rule, len(tagRemoves)),
-				series:         seriesAssign,
-				seriesRule:     appliedRule,
-				metadataSet:    metadataSet,
-				metadataRemove: metadataRemove,
-				flagIntent:     flagIntent,
-				ruleApplied:    ruleApplied,
+				txnID:            txnID,
+				catID:            categorySetCatID,
+				catSlug:          categorySetSlug,
+				catRule:          appliedRule,
+				tagAdds:          make(map[string]ruleapply.Rule, len(tagAdds)),
+				tagRemoves:       make(map[string]ruleapply.Rule, len(tagRemoves)),
+				series:           seriesAssign,
+				seriesRule:       appliedRule,
+				counterparty:     counterpartyAssign,
+				counterpartyRule: appliedRule,
+				metadataSet:      metadataSet,
+				metadataRemove:   metadataRemove,
+				flagIntent:       flagIntent,
+				ruleApplied:      ruleApplied,
 			}
 			for _, slug := range tagAdds {
 				it.tagAdds[slug] = appliedRule
@@ -2037,6 +2079,11 @@ func actionAuditFields(a RuleAction) (string, string) {
 			return "series", a.SeriesShortID
 		}
 		return "series", a.SeriesName
+	case "assign_counterparty":
+		if a.CounterpartyShortID != "" {
+			return "counterparty", a.CounterpartyShortID
+		}
+		return "counterparty", a.CounterpartyName
 	case "set_metadata":
 		return "metadata", a.MetadataKey
 	case "remove_metadata":
@@ -2163,18 +2210,20 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		// the sync resolver. Category: last-writer-wins. Tags: net-diff.
 		// Metadata: last-writer-wins per key, net-diff set↔remove.
 		type txnIntent struct {
-			txnID          pgtype.UUID
-			catID          pgtype.UUID
-			catSlug        string
-			catRule        *compiledRule
-			tagAdds        map[string]*compiledRule // slug → first rule that added it
-			tagRemoves     map[string]*compiledRule
-			series         *RuleAction     // net assign_series intent (last-writer-wins)
-			seriesRule     *compiledRule   // rule that owns the winning series assignment
-			metadataSet    map[string]any  // key → net value to write
-			metadataRemove []string        // net keys to delete
-			flagIntent     string          // "flag" | "unflag" | "" (last-writer-wins)
-			matchingRules  []*compiledRule // every rule whose condition matched (for rule_applied)
+			txnID            pgtype.UUID
+			catID            pgtype.UUID
+			catSlug          string
+			catRule          *compiledRule
+			tagAdds          map[string]*compiledRule // slug → first rule that added it
+			tagRemoves       map[string]*compiledRule
+			series           *RuleAction     // net assign_series intent (last-writer-wins)
+			seriesRule       *compiledRule   // rule that owns the winning series assignment
+			counterparty     *RuleAction     // net assign_counterparty intent (last-writer-wins)
+			counterpartyRule *compiledRule   // rule that owns the winning counterparty assignment
+			metadataSet      map[string]any  // key → net value to write
+			metadataRemove   []string        // net keys to delete
+			flagIntent       string          // "flag" | "unflag" | "" (last-writer-wins)
+			matchingRules    []*compiledRule // every rule whose condition matched (for rule_applied)
 		}
 		var intents []txnIntent
 		rowCount := 0
@@ -2276,6 +2325,14 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 						aCopy := a
 						intent.series = &aCopy
 						intent.seriesRule = cr
+					case "assign_counterparty":
+						if a.CounterpartyShortID == "" && a.CounterpartyName == "" {
+							continue
+						}
+						// Last-writer-wins: a txn binds at most one counterparty.
+						aCopy := a
+						intent.counterparty = &aCopy
+						intent.counterpartyRule = cr
 					case "flag":
 						// Last-writer-wins: a later-stage rule's flag/unflag
 						// overrides an earlier one.
@@ -2289,8 +2346,8 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 				}
 			}
 			if intent.catRule != nil || len(intent.tagAdds) > 0 || len(intent.tagRemoves) > 0 ||
-				intent.series != nil || len(intent.metadataSet) > 0 || len(intent.metadataRemove) > 0 ||
-				intent.flagIntent != "" {
+				intent.series != nil || intent.counterparty != nil || len(intent.metadataSet) > 0 ||
+				len(intent.metadataRemove) > 0 || intent.flagIntent != "" {
 				intents = append(intents, intent)
 			}
 		}
@@ -2343,6 +2400,10 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 			if it.series != nil {
 				ri.series = it.series
 				ri.seriesRule = ruleapply.Rule{ID: it.seriesRule.uuid, ShortID: it.seriesRule.shortID, Name: it.seriesRule.name}
+			}
+			if it.counterparty != nil {
+				ri.counterparty = it.counterparty
+				ri.counterpartyRule = ruleapply.Rule{ID: it.counterpartyRule.uuid, ShortID: it.counterpartyRule.shortID, Name: it.counterpartyRule.name}
 			}
 			for _, cr := range it.matchingRules {
 				ri.ruleApplied = append(ri.ruleApplied, retroRuleApplied{
@@ -2577,13 +2638,15 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 	baseQuery := `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
 		COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 		t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
-		t.date, COALESCE(c.slug, ''), COALESCE(rs.short_id, ''), (t.series_id IS NOT NULL), t.metadata
+		t.date, COALESCE(c.slug, ''), COALESCE(rs.short_id, ''), (t.series_id IS NOT NULL), t.metadata,
+		COALESCE(cp.short_id, ''), (t.counterparty_id IS NOT NULL)
 		FROM transactions t
 		JOIN accounts a ON t.account_id = a.id
 		JOIN bank_connections bc ON a.connection_id = bc.id
 		LEFT JOIN users u ON bc.user_id = u.id
 		LEFT JOIN categories c ON t.category_id = c.id
 		LEFT JOIN recurring_series rs ON rs.id = t.series_id
+		LEFT JOIN counterparties cp ON cp.id = t.counterparty_id
 		WHERE t.deleted_at IS NULL
 		AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
 
@@ -2631,7 +2694,8 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 			if err := rows.Scan(&id, &tctx.Name, &tctx.MerchantName, &tctx.Amount,
 				&tctx.CategoryPrimary, &tctx.CategoryDetailed,
 				&tctx.Pending, &tctx.Provider, &tctx.AccountID, &tctx.UserID, &tctx.UserName,
-				&date, &catSlug, &tctx.SeriesShortID, &tctx.InSeries, &metadataRaw); err != nil {
+				&date, &catSlug, &tctx.SeriesShortID, &tctx.InSeries, &metadataRaw,
+				&tctx.CounterpartyShortID, &tctx.HasCounterparty); err != nil {
 				rows.Close()
 				return nil, fmt.Errorf("scan transaction: %w", err)
 			}
@@ -3086,6 +3150,8 @@ func ActionsSummary(actions []RuleAction, categoryName string) string {
 		return "Add comment"
 	case "assign_series":
 		return "Assign to series"
+	case "assign_counterparty":
+		return "Assign counterparty"
 	case "flag":
 		return "Flag for attention"
 	case "unflag":

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -442,6 +442,53 @@ type CommentResponse struct {
 	UpdatedAt     string  `json:"updated_at"`
 }
 
+// Counterparty types
+
+// CounterpartyResponse is the API/MCP shape of a counterparties row — the
+// canonical, cross-provider "other side" of a transaction (merchant or
+// non-merchant). Enrichment columns are pointers so an un-enriched counterparty
+// omits them.
+type CounterpartyResponse struct {
+	ID                      string  `json:"id"`
+	ShortID                 string  `json:"short_id"`
+	Name                    string  `json:"name"`
+	WebsiteURL              *string `json:"website_url,omitempty"`
+	LogoURL                 *string `json:"logo_url,omitempty"`
+	CategoryID              *string `json:"category_id,omitempty"`
+	MCC                     *string `json:"mcc,omitempty"`
+	CanonicalCounterpartyID *string `json:"canonical_counterparty_id,omitempty"`
+	CreatedAt               string  `json:"created_at"`
+	UpdatedAt               string  `json:"updated_at"`
+}
+
+// AssignCounterpartyInput drives the imperative create/link path (the MCP/REST
+// `assign_counterparty` one-off). Either bind to an existing counterparty
+// (CounterpartyShortID), or resolve-or-create one by name (Name +
+// CreateIfMissing); then link the listed transactions in the same call.
+// Surrogate-first: counterparties are assigned by short_id, not minted-by-name —
+// the by-name path de-dupes on the live name (no UNIQUE constraint).
+type AssignCounterpartyInput struct {
+	CounterpartyShortID *string  // short_id or uuid — bind to an existing counterparty
+	Name                string   // display label + resolve-or-create key (required when CreateIfMissing)
+	CreateIfMissing     bool     // resolve-or-create a counterparty (by Name) when no CounterpartyShortID
+	TransactionIDs      []string // transactions to link (short_id or uuid), ≤50
+	// FailIfExists turns the by-name path into a strict create: return ErrConflict
+	// when a live counterparty already exists with this name. The rule/agent paths
+	// leave this false (resolve-or-create); a deliberate "create from scratch" UI
+	// sets it true.
+	FailIfExists bool
+}
+
+// EditCounterpartyInput is the partial-update payload for UpdateCounterparty —
+// the enrichment lane. Every field is a pointer: nil leaves the column unchanged.
+type EditCounterpartyInput struct {
+	Name       *string // non-empty display label; "" is rejected
+	WebsiteURL *string
+	LogoURL    *string
+	CategoryID *string // category short_id or uuid; resolved before write
+	MCC        *string
+}
+
 // Transaction rule types
 
 // RuleAction is the typed action shape for transaction rules.
@@ -462,6 +509,14 @@ type RuleAction struct {
 	SeriesShortID   string `json:"series_short_id,omitempty"`
 	SeriesName      string `json:"series_name,omitempty"`
 	CreateIfMissing bool   `json:"create_if_missing,omitempty"`
+	// assign_counterparty fields: bind matching transactions to an existing
+	// counterparty (CounterpartyShortID) or, when CreateIfMissing is set, resolve-
+	// or-create one by name (CounterpartyName). Counterparties are surrogate-first
+	// cross-provider entities (rules-as-substrate, P4); unlike series there is no
+	// UNIQUE on name, so the by-name path is a resolve-or-create that de-dupes on
+	// the live name. CreateIfMissing is shared with assign_series.
+	CounterpartyShortID string `json:"counterparty_short_id,omitempty"`
+	CounterpartyName    string `json:"counterparty_name,omitempty"`
 	// set_metadata / remove_metadata fields. MetadataKey is the metadata blob
 	// key (≤128 chars). MetadataValue is the JSON value to write for
 	// set_metadata (any JSON-serializable value); unused by remove_metadata.
@@ -608,6 +663,13 @@ type TransactionContext struct {
 	// InSeries reports whether the transaction is linked to any recurring
 	// series (field: "in_series").
 	InSeries bool
+	// CounterpartyShortID is the short_id of the counterparty this transaction is
+	// bound to (field: "counterparty"), empty when unassigned. Populated from the
+	// counterparties JOIN in the retroactive / preview context query.
+	CounterpartyShortID string
+	// HasCounterparty reports whether the transaction is bound to any counterparty
+	// (field: "has_counterparty").
+	HasCounterparty bool
 	// Metadata holds the transaction's free-form metadata blob so conditions on
 	// dotted fields (field: "metadata.<key>") can read arbitrary enrichment
 	// values. Updated mid-resolver as earlier-stage set_metadata / remove_metadata

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -74,6 +74,13 @@ type Engine struct {
 	// import cycle — the same pattern as OnSyncComplete). Nil-safe: when unset
 	// (series subsystem not wired) the action is a no-op.
 	AssignSeriesInTx func(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, seriesShortID, seriesName string, createIfMissing bool) error
+
+	// AssignCounterpartyInTx materializes an `assign_counterparty` rule action
+	// INSIDE the sync transaction — resolving/creating a counterparty and binding
+	// the transaction. Wired by the app layer in serve.go (function pointer, same
+	// decoupling pattern as AssignSeriesInTx). Nil-safe: when unset (counterparty
+	// subsystem not wired) the action is a no-op.
+	AssignCounterpartyInTx func(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, counterpartyShortID, counterpartyName string, createIfMissing bool) error
 }
 
 // NewEngine creates a new sync engine.
@@ -711,6 +718,14 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 		tctx.InSeries = true
 		tctx.SeriesShortID = resolver.SeriesShortID(dbTxn.SeriesID)
 	}
+	// Seed counterparty binding so rules can condition on it via
+	// field="counterparty" / field="has_counterparty". counterparty_id is NULL on
+	// freshly-synced rows (assign_counterparty rules resolve it post-upsert), so
+	// this is populated mainly on changed / re-synced rows already bound.
+	if dbTxn.CounterpartyID.Valid {
+		tctx.HasCounterparty = true
+		tctx.CounterpartyShortID = resolver.CounterpartyShortID(dbTxn.CounterpartyID)
+	}
 	// Seed the metadata blob so conditions on field="metadata.<key>" can read
 	// the transaction's current enrichment values, and so chaining rules see
 	// earlier-stage set_metadata / remove_metadata writes. A new transaction
@@ -837,6 +852,16 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 		if err := e.AssignSeriesInTx(ctx, tx, dbTxn.ID,
 			result.SeriesAssign.SeriesShortID, result.SeriesAssign.SeriesName, result.SeriesAssign.CreateIfMissing); err != nil {
 			return result.Sources, fmt.Errorf("apply assign_series: %w", err)
+		}
+	}
+
+	// assign_counterparty: bind the transaction to a counterparty within the sync
+	// tx (resolve-or-create + link), via the app-wired hook so the sync package
+	// stays decoupled from the counterparty service. No-op when the hook is unset.
+	if result.CounterpartyAssign != nil && e.AssignCounterpartyInTx != nil {
+		if err := e.AssignCounterpartyInTx(ctx, tx, dbTxn.ID,
+			result.CounterpartyAssign.CounterpartyShortID, result.CounterpartyAssign.CounterpartyName, result.CounterpartyAssign.CreateIfMissing); err != nil {
+			return result.Sources, fmt.Errorf("apply assign_counterparty: %w", err)
 		}
 	}
 

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -68,6 +68,15 @@ type TransactionContext struct {
 	// InSeries reports whether the transaction is linked to any recurring
 	// series (field: "in_series"). Same timing caveat as SeriesShortID.
 	InSeries bool
+	// CounterpartyShortID is the short_id of the counterparty this transaction is
+	// bound to (field: "counterparty"), empty when unassigned. Resolved from the
+	// resolver's counterparty cache at sync time. Like series_id, counterparty_id
+	// is NULL on freshly-synced rows (resolved post-upsert by assign_counterparty
+	// rules), so this matters mostly for changed / re-synced rows + retroactive.
+	CounterpartyShortID string
+	// HasCounterparty reports whether the transaction is bound to any counterparty
+	// (field: "has_counterparty"). Same timing caveat as CounterpartyShortID.
+	HasCounterparty bool
 	// Metadata holds the transaction's free-form metadata blob (the JSONB
 	// `metadata` column) so conditions on dotted fields (field:
 	// "metadata.<key>") can read arbitrary enrichment values. Updated
@@ -125,6 +134,10 @@ type RuleActions struct {
 	// Last-writer-wins: the highest-priority matching rule owns the assignment
 	// (a transaction belongs to at most one series).
 	SeriesAssign *SeriesAssignIntent
+	// CounterpartyAssign, when non-nil, binds the transaction to a counterparty.
+	// Last-writer-wins: the highest-priority matching rule owns the binding
+	// (a transaction binds at most one counterparty).
+	CounterpartyAssign *CounterpartyAssignIntent
 	// MetadataSet maps metadata keys to the value the net-surviving set_metadata
 	// action wrote. Last-writer-wins per key across the pipeline. A later-stage
 	// remove_metadata for the same key cancels the set (the key won't appear
@@ -150,15 +163,17 @@ type RuleActions struct {
 // Kept local so the sync package doesn't import service (preserves the
 // one-way service → sync dependency direction).
 type typedAction struct {
-	Type            string
-	CategorySlug    string
-	TagSlug         string
-	Content         string
-	SeriesShortID   string
-	SeriesName      string
-	CreateIfMissing bool
-	MetadataKey     string
-	MetadataValue   any
+	Type                string
+	CategorySlug        string
+	TagSlug             string
+	Content             string
+	SeriesShortID       string
+	SeriesName          string
+	CounterpartyShortID string
+	CounterpartyName    string
+	CreateIfMissing     bool
+	MetadataKey         string
+	MetadataValue       any
 }
 
 // SeriesAssignIntent is the resolved assign_series action: link the
@@ -171,6 +186,16 @@ type SeriesAssignIntent struct {
 	CreateIfMissing bool
 }
 
+// CounterpartyAssignIntent is the resolved assign_counterparty action: bind the
+// transaction to an existing counterparty (CounterpartyShortID) or resolve-or-
+// create one by name (CounterpartyName + CreateIfMissing). A transaction binds at
+// most one counterparty, so this is last-writer-wins across matching rules.
+type CounterpartyAssignIntent struct {
+	CounterpartyShortID string
+	CounterpartyName    string
+	CreateIfMissing     bool
+}
+
 // RuleResolver loads transaction rules and evaluates them during sync.
 // All matching rules contribute actions (merge non-conflicting).
 type RuleResolver struct {
@@ -178,6 +203,7 @@ type RuleResolver struct {
 	slugCache       map[[16]byte]string    // category UUID bytes -> slug
 	slugToID        map[string]pgtype.UUID // category slug -> UUID (reverse cache)
 	seriesShortID   map[[16]byte]string    // recurring_series UUID bytes -> short_id
+	cpShortID       map[[16]byte]string    // counterparties UUID bytes -> short_id
 	uncategorizedID pgtype.UUID
 	hitCounts       map[[16]byte]int // rule UUID bytes -> hit count accumulator
 }
@@ -222,6 +248,7 @@ func NewRuleResolver(ctx context.Context, pool *pgxpool.Pool, provider string, l
 		slugCache:     make(map[[16]byte]string),
 		slugToID:      make(map[string]pgtype.UUID),
 		seriesShortID: make(map[[16]byte]string),
+		cpShortID:     make(map[[16]byte]string),
 		hitCounts:     make(map[[16]byte]int),
 	}
 
@@ -272,6 +299,26 @@ func NewRuleResolver(ctx context.Context, pool *pgxpool.Pool, provider string, l
 				return nil, fmt.Errorf("scan recurring series short_id: %w", err)
 			}
 			r.seriesShortID[id.Bytes] = shortID
+		}
+	}
+
+	// Load the counterparty id→short_id cache so the `counterparty` condition
+	// field can resolve a transaction's counterparty_id to its short_id without a
+	// per-row query. Tolerate a missing table (older deployments / lite / before
+	// the P4 migration) the same way the series cache does — counterparty
+	// conditions simply won't match.
+	cpRows, err := pool.Query(ctx, "SELECT id, short_id FROM counterparties")
+	if err != nil {
+		logger.Warn("failed to load counterparties cache; counterparty conditions will not match", "error", err)
+	} else {
+		defer cpRows.Close()
+		for cpRows.Next() {
+			var id pgtype.UUID
+			var shortID string
+			if err := cpRows.Scan(&id, &shortID); err != nil {
+				return nil, fmt.Errorf("scan counterparty short_id: %w", err)
+			}
+			r.cpShortID[id.Bytes] = shortID
 		}
 	}
 
@@ -396,6 +443,11 @@ func parseTypedActions(raw []byte, ruleID pgtype.UUID, logger *slog.Logger) []ty
 			}
 			createIfMissing, _ := m["create_if_missing"].(bool)
 			out = append(out, typedAction{Type: t, SeriesShortID: seriesShortID, SeriesName: seriesName, CreateIfMissing: createIfMissing})
+		case "assign_counterparty":
+			cpShortID, _ := m["counterparty_short_id"].(string)
+			cpName, _ := m["counterparty_name"].(string)
+			createIfMissing, _ := m["create_if_missing"].(bool)
+			out = append(out, typedAction{Type: t, CounterpartyShortID: cpShortID, CounterpartyName: cpName, CreateIfMissing: createIfMissing})
 		case "set_metadata":
 			key, _ := m["metadata_key"].(string)
 			out = append(out, typedAction{Type: t, MetadataKey: key, MetadataValue: m["metadata_value"]})
@@ -515,6 +567,16 @@ func (r *RuleResolver) SeriesShortID(id pgtype.UUID) string {
 		return ""
 	}
 	return r.seriesShortID[id.Bytes]
+}
+
+// CounterpartyShortID returns the short_id for a counterparty UUID, or empty
+// string if the counterparty is unknown to the resolver's cache (e.g. created
+// after resolver construction, or the table was unavailable at load time).
+func (r *RuleResolver) CounterpartyShortID(id pgtype.UUID) string {
+	if !id.Valid {
+		return ""
+	}
+	return r.cpShortID[id.Bytes]
 }
 
 // ResolveWithContext evaluates all transaction rules in pipeline-stage order
@@ -685,6 +747,26 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 					ActionField: "series",
 					ActionValue: seriesActionValue(a),
 				})
+			case "assign_counterparty":
+				if a.CounterpartyShortID == "" && a.CounterpartyName == "" {
+					continue
+				}
+				// Last-writer-wins: a transaction binds at most one counterparty,
+				// so a later-stage rule overrides an earlier binding and supersedes
+				// its audit source.
+				result.CounterpartyAssign = &CounterpartyAssignIntent{
+					CounterpartyShortID: a.CounterpartyShortID,
+					CounterpartyName:    a.CounterpartyName,
+					CreateIfMissing:     a.CreateIfMissing,
+				}
+				result.Sources = dropCounterpartySource(result.Sources)
+				result.Sources = append(result.Sources, RuleActionSource{
+					RuleID:      rule.id,
+					RuleShortID: rule.shortID,
+					RuleName:    rule.name,
+					ActionField: "counterparty",
+					ActionValue: counterpartyActionValue(a),
+				})
 			case "set_metadata":
 				if a.MetadataKey == "" {
 					continue
@@ -817,6 +899,32 @@ func dropSeriesSource(src []RuleActionSource) []RuleActionSource {
 	kept := src[:0]
 	for _, s := range src {
 		if s.ActionField == "series" {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept
+}
+
+// counterpartyActionValue is the audit value for an assign_counterparty action:
+// the counterparty short_id when binding to an existing counterparty, else the
+// name it resolves-or-creates under.
+func counterpartyActionValue(a typedAction) string {
+	if a.CounterpartyShortID != "" {
+		return a.CounterpartyShortID
+	}
+	return a.CounterpartyName
+}
+
+// dropCounterpartySource removes any prior counterparty source so the final
+// source slice records only the winning (last) rule's provenance for the binding.
+func dropCounterpartySource(src []RuleActionSource) []RuleActionSource {
+	if len(src) == 0 {
+		return src
+	}
+	kept := src[:0]
+	for _, s := range src {
+		if s.ActionField == "counterparty" {
 			continue
 		}
 		kept = append(kept, s)
@@ -997,6 +1105,10 @@ func evaluateLeaf(c *compiledCondition, tctx TransactionContext) bool {
 		return evaluateString(c, tctx.SeriesShortID)
 	case "in_series":
 		return evaluateBool(c, tctx.InSeries)
+	case "counterparty":
+		return evaluateString(c, tctx.CounterpartyShortID)
+	case "has_counterparty":
+		return evaluateBool(c, tctx.HasCounterparty)
 	case "day_of_month":
 		if tctx.Date.IsZero() {
 			return false

--- a/internal/sync/rule_resolver_counterparty_test.go
+++ b/internal/sync/rule_resolver_counterparty_test.go
@@ -1,0 +1,135 @@
+//go:build !lite
+
+package sync
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// parseTypedActions decodes assign_counterparty by short_id and by name.
+func TestParseTypedActions_AssignCounterparty(t *testing.T) {
+	raw := []byte(`[
+		{"type":"assign_counterparty","counterparty_short_id":"cp123abc"},
+		{"type":"assign_counterparty","counterparty_name":"Venmo","create_if_missing":true}
+	]`)
+	out := parseTypedActions(raw, testUUID(1), slog.Default())
+	if len(out) != 2 {
+		t.Fatalf("expected 2 actions, got %d", len(out))
+	}
+	if out[0].Type != "assign_counterparty" || out[0].CounterpartyShortID != "cp123abc" {
+		t.Errorf("short_id action mis-parsed: %+v", out[0])
+	}
+	if out[1].CounterpartyName != "Venmo" || !out[1].CreateIfMissing {
+		t.Errorf("name action mis-parsed: %+v", out[1])
+	}
+}
+
+// ResolveWithContext records a CounterpartyAssign intent and one counterparty
+// source for a matching assign_counterparty rule.
+func TestResolveWithContext_AssignCounterparty(t *testing.T) {
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				shortID:   "rulecp01",
+				name:      "Venmo → counterparty",
+				actions:   []typedAction{{Type: "assign_counterparty", CounterpartyName: "Venmo", CreateIfMissing: true}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "provider_name", Op: "contains", Value: "venmo"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	result := r.ResolveWithContext("plaid", TransactionContext{Name: "VENMO PAYMENT"}, true)
+	if result == nil || result.CounterpartyAssign == nil {
+		t.Fatal("expected a CounterpartyAssign intent")
+	}
+	if result.CounterpartyAssign.CounterpartyName != "Venmo" || !result.CounterpartyAssign.CreateIfMissing {
+		t.Errorf("unexpected intent: %+v", result.CounterpartyAssign)
+	}
+	cpSources := 0
+	for _, s := range result.Sources {
+		if s.ActionField == "counterparty" {
+			cpSources++
+			if s.ActionValue != "Venmo" {
+				t.Errorf("counterparty source value = %q, want Venmo", s.ActionValue)
+			}
+		}
+	}
+	if cpSources != 1 {
+		t.Errorf("expected 1 counterparty source, got %d", cpSources)
+	}
+}
+
+// ResolveWithContext is last-writer-wins for assign_counterparty: a later-stage
+// rule overrides the earlier binding and supersedes its audit source.
+func TestResolveWithContext_AssignCounterpartyLastWriterWins(t *testing.T) {
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(1),
+				shortID:   "rulelo01",
+				name:      "low",
+				actions:   []typedAction{{Type: "assign_counterparty", CounterpartyShortID: "cpAAAAAA"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "provider_name", Op: "contains", Value: "x"}),
+			},
+			{
+				id:        testUUID(2),
+				shortID:   "rulehi01",
+				name:      "high",
+				actions:   []typedAction{{Type: "assign_counterparty", CounterpartyShortID: "cpBBBBBB"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "provider_name", Op: "contains", Value: "x"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	result := r.ResolveWithContext("plaid", TransactionContext{Name: "x thing"}, true)
+	if result == nil || result.CounterpartyAssign == nil {
+		t.Fatal("expected a CounterpartyAssign intent")
+	}
+	if result.CounterpartyAssign.CounterpartyShortID != "cpBBBBBB" {
+		t.Errorf("last-writer-wins failed: got %q, want cpBBBBBB", result.CounterpartyAssign.CounterpartyShortID)
+	}
+	cpSources := 0
+	for _, s := range result.Sources {
+		if s.ActionField == "counterparty" {
+			cpSources++
+			if s.ActionValue != "cpBBBBBB" {
+				t.Errorf("surviving source value = %q, want cpBBBBBB", s.ActionValue)
+			}
+		}
+	}
+	if cpSources != 1 {
+		t.Errorf("expected exactly 1 surviving counterparty source, got %d", cpSources)
+	}
+}
+
+// evaluateLeaf matches the counterparty (short_id) and has_counterparty (bool)
+// condition fields.
+func TestEvaluateLeaf_Counterparty(t *testing.T) {
+	tctx := TransactionContext{CounterpartyShortID: "cp123abc", HasCounterparty: true}
+
+	yes := mustCompile(t, &Condition{Field: "counterparty", Op: "eq", Value: "cp123abc"})
+	if !evaluateCondition(yes, tctx) {
+		t.Error("expected counterparty eq match")
+	}
+	no := mustCompile(t, &Condition{Field: "counterparty", Op: "eq", Value: "cpZZZZZZ"})
+	if evaluateCondition(no, tctx) {
+		t.Error("expected counterparty eq non-match")
+	}
+	has := mustCompile(t, &Condition{Field: "has_counterparty", Op: "eq", Value: true})
+	if !evaluateCondition(has, tctx) {
+		t.Error("expected has_counterparty true match")
+	}
+	hasNot := mustCompile(t, &Condition{Field: "has_counterparty", Op: "eq", Value: true})
+	if evaluateCondition(hasNot, TransactionContext{}) {
+		t.Error("expected has_counterparty true to NOT match an unbound transaction")
+	}
+}


### PR DESCRIPTION
First PR (A) of the P4 counterparty dimension for rules-as-universal-substrate. Introduces the `counterparties` surrogate entity and the `assign_counterparty` rule action + resolution, mirroring the just-built `assign_series` surrogate path exactly. **Read-model display (PR B) and MCP/REST/admin UI (PR C) are intentionally out of scope.**

## Doctrine
Counterparty = the other side of a transaction (merchants AND non-merchants: Venmo, people, employers). ONE canonical, cross-provider, surrogate-identity (`id`/`short_id`) entity, agent-curated. Resolved PURELY by `assign_counterparty` rules on raw immutable provider fields — **no normalizer, no auto-create (unless `create_if_missing`), NO UNIQUE on name**. `counterparty_id` is rule-resolved post-upsert (like `series_id`); `UpsertTransaction` is unchanged.

## Files by layer
**Migrations**
- `20260620040614_counterparties.sql` — table (`id`, `short_id`+`set_short_id` trigger, `name` NOT NULL, `website_url`, `logo_url`, `category_id` FK→categories ON DELETE SET NULL, `mcc`, `attrs` JSONB, `canonical_counterparty_id` self-ref, timestamps, `deleted_at`; partial indexes on `deleted_at` + canonical; **no unique-on-name**) + `transactions ADD COLUMN counterparty_id UUID NULL REFERENCES counterparties(id) ON DELETE SET NULL` + partial index. Additive → safe on shared DB; faithful Down.
- `20260620040615_annotations_counterparty_kinds.sql` — widen `annotations_kind_check` with `counterparty_assigned` / `counterparty_unlinked`.

**sqlc + service**
- `internal/db/queries/counterparties.sql` — Insert, GetByID/ByShortID/UUIDByShortID, GetByName, List, Update, SoftDelete, LinkTransactionCounterparty (NULL-fill), UnlinkTransactionCounterparty, CounterpartyTransactionCount.
- `internal/service/counterparties.go` — AssignCounterparty (imperative; existing short_id OR name+create_if_missing; ≤50 ids), AssignCounterpartyFromRuleTx (engine hook; resolve-or-create + link), List/Get/Update/Delete, ListCounterpartyGoverningRules (JSONB-containment), Unlink, membership annotations.
- `internal/service/resolve.go` — `resolveCounterpartyID`.
- `internal/service/types.go` — RuleAction `+CounterpartyShortID/Name`, `CounterpartyResponse`, `AssignCounterpartyInput`, `EditCounterpartyInput`, TransactionContext `+CounterpartyShortID/HasCounterparty`.

**assign_counterparty wiring — every assign_series twin**
- `internal/service/rules.go` — validActionTypes, ValidateActions case, actionAuditFields, retroTxnIntent + applyRetroTxnIntent, ApplyRuleRetroactively (extract + populate), ApplyAllRulesRetroactively (fold + materialize), validConditionFields (`counterparty`/`has_counterparty`), service evaluateLeaf, ActionsSummary, transactionContextQuery + GROUP BY + columns(16→18) + scanTransactionContextRow + preview query/scan.
- `internal/sync/rule_resolver.go` — typedAction, parseTypedActions, CounterpartyAssignIntent, RuleActions.CounterpartyAssign, ResolveWithContext (last-writer-wins + dropCounterpartySource + counterpartyActionValue), cpShortID cache (graceful if table missing), evaluateLeaf.
- `internal/sync/engine.go` — `AssignCounterpartyInTx` hook + materialization block + tctx seeding.
- `internal/cli/serve.go` — wire `AssignCounterpartyInTx = svc.AssignCounterpartyFromRuleTx`.

**Tests**
- `internal/service/counterparties_integration_test.go` — assign by short_id, create-by-name (idempotent de-dup), no-auto-create, FailIfExists, retroactive single + **bulk** paths materialize, ListCounterpartyGoverningRules, cascade-delete nulls counterparty_id, condition matching (counterparty/has_counterparty), ValidateActions.
- `internal/sync/rule_resolver_counterparty_test.go` — parseTypedActions, ResolveWithContext (intent + last-writer-wins), evaluateLeaf.

## Evidence
```
go build ./...          # OK
go vet ./...            # OK
go test ./...           # OK (unit)
make test-integration   # OK — new migration applies to breadbox_test, all new tests pass
go build -tags lite     # OK
go build -tags headless # OK
TestOpenAPIDrift        # ok breadbox/internal/api (PR A adds no routes)
```

Wiring audit (assign_series vs assign_counterparty occurrences per file) confirms every structural assign_series site has a counterparty twin; the residual numeric gap is series-only extras (legacy `merchant_key` UnmarshalJSON, prose comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
