### PR TITLE
(beyond-roadmap) feat(counterparties): render counterparty assign/unlink in the activity timeline

### DIFF
--- a/docs/activity-timeline.md
+++ b/docs/activity-timeline.md
@@ -163,14 +163,22 @@ fields the service layer doesn't know about: `TagColor`, `CategoryColor`,
 
 Today's `Type` values:
 
-| Type       | Source kind(s)                   | Renderer                |
-|------------|----------------------------------|-------------------------|
-| `comment`  | `comment`                        | `txdTimelineComment`    |
-| `tag`      | `tag_added`, `tag_removed`       | `txdTimelineSystem`     |
-| `category` | `category_set`                   | `txdTimelineSystem`     |
-| `rule`     | `rule_applied`                   | `txdTimelineSystem`     |
-| `sync`     | `sync_started`, `sync_updated`   | `txdTimelineSystem`     |
-| `review`   | (legacy, retained for fallback)  | `txdTimelineSystem`     |
+| Type           | Source kind(s)                                  | Renderer             |
+|----------------|-------------------------------------------------|----------------------|
+| `comment`      | `comment`                                       | `txdTimelineComment` |
+| `tag`          | `tag_added`, `tag_removed`                       | `txdTimelineSystem`  |
+| `category`     | `category_set`                                  | `txdTimelineSystem`  |
+| `rule`         | `rule_applied`                                  | `txdTimelineSystem`  |
+| `sync`         | `sync_started`, `sync_updated`                   | `txdTimelineSystem`  |
+| `series`       | `series_assigned`, `series_unlinked`             | `txdTimelineSystem`  |
+| `counterparty` | `counterparty_assigned`, `counterparty_unlinked` | `txdTimelineSystem`  |
+| `review`       | (legacy, retained for fallback)                  | `txdTimelineSystem`  |
+
+Both `series` and `counterparty` collapse their two source kinds onto a
+single UI `Type` (the icon is identical; the prebuilt `Summary` from
+`EnrichAnnotations` differentiates the verb — `repeat` for series, `store`
+for counterparty). They render via the `txdSystemSentence` Summary-fallback
+branch, the same path `rule` and `sync` use.
 
 The `transaction_deleted` and `transaction_restored` kinds are written by the REST API soft-delete / restore endpoints (`internal/service/transactions_lifecycle.go`) but are **not yet rendered** by `activityEntryFromAnnotation` — the renderer drops them as unknown. Surfacing them in the timeline is a known follow-up. Until then they're visible to MCP via `list_annotations` (`Raw: true` or filtered by kind) and via the raw annotations table for audit.
 
@@ -656,12 +664,14 @@ and commit both `*.templ` and the generated `*_templ.go` siblings.
 
 ```go
 var mcpAnnotationKinds = map[string][]string{
-    "comment":  {"comment"},
-    "rule":     {"rule_applied"},
-    "tag":      {"tag_added", "tag_removed"},
-    "category": {"category_set"},
-    "sync":     {"sync_started", "sync_updated"},
-    "your":     {"your_new_kind"},
+    "comment":      {"comment"},
+    "rule":         {"rule_applied"},
+    "tag":          {"tag_added", "tag_removed"},
+    "category":     {"category_set"},
+    "sync":         {"sync_started", "sync_updated"},
+    "series":       {"series_assigned", "series_unlinked"},
+    "counterparty": {"counterparty_assigned", "counterparty_unlinked"},
+    "your":         {"your_new_kind"},
 }
 ```
 

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1163,6 +1163,26 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			entry.ActorID = &id
 		}
 		return entry, true
