### PR TITLE
(beyond-roadmap) feat(ui): Workflows-DNA polish — entity avatars + richer rows on series/counterparty pages

### DIFF
--- a/input.css
+++ b/input.css
@@ -513,6 +513,23 @@
   .bb-icon-tile--error   { @apply bg-error/10 text-error; }
   .bb-icon-tile--neutral { @apply bg-base-200 text-base-content/60; }
 
+  /* Entity-avatar gradient monogram — the deterministic-color fallback tile for
+     an entity with no logo (a counterparty without a logo_url). The hue is
+     pinned per-name via an inline `--bb-avatar-hue` (0–360), the same way
+     .bb-tx-avatar reads an inline `--avatar-color`. OKLCH keeps the two stops
+     legible at every hue (fixed lightness/chroma, hue-only spin) so the white
+     monogram letters always read; the slight diagonal + darker second stop give
+     it the calm depth of the Workflows custom-avatar tiles without shouting.
+     Theme-independent on purpose: an identity color, like a DiceBear avatar. */
+  .bb-entity-avatar--mono {
+    background-image: linear-gradient(
+      135deg,
+      oklch(0.64 0.13 var(--bb-avatar-hue)),
+      oklch(0.52 0.15 var(--bb-avatar-hue))
+    );
+    color: oklch(0.99 0 0);
+  }
+
   /* Detail-page entity header — 40×40 tile on mobile, 48×48 at sm+
      for the top-of-page row that pairs an icon with the entity name +
      badges + meta line. The mobile shrink reclaims horizontal space

--- a/internal/admin/counterparties.go
+++ b/internal/admin/counterparties.go
@@ -48,12 +48,18 @@ func CounterpartiesListPageHandler(a *app.App, svc *service.Service, sm *scs.Ses
 			a.Logger.Error("counterparty governing rule counts", "error", err)
 			ruleByShortID, ruleByName = map[string]int{}, map[string]int{}
 		}
+		// Resolve each counterparty's default-category UUID → display name in one
+		// pass, so the row can show a small category chip without an N+1.
+		catNameByUUID := counterpartyCategoryNames(ctx, svc)
 
 		rows := make([]pages.CounterpartyRow, 0, len(all))
 		for _, c := range all {
 			row := counterpartyRow(c)
 			row.MemberCount = counts[c.ID]
 			row.GoverningRuleCount = ruleByShortID[c.ShortID] + ruleByName[c.Name]
+			if c.CategoryID != nil {
+				row.Category = catNameByUUID[*c.CategoryID]
+			}
 			rows = append(rows, row)
 		}
 
@@ -257,6 +263,25 @@ func counterpartyRow(c service.CounterpartyResponse) pages.CounterpartyRow {
 		LogoURL: derefStr(c.LogoURL),
 		Search:  strings.ToLower(c.Name),
 	}
+}
+
+// counterpartyCategoryNames builds a UUID → display-name map across the whole
+// category tree (parents + children), so the list page can label a
+// counterparty's default category in one query rather than N. A child uses its
+// own short display name (not "Parent / Child") to keep the row chip compact.
+func counterpartyCategoryNames(ctx context.Context, svc *service.Service) map[string]string {
+	cats, err := svc.ListCategories(ctx)
+	if err != nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string)
+	for _, parent := range cats {
+		out[parent.ID] = parent.DisplayName
+		for _, child := range parent.Children {
+			out[child.ID] = child.DisplayName
+		}
+	}
+	return out
 }
 
 // counterpartyCategoryOptions flattens the category tree into "Parent / Child"

--- a/internal/admin/subscriptions.go
+++ b/internal/admin/subscriptions.go
@@ -42,12 +42,18 @@ func SubscriptionsListPageHandler(a *app.App, svc *service.Service, sm *scs.Sess
 			a.Logger.Error("series member counts", "error", err)
 			counts = map[string]int{} // degrade gracefully — rows still render
 		}
+		ruleByShortID, ruleByName, err := svc.ListSeriesGoverningRuleCounts(ctx)
+		if err != nil {
+			a.Logger.Error("series governing rule counts", "error", err)
+			ruleByShortID, ruleByName = map[string]int{}, map[string]int{}
+		}
 
 		typesPresent := map[string]bool{}
 		rows := make([]pages.SubscriptionRow, 0, len(all))
 		for _, s := range all {
 			row := subscriptionRow(s)
 			row.MemberCount = counts[s.ID]
+			row.GoverningRuleCount = ruleByShortID[s.ShortID] + ruleByName[s.Name]
 			if row.Type != "" {
 				typesPresent[row.Type] = true
 			}

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -451,6 +452,49 @@ func (s *Service) ListSeriesMemberCounts(ctx context.Context) (map[string]int, e
 		out[formatUUID(r.SeriesID)] = int(r.MemberCount)
 	}
 	return out, nil
+}
+
+// ListSeriesGoverningRuleCounts tallies, in one pass over every `assign_series`
+// rule, how many such rules target each series — by its short_id (assign-to-
+// existing) or by its name (mint-by-name). Returns two maps (byShortID, byName)
+// so the /recurring list handler can label each row's governing-rule count
+// without an N+1 of ListGoverningRules. Mirrors
+// ListCounterpartyGoverningRuleCounts.
+func (s *Service) ListSeriesGoverningRuleCounts(ctx context.Context) (byShortID map[string]int, byName map[string]int, err error) {
+	rows, err := s.Pool.Query(ctx,
+		`SELECT actions FROM transaction_rules
+		   WHERE actions @> '[{"type":"assign_series"}]'::jsonb`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("query series governing rule counts: %w", err)
+	}
+	defer rows.Close()
+
+	byShortID = map[string]int{}
+	byName = map[string]int{}
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, nil, fmt.Errorf("scan rule actions: %w", err)
+		}
+		var actions []RuleAction
+		if err := json.Unmarshal(raw, &actions); err != nil {
+			continue // a malformed action blob shouldn't break the whole tally
+		}
+		for _, a := range actions {
+			if a.Type != "assign_series" {
+				continue
+			}
+			if sid := strings.TrimSpace(a.SeriesShortID); sid != "" {
+				byShortID[sid]++
+			} else if name := strings.TrimSpace(a.SeriesName); name != "" {
+				byName[name]++
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate rule actions: %w", err)
+	}
+	return byShortID, byName, nil
 }
 
 // ListGoverningRules returns the rules whose `assign_series` action targets this

--- a/internal/templates/components/entity_avatar.go
+++ b/internal/templates/components/entity_avatar.go
@@ -1,3 +1,5 @@
+//go:build !headless && !lite
+
 package components
 
 import (

--- a/internal/templates/components/entity_avatar.go
+++ b/internal/templates/components/entity_avatar.go
@@ -1,0 +1,213 @@
+package components
+
+import (
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// EntityAvatar is the shared rounded-square identity tile that brings the
+// Workflows-gallery avatar DNA to entity surfaces (/counterparties, /recurring).
+// It renders one of three shapes, picked by which fields are set, in priority
+// order:
+//
+//  1. Image — when ImageURL is set (a counterparty's logo_url): the image,
+//     object-contain on a quiet base-200 tile.
+//  2. Tinted icon — when Icon is set (a series, keyed by type): a lucide glyph
+//     on a semantic tone tint (the same .bb-icon-tile--* tones EntityHeader and
+//     IconTile use), so a subscription/bill/loan/other reads as a distinct,
+//     calm color.
+//  3. Gradient monogram — the fallback (a counterparty with no logo): the first
+//     one or two letters of Name on a deterministic OKLCH gradient whose hue is
+//     a stable hash of Seed (or Name). This is the "colored monogram avatar for
+//     custom items" half of the Workflows DNA — every nameless counterparty gets
+//     a stable, legible identity color without a logo.
+//
+// The component is entity-neutral: both pages (and, optionally, transaction
+// rows) drive it purely through props.
+
+// EntityAvatarSize is the tile size token. Detail headers pass Size="" and size
+// the tile through Class (e.g. "w-full h-full") so the avatar fills the
+// EntityHeader tile slot.
+type EntityAvatarSize string
+
+const (
+	// EntityAvatarSizeSM is the dense list-row tile (36×36).
+	EntityAvatarSizeSM EntityAvatarSize = "sm"
+	// EntityAvatarSizeMD is the default tile (40×40), matching the legacy
+	// per-row logo tile the avatar replaces.
+	EntityAvatarSizeMD EntityAvatarSize = "md"
+)
+
+// EntityAvatarProps configures EntityAvatar. See the component doc for the
+// three render shapes and their precedence.
+type EntityAvatarProps struct {
+	// Name drives the monogram letters and, when Seed is empty, the monogram's
+	// deterministic gradient hue. Also used as the image alt text.
+	Name string
+	// ImageURL, when set, renders the image shape (a counterparty logo).
+	ImageURL string
+	// Icon, when set (and ImageURL is empty), renders the tinted-icon shape — a
+	// lucide glyph name (a series type glyph).
+	Icon string
+	// Tone tints the icon shape. Reuses the EntityHeader IconTone vocabulary
+	// (primary/info/success/warning/error/neutral/accent). Ignored unless Icon
+	// is set. Empty defaults to neutral.
+	Tone IconTone
+	// Seed overrides the monogram gradient hash input. Defaults to Name. Pass a
+	// stable id (e.g. a short_id) when two entities legitimately share a name
+	// but should read as distinct.
+	Seed string
+	// Size is the tile size token (sm | md). Empty lets Class drive sizing — the
+	// detail-header path passes "w-full h-full" to fill the EntityHeader slot.
+	Size EntityAvatarSize
+	// Class appends extra utilities (sizing for the header fill, an outer ring,
+	// etc.).
+	Class string
+}
+
+// entityAvatarSeed returns the gradient hash input — Seed when set, else Name.
+func entityAvatarSeed(p EntityAvatarProps) string {
+	if strings.TrimSpace(p.Seed) != "" {
+		return p.Seed
+	}
+	return p.Name
+}
+
+// entityAvatarHue maps a seed string to a stable hue in [0,360). FNV-1a keeps it
+// deterministic and well-spread, so two different names rarely collide on color.
+func entityAvatarHue(seed string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(strings.ToLower(strings.TrimSpace(seed))))
+	return int(h.Sum32() % 360)
+}
+
+// entityAvatarHueStyle is the inline style that pins the monogram gradient's
+// hue. The .bb-entity-avatar--mono class reads --bb-avatar-hue to build the
+// OKLCH gradient — mirrors how .bb-tx-avatar consumes an inline --avatar-color.
+func entityAvatarHueStyle(seed string) string {
+	return "--bb-avatar-hue:" + strconv.Itoa(entityAvatarHue(seed))
+}
+
+// entityAvatarLetters returns the 1–2 letter monogram for a name: the initials
+// of the first two words, else the first two letters of a single word, upper-
+// cased. Falls back to "?" for an empty/symbol-only name.
+func entityAvatarLetters(name string) string {
+	fields := strings.Fields(name)
+	var letters []rune
+	for _, f := range fields {
+		for _, r := range f {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				letters = append(letters, unicode.ToUpper(r))
+				break
+			}
+		}
+		if len(letters) == 2 {
+			break
+		}
+	}
+	if len(letters) == 0 {
+		// Single word with no word-boundary second initial, or a name the field
+		// split didn't yield letters for — take the first two alphanumerics.
+		for _, r := range name {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				letters = append(letters, unicode.ToUpper(r))
+			}
+			if len(letters) == 2 {
+				break
+			}
+		}
+	} else if len(letters) == 1 {
+		// One word → pad with its second alphanumeric for a fuller monogram.
+		runes := []rune(strings.ToUpper(fields[0]))
+		for i := 1; i < len(runes); i++ {
+			if unicode.IsLetter(runes[i]) || unicode.IsDigit(runes[i]) {
+				letters = append(letters, runes[i])
+				break
+			}
+		}
+	}
+	if len(letters) == 0 {
+		return "?"
+	}
+	return string(letters)
+}
+
+// entityAvatarTileClass assembles the tile's structural classes (flex centering,
+// rounding, shrink, size token, caller extras). The shape-specific background is
+// added by the templ.
+func entityAvatarTileClass(size EntityAvatarSize, extra string) string {
+	parts := []string{"flex items-center justify-center shrink-0 overflow-hidden", entityAvatarRadius(size)}
+	if s := entityAvatarSizeClass(size); s != "" {
+		parts = append(parts, s)
+	}
+	if strings.TrimSpace(extra) != "" {
+		parts = append(parts, extra)
+	}
+	return strings.Join(parts, " ")
+}
+
+// entityAvatarRadius keeps the rounded-square family: rounded-lg on the dense sm
+// tile, rounded-xl elsewhere (matches .bb-tx-avatar / .bb-icon-header__tile).
+func entityAvatarRadius(size EntityAvatarSize) string {
+	if size == EntityAvatarSizeSM {
+		return "rounded-lg"
+	}
+	return "rounded-xl"
+}
+
+// entityAvatarSizeClass maps a size token to w/h utilities. Empty (header path)
+// returns "" so the caller's Class drives sizing.
+func entityAvatarSizeClass(size EntityAvatarSize) string {
+	switch size {
+	case EntityAvatarSizeSM:
+		return "w-9 h-9"
+	case EntityAvatarSizeMD:
+		return "w-10 h-10"
+	default:
+		return ""
+	}
+}
+
+// entityAvatarIconClass sizes the lucide glyph for the tinted-icon shape.
+func entityAvatarIconClass(size EntityAvatarSize) string {
+	switch size {
+	case EntityAvatarSizeSM:
+		return "w-4 h-4"
+	case EntityAvatarSizeMD:
+		return "w-5 h-5"
+	default:
+		return "w-5 h-5 sm:w-6 sm:h-6"
+	}
+}
+
+// entityAvatarLetterClass sizes the monogram letters per tile size. Two letters
+// get a slightly smaller type so they don't crowd the tile.
+func entityAvatarLetterClass(size EntityAvatarSize, twoLetters bool) string {
+	base := "font-semibold leading-none tracking-tight select-none"
+	switch size {
+	case EntityAvatarSizeSM:
+		if twoLetters {
+			return base + " text-[0.65rem]"
+		}
+		return base + " text-xs"
+	case EntityAvatarSizeMD:
+		if twoLetters {
+			return base + " text-xs"
+		}
+		return base + " text-sm"
+	default: // header fill
+		if twoLetters {
+			return base + " text-sm sm:text-base"
+		}
+		return base + " text-base sm:text-lg"
+	}
+}
+
+// entityAvatarToneClass resolves the icon-shape tint to a .bb-icon-tile--* class,
+// reusing the exact tones EntityHeader/IconTile use so series tiles match the
+// rest of the surface. Empty tone → neutral.
+func entityAvatarToneClass(t IconTone) string {
+	return iconToneClass(t)
+}

--- a/internal/templates/components/entity_avatar.templ
+++ b/internal/templates/components/entity_avatar.templ
@@ -1,0 +1,24 @@
+package components
+
+// EntityAvatar — the shared rounded-square identity tile (see entity_avatar.go
+// for the prop contract and the three render shapes). Image → tinted icon →
+// gradient monogram, in that precedence.
+templ EntityAvatar(p EntityAvatarProps) {
+	if p.ImageURL != "" {
+		<div class={ entityAvatarTileClass(p.Size, p.Class) + " bg-base-200" }>
+			<img src={ p.ImageURL } alt={ p.Name } class="w-full h-full object-contain" loading="lazy"/>
+		</div>
+	} else if p.Icon != "" {
+		<div class={ entityAvatarTileClass(p.Size, p.Class), entityAvatarToneClass(p.Tone) }>
+			@LucideIcon(p.Icon, entityAvatarIconClass(p.Size))
+		</div>
+	} else {
+		<div
+			class={ entityAvatarTileClass(p.Size, p.Class) + " bb-entity-avatar--mono" }
+			style={ entityAvatarHueStyle(entityAvatarSeed(p)) }
+			aria-hidden="true"
+		>
+			<span class={ entityAvatarLetterClass(p.Size, len(entityAvatarLetters(p.Name)) > 1) }>{ entityAvatarLetters(p.Name) }</span>
+		</div>
+	}
+}

--- a/internal/templates/components/entity_avatar_test.go
+++ b/internal/templates/components/entity_avatar_test.go
@@ -1,0 +1,73 @@
+package components
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEntityAvatarLetters(t *testing.T) {
+	cases := map[string]string{
+		"Amazon":            "AM",
+		"Netflix":           "NE",
+		"John Smith":        "JS",
+		"acme corp":         "AC",
+		"  spaced  out  ":   "SO",
+		"x":                 "X",
+		"4Front":            "4F",
+		"":                  "?",
+		"   ":               "?",
+		"!!!":               "?",
+		"Spotify Premium":   "SP",
+		"a b c":             "AB", // first two word-initials only
+		"E*Trade":           "ET", // symbol skipped inside the word
+	}
+	for in, want := range cases {
+		if got := entityAvatarLetters(in); got != want {
+			t.Errorf("entityAvatarLetters(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEntityAvatarHueDeterministic(t *testing.T) {
+	// Same seed → same hue, every time.
+	if a, b := entityAvatarHue("Amazon"), entityAvatarHue("Amazon"); a != b {
+		t.Fatalf("hue not stable: %d != %d", a, b)
+	}
+	// Case/whitespace-insensitive (the seed is normalized).
+	if a, b := entityAvatarHue("Amazon"), entityAvatarHue("  amazon "); a != b {
+		t.Errorf("hue not normalized: %d != %d", a, b)
+	}
+	// Always in range.
+	for _, s := range []string{"", "Netflix", "ACME Corp", "🍞", "long name with words"} {
+		if h := entityAvatarHue(s); h < 0 || h >= 360 {
+			t.Errorf("entityAvatarHue(%q) = %d, out of [0,360)", s, h)
+		}
+	}
+	// Distinct names generally get distinct hues (sanity, not a guarantee).
+	if entityAvatarHue("Amazon") == entityAvatarHue("Netflix") {
+		t.Errorf("expected Amazon and Netflix to differ in hue")
+	}
+}
+
+func TestEntityAvatarSeedFallsBackToName(t *testing.T) {
+	if got := entityAvatarSeed(EntityAvatarProps{Name: "Amazon"}); got != "Amazon" {
+		t.Errorf("seed should fall back to Name, got %q", got)
+	}
+	if got := entityAvatarSeed(EntityAvatarProps{Name: "Amazon", Seed: "cp_123"}); got != "cp_123" {
+		t.Errorf("seed should prefer Seed, got %q", got)
+	}
+}
+
+func TestEntityAvatarTileClass(t *testing.T) {
+	// sm tile is rounded-lg + 36px; md is rounded-xl + 40px; empty size lets the
+	// caller's extra classes drive sizing (header fill).
+	if got := entityAvatarTileClass(EntityAvatarSizeSM, ""); !strings.Contains(got, "w-9 h-9") || !strings.Contains(got, "rounded-lg") {
+		t.Errorf("sm tile class = %q", got)
+	}
+	if got := entityAvatarTileClass(EntityAvatarSizeMD, ""); !strings.Contains(got, "w-10 h-10") || !strings.Contains(got, "rounded-xl") {
+		t.Errorf("md tile class = %q", got)
+	}
+	if got := entityAvatarTileClass("", "w-full h-full"); !strings.Contains(got, "w-full h-full") {
+		t.Errorf("header tile class should carry extra, = %q", got)
+	}
+}

--- a/internal/templates/components/entity_avatar_test.go
+++ b/internal/templates/components/entity_avatar_test.go
@@ -1,3 +1,5 @@
+//go:build !headless && !lite
+
 package components
 
 import (

--- a/internal/templates/components/pages/counterparties.templ
+++ b/internal/templates/components/pages/counterparties.templ
@@ -46,25 +46,34 @@ templ CounterpartiesList(p CounterpartiesListProps) {
 	</div>
 }
 
-// counterpartiesListRow renders one counterparty as a daisy list-row: a leading
-// logo thumbnail (or fallback glyph), the name on the title line, the
-// linked-charge + governing-rule counts on the body line, and a chevron. The
-// whole row links to the detail page.
+// counterpartiesListRow renders one counterparty as a daisy list-row in the
+// Workflows-gallery idiom: a leading EntityAvatar (the logo image when set, else
+// a deterministic gradient monogram of the name), the name on the title line
+// with an optional category chip, the linked-charge + governing-rule counts on
+// the body line, and a chevron. The whole row links to the detail page.
 templ counterpartiesListRow(c CounterpartyRow) {
 	<li
-		class="list-row transition-colors hover:bg-base-200/40 items-center"
+		class="list-row rounded-xl transition-colors hover:bg-base-200/40 focus-within:bg-base-200/40 items-center"
 		data-search={ c.Search }
 		x-show="matches($el)"
 	>
 		<a
-			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-lg"
+			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-xl"
 			href={ templ.SafeURL("/counterparties/" + c.ShortID) }
 			aria-label={ "Open counterparty " + c.Name }
 		>
-			@counterpartyLogoTile(c.LogoURL, c.Name)
+			@components.EntityAvatar(components.EntityAvatarProps{
+				Name:     c.Name,
+				ImageURL: c.LogoURL,
+				Seed:     c.ShortID,
+				Size:     components.EntityAvatarSizeMD,
+			})
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 min-w-0">
 					<span data-private="merchant" class="font-medium text-sm text-base-content truncate">{ c.Name }</span>
+					if c.Category != "" {
+						<span class="badge badge-ghost badge-sm shrink-0 hidden sm:inline-flex">{ c.Category }</span>
+					}
 				</div>
 				<div class="mt-0.5 text-xs text-base-content/55 min-w-0 line-clamp-1">
 					{ counterpartyRowMeta(c.MemberCount, c.GoverningRuleCount) }
@@ -75,20 +84,6 @@ templ counterpartiesListRow(c CounterpartyRow) {
 			</div>
 		</a>
 	</li>
-}
-
-// counterpartyLogoTile is the leading glyph for a counterparty row/header — the
-// logo image when one is set, otherwise a quiet "store" tile.
-templ counterpartyLogoTile(logoURL, name string) {
-	if logoURL != "" {
-		<div class="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 bg-base-200 overflow-hidden">
-			<img src={ logoURL } alt={ name } class="w-full h-full object-contain" loading="lazy"/>
-		</div>
-	} else {
-		<div class="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 bg-base-200">
-			@components.LucideIcon("store", "w-4 h-4 text-base-content/50")
-		</div>
-	}
 }
 
 // CounterpartyDetail renders /counterparties/{short_id} under the
@@ -102,8 +97,8 @@ templ CounterpartyDetail(p CounterpartyDetailProps) {
 		@components.EntityHeader(components.EntityHeaderProps{
 			Title:            p.Counterparty.Name,
 			TitlePrivateKind: "merchant",
-			IconComponent:    counterpartyHeaderIcon(p.Counterparty.LogoURL, p.Counterparty.Name),
-			IconTone:         components.IconToneNeutral,
+			IconComponent:    counterpartyHeaderIcon(p.Counterparty),
+			IconTone:         components.IconToneDefault,
 			Meta:             counterpartyDetailMeta(p),
 		})
 		<!-- Linked charges (what's bound) + Governing rules (what defines it) -->
@@ -210,14 +205,17 @@ templ CounterpartyForm(p CounterpartyFormProps) {
 	</form>
 }
 
-// counterpartyHeaderIcon renders the EntityHeader leading tile content — the logo
-// image when set, otherwise a store glyph.
-templ counterpartyHeaderIcon(logoURL, name string) {
-	if logoURL != "" {
-		<img src={ logoURL } alt={ name } class="w-6 h-6 object-contain" loading="lazy"/>
-	} else {
-		@components.LucideIcon("store", "w-5 h-5 sm:w-6 sm:h-6")
-	}
+// counterpartyHeaderIcon renders the EntityHeader leading tile content — the same
+// EntityAvatar the list rows use (logo image when set, else a deterministic
+// gradient monogram), sized to fill the header tile slot so the detail hero
+// matches the list.
+templ counterpartyHeaderIcon(c CounterpartyRow) {
+	@components.EntityAvatar(components.EntityAvatarProps{
+		Name:     c.Name,
+		ImageURL: c.LogoURL,
+		Seed:     c.ShortID,
+		Class:    "w-full h-full",
+	})
 }
 
 // counterpartyDetailMeta is the quiet sub-title line — the linked-charge count.

--- a/internal/templates/components/pages/counterparties_types.go
+++ b/internal/templates/components/pages/counterparties_types.go
@@ -26,7 +26,8 @@ type CounterpartiesListProps struct {
 type CounterpartyRow struct {
 	ShortID            string
 	Name               string
-	LogoURL            string // optional 16×16 thumbnail on the row
+	LogoURL            string // optional logo image on the row/header (logo_url)
+	Category           string // resolved display name of the default category, "" when unset
 	MemberCount        int    // linked live charges
 	GoverningRuleCount int    // assign_counterparty rules that define membership
 

--- a/internal/templates/components/pages/subscription_detail.templ
+++ b/internal/templates/components/pages/subscription_detail.templ
@@ -23,8 +23,8 @@ templ SubscriptionDetail(p SubscriptionDetailProps) {
 		@components.EntityHeader(components.EntityHeaderProps{
 			Title:            p.Series.Name,
 			TitlePrivateKind: "merchant",
-			Icon:             subscriptionTypeIcon(p.Series.Type),
-			IconTone:         components.IconToneNeutral,
+			IconComponent:    seriesHeaderIcon(p.Series.Type),
+			IconTone:         components.IconToneDefault,
 			Badges:           seriesDetailBadges(p.Series),
 			Meta:             seriesDetailMeta(p),
 			Action:           seriesDetailActions(),
@@ -127,6 +127,17 @@ templ seriesLinkChargeBtn() {
 		@components.LucideIcon("plus", "w-3.5 h-3.5")
 		Link a charge
 	</button>
+}
+
+// seriesHeaderIcon renders the EntityHeader leading tile content — the same
+// type-tinted EntityAvatar the ledger rows use, sized to fill the header tile
+// slot so the detail hero matches the list.
+templ seriesHeaderIcon(typ string) {
+	@components.EntityAvatar(components.EntityAvatarProps{
+		Icon:  subscriptionTypeIcon(typ),
+		Tone:  subscriptionTypeTone(typ),
+		Class: "w-full h-full",
+	})
 }
 
 // seriesDetailBadges is the EntityHeader badge row: the structured type chip.

--- a/internal/templates/components/pages/subscriptions_list.templ
+++ b/internal/templates/components/pages/subscriptions_list.templ
@@ -61,19 +61,21 @@ templ subscriptionsTypeFilterBtn(t SubscriptionTypeFilter) {
 	>{ t.Label }</button>
 }
 
-// subscriptionsListRow renders one series as a daisy list-row: a leading type
-// glyph, the name + type chip on the title line, the linked-charge count on the
-// body line, and a chevron affordance. The whole row links to the detail page.
+// subscriptionsListRow renders one series as a daisy list-row in the
+// Workflows-gallery idiom: a leading type-tinted EntityAvatar (a distinct calm
+// tint + glyph per series type), the name + type chip on the title line, the
+// linked-charge + governing-rule counts on the body line, and a chevron
+// affordance. The whole row links to the detail page.
 templ subscriptionsListRow(s SubscriptionRow) {
 	<li
-		class="list-row transition-colors hover:bg-base-200/40 items-center"
+		class="list-row rounded-xl transition-colors hover:bg-base-200/40 focus-within:bg-base-200/40 items-center"
 		data-series-card
 		data-type={ s.Type }
 		data-search={ s.Search }
 		x-show="(filterType === 'all' || filterType === $el.dataset.type) && matches($el)"
 	>
 		<a
-			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-lg"
+			class="contents no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-xl"
 			href={ templ.SafeURL("/recurring/" + s.ShortID) }
 			aria-label={ "Open recurring series " + s.Name }
 		>
@@ -84,7 +86,7 @@ templ subscriptionsListRow(s SubscriptionRow) {
 					@components.SeriesTypeChip(s.TypeLabel, "xs")
 				</div>
 				<div class="mt-0.5 text-xs text-base-content/55 min-w-0 line-clamp-1">
-					{ subscriptionMemberCount(s.MemberCount) }
+					{ subscriptionRowMeta(s.MemberCount, s.GoverningRuleCount) }
 				</div>
 			</div>
 			<div class="shrink-0 self-center">
@@ -94,12 +96,15 @@ templ subscriptionsListRow(s SubscriptionRow) {
 	</li>
 }
 
-// subscriptionsTypeTile is the leading glyph for a ledger row — a quiet,
-// type-keyed icon tile (subscription → repeat, bill → receipt, loan → landmark).
+// subscriptionsTypeTile is the leading EntityAvatar for a ledger row — a
+// type-tinted tile (subscription → primary/repeat, bill → warning/receipt,
+// loan → info/landmark, other → neutral/shapes).
 templ subscriptionsTypeTile(typ string) {
-	<div class="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 bg-base-200">
-		@components.LucideIcon(subscriptionTypeIcon(typ), "w-4 h-4 text-base-content/50")
-	</div>
+	@components.EntityAvatar(components.EntityAvatarProps{
+		Icon: subscriptionTypeIcon(typ),
+		Tone: subscriptionTypeTone(typ),
+		Size: components.EntityAvatarSizeMD,
+	})
 }
 
 // subscriptionTypeIcon maps a series type to its lucide glyph (shared by the
@@ -110,6 +115,8 @@ func subscriptionTypeIcon(typ string) string {
 		return "receipt"
 	case "loan":
 		return "landmark"
+	case "other":
+		return "shapes"
 	default:
 		return "repeat"
 	}

--- a/internal/templates/components/pages/subscriptions_list_test.go
+++ b/internal/templates/components/pages/subscriptions_list_test.go
@@ -68,3 +68,40 @@ func TestSubscriptionMemberCount(t *testing.T) {
 		}
 	}
 }
+
+// TestSubscriptionRowMeta pins the body-line composition: charges always show;
+// the rule count is appended only when at least one governing rule exists
+// (mirrors counterpartyRowMeta so the two surfaces read identically).
+func TestSubscriptionRowMeta(t *testing.T) {
+	cases := []struct {
+		members, rules int
+		want           string
+	}{
+		{0, 0, "0 charges"},
+		{1, 0, "1 charge"},
+		{4, 1, "4 charges · 1 rule"},
+		{4, 3, "4 charges · 3 rules"},
+	}
+	for _, c := range cases {
+		if got := subscriptionRowMeta(c.members, c.rules); got != c.want {
+			t.Errorf("subscriptionRowMeta(%d,%d) = %q, want %q", c.members, c.rules, got, c.want)
+		}
+	}
+}
+
+// TestSubscriptionTypeTone pins the type→tone mapping to the vivid tones only
+// (so subscription never collapses to gray on the dark theme).
+func TestSubscriptionTypeTone(t *testing.T) {
+	cases := map[string]string{
+		"subscription": "success",
+		"bill":         "warning",
+		"loan":         "info",
+		"other":        "neutral",
+		"":             "neutral",
+	}
+	for typ, want := range cases {
+		if got := string(subscriptionTypeTone(typ)); got != want {
+			t.Errorf("subscriptionTypeTone(%q) = %q, want %q", typ, got, want)
+		}
+	}
+}

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -35,12 +35,13 @@ type SubscriptionTypeFilter struct {
 // detail page). A thin series carries only an identity (short_id, name), a
 // structured type, its linked-charge count, and its inherited tags.
 type SubscriptionRow struct {
-	ShortID     string // short_id — drives the detail link
-	Name        string
-	Type        string // subscription | bill | loan | other (raw, drives the filter)
-	TypeLabel   string // "Subscription" | "Bill" | "Loan" | "Other"
-	MemberCount int    // linked live charges
-	Tags        []string
+	ShortID            string // short_id — drives the detail link
+	Name               string
+	Type               string // subscription | bill | loan | other (raw, drives the filter)
+	TypeLabel          string // "Subscription" | "Bill" | "Loan" | "Other"
+	MemberCount        int    // linked live charges
+	GoverningRuleCount int    // assign_series rules that define membership
+	Tags               []string
 
 	// Search is the lowercase haystack for the client-side filter input.
 	Search string
@@ -122,6 +123,42 @@ func subscriptionMemberCount(n int) string {
 		return "1 charge"
 	}
 	return fmt.Sprintf("%d charges", n)
+}
+
+// subscriptionRowMeta renders the "N charges · M rules" body line on a series
+// row, mirroring counterpartyRowMeta: the charge count always shows; the rule
+// count is appended only when at least one governing rule exists (keeping the
+// line quiet for an as-yet-ungoverned series).
+func subscriptionRowMeta(memberCount, ruleCount int) string {
+	parts := []string{subscriptionMemberCount(memberCount)}
+	switch ruleCount {
+	case 0:
+		// nothing — keep the line quiet when no rules govern it
+	case 1:
+		parts = append(parts, "1 rule")
+	default:
+		parts = append(parts, fmt.Sprintf("%d rules", ruleCount))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// subscriptionTypeTone maps a series type to a calm, distinct EntityAvatar tint.
+// It deliberately uses only the *vivid* semantic tones (success/warning/info) +
+// neutral, because in the dark theme primary/secondary/accent collapse to gray
+// (see the theme's vivid-tones rule) — a primary tint would read identically to
+// neutral. So: subscription → success (green), bill → warning (amber), loan →
+// info (blue), other → neutral (gray, the quiet bucket).
+func subscriptionTypeTone(typ string) components.IconTone {
+	switch typ {
+	case "bill":
+		return components.IconToneWarning
+	case "loan":
+		return components.IconToneInfo
+	case "subscription":
+		return components.IconToneSuccess
+	default:
+		return components.IconToneNeutral
+	}
 }
 
 // subscriptionSearchHaystack builds the lowercase filter haystack for a row.


### PR DESCRIPTION
Brings the **Workflows-gallery avatar DNA** to `/counterparties` and `/recurring` so both surfaces read as one polished product — matching the most refined surface in the app.

## What changed

### New shared `components.EntityAvatar`
A rounded-square identity tile (`internal/templates/components/entity_avatar.templ` + `entity_avatar.go`) with **three shapes by precedence**:
1. **Logo image** — a counterparty's `logo_url`, object-contain on a quiet tile.
2. **Type-tinted icon** — a series, keyed by type, reusing the existing `.bb-icon-tile--*` tones (so it matches `EntityHeader`/`IconTile` exactly).
3. **Gradient monogram** — the no-logo fallback: the name's 1–2 initials on a **deterministic OKLCH gradient** whose hue is a stable FNV-1a hash of the name. This is the "colored monogram for custom items" half of the Workflows DNA — every nameless counterparty gets a stable identity color without a logo.

The gradient is driven by an inline `--bb-avatar-hue` consumed by a new `.bb-entity-avatar--mono` CSS rule — the same pattern `.bb-tx-avatar` uses for `--avatar-color`. Entity-neutral: both pages drive it purely through props. Pure helpers are unit-tested (`entity_avatar_test.go`: letters, hue determinism/normalization, tile classes).

### Richer rows + matching detail heroes
- **Counterparties** (`counterparties.templ`): `EntityAvatar` leading tile, a **category chip**, and a **`N charges · M rules`** body line. The detail header fills the `EntityHeader` icon slot with the same avatar.
- **Series** (`subscriptions_list.templ`): **type-tinted** `EntityAvatar` (subscription→green, bill→amber, loan→blue, other→neutral — vivid-only tones so subscription never collapses to gray on the dark theme), type chip, and the same `charges · rules` line. Detail header matches.

### Handlers / service
- New `Service.ListSeriesGoverningRuleCounts` (one pass over `assign_series` actions), mirroring the existing counterparty method; wired into the `/recurring` list.
- `/counterparties` list resolves each default-category UUID → display name for the chip (one query, no N+1).

No service/MCP/REST response shapes changed beyond the one new read query.

## Evidence

`go build ./... && go vet ./... && go test ./...` — all green. Focused integration tests (`TestListGoverningRules`, `TestListCounterpartyGoverningRules`, `TestListSeriesMemberCounts`) pass against `breadbox_test`.

Screenshots captured against a **throwaway seeded DB** (created + dropped; the shared dev DB was never migrated):

**/counterparties** — logo tiles (Amazon, Netflix) + deterministic gradient monograms, category chips, charges · rules
![counterparties list](https://bb-artifacts.exe.xyz/f/0cfcd6fad32428c5.jpeg)

**Counterparty detail** — monogram fills the hero, matching the list
![counterparty detail](https://bb-artifacts.exe.xyz/f/5511dafd7381f177.jpeg)

**/recurring** — type-tinted avatars (green sub / amber bill / blue loan / gray other), type chip, charges · rules
![recurring list](https://bb-artifacts.exe.xyz/f/161a075b007cff67.jpeg)

**Series detail** — type-tinted hero matches the list
![series detail](https://bb-artifacts.exe.xyz/f/24434e98e896cd29.jpeg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
