### PR TITLE
test(agents): reviewer-authors-rule E2E (P5-2)

### DIFF
--- a/internal/mcp/rules_reviewer_response_shape_integration_test.go
+++ b/internal/mcp/rules_reviewer_response_shape_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration && !lite
+
+package mcp
+
+// MCP-layer assertion for the reviewer-authors-rule loop (P5-PR2 / T5).
+//
+// Companion to the service-layer rules_reviewer_e2e_integration_test.go: this
+// proves the same loop survives the MCP tool boundary. An agent calls
+// create_transaction_rule with an assign_series action and apply_retroactively,
+// and we lock the response envelope (rule + retroactive_matches) plus the
+// side-effect (a series is minted and members link). Asserts are strict on
+// shape, loose on values — mirrors flag_tool_response_shape_integration_test.go.
+
+import (
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// reviewerFreshTxn creates a fresh Netflix charge on the seeded primary account
+// and returns its UUID string.
+func reviewerFreshTxn(t *testing.T, f *fixtures, extID, date string, cents int64) string {
+	t.Helper()
+	q := f.svc.svc.Queries
+	accts, err := f.svc.svc.ListAccounts(f.ctx, nil)
+	if err != nil || len(accts) == 0 {
+		t.Fatalf("reviewerFreshTxn: ListAccounts: err=%v n=%d", err, len(accts))
+	}
+	var primaryShort string
+	for _, a := range accts {
+		if a.Name == "Primary Credit Card" {
+			primaryShort = a.ShortID
+			break
+		}
+	}
+	if primaryShort == "" {
+		t.Fatal("reviewerFreshTxn: could not find Primary Credit Card in accounts")
+	}
+	primaryUUID, err := q.GetAccountUUIDByShortID(f.ctx, primaryShort)
+	if err != nil {
+		t.Fatalf("reviewerFreshTxn: GetAccountUUIDByShortID: %v", err)
+	}
+	txn := testutil.MustCreateTransaction(t, q, primaryUUID, extID, "Netflix", cents, date)
+	return formatUUIDTest(t, txn.ID)
+}
+
+// TestReviewerCreateRuleAssignSeriesResponseShape pins the create_transaction_rule
+// envelope when an agent authors an assign_series rule and applies it
+// retroactively in one call: required keys `rule` and `retroactive_matches`
+// must be present, and the side-effect must mint a Netflix series with linked
+// members.
+func TestReviewerCreateRuleAssignSeriesResponseShape(t *testing.T) {
+	f := seedFixtures(t)
+	reviewerFreshTxn(t, f, "txn_reviewer_nflx_1", "2026-01-15", 1549)
+	reviewerFreshTxn(t, f, "txn_reviewer_nflx_2", "2026-02-16", 1499)
+
+	res, _, err := f.svc.handleCreateTransactionRule(f.ctx, nil, createTransactionRuleInput{
+		Name: "Netflix → series",
+		Conditions: map[string]any{
+			"field": "provider_name",
+			"op":    "contains",
+			"value": "netflix",
+		},
+		Actions: []map[string]any{{
+			"type":              "assign_series",
+			"series_name":       "Netflix",
+			"create_if_missing": true,
+		}},
+		ApplyRetroactively: true,
+	})
+	out := decodeToolResult[map[string]any](t, "reviewer:create_transaction_rule", res, err)
+
+	requireKeys(t, "reviewer:create_transaction_rule", out, "rule", "retroactive_matches")
+
+	rule, ok := out["rule"].(map[string]any)
+	if !ok {
+		t.Fatalf("reviewer:create_transaction_rule: rule is %T, want object", out["rule"])
+	}
+	requireKeys(t, "reviewer:create_transaction_rule.rule", rule, "actions", "created_by_type")
+
+	// Side-effect: a Netflix series exists after retroactive apply.
+	all, err := f.svc.svc.ListSeries(f.ctx, nil)
+	if err != nil {
+		t.Fatalf("ListSeries: %v", err)
+	}
+	var found *service.SeriesResponse
+	for i := range all {
+		if all[i].Name == "Netflix" {
+			found = &all[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("reviewer loop via MCP did not mint a Netflix series")
+	}
+	if matches, _ := out["retroactive_matches"].(float64); matches < 2 {
+		t.Errorf("retroactive_matches = %v, want >= 2", out["retroactive_matches"])
+	}
+}

--- a/internal/service/rules_reviewer_e2e_integration_test.go
+++ b/internal/service/rules_reviewer_e2e_integration_test.go
@@ -1,0 +1,189 @@
+//go:build integration && !lite
+
+package service_test
+
+// Reviewer-authors-rule E2E (P5-PR2 / T5).
+//
+// These tests prove the doctrine's core loop end-to-end at the service layer:
+// a scheduled REVIEWER (agent or user) authors a transaction rule, the next
+// sync applies it retroactively, and the matching transactions resolve to the
+// right surrogate entity (a recurring series or a counterparty). No fake
+// sidecar is involved — the orchestrator/sidecar protocol is a separate
+// concern; what's load-bearing for the doctrine is the
+// rule → apply → membership pipeline, exercised here through the real
+// CreateTransactionRule + ApplyAllRulesRetroactively service methods.
+//
+// Coverage:
+//   - TestReviewerAuthorsRecurrenceRule: provider_name contains + amount approx
+//     → assign_series(create_if_missing) → series minted, all members linked.
+//   - TestReviewerAuthorsCounterpartyRule: provider_name contains
+//     → assign_counterparty(create_if_missing) → counterparty resolved, members
+//     bound (exercises the P4 action through the reviewer loop).
+//   - TestReviewerAuthorsDayOfMonthRule: the recurrence idiom day_of_month
+//     approx D ± N → assign_series matches only the in-window charges.
+//
+// Shared fixtures (newService, seedTxnFixture, findSeriesByName,
+// countLinkedMembers, findCounterpartyByName, countLinkedCounterparty, fp) and
+// the testutil helpers live in the sibling _test.go files of this package.
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// TestReviewerAuthorsRecurrenceRule is the canonical reviewer loop: a reviewer
+// sees ~monthly Netflix charges with no series, authors ONE rule on stable
+// fields (provider_name + amount), and the next sync (modeled by
+// ApplyAllRulesRetroactively) mints the series and links every member. The
+// amount approx condition exercises the P1 numeric `approx` operator through
+// the bulk retroactive path; the seeded amounts differ slightly (15.49 /
+// 14.99 / 15.99) so the ± window does real work rather than an exact match.
+func TestReviewerAuthorsRecurrenceRule(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Three "Netflix" charges (provider_name contains "Netflix"), ~$15.49, on
+	// different month-days — no series assigned yet.
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_jan", "Netflix", 1549, "2026-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_feb", "Netflix", 1499, "2026-02-17")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_mar", "Netflix", 1599, "2026-03-16")
+
+	// Sanity: no Netflix series exists before the reviewer authors the rule.
+	if s := findSeriesByName(t, svc, "Netflix"); s != nil {
+		t.Fatalf("precondition: Netflix series already exists (%s)", s.ShortID)
+	}
+
+	// The reviewer authors the rule. Conditions are on STABLE fields only
+	// (provider_name + amount), never mutable account_name/category/series.
+	// Lowercase "netflix" exercises the case-insensitive `contains` op against
+	// the seeded "Netflix" provider_name.
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name: "Netflix subscription → series",
+		Conditions: service.Condition{And: []service.Condition{
+			{Field: "provider_name", Op: "contains", Value: "netflix"},
+			{Field: "amount", Op: "approx", Value: 15.49, Tolerance: fp(1.0)},
+		}},
+		Actions: []service.RuleAction{{
+			Type:            "assign_series",
+			SeriesName:      "Netflix",
+			CreateIfMissing: true,
+		}},
+		Actor: service.Actor{Type: "agent", ID: "agent-1", Name: "Transaction Reviewer"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+	if rule.CreatedByType != "agent" {
+		t.Errorf("rule created_by_type = %q, want agent", rule.CreatedByType)
+	}
+
+	// The next sync applies all enabled rules retroactively.
+	if _, err := svc.ApplyAllRulesRetroactively(ctx); err != nil {
+		t.Fatalf("ApplyAllRulesRetroactively: %v", err)
+	}
+
+	// Assert: a "Netflix" series now exists and all 3 transactions are members.
+	series := findSeriesByName(t, svc, "Netflix")
+	if series == nil {
+		t.Fatal("reviewer loop did not mint a Netflix series")
+	}
+	if got := countLinkedMembers(t, pool, series.ID); got != 3 {
+		t.Errorf("linked series members = %d, want 3", got)
+	}
+}
+
+// TestReviewerAuthorsCounterpartyRule mirrors the recurrence loop but targets
+// the P4 counterparty entity: the reviewer authors a rule whose action is
+// assign_counterparty(create_if_missing), and the next sync resolves all
+// matching transactions to a single Netflix counterparty. Proves the P4 action
+// materializes through the reviewer→apply pipeline (the bulk retroactive path
+// that historically dropped assign_series).
+func TestReviewerAuthorsCounterpartyRule(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_a", "Netflix", 1549, "2026-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_b", "Netflix", 1499, "2026-02-17")
+	testutil.MustCreateTransaction(t, queries, acctID, "NETFLIX_c", "Netflix", 1599, "2026-03-16")
+
+	if cp := findCounterpartyByName(t, svc, "Netflix"); cp != nil {
+		t.Fatalf("precondition: Netflix counterparty already exists (%s)", cp.ShortID)
+	}
+
+	if _, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:       "Netflix → counterparty",
+		Conditions: service.Condition{Field: "provider_name", Op: "contains", Value: "netflix"},
+		Actions: []service.RuleAction{{
+			Type:             "assign_counterparty",
+			CounterpartyName: "Netflix",
+			CreateIfMissing:  true,
+		}},
+		Actor: service.Actor{Type: "agent", ID: "agent-1", Name: "Transaction Reviewer"},
+	}); err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	if _, err := svc.ApplyAllRulesRetroactively(ctx); err != nil {
+		t.Fatalf("ApplyAllRulesRetroactively: %v", err)
+	}
+
+	cp := findCounterpartyByName(t, svc, "Netflix")
+	if cp == nil {
+		t.Fatal("reviewer loop did not resolve a Netflix counterparty")
+	}
+	if got := countLinkedCounterparty(t, pool, cp.ID); got != 3 {
+		t.Errorf("bound counterparty members = %d, want 3", got)
+	}
+}
+
+// TestReviewerAuthorsDayOfMonthRule exercises the date-part recurrence idiom
+// (day_of_month approx D ± N) through the reviewer loop: the reviewer encodes
+// "around the 15th of the month" and the next sync links only the in-window
+// charges — an off-day charge on the 28th is correctly excluded from the
+// series even though it shares the merchant and amount.
+func TestReviewerAuthorsDayOfMonthRule(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// In-window: days 14/15/16, within 15 ± 3.
+	testutil.MustCreateTransaction(t, queries, acctID, "HULU_jan", "Hulu", 1499, "2026-01-14")
+	testutil.MustCreateTransaction(t, queries, acctID, "HULU_feb", "Hulu", 1499, "2026-02-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "HULU_mar", "Hulu", 1499, "2026-03-16")
+	// Out-of-window day: the 28th — same merchant + amount, but off-cadence.
+	testutil.MustCreateTransaction(t, queries, acctID, "HULU_off", "Hulu", 1499, "2026-04-28")
+
+	if _, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name: "Hulu mid-month → series",
+		Conditions: service.Condition{And: []service.Condition{
+			{Field: "provider_name", Op: "contains", Value: "hulu"},
+			{Field: "day_of_month", Op: "approx", Value: 15, Tolerance: fp(3)},
+		}},
+		Actions: []service.RuleAction{{
+			Type:            "assign_series",
+			SeriesName:      "Hulu",
+			CreateIfMissing: true,
+		}},
+		Actor: service.Actor{Type: "agent", ID: "agent-1", Name: "Transaction Reviewer"},
+	}); err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	if _, err := svc.ApplyAllRulesRetroactively(ctx); err != nil {
+		t.Fatalf("ApplyAllRulesRetroactively: %v", err)
+	}
+
+	series := findSeriesByName(t, svc, "Hulu")
+	if series == nil {
+		t.Fatal("reviewer loop did not mint a Hulu series")
+	}
+	// Only the 3 in-window charges link; the 28th is excluded by the date-part.
+	if got := countLinkedMembers(t, pool, series.ID); got != 3 {
+		t.Errorf("linked series members = %d, want 3 (off-day charge must be excluded)", got)
+	}
+}


