### PR TITLE
(beyond-roadmap) fix(feed): legible series/counterparty membership events in the activity feed

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -764,6 +764,19 @@ func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(str
 			if cd.Icon != nil {
 				display.Icon = *cd.Icon
 			}
+		case "series_assigned", "series_unlinked":
+			// Membership subjects carry their human name in sub.Name (the
+			// enriched Annotation.Subject) and their short_id in sub.Slug —
+			// there's no slug→display lookup to perform. Stamp the canonical
+			// app icon so the subject reads consistently with the rest of the
+			// product (series → "repeat", counterparty → "store").
+			if display.Icon == "" {
+				display.Icon = "repeat"
+			}
+		case "counterparty_assigned", "counterparty_unlinked":
+			if display.Icon == "" {
+				display.Icon = "store"
+			}
 		}
 		if display.Name == "" {
 			display.Name = sub.Slug

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -1469,6 +1469,10 @@ func bulkSubjectKey(a Annotation) string {
 		return "category:" + a.CategorySlug
 	case "rule_applied":
 		return "rule:" + a.RuleShortID
+	case "series_assigned", "series_unlinked":
+		return "series:" + annotationPayloadString(a, "series_id")
+	case "counterparty_assigned", "counterparty_unlinked":
+		return "counterparty:" + annotationPayloadString(a, "counterparty_id")
 	}
 	return ""
 }
@@ -1481,8 +1485,26 @@ func bulkSubjectSlug(a Annotation) string {
 		return a.CategorySlug
 	case "rule_applied":
 		return a.RuleShortID
+	case "series_assigned", "series_unlinked":
+		return annotationPayloadString(a, "series_id")
+	case "counterparty_assigned", "counterparty_unlinked":
+		return annotationPayloadString(a, "counterparty_id")
 	}
 	return ""
+}
+
+// annotationPayloadString reads a string field from an annotation's untyped
+// payload, returning "" when absent or not a string. The bulk-action subject
+// helpers use it to key membership events (series / counterparty) on their
+// short_id — the payload carries series_id / counterparty_id without a typed
+// field threaded through every call site. The subject *name* still comes from
+// the enriched Annotation.Subject.
+func annotationPayloadString(a Annotation, key string) string {
+	if a.Payload == nil {
+		return ""
+	}
+	s, _ := a.Payload[key].(string)
+	return s
 }
 
 // sampleTxFromRow projects a feed-activity row into the small FeedSampleTx

--- a/internal/service/feed_test.go
+++ b/internal/service/feed_test.go
@@ -130,3 +130,73 @@ func typesOf(evs []FeedEvent) []string {
 	}
 	return out
 }
