### PR TITLE
feat(feed): collapse per-rule list into a sync-log summary

### DIFF
--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -554,27 +554,10 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if len(s.RuleOutcomes) > 0 {
-		<div class="mt-1 flex items-center gap-1.5 flex-wrap text-base-content/55">
+		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="mt-1 inline-flex items-center gap-1.5 text-base-content/55 hover:text-primary transition-colors no-underline">
 			@components.LucideIcon("zap", "w-3 h-3 text-primary opacity-70")
-			for i, ro := range s.RuleOutcomes {
-				if i > 0 {
-					<span class="text-base-content/25">·</span>
-				}
-				if ro.RuleShortID != "" {
-					<a href={ templ.SafeURL("/rules/" + ro.RuleShortID) } class="hover:text-primary transition-colors no-underline">
-						<span class="font-medium text-base-content/85">{ feedNonEmpty(ro.RuleName, "A rule") }</span>
-						<span>&nbsp;applied to&nbsp;</span>
-						<span class="font-medium tabular-nums text-base-content/85">{ fmt.Sprintf("%d", ro.Count) }</span>
-					</a>
-				} else {
-					<span>
-						<span class="font-medium text-base-content/85">{ feedNonEmpty(ro.RuleName, "A rule") }</span>
-						<span>&nbsp;applied to&nbsp;</span>
-						<span class="font-medium tabular-nums text-base-content/85">{ fmt.Sprintf("%d", ro.Count) }</span>
-					</span>
-				}
-			}
-		</div>
+			<span class="font-medium text-base-content/85">{ feedRuleSummaryText(s.RuleOutcomes) }</span>
+		</a>
 	}
 }
 
@@ -1044,6 +1027,21 @@ func feedNonEmpty(a, fallback string) string {
 		return a
 	}
 	return fallback
+}
+
+// feedRuleSummaryText renders the one-line rule-application summary shown on
+// a sync card — e.g. "3 rules applied · 12 hits". The per-rule breakdown
+// (which rule, how many each) lives on the sync-log detail page that the
+// summary links to, so the feed stays a glanceable headline.
+func feedRuleSummaryText(outcomes []FeedRuleOutcome) string {
+	rules := len(outcomes)
+	total := 0
+	for _, o := range outcomes {
+		total += o.Count
+	}
+	return fmt.Sprintf("%d %s applied · %d %s",
+		rules, pluralLabel("rule", rules != 1),
+		total, pluralLabel("hit", total != 1))
 }
 
 // feedDisplayName resolves the preferred display label for a feed tx ref:


### PR DESCRIPTION
## What

The sync card in the activity feed listed **every** rule that fired during a sync — `Rule A applied to 4 · Rule B applied to 3 · Rule C applied to 2 · …` — which wraps across lines and competes with the card's headline. The **sync-log detail page already shows the full per-rule breakdown** (the "Rule Hits" section), so the feed only needs a glanceable top-level summary.

This replaces the per-rule loop with a single line — **`N rules applied · M hits`** — that links straight to the sync log where the breakdown lives.

## Change

- `feedSyncBody` (`internal/templates/components/pages/feed.templ`): the `s.RuleOutcomes` block is now one `<a>` linking to `/logs/sync-logs/{id}` instead of a per-rule list of `/rules/{shortID}` links.
- New `feedRuleSummaryText` helper sums hit counts and pluralizes ("1 rule applied · 3 hits" vs "3 rules applied · 9 hits").
- Net **−20 / +18 LOC**, one file.

## Evidence

Rendered the real `feedSyncBody` component with controlled rule-outcome data (the live dev feed only windows the last 3 days, and the only rule-hit syncs are older). Before = the removed per-rule list; After = the new summary.

<img src="https://bb-artifacts.exe.xyz/f/eb7db7098f92f85b.jpeg" width="800" alt="Feed sync card — before (per-rule list) vs after (summary linking to sync log)">

`go build ./...`, `go vet ./internal/templates/...`, and `go test ./internal/templates/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
