### PR TITLE
fix(feed): drop redundant added/modified breakdown from sync rows

### DIFF
--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -520,20 +520,14 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		}
 		@feedRowTimestamp(it.TimestampStr, now)
 	</div>
-	if s.AddedCount+s.ModifiedCount+s.RemovedCount > 0 {
+	// The added/modified/removed breakdown is intentionally omitted here:
+	// feedSyncAction already states the primary count ("1 new transaction",
+	// "5 transactions updated"), so repeating it as chips is redundant (#1910).
+	// The trigger context (manual run / webhook / first sync) is not in the
+	// headline, so it stays.
+	if s.Trigger != "" && s.Trigger != "cron" {
 		<div class="text-base-content/55 mt-0.5 flex items-center gap-2 flex-wrap">
-			if s.AddedCount > 0 {
-				<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-success" aria-hidden="true"></span>{ fmt.Sprintf("%d added", s.AddedCount) }</span>
-			}
-			if s.ModifiedCount > 0 {
-				<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-info" aria-hidden="true"></span>{ fmt.Sprintf("%d modified", s.ModifiedCount) }</span>
-			}
-			if s.RemovedCount > 0 {
-				<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-base-content/30" aria-hidden="true"></span>{ fmt.Sprintf("%d removed", s.RemovedCount) }</span>
-			}
-			if s.Trigger != "" && s.Trigger != "cron" {
-				<span class="text-base-content/45">&middot; { feedTriggerLabel(s.Trigger) }</span>
-			}
+			<span class="text-base-content/45">{ feedTriggerLabel(s.Trigger) }</span>
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {


### PR DESCRIPTION
Closes #1910.

## What

In the home timeline feed (`/`), each sync row showed an added/modified chip breakdown ("• 1 added • 1 modified") directly under the headline. The headline already states the primary count — **"1 new transaction"**, **"3 transactions updated"**, **"2 transactions removed"** — so repeating it as chips is redundant noise.

This is the issue's exact ask: *"we don't need to show added / modified as generally the event title has enough context."*

## Change

`feedSyncBody` in `internal/templates/components/pages/feed.templ`:

- Removed the added / modified / removed count chips.
- **Kept** the trigger context (`manual run`, `webhook`, `first sync`) — that is *not* in the headline, so it is genuinely additive. It now renders on its own gated line, without the orphaned leading separator it used to inherit from the chip row.
- Counts remain one click away on the linked sync-log detail page (`/logs/sync-logs/{id}`), and the sample-transaction list below each row is untouched.

Net diff: 7 insertions, 13 deletions, one file.

## Evidence

Captured at the issue's mobile viewport (402px wide, dark). Seed data covers every case: added+modified (the exact screenshot from the issue), added-only, modified-only + webhook trigger, and added+removed + manual trigger.

(Screenshots are linked rather than inlined — this PR is authored through an API layer that strips inline image embeds; the links open the JPEGs directly.)

- **Before** — redundant `1 added / 1 modified` chips under each headline: https://bb-artifacts.exe.xyz/f/9534bf143f36c349.jpg
- **After** — chips gone; `webhook` / `manual run` trigger labels preserved: https://bb-artifacts.exe.xyz/f/9ffbfdc706519f4f.jpg

The two red "Sync failed … unknown provider: teller" rows at the top of the captures are an artifact of the seed connections (no real Teller provider in the dev box) — unrelated to this change.

## Validation

- `templ generate` + `go build ./...` + `go vet ./internal/templates/...` — all clean.
- Before/after rendered in headless Chromium against a local server with seeded sync logs.