### PR TITLE
docs(agents): add assign_counterparty to the rule grammar + curriculum

### DIFF
--- a/prompts/agents/rules-curriculum.md
+++ b/prompts/agents/rules-curriculum.md
@@ -76,6 +76,7 @@ makes a rule that fights itself or silently stops firing:
 - `account_name`, `user_name` — display labels, renameable.
 - `category` — *output* of categorization; a rule keyed on it chases its own tail.
 - `tags`, `series`, `in_series` — set by rules/agents; not bank facts.
+- `counterparty`, `has_counterparty` — set by `assign_counterparty` rules/agents; not bank facts.
 
 The date-parts are the one safe *derived* exception: they're pure functions of
 the immutable date, so a condition on them is as durable as one on `amount`.
@@ -139,11 +140,33 @@ one-off MCP tools. See `breadbox://rule-dsl` for exact shapes.
 | `set_metadata` | Merge key/value metadata onto the transaction. |
 | `flag` / `unflag` | Raise (or clear) a flag for human attention. |
 | `assign_series` | Link the transaction to a recurring series (the recurrence idiom above). |
-
-<!-- assign_counterparty is intentionally omitted here. Add it to this catalog
-     and document the "known entity worth tracking" idiom once counterparties
-     land (P4). -->
+| `assign_counterparty` | Bind the transaction to a counterparty — the entity on the other side (the counterparties idiom below). |
 
 A transaction joins at most one series; a higher-priority `assign_series`
 overrides a lower one. Pick priority bands per `breadbox://rule-dsl` so
 specific rules outrank broad ones.
+
+## The counterparties idiom — name the entity behind the charge
+
+A **counterparty** is the other side of a transaction — not just merchants,
+but **non-merchants** too: a Venmo recipient, a person, an employer, a
+landlord. When you figure out *who* a charge actually is (the cryptic
+`provider_name` is really your contractor; three different feeds are all the
+same employer), don't fix the one row — author an `assign_counterparty` rule
+on the **raw provider fields**, and every future charge resolves to that
+entity automatically:
+
+```jsonc
+// "ACH credit from cryptic payroll descriptor → my employer"
+{ "field": "provider_name", "op": "contains", "value": "ACME PAYROLL" }
+// action: { "type": "assign_counterparty", "counterparty_name": "Acme Inc", "create_if_missing": true }
+```
+
+**Reuse, don't duplicate.** A counterparty is cross-provider on purpose — the
+same person or business shows up under different descriptors across Plaid,
+Teller, and Venmo. Before minting a new one by name, look for an existing
+counterparty and bind to it by `counterparty_short_id`. The by-name path
+resolves-or-creates (it de-dupes on the live name), but pointing several
+raw-field rules at **one** counterparty is how you collapse those descriptors
+into a single entity. Default is assign-to-existing; nothing is created unless
+you pass `create_if_missing`.

--- a/prompts/mcp/rule-dsl.md
+++ b/prompts/mcp/rule-dsl.md
@@ -72,11 +72,12 @@ A condition is one of:
 **Identity / membership fields:**
 - `account_id`, `account_name`, `user_id`, `user_name` — string.
 - `series` — short_id of the recurring series the transaction belongs to (`""` when unassigned). `in_series` — bool.
+- `counterparty` — short_id of the counterparty (the other side of the transaction) it's bound to (`""` when unassigned). `has_counterparty` — bool. Both are **derived/mutable** (set by `assign_counterparty` rules/agents, like `series`/`in_series`) — author membership on the **raw provider fields**, not on these.
 - `tags` — current tag slugs (see tags ops above).
 - `metadata.<key>` — reads a key from the transaction's free-form metadata blob (e.g. `metadata.tax_deductible`); supports the string/numeric ops plus `exists` / `not_exists`.
 - `category` — the **assigned** category slug (changes when a rule/agent/user reassigns; useful for rule chaining).
 
-**Stable-vs-mutable guidance.** Condition on the **raw provider fields, date-parts, and `amount`** — they never change, so a rule keeps matching deterministically. Avoid conditioning on `account_name`, `category`, or `series` unless you specifically want to react to a *current, mutable* value (e.g. rule chaining off `category`, or retroactively tagging existing series members) — those can shift out from under the rule.
+**Stable-vs-mutable guidance.** Condition on the **raw provider fields, date-parts, and `amount`** — they never change, so a rule keeps matching deterministically. Avoid conditioning on `account_name`, `category`, `series`, or `counterparty` unless you specifically want to react to a *current, mutable* value (e.g. rule chaining off `category`, or retroactively tagging existing series members) — those can shift out from under the rule.
 
 ## The recurrence idiom
 
