### PR TITLE
(beyond-roadmap) fix(rules): surface retroactive Apply for membership/metadata rules on the rule detail

### DIFF
--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -397,9 +397,11 @@ templ ruleDetailRecentApplications(p RuleDetailProps) {
 // ruleDetailPendingMatches renders the "Matching transactions" card — only
 // rendered when preview data is available.
 //
-// Retroactive apply runs set_category + add_tag + remove_tag (add_comment
-// is sync-only). The card always renders when preview data exists so users
-// get explicit confirmation that preview ran, even when there are zero
+// Retroactive apply runs every materializing action the engine supports —
+// set_category, add_tag, remove_tag, assign_series, assign_counterparty,
+// set_metadata, remove_metadata, flag, unflag (add_comment is the only
+// sync-only action). The card always renders when preview data exists so
+// users get explicit confirmation that preview ran, even when there are zero
 // matches or the rule is comment-only (non-retroactive).
 templ ruleDetailPendingMatches(p RuleDetailProps) {
 	if p.Rule != nil && p.Preview != nil {
@@ -532,6 +534,8 @@ templ ruleDetailApplyModal(p RuleDetailProps) {
 							<ul class="mt-3 text-xs text-base-content/50 space-y-1 list-disc pl-4">
 								<li><code class="text-[10px]">set_category</code> writes the category directly — last-writer-wins, no lock.</li>
 								<li><code class="text-[10px]">add_tag</code> / <code class="text-[10px]">remove_tag</code> apply to every match.</li>
+								<li><code class="text-[10px]">assign_series</code> links matching charges to the series; <code class="text-[10px]">assign_counterparty</code> binds them to the counterparty.</li>
+								<li><code class="text-[10px]">set_metadata</code> / <code class="text-[10px]">remove_metadata</code> and <code class="text-[10px]">flag</code> / <code class="text-[10px]">unflag</code> apply to every match.</li>
 								<li><code class="text-[10px]">add_comment</code> is sync-only — it won't fire retroactively.</li>
 							</ul>
 							<div class="form-control mt-4">

--- a/internal/templates/components/pages/rule_detail_types.go
+++ b/internal/templates/components/pages/rule_detail_types.go
@@ -79,12 +79,21 @@ func ruleConditionMatchAll(c service.Condition) bool {
 	return c.Field == "" && len(c.And) == 0 && len(c.Or) == 0 && c.Not == nil
 }
 
-// ruleHasRetroactiveAction mirrors the funcMap helper — true when the rule
-// has at least one set_category / add_tag / remove_tag action.
+// ruleHasRetroactiveAction reports whether a rule has at least one action that
+// the engine actually materializes against already-synced transactions. This
+// MUST stay aligned with Service.ApplyRuleRetroactively (internal/service/rules.go):
+// that path materializes set_category, add_tag, remove_tag, assign_series,
+// assign_counterparty, set_metadata, remove_metadata, flag, and unflag. Only
+// add_comment is sync-only (an explicit no-op retroactively). Treating a
+// membership/metadata/flag rule as non-retroactive here would wrongly hide the
+// "Apply now" affordance even though the engine would back-fill it.
 func ruleHasRetroactiveAction(actions []service.RuleAction) bool {
 	for _, a := range actions {
 		switch a.Type {
-		case "set_category", "add_tag", "remove_tag":
+		case "set_category", "add_tag", "remove_tag",
+			"assign_series", "assign_counterparty",
+			"set_metadata", "remove_metadata",
+			"flag", "unflag":
 			return true
 		}
 	}

--- a/internal/templates/components/pages/rule_detail_types_test.go
+++ b/internal/templates/components/pages/rule_detail_types_test.go
@@ -1,0 +1,60 @@
+//go:build !headless && !lite
+
+package pages
+
+import (
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// retroactiveActionTypes is the canonical set of action types that
+// Service.ApplyRuleRetroactively materializes against already-synced
+// transactions (internal/service/rules.go). add_comment is deliberately
+// excluded — it is the only sync-only action. This list is the source of
+// truth the UI gate (ruleHasRetroactiveAction) must mirror so the rule
+// detail page never hides "Apply now" for a rule the engine would back-fill.
+var retroactiveActionTypes = []string{
+	"set_category",
+	"add_tag",
+	"remove_tag",
+	"assign_series",
+	"assign_counterparty",
+	"set_metadata",
+	"remove_metadata",
+	"flag",
+	"unflag",
+}
+
+func TestRuleHasRetroactiveActionMatchesEngineSet(t *testing.T) {
+	for _, typ := range retroactiveActionTypes {
+		actions := []service.RuleAction{{Type: typ}}
+		if !ruleHasRetroactiveAction(actions) {
+			t.Errorf("ruleHasRetroactiveAction(%q) = false, want true — the engine materializes this action retroactively", typ)
+		}
+	}
+}
+
+func TestRuleHasRetroactiveActionExcludesCommentOnly(t *testing.T) {
+	// add_comment is sync-only; a comment-only rule must NOT surface the
+	// retroactive Apply affordance.
+	if ruleHasRetroactiveAction([]service.RuleAction{{Type: "add_comment"}}) {
+		t.Error("ruleHasRetroactiveAction([add_comment]) = true, want false — add_comment is sync-only")
+	}
+	// An empty action list is also non-retroactive.
+	if ruleHasRetroactiveAction(nil) {
+		t.Error("ruleHasRetroactiveAction(nil) = true, want false")
+	}
+}
+
+func TestRuleHasRetroactiveActionMixedRetroWins(t *testing.T) {
+	// A rule that mixes a sync-only action with a materializing one is still
+	// retroactive — the materializing action gets backfilled.
+	actions := []service.RuleAction{
+		{Type: "add_comment"},
+		{Type: "assign_counterparty"},
+	}
+	if !ruleHasRetroactiveAction(actions) {
+		t.Error("ruleHasRetroactiveAction([add_comment, assign_counterparty]) = false, want true")
+	}
+}


### PR DESCRIPTION
## What & why

Found via an e2e doctrine smoke test: the rule **detail** page hid its retroactive **Apply now** affordance for rules whose action is `assign_counterparty` / `assign_series` / `set_metadata` / `flag` etc., even though the engine *does* back-fill them. The page gated the affordance + explainer copy on `ruleHasRetroactiveAction`, which only returned true for `set_category` / `add_tag` / `remove_tag`. So one of these rules showed *"This rule only adds comments, which fire on sync — no retroactive preview is available"* and hid the Apply button — blocking the doctrine's "improve the enrichment layer on already-synced data via the UI" path.

This is **display/gating-only** — no engine change. The Apply button still POSTs to the existing `/-/rules/{id}/apply` handler, which already handles every type.

## The engine's actual retroactive action set (source of truth)

Derived by reading `Service.ApplyRuleRetroactively` (`internal/service/rules.go`) — specifically the action-intent extraction switch and the shared `applyRetroTxnIntent` writer (cross-checked against `ApplyAllRulesRetroactively`). The path **materializes** these against already-synced rows:

| action | retroactive? |
|---|---|
| `set_category` | ✅ bulk UPDATE |
| `add_tag` / `remove_tag` | ✅ |
| `assign_series` | ✅ resolve-or-mint + link |
| `assign_counterparty` | ✅ resolve-or-create + bind |
| `set_metadata` / `remove_metadata` | ✅ `(metadata - removeKeys) || setObj` |
| `flag` / `unflag` | ✅ |
| `add_comment` | ❌ **sync-only** — explicit no-op retroactively (`// sync-only; skip retroactively.`) |

`add_comment` is the *only* sync-only action, so a non-retroactive rule is by definition comment-only — the existing "comment-only" copy stays accurate.

## Changes (gate + copy)

- **`ruleHasRetroactiveAction`** (`rule_detail_types.go`) now returns true for exactly the 9 materializing action types; doc comment rewritten to name `ApplyRuleRetroactively` as the source of truth.
- **Apply-modal action list** (`rule_detail.templ`) now describes the full set: `assign_series` links charges to the series, `assign_counterparty` binds them to the counterparty, plus metadata + flag/unflag — and keeps the `add_comment` sync-only line. Irreversibility warning unchanged.
- **Preview-card doc comment** updated to the same set.
- **Unit test** (`rule_detail_types_test.go`) asserts the gate matches the engine's set exactly and still excludes the comment-only / empty cases.

## Verification (build-tags rule)

```
make templ
go build ./...                 # OK
go build -tags=lite ./...       # OK
go build -tags=headless ./...   # OK
go vet ./...                    # clean
go test ./...                   # all green (new pages tests pass)
```

## Screenshot

Seeded a **throwaway** DB (`breadbox_retroapply_shot`, dropped after) with an `assign_counterparty` rule (2 matching Starbucks txns) + a comment-only contrast rule.

**`assign_counterparty` rule detail — Apply affordance present, "2 pending":**
![card](https://bb-artifacts.exe.xyz/f/4253ca2ef9831bad.jpeg)

**Apply modal — corrected explainer copy (series/counterparty/metadata/flag), irreversibility warning intact:**
![modal](https://bb-artifacts.exe.xyz/f/b1e046ad76be0a43.jpeg)

**Contrast — comment-only rule still correctly shows no retroactive Apply:**
![comment-only](https://bb-artifacts.exe.xyz/f/2c8c23cc580b7d75.jpeg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fRHZ1CTjEZ1xFwQmW27jU
