### PR TITLE
(beyond-roadmap) feat(counterparties): brand logos via logo.dev (hotlink + monogram fallback)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -622,22 +622,31 @@ The following keys are seeded during initial migration and used by the applicati
 | `sync_interval_hours` | `12` | How often the cron sync runs, in hours. |
 | `setup_complete` | `false` | Whether the first-run setup wizard has been completed. |
 | `counterparty_logos` | `true` | Whether counterparty avatars hotlink brand logos from logo.dev (see below). `false` disables it (monogram everywhere). Overridable via `BREADBOX_COUNTERPARTY_LOGOS`. |
-| `logo_dev_token` | `(empty)` | Optional logo.dev publishable key (`pk_…`) for higher rate limits. Stored in plaintext (publishable keys are public by design). Overridable via `LOGO_DEV_TOKEN`. |
+| `logo_dev_token` | `(empty)` | logo.dev publishable key (`pk_…`). **Required for logos to appear** — logo.dev's image API 401s without a token. Stored in plaintext (publishable keys are public by design). Overridable via `LOGO_DEV_TOKEN`. |
 
 #### Counterparty brand logos (logo.dev)
 
 Counterparty avatars (`/counterparties` rows and detail headers) show real brand
-logos **hotlinked** from the free [logo.dev](https://logo.dev) image API
-(`https://img.logo.dev/{domain}?size=128&format=png&retina=true&fallback=404`).
+logos **hotlinked** from the [logo.dev](https://logo.dev) image API
+(`https://img.logo.dev/{domain}?token={pk}&size=128&format=png&retina=true&fallback=404`).
 The domain is derived at render time from the counterparty's `website_url`
 (scheme + leading `www.` stripped); a counterparty with no website, or with a
-manual `logo_url` override, never hits logo.dev. Precedence for the rendered
-avatar is: manual `logo_url` → logo.dev hotlink → gradient monogram.
+manual `logo_url` override, never hits logo.dev.
+
+**Token-gated.** logo.dev's image API requires a publishable key — a tokenless
+request 401s on every render. The feature is therefore gated on a configured
+`logo_dev_token`: with no token (the default), every counterparty renders its
+gradient monogram and **no request leaves the browser for logo.dev** — a correct,
+complete default. Paste a free publishable key in Settings → General →
+Counterparties to light up real logos. The full resolution chain per avatar is:
+manual `logo_url` → (`counterparty_logos` enabled + token + derivable domain)
+logo.dev hotlink → gradient monogram.
 
 **Hotlink, not fetch-and-store.** Breadbox does not download or cache the logo;
-the browser loads it directly from logo.dev. When logo.dev has no logo for the
-domain (or no token is configured) the image errors and the avatar degrades to
-the gradient monogram — it never shows a broken image.
+the browser loads it directly from logo.dev. `fallback=404` makes an unknown
+domain 404 (rather than logo.dev's own placeholder), so the avatar's `<img>`
+`onerror` removes the image and reveals the gradient monogram underneath — it
+never shows a broken image.
 
 **Privacy.** Because logos are hotlinked, the counterparty's **domain is sent to
 logo.dev on every render** of a counterparty surface. Households that prefer not

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -621,6 +621,33 @@ The following keys are seeded during initial migration and used by the applicati
 | `webhook_url` | `(empty)` | Publicly accessible URL for Plaid webhooks. Optional. |
 | `sync_interval_hours` | `12` | How often the cron sync runs, in hours. |
 | `setup_complete` | `false` | Whether the first-run setup wizard has been completed. |
+| `counterparty_logos` | `true` | Whether counterparty avatars hotlink brand logos from logo.dev (see below). `false` disables it (monogram everywhere). Overridable via `BREADBOX_COUNTERPARTY_LOGOS`. |
+| `logo_dev_token` | `(empty)` | Optional logo.dev publishable key (`pk_…`) for higher rate limits. Stored in plaintext (publishable keys are public by design). Overridable via `LOGO_DEV_TOKEN`. |
+
+#### Counterparty brand logos (logo.dev)
+
+Counterparty avatars (`/counterparties` rows and detail headers) show real brand
+logos **hotlinked** from the free [logo.dev](https://logo.dev) image API
+(`https://img.logo.dev/{domain}?size=128&format=png&retina=true&fallback=404`).
+The domain is derived at render time from the counterparty's `website_url`
+(scheme + leading `www.` stripped); a counterparty with no website, or with a
+manual `logo_url` override, never hits logo.dev. Precedence for the rendered
+avatar is: manual `logo_url` → logo.dev hotlink → gradient monogram.
+
+**Hotlink, not fetch-and-store.** Breadbox does not download or cache the logo;
+the browser loads it directly from logo.dev. When logo.dev has no logo for the
+domain (or no token is configured) the image errors and the avatar degrades to
+the gradient monogram — it never shows a broken image.
+
+**Privacy.** Because logos are hotlinked, the counterparty's **domain is sent to
+logo.dev on every render** of a counterparty surface. Households that prefer not
+to leak counterparty domains can disable hotlinking from
+**Settings → General → Counterparties** (writes `counterparty_logos=false`), at
+which point every counterparty falls back to its monogram and no request leaves
+the browser for logo.dev. A self-hosted, single-household deployment is exempt
+from logo.dev's commercial link-back/attribution requirement (it's personal,
+non-commercial use). An optional publishable token (`logo_dev_token` /
+`LOGO_DEV_TOKEN`) raises rate limits; it is a public key by design.
 
 ---
 

--- a/internal/admin/counterparties.go
+++ b/internal/admin/counterparties.go
@@ -52,6 +52,10 @@ func CounterpartiesListPageHandler(a *app.App, svc *service.Service, sm *scs.Ses
 		// pass, so the row can show a small category chip without an N+1.
 		catNameByUUID := counterpartyCategoryNames(ctx, svc)
 
+		// Resolve the logo.dev hotlink config once for the whole list (env →
+		// app_config → default); each row derives its own URL from its website.
+		logosEnabled, logoToken := svc.CounterpartyLogoSettings(ctx)
+
 		rows := make([]pages.CounterpartyRow, 0, len(all))
 		for _, c := range all {
 			row := counterpartyRow(c)
@@ -60,6 +64,7 @@ func CounterpartiesListPageHandler(a *app.App, svc *service.Service, sm *scs.Ses
 			if c.CategoryID != nil {
 				row.Category = catNameByUUID[*c.CategoryID]
 			}
+			row.LogoDevURL = counterpartyLogoDevURL(logosEnabled, row.LogoURL, c.WebsiteURL, logoToken)
 			rows = append(rows, row)
 		}
 
@@ -114,6 +119,11 @@ func CounterpartyDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateR
 			}
 		}
 		row.GoverningRuleCount = len(governing)
+
+		// Hotlink a logo.dev brand logo into the header avatar (when enabled and
+		// no manual logo_url override), mirroring the list rows.
+		logosEnabled, logoToken := svc.CounterpartyLogoSettings(ctx)
+		row.LogoDevURL = counterpartyLogoDevURL(logosEnabled, row.LogoURL, c.WebsiteURL, logoToken)
 
 		props := pages.CounterpartyDetailProps{
 			CSRFToken:       GetCSRFToken(r),
@@ -307,6 +317,17 @@ func counterpartyCategoryOptions(ctx context.Context, svc *service.Service, curr
 		}
 	}
 	return out
+}
+
+// counterpartyLogoDevURL returns the logo.dev hotlink URL for a counterparty's
+// avatar, or "" to fall back to the monogram. It emits a URL only when logos are
+// enabled, there is no manual logo_url override (that wins), and a registrable
+// domain can be derived from the website. token is the optional publishable key.
+func counterpartyLogoDevURL(enabled bool, manualLogoURL string, websiteURL *string, token string) string {
+	if !enabled || manualLogoURL != "" {
+		return ""
+	}
+	return components.LogoDevURL(derefStr(websiteURL), token)
 }
 
 // derefStr returns the pointed-to string or "".

--- a/internal/admin/counterparties.go
+++ b/internal/admin/counterparties.go
@@ -320,11 +320,16 @@ func counterpartyCategoryOptions(ctx context.Context, svc *service.Service, curr
 }
 
 // counterpartyLogoDevURL returns the logo.dev hotlink URL for a counterparty's
-// avatar, or "" to fall back to the monogram. It emits a URL only when logos are
-// enabled, there is no manual logo_url override (that wins), and a registrable
-// domain can be derived from the website. token is the optional publishable key.
+// avatar, or "" to fall back to the gradient monogram. The feature is
+// token-gated: logo.dev's image API requires a publishable key (a tokenless
+// request 401s on every render), so a URL is emitted only when ALL of these
+// hold — logos enabled, a publishable token configured, no manual logo_url
+// override (that wins), and a registrable domain derivable from the website.
+// With no token configured the default state is monograms everywhere, which is
+// correct and complete; paste a key in Settings → General → Counterparties to
+// light up real brand logos.
 func counterpartyLogoDevURL(enabled bool, manualLogoURL string, websiteURL *string, token string) string {
-	if !enabled || manualLogoURL != "" {
+	if !enabled || token == "" || manualLogoURL != "" {
 		return ""
 	}
 	return components.LogoDevURL(derefStr(websiteURL), token)

--- a/internal/admin/counterparties_logo_test.go
+++ b/internal/admin/counterparties_logo_test.go
@@ -1,0 +1,44 @@
+//go:build !headless && !lite
+
+package admin
+
+import "testing"
+
+// TestCounterpartyLogoDevURL covers the token-gated emission of a logo.dev
+// hotlink for a counterparty avatar. The full resolution chain is:
+// explicit logo_url → (enabled + token + derivable domain) logo.dev → monogram.
+func TestCounterpartyLogoDevURL(t *testing.T) {
+	site := func(s string) *string { return &s }
+	const wantURL = "https://img.logo.dev/amazon.com?size=128&format=png&retina=true&fallback=404&token=pk_test"
+
+	t.Run("enabled+token+domain → URL", func(t *testing.T) {
+		if got := counterpartyLogoDevURL(true, "", site("https://www.amazon.com"), "pk_test"); got != wantURL {
+			t.Fatalf("got %q, want %q", got, wantURL)
+		}
+	})
+	t.Run("no token → monogram (no URL)", func(t *testing.T) {
+		if got := counterpartyLogoDevURL(true, "", site("https://amazon.com"), ""); got != "" {
+			t.Fatalf("got %q, want \"\" (token required)", got)
+		}
+	})
+	t.Run("disabled → no URL", func(t *testing.T) {
+		if got := counterpartyLogoDevURL(false, "", site("https://amazon.com"), "pk_test"); got != "" {
+			t.Fatalf("got %q, want \"\" (toggle off)", got)
+		}
+	})
+	t.Run("manual logo_url wins → no logo.dev URL", func(t *testing.T) {
+		if got := counterpartyLogoDevURL(true, "https://cdn.example.com/a.png", site("https://amazon.com"), "pk_test"); got != "" {
+			t.Fatalf("got %q, want \"\" (manual override wins)", got)
+		}
+	})
+	t.Run("no website → no URL", func(t *testing.T) {
+		if got := counterpartyLogoDevURL(true, "", nil, "pk_test"); got != "" {
+			t.Fatalf("got %q, want \"\" (no domain)", got)
+		}
+	})
+	t.Run("non-domain website → no URL", func(t *testing.T) {
+		if got := counterpartyLogoDevURL(true, "", site("localhost"), "pk_test"); got != "" {
+			t.Fatalf("got %q, want \"\" (single-label host)", got)
+		}
+	})
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -448,6 +448,8 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/settings/sync/schedules/{shortID}/toggle", ScheduleToggleHandler(a, svc, sm))
 		r.Post("/settings/sync/schedules/{shortID}/delete", ScheduleDeleteHandler(a, svc, sm))
 		r.Post("/settings/avatar-style", SettingsAvatarStylePostHandler(a, sm))
+		r.Post("/settings/counterparty-logos", SettingsCounterpartyLogosPostHandler(a, sm))
+		r.Post("/settings/logo-dev-token", SettingsLogoDevTokenPostHandler(a, sm))
 	})
 
 	// Admin API (authenticated, JSON responses).

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -83,6 +83,10 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 	}
 	agentAvatarStyle := appconfig.String(ctx, a.Queries, appconfig.KeyAvatarAgentStyle, avatar.DefaultAgentStyle)
 
+	// Counterparty logo hotlinking (env → app_config → default) for the
+	// Appearance section's toggle + optional logo.dev publishable token.
+	counterpartyLogos, logoDevToken := a.Service.CounterpartyLogoSettings(ctx)
+
 	nextSyncTime := ""
 	if a.Scheduler != nil {
 		nextSyncTime = formatNextSync(a.Scheduler.NextRun())
@@ -113,6 +117,8 @@ func buildSettingsProps(a *app.App, r *http.Request) (pages.SettingsProps, map[s
 		AvatarUserStyle:      userAvatarStyle,
 		AvatarAgentStyle:     agentAvatarStyle,
 		AvatarStyles:         avatar.AvailableStyles,
+		CounterpartyLogos:    counterpartyLogos,
+		LogoDevToken:         logoDevToken,
 	}
 	if a.VersionChecker != nil {
 		if updateAvailable, latest, err := a.VersionChecker.CheckForUpdate(ctx); err == nil && updateAvailable != nil && *updateAvailable && latest != nil {
@@ -283,6 +289,48 @@ func SettingsAvatarStylePostHandler(a *app.App, sm *scs.SessionManager) http.Han
 
 		SetFlash(ctx, sm, "success", label+" updated.")
 		http.Redirect(w, r, "/settings/general", http.StatusSeeOther)
+	}
+}
+
+// SettingsCounterpartyLogosPostHandler serves POST /settings/counterparty-logos
+// — the auto-save toggle for hotlinking brand logos from logo.dev onto
+// counterparty avatars. An unchecked checkbox omits the field, so absence = off.
+// Returns 204 (the auto-save form shows its own toast).
+func SettingsCounterpartyLogosPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		enabled := r.FormValue("counterparty_logos") == "true"
+		val := "false"
+		if enabled {
+			val = "true"
+		}
+		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+			Key:   appconfig.KeyCounterpartyLogos,
+			Value: pgconv.Text(val),
+		}); err != nil {
+			a.Logger.Error("save counterparty logos toggle", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// SettingsLogoDevTokenPostHandler serves POST /settings/logo-dev-token — the
+// auto-save input for the optional logo.dev publishable key appended to
+// hotlinked logo URLs. The key is public by design (it rides in the <img src>),
+// so it's stored in plaintext. Empty clears it. Returns 204.
+func SettingsLogoDevTokenPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimSpace(r.FormValue("logo_dev_token"))
+		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+			Key:   appconfig.KeyLogoDevToken,
+			Value: pgconv.Text(token),
+		}); err != nil {
+			a.Logger.Error("save logo.dev token", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/appconfig/keys.go
+++ b/internal/appconfig/keys.go
@@ -151,6 +151,23 @@ const (
 	// Settings → Developer. The BB_ARTIFACTS_UPLOAD_TOKEN env var overrides it.
 	KeyDevModeUploadToken = "devmode.upload_token"
 
+	// KeyCounterpartyLogos toggles hotlinking real brand logos from logo.dev on
+	// counterparty rows and detail headers. "true" (the default) emits a
+	// logo.dev image URL for any counterparty with a derivable website domain
+	// (and no manual logo_url override); "false" disables the hotlink so every
+	// counterparty falls back to its gradient monogram. Precedence env →
+	// app_config → default; the BREADBOX_COUNTERPARTY_LOGOS env var overrides.
+	KeyCounterpartyLogos = "counterparty_logos"
+
+	// KeyLogoDevToken is an OPTIONAL logo.dev publishable key (pk_…) appended to
+	// hotlinked logo URLs for higher rate limits. Publishable keys are public by
+	// design — they ride in the <img src> visible in page source — so this is
+	// stored in plaintext (not AES-GCM encrypted like real secrets). Empty =
+	// unauthenticated hotlinks; logo.dev then answers 401 and the avatar
+	// degrades to the monogram. Precedence env → app_config → default; the
+	// LOGO_DEV_TOKEN env var overrides.
+	KeyLogoDevToken = "logo_dev_token"
+
 	// KeyInstanceTimezone is the IANA timezone (e.g. "America/Los_Angeles")
 	// every cron schedule — sync schedules AND agent/workflow schedules — is
 	// evaluated in, and that schedule previews are rendered in. Unset or

--- a/internal/service/counterparty_logos.go
+++ b/internal/service/counterparty_logos.go
@@ -1,0 +1,40 @@
+//go:build !lite
+
+package service
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"breadbox/internal/appconfig"
+)
+
+// CounterpartyLogoSettings resolves whether counterparty brand-logo hotlinking
+// (via logo.dev) is enabled and the optional publishable token to authenticate
+// the hotlinks, honoring the project-wide precedence env → app_config → default:
+//
+//   - enabled: BREADBOX_COUNTERPARTY_LOGOS env ("true"/"1" on, else off) wins;
+//     otherwise the counterparty_logos app_config row; otherwise true.
+//   - token: LOGO_DEV_TOKEN env wins; otherwise the logo_dev_token app_config
+//     row; otherwise "". The token is a logo.dev publishable key (public by
+//     design — it rides in the <img src>), so it is stored in plaintext.
+//
+// The admin counterparty handlers call this once per request and hand the
+// resolved (enabled, token) to components.LogoDevURL when building each row's
+// avatar, so a single read governs the whole page.
+func (s *Service) CounterpartyLogoSettings(ctx context.Context) (enabled bool, token string) {
+	if v, ok := os.LookupEnv("BREADBOX_COUNTERPARTY_LOGOS"); ok {
+		t := strings.TrimSpace(v)
+		enabled = strings.EqualFold(t, "true") || t == "1"
+	} else {
+		enabled = appconfig.Bool(ctx, s.Queries, appconfig.KeyCounterpartyLogos, true)
+	}
+
+	if v := strings.TrimSpace(os.Getenv("LOGO_DEV_TOKEN")); v != "" {
+		token = v
+	} else {
+		token = appconfig.String(ctx, s.Queries, appconfig.KeyLogoDevToken, "")
+	}
+	return enabled, token
+}

--- a/internal/service/counterparty_logos_integration_test.go
+++ b/internal/service/counterparty_logos_integration_test.go
@@ -1,0 +1,56 @@
+//go:build integration && !lite
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/appconfig"
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+)
+
+// TestCounterpartyLogoSettings exercises the env → app_config → default
+// precedence for the counterparty logo.dev toggle + token.
+func TestCounterpartyLogoSettings(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Default (no env, no DB row): enabled, no token.
+	if enabled, token := svc.CounterpartyLogoSettings(ctx); !enabled || token != "" {
+		t.Fatalf("default = (%v, %q), want (true, \"\")", enabled, token)
+	}
+
+	// app_config disables + sets a token.
+	mustSet := func(key, val string) {
+		t.Helper()
+		if err := queries.SetAppConfig(ctx, db.SetAppConfigParams{Key: key, Value: pgconv.Text(val)}); err != nil {
+			t.Fatalf("SetAppConfig(%s): %v", key, err)
+		}
+	}
+	mustSet(appconfig.KeyCounterpartyLogos, "false")
+	mustSet(appconfig.KeyLogoDevToken, "pk_db_token")
+
+	if enabled, token := svc.CounterpartyLogoSettings(ctx); enabled || token != "pk_db_token" {
+		t.Fatalf("db = (%v, %q), want (false, \"pk_db_token\")", enabled, token)
+	}
+
+	// Re-enable via app_config.
+	mustSet(appconfig.KeyCounterpartyLogos, "true")
+	if enabled, _ := svc.CounterpartyLogoSettings(ctx); !enabled {
+		t.Fatalf("db re-enable = %v, want true", enabled)
+	}
+
+	// Env overrides app_config (both directions).
+	t.Setenv("BREADBOX_COUNTERPARTY_LOGOS", "false")
+	t.Setenv("LOGO_DEV_TOKEN", "pk_env_token")
+	if enabled, token := svc.CounterpartyLogoSettings(ctx); enabled || token != "pk_env_token" {
+		t.Fatalf("env = (%v, %q), want (false, \"pk_env_token\")", enabled, token)
+	}
+
+	t.Setenv("BREADBOX_COUNTERPARTY_LOGOS", "1")
+	if enabled, _ := svc.CounterpartyLogoSettings(ctx); !enabled {
+		t.Fatalf("env=1 = %v, want true", enabled)
+	}
+}

--- a/internal/templates/components/entity_avatar.go
+++ b/internal/templates/components/entity_avatar.go
@@ -48,8 +48,16 @@ type EntityAvatarProps struct {
 	// Name drives the monogram letters and, when Seed is empty, the monogram's
 	// deterministic gradient hue. Also used as the image alt text.
 	Name string
-	// ImageURL, when set, renders the image shape (a counterparty logo).
+	// ImageURL, when set, renders the image shape (a counterparty's manual
+	// logo_url override) — top precedence, no monogram fallback.
 	ImageURL string
+	// LogoDevURL, when set (and ImageURL is empty), renders a hotlinked
+	// logo.dev brand logo OVER the gradient monogram: the image covers the
+	// monogram on load and removes itself on error (unknown domain / no token /
+	// network), so the tile degrades gracefully to the monogram and never shows
+	// a broken image. Build it with LogoDevURL(websiteURL, token). Counterparty
+	// surfaces only — series pass an Icon instead.
+	LogoDevURL string
 	// Icon, when set (and ImageURL is empty), renders the tinted-icon shape — a
 	// lucide glyph name (a series type glyph).
 	Icon string

--- a/internal/templates/components/entity_avatar.templ
+++ b/internal/templates/components/entity_avatar.templ
@@ -8,6 +8,23 @@ templ EntityAvatar(p EntityAvatarProps) {
 		<div class={ entityAvatarTileClass(p.Size, p.Class) + " bg-base-200" }>
 			<img src={ p.ImageURL } alt={ p.Name } class="w-full h-full object-contain" loading="lazy"/>
 		</div>
+	} else if p.LogoDevURL != "" {
+		<!-- Hotlinked logo.dev brand logo over the gradient monogram: the image
+		     covers the monogram on load and self-removes on error (unknown
+		     domain / no token / network), revealing the monogram underneath. -->
+		<div
+			class={ entityAvatarTileClass(p.Size, p.Class) + " bb-entity-avatar--mono relative" }
+			style={ entityAvatarHueStyle(entityAvatarSeed(p)) }
+		>
+			<span class={ entityAvatarLetterClass(p.Size, len(entityAvatarLetters(p.Name)) > 1) } aria-hidden="true">{ entityAvatarLetters(p.Name) }</span>
+			<img
+				src={ p.LogoDevURL }
+				alt={ p.Name }
+				class="absolute inset-0 w-full h-full object-contain bg-base-200"
+				loading="lazy"
+				onerror="this.remove()"
+			/>
+		</div>
 	} else if p.Icon != "" {
 		<div class={ entityAvatarTileClass(p.Size, p.Class), entityAvatarToneClass(p.Tone) }>
 			@LucideIcon(p.Icon, entityAvatarIconClass(p.Size))

--- a/internal/templates/components/logo_dev.go
+++ b/internal/templates/components/logo_dev.go
@@ -1,0 +1,81 @@
+//go:build !headless && !lite
+
+package components
+
+import (
+	"net/url"
+	"strings"
+)
+
+// logo.dev hotlinking — turn a counterparty's website into a brand-logo image
+// URL served by the free https://img.logo.dev/{domain} API. The image rides in
+// the avatar's <img src> and degrades to the gradient monogram (via the img's
+// onerror) when logo.dev has no logo for the domain or no token is configured.
+//
+// The verified endpoint shape (curled against the public API):
+//
+//	https://img.logo.dev/{domain}?size=128&format=png&retina=true&fallback=404[&token=pk_…]
+//
+//   - A publishable token is required for a real logo; without it logo.dev
+//     answers 401 (→ onerror → monogram). The token is therefore appended only
+//     when configured, and the whole feature still degrades gracefully unset.
+//   - fallback=404 makes UNKNOWN domains answer 404 rather than logo.dev's own
+//     generic monogram, so an unknown counterparty degrades to *our* branded
+//     gradient monogram instead of a foreign placeholder.
+//   - size=128 + retina=true asks for a crisp 2× tile; the avatar renders it
+//     object-contain at 36–40px.
+
+const logoDevHost = "https://img.logo.dev/"
+
+// LogoDevDomain derives the registrable host to hand logo.dev from a
+// counterparty website URL: it strips the scheme, any leading "www.", the path,
+// and the port, and lower-cases the result. A blank input, a host with no dot
+// (e.g. "localhost", a bare word), or an unparseable URL all return "" — the
+// caller then emits no logo.dev URL and the avatar shows its monogram.
+//
+//	""                              → ""
+//	"https://www.amazon.com/foo"    → "amazon.com"
+//	"amazon.com"                    → "amazon.com"
+//	"HTTP://Netflix.com"            → "netflix.com"
+//	"https://shop.example.co.uk:8080" → "shop.example.co.uk"  (non-www subdomain kept)
+func LogoDevDomain(websiteURL string) string {
+	raw := strings.TrimSpace(websiteURL)
+	if raw == "" {
+		return ""
+	}
+	// url.Parse only finds a Host when a scheme (or "//") is present; a bare
+	// "amazon.com" parses entirely into Path. Prepend a scheme when none is
+	// present so Hostname() resolves consistently.
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	host = strings.TrimPrefix(host, "www.")
+	// Require a dotted domain — a single label ("localhost", "amazon") is not a
+	// hotlinkable brand domain.
+	if host == "" || !strings.Contains(host, ".") {
+		return ""
+	}
+	return host
+}
+
+// LogoDevURL builds the logo.dev hotlink image URL for a counterparty website,
+// or "" when no registrable domain can be derived (→ the avatar renders its
+// monogram). token is appended only when non-empty.
+func LogoDevURL(websiteURL, token string) string {
+	domain := LogoDevDomain(websiteURL)
+	if domain == "" {
+		return ""
+	}
+	// Built by hand (rather than url.Values.Encode, which sorts keys) so the
+	// query order is stable and readable in page source, with token last.
+	u := logoDevHost + domain + "?size=128&format=png&retina=true&fallback=404"
+	if t := strings.TrimSpace(token); t != "" {
+		u += "&token=" + url.QueryEscape(t)
+	}
+	return u
+}

--- a/internal/templates/components/logo_dev_test.go
+++ b/internal/templates/components/logo_dev_test.go
@@ -1,0 +1,71 @@
+//go:build !headless && !lite
+
+package components
+
+import "testing"
+
+func TestLogoDevDomain(t *testing.T) {
+	cases := map[string]string{
+		"":                                   "",
+		"   ":                                "",
+		"amazon.com":                         "amazon.com",
+		"https://amazon.com":                 "amazon.com",
+		"https://www.amazon.com":             "amazon.com",
+		"https://www.amazon.com/foo/bar?x=1": "amazon.com",
+		"http://www.amazon.com":              "amazon.com",
+		"HTTP://Netflix.com":                 "netflix.com",
+		"www.netflix.com":                    "netflix.com",
+		// Non-www subdomains are kept (only a leading www. is stripped).
+		"https://shop.example.co.uk":      "shop.example.co.uk",
+		"https://shop.example.co.uk:8080": "shop.example.co.uk",
+		"sub.domain.example.com":          "sub.domain.example.com",
+		// Single-label / non-domains → no hotlink.
+		"localhost":         "",
+		"amazon":            "",
+		"http://localhost":  "",
+		"https://localhost": "",
+		// Stripping "www." from "www.co" leaves "co" (no dot) → rejected.
+		"www.co":     "",
+		"ftp://x.io": "x.io",
+	}
+
+	for in, want := range cases {
+		if got := LogoDevDomain(in); got != want {
+			t.Errorf("LogoDevDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLogoDevURL(t *testing.T) {
+	const base = "https://img.logo.dev/amazon.com?size=128&format=png&retina=true&fallback=404"
+
+	// No website → no URL (avatar shows monogram).
+	if got := LogoDevURL("", "pk_x"); got != "" {
+		t.Errorf("LogoDevURL(empty) = %q, want \"\"", got)
+	}
+	// A non-domain → no URL.
+	if got := LogoDevURL("localhost", "pk_x"); got != "" {
+		t.Errorf("LogoDevURL(localhost) = %q, want \"\"", got)
+	}
+
+	// No token → bare URL (logo.dev 401s → onerror → monogram, by design).
+	if got := LogoDevURL("https://www.amazon.com/cart", ""); got != base {
+		t.Errorf("LogoDevURL(no token) = %q, want %q", got, base)
+	}
+
+	// Token present → appended last, URL-escaped.
+	wantTok := base + "&token=pk_live_123"
+	if got := LogoDevURL("amazon.com", "pk_live_123"); got != wantTok {
+		t.Errorf("LogoDevURL(token) = %q, want %q", got, wantTok)
+	}
+
+	// A token with reserved characters is query-escaped.
+	if got := LogoDevURL("amazon.com", "a b&c"); got != base+"&token=a+b%26c" {
+		t.Errorf("LogoDevURL(escaped token) = %q", got)
+	}
+
+	// Whitespace-only token is treated as absent.
+	if got := LogoDevURL("amazon.com", "   "); got != base {
+		t.Errorf("LogoDevURL(blank token) = %q, want %q", got, base)
+	}
+}

--- a/internal/templates/components/pages/counterparties.templ
+++ b/internal/templates/components/pages/counterparties.templ
@@ -63,10 +63,11 @@ templ counterpartiesListRow(c CounterpartyRow) {
 			aria-label={ "Open counterparty " + c.Name }
 		>
 			@components.EntityAvatar(components.EntityAvatarProps{
-				Name:     c.Name,
-				ImageURL: c.LogoURL,
-				Seed:     c.ShortID,
-				Size:     components.EntityAvatarSizeMD,
+				Name:       c.Name,
+				ImageURL:   c.LogoURL,
+				LogoDevURL: c.LogoDevURL,
+				Seed:       c.ShortID,
+				Size:       components.EntityAvatarSizeMD,
 			})
 			<div class="min-w-0">
 				<div class="flex items-center gap-2 min-w-0">
@@ -211,10 +212,11 @@ templ CounterpartyForm(p CounterpartyFormProps) {
 // matches the list.
 templ counterpartyHeaderIcon(c CounterpartyRow) {
 	@components.EntityAvatar(components.EntityAvatarProps{
-		Name:     c.Name,
-		ImageURL: c.LogoURL,
-		Seed:     c.ShortID,
-		Class:    "w-full h-full",
+		Name:       c.Name,
+		ImageURL:   c.LogoURL,
+		LogoDevURL: c.LogoDevURL,
+		Seed:       c.ShortID,
+		Class:      "w-full h-full",
 	})
 }
 

--- a/internal/templates/components/pages/counterparties_types.go
+++ b/internal/templates/components/pages/counterparties_types.go
@@ -26,7 +26,8 @@ type CounterpartiesListProps struct {
 type CounterpartyRow struct {
 	ShortID            string
 	Name               string
-	LogoURL            string // optional logo image on the row/header (logo_url)
+	LogoURL            string // manual logo image on the row/header (logo_url) — top precedence
+	LogoDevURL         string // hotlinked logo.dev brand logo (derived from website_url) — used only when LogoURL is unset and logos are enabled; degrades to the monogram on error
 	Category           string // resolved display name of the default category, "" when unset
 	MemberCount        int    // linked live charges
 	GoverningRuleCount int    // assign_counterparty rules that define membership

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -27,6 +27,7 @@ templ SettingsGeneral(p SettingsProps) {
 		<div>
 			@settingsSyncSection(p)
 			@settingsAppearanceSection()
+			@settingsCounterpartiesSection(p)
 			@settingsAvatarsSection(p)
 			@settingsSyncLogsSection(p)
 		</div>
@@ -54,6 +55,52 @@ templ settingsAppearanceSection() {
 			Caption: "System follows your OS light/dark setting",
 		}) {
 			@components.ThemeControl()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+// General — Counterparties (brand logos)
+// ---------------------------------------------------------------------
+
+// settingsCounterpartiesSection toggles hotlinking real brand logos from
+// logo.dev onto counterparty rows and headers. When on, every counterparty
+// with a website (and no manual logo) shows its brand logo, hotlinked at render
+// time from img.logo.dev — the domain is sent to logo.dev on each render. When
+// off (or when logo.dev has no logo), the counterparty falls back to its
+// gradient monogram. The optional publishable token lifts rate limits; it's a
+// public key (it rides in the image URL), so it's shown in the clear. Both
+// controls auto-save on change.
+templ settingsCounterpartiesSection(p SettingsProps) {
+	@components.SettingsSection(components.SettingsSectionProps{
+		Icon:    "store",
+		Title:   "Counterparties",
+		Caption: "Brand logos for merchants and other counterparties",
+	}) {
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "Counterparty logos",
+			Caption: "Hotlink brand logos from logo.dev (the domain is sent to logo.dev on render); falls back to a monogram",
+		}) {
+			@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
+				Action:    "/settings/counterparty-logos",
+				CSRFToken: p.CSRFToken,
+				Label:     "Counterparty logos saved",
+			}) {
+				<input type="checkbox" name="counterparty_logos" value="true" class="toggle toggle-sm toggle-primary" checked?={ p.CounterpartyLogos } aria-label="Enable counterparty brand logos"/>
+			}
+		}
+		@components.SettingsRow(components.SettingsRowProps{
+			Label:   "logo.dev token",
+			Caption: "Optional publishable key (pk_…) for higher rate limits — public by design",
+			Stack:   true,
+		}) {
+			@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
+				Action:    "/settings/logo-dev-token",
+				CSRFToken: p.CSRFToken,
+				Label:     "logo.dev token saved",
+			}) {
+				<input type="text" name="logo_dev_token" value={ p.LogoDevToken } placeholder="pk_… (optional)" autocomplete="off" spellcheck="false" class="input input-sm w-full font-mono" aria-label="logo.dev publishable token"/>
+			}
 		}
 	}
 }

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -79,7 +79,7 @@ templ settingsCounterpartiesSection(p SettingsProps) {
 	}) {
 		@components.SettingsRow(components.SettingsRowProps{
 			Label:   "Counterparty logos",
-			Caption: "Hotlink brand logos from logo.dev (the domain is sent to logo.dev on render); falls back to a monogram",
+			Caption: "Hotlink brand logos from logo.dev (the domain is sent to logo.dev on render); needs a token below, else falls back to a monogram",
 		}) {
 			@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
 				Action:    "/settings/counterparty-logos",
@@ -91,7 +91,7 @@ templ settingsCounterpartiesSection(p SettingsProps) {
 		}
 		@components.SettingsRow(components.SettingsRowProps{
 			Label:   "logo.dev token",
-			Caption: "Optional publishable key (pk_…) for higher rate limits — public by design",
+			Caption: "Publishable key (pk_…) — required for logos to appear. Get a free token at logo.dev. Public by design.",
 			Stack:   true,
 		}) {
 			@components.SettingsAutoSaveForm(components.SettingsAutoSaveFormProps{
@@ -99,7 +99,7 @@ templ settingsCounterpartiesSection(p SettingsProps) {
 				CSRFToken: p.CSRFToken,
 				Label:     "logo.dev token saved",
 			}) {
-				<input type="text" name="logo_dev_token" value={ p.LogoDevToken } placeholder="pk_… (optional)" autocomplete="off" spellcheck="false" class="input input-sm w-full font-mono" aria-label="logo.dev publishable token"/>
+				<input type="text" name="logo_dev_token" value={ p.LogoDevToken } placeholder="pk_… (paste to enable logos)" autocomplete="off" spellcheck="false" class="input input-sm w-full font-mono" aria-label="logo.dev publishable token"/>
 			}
 		}
 	}

--- a/internal/templates/components/pages/settings_types.go
+++ b/internal/templates/components/pages/settings_types.go
@@ -82,4 +82,11 @@ type SettingsProps struct {
 	AvatarUserStyle  string
 	AvatarAgentStyle string
 	AvatarStyles     []avatar.StyleOption
+
+	// CounterpartyLogos toggles hotlinking real brand logos from logo.dev on
+	// counterparty rows/headers (default on). LogoDevToken is the optional
+	// logo.dev publishable key (pk_…) for higher rate limits — public by design,
+	// so it's shown in the clear.
+	CounterpartyLogos bool
+	LogoDevToken      string
 }


### PR DESCRIPTION
Counterparty avatars now show real brand logos, **hotlinked** from the [logo.dev](https://logo.dev) image API, degrading to the gradient monogram (#1898's `EntityAvatar`) whenever logo.dev has no logo or the feature is unconfigured — never a broken image. Hotlink, not fetch-and-store (per the user's choice).

## Verified logo.dev endpoint

I curled the API to settle the exact shape:

| Request | Result |
|---|---|
| `https://img.logo.dev/stripe.com` (no token) | **401** `application/json` |
| `https://img.logo.dev/stripe.com?token={pk}&size=128&format=png&retina=true` | **200** `image/png` (2999 B) |
| `https://img.logo.dev/amazon.com?token={pk}&...` | **200** `image/png` (9631 B) |
| unknown domain + default fallback | 202 logo.dev placeholder PNG |
| unknown domain + `&fallback=404` | **404** → `onerror` → our monogram |

**A publishable token is mandatory** (there is no free no-token image endpoint — `logo.dev/api/image?domain=` just 308-redirects). The feature is therefore **token-gated**: the chosen URL shape is
`https://img.logo.dev/{domain}?token={pk}&size=128&format=png&retina=true&fallback=404`,
and `fallback=404` makes unknown domains degrade to *our* gradient monogram (not logo.dev's placeholder).

## Resolution chain (per avatar)

**explicit `logo_url` (manual override)** → **(`counterparty_logos` enabled + `logo_dev_token` set + derivable domain) logo.dev hotlink** → **gradient monogram**

- Domain derivation: strip scheme + leading `www.`, drop path/port, lower-case; single-label hosts (`localhost`, bare words) are rejected → monogram.
- The logo.dev `<img>` renders over the monogram and self-removes on `onerror` (404/network), revealing the monogram — never a broken image.
- Series are unaffected (type-tinted icon tiles).

## Config & toggle (env → app_config → default)

- `counterparty_logos` (bool, default **true**) — `BREADBOX_COUNTERPARTY_LOGOS` env overrides.
- `logo_dev_token` (string, optional, **required for logos to appear**) — `LOGO_DEV_TOKEN` env overrides. A publishable key is public by design (rides in the `<img src>`), so it's stored in plaintext.
- **Settings → General → Counterparties**: an auto-save toggle + a token text input ("required for logos to appear. Get a free token at logo.dev"). Default state (no token) = monograms everywhere — correct and complete.

## Privacy / docs

`docs/data-model.md` documents the keys + a privacy note: the counterparty **domain is sent to logo.dev on render**; the toggle disables hotlinking (no request leaves the browser); self-hosted single-household use is exempt from logo.dev's commercial link-back attribution.

## Verification — all build tags green

```
go build ./...                 ✅
go build -tags=lite ./...      ✅
go build -tags=headless ./...  ✅
go vet ./...                   ✅
go test ./...                  ✅ (only flaky agent timing test, passes alone)
make test-integration (touched): TestCounterpartyLogoSettings (env→db→default) ✅
```

New tests: domain-derivation + URL builder unit tests (`internal/templates/components/logo_dev_test.go`); the token-gate (`internal/admin/counterparties_logo_test.go` — token present/absent, toggle off, manual override, no/bad domain); config-precedence integration test (`internal/service/counterparty_logos_integration_test.go`).

`internal/templates/components/entity_avatar.go` and the new helper carry `//go:build !headless && !lite` (the #1898 lesson).

## Screenshot

Throwaway DB (`breadbox_logodev`, migrated separately — the shared dev DB was never touched), seeded with branded + website-less counterparties and logo.dev's own published demo key so real logos render (not faked):

**/counterparties** — Amazon / Netflix / Spotify / Stripe / GitHub show brand logos; "Local Coffee Co" (LC) and "The Babysitter" (TB) show gradient monograms:

![counterparties](https://bb-artifacts.exe.xyz/f/d83b99003c6cf849.png)

**Settings → General → Counterparties** — toggle + token control:

![settings](https://bb-artifacts.exe.xyz/f/333c2ac36a150c68.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