+
+// TestBulkSubjectKeyMembership verifies the bulk-action dedup key + slug for
+// series / counterparty membership annotations read their short_id out of the
+// untyped payload so same-series rows collapse into one subject (mirroring how
+// category_set keys on the category slug). Without these cases the subjects
+// never group and the bucket can't render a single-subject label.
+func TestBulkSubjectKeyMembership(t *testing.T) {
+	cases := []struct {
+		name    string
+		ann     Annotation
+		wantKey string
+		wantSlug string
+	}{
+		{
+			name: "series_assigned keys on series_id",
+			ann: Annotation{
+				Kind:    "series_assigned",
+				Subject: "Netflix",
+				Payload: map[string]interface{}{"series_id": "ser123ab", "series_name": "Netflix"},
+			},
+			wantKey:  "series:ser123ab",
+			wantSlug: "ser123ab",
+		},
+		{
+			name: "series_unlinked keys on series_id",
+			ann: Annotation{
+				Kind:    "series_unlinked",
+				Payload: map[string]interface{}{"series_id": "ser123ab"},
+			},
+			wantKey:  "series:ser123ab",
+			wantSlug: "ser123ab",
+		},
+		{
+			name: "counterparty_assigned keys on counterparty_id",
+			ann: Annotation{
+				Kind:    "counterparty_assigned",
+				Payload: map[string]interface{}{"counterparty_id": "cp9988xy"},
+			},
+			wantKey:  "counterparty:cp9988xy",
+			wantSlug: "cp9988xy",
+		},
+		{
+			name: "missing payload yields empty short_id, not a panic",
+			ann: Annotation{
+				Kind: "series_assigned",
+			},
+			wantKey:  "series:",
+			wantSlug: "",
+		},
+		{
+			name: "category_set still keys on the slug (regression guard)",
+			ann: Annotation{
+				Kind:         "category_set",
+				CategorySlug: "groceries",
+			},
+			wantKey:  "category:groceries",
+			wantSlug: "groceries",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := bulkSubjectKey(c.ann); got != c.wantKey {
+				t.Errorf("bulkSubjectKey = %q, want %q", got, c.wantKey)
+			}
+			if got := bulkSubjectSlug(c.ann); got != c.wantSlug {
+				t.Errorf("bulkSubjectSlug = %q, want %q", got, c.wantSlug)
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -957,6 +957,14 @@ func feedBulkVerb(kind string) string {
 		return "categorised"
 	case "rule_applied":
 		return "ran a rule on"
+	case "series_assigned":
+		return "assigned to a series"
+	case "series_unlinked":
+		return "removed from a series"
+	case "counterparty_assigned":
+		return "assigned to a counterparty"
+	case "counterparty_unlinked":
+		return "removed from a counterparty"
 	case "comment":
 		return "commented on"
 	}
@@ -981,6 +989,10 @@ func feedBulkKindBreakdown(b *FeedBulkAction) string {
 		{"tag_added", "tag-added"},
 		{"tag_removed", "tag-removed"},
 		{"rule_applied", "rule-applied"},
+		{"series_assigned", "series-assigned"},
+		{"series_unlinked", "series-removed"},
+		{"counterparty_assigned", "counterparty-assigned"},
+		{"counterparty_unlinked", "counterparty-removed"},
 		{"comment", "commented"},
 	}
 	parts := []string{}
@@ -1015,6 +1027,14 @@ func feedBulkSubjectLabel(b *FeedBulkAction) string {
 		return "as " + name
 	case "rule_applied":
 		return "with rule " + name
+	case "series_assigned":
+		return "to the " + name + " series"
+	case "series_unlinked":
+		return "from the " + name + " series"
+	case "counterparty_assigned":
+		return "to " + name
+	case "counterparty_unlinked":
+		return "from " + name
 	}
 	return ""
 }

--- a/internal/templates/components/pages/feed_membership_test.go
+++ b/internal/templates/components/pages/feed_membership_test.go
@@ -1,0 +1,86 @@
+//go:build !headless && !lite
+
+package pages
+
+import "testing"
+
+// TestFeedBulkMembershipVerbs locks the headline verbs for series /
+// counterparty membership bulk-action buckets so they read legibly instead
+// of falling through to the generic "updated".
+func TestFeedBulkMembershipVerbs(t *testing.T) {
+	cases := map[string]string{
+		"series_assigned":       "assigned to a series",
+		"series_unlinked":       "removed from a series",
+		"counterparty_assigned": "assigned to a counterparty",
+		"counterparty_unlinked": "removed from a counterparty",
+		// regression guard: the pre-existing kinds keep their verbs.
+		"category_set": "categorised",
+		"rule_applied": "ran a rule on",
+		// unknown kinds still fall through to the generic verb.
+		"something_new": "updated",
+	}
+	for kind, want := range cases {
+		if got := feedBulkVerb(kind); got != want {
+			t.Errorf("feedBulkVerb(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+// TestFeedBulkMembershipSubjectLabel locks the single-subject phrasing for
+// membership buckets ("to the Netflix series", "to Amazon").
+func TestFeedBulkMembershipSubjectLabel(t *testing.T) {
+	cases := []struct {
+		kind string
+		name string
+		want string
+	}{
+		{"series_assigned", "Netflix", "to the Netflix series"},
+		{"series_unlinked", "Netflix", "from the Netflix series"},
+		{"counterparty_assigned", "Amazon", "to Amazon"},
+		{"counterparty_unlinked", "Amazon", "from Amazon"},
+		{"category_set", "Groceries", "as Groceries"},
+	}
+	for _, c := range cases {
+		b := &FeedBulkAction{
+			Kind:     c.kind,
+			Subjects: []FeedBulkSubject{{Name: c.name, Count: 3}},
+		}
+		if got := feedBulkSubjectLabel(b); got != c.want {
+			t.Errorf("feedBulkSubjectLabel(kind=%q name=%q) = %q, want %q", c.kind, c.name, got, c.want)
+		}
+	}
+}
+
+// TestFeedBulkKindBreakdownMembership verifies mixed-kind breakdown lines name
+// membership kinds with friendly labels instead of the raw kind string.
+func TestFeedBulkKindBreakdownMembership(t *testing.T) {
+	b := &FeedBulkAction{
+		Kind: "mixed",
+		KindCounts: map[string]int{
+			"series_assigned":       5,
+			"counterparty_assigned": 2,
+			"category_set":          3,
+		},
+	}
+	got := feedBulkKindBreakdown(b)
+	// Order is fixed: category_set first, then series, then counterparty.
+	want := "3 categorised · 5 series-assigned · 2 counterparty-assigned"
+	if got != want {
+		t.Errorf("feedBulkKindBreakdown = %q, want %q", got, want)
+	}
+	// No raw kind string should leak into the rendered breakdown.
+	for _, raw := range []string{"series_assigned", "counterparty_assigned"} {
+		if contains(got, raw) {
+			t.Errorf("breakdown %q leaked raw kind %q", got, raw)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Display-only completeness fix for the rules-as-universal-substrate sprint: render series/counterparty membership events in the home Feed as legibly as `category_set` / `rule_applied`.

## The gap (before)
Membership annotations (`series_assigned`, `series_unlinked`, `counterparty_assigned`, `counterparty_unlinked` — added this sprint) reach `/feed` (the query excludes only `sync_started`/`sync_updated`) and #1896 enriched their per-tx `Summary`, **but the feed's bulk-action rendering had no cases for them**:

- `feedBulkVerb` → fell through to the generic **"updated"** instead of "assigned to a series", etc.
- `feedBulkKindBreakdown` → the fallback loop printed the **raw kind string** ("6 series_assigned") in mixed buckets.
- `feedBulkSubjectLabel` + the service dedup/value helpers (`bulkSubjectKey`/`bulkSubjectSlug`) had no membership cases, so subjects never grouped into a single-subject label.

## What changed (display-only — no engine/schema/emission changes)

| Site | series_assigned | series_unlinked | counterparty_assigned | counterparty_unlinked |
|------|-----------------|------------------|------------------------|------------------------|
| `feedBulkVerb` (verb) | assigned to a series | removed from a series | assigned to a counterparty | removed from a counterparty |
| `feedBulkKindBreakdown` (label) | series-assigned | series-removed | counterparty-assigned | counterparty-removed |
| `feedBulkSubjectLabel` (1-subject) | to the {name} series | from the {name} series | to {name} | from {name} |
| `bulkSubjectKey` (dedup) | `series:`+short_id | `series:`+short_id | `counterparty:`+short_id | `counterparty:`+short_id |
| admin `projectFeedBulkAction` (icon) | `repeat` | `repeat` | `store` | `store` |

The subject **name** flows from the enriched `Annotation.Subject` (#1896); the dedup key reads the short_id out of the untyped payload (`series_id` / `counterparty_id`) via a small `annotationPayloadString` helper. Breakdown order is fixed so mixed buckets are stable and never leak a raw kind.

### Feed sites updated
- `internal/templates/components/pages/feed.templ` — `feedBulkVerb`, `feedBulkKindBreakdown`, `feedBulkSubjectLabel`.
- `internal/service/feed.go` — `bulkSubjectKey`, `bulkSubjectSlug` (+ `annotationPayloadString`).
- `internal/admin/feed.go` — `projectFeedBulkAction` subject switch (canonical icons).

Note: the feed renders membership rows through the **bulk_action** row, whose rail tile is the **actor avatar** (not a per-kind icon), so there is no kind→icon tile switch in the feed itself to extend; the canonical icons are stamped on the subject chip in the admin projection for consistency with the rest of the app.

## Evidence

Screenshot — `/feed` with seeded membership annotations rendering proper verbs + subject labels (no "updated", no raw kind strings):

![feed membership events](https://bb-artifacts.exe.xyz/f/cb6178ed19cf6b17.jpg)

- **Alice** → *assigned to a series* · 6 transactions · *to the Netflix series*
- **Bob** → *assigned to a counterparty* · 4 transactions · *to Amazon*

A mixed-actor seed (both kinds in one window) renders the breakdown line **"6 series-assigned · 4 counterparty-assigned"** — confirmed during validation.

### Build / vet / test (all build tags green)
```
go build ./...               # ok
go build -tags=lite ./...    # ok
go build -tags=headless ./...# ok
go vet ./...                 # ok
go test ./...                # ok (the one flaky timing test in internal/agent,
                             #     TestSidecarRun_ConcurrentRunsNoLongerSerialize,
                             #     passes on re-run — unrelated to this change)
```

New tests: `TestFeedBulkMembershipVerbs`, `TestFeedBulkMembershipSubjectLabel`, `TestFeedBulkKindBreakdownMembership` (pages), `TestBulkSubjectKeyMembership` (service) — cover all four kinds, a missing-payload guard, and a `category_set` regression guard.

Screenshot was produced against a **throwaway** `breadbox_feedkinds` DB (created, migrated, seeded, dropped); the shared dev `breadbox` DB was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
