### PR TITLE
feat(counterparties): read-model join + display (P4-B)

### DIFF
--- a/internal/admin/csv_export.go
+++ b/internal/admin/csv_export.go
@@ -74,7 +74,7 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 			row := []string{
 				tx.Date,
 				tx.Name,
-				ptrutil.Deref(tx.MerchantName),
+				csvMerchant(tx),
 				strconv.FormatFloat(tx.Amount, 'f', 2, 64),
 				ptrutil.Deref(tx.IsoCurrencyCode),
 				tx.AccountName,
@@ -90,4 +90,14 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 			}
 		}
 	}
+}
+
+// csvMerchant resolves the Merchant column using the read-model display
+// convention: the assigned counterparty's name when present, otherwise the
+// raw provider merchant name (empty when neither is set).
+func csvMerchant(tx service.AdminTransactionRow) string {
+	if tx.CounterpartyName != nil && *tx.CounterpartyName != "" {
+		return *tx.CounterpartyName
+	}
+	return ptrutil.Deref(tx.MerchantName)
 }

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -782,6 +782,7 @@ func projectSampleTx(tx service.FeedSampleTx) pages.FeedTransactionRef {
 		ShortID:             tx.ShortID,
 		Name:                tx.Name,
 		MerchantName:        tx.MerchantName,
+		CounterpartyName:    tx.CounterpartyName,
 		Amount:              tx.Amount,
 		Currency:            tx.Currency,
 		Date:                tx.Date,

--- a/internal/service/counterparty_readmodel_integration_test.go
+++ b/internal/service/counterparty_readmodel_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// TestReadModel_ListTransactionsSurfacesCounterparty asserts the
+// LEFT JOIN counterparties in ListTransactions / GetTransaction surfaces the
+// assigned counterparty's name+short_id, and leaves it nil for unbound rows.
+func TestReadModel_ListTransactionsSurfacesCounterparty(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	bound := testutil.MustCreateTransaction(t, queries, acctID, "VENMO PAYMENT", "Venmo", 1599, "2026-03-15")
+	loose := testutil.MustCreateTransaction(t, queries, acctID, "STARBUCKS", "Starbucks", 599, "2026-03-16")
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	cp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Venmo", CreateIfMissing: true, TransactionIDs: []string{bound.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("assign counterparty: %v", err)
+	}
+
+	res, err := svc.ListTransactions(ctx, service.TransactionListParams{})
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	var sawBound, sawLoose bool
+	for _, tx := range res.Transactions {
+		switch tx.ShortID {
+		case bound.ShortID:
+			sawBound = true
+			if tx.CounterpartyName == nil || *tx.CounterpartyName != "Venmo" {
+				t.Errorf("bound txn CounterpartyName = %v, want Venmo", tx.CounterpartyName)
+			}
+			if tx.CounterpartyShortID == nil || *tx.CounterpartyShortID != cp.ShortID {
+				t.Errorf("bound txn CounterpartyShortID = %v, want %s", tx.CounterpartyShortID, cp.ShortID)
+			}
+		case loose.ShortID:
+			sawLoose = true
+			if tx.CounterpartyName != nil {
+				t.Errorf("loose txn CounterpartyName = %v, want nil", tx.CounterpartyName)
+			}
+		}
+	}
+	if !sawBound || !sawLoose {
+		t.Fatalf("did not see both txns in list (bound=%v loose=%v)", sawBound, sawLoose)
+	}
+
+	// GetTransaction (single detail) surfaces the same join.
+	got, err := svc.GetTransaction(ctx, bound.ShortID)
+	if err != nil {
+		t.Fatalf("GetTransaction: %v", err)
+	}
+	if got.CounterpartyName == nil || *got.CounterpartyName != "Venmo" {
+		t.Errorf("GetTransaction CounterpartyName = %v, want Venmo", got.CounterpartyName)
+	}
+}
+
+// TestReadModel_MerchantSummaryGroupsByCounterparty asserts the ListMerchants
+// rollup collapses bound charges under COALESCE(cp.name, ...) and exposes the
+// counterparty short_id on the group.
+func TestReadModel_MerchantSummaryGroupsByCounterparty(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	// Two charges with DIFFERENT raw provider names that both map to one
+	// counterparty — the rollup must collapse them into a single group keyed
+	// by the counterparty name (not the raw provider strings).
+	d1 := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
+	d2 := time.Now().AddDate(0, 0, -4).Format("2006-01-02")
+	a := testutil.MustCreateTransaction(t, queries, acctID, "VENMO PAYMENT 1", "Venmo *Alice", 1500, d1)
+	b := testutil.MustCreateTransaction(t, queries, acctID, "VENMO PAYMENT 2", "Venmo *Bob", 2500, d2)
+	actor := service.Actor{Type: "user", Name: "Tester"}
+
+	cp, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name: "Venmo", CreateIfMissing: true, TransactionIDs: []string{a.ShortID, b.ShortID},
+	}, actor)
+	if err != nil {
+		t.Fatalf("assign counterparty: %v", err)
+	}
+
+	res, err := svc.GetMerchantSummary(ctx, service.MerchantSummaryParams{})
+	if err != nil {
+		t.Fatalf("GetMerchantSummary: %v", err)
+	}
+	var found *service.MerchantSummaryRow
+	for i := range res.Merchants {
+		if res.Merchants[i].Merchant == "Venmo" {
+			found = &res.Merchants[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("merchant rollup did not contain a 'Venmo' counterparty group: %+v", res.Merchants)
+	}
+	if found.TransactionCount != 2 {
+		t.Errorf("Venmo group count = %d, want 2 (both raw provider names collapsed)", found.TransactionCount)
+	}
+	if found.CounterpartyShortID == nil || *found.CounterpartyShortID != cp.ShortID {
+		t.Errorf("Venmo group CounterpartyShortID = %v, want %s", found.CounterpartyShortID, cp.ShortID)
+	}
+}

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -28,10 +28,13 @@ type FeedActivityRow struct {
 	TransactionShortID string
 	TransactionName    string
 	MerchantName       string
-	Amount             float64
-	IsoCurrencyCode    string
-	TransactionDate    string
-	Pending            bool
+	// CounterpartyName is the assigned counterparty's name when present; the
+	// preferred display over MerchantName / provider name. Nil when unassigned.
+	CounterpartyName *string
+	Amount           float64
+	IsoCurrencyCode  string
+	TransactionDate  string
+	Pending          bool
 
 	AccountName     string
 	InstitutionName string
@@ -70,6 +73,7 @@ SELECT
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name,
     cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug,
+    cp.name AS counterparty_name,
     (SELECT COUNT(*)::int FROM transaction_tags tt WHERE tt.transaction_id = t.id) AS tag_count
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
@@ -77,6 +81,7 @@ LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
 LEFT JOIN categories cat ON t.category_id = cat.id
 LEFT JOIN categories pcat ON cat.parent_id = pcat.id
+LEFT JOIN counterparties cp ON t.counterparty_id = cp.id
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
    AND aa.id::text = a.actor_id
@@ -266,11 +271,14 @@ type FeedSampleTx struct {
 	ShortID      string
 	Name         string
 	MerchantName string
-	Amount       float64
-	Currency     string
-	Date         string
-	AccountName  string
-	Institution  string
+	// CounterpartyName is the assigned counterparty's name when present; the
+	// preferred display over MerchantName / provider name. Nil when unassigned.
+	CounterpartyName *string
+	Amount           float64
+	Currency         string
+	Date             string
+	AccountName      string
+	Institution      string
 	// Pending mirrors `transactions.pending` so the feed card can render
 	// the same clock-icon pending mark used on `/transactions/{id}` and
 	// the transactions list — preliminary rows often re-show as posted
@@ -550,6 +558,7 @@ SELECT
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name,
     cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug,
+    cp.name AS counterparty_name,
     (SELECT COUNT(*)::int FROM transaction_tags tt WHERE tt.transaction_id = t.id) AS tag_count
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
@@ -557,6 +566,7 @@ LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
 LEFT JOIN categories cat ON t.category_id = cat.id
 LEFT JOIN categories pcat ON cat.parent_id = pcat.id
+LEFT JOIN counterparties cp ON t.counterparty_id = cp.id
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
    AND aa.id::text = a.actor_id
@@ -621,6 +631,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		accountName, institutionName        pgtype.Text
 		catDisplay, catColor                pgtype.Text
 		catIcon, catSlug                    pgtype.Text
+		counterpartyName                    pgtype.Text
 		tagCount                            int
 	)
 
@@ -631,6 +642,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate, &pending,
 		&accountName, &institutionName,
 		&catDisplay, &catColor, &catIcon, &catSlug,
+		&counterpartyName,
 		&tagCount,
 	); err != nil {
 		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
@@ -715,6 +727,10 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 	if catSlug.Valid {
 		v := catSlug.String
 		row.CategorySlug = &v
+	}
+	if counterpartyName.Valid && counterpartyName.String != "" {
+		v := counterpartyName.String
+		row.CounterpartyName = &v
 	}
 	return row, nil
 }
@@ -912,12 +928,14 @@ func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRo
 SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
        t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name,
        cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug,
+       cp.name AS counterparty_name,
        (SELECT COUNT(*)::int FROM transaction_tags tt WHERE tt.transaction_id = t.id) AS tag_count
 FROM transactions t
 JOIN accounts ac ON ac.id = t.account_id
 JOIN bank_connections bc ON ac.connection_id = bc.id
 LEFT JOIN categories cat ON t.category_id = cat.id
 LEFT JOIN categories pcat ON cat.parent_id = pcat.id
+LEFT JOIN counterparties cp ON t.counterparty_id = cp.id
 WHERE t.created_at >= $1
   AND t.deleted_at IS NULL
   AND bc.id::text = ANY($2::text[])
@@ -950,21 +968,28 @@ ORDER BY t.created_at DESC
 			institutionName      pgtype.Text
 			catDisplay, catColor pgtype.Text
 			catIcon, catSlug     pgtype.Text
+			counterpartyName     pgtype.Text
 			tagCount             int
 		)
