### PR TITLE
fix(rules): align admin rule-form field options with engine field names

### DIFF
--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -175,15 +175,15 @@ templ RuleForm(p RuleFormProps) {
 								<select x-model="cond.field" @change="onFieldChange(idx)" class="select select-xs bg-base-100 flex-1 min-w-0">
 									<option value="">Field...</option>
 									<optgroup label="Transaction">
-										<option value="name">Name</option>
-										<option value="merchant_name">Merchant</option>
+										<option value="provider_name">Name</option>
+										<option value="provider_merchant_name">Merchant</option>
 										<option value="amount">Amount</option>
 										<option value="pending">Pending</option>
 									</optgroup>
 									<optgroup label="Category">
 										<option value="category">Category (assigned)</option>
-										<option value="category_primary">Category (raw primary)</option>
-										<option value="category_detailed">Category (raw detail)</option>
+										<option value="provider_category_primary">Category (raw primary)</option>
+										<option value="provider_category_detailed">Category (raw detail)</option>
 									</optgroup>
 									<optgroup label="Tags">
 										<option value="tags">Tag</option>

--- a/static/js/admin/components/rule_form.js
+++ b/static/js/admin/components/rule_form.js
@@ -15,8 +15,8 @@
 document.addEventListener('alpine:init', function () {
   Alpine.data('ruleForm', function () {
     var fieldTypes = {
-      name: 'string', merchant_name: 'string', amount: 'numeric',
-      category_primary: 'string', category_detailed: 'string',
+      provider_name: 'string', provider_merchant_name: 'string', amount: 'numeric',
+      provider_category_primary: 'string', provider_category_detailed: 'string',
       category: 'string',
       pending: 'bool', provider: 'string',
       account_id: 'string', account_name: 'string',


### PR DESCRIPTION
## What

The admin **visual rule builder** offered `Name`, `Merchant`, `Category (raw primary)`, `Category (raw detail)` as condition fields, but emitted the **un-prefixed** option values `name`, `merchant_name`, `category_primary`, `category_detailed`. The rule engine's `validConditionFields` map (and the resolver, matcher, and the rule-detail label map) only recognize the canonical `provider_*` names — so submitting **any** rule that matched on one of these fields failed with:

> `invalid parameter: unknown field "merchant_name"`

This silently broke the doctrine's core path. A `Merchant contains AMAZON → assign_counterparty` (or `assign_series`) rule — exactly what the rules-as-substrate sprint is built around — **could not be authored from the admin UI at all**. The toast surfaced the error, but the user had no way to know the "Merchant" option itself was poisoned.

## Fix

Rename four option values in `rule_form.templ` and the matching `fieldTypes` keys in `rule_form.js` to the canonical names the backend already expects:

| Form label | before | after |
|---|---|---|
| Name | `name` | `provider_name` |
| Merchant | `merchant_name` | `provider_merchant_name` |
| Category (raw primary) | `category_primary` | `provider_category_primary` |
| Category (raw detail) | `category_detailed` | `provider_category_detailed` |

No engine change — the validator, resolver, matcher, and detail-page label map already use `provider_*`. This is purely the form catching up to the contract.

## Verification (live UI, throwaway DB on the sprint binary)

Authored `Merchant contains AMAZON → assign_counterparty: Amazon` through the real form, saved, applied retroactively → counterparty membership, governing rule, transaction timeline, and feed all populate. Same for `Merchant contains NETFLIX → assign_series: Netflix` (3 charges). **Edit mode round-trips**: an existing rule's `provider_merchant_name` condition now matches the "Merchant" option instead of rendering a blank field select.

Rule authored + applied (counterparty):
![rule form](https://bb-artifacts.exe.xyz/f/fe1f022f826d7379.jpeg)

Counterparty detail — linked charges + governing rule:
![counterparty detail](https://bb-artifacts.exe.xyz/f/2f4537d6bfe96cb6.jpeg)

Series detail — linked charges + governing rule:
![series detail](https://bb-artifacts.exe.xyz/f/72bc581adbfffa2c.jpeg)

Transaction timeline — legible `counterparty_assigned` event:
![timeline](https://bb-artifacts.exe.xyz/f/7ff9668184273452.jpeg)

Feed — membership events render legibly:
![feed](https://bb-artifacts.exe.xyz/f/0855e565bc10c1af.jpeg)

## Build / tests

`go build` default + `headless` + `lite` all green; `go vet` and `go test ./internal/templates/components/pages/...` (incl. `feed_membership_test.go`) pass. Diff is 6 lines across 2 files; generated `*_templ.go` is gitignored (CI regenerates via `make templ`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU