### PR TITLE
(beyond-roadmap) refactor(ui): shared entity components + design-system pass on series/counterparty pages

### DIFF
--- a/internal/templates/components/pages/counterparties.templ
+++ b/internal/templates/components/pages/counterparties.templ
@@ -14,7 +14,8 @@ import (
 // (name · logo · linked-charge count · governing-rule count), linking to its
 // detail page where it can be enriched.
 templ CounterpartiesList(p CounterpartiesListProps) {
-	<div x-data="{ q: '' }">
+	<script src="/static/js/admin/components/counterparties.js"></script>
+	<div x-data="counterpartiesList">
 		@components.PageHeader(components.PageHeaderProps{
 			Title:                "Counterparties",
 			Subtitle:             "The canonical other side of a charge — merchants, people, employers. Membership is defined by the rules that assign charges to each one.",
@@ -53,7 +54,7 @@ templ counterpartiesListRow(c CounterpartyRow) {
 	<li
 		class="list-row transition-colors hover:bg-base-200/40 items-center"
 		data-search={ c.Search }
-		x-show="!q || $el.dataset.search.includes(q.toLowerCase())"
+		x-show="matches($el)"
 	>
 		<a
 			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-lg"
@@ -108,11 +109,11 @@ templ CounterpartyDetail(p CounterpartyDetailProps) {
 		<!-- Linked charges (what's bound) + Governing rules (what defines it) -->
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-5 mt-5">
 			<div>
-				@seriesPanelHeader("receipt", "Linked charges", fmt.Sprintf("%d bound to this counterparty", len(p.MemberRows)), nil)
+				@entityPanelHeader("receipt", "Linked charges", fmt.Sprintf("%d bound to this counterparty", len(p.MemberRows)), nil)
 				if len(p.MemberRows) > 0 {
 					<div class="bb-card p-2 sm:p-3">
 						for _, m := range p.MemberRows {
-							@seriesChargeRow(m)
+							@entityChargeRow(m)
 						}
 					</div>
 				} else {
@@ -124,13 +125,17 @@ templ CounterpartyDetail(p CounterpartyDetailProps) {
 				}
 			</div>
 			<div>
-				@seriesPanelHeader("filter", "Governing rules", counterpartyGoverningSubtitle(len(p.GoverningRules)), seriesNewRuleBtn())
-				@counterpartyGoverningRulesPanel(p.GoverningRules)
+				@entityPanelHeader("filter", "Governing rules", counterpartyGoverningSubtitle(len(p.GoverningRules)), entityRulesBtn())
+				@components.GoverningRulesPanel(components.GoverningRulesPanelProps{
+					Rules:      p.GoverningRules,
+					EntityWord: "counterparty",
+					ActionCode: "assign_counterparty",
+				})
 			</div>
 		</div>
 		<!-- Enrichment — manual edit lane (no auto-fetch) -->
 		<div class="mt-5 max-w-3xl">
-			@seriesPanelHeader("sparkles", "Enrichment", "Name, category, and brand details", nil)
+			@entityPanelHeader("sparkles", "Enrichment", "Name, category, and brand details", nil)
 			<form method="POST" action={ templ.SafeURL("/counterparties/" + p.Counterparty.ShortID) }>
 				<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
 				@components.SettingsSection(components.SettingsSectionProps{
@@ -218,23 +223,4 @@ templ counterpartyHeaderIcon(logoURL, name string) {
 // counterpartyDetailMeta is the quiet sub-title line — the linked-charge count.
 templ counterpartyDetailMeta(p CounterpartyDetailProps) {
 	<span class="text-sm text-base-content/55">{ counterpartyMemberCount(len(p.MemberRows)) }</span>
-}
-
-// counterpartyGoverningRulesPanel lists the assign_counterparty rules that define
-// this counterparty's membership. Reuses the shared GoverningRulesPanel rows; the
-// empty state is counterparty-specific copy.
-templ counterpartyGoverningRulesPanel(rules []components.GoverningRule) {
-	if len(rules) == 0 {
-		<div class="bb-card p-2 sm:p-3">
-			<div class="px-3 py-6 text-center">
-				<div class="text-sm text-base-content/60">No rules assign charges to this counterparty yet.</div>
-				<div class="text-xs text-base-content/40 mt-1">
-					Membership comes from rules with an <code class="font-mono bg-base-200 rounded px-1">assign_counterparty</code> action.
-					Create one on the <a href="/rules" class="link link-hover text-primary">Rules</a> page to define what lands here.
-				</div>
-			</div>
-		</div>
-	} else {
-		@components.GoverningRulesPanel(rules)
-	}
 }

--- a/internal/templates/components/pages/design_sections.templ
+++ b/internal/templates/components/pages/design_sections.templ
@@ -226,14 +226,18 @@ templ SectionRecurringChips() {
 templ SectionRecurringDetail() {
 	<div class="flex flex-col gap-6">
 		@designExample("Governing rules (GoverningRulesPanel)", "A series IS the rules that define it. This panel lists the assign_series rules whose matches put charges into the series — each row links to the rule editor, making the membership relationship explicit. Sits beside the linked-charges list on the detail page.") {
-			@components.GoverningRulesPanel([]components.GoverningRule{
-				{ShortID: "rule0001", Name: "Netflix subscription", ConditionSummary: "merchant contains netflix", ActionSummary: "Assign to series", Enabled: true, HitCount: 11, CreatedByType: "user"},
-				{ShortID: "rule0002", Name: "Streaming round-up", ConditionSummary: "merchant in (netflix, hulu, disney+)", ActionSummary: "2 actions", Enabled: true, HitCount: 4, CreatedByType: "agent"},
-				{ShortID: "rule0003", Name: "Legacy import", ConditionSummary: "Matches all transactions", ActionSummary: "Assign to series", Enabled: false, HitCount: 0, CreatedByType: "user"},
+			@components.GoverningRulesPanel(components.GoverningRulesPanelProps{
+				EntityWord: "series",
+				ActionCode: "assign_series",
+				Rules: []components.GoverningRule{
+					{ShortID: "rule0001", Name: "Netflix subscription", ConditionSummary: "merchant contains netflix", ActionSummary: "Assign to series", Enabled: true, HitCount: 11, CreatedByType: "user"},
+					{ShortID: "rule0002", Name: "Streaming round-up", ConditionSummary: "merchant in (netflix, hulu, disney+)", ActionSummary: "2 actions", Enabled: true, HitCount: 4, CreatedByType: "agent"},
+					{ShortID: "rule0003", Name: "Legacy import", ConditionSummary: "Matches all transactions", ActionSummary: "Assign to series", Enabled: false, HitCount: 0, CreatedByType: "user"},
+				},
 			})
 		}
 		@designExample("Governing rules — empty", "When no rule targets a series, the panel explains the rule-substrate model instead of reading as broken.") {
-			@components.GoverningRulesPanel(nil)
+			@components.GoverningRulesPanel(components.GoverningRulesPanelProps{EntityWord: "series", ActionCode: "assign_series"})
 		}
 	</div>
 }

--- a/internal/templates/components/pages/entity_detail_shared.templ
+++ b/internal/templates/components/pages/entity_detail_shared.templ
@@ -1,0 +1,50 @@
+package pages
+
+import (
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components"
+)
+
+// Shared detail-page chrome for the thin, rule-maintained entities — recurring
+// series (/recurring/{id}) and counterparties (/counterparties/{id}). Both pages
+// read identically under the rules-as-substrate model: a LINKED CHARGES panel
+// beside a GOVERNING RULES panel, each topped by a panel header. These helpers
+// were originally named for series; they're entity-neutral and shared by both
+// detail pages, so they live here to make the cross-page dependency explicit.
+
+// entityPanelHeader is the "icon · Title · subtitle" row above a detail panel,
+// with an optional trailing action. Shared by the series and counterparty detail
+// pages so their panels read identically.
+templ entityPanelHeader(icon, title, subtitle string, action templ.Component) {
+	<div class="flex items-center justify-between gap-2 mb-3">
+		<div class="flex items-center gap-2 min-w-0">
+			@components.LucideIcon(icon, "w-4 h-4 text-base-content/50 shrink-0")
+			<h2 class="text-sm font-semibold text-base-content">{ title }</h2>
+			<span class="text-xs text-base-content/45 truncate hidden sm:inline">· { subtitle }</span>
+		</div>
+		if action != nil {
+			@action
+		}
+	</div>
+}
+
+// entityChargeRow renders one linked charge as a leading date column + the shared
+// TxRowCompact (date suppressed — the left column carries it). Used by the
+// "Linked charges" list on both the series and counterparty detail pages.
+templ entityChargeRow(tx service.AdminTransactionRow) {
+	<div class="flex items-center gap-2">
+		<span class="text-xs text-base-content/45 tabular-nums w-24 shrink-0 text-right">{ entityChargeDate(tx.Date) }</span>
+		<div class="flex-1 min-w-0">
+			@components.TxRowCompactNoDate(tx)
+		</div>
+	</div>
+}
+
+// entityRulesBtn is the trailing "New rule" affordance in a governing-rules panel
+// header — a link to the rule editor. Shared by both detail pages.
+templ entityRulesBtn() {
+	<a href="/rules/new" class="btn btn-ghost btn-xs gap-1.5 shrink-0">
+		@components.LucideIcon("plus", "w-3.5 h-3.5")
+		New rule
+	</a>
+}

--- a/internal/templates/components/pages/entity_detail_shared_types.go
+++ b/internal/templates/components/pages/entity_detail_shared_types.go
@@ -1,0 +1,15 @@
+//go:build !headless && !lite
+
+package pages
+
+import "time"
+
+// entityChargeDate formats an AdminTransactionRow.Date ("2006-01-02") as the
+// leading date label in a linked-charge list ("Jan 2, 2006"); raw on parse fail.
+// Shared by the series and counterparty detail pages (entityChargeRow).
+func entityChargeDate(s string) string {
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t.Format("Jan 2, 2006")
+	}
+	return s
+}

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -32,11 +32,11 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 		<!-- Linked charges (what's in the series) + Governing rules (what defines it) -->
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-5 mt-5">
 			<div>
-				@seriesPanelHeader("receipt", "Linked charges", fmt.Sprintf("%d in this series", len(p.MemberRows)), seriesLinkChargeBtn())
+				@entityPanelHeader("receipt", "Linked charges", fmt.Sprintf("%d in this series", len(p.MemberRows)), seriesLinkChargeBtn())
 				if len(p.MemberRows) > 0 {
 					<div class="bb-card p-2 sm:p-3">
 						for _, m := range p.MemberRows {
-							@seriesChargeRow(m)
+							@entityChargeRow(m)
 						}
 					</div>
 				} else {
@@ -48,13 +48,17 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 				}
 			</div>
 			<div>
-				@seriesPanelHeader("filter", "Governing rules", seriesGoverningSubtitle(len(p.GoverningRules)), seriesNewRuleBtn())
-				@components.GoverningRulesPanel(p.GoverningRules)
+				@entityPanelHeader("filter", "Governing rules", seriesGoverningSubtitle(len(p.GoverningRules)), entityRulesBtn())
+				@components.GoverningRulesPanel(components.GoverningRulesPanelProps{
+					Rules:      p.GoverningRules,
+					EntityWord: "series",
+					ActionCode: "assign_series",
+				})
 			</div>
 		</div>
 		<!-- Tags — inherited by linked charges -->
 		<div class="mt-5">
-			@seriesPanelHeader("tag", "Tags", "Inherited by every linked charge", nil)
+			@entityPanelHeader("tag", "Tags", "Inherited by every linked charge", nil)
 			<div class="bb-card p-5">
 				<div
 					class="flex flex-wrap items-center gap-2"
@@ -86,39 +90,13 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 }
 
 // seriesEditDrawer is the right-side slide-over for the two editable attributes
-// of a thin series — its name and type — committed with one explicit Save.
+// of a thin series — its name and type — committed with one explicit Save. Built
+// on the shared components.Drawer (store-driven open/close, scrim, transitions,
+// Escape-to-close), opened via $store.drawers.open('series-edit').
 templ seriesEditDrawer(p SubscriptionDetailProps) {
-	<div
-		x-show="editOpen"
-		x-cloak
-		x-transition:enter="transition-opacity ease-out duration-200"
-		x-transition:enter-start="opacity-0"
-		x-transition:enter-end="opacity-100"
-		x-transition:leave="transition-opacity ease-in duration-150"
-		x-transition:leave-start="opacity-100"
-		x-transition:leave-end="opacity-0"
-		class="fixed inset-0 bg-black/40 z-40"
-		@click="editOpen = false"
-	></div>
-	<div
-		x-show="editOpen"
-		x-cloak
-		x-transition:enter="transition ease-out duration-200"
-		x-transition:enter-start="translate-x-full"
-		x-transition:enter-end="translate-x-0"
-		x-transition:leave="transition ease-in duration-150"
-		x-transition:leave-start="translate-x-0"
-		x-transition:leave-end="translate-x-full"
-		class="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-base-100 border-l border-base-300 shadow-xl flex flex-col"
-		@keydown.escape.window="editOpen = false"
-	>
+	@components.Drawer(components.DrawerProps{ID: "series-edit", Title: "Edit series"}) {
 		<form class="flex flex-col h-full" @submit.prevent="saveDrawer($event.target)">
-			<div class="flex items-center justify-between gap-3 p-5 border-b border-base-300">
-				<div class="font-semibold">Edit series</div>
-				<button type="button" class="btn btn-ghost btn-sm btn-square" @click="editOpen = false" aria-label="Close">
-					@components.LucideIcon("x", "w-4 h-4")
-				</button>
-			</div>
+			@components.DrawerHeader(components.DrawerHeaderProps{Icon: "pencil", Title: "Edit series"})
 			<div class="flex-1 overflow-y-auto p-5 space-y-4">
 				<div>
 					<div class="text-sm font-medium mb-1.5">Name</div>
@@ -133,30 +111,15 @@ templ seriesEditDrawer(p SubscriptionDetailProps) {
 					</select>
 				</div>
 			</div>
-			<div class="flex items-center justify-end gap-2 p-4 border-t border-base-300">
-				<button type="button" class="btn btn-ghost btn-sm" @click="editOpen = false">Cancel</button>
+			@components.DrawerFooter() {
+				<button type="button" class="btn btn-ghost btn-sm" @click="$store.drawers.close()">Cancel</button>
 				<button type="submit" class="btn btn-primary btn-sm gap-1.5">
 					@components.LucideIcon("check", "w-4 h-4")
 					Save
 				</button>
-			</div>
+			}
 		</form>
-	</div>
-}
-
-// seriesPanelHeader is the "icon · Title · subtitle" row above the detail
-// panels, with an optional trailing action.
-templ seriesPanelHeader(icon, title, subtitle string, action templ.Component) {
-	<div class="flex items-center justify-between gap-2 mb-3">
-		<div class="flex items-center gap-2 min-w-0">
-			@components.LucideIcon(icon, "w-4 h-4 text-base-content/50 shrink-0")
-			<h2 class="text-sm font-semibold text-base-content">{ title }</h2>
-			<span class="text-xs text-base-content/45 truncate hidden sm:inline">· { subtitle }</span>
-		</div>
-		if action != nil {
-			@action
-		}
-	</div>
+	}
 }
 
 templ seriesLinkChargeBtn() {
@@ -164,13 +127,6 @@ templ seriesLinkChargeBtn() {
 		@components.LucideIcon("plus", "w-3.5 h-3.5")
 		Link a charge
 	</button>
-}
-
-templ seriesNewRuleBtn() {
-	<a href="/rules/new" class="btn btn-ghost btn-xs gap-1.5 shrink-0">
-		@components.LucideIcon("plus", "w-3.5 h-3.5")
-		New rule
-	</a>
 }
 
 // seriesDetailBadges is the EntityHeader badge row: the structured type chip.
@@ -186,7 +142,7 @@ templ seriesDetailMeta(p SubscriptionDetailProps) {
 // seriesDetailActions is the EntityHeader trailing cluster — a single Edit
 // affordance that opens the name/type drawer.
 templ seriesDetailActions() {
-	<button type="button" class="btn btn-sm btn-ghost gap-1.5" @click="editOpen = true">
+	<button type="button" class="btn btn-sm btn-ghost gap-1.5" @click="$store.drawers.open('series-edit')">
 		@components.LucideIcon("pencil", "w-4 h-4")
 		Edit
 	</button>

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -1,9 +1,6 @@
 package pages
 
-import (
-	"breadbox/internal/service"
-	"breadbox/internal/templates/components"
-)
+import "breadbox/internal/templates/components"
 
 // SubscriptionsList renders /recurring — the recurring-series ledger under the
 // rules-as-substrate model. A series is a thin entity (name + type) whose
@@ -15,7 +12,6 @@ import (
 // static/js/admin/components/subscriptions.js.
 templ SubscriptionsList(p SubscriptionsListProps) {
 	<script src="/static/js/admin/components/subscriptions.js"></script>
-	<div x-data x-init="$store.shortcuts.setScope('subscriptions')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div x-data="subscriptionsList">
 		@components.PageHeader(components.PageHeaderProps{
 			Title:                "Recurring",
@@ -103,18 +99,6 @@ templ subscriptionsListRow(s SubscriptionRow) {
 templ subscriptionsTypeTile(typ string) {
 	<div class="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 bg-base-200">
 		@components.LucideIcon(subscriptionTypeIcon(typ), "w-4 h-4 text-base-content/50")
-	</div>
-}
-
-// seriesChargeRow renders one linked charge as a leading date column + the
-// shared TxRowCompact (date suppressed — the left column carries it). Used by
-// the detail-page "Charges in this series" list.
-templ seriesChargeRow(tx service.AdminTransactionRow) {
-	<div class="flex items-center gap-2">
-		<span class="text-xs text-base-content/45 tabular-nums w-24 shrink-0 text-right">{ seriesChargeDate(tx.Date) }</span>
-		<div class="flex-1 min-w-0">
-			@components.TxRowCompactNoDate(tx)
-		</div>
 	</div>
 }
 

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -5,7 +5,6 @@ package pages
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -115,15 +114,6 @@ func BuildGoverningRule(r service.TransactionRuleResponse) components.GoverningR
 		CreatedByType:    r.CreatedByType,
 		CreatedByName:    r.CreatedByName,
 	}
-}
-
-// seriesChargeDate formats an AdminTransactionRow.Date ("2006-01-02") as the
-// leading date label in the series charge list ("Jan 2, 2006"); raw on parse fail.
-func seriesChargeDate(s string) string {
-	if t, err := time.Parse("2006-01-02", s); err == nil {
-		return t.Format("Jan 2, 2006")
-	}
-	return s
 }
 
 // subscriptionMemberCount renders the dimmed "N charges" suffix on a row.

--- a/internal/templates/components/series_detail_panels.templ
+++ b/internal/templates/components/series_detail_panels.templ
@@ -25,24 +25,41 @@ type GoverningRule struct {
 	CreatedByName    string
 }
 
-// GoverningRulesPanel lists the rules that define this series' membership. Each
+// GoverningRulesPanelProps configures the entity-neutral governing-rules panel.
+// The rule rows are identical across entities; only the empty-state copy differs,
+// so the caller supplies the entity noun and the rule action it's looking for.
+type GoverningRulesPanelProps struct {
+	// Rules are the rules whose action targets this entity — the durable
+	// definition of its membership.
+	Rules []GoverningRule
+	// EntityWord is the singular noun for the entity ("series",
+	// "counterparty") woven into the empty-state copy.
+	EntityWord string
+	// ActionCode is the rule-action enum the empty state names
+	// ("assign_series", "assign_counterparty").
+	ActionCode string
+}
+
+// GoverningRulesPanel lists the rules that define an entity's membership. Each
 // row names the rule, summarizes its match condition, links to the rule editor,
 // and notes whether it's live — making "these rules define what's in this
-// series" legible at a glance. Empty state explains the rule-substrate model so
-// a series with no governing rules doesn't read as broken.
-templ GoverningRulesPanel(rules []GoverningRule) {
+// {entity}" legible at a glance. Entity-neutral: the empty-state copy is
+// parameterized via EntityWord/ActionCode so the series and counterparty detail
+// pages share one panel. The empty state explains the rule-substrate model so an
+// entity with no governing rules doesn't read as broken.
+templ GoverningRulesPanel(p GoverningRulesPanelProps) {
 	<div class="bb-card p-2 sm:p-3">
-		if len(rules) == 0 {
+		if len(p.Rules) == 0 {
 			<div class="px-3 py-6 text-center">
-				<div class="text-sm text-base-content/60">No rules assign charges to this series yet.</div>
+				<div class="text-sm text-base-content/60">No rules assign charges to this { p.EntityWord } yet.</div>
 				<div class="text-xs text-base-content/40 mt-1">
-					A series' membership comes from rules with an <code class="font-mono bg-base-200 rounded px-1">assign_series</code> action.
+					Membership comes from rules with an <code class="font-mono bg-base-200 rounded px-1">{ p.ActionCode }</code> action.
 					Create one on the <a href="/rules" class="link link-hover text-primary">Rules</a> page to define what lands here.
 				</div>
 			</div>
 		} else {
 			<ul class="divide-y divide-base-200">
-				for _, rule := range rules {
+				for _, rule := range p.Rules {
 					@governingRuleRow(rule)
 				}
 			</ul>

--- a/static/js/admin/components/counterparties.js
+++ b/static/js/admin/components/counterparties.js
@@ -1,0 +1,33 @@
+// Counterparties list page Alpine component for /counterparties.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+// A counterparty is a thin, rule-maintained entity with no detector, so the list
+// is a flat directory with a single client-side filter: a free-text search over
+// the row haystack. Mirrors subscriptionsList (the /recurring ledger). Also
+// scopes the keyboard shortcuts to this page while mounted.
+(function () {
+  document.addEventListener('alpine:init', function () {
+    Alpine.data('counterpartiesList', function () {
+      return {
+        q: '',
+
+        init: function () {
+          var reg = window.Alpine && Alpine.store('shortcuts');
+          if (reg) reg.setScope('counterparties');
+        },
+
+        destroy: function () {
+          var reg = window.Alpine && Alpine.store('shortcuts');
+          if (reg) reg.setScope('global');
+        },
+
+        // Search filter for the directory rows (data-search haystack).
+        matches: function (el) {
+          if (!this.q) return true;
+          return (el.dataset.search || '').indexOf(this.q.toLowerCase()) !== -1;
+        },
+      };
+    });
+  });
+})();

--- a/static/js/admin/components/series_detail.js
+++ b/static/js/admin/components/series_detail.js
@@ -43,7 +43,8 @@
       return {
         seriesId: '',
         currentTags: [],
-        editOpen: false,
+        // Name/type edit lives in the shared components.Drawer ('series-edit'),
+        // opened via $store.drawers — no local open flag needed here.
         // Link-a-charge modal state.
         linkOpen: false,
         linkQuery: '',

--- a/static/js/admin/components/subscriptions.js
+++ b/static/js/admin/components/subscriptions.js
@@ -12,6 +12,19 @@
         filterType: 'all',
         filter: '',
 
+        // Scope the keyboard shortcuts to this page while mounted, and
+        // restore the global scope on teardown. Folded in from a bare
+        // x-init/x-destroy div so the factory owns the page's full lifecycle.
+        init: function () {
+          var reg = window.Alpine && Alpine.store('shortcuts');
+          if (reg) reg.setScope('subscriptions');
+        },
+
+        destroy: function () {
+          var reg = window.Alpine && Alpine.store('shortcuts');
+          if (reg) reg.setScope('global');
+        },
+
         // Search filter for the ledger rows (data-search haystack).
         matches: function (el) {
           if (!this.filter) return true;


### PR DESCRIPTION
Beyond-roadmap, user-directed enhancement for the rules-as-universal-substrate sprint: **shared UI components only** + a **design-system pass** on the series and counterparty detail pages. No service/MCP/REST changes — the entity-specific surfaces (series tags, counterparty enrichment) stay where they are; only the shared admin-UI chrome is consolidated and brought up to the design system.

## Shared UI components (entity-neutral)

- **`components.GoverningRulesPanel` is now parameterized** via `GoverningRulesPanelProps{ Rules, EntityWord, ActionCode }`. The empty-state copy ("No rules assign charges to this *series*/*counterparty* yet", "rules with an `assign_series`/`assign_counterparty` action") is entity-neutral. Both detail pages call the shared panel directly and the bespoke **`counterpartyGoverningRulesPanel` wrapper is deleted**.
- **Series-named shared helpers renamed + relocated** into a new shared file `internal/templates/components/pages/entity_detail_shared.templ` (+ `entity_detail_shared_types.go`), making the cross-page dependency explicit:
  - `seriesPanelHeader` → `entityPanelHeader`
  - `seriesChargeRow` → `entityChargeRow`
  - `seriesNewRuleBtn` → `entityRulesBtn`
  - `seriesChargeDate` → `entityChargeDate`

  All callers in `subscription_detail`, `subscriptions_list`, and `counterparties` updated. Behavior identical.

## Design-system fixes

- **C-3 (P1):** the hand-rolled `seriesEditDrawer` slide-over (a bespoke `fixed inset-y-0 right-0` panel with manual scrim/transitions) is replaced with the shared **`components.Drawer`** + `components.DrawerHeader`/`DrawerFooter`, driven by `$store.drawers`. The `editOpen` flag is gone from the Alpine factory; the Edit trigger is now `$store.drawers.open('series-edit')`. Save still PATCHes `/api/v1/series/{id}` and reloads.
- **C-6/C-7 (P2):** the counterparties list's inline `x-data="{ q: '' }"` is replaced with a named **`counterpartiesList`** Alpine factory in a new `static/js/admin/components/counterparties.js` (mirrors `subscriptions.js`) — search filter via a `matches($el)` helper, and `$store.shortcuts.setScope('counterparties')` on init / `'global'` on destroy.
- **C-1 (P3):** the redundant bare `<div x-data x-init="$store.shortcuts.setScope('subscriptions')">` on `/recurring` is folded into the `subscriptionsList` factory's `init`/`destroy`.

## Evidence

`make templ` + `go build ./... && go vet ./... && go test ./...` all green (also verified the `headless lite` build tag combo). Filter verified live: the counterparties list went 5 visible rows → 1 after filtering to "spotify".

Series detail with the new shared `components.Drawer` edit open:

<img src="https://bb-artifacts.exe.xyz/f/6f243328aaee8c0d.jpeg" width="900" alt="series detail with shared Drawer edit open">

Counterparty detail rendering the shared governing-rules panel (entity-neutral copy, one disabled rule) + enrichment form:

<img src="https://bb-artifacts.exe.xyz/f/7ff70b14cc9482d4.jpeg" width="900" alt="counterparty detail with shared governing rules panel">

Counterparty list (new `counterpartiesList` factory):

<img src="https://bb-artifacts.exe.xyz/f/9fc2e8df6f176c6c.jpeg" width="900" alt="counterparty list">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
