### PR TITLE
Add border to rule "Then" action card to match "When" conditions

### DIFF
--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -183,7 +183,7 @@ templ ruleDetailWhatItDoes(p RuleDetailProps) {
 
 // ruleDetailActionRow renders one action card under the "Then" header.
 templ ruleDetailActionRow(p RuleDetailProps, a service.RuleAction) {
-	<div class="flex items-center gap-3 p-3 bg-base-200/40 rounded-xl">
+	<div class="flex items-center gap-3 p-3 bg-base-200/50 border border-base-content/10 rounded-xl">
 		switch a.Type {
 			case "set_category":
 				<div class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={ ruleCategoryTileBgStyle(p.Rule) }>


### PR DESCRIPTION
Closes #1912.

## What

On the rule detail page (`/rules/{id}`), the **Then** action card was a bare filled surface (`bg-base-200/40`, no border) while the **When** condition rows use `bg-base-200/50` + a hairline border. That made the action card read as a flatter, differently-shaped surface than the conditions directly above it.

This aligns the action card to the exact same treatment so the When / Then sections share one consistent vocabulary.

## Change

One line in `internal/templates/components/pages/rule_detail.templ` (`ruleDetailActionRow`) — the action card's classes:

```
- bg-base-200/40 rounded-xl
+ bg-base-200/50 border border-base-content/10 rounded-xl
```

The border + background now match `components.ConditionRow` (`condition_row.templ`), which renders the "When" rows (`bg-base-200/50 border border-base-content/10 rounded-xl`).

## Validation

Built the binary, ran migrations, seeded an admin, recreated the rule from the issue (`Name is LIME`, `Amount > 0`, `Amount < 50` → Bikes & Scooters), and captured the rule detail page in a real browser (headless Chromium, light theme, 1280×900). The "Set category to Bikes & Scooters" action card now carries the same hairline border as the IF / AND condition rows above it.

`go build ./...`, `go vet ./internal/templates/...`, and `go test ./internal/templates/...` all pass.

**Before / after (side-by-side):** https://bb-artifacts.exe.xyz/f/8a3c02ce2507fd9d.jpg

- Before (from issue #1912): https://bb-artifacts.exe.xyz/f/1431def33af51216.jpg
- After: https://bb-artifacts.exe.xyz/f/f5c5dbdd80161702.jpg

_Screenshots are linked rather than embedded inline: the GitHub MCP tool used to author this PR strips inline image markup, so an embed would render as broken code. The links above open the full images directly on bb-artifacts._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBigcHc3cAZqVbBu9jceR7