### PR TITLE
fix(agents): hide per-run agent API keys from key-management surfaces

### DIFF
--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -22,13 +22,35 @@ WHERE ak.id = $1;
 SELECT * FROM api_keys WHERE key_prefix = $1 LIMIT 1;
 
 -- name: ListApiKeys :many
--- Filters out auto-managed MCP-client identities (client_fingerprint
--- IS NOT NULL). Those rows exist to anchor agent attribution + the
--- per-client avatar to a stable api_keys.id; they're not user-revocable
--- credentials and showing them in /settings/api-keys would confuse
--- users who don't recognise the "mcp-client:claude-desktop@@stdio"
--- prefix or have no way to act on the row.
-SELECT * FROM api_keys WHERE client_fingerprint IS NULL ORDER BY created_at DESC;
+-- Returns only user-manageable credentials. Drives /settings/api-keys, the
+-- REST GET /api/v1/api-keys list, and `breadbox keys list`.
+--
+-- Hides agent machinery — keys a user neither created nor can act on — but
+-- identifies it STRUCTURALLY, never by actor_type. The actor_type column was
+-- added with DEFAULT 'agent' (migration 20260512061200), so every key minted
+-- before that migration — including legitimate user keys — carries
+-- actor_type='agent'. Filtering on `actor_type <> 'agent'` would make those
+-- still-valid user credentials vanish from every management surface while
+-- staying live and un-revocable. So we match the two positively-identifiable
+-- machine shapes instead:
+--   * client_fingerprint IS NOT NULL — auto-managed MCP-client identity rows
+--     (CreateMCPClientApiKey), which anchor per-client agent avatars.
+--   * per-run keys minted by Orchestrator.MintRunAPIKey, identified by a set
+--     workflow_id (modern) OR the `agent:<slug>:<runID>` name (run keys minted
+--     before workflow_id existed). The name match mirrors ParseAgentKeySlug.
+-- These churned on every workflow run — flickering into the list mid-run and
+-- piling up under "revoked" — which is what looked like unexplained key
+-- activity. Their identity + run history surface on the Workflows / agent-runs
+-- pages; the avatar resolver still reads the rows by id (ResolveAgentSlugForActor),
+-- so they're hidden from management, not deleted.
+--
+-- Everything else — user keys (any name), the `system` stdio bootstrap key, and
+-- legacy user keys mislabeled actor_type='agent' by the DEFAULT — stays visible.
+SELECT * FROM api_keys
+WHERE client_fingerprint IS NULL
+  AND workflow_id IS NULL
+  AND name NOT LIKE 'agent:%:%'
+ORDER BY created_at DESC;
 
 -- name: GetApiKeyByClientFingerprint :one
 -- Drives EnsureMCPClientAgentKey's lookup half. Returns the per-client

--- a/internal/service/agent_orchestrator_test.go
+++ b/internal/service/agent_orchestrator_test.go
@@ -214,7 +214,7 @@ func TestOrchestratorRunNow_RunnerErrorPersisted(t *testing.T) {
 }
 
 func TestOrchestratorRunNow_MintRevokeRoundTrip(t *testing.T) {
-	svc, _, _ := newService(t)
+	svc, _, pool := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)
 	def := mustCreateAgentDefinition(t, svc, "orch-mintrevoke", true)
 
@@ -236,16 +236,23 @@ func TestOrchestratorRunNow_MintRevokeRoundTrip(t *testing.T) {
 		t.Error("expected BREADBOX_API_KEY to be set in JobSpec MCP env")
 	}
 
-	// Confirm the minted key was revoked after the run.
-	keys, err := svc.ListAPIKeys(context.Background())
-	if err != nil {
-		t.Fatalf("ListAPIKeys: %v", err)
-	}
+	// Confirm the minted key was both created and revoked after the run.
+	// Agent keys are deliberately filtered out of ListAPIKeys (they're
+	// machinery, not user-managed credentials), so assert against api_keys
+	// directly by the run-key name — scanning ListAPIKeys here would pass
+	// vacuously because the row never appears in it.
 	wantName := "agent:" + def.Slug + ":" + runResp.ShortID
