### PR TITLE
(beyond-roadmap) fix(counterparties): make logo.dev logo source discoverable on the enrichment form

### DIFF
--- a/internal/templates/components/pages/counterparties.templ
+++ b/internal/templates/components/pages/counterparties.templ
@@ -152,10 +152,10 @@ templ CounterpartyDetail(p CounterpartyDetailProps) {
 					@components.SettingsRow(components.SettingsRowProps{Label: "MCC", Caption: "Merchant category code (4 digits)"}) {
 						<input type="text" name="mcc" value={ p.MCC } inputmode="numeric" maxlength="4" placeholder="e.g. 5411" class="input input-sm w-32" aria-label="MCC"/>
 					}
-					@components.SettingsRow(components.SettingsRowProps{Label: "Website", Stack: true}) {
+					@components.SettingsRow(components.SettingsRowProps{Label: "Website", Caption: "Its domain auto-fetches a brand logo via logo.dev when counterparty logos are enabled and a logo.dev token is set in Settings", Stack: true}) {
 						<input type="url" name="website_url" value={ p.WebsiteURL } placeholder="https://example.com" class="input input-sm w-full" aria-label="Website URL"/>
 					}
-					@components.SettingsRow(components.SettingsRowProps{Label: "Logo URL", Caption: "Image hotlinked on counterparty rows", Stack: true}) {
+					@components.SettingsRow(components.SettingsRowProps{Label: "Logo URL", Caption: "Overrides the auto-fetched logo. Hotlinked on counterparty rows.", Stack: true}) {
 						<input type="url" name="logo_url" value={ p.LogoURL } placeholder="https://logo.example.com/acme.png" class="input input-sm w-full" aria-label="Logo URL"/>
 					}
 				}


### PR DESCRIPTION
## What

PR #1900 shipped counterparty brand logos via logo.dev, but the counterparty **enrichment form** (detail-page Details card) never explained the resolution chain, so users couldn't discover how to get a logo. This is a **display/copy-only** discoverability fix — no engine, data, or config changes.

Logo resolution chain (unchanged): explicit `logo_url` → logo.dev hotlink derived from the counterparty's **Website** domain (when `counterparty_logos` is enabled AND a `logo_dev_token` is set in Settings) → gradient monogram.

## Changes

`internal/templates/components/pages/counterparties.templ` — two field hints on the detail-page enrichment form:

| Field | Before | After |
|---|---|---|
| **Website** | *(no hint)* | Its domain auto-fetches a brand logo via logo.dev when counterparty logos are enabled and a logo.dev token is set in Settings |
| **Logo URL** | Image hotlinked on counterparty rows | Overrides the auto-fetched logo. Hotlinked on counterparty rows. |

The Website hint deliberately states the token requirement so it doesn't overclaim (no token → no logo). The `/counterparties/new` create form only has a Name field — no Website/Logo fields — so it was left untouched.

## Evidence

Build-tag sweep (all green):

```
go build ./...                  EXIT:0
go build -tags=lite ./...       EXIT:0
go build -tags=headless ./...   EXIT:0
go vet ./...                    EXIT:0
go test ./...                   ok (one flaky timing test,
                                TestSidecarRun_ConcurrentRunsNoLongerSerialize,
                                passes on isolated re-run; unrelated to copy change)
```

No golden/snapshot test references the old hint text. `make templ` regenerated cleanly.

### Screenshot — Details card with updated hints

<img src="https://bb-artifacts.exe.xyz/f/e91b5c211a956b8e.png" width="800" alt="counterparty enrichment Details card with updated Website and Logo URL hints">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
