### PR TITLE
chore: prune dead code from the P2/P3 deletions (nav badge, unused helper)

### DIFF
--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -23,9 +23,6 @@ type NavBadges struct {
 	PendingReviews       int64
 	ConnectionsAttention int64
 	UnreadReports        int64
-	// SeriesCandidates is the count of recurring-series candidates awaiting a
-	// confirm/reject verdict. Displayed next to the Subscriptions nav link.
-	SeriesCandidates int64
 	// WorkflowFailures is the count of preset-instantiated workflows whose most
 	// recent run errored. Drives a red dot on the Workflows nav link so a failed
 	// automation is visible from any page (mirrors the /workflows card red dot).
@@ -60,10 +57,6 @@ func NavBadgesMiddleware(queries *db.Queries, logger *slog.Logger) func(http.Han
 			} else {
 				logger.Debug("nav badges: count unread agent reports", "error", err)
 			}
-
-			// Recurring series no longer have a candidate/review queue
-			// (rules-as-substrate, P2): membership comes from rules, not a
-			// detector. The nav badge count stays 0.
 
 			if failed, err := queries.CountWorkflowsWithFailedLastRun(ctx); err == nil {
 				badges.WorkflowFailures = failed

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -332,7 +332,6 @@ func navPropsFromData(m map[string]any) components.NavProps {
 		p.UnreadReports = badges.UnreadReports
 		p.ConnectionsAttention = badges.ConnectionsAttention
 		p.PendingReviews = badges.PendingReviews
-		p.SeriesCandidates = badges.SeriesCandidates
 		p.WorkflowFailures = badges.WorkflowFailures
 	}
 	return p

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -687,6 +687,7 @@ func convertMCPActions(actions []map[string]any) []service.RuleAction {
 			TagSlug:         mcpString(a["tag_slug"]),
 			Content:         mcpString(a["content"]),
 			SeriesShortID:   mcpString(a["series_short_id"]),
+			// TODO: remove after existing assign_series rules are migrated off merchant_key
 			SeriesName:      mcpFirstNonEmpty(a["series_name"], a["merchant_key"]),
 			CreateIfMissing: mcpBool(a["create_if_missing"]),
 			MetadataKey:     mcpString(a["metadata_key"]),

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -543,6 +543,7 @@ type ruleActionAlias RuleAction
 // UnmarshalJSON decodes a RuleAction, mapping the legacy assign_series
 // `merchant_key` key onto SeriesName so rules authored before the surrogate-first
 // rebuild (P2) keep working. An explicit `series_name` always wins.
+// TODO: remove after existing assign_series rules are migrated off merchant_key
 func (a *RuleAction) UnmarshalJSON(data []byte) error {
 	var alias ruleActionAlias
 	if err := json.Unmarshal(data, &alias); err != nil {

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -438,6 +438,7 @@ func parseTypedActions(raw []byte, ruleID pgtype.UUID, logger *slog.Logger) []ty
 			// Backward-compat: a rule authored before the surrogate-first rebuild
 			// (P2) stored the mint target under `merchant_key`. Map it onto
 			// SeriesName so existing rules keep firing. An explicit series_name wins.
+			// TODO: remove after existing assign_series rules are migrated off merchant_key
 			if seriesName == "" {
 				seriesName, _ = m["merchant_key"].(string)
 			}

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -20,7 +20,6 @@ type NavProps struct {
 	UnreadReports        int64
 	ConnectionsAttention int64
 	PendingReviews       int64
-	SeriesCandidates     int64
 	// WorkflowFailures is the count of workflows whose most recent run errored;
 	// > 0 lights a red badge on the Workflows link (mirrors the gallery red dot).
 	WorkflowFailures int64
@@ -55,7 +54,7 @@ templ Nav(p NavProps) {
 		@navLink("/transactions", "receipt", "Transactions", navActive(p.CurrentPage, "transactions"))
 		@navLink("/accounts", "wallet", "Accounts", navActive(p.CurrentPage, "accounts"))
 		if p.IsEditor {
-			@navLinkBadge("/recurring", "repeat", "Recurring", navActive(p.CurrentPage, "recurring"), p.SeriesCandidates, "", fmt.Sprintf("%d recurring charges need review", p.SeriesCandidates))
+			@navLink("/recurring", "repeat", "Recurring", navActive(p.CurrentPage, "recurring"))
 		}
 		if p.IsAdmin {
 			@navLinkBadge("/reports", "file-text", "Reports", navActive(p.CurrentPage, "reports"), p.UnreadReports, "", fmt.Sprintf("%d unread reports", p.UnreadReports))

--- a/internal/templates/components/pages/subscriptions_list_types.go
+++ b/internal/templates/components/pages/subscriptions_list_types.go
@@ -160,8 +160,3 @@ func subscriptionTypeTone(typ string) components.IconTone {
 		return components.IconToneNeutral
 	}
 }
-
-// subscriptionSearchHaystack builds the lowercase filter haystack for a row.
-func subscriptionSearchHaystack(name, typeLabel string) string {
-	return strings.ToLower(strings.Join([]string{name, typeLabel}, " "))
-}


### PR DESCRIPTION
Pure dead-code cleanup from the rules-as-universal-substrate sprint's detector (P2) and `category_override`/provenance (P3) removals. **Zero behavior change** — the nav badge was never visible (count always 0), the helper was never called.

## What was removed

1. **Stale `SeriesCandidates` nav-badge chain** (detector-era, always 0):
   - `SeriesCandidates int64` field on `NavBadges` (`internal/admin/middleware.go`)
   - The always-0 population block in `NavBadgesMiddleware` (the dead comment + no-op)
   - The copy into `NavProps` (`internal/admin/templates.go`)
   - The `SeriesCandidates` field on `NavProps` (`internal/templates/components/nav.templ`)
   - The `/recurring` nav entry: `@navLinkBadge(...)` → plain `@navLink("/recurring", "repeat", "Recurring", navActive(...))`. The badge never rendered (count 0) and its tooltip was stale detector-era copy.

2. **Unused `subscriptionSearchHaystack` helper** (`internal/templates/components/pages/subscriptions_list_types.go`) — defined, never called. The `strings` import stays (still used by `subscriptionRowMeta`).

## What was kept (annotated, NOT removed)

3. **`merchant_key` back-compat shims** — still load-bearing for rules authored before the surrogate-first rebuild. Each now carries an explicit removal-trigger comment `// TODO: remove after existing assign_series rules are migrated off merchant_key`:
   - `internal/sync/rule_resolver.go` (merchant_key→SeriesName map)
   - `internal/service/types.go` (`RuleAction.UnmarshalJSON` fallback)
   - `internal/mcp/tools.go` (`convertMCPActions` `mcpFirstNonEmpty`)

## Other dead-code sweep (P2/P3)

Ran `staticcheck -checks U1000` across the touched packages. Findings triaged against `origin/main`:
- `mcpServerURL`, `pendingReviewsCount`/`pendingReviewCountSource`, `scheduleEditURL` — **pre-existing on main**, unrelated to this sprint → left alone (out of scope).
- `datePartFields` (`internal/service/rules.go`) — sprint-introduced and currently unused, but it's a **date-part rules-engine** artifact (a sibling type map above it already lists the same fields), not a detector/`category_override` leftover, and looks staged for an upcoming date-part feature → left alone (conservative).

## Evidence

Grep-proof of no remaining references to removed symbols:
```
$ grep -rn "SeriesCandidates"           --include="*.go" --include="*.templ" .   # (no output)
$ grep -rn "subscriptionSearchHaystack" --include="*.go" .                       # (no output)
$ grep -n  "recurring" internal/templates/components/nav.templ
57: @navLink("/recurring", "repeat", "Recurring", navActive(p.CurrentPage, "recurring"))
$ grep -rn "TODO: remove after existing assign_series" --include="*.go" .
internal/mcp/tools.go:690
internal/sync/rule_resolver.go:441
internal/service/types.go:546
```

All build tags + vet + tests green:
```
go build ./...               → OK
go build -tags=lite ./...     → OK
go build -tags=headless ./... → OK
go vet ./...                  → OK
go test ./...                 → exit 0 (32 packages ok, 0 FAIL/panic)
```

(`nav_templ.go` regenerated via `make templ`; it's gitignored in this repo, so only `nav.templ` appears in the diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