-		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName, &catDisplay, &catColor, &catIcon, &catSlug, &tagCount); err != nil {
+		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName, &catDisplay, &catColor, &catIcon, &catSlug, &counterpartyName, &tagCount); err != nil {
 			return nil, err
+		}
+		var counterpartyPtr *string
+		if counterpartyName.Valid && counterpartyName.String != "" {
+			v := counterpartyName.String
+			counterpartyPtr = &v
 		}
 		t := txRow{
 			FeedSampleTx: FeedSampleTx{
-				ShortID:      shortID,
-				Name:         provName,
-				MerchantName: pgconv.TextOr(merchantName, ""),
-				Currency:     pgconv.TextOr(isoCcy, "USD"),
-				AccountName:  pgconv.TextOr(accountName, ""),
-				Institution:  pgconv.TextOr(institutionName, ""),
-				Pending:      pending,
-				TagCount:     tagCount,
+				ShortID:          shortID,
+				Name:             provName,
+				MerchantName:     pgconv.TextOr(merchantName, ""),
+				CounterpartyName: counterpartyPtr,
+				Currency:         pgconv.TextOr(isoCcy, "USD"),
+				AccountName:      pgconv.TextOr(accountName, ""),
+				Institution:      pgconv.TextOr(institutionName, ""),
+				Pending:          pending,
+				TagCount:         tagCount,
 			},
 			ConnectionID: connID,
 			CreatedAt:    createdAt.Time.UTC(),
@@ -1471,6 +1496,7 @@ func sampleTxFromRow(r FeedActivityRow) FeedSampleTx {
 		ShortID:             r.TransactionShortID,
 		Name:                r.TransactionName,
 		MerchantName:        merchant,
+		CounterpartyName:    r.CounterpartyName,
 		Amount:              r.Amount,
 		Currency:            r.IsoCurrencyCode,
 		Date:                r.TransactionDate,

--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -23,6 +23,8 @@ var validFields = map[string]bool{
 	"authorized_datetime":          true,
 	"provider_name":                true,
 	"provider_merchant_name":       true,
+	"counterparty_short_id":        true,
+	"counterparty_name":            true,
 	"category":                     true,
 	"provider_category_primary":    true,
 	"provider_category_detailed":   true,
@@ -152,6 +154,10 @@ func FilterTransactionFields(t TransactionResponse, fields map[string]bool) map[
 			m["provider_name"] = t.ProviderName
 		case "provider_merchant_name":
 			m["provider_merchant_name"] = t.ProviderMerchantName
+		case "counterparty_short_id":
+			m["counterparty_short_id"] = t.CounterpartyShortID
+		case "counterparty_name":
+			m["counterparty_name"] = t.CounterpartyName
 		case "category":
 			m["category"] = t.Category
 		case "provider_category_primary":

--- a/internal/service/fields_test.go
+++ b/internal/service/fields_test.go
@@ -193,7 +193,7 @@ func strPtr(s string) *string { return &s }
 
 func TestFilterTransactionFields_AllFields(t *testing.T) {
 	// Build a fieldSet with all valid fields
-	fields, err := ParseFields("id,account_id,account_name,user_name,amount,iso_currency_code,date,authorized_date,datetime,authorized_datetime,provider_name,provider_merchant_name,category,provider_category_primary,provider_category_detailed,provider_category_confidence,provider_payment_channel,pending,created_at,updated_at,metadata,flagged_at")
+	fields, err := ParseFields("id,account_id,account_name,user_name,amount,iso_currency_code,date,authorized_date,datetime,authorized_datetime,provider_name,provider_merchant_name,counterparty_short_id,counterparty_name,category,provider_category_primary,provider_category_detailed,provider_category_confidence,provider_payment_channel,pending,created_at,updated_at,metadata,flagged_at")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -24,9 +24,9 @@ type TransactionSummaryParams struct {
 
 // TransactionSummaryResult is the response for a transaction summary query.
 type TransactionSummaryResult struct {
-	Summary []TransactionSummaryRow    `json:"summary"`
-	Totals  TransactionSummaryTotals   `json:"totals"`
-	Filters TransactionSummaryFilters  `json:"filters"`
+	Summary []TransactionSummaryRow   `json:"summary"`
+	Totals  TransactionSummaryTotals  `json:"totals"`
+	Filters TransactionSummaryFilters `json:"filters"`
 }
 
 // TransactionSummaryRow is a single aggregated row.
@@ -257,16 +257,19 @@ func (s *Service) GetMerchantSummary(ctx context.Context, params MerchantSummary
 	args := make([]any, 0, 12)
 	argN := 1
 
-	buf.WriteString(`SELECT COALESCE(t.provider_merchant_name, t.provider_name) AS merchant,
+	buf.WriteString(`SELECT COALESCE(cp.name, t.provider_merchant_name, t.provider_name) AS merchant,
 		COUNT(*) AS transaction_count,
 		SUM(t.amount) AS total_amount,
 		AVG(t.amount) AS avg_amount,
 		MIN(t.date)::text AS first_date,
 		MAX(t.date)::text AS last_date,
-		t.iso_currency_code
+		t.iso_currency_code,
+		cp.short_id AS counterparty_short_id,
+		cp.logo_url AS counterparty_logo_url
 FROM transactions t
 JOIN accounts a ON t.account_id = a.id
-LEFT JOIN bank_connections bc ON a.connection_id = bc.id`)
+LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+LEFT JOIN counterparties cp ON t.counterparty_id = cp.id`)
 
 	joinCategories := false
 	if params.CategorySlug != nil {
@@ -371,7 +374,7 @@ LEFT JOIN bank_connections bc ON a.connection_id = bc.id`)
 		argN = ec.ArgN
 	}
 
-	buf.WriteString(" GROUP BY COALESCE(t.provider_merchant_name, t.provider_name), t.iso_currency_code")
+	buf.WriteString(" GROUP BY t.counterparty_id, COALESCE(cp.name, t.provider_merchant_name, t.provider_name), cp.short_id, cp.logo_url, t.iso_currency_code")
 	buf.WriteString(" HAVING COUNT(*) >= $")
 	buf.WriteString(strconv.Itoa(argN))
 	args = append(args, params.MinCount)
@@ -394,7 +397,7 @@ LEFT JOIN bank_connections bc ON a.connection_id = bc.id`)
 
 	for rows.Next() {
 		var row MerchantSummaryRow
-		err = rows.Scan(&row.Merchant, &row.TransactionCount, &row.TotalAmount, &row.AvgAmount, &row.FirstDate, &row.LastDate, &row.IsoCurrencyCode)
+		err = rows.Scan(&row.Merchant, &row.TransactionCount, &row.TotalAmount, &row.AvgAmount, &row.FirstDate, &row.LastDate, &row.IsoCurrencyCode, &row.CounterpartyShortID, &row.CounterpartyLogoURL)
 		if err != nil {
 			return nil, fmt.Errorf("scan merchant summary row: %w", err)
 		}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -223,14 +223,16 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name, " +
 		"au.short_id AS attributed_user_short_id, au.name AS attributed_user_name, " +
 		"COALESCE(au.short_id, u.short_id) AS effective_user_short_id, " +
-		"t.metadata, t.flagged_at " +
+		"t.metadata, t.flagged_at, " +
+		"cp.short_id AS counterparty_short_id, cp.name AS counterparty_name, cp.logo_url AS counterparty_logo_url " +
 		"FROM transactions t " +
 		"JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
 		"LEFT JOIN users u ON bc.user_id = u.id " +
 		"LEFT JOIN users au ON t.attributed_user_id = au.id " +
 		"LEFT JOIN categories c ON t.category_id = c.id " +
-		"LEFT JOIN categories pc ON c.parent_id = pc.id")
+		"LEFT JOIN categories pc ON c.parent_id = pc.id " +
+		"LEFT JOIN counterparties cp ON t.counterparty_id = cp.id")
 
 	limit := params.Limit
 	if limit <= 0 {
@@ -449,41 +451,44 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	var transactions []TransactionResponse
 	for rows.Next() {
 		var (
-			id                     pgtype.UUID
-			shortID                string
-			externalTransactionID  string
-			pendingTransactionID   pgtype.Text
-			amount                 pgtype.Numeric
-			isoCurrencyCode        pgtype.Text
-			date                   pgtype.Date
-			authorizedDate         pgtype.Date
-			datetime               pgtype.Timestamptz
-			authorizedDatetime     pgtype.Timestamptz
-			name                   string
-			merchantName           pgtype.Text
-			categoryPrimary        pgtype.Text
-			categoryDetailed       pgtype.Text
-			categoryConfidence     pgtype.Text
-			paymentChannel         pgtype.Text
-			pending                bool
-			deletedAt              pgtype.Timestamptz
-			createdAt              pgtype.Timestamptz
-			updatedAt              pgtype.Timestamptz
-			accountName            string
-			accountShortID         string
-			userName               pgtype.Text
-			categoryID             pgtype.UUID
-			catSlug                pgtype.Text
-			catDisplayName         pgtype.Text
-			catIcon                pgtype.Text
-			catColor               pgtype.Text
-			catPrimarySlug         pgtype.Text
-			catPrimaryDisplayName  pgtype.Text
-			attributedUserShortID  pgtype.Text
-			attributedUserName     pgtype.Text
-			effectiveUserShortID   pgtype.Text
-			metadata               []byte
-			flaggedAt              pgtype.Timestamptz
+			id                    pgtype.UUID
+			shortID               string
+			externalTransactionID string
+			pendingTransactionID  pgtype.Text
+			amount                pgtype.Numeric
+			isoCurrencyCode       pgtype.Text
+			date                  pgtype.Date
+			authorizedDate        pgtype.Date
+			datetime              pgtype.Timestamptz
+			authorizedDatetime    pgtype.Timestamptz
+			name                  string
+			merchantName          pgtype.Text
+			categoryPrimary       pgtype.Text
+			categoryDetailed      pgtype.Text
+			categoryConfidence    pgtype.Text
+			paymentChannel        pgtype.Text
+			pending               bool
+			deletedAt             pgtype.Timestamptz
+			createdAt             pgtype.Timestamptz
+			updatedAt             pgtype.Timestamptz
+			accountName           string
+			accountShortID        string
+			userName              pgtype.Text
+			categoryID            pgtype.UUID
+			catSlug               pgtype.Text
+			catDisplayName        pgtype.Text
+			catIcon               pgtype.Text
+			catColor              pgtype.Text
+			catPrimarySlug        pgtype.Text
+			catPrimaryDisplayName pgtype.Text
+			attributedUserShortID pgtype.Text
+			attributedUserName    pgtype.Text
+			effectiveUserShortID  pgtype.Text
+			metadata              []byte
+			flaggedAt             pgtype.Timestamptz
+			counterpartyShortID   pgtype.Text
+			counterpartyName      pgtype.Text
+			counterpartyLogoURL   pgtype.Text
 		)
 
 		if err := rows.Scan(
@@ -499,6 +504,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			&catPrimarySlug, &catPrimaryDisplayName,
 			&attributedUserShortID, &attributedUserName,
 			&effectiveUserShortID, &metadata, &flaggedAt,
+			&counterpartyShortID, &counterpartyName, &counterpartyLogoURL,
 		); err != nil {
 			return nil, fmt.Errorf("scan transaction: %w", err)
 		}
@@ -531,20 +537,20 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 
 		accountShortIDVal := accountShortID
 		transactions = append(transactions, TransactionResponse{
-			ID:                  formatUUID(id),
-			ShortID:             shortID,
-			AccountID:           &accountShortIDVal,
-			AccountName:         &accountName,
-			UserName:            textPtr(userName),
-			AttributedUserID:    textPtr(attributedUserShortID),
-			AttributedUserName:  textPtr(attributedUserName),
-			EffectiveUserID:     textPtr(effectiveUserShortID),
-			Amount:              amountVal,
-			IsoCurrencyCode:     textPtr(isoCurrencyCode),
-			Date:                dateVal,
-			AuthorizedDate:      dateStr(authorizedDate),
-			Datetime:            timestampStr(datetime),
-			AuthorizedDatetime:  timestampStr(authorizedDatetime),
+			ID:                         formatUUID(id),
+			ShortID:                    shortID,
+			AccountID:                  &accountShortIDVal,
+			AccountName:                &accountName,
+			UserName:                   textPtr(userName),
+			AttributedUserID:           textPtr(attributedUserShortID),
+			AttributedUserName:         textPtr(attributedUserName),
+			EffectiveUserID:            textPtr(effectiveUserShortID),
+			Amount:                     amountVal,
+			IsoCurrencyCode:            textPtr(isoCurrencyCode),
+			Date:                       dateVal,
+			AuthorizedDate:             dateStr(authorizedDate),
+			Datetime:                   timestampStr(datetime),
+			AuthorizedDatetime:         timestampStr(authorizedDatetime),
 			ProviderName:               name,
 			ProviderMerchantName:       textPtr(merchantName),
 			Category:                   catInfo,
@@ -552,11 +558,14 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			ProviderCategoryDetailed:   textPtr(categoryDetailed),
 			ProviderCategoryConfidence: textPtr(categoryConfidence),
 			ProviderPaymentChannel:     textPtr(paymentChannel),
-			Pending:             pending,
-			CreatedAt:           pgconv.TimestampStr(createdAt),
-			UpdatedAt:           pgconv.TimestampStr(updatedAt),
-			Metadata:            metadataToRaw(metadata),
-			FlaggedAt:           timestampStr(flaggedAt),
+			Pending:                    pending,
+			CreatedAt:                  pgconv.TimestampStr(createdAt),
+			UpdatedAt:                  pgconv.TimestampStr(updatedAt),
+			Metadata:                   metadataToRaw(metadata),
+			FlaggedAt:                  timestampStr(flaggedAt),
+			CounterpartyShortID:        textPtr(counterpartyShortID),
+			CounterpartyName:           textPtr(counterpartyName),
+			CounterpartyLogoURL:        textPtr(counterpartyLogoURL),
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -804,7 +813,8 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
 		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id, " +
-		"t.flagged_at " +
+		"t.flagged_at, " +
+		"cp.short_id AS counterparty_short_id, cp.name AS counterparty_name, cp.logo_url AS counterparty_logo_url " +
 		"FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -812,6 +822,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"LEFT JOIN users au ON t.attributed_user_id = au.id " +
 		"LEFT JOIN categories c ON t.category_id = c.id " +
 		"LEFT JOIN categories pc ON c.parent_id = pc.id " +
+		"LEFT JOIN counterparties cp ON t.counterparty_id = cp.id " +
 		"WHERE t.deleted_at IS NULL")
 
 	// Track which JOINs are needed for the WHERE clause (used by the count query).
@@ -1030,28 +1041,31 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	var transactions []AdminTransactionRow
 	for rows.Next() {
 		var (
-			id               pgtype.UUID
-			accountID        pgtype.UUID
-			accountName      string
-			institutionName  string
-			userName         string
-			date             pgtype.Date
-			name             string
-			merchantName     pgtype.Text
-			amount           pgtype.Numeric
-			isoCurrencyCode  pgtype.Text
-			categoryID       pgtype.UUID
-			catDisplayName   pgtype.Text
-			catSlug          pgtype.Text
-			catIcon          pgtype.Text
-			catColor         pgtype.Text
-			pending          bool
-			commentCount     int64
-			hasPendingReview bool
-			createdAt        pgtype.Timestamptz
-			updatedAt        pgtype.Timestamptz
-			effectiveUserID  pgtype.UUID
-			flaggedAt        pgtype.Timestamptz
+			id                  pgtype.UUID
+			accountID           pgtype.UUID
+			accountName         string
+			institutionName     string
+			userName            string
+			date                pgtype.Date
+			name                string
+			merchantName        pgtype.Text
+			amount              pgtype.Numeric
+			isoCurrencyCode     pgtype.Text
+			categoryID          pgtype.UUID
+			catDisplayName      pgtype.Text
+			catSlug             pgtype.Text
+			catIcon             pgtype.Text
+			catColor            pgtype.Text
+			pending             bool
+			commentCount        int64
+			hasPendingReview    bool
+			createdAt           pgtype.Timestamptz
+			updatedAt           pgtype.Timestamptz
+			effectiveUserID     pgtype.UUID
+			flaggedAt           pgtype.Timestamptz
+			counterpartyShortID pgtype.Text
+			counterpartyName    pgtype.Text
+			counterpartyLogoURL pgtype.Text
 		)
 
 		if err := rows.Scan(
@@ -1061,6 +1075,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
 			&pending, &commentCount, &hasPendingReview, &createdAt, &updatedAt,
 			&effectiveUserID, &flaggedAt,
+			&counterpartyShortID, &counterpartyName, &counterpartyLogoURL,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
 		}
@@ -1091,6 +1106,9 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			Date:                dateVal,
 			Name:                name,
 			MerchantName:        textPtr(merchantName),
+			CounterpartyShortID: textPtr(counterpartyShortID),
+			CounterpartyName:    textPtr(counterpartyName),
+			CounterpartyLogoURL: textPtr(counterpartyLogoURL),
 			Amount:              amountVal,
 			IsoCurrencyCode:     textPtr(isoCurrencyCode),
 			CategoryID:          catIDPtr,
@@ -1201,7 +1219,8 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
 		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id, " +
-		"t.flagged_at " +
+		"t.flagged_at, " +
+		"cp.short_id AS counterparty_short_id, cp.name AS counterparty_name, cp.logo_url AS counterparty_logo_url " +
 		"FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -1209,6 +1228,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 		"LEFT JOIN users au ON t.attributed_user_id = au.id " +
 		"LEFT JOIN categories c ON t.category_id = c.id " +
 		"LEFT JOIN categories pc ON c.parent_id = pc.id " +
+		"LEFT JOIN counterparties cp ON t.counterparty_id = cp.id " +
 		"WHERE t.deleted_at IS NULL AND t.id = ANY($1)"
 
 	rows, err := s.Pool.Query(ctx, query, uuids)
@@ -1220,28 +1240,31 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 	byID := make(map[string]AdminTransactionRow, len(uuids))
 	for rows.Next() {
 		var (
-			id               pgtype.UUID
-			accountID        pgtype.UUID
-			accountName      string
-			institutionName  string
-			userName         string
-			date             pgtype.Date
-			name             string
-			merchantName     pgtype.Text
-			amount           pgtype.Numeric
-			isoCurrencyCode  pgtype.Text
-			categoryID       pgtype.UUID
-			catDisplayName   pgtype.Text
-			catSlug          pgtype.Text
-			catIcon          pgtype.Text
-			catColor         pgtype.Text
-			pending          bool
-			commentCount     int64
-			hasPendingReview bool
-			createdAt        pgtype.Timestamptz
-			updatedAt        pgtype.Timestamptz
-			effectiveUserID  pgtype.UUID
-			flaggedAt        pgtype.Timestamptz
+			id                  pgtype.UUID
+			accountID           pgtype.UUID
+			accountName         string
+			institutionName     string
+			userName            string
+			date                pgtype.Date
+			name                string
+			merchantName        pgtype.Text
+			amount              pgtype.Numeric
+			isoCurrencyCode     pgtype.Text
+			categoryID          pgtype.UUID
+			catDisplayName      pgtype.Text
+			catSlug             pgtype.Text
+			catIcon             pgtype.Text
+			catColor            pgtype.Text
+			pending             bool
+			commentCount        int64
+			hasPendingReview    bool
+			createdAt           pgtype.Timestamptz
+			updatedAt           pgtype.Timestamptz
+			effectiveUserID     pgtype.UUID
+			flaggedAt           pgtype.Timestamptz
+			counterpartyShortID pgtype.Text
+			counterpartyName    pgtype.Text
+			counterpartyLogoURL pgtype.Text
 		)
 		if err := rows.Scan(
 			&id, &accountID, &accountName,
@@ -1250,6 +1273,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
 			&pending, &commentCount, &hasPendingReview, &createdAt, &updatedAt,
 			&effectiveUserID, &flaggedAt,
+			&counterpartyShortID, &counterpartyName, &counterpartyLogoURL,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
 		}
@@ -1277,6 +1301,9 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			Date:                dateVal,
 			Name:                name,
 			MerchantName:        textPtr(merchantName),
+			CounterpartyShortID: textPtr(counterpartyShortID),
+			CounterpartyName:    textPtr(counterpartyName),
+			CounterpartyLogoURL: textPtr(counterpartyLogoURL),
 			Amount:              amountVal,
 			IsoCurrencyCode:     textPtr(isoCurrencyCode),
 			CategoryID:          catIDPtr,
@@ -1360,12 +1387,14 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 			t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name,
 			t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence,
 			t.provider_payment_channel, t.pending, t.created_at, t.updated_at,
-			t.category_id, t.metadata, t.flagged_at
+			t.category_id, t.metadata, t.flagged_at,
+			cp.short_id AS counterparty_short_id, cp.name AS counterparty_name, cp.logo_url AS counterparty_logo_url
 		FROM transactions t
 		LEFT JOIN accounts a ON a.id = t.account_id
 		LEFT JOIN bank_connections bc ON bc.id = a.connection_id
 		LEFT JOIN users u ON u.id = bc.user_id
 		LEFT JOIN users au ON au.id = t.attributed_user_id
+		LEFT JOIN counterparties cp ON cp.id = t.counterparty_id
 		WHERE t.id = $1 AND t.deleted_at IS NULL
 	`
 
@@ -1396,6 +1425,9 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		categoryID            pgtype.UUID
 		metadata              []byte
 		flaggedAt             pgtype.Timestamptz
+		counterpartyShortID   pgtype.Text
+		counterpartyName      pgtype.Text
+		counterpartyLogoURL   pgtype.Text
 	)
 
 	if err := s.Pool.QueryRow(ctx, q, uid).Scan(
@@ -1407,6 +1439,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		&providerCatPrimary, &providerCatDetailed, &providerCatConf,
 		&providerChannel, &pending, &createdAt, &updatedAt,
 		&categoryID, &metadata, &flaggedAt,
+		&counterpartyShortID, &counterpartyName, &counterpartyLogoURL,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -1450,6 +1483,9 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		UpdatedAt:                  pgconv.TimestampStr(updatedAt),
 		Metadata:                   metadataToRaw(metadata),
 		FlaggedAt:                  timestampStr(flaggedAt),
+		CounterpartyShortID:        textPtr(counterpartyShortID),
+		CounterpartyName:           textPtr(counterpartyName),
+		CounterpartyLogoURL:        textPtr(counterpartyLogoURL),
 	}
 
 	if categoryID.Valid {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -40,22 +40,29 @@ type TransactionCategoryInfo struct {
 }
 
 type TransactionResponse struct {
-	ID                         string                   `json:"id"`
-	ShortID                    string                   `json:"short_id"`
-	AccountID                  *string                  `json:"account_id"`
-	AccountName                *string                  `json:"account_name"`
-	UserName                   *string                  `json:"user_name"`
-	AttributedUserID           *string                  `json:"attributed_user_id,omitempty"`
-	AttributedUserName         *string                  `json:"attributed_user_name,omitempty"`
-	EffectiveUserID            *string                  `json:"effective_user_id,omitempty"`
-	Amount                     float64                  `json:"amount"`
-	IsoCurrencyCode            *string                  `json:"iso_currency_code"`
-	Date                       string                   `json:"date"`
-	AuthorizedDate             *string                  `json:"authorized_date"`
-	Datetime                   *string                  `json:"datetime"`
-	AuthorizedDatetime         *string                  `json:"authorized_datetime"`
-	ProviderName               string                   `json:"provider_name"`
-	ProviderMerchantName       *string                  `json:"provider_merchant_name"`
+	ID                   string  `json:"id"`
+	ShortID              string  `json:"short_id"`
+	AccountID            *string `json:"account_id"`
+	AccountName          *string `json:"account_name"`
+	UserName             *string `json:"user_name"`
+	AttributedUserID     *string `json:"attributed_user_id,omitempty"`
+	AttributedUserName   *string `json:"attributed_user_name,omitempty"`
+	EffectiveUserID      *string `json:"effective_user_id,omitempty"`
+	Amount               float64 `json:"amount"`
+	IsoCurrencyCode      *string `json:"iso_currency_code"`
+	Date                 string  `json:"date"`
+	AuthorizedDate       *string `json:"authorized_date"`
+	Datetime             *string `json:"datetime"`
+	AuthorizedDatetime   *string `json:"authorized_datetime"`
+	ProviderName         string  `json:"provider_name"`
+	ProviderMerchantName *string `json:"provider_merchant_name"`
+	// Counterparty (the other side of the transaction) when one is assigned
+	// via assign_counterparty rules. CounterpartyName is the preferred display
+	// name, falling back to ProviderMerchantName then ProviderName when nil.
+	// CounterpartyLogoURL is non-nil only once enrichment populates it.
+	CounterpartyShortID        *string                  `json:"counterparty_short_id,omitempty"`
+	CounterpartyName           *string                  `json:"counterparty_name,omitempty"`
+	CounterpartyLogoURL        *string                  `json:"counterparty_logo_url,omitempty"`
 	Category                   *TransactionCategoryInfo `json:"category"`
 	ProviderCategoryPrimary    *string                  `json:"provider_category_primary"`
 	ProviderCategoryDetailed   *string                  `json:"provider_category_detailed"`
@@ -334,15 +341,20 @@ type AdminTransactionListParams struct {
 }
 
 type AdminTransactionRow struct {
-	ID                  string
-	AccountID           string
-	AccountName         string
-	InstitutionName     string
-	UserName            string
-	EffectiveUserID     *string
-	Date                string
-	Name                string
-	MerchantName        *string
+	ID              string
+	AccountID       string
+	AccountName     string
+	InstitutionName string
+	UserName        string
+	EffectiveUserID *string
+	Date            string
+	Name            string
+	MerchantName    *string
+	// Counterparty assigned to this transaction (preferred display name over
+	// MerchantName / Name). CounterpartyLogoURL is non-nil once enriched.
+	CounterpartyShortID *string
+	CounterpartyName    *string
+	CounterpartyLogoURL *string
 	Amount              float64
 	IsoCurrencyCode     *string
 	CategoryID          *string
@@ -854,6 +866,11 @@ type MerchantSummaryRow struct {
 	FirstDate        string  `json:"first_date"`
 	LastDate         string  `json:"last_date"`
 	IsoCurrencyCode  string  `json:"iso_currency_code"`
+	// Counterparty grouping fields — non-nil when the rows in this group are
+	// bound to a canonical counterparty (the merchant string is then the
+	// counterparty name). CounterpartyLogoURL is non-nil once enriched.
+	CounterpartyShortID *string `json:"counterparty_short_id,omitempty"`
+	CounterpartyLogoURL *string `json:"counterparty_logo_url,omitempty"`
 }
 
 type MerchantSummaryResult struct {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -749,7 +749,7 @@ templ feedCommentRowBody(it FeedItem, c *FeedComment, now time.Time) {
 			<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
 		}
 		<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
-			{ components.TitleCase(feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name)) }
+			{ components.TitleCase(feedDisplayName(c.Transaction, feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name))) }
 		</a>
 		@feedRowTimestamp(it.TimestampStr, now)
 	</div>
@@ -851,7 +851,7 @@ func feedCommentActor(c *FeedComment) components.TimelineActor {
 func feedTxRowProps(tx FeedTransactionRef, dimmed bool) components.TxRowFeedProps {
 	return components.TxRowFeedProps{
 		ShortID:       tx.ShortID,
-		Description:   feedNonEmpty(tx.Name, tx.MerchantName),
+		Description:   feedDisplayName(tx, feedNonEmpty(tx.Name, tx.MerchantName)),
 		Amount:        tx.Amount,
 		Currency:      tx.Currency,
 		Pending:       tx.Pending,
@@ -1022,6 +1022,18 @@ func feedBulkSubjectLabel(b *FeedBulkAction) string {
 func feedNonEmpty(a, fallback string) string {
 	if strings.TrimSpace(a) != "" {
 		return a
+	}
+	return fallback
+}
+
+// feedDisplayName resolves the preferred display label for a feed tx ref:
+// the assigned counterparty's name when present, otherwise the caller's
+// provider/merchant fallback. Mirrors the COALESCE(counterparty_name, ...)
+// display convention used across the read model while preserving each call
+// site's existing fallback ordering.
+func feedDisplayName(ref FeedTransactionRef, fallback string) string {
+	if ref.CounterpartyName != nil && strings.TrimSpace(*ref.CounterpartyName) != "" {
+		return *ref.CounterpartyName
 	}
 	return fallback
 }

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -170,11 +170,14 @@ type FeedTransactionRef struct {
 	ShortID      string
 	Name         string
 	MerchantName string
-	Amount       float64
-	Currency     string
-	Date         string
-	AccountName  string
-	Institution  string
+	// CounterpartyName is the assigned counterparty's name when present; the
+	// preferred display over MerchantName / provider name. Nil when unassigned.
+	CounterpartyName *string
+	Amount           float64
+	Currency         string
+	Date             string
+	AccountName      string
+	Institution      string
 	// Pending mirrors `transactions.pending`. When true the inline tx-ref
 	// row renders the same small clock-icon mark used on the per-tx page
 	// and the transactions list, signalling the row is still preliminary

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -58,7 +58,7 @@ templ TransactionDetail(p TransactionDetailProps) {
 
 templ txdHero(p TransactionDetailProps) {
 	@components.EntityHeader(components.EntityHeaderProps{
-		Title:            p.Transaction.ProviderName,
+		Title:            txdDisplayName(p),
 		TitlePrivateKind: "merchant",
 		TitleClass:       "break-words",
 		Icon:             txdHeroIcon(p.Transaction.Amount),
@@ -164,6 +164,17 @@ templ txdMain(p TransactionDetailProps) {
 					<p class="text-xs text-base-content/40 mb-1">Date</p>
 					<p class="text-sm font-medium">{ components.FormatDate(p.Transaction.Date) }</p>
 				</div>
+				if p.Transaction.CounterpartyName != nil && *p.Transaction.CounterpartyName != "" {
+					<div>
+						<p class="text-xs text-base-content/40 mb-1">Counterparty</p>
+						<div class="flex items-center gap-1.5">
+							if p.Transaction.CounterpartyLogoURL != nil && *p.Transaction.CounterpartyLogoURL != "" {
+								<img src={ *p.Transaction.CounterpartyLogoURL } alt="" loading="lazy" class="w-4 h-4 rounded-sm object-contain shrink-0"/>
+							}
+							<p data-private="merchant" class="text-sm font-medium">{ *p.Transaction.CounterpartyName }</p>
+						</div>
+					</div>
+				}
 				if p.Transaction.ProviderMerchantName != nil && *p.Transaction.ProviderMerchantName != "" {
 					<div>
 						<p class="text-xs text-base-content/40 mb-1">Merchant</p>
@@ -895,6 +906,16 @@ templ txdInlineTagChip(e service.ActivityEntry) {
 }
 
 // ---- helpers ----
+
+// txdDisplayName is the hero title: the assigned counterparty's name when
+// present, otherwise the raw provider description. Mirrors the
+// COALESCE(counterparty_name, provider_name) display convention.
+func txdDisplayName(p TransactionDetailProps) string {
+	if p.Transaction.CounterpartyName != nil && *p.Transaction.CounterpartyName != "" {
+		return *p.Transaction.CounterpartyName
+	}
+	return p.Transaction.ProviderName
+}
 
 // txdHeroIcon returns the hero icon name based on amount sign — a
 // credit (negative) shows the inbound arrow, a debit (positive) shows

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -58,8 +58,11 @@ templ TxRow(tx service.AdminTransactionRow) {
 			})
 			<!-- Description + meta line -->
 			<div class="flex-1 min-w-0">
-				<div class="flex items-center gap-2">
-					<a href={ templ.URL("/transactions/" + tx.ID) } @click.stop data-private="merchant" class="font-medium text-sm hover:text-primary transition-colors truncate">{ tx.Name }</a>
+				<div class="flex items-center gap-2 min-w-0">
+					if tx.CounterpartyLogoURL != nil && *tx.CounterpartyLogoURL != "" {
+						<img src={ deref(tx.CounterpartyLogoURL) } alt="" loading="lazy" class="w-4 h-4 rounded-sm object-contain shrink-0"/>
+					}
+					<a href={ templ.URL("/transactions/" + tx.ID) } @click.stop data-private="merchant" class="font-medium text-sm hover:text-primary transition-colors truncate">{ txPrimaryName(tx) }</a>
 				</div>
 				<!-- Meta line (sm+). Canonical order across every breakpoint:
 				     [Lead] · {Merchant | Category} · Tags · Comments.
@@ -294,6 +297,17 @@ templ TxRow(tx service.AdminTransactionRow) {
 			</div>
 		</div>
 	</div>
+}
+
+// txPrimaryName is the preferred display name for a transaction row: the
+// assigned counterparty's name when present, otherwise the raw provider
+// description. Mirrors the COALESCE(counterparty_name, provider_name) display
+// convention used across the read model.
+func txPrimaryName(tx service.AdminTransactionRow) string {
+	if tx.CounterpartyName != nil && *tx.CounterpartyName != "" {
+		return *tx.CounterpartyName
+	}
+	return tx.Name
 }
 
 // txMerchantAttr lowercases merchant for the data-tx-merchant filter attr;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3283,6 +3283,9 @@ components:
         iso_currency_code: { type: string }
         name: { type: string }
         merchant_name: { type: string, nullable: true }
+        counterparty_short_id: { type: string, nullable: true, description: "short_id of the assigned counterparty (the other side of the transaction), null when unassigned." }
+        counterparty_name: { type: string, nullable: true, description: "Preferred display name when a counterparty is assigned; falls back to merchant_name then name." }
+        counterparty_logo_url: { type: string, nullable: true, description: "Counterparty logo URL; null until enrichment populates it." }
         category_id: { type: string, nullable: true }
         pending: { type: boolean }
         deleted_at: { type: string, format: date-time, nullable: true }


### PR DESCRIPTION
## P4-PR-B — Counterparty read-model join + display

Part of the rules-as-universal-substrate sprint (P4). Builds on **P4-PR-A** (counterparties entity + `assign_counterparty` action, merged). This PR surfaces the assigned counterparty in every transaction read path, making it the primary display with the on-the-fly `COALESCE(provider_merchant_name, provider_name)` as fallback. No MCP/REST/admin counterparty *pages* — that's PR-C.

### Read-model join
- `internal/service/transactions.go` — `LEFT JOIN counterparties cp ON t.counterparty_id = cp.id` + `cp.short_id/name/logo_url` in `ListTransactions`, `ListTransactionsAdmin`, `GetAdminTransactionRowsByIDs`, and `GetTransaction`.
- `internal/service/types.go` — `CounterpartyShortID/Name/LogoURL` on `TransactionResponse` + `AdminTransactionRow`; `CounterpartyShortID/LogoURL` on `MerchantSummaryRow`.
- `internal/service/transaction_summary.go` — merchant rollup is now counterparty-aware: `SELECT COALESCE(cp.name, provider_merchant_name, provider_name)`, `LEFT JOIN cp`, `GROUP BY t.counterparty_id, COALESCE(...), cp.short_id, cp.logo_url, iso_currency_code`. Distinct raw provider strings that map to one counterparty collapse into a single group.
- `internal/service/fields.go` — `counterparty_short_id` / `counterparty_name` added to the transaction field whitelist + projection.

### Display fallback (prefer counterparty name; 16×16 logo when present)
- `internal/templates/components/tx_row.templ` — list row primary name + optional logo.
- `internal/templates/components/pages/transaction_detail.templ` — hero title + a Counterparty details field.
- `internal/admin/feed.go` + `internal/service/feed.go` + `feed.templ` — feed cards thread `CounterpartyName` through and prefer it (each call site's existing fallback order preserved).
- `internal/admin/csv_export.go` — Merchant column prefers the counterparty name.

### Docs / schema
- `openapi.yaml` — new optional/nullable `counterparty_short_id` / `counterparty_name` / `counterparty_logo_url` on the `Transaction` schema (additive; `additionalProperties: true`).

### Tests — all green
`go build ./... && go vet ./... && go test ./...` clean.

Integration (`make test-integration` against `breadbox_test`):
- `TestReadModel_ListTransactionsSurfacesCounterparty` — assign a counterparty, assert `ListTransactions` + `GetTransaction` surface its name/short_id; unbound rows stay nil.
- `TestReadModel_MerchantSummaryGroupsByCounterparty` — two charges with different raw provider names collapse into one counterparty group with the right count + short_id.
- Full `./internal/service/...` + `./internal/db/...` integration sweep green; `TestOpenAPIDrift` + `TestOpenAPIYAMLValid` green.

### Notes
- `search.go` left untouched: adding `cp.name` to the shared `TransactionSearchColumns` would break the count query (which doesn't join `cp`). Deferred as the optional/lowest-value item.
- Live UI screenshot skipped to avoid migrating the shared dev `breadbox` DB (per spec). Logos are null until PR-C enrichment anyway; behavior is proven by the integration tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