@@ -118,6 +119,8 @@ Rules replace the old recurring-charge detector. Express a subscription/recurrin
 { "type": "unflag" }
 { "type": "assign_series",   "series_name": "Spotify", "create_if_missing": true }
 { "type": "assign_series",   "series_short_id": "ab12cd34" }
+{ "type": "assign_counterparty", "counterparty_short_id": "cp01ab23" }
+{ "type": "assign_counterparty", "counterparty_name": "Jane Doe", "create_if_missing": true }
 ```
 
 - `set_category` — at most one per rule. Use `category_slug` (never `category_id`).
@@ -126,8 +129,7 @@ Rules replace the old recurring-charge detector. Express a subscription/recurrin
 - `set_metadata` / `remove_metadata` — write/clear a key on the transaction's metadata blob. `metadata_value` is any JSON value.
 - `flag` / `unflag` — set/clear the transaction's flag (mirrors the `flag_transaction` tool, sans reason).
 - `assign_series` — **surrogate-first**: provide **exactly one** of `series_short_id` (existing series) OR `series_name` + `create_if_missing: true` (resolve-or-mint a thin series by name). There is **no `merchant_key`** — the legacy key is accepted only as a back-compat alias for `series_name`. Link-and-rollup only; never steals a charge already in another series; honors sticky-reject.
-
-> `assign_counterparty` is **not** available yet — it lands in a later phase. Don't author it.
+- `assign_counterparty` — bind matching transactions to a **counterparty** (the other side of the transaction — merchants AND non-merchants: Venmo recipients, people, employers, landlords). Provide **exactly one** of `counterparty_short_id` (an existing counterparty) OR `counterparty_name` + `create_if_missing: true`. Default is **assign-to-existing**: a counterparty is **never** auto-created unless `create_if_missing` is set. By-name is a **resolve-or-create** that de-dupes on the live name (unlike series there is no UNIQUE on name) — so **reuse an existing counterparty across providers** (look one up first) rather than minting a duplicate. Link-only (NULL-fill).
 
 A rule can carry multiple actions of different types (e.g. `set_category` + `add_tag`). Only `set_category` is singleton.
 


### PR DESCRIPTION
Brings the two agent-facing rule-grammar docs to parity with the engine: the `assign_counterparty` action and the `counterparty` / `has_counterparty` condition fields already exist (merged in P4-PR-A) but were still absent from the grammar agents read, so agents wouldn't author counterparty rules.

## What changed (docs only)

**`prompts/mcp/rule-dsl.md`** (the `breadbox://rule-dsl` MCP resource):
- Added the `counterparty` / `has_counterparty` membership fields, marked **derived/mutable** (like `series` / `in_series`) — author on raw provider fields, not these.
- Added `counterparty` to the stable-vs-mutable guidance.
- Added `assign_counterparty` action examples (`counterparty_short_id` for existing; `counterparty_name` + `create_if_missing: true` for resolve-or-create) and its semantics (default assign-to-existing; counterparty = the other side of a transaction, merchants AND non-merchants; reuse across providers vs duplicating).
- Replaced the "not available yet — don't author it" note.

**`prompts/agents/rules-curriculum.md`** (the curriculum prompt block):
- Added `assign_counterparty` to the action catalog table.
- Listed `counterparty` / `has_counterparty` in the mutable-fields list.
- Replaced the deferred-follow-up HTML comment with the **counterparties idiom**: identify the entity behind a cryptic charge → author an `assign_counterparty` rule on raw fields → future charges resolve automatically; reuse an existing counterparty across providers rather than minting duplicates.

Shapes verified against `internal/service/rules.go` (`validActionTypes`, `ValidateActions` `assign_counterparty` case, `validConditionFields`), `internal/service/types.go` (`RuleAction.CounterpartyShortID` / `CounterpartyName`), and `internal/service/counterparties.go`. Scope respected: did not touch `internal/mcp`, `internal/api`, `internal/admin`, `internal/templates`, `openapi.yaml`, or `docs/*` (owned by the parallel P4-PR-C agent).

## Evidence

```
$ grep -c assign_counterparty prompts/mcp/rule-dsl.md prompts/agents/rules-curriculum.md
prompts/agents/rules-curriculum.md:4
prompts/mcp/rule-dsl.md:4

$ go build ./...   # both files are go:embed-ed — build proves they compile
BUILD_OK
$ go vet ./...
VET_OK
$ go test ./...
EXIT=0   (all packages ok)
```

The `breadbox://rule-dsl` resource content test (`internal/mcp/resources_test.go`) still passes — its required "Transaction rule DSL" title marker is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