### PR DESCRIPTION
Proves the rules-as-substrate doctrine's core loop end-to-end at the service layer: an agent-authored rule, applied retroactively, makes the next sync smarter — matching transactions resolve to the right surrogate entity. **Test-only PR** (no production code).

## What this proves
The doctrine is that agents are scheduled reviewers whose one durable output is a rule. This locks the `rule → apply → membership` pipeline through the real `CreateTransactionRule` + `ApplyAllRulesRetroactively` service methods (no fake sidecar — the orchestrator/sidecar protocol is a separate concern, covered elsewhere).

## New tests
`internal/service/rules_reviewer_e2e_integration_test.go` (`//go:build integration && !lite`, package `service_test`, reuses the existing `newService` / `seedTxnFixture` / `findSeriesByName` / `countLinkedMembers` / `findCounterpartyByName` / `countLinkedCounterparty` / `fp` fixtures):

1. **TestReviewerAuthorsRecurrenceRule** — seed 3 "Netflix" charges (~$15.49 on different month-days, no series). Author a rule on stable fields: `provider_name contains "netflix" AND amount approx 15.49 ±1.00` (exercises the P1 `approx` operator; amounts differ 15.49/14.99/15.99 so the window does real work) → `assign_series(series_name:"Netflix", create_if_missing:true)`. Apply retroactively → assert a Netflix series is minted and all 3 link.
2. **TestReviewerAuthorsCounterpartyRule** — same shape, `assign_counterparty(create_if_missing:true)` → assert all 3 bind to a single Netflix counterparty (exercises the P4-A action through the reviewer loop / bulk retroactive path).
3. **TestReviewerAuthorsDayOfMonthRule** — recurrence idiom `day_of_month approx 15 ±3`; 3 in-window (14/15/16) + 1 off-day (28th, same merchant+amount) → assert only the 3 in-window charges link.

`internal/mcp/rules_reviewer_response_shape_integration_test.go` (companion):

4. **TestReviewerCreateRuleAssignSeriesResponseShape** — drive `handleCreateTransactionRule` with an `assign_series` action + `apply_retroactively`; lock the response envelope (`rule`, `retroactive_matches`) and the side-effect (Netflix series minted, members linked). Mirrors `flag_tool_response_shape_integration_test.go`.

## Evidence

`make test-integration` (full suite, `breadbox_test`): **all packages green**, including:
```
ok  breadbox/internal/service  58.370s
ok  breadbox/internal/mcp       3.052s
ok  breadbox/internal/db        1.506s
```

New tests, verbose:
```
--- PASS: TestReviewerAuthorsRecurrenceRule (0.18s)
--- PASS: TestReviewerAuthorsCounterpartyRule (0.10s)
--- PASS: TestReviewerAuthorsDayOfMonthRule (0.11s)
--- PASS: TestReviewerCreateRuleAssignSeriesResponseShape (0.12s)
```

`go build ./...`, `go vet -tags integration ./...`, `go test ./...` (unit) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
