### PR TITLE
(beyond-roadmap) feat(rules): author assign_series + assign_counterparty from the admin rule form

### DIFF
--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -167,11 +167,18 @@ func RuleFormPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 		// Tags feed the add_tag autocomplete in the form. Best-effort — empty
 		// list just means no datalist suggestions.
 		tags, _ := svc.ListTags(ctx)
+		// Series + counterparties populate the assign_series / assign_counterparty
+		// action dropdowns. Best-effort — an empty list still lets the user
+		// create-by-name.
+		series, _ := svc.ListSeries(ctx, nil)
+		counterparties, _ := svc.ListCounterparties(ctx)
 
 		props := pages.RuleFormProps{
 			IsEdit:         false,
 			FlatCategories: flattenCategories(categories),
 			Tags:           tags,
+			Series:         series,
+			Counterparties: counterparties,
 		}
 
 		data := BaseTemplateData(r, sm, "rules", "New Rule")

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -328,6 +328,8 @@ templ RuleForm(p RuleFormProps) {
 									<option value="tag" :disabled="action.field !== 'tag'        && isActionUsed('tag')">Add tag</option>
 									<option value="tag_remove" :disabled="action.field !== 'tag_remove' && isActionUsed('tag_remove')">Remove tag</option>
 									<option value="comment" :disabled="action.field !== 'comment'    && isActionUsed('comment')">Add comment</option>
+									<option value="series" :disabled="action.field !== 'series'       && isActionUsed('series')">Assign to series</option>
+									<option value="counterparty" :disabled="action.field !== 'counterparty' && isActionUsed('counterparty')">Assign to counterparty</option>
 									<option value="metadata_set">Set metadata</option>
 									<option value="metadata_remove">Remove metadata</option>
 									<option value="flag" :disabled="action.field !== 'flag' && isActionUsed('flag')">Flag for attention</option>
@@ -379,6 +381,42 @@ templ RuleForm(p RuleFormProps) {
 									<div class="w-full sm:w-auto sm:flex-1 min-w-0 order-4 sm:order-none">
 										<textarea x-model="action.value" rows="2" class="textarea textarea-xs bg-base-100 w-full text-xs" placeholder="Comment to attach to matching transactions..."></textarea>
 										<p class="text-[0.65rem] text-base-content/40 mt-1">Plain text. The comment is attributed to this rule.</p>
+									</div>
+								</template>
+								<!-- Value: assign to series. Two mutually-exclusive modes —
+								     pick an existing series (value = short_id) OR create a new one
+								     by name (createName → series_name + create_if_missing). Filling
+								     one disables the other so exactly one identifier is sent. -->
+								<template x-if="action.field === 'series'">
+									<div class="w-full sm:w-auto sm:flex-1 min-w-0 order-4 sm:order-none">
+										<div class="flex flex-wrap items-center gap-2">
+											<select x-model="action.value" :disabled="!!(action.createName && action.createName.trim())" class="select select-xs bg-base-100 w-full sm:flex-1 sm:min-w-0 mt-px disabled:opacity-40">
+												<option value="">Select series…</option>
+												for _, sr := range p.Series {
+													<option value={ sr.ShortID }>{ sr.Name }</option>
+												}
+											</select>
+											<span class="text-[0.65rem] text-base-content/40 shrink-0">or</span>
+											<input type="text" x-model="action.createName" :disabled="!!(action.value)" class="input input-xs bg-base-100 w-full sm:w-44 mt-px disabled:opacity-40" placeholder="create new named…"/>
+										</div>
+										<p class="text-[0.65rem] text-base-content/40 mt-1">Adds matching transactions to a recurring series. Pick an existing one, or name a new series to mint on first match.</p>
+									</div>
+								</template>
+								<!-- Value: assign to counterparty. Same existing-vs-create-by-name
+								     pattern as series above. -->
+								<template x-if="action.field === 'counterparty'">
+									<div class="w-full sm:w-auto sm:flex-1 min-w-0 order-4 sm:order-none">
+										<div class="flex flex-wrap items-center gap-2">
+											<select x-model="action.value" :disabled="!!(action.createName && action.createName.trim())" class="select select-xs bg-base-100 w-full sm:flex-1 sm:min-w-0 mt-px disabled:opacity-40">
+												<option value="">Select counterparty…</option>
+												for _, cp := range p.Counterparties {
+													<option value={ cp.ShortID }>{ cp.Name }</option>
+												}
+											</select>
+											<span class="text-[0.65rem] text-base-content/40 shrink-0">or</span>
+											<input type="text" x-model="action.createName" :disabled="!!(action.value)" class="input input-xs bg-base-100 w-full sm:w-44 mt-px disabled:opacity-40" placeholder="create new named…"/>
+										</div>
+										<p class="text-[0.65rem] text-base-content/40 mt-1">Binds matching transactions to a counterparty. Pick an existing one, or name a new counterparty to create on first match.</p>
 									</div>
 								</template>
 								<!-- Value: set metadata (key + typed value) -->

--- a/internal/templates/components/pages/rule_form_types.go
+++ b/internal/templates/components/pages/rule_form_types.go
@@ -13,6 +13,11 @@ type RuleFormProps struct {
 	Rule           *service.TransactionRuleResponse
 	FlatCategories []service.CategoryResponse
 	Tags           []service.TagResponse
+	// Series + Counterparties feed the assign_series / assign_counterparty action
+	// dropdowns (value = short_id, label = name) so a user can author a
+	// membership-defining rule from the form — not just agents via MCP.
+	Series         []service.SeriesResponse
+	Counterparties []service.CounterpartyResponse
 }
 
 // ruleFormIsEditAttr returns the literal string "true" or "false" for the

--- a/static/js/admin/components/rule_form.js
+++ b/static/js/admin/components/rule_form.js
@@ -92,7 +92,11 @@ document.addEventListener('alpine:init', function () {
     // New action rows start as unpicked drafts so "Action..." is the default
     // and the value input stays disabled until a type is chosen. `key` /
     // `valueType` are only used by the metadata actions.
-    function emptyAction() { return { field: '', value: '', key: '', valueType: 'text', error: '' }; }
+    // `createName` is the membership-defining create-by-name affordance for the
+    // assign_series / assign_counterparty actions: when non-empty it serializes
+    // as *_name + create_if_missing:true; otherwise `value` carries the existing
+    // entity's short_id. The two modes are mutually exclusive in the UI.
+    function emptyAction() { return { field: '', value: '', createName: '', key: '', valueType: 'text', error: '' }; }
 
     // Action type registry — first-class typed actions match the API's
     // supported action.type values (set_category | add_tag | remove_tag |
@@ -103,6 +107,8 @@ document.addEventListener('alpine:init', function () {
       { value: 'tag',             label: 'Add tag' },
       { value: 'tag_remove',      label: 'Remove tag' },
       { value: 'comment',         label: 'Add comment' },
+      { value: 'series',          label: 'Assign to series' },
+      { value: 'counterparty',    label: 'Assign to counterparty' },
       { value: 'metadata_set',    label: 'Set metadata' },
       { value: 'metadata_remove', label: 'Remove metadata' },
       { value: 'flag',            label: 'Flag for attention' },
@@ -126,6 +132,20 @@ document.addEventListener('alpine:init', function () {
       }
       if (a.type === 'add_comment') {
         return { field: 'comment', value: a.content || '', error: '' };
+      }
+      if (a.type === 'assign_series') {
+        // Existing-series mode binds series_short_id; create-by-name mode carries
+        // series_name (+ create_if_missing). Recover whichever was stored.
+        if (a.series_name) {
+          return { field: 'series', value: '', createName: a.series_name, key: '', valueType: 'text', error: '' };
+        }
+        return { field: 'series', value: a.series_short_id || '', createName: '', key: '', valueType: 'text', error: '' };
+      }
+      if (a.type === 'assign_counterparty') {
+        if (a.counterparty_name) {
+          return { field: 'counterparty', value: '', createName: a.counterparty_name, key: '', valueType: 'text', error: '' };
+        }
+        return { field: 'counterparty', value: a.counterparty_short_id || '', createName: '', key: '', valueType: 'text', error: '' };
       }
       if (a.type === 'set_metadata') {
         // Recover the value's type so the editor renders the right control and
@@ -330,8 +350,11 @@ document.addEventListener('alpine:init', function () {
       isActionUsed: function (field) {
         // set_category is backend-singleton; flag/unflag are singleton in the UI
         // (a rule either flags or it doesn't — last-writer-wins makes a second
-        // row meaningless).
-        if (field !== 'category' && field !== 'flag' && field !== 'unflag') return false;
+        // row meaningless). assign_series / assign_counterparty are likewise
+        // singleton: a transaction belongs to one series / one counterparty, so a
+        // second assignment row in the same rule would just be last-writer-wins.
+        if (field !== 'category' && field !== 'flag' && field !== 'unflag' &&
+            field !== 'series' && field !== 'counterparty') return false;
         return this.form.actions.some(function (a) { return a.field === field; });
       },
       // Block "Add action" only while there's an unpicked draft row.
@@ -354,6 +377,7 @@ document.addEventListener('alpine:init', function () {
       onActionTypeChange: function (idx) {
         var a = this.form.actions[idx];
         a.value = '';
+        a.createName = '';
         a.error = '';
         a.key = '';
         a.valueType = 'text';
@@ -537,6 +561,11 @@ document.addEventListener('alpine:init', function () {
             // flag / unflag carry no value — keep them on the field alone.
             if (a.field === 'flag' || a.field === 'unflag') return true;
             if (a.field === 'metadata_set' || a.field === 'metadata_remove') return !!(a.key && a.key.trim());
+            // assign_series / assign_counterparty need EITHER an existing entity
+            // (value = short_id) OR a create-by-name (createName).
+            if (a.field === 'series' || a.field === 'counterparty') {
+              return (a.value && a.value !== '') || !!(a.createName && a.createName.trim());
+            }
             return a.value !== undefined && a.value !== '';
           })
           .map(function (a) {
@@ -546,6 +575,21 @@ document.addEventListener('alpine:init', function () {
             if (a.field === 'comment') return { type: 'add_comment', content: a.value };
             if (a.field === 'flag') return { type: 'flag' };
             if (a.field === 'unflag') return { type: 'unflag' };
+            if (a.field === 'series') {
+              // create-by-name wins when filled; the two modes are mutually
+              // exclusive in the UI, so this yields exactly one identifier — what
+              // ValidateActions requires.
+              if (a.createName && a.createName.trim()) {
+                return { type: 'assign_series', series_name: a.createName.trim(), create_if_missing: true };
+              }
+              return { type: 'assign_series', series_short_id: a.value };
+            }
+            if (a.field === 'counterparty') {
+              if (a.createName && a.createName.trim()) {
+                return { type: 'assign_counterparty', counterparty_name: a.createName.trim(), create_if_missing: true };
+              }
+              return { type: 'assign_counterparty', counterparty_short_id: a.value };
+            }
             if (a.field === 'metadata_set') {
               // Coerce the value to its declared JSON type so the stored blob is
               // typed (boolean true, number 100) rather than always a string.


### PR DESCRIPTION
## The gap (doctrine)

The rule engine and MCP have long supported the `assign_series` and `assign_counterparty` actions, but the **admin rule-form editor** never offered them — its `actionTypes` only included `set_category` / `add_tag` / `remove_tag` / `add_comment` / `set_metadata` / `remove_metadata` / `flag` / `unflag`. So a **user** could not author a membership-defining rule from the UI; only **agents** could, via MCP.

The rules-as-substrate doctrine holds that intelligence accrues as rules authored by **users *and* agents**. This closes the gap.

## What was added

End-to-end, both actions are now first-class authorable actions in the admin rule form:

- **`static/js/admin/components/rule_form.js`** — added `assign_series` / `assign_counterparty` to `actionTypes`; parse (`actionToForm`, JSON → form) and serialize (submit, form → JSON) following the existing `set_category` / `flag` patterns; singleton enforcement (`isActionUsed`) since a transaction belongs to one series / one counterparty; a new `createName` field on the action draft for the create-by-name affordance.
- **`internal/templates/components/pages/rule_form.templ`** — two action-row UIs modeled on the category dropdown: a `<select>` of existing series / counterparties (value = `short_id`, label = name) plus a mutually-exclusive **"create new named…"** text input. Filling one disables the other.
- **`internal/templates/components/pages/rule_form_types.go`** + **`internal/admin/rules.go`** — thread `svc.ListSeries(ctx, nil)` and `svc.ListCounterparties(ctx)` through `RuleFormProps` so the dropdowns populate.

### How entity selection works

Two mutually-exclusive modes per action row:

1. **Existing entity** — pick from the `<select>`; serializes as `{type, *_short_id}`.
2. **Create by name** — type into the "create new named…" input; serializes as `{type, *_name, create_if_missing:true}`.

Filling one disables the other in the UI, so **exactly one identifier** ever reaches `ValidateActions` (which requires exactly one of `*_short_id` / `*_name`, and `create_if_missing=true` when a name is used).

## JSON shapes (verified against the engine)

```json
{"type": "assign_series", "series_short_id": "pKjZZq87"}
{"type": "assign_series", "series_name": "Spotify Premium", "create_if_missing": true}
{"type": "assign_counterparty", "counterparty_short_id": "ab12Cd34"}
{"type": "assign_counterparty", "counterparty_name": "Trader Joe's", "create_if_missing": true}
```

These match `internal/service/types.go` `RuleAction` and `internal/service/rules.go` `ValidateActions`.

## Round-trip verification (live, seeded throwaway DB)

Authored a rule with **both** actions (series = existing "Spotify Premium" → `series_short_id`; counterparty = create-by-name "Trader Joe's" → `counterparty_name` + `create_if_missing`). The persisted row stored exactly:

```json
[{"type": "assign_series", "series_short_id": "pKjZZq87"},
 {"type": "assign_counterparty", "counterparty_name": "Trader Joe's", "create_if_missing": true}]
```

Re-opening the **edit** form re-populated both rows correctly (series back to its short_id with the create-input disabled; counterparty back to create-by-name with the entity select disabled). The new counterparty is *not* minted at rule-creation time — `create_if_missing` mints lazily on first match, per the rules-as-substrate model.

## Build / vet / test

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — green (one unrelated flaky timing test, `TestSidecarRun_ConcurrentRunsNoLongerSerialize`, passes on re-run)
- `go test -tags=integration -p 1 ./internal/admin/...` — `ok`

No JS test harness exists in the repo (no Node), and the Go change is a props passthrough, so no existing serialization test required extension. The serialization was instead verified live (above).

## Screenshot

Rule form with an `assign_series` row (existing-series select populated, "Spotify Premium") and an `assign_counterparty` row (create-by-name "Trader Joe's"). Note the action dropdown now lists both new actions, and the second row's dropdown omits "Assign to series" (singleton already used).

![rule form assign actions](https://bb-artifacts.exe.xyz/f/1285521b2518019a.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