+
+	case "counterparty_assigned", "counterparty_unlinked":
+		// Counterparty membership: actor is the user/agent who set it, or the
+		// system (rule / detection). Mirrors series exactly — Summary is the
+		// canonical sentence built by EnrichAnnotations; both kinds collapse to
+		// a single "counterparty" type (the icon is identical and the Summary
+		// differentiates the verb).
+		entry := service.ActivityEntry{
+			Type:               "counterparty",
+			Timestamp:          a.CreatedAt,
+			ActorName:          a.ActorName,
+			ActorType:          a.ActorType,
+			ActorAvatarVersion: a.ActorAvatarVersion,
+			Summary:            a.Summary,
+		}
+		if a.ActorID != nil && *a.ActorID != "" {
+			id := *a.ActorID
+			entry.ActorID = &id
+		}
+		return entry, true
 	}
 	return service.ActivityEntry{}, false
 }

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -17,7 +17,7 @@ import (
 
 type listAnnotationsInput struct {
 	TransactionID string   `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
-	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category, sync, series. Empty = all kinds. Pass ['comment'] for the comment-only timeline. Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied|started|updated|linked|unlinked) for the specific event. Pass ['series'] to see recurring-series link/unlink events."`
+	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category, sync, series, counterparty. Empty = all kinds. Pass ['comment'] for the comment-only timeline. Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied|started|updated|linked|unlinked) for the specific event. Pass ['series'] to see recurring-series link/unlink events; pass ['counterparty'] to see counterparty set/remove events."`
 	ActorTypes    []string `json:"actor_types,omitempty" jsonschema:"Optional actor-type filter: any of user, agent, system. Empty = all actors. Pass ['user'] for the canonical 'any human input?' check — drops rule churn and prior agent activity in one filter. Combine with kinds for fine-grained slices."`
 	Since         string   `json:"since,omitempty" jsonschema:"Optional RFC3339 timestamp; return only annotations whose created_at is strictly after this time. Lets an agent that already saw the timeline once skip to the new tail. Malformed timestamps are rejected with a clear error."`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Optional cap on returned rows — returns the most recent N (timeline tail) in chronological order. 0 (default) = full timeline; max 200; negative is rejected. Pair with since to bound a delta read."`
@@ -129,12 +129,13 @@ func normalizeAnnotationLimit(limit int) (int, error) {
 // rule_applied, category_set) — agents see one normalized name plus an `action`
 // field on each row.
 var mcpAnnotationKinds = map[string][]string{
-	"comment":  {"comment"},
-	"rule":     {"rule_applied"},
-	"tag":      {"tag_added", "tag_removed"},
-	"category": {"category_set"},
-	"sync":     {"sync_started", "sync_updated"},
-	"series":   {"series_assigned", "series_unlinked"},
+	"comment":      {"comment"},
+	"rule":         {"rule_applied"},
+	"tag":          {"tag_added", "tag_removed"},
+	"category":     {"category_set"},
+	"sync":         {"sync_started", "sync_updated"},
+	"series":       {"series_assigned", "series_unlinked"},
+	"counterparty": {"counterparty_assigned", "counterparty_unlinked"},
 }
 
 // mapAnnotationKinds translates the agent-facing generic kinds into the raw DB
@@ -150,7 +151,7 @@ func mapAnnotationKinds(kinds []string) ([]string, error) {
 	for _, k := range kinds {
 		raw, ok := mcpAnnotationKinds[k]
 		if !ok {
-			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category, sync, series", k)
+			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category, sync, series, counterparty", k)
 		}
 		for _, r := range raw {
 			if seen[r] {

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -280,6 +280,16 @@ func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) An
 		}
 		a.Subject = seriesName
 		a.Summary = formatSeriesMembershipSummary(a.ActorName, a.Action, seriesName)
+
+	case "counterparty_assigned", "counterparty_unlinked":
+		cpName, _ := a.Payload["counterparty_name"].(string)
+		if a.Kind == "counterparty_assigned" {
+			a.Action = "set"
+		} else {
+			a.Action = "removed"
+		}
+		a.Subject = cpName
+		a.Summary = formatCounterpartyMembershipSummary(a.ActorName, a.Action, cpName)
 	}
 
 	return a
@@ -301,6 +311,29 @@ func formatSeriesMembershipSummary(actor, action, seriesName string) string {
 		return capVerb + " " + prep + " " + seriesName
 	}
 	return actor + " " + verb + " this " + prep + " " + seriesName
+}
+
+// formatCounterpartyMembershipSummary renders the timeline sentence for a
+// counterparty_assigned / counterparty_unlinked row, e.g.
+// "Alice set the counterparty to Netflix" / "Counterparty set to Netflix"
+// (system) and "Alice removed the counterparty" / "Counterparty removed".
+// Mirrors formatSeriesMembershipSummary — counterparty events read the same
+// as series events, just pointing at a counterparty instead of a series.
+func formatCounterpartyMembershipSummary(actor, action, cpName string) string {
+	if action == "removed" {
+		if actor == "" {
+			return "Counterparty removed"
+		}
+		return actor + " removed the counterparty"
+	}
+	if cpName == "" {
+		cpName = "a counterparty"
+	}
+	if actor == "" {
+		// System-attributed (rule / detection): no actor name.
+		return "Counterparty set to " + cpName
+	}
+	return actor + " set the counterparty to " + cpName
 }
 
 // formatDeletedCommentSummary renders the tombstone sentence shown in place

--- a/internal/service/annotations_enrich_test.go
+++ b/internal/service/annotations_enrich_test.go
@@ -504,6 +504,95 @@ func TestEnrichAnnotations_UnknownKindRoundTrips(t *testing.T) {
 	}
 }
 
+// Series membership rows render the prebuilt Summary differentiating
+// linked/unlinked, mirroring the counterparty twin below.
+func TestEnrichAnnotations_SeriesMembershipSummaries(t *testing.T) {
+	rows := []Annotation{
+		{
+			ID:        "s-assigned",
+			Kind:      "series_assigned",
+			ActorName: "Alice",
+			Payload:   map[string]interface{}{"series_id": "SER12345", "series_name": "Netflix"},
+			CreatedAt: "2026-04-04T12:00:00Z",
+		},
+		{
+			ID:        "s-unlinked",
+			Kind:      "series_unlinked",
+			ActorName: "", // system-attributed
+			Payload:   map[string]interface{}{"series_id": "SER12345", "series_name": "Netflix"},
+			CreatedAt: "2026-04-04T12:01:00Z",
+		},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if out[0].Action != "linked" || out[0].Subject != "Netflix" {
+		t.Errorf("assigned: Action=%q Subject=%q", out[0].Action, out[0].Subject)
+	}
+	if out[0].Summary != "Alice linked this to Netflix" {
+		t.Errorf("assigned Summary = %q", out[0].Summary)
+	}
+	if out[1].Summary != "Unlinked from Netflix" {
+		t.Errorf("unlinked Summary = %q", out[1].Summary)
+	}
+}
+
+// Counterparty membership rows mirror series exactly: a prebuilt Summary
+// differentiating set/remove, surfaced via the same Summary-fallback render
+// path. (rules-substrate doctrine: counterparty events read like series.)
+func TestEnrichAnnotations_CounterpartyMembershipSummaries(t *testing.T) {
+	rows := []Annotation{
+		{
+			ID:        "cp-assigned-actor",
+			Kind:      "counterparty_assigned",
+			ActorName: "Alice",
+			Payload:   map[string]interface{}{"counterparty_id": "CPX12345", "counterparty_name": "Netflix"},
+			CreatedAt: "2026-04-04T12:00:00Z",
+		},
+		{
+			ID:        "cp-assigned-system",
+			Kind:      "counterparty_assigned",
+			ActorName: "", // system-attributed (rule / detection)
+			Payload:   map[string]interface{}{"counterparty_id": "CPX12345", "counterparty_name": "Netflix"},
+			CreatedAt: "2026-04-04T12:01:00Z",
+		},
+		{
+			ID:        "cp-unlinked-actor",
+			Kind:      "counterparty_unlinked",
+			ActorName: "Bob",
+			Payload:   map[string]interface{}{"counterparty_id": "CPX12345", "counterparty_name": "Netflix"},
+			CreatedAt: "2026-04-04T12:02:00Z",
+		},
+		{
+			ID:        "cp-unlinked-system",
+			Kind:      "counterparty_unlinked",
+			ActorName: "",
+			Payload:   map[string]interface{}{"counterparty_id": "CPX12345", "counterparty_name": "Netflix"},
+			CreatedAt: "2026-04-04T12:03:00Z",
+		},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 4 {
+		t.Fatalf("len = %d, want 4", len(out))
+	}
+	if out[0].Action != "set" || out[0].Subject != "Netflix" {
+		t.Errorf("assigned-actor: Action=%q Subject=%q", out[0].Action, out[0].Subject)
+	}
+	if out[0].Summary != "Alice set the counterparty to Netflix" {
+		t.Errorf("assigned-actor Summary = %q", out[0].Summary)
+	}
+	if out[1].Summary != "Counterparty set to Netflix" {
+		t.Errorf("assigned-system Summary = %q", out[1].Summary)
+	}
+	if out[2].Action != "removed" || out[2].Summary != "Bob removed the counterparty" {
+		t.Errorf("unlinked-actor: Action=%q Summary=%q", out[2].Action, out[2].Summary)
+	}
+	if out[3].Summary != "Counterparty removed" {
+		t.Errorf("unlinked-system Summary = %q", out[3].Summary)
+	}
+}
+
 func TestEnrichAnnotations_PreservesOrder(t *testing.T) {
 	rows := []Annotation{
 		{ID: "a", Kind: "comment", ActorName: "alice", Payload: map[string]interface{}{"content": "1"}, CreatedAt: "2026-04-01T00:00:00Z"},

--- a/internal/service/counterparties_integration_test.go
+++ b/internal/service/counterparties_integration_test.go
@@ -90,6 +90,49 @@ func TestAssignCounterparty_CreateByName(t *testing.T) {
 	}
 }
 
+// TestAssignCounterparty_EmitsEnrichedAnnotation proves the end-to-end timeline
+// path: assigning a counterparty writes a counterparty_assigned annotation that
+// EnrichAnnotations resolves into the human "set the counterparty to {name}"
+// sentence — the parity twin of the series_assigned timeline event.
+func TestAssignCounterparty_EmitsEnrichedAnnotation(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	_, members := seedCounterpartyCharges(t, queries, "NETFLIX", []string{"2026-04-15"})
+	actor := service.Actor{Type: "user", ID: "u1", Name: "Alice"}
+
+	if _, err := svc.AssignCounterparty(ctx, service.AssignCounterpartyInput{
+		Name:            "Netflix",
+		CreateIfMissing: true,
+		TransactionIDs:  shortIDs(members),
+	}, actor); err != nil {
+		t.Fatalf("AssignCounterparty: %v", err)
+	}
+
+	anns, err := svc.ListAnnotations(ctx, members[0].ShortID, service.ListAnnotationsParams{})
+	if err != nil {
+		t.Fatalf("ListAnnotations: %v", err)
+	}
+	var found *service.Annotation
+	for i := range anns {
+		if anns[i].Kind == "counterparty_assigned" {
+			found = &anns[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no counterparty_assigned annotation on the linked charge; got %d annotations", len(anns))
+	}
+	if found.Action != "set" {
+		t.Errorf("Action = %q, want set", found.Action)
+	}
+	if found.Subject != "Netflix" {
+		t.Errorf("Subject = %q, want Netflix", found.Subject)
+	}
+	if found.Summary != "Alice set the counterparty to Netflix" {
+		t.Errorf("Summary = %q, want %q", found.Summary, "Alice set the counterparty to Netflix")
+	}
+}
+
 // TestAssignCounterparty_FailIfExists makes the by-name path a strict create.
 func TestAssignCounterparty_FailIfExists(t *testing.T) {
 	svc, _, _ := newService(t)

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -455,6 +455,8 @@ templ txdSystemSentence(e service.ActivityEntry) {
 		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
 	} else if e.Type == "series" {
 		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
+	} else if e.Type == "counterparty" {
+		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
 	} else if e.Type == "tag" {
 		if e.ActorName != "" {
 			@txdActorInline(e)
@@ -553,6 +555,10 @@ templ txdSystemIcon(e service.ActivityEntry) {
 	} else if e.Type == "series" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-info/15 ring-4 ring-base-100" aria-hidden="true">
 			@components.LucideIcon("repeat", "w-3 h-3 text-info")
+		</span>
+	} else if e.Type == "counterparty" {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-info/15 ring-4 ring-base-100" aria-hidden="true">
+			@components.LucideIcon("store", "w-3 h-3 text-info")
 		</span>
 	} else if e.Type == "review" {
 		<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", txdReviewBg(e.ReviewStatus) } aria-hidden="true">


### PR DESCRIPTION
**(beyond-roadmap doctrine enhancement — rules-as-universal-substrate)** Close a half-wired P4 gap: counterparty assignment events are now first-class activity-timeline rows, rendering exactly like the `series_assigned` twin instead of being silently dropped as unknown kinds.

## The gap
P4 added the `counterparty_assigned` / `counterparty_unlinked` annotation kinds (migration `20260620040615_annotations_counterparty_kinds.sql`) and `service.AssignCounterparty` / `UnlinkCounterparty` already **write** them. But the timeline's enrichment + rendering only handled the `series_*` equivalents, so counterparty events never surfaced on the transaction activity timeline — inconsistent with series.

## Sites updated (parity with `series_assigned`)
| Site | Series handling | Counterparty twin added |
|------|-----------------|-------------------------|
| `internal/service/annotations_enrich.go` | `series_assigned/_unlinked` → `formatSeriesMembershipSummary` | `counterparty_assigned/_unlinked` → `formatCounterpartyMembershipSummary` (resolves `counterparty_name` from payload, same shape the service writes) |
| `internal/admin/transactions.go` | maps to `"series"` ActivityEntry type | maps to `"counterparty"` type, Summary passed through identically |
| `internal/templates/components/pages/transaction_detail.templ` | `repeat` icon + Summary-fallback sentence | `store` icon (info tint) + Summary-fallback sentence |
| `internal/mcp/tools_tags.go` | `"series": {series_assigned, series_unlinked}` | `"counterparty": {counterparty_assigned, counterparty_unlinked}` + schema/error enum text |
| `docs/activity-timeline.md` | (Type table was stale) | documented both `series` and `counterparty` Type rows per the "add a new system-event kind" contract |

The home Feed (`internal/admin/feed.go`) does **not** special-case `series_*`, so no feed change is needed to maintain parity.

Per the doctrine "counterparty events should look/behave identically, just pointing at counterparties": both kinds collapse onto a single UI `Type`, render via the prebuilt-`Summary` fallback path (same as `rule`/`sync`/`series`), and the Summary differentiates the verb. Summaries: `Alice set the counterparty to Netflix` / `Counterparty set to Netflix` (system) / `Bob removed the counterparty` / `Counterparty removed`.

## Verify
- `go build ./...` ✅  `go vet ./...` ✅  `go test ./...` ✅
- New unit tests: `TestEnrichAnnotations_CounterpartyMembershipSummaries` + `TestEnrichAnnotations_SeriesMembershipSummaries` (actor + system variants) ✅
- New integration test: `TestAssignCounterparty_EmitsEnrichedAnnotation` — assigns a counterparty and asserts `ListAnnotations` returns the enriched `set the counterparty to {name}` row ✅ (run against `breadbox_test`)

## Evidence
Transaction detail activity timeline showing the counterparty event (seeded on a throwaway DB, not the shared dev DB):

![counterparty timeline event](https://bb-artifacts.exe.xyz/f/5455c1dbf653f717.jpeg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