-	for _, k := range keys {
-		if k.Name == wantName && k.RevokedAt == nil {
-			t.Errorf("minted key %q should be revoked, but RevokedAt is nil", wantName)
-		}
+	var total, unrevoked int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*), COUNT(*) FILTER (WHERE revoked_at IS NULL) FROM api_keys WHERE name = $1`,
+		wantName).Scan(&total, &unrevoked); err != nil {
+		t.Fatalf("query minted key: %v", err)
+	}
+	if total == 0 {
+		t.Errorf("expected a minted key named %q, found none", wantName)
+	}
+	if unrevoked != 0 {
+		t.Errorf("minted key %q should be revoked, but %d unrevoked row(s) remain", wantName, unrevoked)
 	}
 	// Touch the unused appconfig reader to keep the import live in case
 	// the test file evolves to read settings directly.
@@ -419,7 +426,7 @@ func TestOrchestratorRunNow_CleanSuccess_LeavesHitCapNil(t *testing.T) {
 // contention. The 4th concurrent attempt should still lock — the cap is
 // a real ceiling, not a no-op.
 func TestOrchestratorRunNow_TripleConcurrency(t *testing.T) {
-	svc, _, _ := newService(t)
+	svc, _, pool := newService(t)
 	encKey := seedSubscriptionAuth(t, svc)
 	def := mustCreateAgentDefinition(t, svc, "orch-3x", true)
 
@@ -480,16 +487,20 @@ func TestOrchestratorRunNow_TripleConcurrency(t *testing.T) {
 		t.Errorf("max concurrent runs observed = %d, want 3 (cap=3 should NOT serialize)", got)
 	}
 
-	// Every successful run minted an api_key and revoked it. After all three
-	// complete, no `agent:orch-3x:*` key should remain unrevoked.
-	keys, err := svc.ListAPIKeys(context.Background())
-	if err != nil {
-		t.Fatalf("ListAPIKeys: %v", err)
+	// Every successful run minted an api_key and revoked it. Agent keys are
+	// filtered out of ListAPIKeys, so query api_keys directly: the runs' keys
+	// must exist and none may remain unrevoked after all three complete.
+	var total, unrevoked int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*), COUNT(*) FILTER (WHERE revoked_at IS NULL) FROM api_keys WHERE name LIKE 'agent:orch-3x:%'`,
+	).Scan(&total, &unrevoked); err != nil {
+		t.Fatalf("query minted keys: %v", err)
 	}
-	for _, k := range keys {
-		if strings.HasPrefix(k.Name, "agent:orch-3x:") && k.RevokedAt == nil {
-			t.Errorf("unrevoked minted key after concurrent runs: %s", k.Name)
-		}
+	if total == 0 {
+		t.Error("expected minted keys for the concurrent runs, found none")
+	}
+	if unrevoked != 0 {
+		t.Errorf("expected all minted keys revoked after concurrent runs, but %d remain unrevoked", unrevoked)
 	}
 }
 

--- a/internal/service/apikeys_actor_integration_test.go
+++ b/internal/service/apikeys_actor_integration_test.go
@@ -68,6 +68,77 @@ func TestCreateAPIKey_StoresActorColumns(t *testing.T) {
 	}
 }
 
+// TestListAPIKeys_ExcludesAgentKeys verifies that ListAPIKeys returns only
+// user-manageable credentials. Agent machinery — per-run keys minted+revoked
+// on every workflow run, and auto-managed MCP-client identity rows — is hidden
+// so the mint/revoke churn never appears in /settings/api-keys, the REST list,
+// or `breadbox keys list`.
+//
+// Crucially the filter is STRUCTURAL, not `actor_type <> 'agent'`: the
+// actor_type column defaults to 'agent' (migration 20260512061200), so any key
+// created before that migration — including legitimate user keys — is stamped
+// 'agent'. The legacy-user-key case below is the regression guard: such a key
+// must stay visible and revocable. See the ListApiKeys query comment.
+func TestListAPIKeys_ExcludesAgentKeys(t *testing.T) {
+	svc, _, pool := newService(t)
+	ctx := context.Background()
+
+	mk := func(name, actorType string) {
+		t.Helper()
+		if _, err := svc.CreateAPIKey(ctx, service.CreateAPIKeyParams{
+			Name:      name,
+			Scope:     "full_access",
+			ActorType: actorType,
+		}); err != nil {
+			t.Fatalf("CreateAPIKey(%s/%s): %v", name, actorType, err)
+		}
+	}
+	mk("user-key", "user")
+	mk("system-key", "system")
+	mk("agent:reviewer:RUN12345", "agent") // run-key shape → hidden
+
+	// A legitimate user key created BEFORE the actor-columns migration: the
+	// DEFAULT 'agent' backfilled it to actor_type='agent', but it has a normal
+	// name, no workflow_id, and no client_fingerprint. It must NOT be hidden.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type)
+		 VALUES ('legacy-deploy-key', 'legacyhash01', 'bb_legacy01', 'full_access', 'agent')`,
+	); err != nil {
+		t.Fatalf("insert legacy key: %v", err)
+	}
+
+	// An auto-managed MCP-client identity row (client_fingerprint set) → hidden.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO api_keys (name, key_hash, key_prefix, scope, actor_type, client_fingerprint)
+		 VALUES ('mcp-client:claude@@stdio', 'mcphash01', 'bb_mcp0001', 'full_access', 'agent', 'claude@@stdio')`,
+	); err != nil {
+		t.Fatalf("insert mcp-client key: %v", err)
+	}
+
+	keys, err := svc.ListAPIKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+
+	present := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		present[k.Name] = true
+	}
+
+	wantVisible := []string{"user-key", "system-key", "legacy-deploy-key"}
+	for _, name := range wantVisible {
+		if !present[name] {
+			t.Errorf("ListAPIKeys hid %q — it should be user-manageable", name)
+		}
+	}
+	wantHidden := []string{"agent:reviewer:RUN12345", "mcp-client:claude@@stdio"}
+	for _, name := range wantHidden {
+		if present[name] {
+			t.Errorf("ListAPIKeys leaked agent machinery %q — should be hidden", name)
+		}
+	}
+}
+
 // TestCreateAPIKey_RejectsBadActorType ensures the service guards the enum
 // before the CHECK constraint runs — so callers see a clean error rather
 // than a Postgres error.


