### PR TITLE
(beyond-roadmap) fix(rules): legible action icon + summary for all action types in the rules list

### DIFF
--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -3156,6 +3156,16 @@ func ActionsSummary(actions []RuleAction, categoryName string) string {
 		return "Flag for attention"
 	case "unflag":
 		return "Clear flag"
+	case "set_metadata":
+		if a.MetadataKey != "" {
+			return "Set metadata: " + a.MetadataKey
+		}
+		return "Set metadata"
+	case "remove_metadata":
+		if a.MetadataKey != "" {
+			return "Remove metadata: " + a.MetadataKey
+		}
+		return "Remove metadata"
 	default:
 		return a.Type
 	}

--- a/internal/service/rules_test.go
+++ b/internal/service/rules_test.go
@@ -422,6 +422,51 @@ func TestActionsSummary(t *testing.T) {
 			expected: "Add comment",
 		},
 		{
+			name:     "single remove_tag",
+			actions:  []RuleAction{{Type: "remove_tag", TagSlug: "needs-review"}},
+			expected: "Remove tag needs-review",
+		},
+		{
+			name:     "single assign_series",
+			actions:  []RuleAction{{Type: "assign_series", SeriesName: "Netflix"}},
+			expected: "Assign to series",
+		},
+		{
+			name:     "single assign_counterparty",
+			actions:  []RuleAction{{Type: "assign_counterparty", CounterpartyName: "Amazon"}},
+			expected: "Assign counterparty",
+		},
+		{
+			name:     "single flag",
+			actions:  []RuleAction{{Type: "flag"}},
+			expected: "Flag for attention",
+		},
+		{
+			name:     "single unflag",
+			actions:  []RuleAction{{Type: "unflag"}},
+			expected: "Clear flag",
+		},
+		{
+			name:     "single set_metadata with key",
+			actions:  []RuleAction{{Type: "set_metadata", MetadataKey: "tax_deductible", MetadataValue: true}},
+			expected: "Set metadata: tax_deductible",
+		},
+		{
+			name:     "single set_metadata without key",
+			actions:  []RuleAction{{Type: "set_metadata"}},
+			expected: "Set metadata",
+		},
+		{
+			name:     "single remove_metadata with key",
+			actions:  []RuleAction{{Type: "remove_metadata", MetadataKey: "tax_deductible"}},
+			expected: "Remove metadata: tax_deductible",
+		},
+		{
+			name:     "single remove_metadata without key",
+			actions:  []RuleAction{{Type: "remove_metadata"}},
+			expected: "Remove metadata",
+		},
+		{
 			name: "multiple actions returns count",
 			actions: []RuleAction{
 				{Type: "set_category", CategorySlug: "x"},

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -230,6 +230,75 @@ templ ruleDetailActionRow(p RuleDetailProps, a service.RuleAction) {
 					<p class="text-sm">Add comment</p>
 					<p class="text-xs text-base-content/60 mt-0.5 italic">{ "“" + a.Content + "”" }</p>
 				</div>
+			case "assign_series":
+				<div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+					@components.LucideIcon("repeat", "w-4 h-4 text-primary")
+				</div>
+				<div class="flex-1 min-w-0">
+					if ruleActionEntityName(a) != "" {
+						<p class="text-sm">Assign to series <span class="font-semibold">{ ruleActionEntityName(a) }</span></p>
+					} else {
+						<p class="text-sm">Assign to series</p>
+					}
+					<p class="text-xs text-base-content/40">Matching transactions are linked to the series during sync.</p>
+				</div>
+			case "assign_counterparty":
+				<div class="w-8 h-8 rounded-lg bg-secondary/10 flex items-center justify-center shrink-0">
+					@components.LucideIcon("store", "w-4 h-4 text-secondary")
+				</div>
+				<div class="flex-1 min-w-0">
+					if ruleActionEntityName(a) != "" {
+						<p class="text-sm">Assign to counterparty <span class="font-semibold">{ ruleActionEntityName(a) }</span></p>
+					} else {
+						<p class="text-sm">Assign to counterparty</p>
+					}
+					<p class="text-xs text-base-content/40">Matching transactions are bound to the counterparty during sync.</p>
+				</div>
+			case "flag":
+				<div class="w-8 h-8 rounded-lg bg-warning/10 flex items-center justify-center shrink-0">
+					@components.LucideIcon("flag", "w-4 h-4 text-warning")
+				</div>
+				<div class="flex-1 min-w-0">
+					<p class="text-sm">Flag for attention</p>
+					<p class="text-xs text-base-content/40">Surfaces matching transactions via the flagged filter.</p>
+				</div>
+			case "unflag":
+				<div class="w-8 h-8 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+					@components.LucideIcon("flag-off", "w-4 h-4 text-base-content opacity-40")
+				</div>
+				<div class="flex-1 min-w-0">
+					<p class="text-sm">Clear flag</p>
+					<p class="text-xs text-base-content/40">Clears the flag on matching transactions.</p>
+				</div>
+			case "set_metadata":
+				<div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
+					@components.LucideIcon("braces", "w-4 h-4 text-info")
+				</div>
+				<div class="flex-1 min-w-0">
+					<p class="text-sm">
+						Set metadata
+						if a.MetadataKey != "" {
+							<span class="font-semibold">{ a.MetadataKey }</span>
+						}
+						if ruleMetadataValueText(a) != "" {
+							= <span class="font-semibold">{ ruleMetadataValueText(a) }</span>
+						}
+					</p>
+					<p class="text-xs text-base-content/40">Upserts one metadata key on matching transactions.</p>
+				</div>
+			case "remove_metadata":
+				<div class="w-8 h-8 rounded-lg bg-error/10 flex items-center justify-center shrink-0">
+					@components.LucideIcon("braces", "w-4 h-4 text-error")
+				</div>
+				<div class="flex-1 min-w-0">
+					<p class="text-sm">
+						Remove metadata
+						if a.MetadataKey != "" {
+							<span class="font-semibold">{ a.MetadataKey }</span>
+						}
+					</p>
+					<p class="text-xs text-base-content/40">Deletes one metadata key from matching transactions.</p>
+				</div>
 			default:
 				<div class="w-8 h-8 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
 					@components.LucideIcon("settings", "w-4 h-4 text-base-content opacity-40")

--- a/internal/templates/components/pages/rule_detail_types.go
+++ b/internal/templates/components/pages/rule_detail_types.go
@@ -4,6 +4,7 @@ package pages
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"breadbox/internal/service"
@@ -26,8 +27,8 @@ type RuleDetailProps struct {
 	ActionCategoryName  string
 	Categories          []service.CategoryResponse
 	// LastActiveTime is the parsed last_hit_at; zero value means "never".
-	LastActiveTime time.Time
-	HasLastActive  bool
+	LastActiveTime   time.Time
+	HasLastActive    bool
 	ConditionSummary string
 	// ConditionRows is the pre-formatted list of ConditionRowProps the handler
 	// computes for non-match-all rules. Empty when the rule matches everything
@@ -244,4 +245,33 @@ func syncHistoryHitCount(h map[string]any) int {
 		return int(v)
 	}
 	return 0
+}
+
+// ruleActionEntityName returns the human display name for an assign_series /
+// assign_counterparty action — the by-name value when the rule mints/binds by
+// name, otherwise the short ID it targets, otherwise "". Used by the rule
+// detail "Then" card so surrogate-first actions read legibly.
+func ruleActionEntityName(a service.RuleAction) string {
+	switch a.Type {
+	case "assign_series":
+		if n := strings.TrimSpace(a.SeriesName); n != "" {
+			return n
+		}
+		return strings.TrimSpace(a.SeriesShortID)
+	case "assign_counterparty":
+		if n := strings.TrimSpace(a.CounterpartyName); n != "" {
+			return n
+		}
+		return strings.TrimSpace(a.CounterpartyShortID)
+	}
+	return ""
+}
+
+// ruleMetadataValueText renders a set_metadata action's value for display.
+// Returns "" when there is no value so the caller can omit the "= value" tail.
+func ruleMetadataValueText(a service.RuleAction) string {
+	if a.MetadataValue == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", a.MetadataValue)
 }

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -460,6 +460,14 @@ func rulesActionIcon(r RulesRow) string {
 		return "message-square"
 	case "assign_series":
 		return "repeat"
+	case "assign_counterparty":
+		return "store"
+	case "flag":
+		return "flag"
+	case "unflag":
+		return "flag-off"
+	case "set_metadata", "remove_metadata":
+		return "braces"
 	default:
 		return "layers"
 	}

--- a/internal/templates/components/pages/rules_types.go
+++ b/internal/templates/components/pages/rules_types.go
@@ -31,8 +31,8 @@ type RulesProps struct {
 
 	// Filter state — driven by query params, echoed back so the toolbar
 	// shows the active filter. Empty string == no filter for that dim.
-	Search       string
-	CategorySlug string
+	Search        string
+	CategorySlug  string
 	EnabledFilter string // "", "true", "false"
 	CreatorType   string // "", "user", "agent", "system"
 
@@ -58,13 +58,13 @@ type RulesCategoryOption struct {
 // that need helper logic (relative time, condition counts, expired flag)
 // so the templ stays free of funcMap shims.
 type RulesRow struct {
-	ID         string
-	Name       string
-	Enabled    bool
-	IsSystem   bool
-	HitCount   int
-	Priority   int
-	LastHitAt  *string // RFC3339; rendered via LastHitAtRelative
+	ID                string
+	Name              string
+	Enabled           bool
+	IsSystem          bool
+	HitCount          int
+	Priority          int
+	LastHitAt         *string // RFC3339; rendered via LastHitAtRelative
 	LastHitAtRelative string
 
 	// Creator identity — drives the agent avatar on agent-authored rows
@@ -82,14 +82,16 @@ type RulesRow struct {
 
 	// Conditions/actions surface counts + summaries; the row only needs
 	// the scalar derivatives.
-	ConditionCount  int
-	IsMatchAll      bool
+	ConditionCount   int
+	IsMatchAll       bool
 	ConditionSummary string
-	ActionsCount    int
-	ActionsSummary  string
+	ActionsCount     int
+	ActionsSummary   string
 	// PrimaryActionType is the single action's type ("set_category",
-	// "add_tag", "remove_tag", "add_comment", "assign_series") when the
-	// rule has exactly one action; "" when it has zero or multiple actions.
+	// "add_tag", "remove_tag", "add_comment", "assign_series",
+	// "assign_counterparty", "flag", "unflag", "set_metadata",
+	// "remove_metadata") when the rule has exactly one action; "" when it
+	// has zero or multiple actions.
 	// Drives the Action-column icon so the column reflects what the rule
 	// *does*, not just whether it sets a category.
 	PrimaryActionType string


### PR DESCRIPTION
Display-only legibility fix for the rules-as-universal-substrate sprint: the `/rules` list and the rule-detail page now summarize **every** action type with a meaningful icon + text, not just the original five.

## The gap

`rulesActionIcon` (rules list) only mapped `set_category` / `add_tag` / `remove_tag` / `add_comment` / `assign_series`. Every other action type — `assign_counterparty`, `flag`, `unflag`, `set_metadata`, `remove_metadata` (all added this sprint) — fell through to a generic **"layers"** icon. The rule-detail "Then" card was worse: anything outside the original four rendered as **"Unknown action type"**.

## Fix (icons + summary text only — no engine/semantics change)

### Action → icon / label mapping added

| Action type | List icon | Detail icon | Summary text |
|---|---|---|---|
| `assign_counterparty` | `store` | `store` | "Assign counterparty" *(already covered)* |
| `flag` | `flag` | `flag` | "Flag for attention" *(already covered)* |
| `unflag` | `flag-off` | `flag-off` | "Clear flag" *(already covered)* |
| `set_metadata` | `braces` | `braces` | **"Set metadata: {key}"** *(new)* |
| `remove_metadata` | `braces` | `braces` | **"Remove metadata: {key}"** *(new)* |
| `assign_series` | `repeat` *(existing)* | `repeat` *(new detail row)* | "Assign to series" |

Icons match existing usage: `store` = Counterparties nav + EntityAvatar; `flag` / `flag-off` = the rule form's flag/unflag action hints; `braces` = the JSON/key-value icon used on `/settings/connectors`.

### What `service.ActionsSummary` already covered vs. what was added

`assign_counterparty`, `flag`, `unflag`, and `assign_series` were **already** labeled in `ActionsSummary`. The only gaps were `set_metadata` and `remove_metadata` — added as "Set metadata: {key}" / "Remove metadata: {key}" (key omitted when absent), consistent with the existing "Add tag {slug}" / "Set category: {name}" style.

### Files

- `internal/templates/components/pages/rules.templ` — `rulesActionIcon` cases.
- `internal/service/rules.go` — `ActionsSummary` metadata cases.
- `internal/templates/components/pages/rule_detail.templ` — full per-action "Then" rows for assign_series / assign_counterparty / flag / unflag / set_metadata / remove_metadata (was "Unknown action type").
- `internal/templates/components/pages/rule_detail_types.go` — `ruleActionEntityName` / `ruleMetadataValueText` helpers.
- `internal/templates/components/pages/rules_types.go` — `PrimaryActionType` doc comment accuracy.
- `internal/service/rules_test.go` — `TestActionsSummary` extended to every action type.

## Evidence

Seeded a throwaway DB with rules covering every action type. The list now renders the varied, meaningful icons + summaries:

![rules list with meaningful action icons](https://bb-artifacts.exe.xyz/f/82cc46b884bded21.jpeg)

### Build / vet / test — all green

```
go build ./...                  # OK
go build -tags=lite ./...       # OK
go build -tags=headless ./...   # OK
go vet ./...                    # OK
go test ./...                   # green (TestActionsSummary covers all action types)
```

(`TestSidecarRun_ConcurrentRunsNoLongerSerialize` flaked once on a loaded machine — a timing-only assertion unrelated to this change — and passed on rerun.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