### PR DESCRIPTION
## Problem

Every workflow run mints a scoped API key (`agent:<slug>:<runID>`) and revokes it in a `defer`. The mint-and-revoke itself is good design — least-privilege, per-run attribution, no long-lived agent secret to harvest (see `.claude/rules/agents.md` "Mint-and-revoke"). But the **plumbing leaked into the user-facing key list**: ephemeral keys flickered into `/settings/api-keys` mid-run and piled up under "revoked", reading as unexplained key activity the user never created and can't meaningfully manage.

## Fix

Filter agent machinery out of `ListApiKeys` — the single chokepoint behind the admin UI, REST `GET /api/v1/api-keys`, and `breadbox keys list`. An agent's identity + run history already surface on the Workflows / agent-runs pages.

The filter is **structural, not `actor_type`-based**, and that distinction is load-bearing:

> The `actor_type` column was added with `DEFAULT 'agent'` (migration `20260512061200`). So every key created **before** that migration — including legitimate user keys — was backfilled to `actor_type='agent'`. A naive `WHERE actor_type <> 'agent'` filter would hide those still-valid user credentials from every management surface while leaving them live and un-revocable.

Instead we match the two positively-identifiable machine shapes:
- `client_fingerprint IS NOT NULL` — auto-managed MCP-client identity rows.
- per-run keys — `workflow_id` set (modern) **or** the `agent:<slug>:<runID>` name (run keys minted before `workflow_id` existed). The name match mirrors `ParseAgentKeySlug`.

```sql
SELECT * FROM api_keys
WHERE client_fingerprint IS NULL
  AND workflow_id IS NULL
  AND name NOT LIKE 'agent:%:%'
ORDER BY created_at DESC;
```

## Deliberately *not* done

**No hard-delete prune of old revoked agent keys.** I'd floated this for unbounded `api_keys` growth, but the activity feed re-resolves historical agent avatars from the live `api_keys` row by id (`feed.go` -> `ResolveAgentSlugForActor` / `GetAgentIdentityByApiKeyID`). Deleting would degrade past attribution. The revoked rows are deliberately load-bearing; growth is the deliberate cost of durable identity.

## ⚠️ Pre-existing landmine surfaced (separate decision)

The same `actor_type DEFAULT 'agent'` mislabel means `CleanupOrphanedAgentApiKeys` (the startup sweep) **auto-revokes legacy user keys** stamped `agent` after 1h. On any instance that had user API keys before `20260512` (possibly prod), those may already have been silently revoked. This PR's structural filter keeps such keys *visible/revocable*, but does **not** un-revoke or re-label them — that's a credential-semantics change on prod data that deserves your explicit call. Happy to follow up with a corrective backfill migration if you want it.

## Tests

- **New** `TestListAPIKeys_ExcludesAgentKeys` — asserts run-key-shaped keys and MCP-client rows are hidden, while user, system, **and the legacy-mislabeled-user-key** (`actor_type='agent'`, normal name) stay visible. That last case is the regression guard for the trap above.
- **Fixed** `TestOrchestratorRunNow_{MintRevokeRoundTrip,TripleConcurrency}` — their mint-revoke assertions scanned `ListAPIKeys` and went **vacuous** once agent keys were filtered out. They now query `api_keys` directly and assert the key was *both* minted and revoked (stronger than before).

`go build`/`go vet`/touched-package integration tests green. (Pre-existing `series_tags` test-DB schema drift from another worktree is unrelated.)

## Review

Authored with a high-effort workflow-backed code review (8 finders + adversarial verify) — it caught the `actor_type DEFAULT` regression, which this final version fixes structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAhDs9z68QbpRk19xxA55L
